### PR TITLE
Make `loom launch` task-first and self-explanatory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,18 @@ cd e2e && npm test                    # Playwright suite
 The integration test shells out to real `git` and `tmux`. If it hangs, look
 for stray `weaver-test-*` tmux sessions.
 
+## Landing changes
+
+**Open a pull request by default.** Don't push to or merge into `main` directly.
+Work on a branch, run the checks above (formatters, `cargo clippy`, and
+`WEAVER_SKIP_FRONTEND=1 cargo test --workspace`), make them pass, then
+`gh pr create` and let review + CI gate the merge. This holds for every change —
+features, fixes, docs, refactors — unless the user explicitly tells you to
+commit straight to the base branch. Agents working in a weaver worktree are
+already on their own branch; finishing the work means committing it and opening
+the PR, not integrating it yourself (see the builtin
+[crates/weaver-core/WEAVER.md](crates/weaver-core/WEAVER.md)).
+
 ## Storage & state
 
 - **SQLite** at `$WEAVER_HOME/weaver.db` (default `~/.weaver/weaver.db`),

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ key decoupling — the agent CLI never speaks HTTP.
 ```sh
 # Orchestrator (optional)
 loom serve                            # run the daemon (REST + UI + tmux + monitor)
-loom launch "add-health-endpoint"     # new worktree + tmux + agent
-loom launch "big-refactor" --model opus --effort high   # pick model tier + reasoning effort
+loom launch "Add a /health endpoint"  # new worktree + tmux + agent, seeded with the task
+loom launch "Refactor the parser" --name parser-refactor   # override the branch slug
+loom launch "Big refactor" --model opus --effort high      # pick model tier + reasoning effort
 loom ps                               # list active sessions
 loom show <branch>                    # session detail
 loom attach <branch>                  # exec tmux attach (or use the browser terminal)
@@ -69,10 +70,19 @@ weaver where                          # debug: print resolved repo / branch / br
 weaver log --limit 50                 # recent events for the current branch
 ```
 
-`loom launch --issue 123` seeds the branch's title / goal / description from a
-GitHub issue (via the `gh` CLI). `loom launch --claim 7` does the same from an
-existing weaver issue and moves it out of the repo backlog; `loom issues` prints
-the repo's board across branches.
+`loom launch`'s positional argument is the **task**: it becomes the branch goal
+and the agent's opening prompt, and the `weaver/<slug>` branch name is derived
+from it (override with `--name`). The agent is `claude` unless you pass
+`--agent` or change `agent.default`, so the common case is just `loom launch
+"<what to do>"`. A `loom launch` with no task and nothing to pick up prints a
+usage hint and exits without launching.
+
+Three flags seed the task from existing work instead of a fresh description:
+`loom launch --issue 123` takes the branch's title / goal / description from a
+GitHub issue (via the `gh` CLI), `loom launch --claim 7` takes them from an
+existing weaver issue and moves it out of the repo backlog, and `loom launch
+--branch <name>` resumes an existing branch. `loom issues` prints the repo's
+board across branches.
 
 `loom launch --model <haiku|sonnet|opus> --effort <low|medium|high|xhigh|max>`
 (both also selectors in the web create form) pin the session's Claude model

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -39,27 +39,48 @@ enum Cmd {
     /// Stop and re-start the loom daemon.
     Restart,
 
-    /// Launch a new session: worktree + tmux + agent.
+    /// Launch a new session: worktree + tmux + agent, seeded with a task.
+    ///
+    /// The positional argument is the task the agent should work on — it
+    /// becomes the branch goal and the agent's opening prompt:
+    ///
+    ///     loom launch "Add a /health endpoint and a test for it"
+    ///
+    /// The branch name (`weaver/<slug>`) is derived from the task; override it
+    /// with `--name`. To pick up existing work instead of describing a new
+    /// task, use `--claim <id>`, `--issue <n>`, or `--branch <name>`.
     Launch {
-        /// Optional name (becomes the `weaver/<name>` branch slug). When the
-        /// name matches an existing branch in the repo, that branch is adopted
-        /// instead of creating a new one.
+        /// What the agent should do. Sets the branch goal and is fed to the
+        /// agent as its first prompt. Multiple words are joined, so quoting is
+        /// optional. Omit only when seeding from `--claim`/`--issue`/`--branch`.
+        task: Vec<String>,
+        /// Branch slug to create (`weaver/<name>`). Defaults to a slug derived
+        /// from the task. Mutually exclusive with `--branch`.
+        #[arg(long)]
         name: Option<String>,
+        /// Agent to run: `claude` (the default), `shell` for a plain shell, or
+        /// any other command. Optional — omit to use the configured
+        /// `agent.default` (see `weaver config get agent.default`).
         #[arg(long)]
         agent: Option<String>,
+        /// Branch to fork the new worktree from. Defaults to the repo's current
+        /// branch.
         #[arg(long)]
         base: Option<String>,
-        #[arg(long)]
-        goal: Option<String>,
+        /// One-line title shown on the dashboard. Defaults to a title derived
+        /// from the task.
         #[arg(long)]
         title: Option<String>,
+        /// Seed the task from a GitHub issue (by number, via the `gh` CLI):
+        /// fills in title, goal, and description.
         #[arg(long)]
         issue: Option<i64>,
         /// Claim an existing weaver issue (by id) for this session: seeds the
         /// goal from it and moves it out of the repo backlog.
         #[arg(long)]
         claim: Option<i64>,
-        /// Attach to this existing branch rather than creating a new one.
+        /// Resume an existing branch rather than creating a new one. Mutually
+        /// exclusive with `--name`.
         #[arg(long)]
         branch: Option<String>,
         /// Model tier: haiku, sonnet, or opus. Omit to inherit the configured
@@ -125,17 +146,31 @@ async fn run() -> Result<()> {
         Cmd::Stop => cmd_stop().await,
         Cmd::Restart => cmd_restart().await,
         Cmd::Launch {
+            task,
             name,
             agent,
             base,
-            goal,
             title,
             issue,
             claim,
             branch,
             model,
             effort,
-        } => cmd_launch(name, agent, base, goal, title, issue, claim, branch, model, effort).await,
+        } => {
+            cmd_launch(LaunchArgs {
+                goal: task.join(" "),
+                name,
+                agent,
+                base,
+                title,
+                issue,
+                claim,
+                branch,
+                model,
+                effort,
+            })
+            .await
+        }
         Cmd::Ps => cmd_ps().await,
         Cmd::Issues { all, backlog } => cmd_issues(all, backlog).await,
         Cmd::Show { branch } => cmd_show(branch).await,
@@ -362,22 +397,60 @@ async fn cmd_restart() -> Result<()> {
 // Session commands (HTTP)
 // ---------------------------------------------------------------------------
 
-#[allow(clippy::too_many_arguments)]
-async fn cmd_launch(
+/// Parsed `loom launch` inputs, after folding the positional task words into a
+/// single `goal` string.
+struct LaunchArgs {
+    goal: String,
     name: Option<String>,
     agent: Option<String>,
     base: Option<String>,
-    goal: Option<String>,
     title: Option<String>,
     issue: Option<i64>,
     claim: Option<i64>,
     branch: Option<String>,
     model: Option<String>,
     effort: Option<String>,
-) -> Result<()> {
+}
+
+/// A bare `loom launch` with nothing to work on — no task, no name, no title,
+/// and nothing to pick up (`--claim`/`--issue`/`--branch`). Launching anyway
+/// would spawn an agent with an empty goal that "starts unprompted", so we
+/// stop and point the user at the useful forms instead.
+fn launch_underspecified(a: &LaunchArgs) -> bool {
+    a.goal.trim().is_empty()
+        && a.name.is_none()
+        && a.title.is_none()
+        && a.issue.is_none()
+        && a.claim.is_none()
+        && a.branch.is_none()
+}
+
+const LAUNCH_HINT: &str = "nothing to do — give the agent a task or something to pick up:
+  loom launch \"<what the agent should do>\"   # the common case
+  loom launch --claim <id>                     # pick up a weaver issue
+  loom launch --issue <n>                      # seed from a GitHub issue
+  loom launch --branch <name>                  # resume an existing branch
+  loom launch --name <slug> --agent shell      # an empty named worktree (no task)
+See `loom launch --help` for all options.";
+
+async fn cmd_launch(a: LaunchArgs) -> Result<()> {
+    if launch_underspecified(&a) {
+        bail!("{LAUNCH_HINT}");
+    }
+    let LaunchArgs {
+        goal,
+        name,
+        agent,
+        base,
+        title,
+        issue,
+        claim,
+        branch,
+        model,
+        effort,
+    } = a;
     let client = Client::new();
     let cwd = std::env::current_dir()?;
-    let goal = goal.unwrap_or_default();
     let ws = client
         .post(
             "/api/sessions",
@@ -427,7 +500,7 @@ async fn cmd_ps() -> Result<()> {
     let list = client.get("/api/sessions").await?;
     let rows = list.as_array().cloned().unwrap_or_default();
     if rows.is_empty() {
-        println!("no sessions — start one with `loom launch \"<name>\"`");
+        println!("no sessions — start one with `loom launch \"<task>\"`");
         return Ok(());
     }
     println!(
@@ -655,5 +728,51 @@ mod tests {
     fn truncate_respects_the_max_length() {
         assert_eq!(truncate("short", 10), "short");
         assert_eq!(truncate("a very long string", 6), "a ver…");
+    }
+
+    fn empty_launch() -> LaunchArgs {
+        LaunchArgs {
+            goal: String::new(),
+            name: None,
+            agent: None,
+            base: None,
+            title: None,
+            issue: None,
+            claim: None,
+            branch: None,
+            model: None,
+            effort: None,
+        }
+    }
+
+    #[test]
+    fn bare_launch_is_underspecified() {
+        // `loom launch` with nothing, or only an agent/model/effort/base
+        // selector, has no actual task to run.
+        assert!(launch_underspecified(&empty_launch()));
+        let only_agent = LaunchArgs {
+            agent: Some("shell".into()),
+            base: Some("main".into()),
+            model: Some("opus".into()),
+            ..empty_launch()
+        };
+        assert!(launch_underspecified(&only_agent));
+    }
+
+    #[test]
+    fn anything_to_work_on_is_enough() {
+        let cases = [
+            LaunchArgs { goal: "fix the bug".into(), ..empty_launch() },
+            LaunchArgs { name: Some("scratch".into()), ..empty_launch() },
+            LaunchArgs { title: Some("A title".into()), ..empty_launch() },
+            LaunchArgs { issue: Some(42), ..empty_launch() },
+            LaunchArgs { claim: Some(7), ..empty_launch() },
+            LaunchArgs { branch: Some("weaver/foo".into()), ..empty_launch() },
+        ];
+        for a in cases {
+            assert!(!launch_underspecified(&a));
+        }
+        // Whitespace-only task words still count as empty.
+        assert!(launch_underspecified(&LaunchArgs { goal: "   ".into(), ..empty_launch() }));
     }
 }


### PR DESCRIPTION
## Why

Launching a session was the most confusing part of the CLI:

- The positional argument was the branch **name**, not the task — so
  `loom launch "add-health-endpoint"` named a branch but gave the agent **no
  goal** ("started unprompted"). The README never even showed how to set a goal
  from the CLI.
- `--agent`, `--base`, `--goal`, `--title`, `--issue` had **no help text**, so
  you couldn't tell from `--help` whether `--agent` was required. (It isn't — it
  defaults to `claude` / `agent.default`.)
- A bare `loom launch` silently spawned an empty, goalless agent session — an
  expensive footgun.
- The old `name` doc comment also lied: it claimed a name matching an existing
  branch was "adopted", but the code returns a conflict error.

## What

- **Positional argument is now the task.** It sets the branch goal and the
  agent's opening prompt; the `weaver/<slug>` branch name is derived from it.
  Override the slug with the new `--name` flag.
  ```
  loom launch "Add a /health endpoint"          # the common case
  loom launch "Refactor the parser" --name parser-refactor
  ```
- **Every flag has help text.** `--agent` now states it's optional and defaults
  to the configured `agent.default`.
- **Bare `loom launch` is rejected** with a hint listing the useful forms
  (`--claim`, `--issue`, `--branch`, `--name … --agent shell`) instead of
  spawning an unprompted agent.
- **Docs:** README updated to match; AGENTS.md gains a "Landing changes" section
  instructing agents to open PRs by default rather than merging into the base
  branch.

The CLI surface change is safe: the Vue frontend and all tests drive the REST
API (`POST /api/sessions` with a `goal` field) directly, not the `loom` binary's
arg parsing. The removed `--goal` flag had no other consumers.

## Test plan

- `WEAVER_SKIP_FRONTEND=1 cargo test --workspace` — green (incl. new unit tests
  for the empty-launch guard, and the git+tmux integration tests).
- `cargo clippy -p loom` — clean.
- Manual: `loom launch --help` reads clearly; bare `loom launch` prints the hint
  and exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)