### PR TITLE
Add overridable WEAVER.md; replace merge with archive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,9 @@
 # AGENTS.md
 
 Engineer-facing notes for hacking on weaver itself. For user-facing docs read
-[README.md](README.md); for the prompt the in-workspace agent sees, read
-[crates/weaver-core/primer.md](crates/weaver-core/primer.md).
+[README.md](README.md); for the prompt the in-workspace agent sees, read the
+builtin [crates/weaver-core/WEAVER.md](crates/weaver-core/WEAVER.md) (a repo can
+ship its own `WEAVER.md` to override it).
 
 ## Mental model
 
@@ -103,7 +104,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/health` | liveness probe |
 | `GET /api/sessions` / `POST /api/sessions` | list / create sessions |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
-| `POST /api/sessions/{id}/{note,summarize,merge,adopt}` | actions |
+| `POST /api/sessions/{id}/{note,summarize,archive,adopt}` | actions |
 | `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ PTY ⇄ tmux (the interaction surface) |
 | `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |
@@ -160,7 +161,7 @@ block into the worktree's `.claude/settings.local.json` (see
 
 | Claude hook event | shells out to |
 |---|---|
-| `SessionStart` | `weaver hook --event session-start` (also injects [[crates/weaver-core/primer.md]] as `additionalContext`) |
+| `SessionStart` | `weaver hook --event session-start` (also injects the repo's `WEAVER.md`, or the builtin [[crates/weaver-core/WEAVER.md]], as `additionalContext`) |
 | `UserPromptSubmit` | `weaver hook --event working` |
 | `Notification` | `weaver hook --event waiting` |
 | `Stop` | `weaver hook --event idle` |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ loom ps                               # list active sessions
 loom show <branch>                    # session detail
 loom attach <branch>                  # exec tmux attach (or use the browser terminal)
 loom summary <branch>                 # force a fresh summary now
-loom merge <branch>                   # merge the branch into its base
+loom archive <branch>                 # tear down tmux + worktree, keep branch + history
 loom adopt <branch>                   # recreate tmux for an orphaned session
 loom rm <branch>                      # remove worktree + tmux + db row
 loom open                             # open the web UI
@@ -131,7 +131,7 @@ Loom serves a JSON API under `/api`; the Vue SPA is the primary consumer.
 
 - `GET /api/health`
 - `GET POST /api/sessions`, `GET PATCH DELETE /api/sessions/{id}`,
-  `POST /api/sessions/{id}/{note,summarize,merge,adopt}`,
+  `POST /api/sessions/{id}/{note,summarize,archive,adopt}`,
   `GET /api/sessions/{id}/{diff,log,events}`,
   `GET /api/sessions/{id}/terminal` (WebSocket: xterm.js ⇄ PTY ⇄ tmux)
 - `GET /api/branches`, `GET PATCH /api/branches/{id}`,

--- a/crates/loom/frontend/src/components/StatusBadge.vue
+++ b/crates/loom/frontend/src/components/StatusBadge.vue
@@ -12,6 +12,7 @@ const palette: Record<string, string> = {
   orphaned: 'bg-amber-900 text-amber-200',
   done: 'bg-indigo-800 text-indigo-100',
   error: 'bg-red-800 text-red-100',
+  archived: 'bg-subtle text-muted',
 };
 
 const cls = computed(() => palette[props.status] ?? 'bg-subtle text-fg');

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -132,11 +132,17 @@ const summarize = () =>
     await loadSession();
   });
 
-const merge = () =>
-  act('merge', async () => {
-    if (!confirm('Merge this branch into its base branch?')) return;
-    const res = (await post(`/sessions/${props.id}/merge`)) as { branch: string };
-    notice.value = `Merged ${res.branch}.`;
+const archive = () =>
+  act('archive', async () => {
+    if (
+      !confirm(
+        'Archive this session? This tears down its tmux and removes the worktree, ' +
+          'but keeps the branch and its weaver history for reference.',
+      )
+    )
+      return;
+    const res = (await post(`/sessions/${props.id}/archive`)) as { branch: string };
+    notice.value = `Archived ${res.branch}.`;
     await loadSession();
   });
 
@@ -369,11 +375,12 @@ onUnmounted(() => source?.close());
             {{ busy === 'adopt' ? 'Adopting…' : 'Adopt' }}
           </button>
           <button
+            v-if="ws.status !== 'archived'"
             class="rounded bg-indigo-700 hover:bg-indigo-600 px-3 py-1.5 text-sm"
-            :disabled="busy === 'merge'"
-            @click="merge"
+            :disabled="busy === 'archive'"
+            @click="archive"
           >
-            Merge
+            {{ busy === 'archive' ? 'Archiving…' : 'Archive' }}
           </button>
           <button
             class="rounded bg-red-800 hover:bg-red-700 px-3 py-1.5 text-sm"

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1,7 +1,7 @@
 //! loom — the orchestration CLI.
 //!
 //! Most subcommands talk to the running loom daemon over HTTP (session
-//! lifecycle, summary, merge, adopt). `serve` runs the daemon itself;
+//! lifecycle, summary, archive, adopt). `serve` runs the daemon itself;
 //! `start`/`stop`/`restart`/`status` manage its background lifecycle. To
 //! interact with an agent, `attach` to its tmux (the browser terminal is the
 //! other interaction surface).
@@ -88,8 +88,8 @@ enum Cmd {
     Attach { branch: String },
     /// Force a fresh summary of a session.
     Summary { branch: String },
-    /// Merge a session's branch into its base branch.
-    Merge { branch: String },
+    /// Archive a session: tear down tmux + worktree, keep branch + history.
+    Archive { branch: String },
     /// Recreate the tmux session for an orphaned session.
     Adopt { branch: String },
     /// Remove a session (worktree + tmux + DB row).
@@ -141,7 +141,7 @@ async fn run() -> Result<()> {
         Cmd::Show { branch } => cmd_show(branch).await,
         Cmd::Attach { branch } => cmd_attach(branch).await,
         Cmd::Summary { branch } => cmd_summary(branch).await,
-        Cmd::Merge { branch } => cmd_merge(branch).await,
+        Cmd::Archive { branch } => cmd_archive(branch).await,
         Cmd::Adopt { branch } => cmd_adopt(branch).await,
         Cmd::Rm {
             branch,
@@ -572,15 +572,21 @@ async fn cmd_summary(key: String) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_merge(key: String) -> Result<()> {
+async fn cmd_archive(key: String) -> Result<()> {
     let client = Client::new();
     let res = client
-        .post(&format!("/api/sessions/{key}/merge"), json!({}))
+        .post(&format!("/api/sessions/{key}/archive"), json!({}))
         .await?;
-    println!("merged {}", str_field(&res, "branch"));
-    let output = str_field(&res, "output");
-    if !output.is_empty() {
-        println!("{output}");
+    println!(
+        "archived {} (tmux + worktree removed; branch and history kept)",
+        str_field(&res, "branch")
+    );
+    if let Some(warnings) = res.get("warnings").and_then(Value::as_array) {
+        for w in warnings {
+            if let Some(w) = w.as_str() {
+                eprintln!("  warning: {w}");
+            }
+        }
     }
     Ok(())
 }

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -38,11 +38,11 @@ pub struct Session {
 /// "idle"). Liveness is all the orchestrator can know for sure; the agent
 /// reports the rest via `weaver status`.
 pub const STATUSES: &[&str] = &[
-    "created", "launching", "running", "orphaned", "done", "error",
+    "created", "launching", "running", "orphaned", "done", "error", "archived",
 ];
 
 pub fn is_terminal(status: &str) -> bool {
-    matches!(status, "done" | "error")
+    matches!(status, "done" | "error" | "archived")
 }
 
 pub struct NewSession {

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -5,7 +5,7 @@
 //! * `/api/sessions` — list + create active sessions (each session is one
 //!   tmux + one agent attached to a branch).
 //! * `/api/sessions/{id}` — GET / PATCH / DELETE a single session, plus the
-//!   action subroutes `/note`, `/summarize`, `/merge`, `/adopt`,
+//!   action subroutes `/note`, `/summarize`, `/archive`, `/adopt`,
 //!   `/log`, `/events`, and `/terminal` (a WebSocket bridged to the session's
 //!   tmux via a PTY — see `crate::terminal`). Interacting with the agent
 //!   (keystrokes, keys, TUIs) happens entirely over `/terminal`.
@@ -340,7 +340,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/sessions/{id}/note", post(note_session))
         .route("/sessions/{id}/summarize", post(summarize_session))
-        .route("/sessions/{id}/merge", post(merge_session))
+        .route("/sessions/{id}/archive", post(archive_session))
         .route("/sessions/{id}/adopt", post(adopt_session))
         .route("/sessions/{id}/tree", get(tree_session))
         .route("/sessions/{id}/file", get(file_session))
@@ -921,39 +921,42 @@ async fn summarize_session(
     Ok(Json(json!({ "description": description })))
 }
 
-async fn merge_session(
+/// Archive a session: tear down its tmux and remove the worktree, but keep the
+/// branch (and its commits), the session row, notes, summaries and run history.
+/// This is the "I'm done with this workstream" action — unlike delete, the
+/// weaver/loom record is preserved for future reference, and the git branch is
+/// left intact so the work can be revisited or a worktree recreated later.
+async fn archive_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
+    let mut warnings: Vec<String> = Vec::new();
+
+    tmux::kill_session(&session.tmux_session).await.ok();
     let repo_root = PathBuf::from(&branch.repo_root);
-    if !git::is_clean(&repo_root).await? {
-        return Err(AppError::conflict(
-            "main checkout has uncommitted changes; commit or stash, then merge",
-        ));
+    let work_dir = PathBuf::from(&session.work_dir);
+    if work_dir.exists() {
+        if let Err(e) = git::worktree_remove(&repo_root, &work_dir).await {
+            warnings.push(format!("worktree remove: {e}"));
+            tokio::fs::remove_dir_all(&work_dir).await.ok();
+        }
     }
-    let current = git::current_branch(&repo_root).await?;
-    if current != branch.base_branch {
-        return Err(AppError::conflict(format!(
-            "repo is on '{current}', expected base branch '{}'",
-            branch.base_branch
-        )));
-    }
-    let output = git::merge(&repo_root, &branch.branch)
-        .await
-        .map_err(|e| AppError::conflict(e.to_string()))?;
-    session_mod::set_status(&st.db, &session.id, "done").await?;
+    session_mod::set_status(&st.db, &session.id, "archived").await?;
     events::record(
         &st.db,
         &st.bus,
         &branch.id,
         "status",
-        json!({ "status": "done", "reason": "merged" }),
+        json!({ "status": "archived", "reason": "session archived" }),
     )
     .await
     .ok();
+    if !warnings.is_empty() {
+        tracing::warn!(branch = %branch.id, warnings = warnings.len(), "session archived with warnings");
+    }
     Ok(Json(
-        json!({ "merged": true, "branch": branch.branch, "output": output }),
+        json!({ "archived": true, "branch": branch.branch, "warnings": warnings }),
     ))
 }
 

--- a/crates/loom/tests/integration.rs
+++ b/crates/loom/tests/integration.rs
@@ -600,6 +600,67 @@ async fn session_lifecycle() {
         .await
         .unwrap();
 
+    // ---- Archive -------------------------------------------------------------
+    // Archiving tears down tmux + worktree but, unlike delete, keeps the session
+    // row (marked `archived`), the git branch, and the weaver history.
+    let arch = client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "archive me",
+                "cwd": repo.path().to_string_lossy(),
+                "agent": "shell",
+            }),
+        )
+        .await
+        .unwrap();
+    let arch_id = arch["id"].as_str().unwrap().to_string();
+    let arch_session = arch["tmux_session"].as_str().unwrap().to_string();
+    let arch_work_dir = arch["work_dir"].as_str().unwrap().to_string();
+    assert!(tmux::has_session(&arch_session).await, "archive session missing");
+    assert!(Path::new(&arch_work_dir).exists(), "archive worktree missing");
+    // A note proves the weaver history survives the archive.
+    client
+        .post(
+            &format!("/api/sessions/{arch_id}/note"),
+            json!({ "text": "decision: keep going" }),
+        )
+        .await
+        .unwrap();
+
+    let res = client
+        .post(&format!("/api/sessions/{arch_id}/archive"), json!({}))
+        .await
+        .unwrap();
+    assert_eq!(res["archived"], true);
+    assert!(
+        !tmux::has_session(&arch_session).await,
+        "archive should kill the tmux session"
+    );
+    assert!(
+        !Path::new(&arch_work_dir).exists(),
+        "archive should remove the worktree"
+    );
+    // The session row persists, now terminal/`archived`.
+    let view = client.get(&format!("/api/sessions/{arch_id}")).await.unwrap();
+    assert_eq!(view["status"], "archived");
+    // The git branch is left intact for future reference.
+    assert!(
+        weaver_core::git::branch_exists(repo.path(), "weaver/archive-me").await,
+        "archive must not delete the branch"
+    );
+    // The note history survives in the branch log.
+    let log = client.get(&format!("/api/sessions/{arch_id}/log")).await.unwrap();
+    assert!(
+        serde_json::to_string(&log).unwrap().contains("keep going"),
+        "note history should survive archive"
+    );
+    // An archived session can still be fully removed afterwards.
+    client
+        .delete(&format!("/api/sessions/{arch_id}"))
+        .await
+        .unwrap();
+
     // Deleting the session tears down the tmux session and the DB row.
     client.delete(&format!("/api/sessions/{id}")).await.unwrap();
     assert!(

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -2,6 +2,9 @@ You are running inside a **weaver session**: a detached agent workstream in a
 git worktree on its own branch. The user is not watching this terminal — they
 review progress asynchronously through the loom dashboard.
 
+This document describes how to work *with weaver*. It is distinct from any
+`AGENTS.md` in the repo, which describes the project itself — read that too.
+
 ## The `weaver` CLI
 
 It is on your `PATH`. From anywhere in the worktree you can run:
@@ -49,3 +52,27 @@ often wrong (e.g. it read "idle" while you were really waiting on a workflow).
   dashboard. State the question as plain text, record it with `weaver note`,
   set `weaver status attention "<the question>"`, and continue with your best
   assumption.
+
+## Finishing work
+
+You are on a dedicated branch in your own worktree. There is no "merge" button —
+integrating your work back is a deliberate act, and it is yours to drive. When
+the work is ready:
+
+- **Commit** your changes with a clear message and keep the worktree clean.
+- **Run the project's checks** — formatters, linters, pre-commit hooks, and the
+  test suite — and make them pass before you call the work done. If the repo
+  documents specific commands (often in `AGENTS.md`), use those.
+- **Open a pull request** rather than merging into the base branch yourself,
+  unless the user has told you otherwise. Most teams gate integration on review
+  and CI; respect that. Use the project's normal PR workflow (e.g. `gh pr
+  create`).
+- Record what you did and any follow-ups with `weaver note`, set a concise
+  summary with `weaver describe`, and raise `weaver status attention "ready for
+  review"` so the user knows to look.
+
+When a session is finished with, the user may **archive** it from the dashboard:
+that tears down this tmux session and removes the worktree, but preserves the
+branch and the weaver history (goal, notes, summaries) for future reference. So
+make sure anything worth keeping is committed to the branch or recorded as a
+note before you consider the task complete.

--- a/crates/weaver-core/src/agent.rs
+++ b/crates/weaver-core/src/agent.rs
@@ -1,5 +1,5 @@
 //! Agent-facing helpers that are pure (no tmux, no process spawning): the
-//! Claude Code hook config and the SessionStart primer.
+//! Claude Code hook config and the SessionStart primer (a WEAVER.md).
 
 use serde_json::{json, Value};
 
@@ -27,17 +27,26 @@ pub fn hooks_json(weaver_bin: &str) -> Value {
     })
 }
 
-/// The session primer, kept as a standalone markdown doc and catted in at
-/// build time so `weaver hook` stays self-contained wherever it runs.
-const PRIMER: &str = include_str!("../primer.md");
+/// The builtin WEAVER.md — how an agent works inside a weaver session — kept as
+/// a standalone markdown doc and catted in at build time so `weaver hook` stays
+/// self-contained wherever it runs. A repo may ship its own `WEAVER.md` to
+/// override this; see [`session_primer`].
+const BUILTIN_WEAVER_MD: &str = include_str!("../WEAVER.md");
 
-/// Context injected at SessionStart (via the `session-start` weaver hook): tells
-/// the agent it is in a weaver session and how it is expected to behave.
-pub fn session_primer() -> String {
+/// The builtin WEAVER.md, used when the repo doesn't ship its own.
+pub fn builtin_weaver_md() -> &'static str {
+    BUILTIN_WEAVER_MD
+}
+
+/// Context injected at SessionStart (via the `session-start` weaver hook): a
+/// WEAVER.md telling the agent it is in a weaver session and how it is expected
+/// to behave. `weaver_md` is the repo's own WEAVER.md when present, else
+/// [`builtin_weaver_md`].
+pub fn session_primer(weaver_md: &str) -> String {
     json!({
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
-            "additionalContext": PRIMER,
+            "additionalContext": weaver_md,
         }
     })
     .to_string()
@@ -66,12 +75,19 @@ mod tests {
     }
 
     #[test]
-    fn session_primer_is_session_start_additional_context() {
-        let v: Value = serde_json::from_str(&session_primer()).unwrap();
+    fn session_primer_wraps_the_builtin_weaver_md() {
+        let v: Value = serde_json::from_str(&session_primer(builtin_weaver_md())).unwrap();
         assert_eq!(v["hookSpecificOutput"]["hookEventName"], "SessionStart");
         assert!(v["hookSpecificOutput"]["additionalContext"]
             .as_str()
             .unwrap()
             .contains("weaver note"));
+    }
+
+    #[test]
+    fn session_primer_passes_a_repo_override_through_verbatim() {
+        let custom = "# Our team's weaver workflow\nrun `make ci` before any PR.";
+        let v: Value = serde_json::from_str(&session_primer(custom)).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["additionalContext"], custom);
     }
 }

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -278,18 +278,6 @@ pub async fn diff_stat(work_dir: &Path, since: &str) -> Result<DiffStat> {
     Ok(stat)
 }
 
-/// True when the working tree has no uncommitted changes.
-pub async fn is_clean(dir: &Path) -> Result<bool> {
-    Ok(git(dir, &["status", "--porcelain"]).await?.is_empty())
-}
-
-/// Merge `branch` into the current branch of `repo_root` (no fast-forward).
-pub async fn merge(repo_root: &Path, branch: &str) -> Result<String> {
-    let out = git(repo_root, &["merge", "--no-ff", branch]).await?;
-    tracing::info!(%branch, repo = %repo_root.display(), "branch merged");
-    Ok(out)
-}
-
 // ---------------------------------------------------------------------------
 // Worktree browsing — file listing, change detection, and blob reads, used by
 // loom's file-viewer endpoints.

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -488,6 +488,25 @@ async fn ensure_issue_in_repo(db: &db::Db, id: i64, repo_root: &str) -> Result<i
     Ok(i)
 }
 
+/// The WEAVER.md to inject at session start: the repo's own copy when it ships
+/// one, else the builtin. We look in the worktree the hook is actually running
+/// in (its cwd at launch is the worktree root) and then in the primary checkout,
+/// so a `WEAVER.md` committed on the base branch is picked up either way.
+fn weaver_md_for_branch(branch: &branch::Branch) -> String {
+    let candidates = std::env::current_dir()
+        .ok()
+        .into_iter()
+        .chain(std::iter::once(std::path::PathBuf::from(&branch.repo_root)));
+    for dir in candidates {
+        if let Ok(md) = std::fs::read_to_string(dir.join("WEAVER.md")) {
+            if !md.trim().is_empty() {
+                return md;
+            }
+        }
+    }
+    weaver_core::agent::builtin_weaver_md().to_string()
+}
+
 async fn cmd_hook(event: String) -> Result<()> {
     // Hooks must never break the agent: best-effort, swallow errors.
     let result: Result<()> = (async {
@@ -496,7 +515,8 @@ async fn cmd_hook(event: String) -> Result<()> {
         events::record_local(&db, &b.id, "hook", json!({ "event": event })).await?;
         match event.as_str() {
             "session-start" => {
-                print!("{}", weaver_core::agent::session_primer());
+                let weaver_md = weaver_md_for_branch(&b);
+                print!("{}", weaver_core::agent::session_primer(&weaver_md));
             }
             "idle" => {
                 // Claude Code's Stop hook pipes a JSON payload on stdin that

--- a/docs/browser-terminal.md
+++ b/docs/browser-terminal.md
@@ -320,7 +320,7 @@ function resizeFrame(cols: number, rows: number): Uint8Array {
 - Remove: the `screen` ref, the `screen` branch of the SSE `onStream` handler, the
   `/pane` fetch in `loadAll`, and the `send()` / `stop()` functions.
 - Keep: everything else (title/goal/description editing, status/summary/note/issue
-  SSE handling, diff, merge, remove, adopt).
+  SSE handling, diff, archive, remove, adopt).
 
 ## 9. CLI (`crates/loom/src/bin/loom.rs`)
 

--- a/docs/repo-scoped-issues.md
+++ b/docs/repo-scoped-issues.md
@@ -89,7 +89,7 @@ a separate query (`open_count_for_repo`).
 ## The default: branch vs repo
 
 `weaver issue ls`'s dominant caller is the **in-worktree agent** (see
-[primer.md](../crates/weaver-core/primer.md): "the branch's issue list"). Its
+[WEAVER.md](../crates/weaver-core/WEAVER.md): "the branch's issue list"). Its
 mental model and its context budget are branch-local. A repo-wide dump (dozens
 of items from unrelated workstreams) is noise that pollutes the agent's context
 and invites scope creep ("I see #42 about the logger, let me fix that too" while
@@ -160,5 +160,6 @@ Repo backlog (5 unclaimed, showing 5):
 - **Removing a session (`loom rm`) clears `claimed_branch`** on its issues — the
   issue returns *open* to the unclaimed backlog, ready to be re-picked.
 - *Interaction to watch:* an issue worked-but-not-closed before teardown
-  reappears in the backlog. That's intended — merge isn't "resolved"; close is.
+  reappears in the backlog. That's intended — shipping the work isn't
+  "resolved"; close is.
   The fix is simply to `close` when actually done.


### PR DESCRIPTION
Closes #4.

Gives agents explicit, customizable guidance for working in the weaver/loom environment, and replaces the rarely-useful merge button with an archive action.

## Changes

**Builtin, overridable `WEAVER.md`**
- Renames the builtin primer (`primer.md` → `WEAVER.md`) and expands it with a "Finishing work" section: commit, run the project's checks, and open a PR rather than merging into the base branch directly.
- `weaver hook --event session-start` now injects the repo's own `WEAVER.md` when present (checked in the worktree the hook runs in, then the primary checkout), falling back to the builtin. Teams can drop a `WEAVER.md` in their repo to tailor how agents behave.

**Remove the "merge" button**
- Integration in practice is a PR/review flow that can't be mechanized. Removes the UI button, the `POST /sessions/{id}/merge` endpoint, `loom merge`, and the now-unused `git::merge`/`git::is_clean` helpers.

**Add an "archive" action instead**
- New terminal `archived` status, `POST /sessions/{id}/archive`, `loom archive`, and a dashboard button.
- Archiving tears down tmux and removes the worktree, but **keeps the branch, the session row, notes, summaries, and run history** for future reference (unlike `Remove`, which deletes everything).

## Testing
- `cargo build --all-targets`, `cargo clippy --lib --bins` (clean), unit tests pass.
- Frontend builds via rspack.
- Archive coverage added to the integration suite (folded into the existing single end-to-end test, since separate `#[tokio::test]`s race on process-global env vars): verifies tmux + worktree are gone, status is `archived`, the git branch survives, and a note persists in the branch log.

> Note: the terminal-section assertion in the integration test (websocket-close / burst) is pre-existing flaky (~1/3 failures on `main` too); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)