### PR TITLE
Remember recently-used repos for the new-workspace form

### DIFF
--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -31,6 +31,28 @@ test.describe('creating a workspace via the UI form', () => {
     expect(all[0].agent_kind).toBe('shell');
   });
 
+  test('the repository field offers recently-used repos', async ({ page, weaver }) => {
+    // Seed a workspace so its repo is recorded as recently used.
+    const ws = await weaver.seedWorkspace({ goal: 'seed', name: 'seed-ws' });
+
+    await page.goto(weaver.baseUrl);
+    await page.getByRole('button', { name: 'New workspace' }).click();
+
+    const repoInput = page.getByPlaceholder('/home/you/code/project');
+    // The dropdown stays hidden until the repository field is focused.
+    await expect(page.getByTestId('recent-repo')).toBeHidden();
+    await repoInput.focus();
+
+    const recent = page.getByTestId('recent-repo');
+    await expect(recent).toHaveCount(1);
+    await expect(recent.first()).toContainText(ws.repo_root);
+
+    // Picking a recent repo fills the field and closes the dropdown.
+    await recent.first().click();
+    await expect(repoInput).toHaveValue(ws.repo_root);
+    await expect(page.getByTestId('recent-repo')).toBeHidden();
+  });
+
   test('Cancel hides the form again', async ({ page, weaver }) => {
     await page.goto(weaver.baseUrl);
     await page.getByRole('button', { name: 'New workspace' }).click();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,6 +20,12 @@ export interface Workspace {
   pending_prompt: string;
 }
 
+export interface RecentRepo {
+  repo_root: string;
+  last_used_at: string;
+  active_workspaces: number;
+}
+
 export interface WeaverEvent {
   id: number;
   workspace_id: string;

--- a/frontend/src/views/WorkspaceList.vue
+++ b/frontend/src/views/WorkspaceList.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { get, post } from '../api';
-import type { Workspace } from '../types';
+import type { Workspace, RecentRepo } from '../types';
 import StatusBadge from '../components/StatusBadge.vue';
 
 const workspaces = ref<Workspace[]>([]);
+const recentRepos = ref<RecentRepo[]>([]);
 const error = ref('');
 const showForm = ref(false);
 const repo = ref('');
+const repoFocused = ref(false);
 const title = ref('');
 const goal = ref('');
 const name = ref('');
@@ -23,6 +25,22 @@ function slugify(s: string): string {
     .slice(0, 40);
 }
 
+// Final path segment of a repo root, used as its short label in the dropdown.
+function repoName(path: string): string {
+  return path.replace(/\/+$/, '').split('/').pop() || path;
+}
+
+// Recently-used repos, narrowed to those matching what the user has typed.
+const repoMatches = computed(() => {
+  const q = repo.value.trim().toLowerCase();
+  return recentRepos.value.filter((r) => r.repo_root.toLowerCase().includes(q));
+});
+
+function pickRepo(path: string) {
+  repo.value = path;
+  repoFocused.value = false;
+}
+
 // Keep the name in sync with the title (or goal) until the user edits it.
 watch([title, goal], ([t, g]) => {
   if (!nameEdited.value) name.value = slugify(t || g);
@@ -34,6 +52,14 @@ async function load() {
     error.value = '';
   } catch (e) {
     error.value = (e as Error).message;
+  }
+}
+
+async function loadRecentRepos() {
+  try {
+    recentRepos.value = (await get('/repos/recent')) as RecentRepo[];
+  } catch {
+    // The recent-repos dropdown is a convenience; ignore failures here.
   }
 }
 
@@ -55,6 +81,7 @@ async function create() {
     nameEdited.value = false;
     showForm.value = false;
     await load();
+    await loadRecentRepos();
   } catch (e) {
     error.value = (e as Error).message;
   } finally {
@@ -64,6 +91,7 @@ async function create() {
 
 onMounted(() => {
   load();
+  loadRecentRepos();
   timer = window.setInterval(load, 3000);
 });
 onUnmounted(() => clearInterval(timer));
@@ -86,13 +114,47 @@ onUnmounted(() => clearInterval(timer));
       class="mb-5 rounded border border-neutral-800 bg-neutral-900 p-4 space-y-3"
       @submit.prevent="create"
     >
-      <div>
-        <label class="block text-xs text-neutral-400 mb-1">Repository path (on the server)</label>
+      <div class="relative">
+        <label class="block text-xs text-neutral-400 mb-1">
+          Repository path (on the server)
+          <span v-if="recentRepos.length" class="text-neutral-600">— or pick a recent one</span>
+        </label>
         <input
           v-model="repo"
+          @focus="repoFocused = true"
+          @input="repoFocused = true"
+          @blur="repoFocused = false"
           placeholder="/home/you/code/project"
+          autocomplete="off"
+          spellcheck="false"
           class="w-full rounded bg-neutral-800 px-2 py-1.5 text-sm outline-none focus:ring-1 ring-emerald-600"
         />
+        <ul
+          v-if="repoFocused && repoMatches.length"
+          data-testid="recent-repos"
+          class="absolute left-0 right-0 z-10 mt-1 max-h-56 overflow-auto rounded border border-neutral-700 bg-neutral-800 shadow-lg"
+        >
+          <li v-for="r in repoMatches" :key="r.repo_root">
+            <button
+              type="button"
+              data-testid="recent-repo"
+              @mousedown.prevent="pickRepo(r.repo_root)"
+              class="flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left hover:bg-neutral-700"
+            >
+              <span class="min-w-0">
+                <span class="block truncate text-sm">{{ repoName(r.repo_root) }}</span>
+                <span class="block truncate text-xs text-neutral-500 font-mono">{{ r.repo_root }}</span>
+              </span>
+              <span
+                v-if="r.active_workspaces"
+                :title="`${r.active_workspaces} active workspace(s)`"
+                class="shrink-0 rounded bg-neutral-700 px-1.5 py-0.5 text-xs text-neutral-300"
+              >
+                {{ r.active_workspaces }}
+              </span>
+            </button>
+          </li>
+        </ul>
       </div>
       <div>
         <label class="block text-xs text-neutral-400 mb-1">Title</label>

--- a/src/db.rs
+++ b/src/db.rs
@@ -54,6 +54,14 @@ CREATE TABLE IF NOT EXISTS settings (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+-- Repositories the user has started a workspace in. Unlike `workspaces`, a
+-- row here outlives the removal of all of a repo's workspaces, so the web UI
+-- can keep offering recently-used repos when starting a new session.
+CREATE TABLE IF NOT EXISTS recent_repos (
+    repo_root    TEXT PRIMARY KEY,
+    last_used_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
 "#;
 
 /// Root directory for all weaver state on this machine.
@@ -143,6 +151,16 @@ async fn migrate(pool: &Db) -> Result<()> {
             tracing::debug!(error = %e, statement = %stmt, "idempotent alter skipped");
         }
     }
+    // Backfill `recent_repos` from any pre-existing workspaces so the feature
+    // works on databases created before the table existed. `INSERT OR IGNORE`
+    // makes this idempotent: it never overwrites a repo's recorded recency.
+    sqlx::query(
+        "INSERT OR IGNORE INTO recent_repos (repo_root, last_used_at)
+         SELECT repo_root, MAX(created_at) FROM workspaces GROUP BY repo_root",
+    )
+    .execute(pool)
+    .await
+    .context("seeding recent_repos from existing workspaces")?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod events;
 pub mod git;
 pub mod github;
 pub mod monitor;
+pub mod repo;
 pub mod server;
 pub mod summary;
 pub mod tmux;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,0 +1,118 @@
+//! Recently-used repositories, stored in the `recent_repos` table.
+//!
+//! Every time a workspace is created its repo root is recorded here. Unlike
+//! the `workspaces` table, an entry survives the removal of all of a repo's
+//! workspaces — that is the point: the dashboard remembers where you have been
+//! working so it can offer those repos when you start a new session.
+
+use anyhow::Result;
+use serde::Serialize;
+use sqlx::FromRow;
+
+use crate::db::{now_iso, Db};
+
+/// A repository the user has started a workspace in.
+#[derive(Debug, Clone, Serialize, FromRow)]
+pub struct RecentRepo {
+    /// Absolute path to the repository root.
+    pub repo_root: String,
+    /// When a workspace was last created in this repo.
+    pub last_used_at: String,
+    /// How many of this repo's workspaces are still tracked (may be zero).
+    pub active_workspaces: i64,
+}
+
+/// Record that a workspace was just created in `repo_root`, bumping its
+/// recency. Inserts the repo on first use and refreshes `last_used_at` after.
+pub async fn record_use(db: &Db, repo_root: &str) -> Result<()> {
+    tracing::debug!(repo_root, "recording recent repo use");
+    sqlx::query(
+        "INSERT INTO recent_repos (repo_root, last_used_at) VALUES (?, ?)
+         ON CONFLICT(repo_root) DO UPDATE SET last_used_at = excluded.last_used_at",
+    )
+    .bind(repo_root)
+    .bind(now_iso())
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// The most recently used repositories, newest first, capped at `limit`.
+pub async fn recent(db: &Db, limit: i64) -> Result<Vec<RecentRepo>> {
+    let rows = sqlx::query_as::<_, RecentRepo>(
+        "SELECT r.repo_root,
+                r.last_used_at,
+                (SELECT COUNT(*) FROM workspaces w WHERE w.repo_root = r.repo_root)
+                    AS active_workspaces
+         FROM recent_repos r
+         ORDER BY r.last_used_at DESC
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(db)
+    .await?;
+    tracing::debug!(count = rows.len(), "listed recent repos");
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::connect_in_memory;
+
+    async fn add_workspace(db: &Db, id: &str, repo_root: &str) {
+        sqlx::query(
+            "INSERT INTO workspaces (id,name,repo_root,work_dir,branch,tmux_session)
+             VALUES (?,?,?,?,?,?)",
+        )
+        .bind(id)
+        .bind(id)
+        .bind(repo_root)
+        .bind(format!("/w/{id}"))
+        .bind(format!("b/{id}"))
+        .bind(format!("s-{id}"))
+        .execute(db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn records_and_orders_by_recency() {
+        let db = connect_in_memory().await.unwrap();
+        record_use(&db, "/code/alpha").await.unwrap();
+        record_use(&db, "/code/beta").await.unwrap();
+        // Re-using alpha moves it back to the front.
+        record_use(&db, "/code/alpha").await.unwrap();
+
+        let rows = recent(&db, 10).await.unwrap();
+        let paths: Vec<&str> = rows.iter().map(|r| r.repo_root.as_str()).collect();
+        assert_eq!(paths, ["/code/alpha", "/code/beta"]);
+        assert_eq!(rows.len(), 2, "re-use must not create a duplicate row");
+    }
+
+    #[tokio::test]
+    async fn counts_active_workspaces_and_survives_their_removal() {
+        let db = connect_in_memory().await.unwrap();
+        record_use(&db, "/code/alpha").await.unwrap();
+        add_workspace(&db, "w1", "/code/alpha").await;
+        add_workspace(&db, "w2", "/code/alpha").await;
+
+        let rows = recent(&db, 10).await.unwrap();
+        assert_eq!(rows[0].active_workspaces, 2);
+
+        // Removing every workspace leaves the repo in the list, count zero.
+        sqlx::query("DELETE FROM workspaces").execute(&db).await.unwrap();
+        let rows = recent(&db, 10).await.unwrap();
+        assert_eq!(rows.len(), 1, "repo is remembered after its workspaces go");
+        assert_eq!(rows[0].active_workspaces, 0);
+    }
+
+    #[tokio::test]
+    async fn limit_caps_the_result() {
+        let db = connect_in_memory().await.unwrap();
+        for i in 0..5 {
+            record_use(&db, &format!("/code/r{i}")).await.unwrap();
+        }
+        assert_eq!(recent(&db, 3).await.unwrap().len(), 3);
+    }
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -23,7 +23,7 @@ use tower_http::services::{ServeDir, ServeFile};
 use crate::db::Db;
 use crate::events::{Event, EventBus};
 use crate::workspace::{NewWorkspace, Workspace};
-use crate::{agent, config, db, events, git, github, tmux, workspace};
+use crate::{agent, config, db, events, git, github, repo, tmux, workspace};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -121,6 +121,7 @@ pub fn router(state: AppState) -> Router {
         .route("/workspaces/{id}/pane", get(pane_workspace))
         .route("/workspaces/{id}/log", get(log_workspace))
         .route("/workspaces/{id}/events", get(events_sse))
+        .route("/repos/recent", get(recent_repos))
         .route("/hook", post(hook))
         .route("/settings", get(list_settings).post(set_setting))
         .with_state(state);
@@ -304,6 +305,10 @@ async fn create_workspace(
         },
     )
     .await?;
+    // Remember this repo so the dashboard can offer it for the next workspace.
+    if let Err(e) = repo::record_use(&st.db, &ws.repo_root).await {
+        tracing::warn!(workspace = %ws.id, error = %e, "failed to record recent repo");
+    }
     events::record(
         &st.db,
         &st.bus,
@@ -618,6 +623,24 @@ async fn events_sse(
             .unwrap_or_default()))
     });
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+// ---------------------------------------------------------------------------
+// Recent repositories
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RecentReposQuery {
+    /// How many repos to return. Defaults to 10; clamped to [1, 50].
+    limit: Option<i64>,
+}
+
+async fn recent_repos(
+    State(st): State<AppState>,
+    Query(q): Query<RecentReposQuery>,
+) -> ApiResult<Json<Vec<repo::RecentRepo>>> {
+    let limit = q.limit.unwrap_or(10).clamp(1, 50);
+    Ok(Json(repo::recent(&st.db, limit).await?))
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -71,6 +71,7 @@ async fn workspace_lifecycle() {
     let id = ws["id"].as_str().unwrap().to_string();
     let session = ws["tmux_session"].as_str().unwrap().to_string();
     let work_dir = ws["work_dir"].as_str().unwrap().to_string();
+    let repo_root = ws["repo_root"].as_str().unwrap().to_string();
 
     // Worktree, branch and tmux session all exist.
     assert!(
@@ -88,6 +89,13 @@ async fn workspace_lifecycle() {
     // It shows up in the listing.
     let list = client.get("/api/workspaces").await.unwrap();
     assert_eq!(list.as_array().unwrap().len(), 1);
+
+    // Creating the workspace recorded its repo as recently used.
+    let recent = client.get("/api/repos/recent").await.unwrap();
+    let recent = recent.as_array().unwrap();
+    assert_eq!(recent.len(), 1, "repo should be recorded after first workspace");
+    assert_eq!(recent[0]["repo_root"], repo_root);
+    assert_eq!(recent[0]["active_workspaces"], 1);
 
     // Text sent to the workspace reaches the pane.
     client
@@ -186,4 +194,12 @@ async fn workspace_lifecycle() {
     );
     let list = client.get("/api/workspaces").await.unwrap();
     assert_eq!(list.as_array().unwrap().len(), 0);
+
+    // The repo is still remembered after every workspace in it is gone — that
+    // is what lets the dashboard offer it for the next session.
+    let recent = client.get("/api/repos/recent").await.unwrap();
+    let recent = recent.as_array().unwrap();
+    assert_eq!(recent.len(), 1, "recent repo should outlive its workspaces");
+    assert_eq!(recent[0]["repo_root"], repo_root);
+    assert_eq!(recent[0]["active_workspaces"], 0);
 }


### PR DESCRIPTION
## Summary

Starting a new session previously meant retyping the full repository path into the New Workspace form every time. This adds a dropdown of recently-used repositories so you can pick one instead.

Designed API-first — the UI is a thin client of a new REST endpoint.

## REST API (designed first)

- **`GET /api/repos/recent?limit=N`** → `[{ repo_root, last_used_at, active_workspaces }]`, newest first.
- Backed by a new durable **`recent_repos`** table. Unlike `workspaces`, an entry **outlives the removal of all its workspaces** — that is the point of "remember": the dashboard still knows where you have been working after you clean up.
- The table is **seeded on migration** from existing workspaces, so the feature works immediately on pre-existing databases.
- New **`src/repo.rs`** module (`record_use`, `recent`), mirroring `config.rs`. `create_workspace` records the repo after every successful creation.

## UI

The **Repository path** field in the New Workspace form is now a focus-triggered combobox:

- Focusing or typing in the field shows a dropdown of recent repos, each with its short name, full path, and an active-workspace count badge.
- Picking one fills the field; free-typing a new path still works, and the list filters as you type.

## Tests

- New `repo.rs` unit tests: recency ordering, no duplicate on re-use, survives workspace removal, limit.
- Integration test extended: repo recorded on creation; still listed with `active_workspaces: 0` after every workspace is deleted.
- New e2e test: dropdown appears on focus, shows the seeded repo, picking it fills the field.
- Full suite green: 21 lib tests + integration test, 14/14 e2e; `tsc` + `rspack` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)