### PR TITLE
Add agent-declared attention status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ needing the daemon to be reachable.
 | Path | What's in it |
 |---|---|
 | `crates/weaver-core/` | lib: `branches`, `issues`, `notes`, `events`, `db`, `git`, `config`, agent helpers. Pure logic; used by both binaries. |
-| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `describe`, `note`, `issue …`, `where`, `log`, `hook`, `status`, `config`) |
+| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `describe`, `note`, `status` [read or set attention], `issue …`, `where`, `log`, `hook`, `config`) |
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
@@ -117,8 +117,15 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 top-level (`id`, `status`, `work_dir`, `tmux_session`, `agent_kind`, `model`,
 `effort`, `pending_prompt`, `github_repo`, `last_activity_at`, `summary_updated_at`,
 `created_at`, `updated_at`) plus a nested `branch: BranchView`
-(`id`, `name`, `title`, `goal`, `description`, `repo_root`, `branch`,
-`base_branch`, `created_at`, `updated_at`, `open_issue_count`).
+(`id`, `name`, `title`, `goal`, `description`, `attention`, `attention_note`,
+`repo_root`, `branch`, `base_branch`, `created_at`, `updated_at`,
+`open_issue_count`).
+
+Status is two orthogonal axes. The session's `status` is the **lifecycle**
+(orchestrator-owned, mechanical): `created` / `launching` / `running` /
+`orphaned` / `done` / `error`. The branch's `attention` (+ `attention_note`) is
+the **agent-declared** "does this need me?" signal: `ok` / `attention` /
+`blocked`, set via `weaver status`. The dashboard filters on `attention`.
 
 There is **no** `/api/hook` endpoint — see "Status detection" below.
 
@@ -142,27 +149,43 @@ There is **no** `/api/hook` endpoint — see "Status detection" below.
   first-class status, recovered via `loom adopt` (or the Adopt button in the
   UI).
 
-## Status detection
+## Status & attention
 
-Two paths, picked per agent kind:
+Two distinct axes (see the SessionView note above): the mechanical **lifecycle**
+`sessions.status`, and the agent-declared **attention** on the branch.
 
-1. **Claude Code hooks** — `loom launch` merges a `hooks` block into the
-   worktree's `.claude/settings.local.json` (see `loom::agent::install_hooks`
-   and `weaver_core::agent::hooks_json`). The mapping is:
+**Lifecycle** is driven by Claude Code hooks. `loom launch` merges a `hooks`
+block into the worktree's `.claude/settings.local.json` (see
+`loom::agent::install_hooks` and `weaver_core::agent::hooks_json`):
 
-   | Claude hook event | shells out to |
-   |---|---|
-   | `SessionStart` | `weaver hook --event session-start` (also injects [[crates/weaver-core/primer.md]] as `additionalContext`) |
-   | `UserPromptSubmit` | `weaver hook --event working` |
-   | `Notification` | `weaver hook --event waiting` |
-   | `Stop` | `weaver hook --event idle` |
+| Claude hook event | shells out to |
+|---|---|
+| `SessionStart` | `weaver hook --event session-start` (also injects [[crates/weaver-core/primer.md]] as `additionalContext`) |
+| `UserPromptSubmit` | `weaver hook --event working` |
+| `Notification` | `weaver hook --event waiting` |
+| `Stop` | `weaver hook --event idle` |
 
-   `weaver hook` writes an `events` row keyed on the branch resolved from
-   `$WEAVER_BRANCH` (set by the launcher) — no HTTP. Loom's monitor consumes
-   new `hook` rows on its next tick and flips `sessions.status` accordingly.
-   On `waiting`, the monitor snapshots the tmux pane into `pending_prompt`.
-2. **Tmux stillness** — for non-Claude agents the monitor diffs pane captures
-   over time and demotes `working` → `idle` after enough still ticks.
+`weaver hook` writes an `events` row keyed on the branch resolved from
+`$WEAVER_BRANCH` (set by the launcher) — no HTTP. Loom's monitor (`apply_hook`)
+consumes new `hook` rows on its next tick. Any hook means the agent process is
+alive, so all three set `status = running` (this also promotes a freshly
+`launching` session). The orchestrator no longer guesses working/waiting/idle:
+liveness is all it can know for sure, so there is no stillness-based idle
+demotion any more.
+
+The hooks also nudge **attention** where they carry a genuine signal:
+`working` clears it to `ok` and drops any pending prompt (the user is engaged);
+`waiting` raises it to `attention` ("Waiting for input") and snapshots the tmux
+pane into `pending_prompt` (Claude is blocked asking the user); `idle` (a turn
+ending) leaves attention untouched, so a finished-but-fine agent isn't mistaken
+for one that needs you.
+
+**Attention** is otherwise the agent's own call, set via `weaver status <level>
+["<note>"]`. That writes the branch's `attention`/`attention_note` columns
+directly (daemon-less, like `weaver describe`) and an `attention` event the
+monitor re-broadcasts over SSE. Last write wins, so an explicit declaration
+overrides the hook-inferred default. The PATCH `/api/sessions/{id}` and
+`/api/branches/{id}` routes accept `attention`/`attention_note` too, for the UI.
 
 Orphan detection is independent: if `tmux has-session` says no, the session
 becomes `orphaned` and is eligible for `loom adopt`.
@@ -176,6 +199,9 @@ weaver goal "ship the feature"          # set the branch's goal
 weaver goal                             # print the goal
 weaver describe "Wired up routes; tests pass"
 weaver note   "blocked on the DB schema"
+weaver status attention "ready for review"   # declare how the agent is doing
+weaver status ok "waiting on PR review feedback"
+weaver status                           # read goal + attention + open issues
 weaver issue add "Backfill old rows" --body "ETA after the schema change"
 weaver issue add "Audit the logger" --repo  # unclaimed repo backlog item
 weaver issue ls                         # this branch's work + unclaimed backlog

--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ weaver goal "ship the feature"
 weaver goal                           # print the current goal
 weaver describe "Wired up routes; tests pass."
 weaver note    "blocked on the DB schema"
+weaver status attention "ready for review"   # how the agent is doing (ok|attention|blocked)
 weaver issue add "Backfill old rows" --body "ETA after the schema change"
 weaver issue add "Audit the logger" --repo   # unclaimed repo backlog item
 weaver issue ls                       # this branch's work + the repo backlog
 weaver issue ls --mine                # just this branch's claimed issues
 weaver issue ls --repo                # the whole repo, grouped by branch
 weaver issue close 7
-weaver status                         # title + goal + open-issue count
+weaver status                         # goal + attention + open-issue count
 weaver where                          # debug: print resolved repo / branch / branch-id
 weaver log --limit 50                 # recent events for the current branch
 ```
@@ -80,19 +81,28 @@ and spliced into the launch as `--model` / `--effort`. Both are stored per
 session, so adopting a recovered session resumes with the same settings. Omit
 either to inherit `agent.claude_args`.
 
-## Status detection
+## Status & attention
 
-A session's status is one of `created`, `launching`, `working`, `waiting`,
-`idle`, `orphaned`, `done`, or `error`. `done` and `error` are terminal; the
-rest, including `orphaned`, are recoverable.
+Status has two independent axes.
 
-Claude-backed sessions report status via Claude Code hooks installed into
+The **lifecycle** (`session.status`) is mechanical and orchestrator-owned:
+`created`, `launching`, `running`, `orphaned`, `done`, or `error`. `done` and
+`error` are terminal; the rest, including `orphaned`, are recoverable. Claude-
+backed sessions drive it via Claude Code hooks installed into
 `.claude/settings.local.json` by `loom launch`. Each hook shells out to
-`weaver hook --event {working|waiting|idle|session-start}`, which writes an
-`events` row keyed on the branch. The loom monitor consumes new `hook` rows
-on its next tick. Other agents fall back to tmux screen-stillness detection.
-When a session goes `waiting`, the monitor snapshots the tmux pane into
-`pending_prompt` so the UI can show what the agent is blocked on.
+`weaver hook --event {working|waiting|idle|session-start}`, writing an `events`
+row the monitor consumes on its next tick; any hook means the agent process is
+alive → `running`. When Claude blocks asking the user (the `waiting`/Notification
+hook), the monitor snapshots the tmux pane into `pending_prompt` so the UI can
+show what the agent is waiting on.
+
+The **attention** axis is the agent's own signal of whether it needs you:
+`ok` (going fine, or blocked on something external like a CI run or PR review),
+`attention` (a question, a decision, "ready for review"), or `blocked` (stuck,
+needs help). Agents set it with `weaver status <level> "<note>"`; the dashboard
+shows it and lets you filter for sessions that need a human. It replaces the old
+guessed working/waiting/idle indicator, which was often wrong — e.g. it read
+"idle" while the agent was actually waiting on a background workflow.
 
 ## Adoption
 

--- a/crates/loom/frontend/src/components/AttentionBadge.vue
+++ b/crates/loom/frontend/src/components/AttentionBadge.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+// The agent-declared attention axis: does this session need me? Green = ok,
+// amber = wants attention, red = blocked / needs help. Distinct from the
+// mechanical lifecycle StatusBadge. Solid status hues (no semantic token
+// exists for green/amber/red) read on both light and dark themes.
+const props = defineProps<{ level: string; note?: string }>();
+
+interface Style {
+  label: string;
+  cls: string;
+  dot: string;
+}
+
+const styles: Record<string, Style> = {
+  ok: { label: 'OK', cls: 'bg-emerald-700 text-emerald-50', dot: 'bg-emerald-300' },
+  attention: { label: 'Attention', cls: 'bg-amber-600 text-amber-50', dot: 'bg-amber-200' },
+  blocked: { label: 'Blocked', cls: 'bg-red-700 text-red-50', dot: 'bg-red-300' },
+};
+
+const style = computed(
+  () => styles[props.level] ?? { label: props.level, cls: 'bg-subtle text-fg', dot: 'bg-faint' },
+);
+</script>
+
+<template>
+  <span
+    :class="style.cls"
+    data-testid="attention-badge"
+    :data-level="level"
+    :title="note || style.label"
+    class="inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-medium uppercase tracking-wide"
+  >
+    <span :class="style.dot" class="h-1.5 w-1.5 rounded-full"></span>
+    {{ style.label }}
+  </span>
+</template>

--- a/crates/loom/frontend/src/components/StatusBadge.vue
+++ b/crates/loom/frontend/src/components/StatusBadge.vue
@@ -3,12 +3,12 @@ import { computed } from 'vue';
 
 const props = defineProps<{ status: string }>();
 
+// Lifecycle (mechanical) status. How the agent is *doing* is the separate
+// attention axis — see AttentionBadge.vue.
 const palette: Record<string, string> = {
   created: 'bg-subtle text-fg',
   launching: 'bg-sky-800 text-sky-100',
-  working: 'bg-accent text-accent-fg',
-  waiting: 'bg-amber-700 text-amber-100',
-  idle: 'bg-subtle text-fg',
+  running: 'bg-accent text-accent-fg',
   orphaned: 'bg-amber-900 text-amber-200',
   done: 'bg-indigo-800 text-indigo-100',
   error: 'bg-red-800 text-red-100',

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -9,6 +9,12 @@ export interface Branch {
   title: string;
   goal: string;
   description: string;
+  /** Agent-declared attention level: 'ok' | 'attention' | 'blocked'. The
+   *  "does this need me?" signal, set by the agent via `weaver status`. */
+  attention: string;
+  /** Short free-text reason for the attention level, e.g. "Waiting for PR
+   *  review feedback". */
+  attention_note: string;
   repo_root: string;
   branch: string;
   base_branch: string;

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router';
 import { get, post, patch, del } from '../api';
 import type { Session, WeaverEvent, Issue } from '../types';
 import StatusBadge from '../components/StatusBadge.vue';
+import AttentionBadge from '../components/AttentionBadge.vue';
 import AgentTerminal from '../components/AgentTerminal.vue';
 import ScratchPanel from '../components/ScratchPanel.vue';
 
@@ -20,6 +21,8 @@ const notice = ref('');
 const titleDraft = ref('');
 const goalDraft = ref('');
 const descDraft = ref('');
+const attnLevelDraft = ref('ok');
+const attnNoteDraft = ref('');
 
 const busy = ref('');
 
@@ -30,6 +33,8 @@ async function loadSession() {
   titleDraft.value = ws.value.branch.title;
   goalDraft.value = ws.value.branch.goal;
   descDraft.value = ws.value.branch.description;
+  attnLevelDraft.value = ws.value.branch.attention || 'ok';
+  attnNoteDraft.value = ws.value.branch.attention_note;
 }
 
 async function loadIssues() {
@@ -59,9 +64,19 @@ async function loadAll() {
   }
 }
 
+const saveAttention = () =>
+  act('attention', async () => {
+    await patch(`/sessions/${props.id}`, {
+      attention: attnLevelDraft.value,
+      attention_note: attnNoteDraft.value,
+    });
+    notice.value = 'Attention updated.';
+    await loadSession();
+  });
+
 function openStream() {
   source = new EventSource(`/api/sessions/${props.id}/events`);
-  for (const kind of ['status', 'summary', 'note']) {
+  for (const kind of ['status', 'attention', 'summary', 'note']) {
     source.addEventListener(kind, (e) => {
       const ev = JSON.parse((e as MessageEvent).data) as WeaverEvent;
       events.value.push(ev);
@@ -142,6 +157,8 @@ const adopt = () =>
 function eventLine(ev: WeaverEvent): string {
   const d = ev.data || {};
   if (ev.kind === 'status') return `status → ${d.status ?? '?'}`;
+  if (ev.kind === 'attention')
+    return `attention → ${d.level ?? '?'}${d.note ? ` (${d.note})` : ''}`;
   if (ev.kind === 'summary') return `summary: ${d.description ?? ''}`;
   if (ev.kind === 'note') return String(d.text ?? '');
   if (ev.kind === 'issue_added') return `issue added: ${d.title ?? ''}`;
@@ -162,8 +179,16 @@ onUnmounted(() => source?.close());
     <div class="flex items-center gap-3 mb-1">
       <router-link to="/" class="text-muted hover:text-muted text-sm">← all</router-link>
       <h1 class="text-xl font-semibold">{{ ws.branch.title || ws.branch.name }}</h1>
+      <AttentionBadge :level="ws.branch.attention || 'ok'" :note="ws.branch.attention_note" />
       <StatusBadge :status="ws.status" />
     </div>
+    <p
+      v-if="ws.branch.attention_note"
+      class="text-sm text-muted mb-1"
+      data-testid="attention-note"
+    >
+      {{ ws.branch.attention_note }}
+    </p>
     <div class="text-xs text-faint font-mono mb-1">
       {{ ws.id }} · {{ ws.branch.branch }} (base {{ ws.branch.base_branch }}) ·
       {{ ws.agent_kind }} · {{ ws.tmux_session }}
@@ -225,6 +250,35 @@ onUnmounted(() => source?.close());
             @click="saveGoal"
           >
             Save goal
+          </button>
+        </section>
+
+        <section class="rounded border border-line bg-surface p-4">
+          <label class="block text-xs text-muted mb-1">
+            Attention — the agent's signal, set via <code>weaver status</code>
+          </label>
+          <div class="flex gap-2">
+            <select
+              v-model="attnLevelDraft"
+              data-testid="attention-select"
+              class="rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
+            >
+              <option value="ok">OK</option>
+              <option value="attention">Attention</option>
+              <option value="blocked">Blocked</option>
+            </select>
+            <input
+              v-model="attnNoteDraft"
+              placeholder="Waiting for PR review feedback"
+              class="min-w-0 flex-1 rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
+            />
+          </div>
+          <button
+            class="mt-2 rounded bg-subtle hover:bg-subtle-hover px-2 py-1 text-xs"
+            :disabled="busy === 'attention'"
+            @click="saveAttention"
+          >
+            Save attention
           </button>
         </section>
 

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -3,8 +3,33 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { get, post } from '../api';
 import type { Session, RecentRepo, RepoBranch } from '../types';
 import StatusBadge from '../components/StatusBadge.vue';
+import AttentionBadge from '../components/AttentionBadge.vue';
 
 const sessions = ref<Session[]>([]);
+
+// Attention filter — the dashboard's "which sessions need me?" control.
+type AttentionFilter = 'all' | 'attention' | 'ok';
+const filter = ref<AttentionFilter>('all');
+
+// Treat an unset/unknown level as 'ok' so older rows count as fine.
+function levelOf(s: Session): string {
+  return s.branch.attention || 'ok';
+}
+
+const counts = computed(() => {
+  const c = { all: sessions.value.length, attention: 0, ok: 0 };
+  for (const s of sessions.value) {
+    if (levelOf(s) === 'ok') c.ok += 1;
+    else c.attention += 1; // 'attention' and 'blocked' both "need me"
+  }
+  return c;
+});
+
+const filteredSessions = computed(() => {
+  if (filter.value === 'all') return sessions.value;
+  if (filter.value === 'ok') return sessions.value.filter((s) => levelOf(s) === 'ok');
+  return sessions.value.filter((s) => levelOf(s) !== 'ok');
+});
 const recentRepos = ref<RecentRepo[]>([]);
 const error = ref('');
 const showForm = ref(false);
@@ -352,11 +377,29 @@ onUnmounted(() => clearInterval(timer));
       No sessions yet.
     </p>
 
+    <!-- Attention filter: jump straight to the sessions that need a human. -->
+    <div v-if="sessions.length" class="mb-3 inline-flex rounded border border-line text-xs overflow-hidden">
+      <button
+        v-for="opt in (['all', 'attention', 'ok'] as const)"
+        :key="opt"
+        type="button"
+        :data-testid="`filter-${opt}`"
+        :class="[
+          'px-3 py-1 border-l border-line first:border-l-0',
+          filter === opt ? 'bg-accent text-accent-fg' : 'bg-input text-muted hover:bg-subtle',
+        ]"
+        @click="filter = opt"
+      >
+        {{ opt === 'all' ? 'All' : opt === 'attention' ? 'Needs attention' : 'OK' }}
+        <span class="opacity-70">{{ counts[opt] }}</span>
+      </button>
+    </div>
+
     <div v-if="sessions.length" class="overflow-x-auto rounded border border-line">
       <table class="w-full border-collapse text-sm">
         <thead>
           <tr class="border-b border-line bg-surface text-left text-xs uppercase tracking-wide text-muted">
-            <th class="px-3 py-2 font-medium">Status</th>
+            <th class="px-3 py-2 font-medium">Attention</th>
             <th class="px-3 py-2 font-medium">Title</th>
             <th class="px-3 py-2 font-medium">Goal</th>
             <th class="px-3 py-2 font-medium">Latest status</th>
@@ -365,7 +408,7 @@ onUnmounted(() => clearInterval(timer));
         </thead>
         <tbody>
           <tr
-            v-for="s in sessions"
+            v-for="s in filteredSessions"
             :key="s.id"
             data-testid="session-card"
             :data-session-id="s.id"
@@ -373,8 +416,12 @@ onUnmounted(() => clearInterval(timer));
             @click="$router.push(`/s/${s.id}`)"
           >
             <td class="px-3 py-2 align-top">
-              <router-link :to="`/s/${s.id}`" class="inline-block" @click.stop>
-                <StatusBadge :status="s.status" />
+              <router-link :to="`/s/${s.id}`" class="block space-y-1" @click.stop>
+                <AttentionBadge :level="levelOf(s)" :note="s.branch.attention_note" />
+                <span v-if="s.branch.attention_note" class="block max-w-[14rem] truncate text-xs text-muted">
+                  {{ s.branch.attention_note }}
+                </span>
+                <StatusBadge :status="s.status" class="opacity-80" />
               </router-link>
             </td>
             <td class="px-3 py-2 align-top">

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -430,13 +430,17 @@ async fn cmd_ps() -> Result<()> {
         println!("no sessions — start one with `loom launch \"<name>\"`");
         return Ok(());
     }
-    println!("{:<10}  {:<9}  {:<24}  TITLE", "ID", "STATUS", "NAME");
+    println!(
+        "{:<10}  {:<9}  {:<10}  {:<22}  TITLE",
+        "ID", "STATUS", "ATTENTION", "NAME"
+    );
     for ws in rows {
         println!(
-            "{:<10}  {:<9}  {:<24}  {}",
+            "{:<10}  {:<9}  {:<10}  {:<22}  {}",
             str_field(&ws, "id"),
             str_field(&ws, "status"),
-            truncate(branch_str(&ws, "name"), 24),
+            branch_str(&ws, "attention"),
+            truncate(branch_str(&ws, "name"), 22),
             truncate(branch_str(&ws, "title"), 46),
         );
     }
@@ -495,6 +499,14 @@ fn print_session(ws: &Value) {
     );
     println!("  title:    {}", branch_str(ws, "title"));
     println!("  status:   {}", str_field(ws, "status"));
+    let attention = branch_str(ws, "attention");
+    let attention_note = branch_str(ws, "attention_note");
+    let attention = if attention_note.is_empty() {
+        attention.to_string()
+    } else {
+        format!("{attention} — {attention_note}")
+    };
+    println!("  attention: {attention}");
     let goal = branch_str(ws, "goal");
     println!(
         "  goal:     {}",

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -126,7 +126,7 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO sessions (id, branch_id, work_dir, tmux_session, status)
-             VALUES ('s1', 't1', '/w', 'weaver-s1', 'idle')",
+             VALUES ('s1', 't1', '/w', 'weaver-s1', 'running')",
         )
         .execute(&db)
         .await

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -1,10 +1,11 @@
-//! Background task: detects when a session's tmux has ended, drives
-//! screen-stillness idle detection, and consumes `hook` events written by the
-//! `weaver hook` CLI to update session status.
+//! Background task: detects when a session's tmux has ended and consumes the
+//! event rows the `weaver` CLI writes — `hook` events (Claude lifecycle) and
+//! `attention` events (`weaver status`) — reflecting them onto the session and
+//! the dashboard.
 //!
 //! The browser terminal (xterm.js over a PTY) is the live-screen surface; this
 //! loop no longer pushes a `screen` mirror to clients. It still `capture`s the
-//! pane internally to hash for stillness/idle/orphan detection.
+//! pane internally to hash for activity (last-activity) and orphan detection.
 
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
@@ -14,13 +15,12 @@ use serde_json::json;
 use crate::session as session_mod;
 use crate::web::AppState;
 use crate::{events, tmux};
+use weaver_core::branch as branch_mod;
 
 const TICK: Duration = Duration::from_millis(1500);
-const IDLE_TICKS: u32 = 10;
 
 pub async fn run(state: AppState) {
     let mut screen_hash: HashMap<String, u64> = HashMap::new();
-    let mut still_ticks: HashMap<String, u32> = HashMap::new();
     // Watermark: process every event written after this id, then advance.
     let mut last_event = events::max_id(&state.db).await.unwrap_or(0);
     tracing::info!(tick_ms = TICK.as_millis() as u64, "monitor loop started");
@@ -28,14 +28,23 @@ pub async fn run(state: AppState) {
     loop {
         tokio::time::sleep(TICK).await;
 
-        // 1. Consume any new event rows (hooks, etc.) and reflect them on the
-        //    relevant session.
+        // 1. Consume any new event rows and reflect them on the relevant
+        //    session / branch.
         match events::since(&state.db, last_event).await {
             Ok(new_events) => {
                 for ev in new_events {
                     last_event = last_event.max(ev.id);
-                    if ev.kind != "hook" {
-                        continue;
+                    match ev.kind.as_str() {
+                        // `weaver status` wrote the branch's attention fields
+                        // directly (daemon-less) but, going through the CLI,
+                        // never touched the bus. Re-broadcast so live dashboards
+                        // refresh; nothing else to do.
+                        "attention" => {
+                            state.bus.publish(ev.clone());
+                            continue;
+                        }
+                        "hook" => {}
+                        _ => continue,
                     }
                     let kind = ev
                         .data
@@ -46,42 +55,9 @@ pub async fn run(state: AppState) {
                     if kind.is_empty() {
                         continue;
                     }
-                    // `session-start` fires only to inject the primer via
-                    // `additionalContext`; it intentionally does not change
-                    // session status (otherwise a resume would flip an idle
-                    // session to working with no user action).
-                    let status = match kind.as_str() {
-                        "working" => "working",
-                        "waiting" => "waiting",
-                        "idle" => "idle",
-                        _ => continue,
-                    };
-                    if let Ok(Some(session)) =
-                        session_mod::active_for_branch(&state.db, &ev.branch_id).await
-                    {
-                        let _ = session_mod::set_status(&state.db, &session.id, status).await;
-                        let _ = session_mod::touch(&state.db, &session.id).await;
-                        let prompt = if status == "waiting" {
-                            tmux::capture(&session.tmux_session, 0)
-                                .await
-                                .map(|s| s.trim().to_string())
-                                .unwrap_or_default()
-                        } else {
-                            String::new()
-                        };
-                        let _ =
-                            session_mod::set_pending_prompt(&state.db, &session.id, &prompt).await;
-                        let mut data = json!({ "status": status, "source": "hook" });
-                        if !prompt.is_empty() {
-                            data["prompt"] = json!(prompt);
-                        }
-                        let _ =
-                            events::record(&state.db, &state.bus, &ev.branch_id, "status", data)
-                                .await;
-                        // Bump the watermark past our own freshly-recorded
-                        // event so we don't loop on it.
-                        last_event = events::max_id(&state.db).await.unwrap_or(last_event);
-                    }
+                    last_event = apply_hook(&state, &ev.branch_id, &kind)
+                        .await
+                        .unwrap_or(last_event);
                 }
             }
             Err(e) => tracing::warn!("monitor: reading new events failed: {e}"),
@@ -124,38 +100,113 @@ pub async fn run(state: AppState) {
                 continue;
             }
 
+            // Hash the pane to detect activity and bump `last_activity_at`.
+            // Inferred working→idle demotion is gone: liveness is all we can
+            // know, and the agent reports the rest via `weaver status`.
             let screen = tmux::capture(&session.tmux_session, 0)
                 .await
                 .unwrap_or_default();
             let h = hash(&normalize_screen(&screen));
             if screen_hash.get(&session.id) != Some(&h) {
                 screen_hash.insert(session.id.clone(), h);
-                still_ticks.insert(session.id.clone(), 0);
                 let _ = session_mod::touch(&state.db, &session.id).await;
-            } else {
-                let ticks = still_ticks.entry(session.id.clone()).or_insert(0);
-                *ticks += 1;
-                if session.agent_kind != "claude"
-                    && session.status == "working"
-                    && *ticks >= IDLE_TICKS
-                {
-                    let _ = session_mod::set_status(&state.db, &session.id, "idle").await;
-                    let _ = events::record(
-                        &state.db,
-                        &state.bus,
-                        &session.branch_id,
-                        "status",
-                        json!({ "status": "idle", "source": "monitor" }),
-                    )
-                    .await;
-                    last_event = events::max_id(&state.db).await.unwrap_or(last_event);
-                }
             }
         }
 
         screen_hash.retain(|k, _| alive.contains(k));
-        still_ticks.retain(|k, _| alive.contains(k));
     }
+}
+
+/// Reflect a Claude lifecycle hook (`working` / `waiting` / `idle`) onto the
+/// active session and its branch, broadcasting only what actually changed.
+/// Returns the new event watermark (it records its own bus events). `None` when
+/// there is no active session for the branch.
+///
+/// Mapping rationale: hooks now drive only liveness and the genuine
+/// attention signals. Any hook means the agent process is alive → `running`
+/// (this also promotes a freshly-`launching` session). Beyond that:
+///
+/// * `working` (a prompt was submitted — the user is engaged) clears attention
+///   back to `ok` and drops any pending prompt.
+/// * `waiting` (Claude is blocked asking the user) raises attention to
+///   `attention` and snapshots the pane as the pending prompt.
+/// * `idle` (a turn ended) leaves attention untouched — a finished-but-fine
+///   agent must not be mistaken for one that needs the user. If it actually
+///   needs something it will have said so via `weaver status`.
+async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64> {
+    enum Prompt {
+        Capture,
+        Clear,
+        Leave,
+    }
+    let (attention, prompt): (Option<(&str, &str)>, Prompt) = match kind {
+        "working" => (Some(("ok", "")), Prompt::Clear),
+        "waiting" => (Some(("attention", "Waiting for input")), Prompt::Capture),
+        "idle" => (None, Prompt::Leave),
+        // `session-start` and anything unknown carry no status signal.
+        _ => return None,
+    };
+
+    let session = session_mod::active_for_branch(&state.db, branch_id).await.ok()??;
+
+    // Lifecycle: alive → running. Idempotent once running; never overrides a
+    // terminal state.
+    let status_changed =
+        session.status != "running" && !session_mod::is_terminal(&session.status);
+    if status_changed {
+        let _ = session_mod::set_status(&state.db, &session.id, "running").await;
+    }
+    let _ = session_mod::touch(&state.db, &session.id).await;
+
+    match prompt {
+        Prompt::Capture => {
+            let p = tmux::capture(&session.tmux_session, 0)
+                .await
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
+            let _ = session_mod::set_pending_prompt(&state.db, &session.id, &p).await;
+        }
+        Prompt::Clear => {
+            let _ = session_mod::set_pending_prompt(&state.db, &session.id, "").await;
+        }
+        Prompt::Leave => {}
+    }
+
+    // Attention, only when the hook carries a signal and the value differs.
+    let mut attention_changed: Option<(&str, &str)> = None;
+    if let Some((level, note)) = attention {
+        if let Ok(Some(branch)) = branch_mod::get(&state.db, branch_id).await {
+            if branch.attention != level || branch.attention_note != note {
+                let _ = branch_mod::set_attention(&state.db, branch_id, level, note).await;
+                attention_changed = Some((level, note));
+            }
+        }
+    }
+
+    if status_changed {
+        let _ = events::record(
+            &state.db,
+            &state.bus,
+            branch_id,
+            "status",
+            json!({ "status": "running", "source": "hook" }),
+        )
+        .await;
+    }
+    if let Some((level, note)) = attention_changed {
+        let _ = events::record(
+            &state.db,
+            &state.bus,
+            branch_id,
+            "attention",
+            json!({ "level": level, "note": note, "source": "hook" }),
+        )
+        .await;
+    }
+    // Advance the watermark past our own freshly-recorded events so the next
+    // tick doesn't reprocess them. `None` on a read error just leaves the
+    // caller's watermark untouched (the consumed event is already accounted for).
+    events::max_id(&state.db).await.ok()
 }
 
 fn hash(s: &str) -> u64 {

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -27,8 +27,18 @@ pub struct Session {
     pub created_at: String,
 }
 
+/// Session **lifecycle** states — the mechanical, orchestrator-owned axis: is
+/// the agent process being set up, alive, lost, or finished. How the agent is
+/// *doing* (whether it needs the user) is the separate, agent-declared
+/// `attention` axis on the branch — see [`weaver_core::branch::ATTENTION_LEVELS`].
+///
+/// `running` replaces the old inferred `working`/`waiting`/`idle` trio: those
+/// guessed at the agent's state from hooks and screen stillness and were
+/// frequently wrong (e.g. an agent waiting on a background workflow looked
+/// "idle"). Liveness is all the orchestrator can know for sure; the agent
+/// reports the rest via `weaver status`.
 pub const STATUSES: &[&str] = &[
-    "created", "launching", "working", "waiting", "idle", "orphaned", "done", "error",
+    "created", "launching", "running", "orphaned", "done", "error",
 ];
 
 pub fn is_terminal(status: &str) -> bool {

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -27,7 +27,7 @@
 //! ```json
 //! {
 //!   "id": "<session id>",
-//!   "status": "working",
+//!   "status": "running",            // lifecycle: created|launching|running|orphaned|done|error
 //!   "work_dir": "/path/to/.worktrees/foo",
 //!   "tmux_session": "weaver-abcd1234",
 //!   "agent_kind": "claude",
@@ -43,6 +43,8 @@
 //!     "title": "...",
 //!     "goal": "...",
 //!     "description": "...",
+//!     "attention": "ok",            // agent-declared: ok|attention|blocked
+//!     "attention_note": "",         // short reason, e.g. "Waiting for PR feedback"
 //!     "repo_root": "/path/to/repo",
 //!     "branch": "weaver/feature-x",
 //!     "base_branch": "main",
@@ -163,6 +165,10 @@ pub struct BranchView {
     pub title: String,
     pub goal: String,
     pub description: String,
+    /// Agent-declared attention level (`ok` | `attention` | `blocked`) and its
+    /// short note — the "does this need me?" signal the dashboard filters on.
+    pub attention: String,
+    pub attention_note: String,
     pub repo_root: String,
     pub branch: String,
     pub base_branch: String,
@@ -192,6 +198,8 @@ impl BranchView {
             title: branch.title.clone(),
             goal: branch.goal.clone(),
             description: branch.description.clone(),
+            attention: branch.attention.clone(),
+            attention_note: branch.attention_note.clone(),
             repo_root: branch.repo_root.clone(),
             branch: branch.branch.clone(),
             base_branch: branch.base_branch.clone(),
@@ -650,7 +658,7 @@ async fn create_session(
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let status = if matches!(agent.as_str(), "shell" | "none") {
-        "idle"
+        "running"
     } else {
         "launching"
     };
@@ -736,6 +744,48 @@ struct PatchSessionReq {
     title: Option<String>,
     goal: Option<String>,
     description: Option<String>,
+    /// Agent-declared attention level (`ok` | `attention` | `blocked`) and note.
+    /// Branch-level; lets the dashboard set/clear what the agent set via
+    /// `weaver status`.
+    attention: Option<String>,
+    attention_note: Option<String>,
+}
+
+/// Apply an attention patch to a branch: validate the level, update the branch
+/// fields, and broadcast an `attention` event. A missing `level`/`note` keeps the
+/// branch's current value, so a caller can change one without clobbering the
+/// other. No-op when neither is supplied.
+async fn apply_attention_patch(
+    st: &AppState,
+    branch: &Branch,
+    level: Option<&str>,
+    note: Option<&str>,
+) -> ApiResult<()> {
+    if level.is_none() && note.is_none() {
+        return Ok(());
+    }
+    let level = level
+        .map(str::trim)
+        .unwrap_or(branch.attention.as_str())
+        .to_ascii_lowercase();
+    if !branch_mod::is_valid_attention(&level) {
+        return Err(AppError::bad_request(format!(
+            "invalid attention '{level}' — expected one of {}",
+            branch_mod::ATTENTION_LEVELS.join(", ")
+        )));
+    }
+    let note = note.map(str::trim).unwrap_or(branch.attention_note.as_str());
+    branch_mod::set_attention(&st.db, &branch.id, &level, note).await?;
+    events::record(
+        &st.db,
+        &st.bus,
+        &branch.id,
+        "attention",
+        json!({ "level": level, "note": note, "source": "manual" }),
+    )
+    .await
+    .ok();
+    Ok(())
 }
 
 async fn patch_session(
@@ -744,6 +794,8 @@ async fn patch_session(
     Json(req): Json<PatchSessionReq>,
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
+    apply_attention_patch(&st, &branch, req.attention.as_deref(), req.attention_note.as_deref())
+        .await?;
     if let Some(title) = &req.title {
         branch_mod::set_title(&st.db, &branch.id, title).await?;
     }
@@ -1284,6 +1336,8 @@ struct PatchBranchReq {
     title: Option<String>,
     goal: Option<String>,
     description: Option<String>,
+    attention: Option<String>,
+    attention_note: Option<String>,
 }
 
 async fn patch_branch(
@@ -1292,6 +1346,8 @@ async fn patch_branch(
     Json(req): Json<PatchBranchReq>,
 ) -> ApiResult<Json<BranchView>> {
     let branch = require_branch(&st.db, &key).await?;
+    apply_attention_patch(&st, &branch, req.attention.as_deref(), req.attention_note.as_deref())
+        .await?;
     if let Some(title) = &req.title {
         branch_mod::set_title(&st.db, &branch.id, title).await?;
     }

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -96,6 +96,7 @@ async fn hook_event_drives_session_status() {
     };
 
     // What `weaver hook --event working` would do: write a `hook` event row.
+    // Any hook means the agent process is alive → lifecycle `running`.
     weaver_core::events::record_local(
         &pool,
         &branch_id,
@@ -111,11 +112,28 @@ async fn hook_event_drives_session_status() {
         tokio::time::sleep(Duration::from_millis(200)).await;
         let ws = client.get(&format!("/api/sessions/{id}")).await.unwrap();
         got = ws["status"].as_str().unwrap_or("").to_string();
-        if got == "working" {
+        if got == "running" {
             break;
         }
     }
-    assert_eq!(got, "working", "monitor should have flipped status to working");
+    assert_eq!(got, "running", "monitor should have flipped status to running");
+
+    // A `waiting` hook (Claude blocked asking the user) raises the agent-declared
+    // attention axis to `attention` with a note — the dashboard's "needs me" flag.
+    weaver_core::events::record_local(&pool, &branch_id, "hook", json!({ "event": "waiting" }))
+        .await
+        .unwrap();
+    let mut attention = String::new();
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let ws = client.get(&format!("/api/sessions/{id}")).await.unwrap();
+        attention = ws["branch"]["attention"].as_str().unwrap_or("").to_string();
+        if attention == "attention" {
+            assert_eq!(ws["branch"]["attention_note"], "Waiting for input");
+            break;
+        }
+    }
+    assert_eq!(attention, "attention", "waiting hook should raise attention");
 
     // Verify the hook event row landed too.
     let log = client

--- a/crates/loom/tests/integration.rs
+++ b/crates/loom/tests/integration.rs
@@ -258,7 +258,7 @@ async fn session_lifecycle() {
     }
 
     // A hook flips the session status. The monitor consumes new `hook`
-    // event rows on its next tick.
+    // event rows on its next tick; any hook means the agent is alive → running.
     let branch_id = {
         let s = loom::session::get(&pool, &id).await.unwrap().unwrap();
         s.branch_id
@@ -266,16 +266,16 @@ async fn session_lifecycle() {
     weaver_core::events::record_local(&pool, &branch_id, "hook", json!({ "event": "working" }))
         .await
         .unwrap();
-    let mut working = false;
+    let mut running = false;
     for _ in 0..40 {
         tokio::time::sleep(Duration::from_millis(200)).await;
         let ws = client.get(&format!("/api/sessions/{id}")).await.unwrap();
-        if ws["status"] == "working" {
-            working = true;
+        if ws["status"] == "running" {
+            running = true;
             break;
         }
     }
-    assert!(working, "monitor should have flipped status to working");
+    assert!(running, "monitor should have flipped status to running");
 
     // Scratch files: empty to start, then an upload lands at scratch/<name> in
     // the worktree, is listed, and can be deleted. Path-traversal names are

--- a/crates/weaver-core/primer.md
+++ b/crates/weaver-core/primer.md
@@ -9,14 +9,35 @@ It is on your `PATH`. From anywhere in the worktree you can run:
 - `weaver goal` — print the task this branch was created for.
 - `weaver note "<text>"` — append a progress note, or a decision and its
   rationale, to the branch log.
-- `weaver describe "<text>"` — set the one-line status shown on the dashboard.
+- `weaver describe "<text>"` — set the one-line summary shown on the dashboard.
+- `weaver status <level> "<note>"` — tell the dashboard how you are doing.
+  `level` is one of `ok`, `attention`, or `blocked`; the note is a short reason.
 - `weaver issue add "<title>"` — add a task claimed by this branch (`--repo`
   files it in the shared repo backlog instead).
 - `weaver issue ls` — this branch's tasks plus the unclaimed repo backlog
   (`--mine` for just yours, `--repo` for the whole repo). `weaver issue close N`.
-- `weaver status` — show the current goal, open-issue count, and latest summary.
+- `weaver status` — with no argument, show the goal, attention, open-issue
+  count, and latest summary.
 
 These talk directly to the weaver database — no daemon required.
+
+## Signalling your status
+
+The user scans the dashboard for sessions that need them. Keep your attention
+level honest with `weaver status <level> "<reason>"`:
+
+- `ok` — progressing normally, **or** blocked on something external that is not
+  the user (a CI run, a PR review, a long workflow). No action needed.
+  Example: `weaver status ok "waiting on PR review feedback"`.
+- `attention` — you want the user to look: a question, a decision to confirm, or
+  "done — ready for review". Example: `weaver status attention "ready for review"`.
+- `blocked` — you are stuck or hit an error and need help to proceed.
+  Example: `weaver status blocked "build broken, can't reproduce locally"`.
+
+Set it as your situation changes — especially raise it to `attention` before you
+finish a turn expecting the user, and drop back to `ok` once you are moving
+again. This replaces the old guessed working/waiting/idle indicator, which was
+often wrong (e.g. it read "idle" while you were really waiting on a workflow).
 
 ## How to work here
 
@@ -26,4 +47,5 @@ These talk directly to the weaver database — no daemon required.
   matters. But **never block on an interactive TUI prompt** — multiple-choice
   menus, plan-approval dialogs, and the like cannot be answered from the
   dashboard. State the question as plain text, record it with `weaver note`,
-  and continue with your best assumption.
+  set `weaver status attention "<the question>"`, and continue with your best
+  assumption.

--- a/crates/weaver-core/src/branch.rs
+++ b/crates/weaver-core/src/branch.rs
@@ -17,8 +17,33 @@ pub struct Branch {
     pub goal: String,
     pub title: String,
     pub description: String,
+    /// Agent-declared attention level: one of [`ATTENTION_LEVELS`].
+    pub attention: String,
+    /// Short free-text reason for the current attention level.
+    pub attention_note: String,
     pub created_at: String,
     pub updated_at: String,
+}
+
+/// Agent-declared attention levels, ordered calm → urgent:
+///
+/// * `ok` — progressing fine, or blocked on something external (a CI run, a PR
+///   review) that is *not* the user. No action needed.
+/// * `attention` — the agent wants the user to look: a question, a decision to
+///   confirm, or "done, ready for review".
+/// * `blocked` — the agent is stuck or hit an error and needs help to proceed.
+///
+/// This is the agent's own signal, distinct from the orchestrator's mechanical
+/// session lifecycle (`launching` / `running` / `orphaned` / …). It is what the
+/// dashboard surfaces and filters on for "which sessions need me?".
+pub const ATTENTION_LEVELS: &[&str] = &["ok", "attention", "blocked"];
+
+/// The default attention level for a freshly-created branch.
+pub const DEFAULT_ATTENTION: &str = "ok";
+
+/// Whether `level` is a recognized attention level.
+pub fn is_valid_attention(level: &str) -> bool {
+    ATTENTION_LEVELS.contains(&level)
 }
 
 /// An 8-character lowercase-alphanumeric id (re-used for branches and sessions).
@@ -192,6 +217,21 @@ pub async fn set_description(db: &Db, id: &str, description: &str) -> Result<()>
         .bind(id)
         .execute(db)
         .await?;
+    Ok(())
+}
+
+/// Set the agent-declared attention level and its short note in one write.
+/// `level` is assumed already validated by the caller (see [`is_valid_attention`]).
+pub async fn set_attention(db: &Db, id: &str, level: &str, note: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE branches SET attention = ?, attention_note = ?, updated_at = ? WHERE id = ?",
+    )
+    .bind(level)
+    .bind(note)
+    .bind(now_iso())
+    .bind(id)
+    .execute(db)
+    .await?;
     Ok(())
 }
 

--- a/crates/weaver-core/src/db.rs
+++ b/crates/weaver-core/src/db.rs
@@ -17,6 +17,11 @@ CREATE TABLE IF NOT EXISTS branches (
     goal         TEXT NOT NULL DEFAULT '',
     title        TEXT NOT NULL DEFAULT '',
     description  TEXT NOT NULL DEFAULT '',
+    -- Agent-declared attention: an urgency level (ok | attention | blocked) and
+    -- a short free-text reason ("Waiting for PR review feedback"). This is the
+    -- agent's own signal of whether it needs the user, set via `weaver status`.
+    attention      TEXT NOT NULL DEFAULT 'ok',
+    attention_note TEXT NOT NULL DEFAULT '',
     created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     UNIQUE(repo_root, branch)
@@ -181,7 +186,25 @@ async fn migrate(pool: &Db) -> Result<()> {
             .await
             .with_context(|| format!("running migration: {trimmed}"))?;
     }
+    // Additive column migrations for databases created before the column
+    // existed. `CREATE TABLE IF NOT EXISTS` above is a no-op on such DBs, so we
+    // add the column explicitly and ignore the "duplicate column" error.
+    add_column_if_missing(pool, "branches", "attention", "TEXT NOT NULL DEFAULT 'ok'").await?;
+    add_column_if_missing(pool, "branches", "attention_note", "TEXT NOT NULL DEFAULT ''").await?;
     Ok(())
+}
+
+/// Run `ALTER TABLE … ADD COLUMN`, treating an already-present column as success.
+async fn add_column_if_missing(pool: &Db, table: &str, column: &str, decl: &str) -> Result<()> {
+    let sql = format!("ALTER TABLE {table} ADD COLUMN {column} {decl}");
+    match sqlx::query(&sql).execute(pool).await {
+        Ok(_) => {
+            tracing::info!(%table, %column, "added column");
+            Ok(())
+        }
+        Err(e) if e.to_string().contains("duplicate column name") => Ok(()),
+        Err(e) => Err(e).with_context(|| format!("adding column {table}.{column}")),
+    }
 }
 
 /// Column names of `table`, or empty if it doesn't exist.

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -23,8 +23,21 @@ struct Cli {
 enum Cmd {
     /// Print or set the goal of the current branch.
     Goal { text: Vec<String> },
-    /// Show the current branch's title, goal, and open-issue count.
-    Status,
+    /// Show the current branch's status, or set the agent's attention level.
+    ///
+    /// With no arguments it prints the title, goal, attention, and open-issue
+    /// count. Given a level (`ok`, `attention`, or `blocked`) and an optional
+    /// note, it declares how the agent is doing — what the dashboard surfaces
+    /// and filters on. Use `attention` to ask the user to look ("ready for
+    /// review", a question) and `blocked` when stuck and needing help; `ok`
+    /// covers both progressing normally and being blocked on something external
+    /// (a CI run, a PR review) that is not the user.
+    Status {
+        /// Attention level to set: `ok`, `attention`, or `blocked`. Omit to read.
+        level: Option<String>,
+        /// Short reason shown beside the level, e.g. "Waiting for PR feedback".
+        note: Vec<String>,
+    },
     /// Set the description of the current branch.
     Describe { text: Vec<String> },
     /// Append a note to the current branch.
@@ -116,7 +129,7 @@ async fn run() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
         Cmd::Goal { text } => cmd_goal(text.join(" ")).await,
-        Cmd::Status => cmd_status().await,
+        Cmd::Status { level, note } => cmd_status(level, note.join(" ")).await,
         Cmd::Describe { text } => cmd_describe(text.join(" ")).await,
         Cmd::Note { text } => cmd_note(text.join(" ")).await,
         Cmd::Issue { cmd } => cmd_issue(cmd).await,
@@ -204,6 +217,11 @@ async fn cmd_log(limit: i64) -> Result<()> {
             s.to_string()
         } else if let Some(s) = ev.data.get("status").and_then(Value::as_str) {
             s.to_string()
+        } else if let Some(level) = ev.data.get("level").and_then(Value::as_str) {
+            match ev.data.get("note").and_then(Value::as_str) {
+                Some(n) if !n.is_empty() => format!("{level} — {n}"),
+                _ => level.to_string(),
+            }
         } else if let Some(s) = ev.data.get("event").and_then(Value::as_str) {
             s.to_string()
         } else if let Some(s) = ev.data.get("goal").and_then(Value::as_str) {
@@ -221,9 +239,12 @@ async fn cmd_log(limit: i64) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_status() -> Result<()> {
+async fn cmd_status(level: Option<String>, note: String) -> Result<()> {
     let db = open_db().await?;
     let b = branch::resolve(&db).await?;
+    if let Some(level) = level {
+        return cmd_status_set(&db, &b, &level, &note).await;
+    }
     let open = issue::open_count_for_branch(&db, &b.repo_root, &b.branch)
         .await
         .unwrap_or(0);
@@ -240,7 +261,40 @@ async fn cmd_status() -> Result<()> {
     if !b.description.is_empty() {
         println!("summary:     {}", b.description);
     }
+    let attention = if b.attention_note.is_empty() {
+        b.attention.clone()
+    } else {
+        format!("{} — {}", b.attention, b.attention_note)
+    };
+    println!("attention:   {attention}");
     println!("open issues: {open}");
+    Ok(())
+}
+
+/// Declare the agent's attention level (and optional note) on the branch. Writes
+/// the branch fields directly (daemon-less) and an `attention` event so a
+/// running loom can push the change to the dashboard on its next tick.
+async fn cmd_status_set(
+    db: &db::Db,
+    b: &branch::Branch,
+    level: &str,
+    note: &str,
+) -> Result<()> {
+    let level = level.trim().to_ascii_lowercase();
+    if !branch::is_valid_attention(&level) {
+        bail!(
+            "unknown status '{level}' — expected one of {}",
+            branch::ATTENTION_LEVELS.join(", ")
+        );
+    }
+    let note = note.trim();
+    branch::set_attention(db, &b.id, &level, note).await?;
+    events::record_local(db, &b.id, "attention", json!({ "level": level, "note": note })).await?;
+    if note.is_empty() {
+        println!("status: {level}");
+    } else {
+        println!("status: {level} — {note}");
+    }
     Ok(())
 }
 

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -165,6 +165,47 @@ fn status_with_no_id_reports_current_branch() {
     assert!(out.contains("branch:      feature-test"), "status: {out}");
     assert!(out.contains("goal:        do the thing"), "status: {out}");
     assert!(out.contains("open issues: 1"), "status: {out}");
+    // A fresh branch defaults to the calm `ok` attention level.
+    assert!(out.contains("attention:   ok"), "status: {out}");
+}
+
+#[test]
+fn status_set_attention_level_and_note() {
+    let env = setup();
+    // Declare an attention level with a note, then read it back.
+    let out = run(&env, &["status", "attention", "Waiting", "for", "PR", "feedback"]);
+    assert!(out.contains("attention — Waiting for PR feedback"), "set output: {out}");
+
+    let out = run(&env, &["status"]);
+    assert!(
+        out.contains("attention:   attention — Waiting for PR feedback"),
+        "status read: {out}"
+    );
+
+    // Setting a level with no note clears the note.
+    run(&env, &["status", "ok"]);
+    let out = run(&env, &["status"]);
+    assert!(out.contains("attention:   ok"), "status read: {out}");
+    assert!(!out.contains("Waiting for PR feedback"), "note should be cleared: {out}");
+
+    // The set also writes an `attention` event to the branch log.
+    let log = run(&env, &["log"]);
+    assert!(log.contains("attention"), "log should record attention events: {log}");
+}
+
+#[test]
+fn status_set_rejects_unknown_level() {
+    let env = setup();
+    let out = Command::new(weaver_bin())
+        .args(["status", "bogus"])
+        .current_dir(&env.repo_path)
+        .env("WEAVER_HOME", &env.home_path)
+        .env("WEAVER_API", "http://127.0.0.1:1")
+        .output()
+        .expect("failed to spawn weaver");
+    assert!(!out.status.success(), "unknown level should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("unknown status 'bogus'"), "stderr: {stderr}");
 }
 
 #[test]

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -18,6 +18,9 @@ export interface Branch {
   title: string;
   goal: string;
   description: string;
+  /** Agent-declared attention level: 'ok' | 'attention' | 'blocked'. */
+  attention: string;
+  attention_note: string;
   repo_root: string;
   branch: string;
   base_branch: string;
@@ -63,6 +66,12 @@ export interface WeaverFixture {
   listSessions(): Promise<Session[]>;
   /** Flip a session's status by writing a hook event row via `weaver hook`. */
   hook(session: Session, event: 'working' | 'waiting' | 'idle'): Promise<void>;
+  /** Declare the agent's attention level + note via `weaver status`. */
+  setStatus(
+    session: Session,
+    level: 'ok' | 'attention' | 'blocked',
+    note?: string,
+  ): Promise<void>;
 }
 
 /** Ensure the loom binary and the Vue frontend bundle both exist. */
@@ -226,6 +235,16 @@ export const test = base.extend<{ weaver: WeaverFixture }>({
         // `weaver hook` writes an `events` row keyed on the branch resolved
         // from $WEAVER_BRANCH; the loom monitor consumes it on its next tick.
         execFileSync(WEAVER_BINARY, ['hook', '--event', event], {
+          env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
+          stdio: 'pipe',
+        });
+      },
+
+      async setStatus(session, level, note) {
+        // `weaver status <level> [note]` writes the branch's attention fields
+        // directly and records an `attention` event the monitor re-broadcasts.
+        const args = ['status', level, ...(note ? [note] : [])];
+        execFileSync(WEAVER_BINARY, args, {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
           stdio: 'pipe',
         });

--- a/e2e/tests/status-hook.spec.ts
+++ b/e2e/tests/status-hook.spec.ts
@@ -1,32 +1,56 @@
 import { test, expect } from '../fixtures/weaver';
 
-test.describe('status reflects hook events', () => {
-  test('detail view updates the status badge via SSE after a hook', async ({ page, weaver }) => {
+test.describe('status reflects hook and attention events', () => {
+  test('detail view: hooks drive lifecycle + attention via SSE', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Watch my status', name: 'hook-detail' });
 
     await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
-    const badge = page.getByTestId('status-badge').first();
-    await expect(badge).toBeVisible();
+    const status = page.getByTestId('status-badge').first();
+    const attention = page.getByTestId('attention-badge').first();
+    await expect(status).toBeVisible();
 
-    // Flip status by shelling out to `weaver hook`; the monitor consumes the
-    // resulting event row and the SSE stream pushes the new status through.
+    // Any hook means the agent process is alive → lifecycle `running`.
     await weaver.hook(s, 'working');
-    await expect(badge).toHaveText(/working/i);
+    await expect(status).toHaveText(/running/i);
 
+    // A `waiting` hook (Claude blocked on the user) raises the attention axis.
     await weaver.hook(s, 'waiting');
-    await expect(badge).toHaveText(/waiting/i);
+    await expect(attention).toHaveText(/attention/i);
   });
 
-  test('list view picks up a hooked status via polling', async ({ page, weaver }) => {
-    const s = await weaver.seedSession({ goal: 'Watch list status', name: 'hook-list' });
+  test('detail view: weaver status sets attention + note via SSE', async ({ page, weaver }) => {
+    const s = await weaver.seedSession({ goal: 'Declare my status', name: 'status-detail' });
+
+    await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    const attention = page.getByTestId('attention-badge').first();
+    await expect(attention).toBeVisible();
+
+    await weaver.setStatus(s, 'blocked', 'tests failing, need help');
+    await expect(attention).toHaveText(/blocked/i);
+    await expect(page.getByTestId('attention-note')).toHaveText(/tests failing, need help/i);
+  });
+
+  test('list view: attention filter narrows to sessions that need a human', async ({
+    page,
+    weaver,
+  }) => {
+    const fine = await weaver.seedSession({ goal: 'All good here', name: 'fine-one' });
+    const stuck = await weaver.seedSession({ goal: 'Help needed', name: 'stuck-one' });
+
+    await weaver.setStatus(stuck, 'attention', 'waiting on PR feedback');
 
     await page.goto(weaver.baseUrl);
-    const card = page.locator(`[data-session-id="${s.id}"]`);
-    await expect(card.getByTestId('status-badge')).toBeVisible();
+    const stuckCard = page.locator(`[data-session-id="${stuck.id}"]`);
+    const fineCard = page.locator(`[data-session-id="${fine.id}"]`);
 
-    await weaver.hook(s, 'working');
+    // The list polls every 3s; allow time for the attention to propagate.
+    await expect(stuckCard.getByTestId('attention-badge').first()).toHaveText(/attention/i, {
+      timeout: 10_000,
+    });
 
-    // The list polls every 3s; allow generous time for it to refresh.
-    await expect(card.getByTestId('status-badge')).toHaveText(/working/i, { timeout: 10_000 });
+    // Filtering to "needs attention" hides the OK session.
+    await page.getByTestId('filter-attention').click();
+    await expect(stuckCard).toBeVisible();
+    await expect(fineCard).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Closes #3.

Loom used to *infer* agent status from Claude hooks and screen-stillness, which was often misleading — e.g. it read "idle" while the agent was actually waiting on a background workflow. This lets agents say how they're doing directly, and replaces the inferred working/waiting/idle indicator.

## Two orthogonal axes

**Lifecycle** (`session.status`, orchestrator-owned, mechanical): the inferred `working`/`waiting`/`idle` trio collapses into a single `running`. Values are now `created | launching | running | orphaned | done | error`. Any Claude hook means the process is alive → `running`; the stillness→idle demotion is removed.

**Attention** (agent-owned, on the branch): a level — `ok` | `attention` | `blocked` — plus a short free-text note like *"Waiting for PR review feedback"*.
- `ok` — going fine, or blocked on something external that isn't the user (a CI run, a PR review).
- `attention` — wants the user: a question, a decision, "ready for review".
- `blocked` — stuck / errored, needs help.

## How it works
- `weaver status <level> ["note"]` sets it; `weaver status` (no args) reads it. Writes the branch fields directly (daemon-less, mirrors `weaver describe`) plus an `attention` event the monitor re-broadcasts over SSE — so it's durable across loom restarts.
- Claude hooks still nudge attention where they carry a real signal (`waiting`→`attention` + pending-prompt snapshot; `working`→`ok`; `idle` leaves it alone so a finished-but-fine agent isn't mistaken for one that needs you). An explicit `weaver status` is last-write-wins.
- REST: `PATCH /api/sessions/{id}` and `/api/branches/{id}` accept `attention`/`attention_note`; both surfaced in `BranchView`/`SessionView`.
- Loom UI: green/amber/red attention badge on the list + detail views, an editor on the detail view, and an **All / Needs attention / OK** filter so users can jump to sessions that need them. `loom ps`/`show` print it too.

## Naming
Researched common severity conventions (alerting `ok/warning/critical`, health `healthy/degraded/unhealthy`, traffic-light). Landed on `ok` / `attention` / `blocked` — color-codeable, reads naturally uppercased, and the note disambiguates the "why".

## Migration
Additive `attention` / `attention_note` columns on `branches` with an `ALTER TABLE … ADD COLUMN` fallback for existing DBs (legacy rows default to `ok`). Verified the upgrade path against a hand-built old-shape DB.

## Tests / docs
- Updated Rust integration tests (`hook_monitor` now asserts `running` + the attention axis; `integration`, loom `db` test) and added `weaver status` CLI tests. Full `cargo test --workspace` passes (git+tmux integration included).
- Updated e2e fixture (`setStatus`) + `status-hook` spec (lifecycle, attention via SSE, list filter).
- Updated the session primer (injected into every agent), `AGENTS.md`, and `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)