### PR TITLE
loom UI: terminal-first detail, single attention signal, live-reload dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ backed sessions drive it via Claude Code hooks installed into
 `weaver hook --event {working|waiting|idle|session-start}`, writing an `events`
 row the monitor consumes on its next tick; any hook means the agent process is
 alive → `running`. When Claude blocks asking the user (the `waiting`/Notification
-hook), the monitor snapshots the tmux pane into `pending_prompt` so the UI can
-show what the agent is waiting on.
+hook), the monitor raises the branch's **attention** to `attention`; the live
+prompt itself is read straight from the terminal, one tab away.
 
 The **attention** axis is the agent's own signal of whether it needs you:
 `ok` (going fine, or blocked on something external like a CI run or PR review),

--- a/crates/loom/frontend/package-lock.json
+++ b/crates/loom/frontend/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@rspack/cli": "^2.0",
         "@rspack/core": "^2.0",
+        "@rspack/dev-server": "^2.0.3",
         "@tailwindcss/postcss": "^4.2.1",
         "postcss": "^8.5.15",
         "postcss-loader": "^8.2.1",
@@ -413,6 +414,46 @@
           "optional": true
         },
         "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/dev-middleware": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/dev-middleware/-/dev-middleware-2.0.3.tgz",
+      "integrity": "sha512-GxnGj9jy76G3eCPyZei81fwKLAMLZaPEEqFz1/QDYquhwi/qYZX5fekFJ1XVpuwxGEK9KSX3hxZylfwrs4cmLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rspack/core": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/dev-server": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-2.0.3.tgz",
+      "integrity": "sha512-S29nOxXQS9o+0uGNe7SgND2dAKnte5ZTD5tiT3/B4lKbviqpXD4tbH7NZWA3hGwlSkmOIbFlysYPL1bVHuBcSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rspack/dev-middleware": "^2.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rspack/core": "^2.0.0-0",
+        "selfsigned": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "selfsigned": {
           "optional": true
         }
       }

--- a/crates/loom/frontend/package.json
+++ b/crates/loom/frontend/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "build": "rspack build",
-    "dev": "rspack serve"
+    "build": "rspack build --mode production",
+    "dev": "rspack serve --mode development"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@rspack/cli": "^2.0",
     "@rspack/core": "^2.0",
+    "@rspack/dev-server": "^2.0.3",
     "@tailwindcss/postcss": "^4.2.1",
     "postcss": "^8.5.15",
     "postcss-loader": "^8.2.1",

--- a/crates/loom/frontend/rspack.config.js
+++ b/crates/loom/frontend/rspack.config.js
@@ -2,29 +2,71 @@ const path = require('path');
 const { HtmlRspackPlugin } = require('@rspack/core');
 const { VueLoaderPlugin } = require('rspack-vue-loader');
 
-module.exports = {
-  entry: './src/main.ts',
-  output: {
-    path: path.resolve(__dirname, '../static/dist'),
-    filename: 'app.[contenthash:8].js',
-    clean: true,
-  },
-  resolve: {
-    extensions: ['.ts', '.js', '.vue'],
-  },
-  plugins: [
-    new VueLoaderPlugin(),
-    new HtmlRspackPlugin({ template: './src/index.html', filename: 'index.html' }),
-  ],
-  module: {
-    rules: [
-      { test: /\.vue$/, loader: 'rspack-vue-loader', options: { experimentalInlineMatchResource: true } },
-      { test: /\.ts$/, loader: 'builtin:swc-loader', options: { jsc: { parser: { syntax: 'typescript' } } }, type: 'javascript/auto' },
-      { test: /\.css$/, use: ['postcss-loader'], type: 'css' },
+// One config, two modes. `npm run build` (rspack build --mode production) emits
+// the hashed, on-disk bundle the loom server serves from `static/dist`.
+// `npm run dev` (rspack serve --mode development) runs an in-memory dev server
+// with Vue HMR, proxying every `/api` call — REST, the SSE event stream, and
+// the terminal WebSocket — to the already-running loom backend. The dev server
+// never writes to disk, so it leaves the production `static/dist` untouched.
+module.exports = (_env, argv) => {
+  const isDev = (argv && argv.mode) === 'development';
+
+  // The running loom backend the dev server proxies to. Matches loom's default
+  // bind address; override with WEAVER_API to point at a server elsewhere.
+  const backend = process.env.WEAVER_API || 'http://127.0.0.1:7878';
+
+  return {
+    entry: './src/main.ts',
+    output: {
+      path: path.resolve(__dirname, '../static/dist'),
+      filename: isDev ? 'app.js' : 'app.[contenthash:8].js',
+      clean: !isDev,
+    },
+    resolve: {
+      extensions: ['.ts', '.js', '.vue'],
+    },
+    plugins: [
+      new VueLoaderPlugin(),
+      new HtmlRspackPlugin({ template: './src/index.html', filename: 'index.html' }),
     ],
-  },
-  experiments: {
-    css: true,
-  },
-  mode: 'production',
+    module: {
+      rules: [
+        { test: /\.vue$/, loader: 'rspack-vue-loader', options: { experimentalInlineMatchResource: true } },
+        { test: /\.ts$/, loader: 'builtin:swc-loader', options: { jsc: { parser: { syntax: 'typescript' } } }, type: 'javascript/auto' },
+        { test: /\.css$/, use: ['postcss-loader'], type: 'css' },
+      ],
+    },
+    experiments: {
+      css: true,
+    },
+    mode: isDev ? 'development' : 'production',
+    devtool: isDev ? 'eval-cheap-module-source-map' : false,
+    devServer: {
+      host: '127.0.0.1',
+      port: 5178,
+      hot: true,
+      // Don't gzip; it buffers the `/api/.../events` SSE stream.
+      compress: false,
+      // SPA deep links (the app uses hash routing, but keep this for safety).
+      historyApiFallback: true,
+      client: {
+        overlay: { errors: true, warnings: false },
+      },
+      proxy: [
+        {
+          context: ['/api'],
+          target: backend,
+          changeOrigin: true,
+          // Upgrade /api/sessions/{id}/terminal to a proxied WebSocket.
+          ws: true,
+          // The backend's CSWSH guard (terminal.rs `origin_ok`) only accepts a
+          // WebSocket whose Origin is loopback on its OWN bound port. The
+          // browser's Origin here is the dev server (:5178) and `changeOrigin`
+          // rewrites only Host — so rewrite Origin to the backend too, or the
+          // terminal handshake 403s. Harmless for the REST routes (permissive CORS).
+          headers: { origin: backend },
+        },
+      ],
+    },
+  };
 };

--- a/crates/loom/frontend/src/components/AttentionBadge.vue
+++ b/crates/loom/frontend/src/components/AttentionBadge.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-// The agent-declared attention axis: does this session need me? Green = ok,
-// amber = wants attention, red = blocked / needs help. Distinct from the
-// mechanical lifecycle StatusBadge. Solid status hues (no semantic token
-// exists for green/amber/red) read on both light and dark themes.
+// The agent-declared attention axis: does this session need me? This is the ONE
+// reserved loud signal in the UI. `ok` is intentionally a quiet ghost chip — it
+// should recede so the loud amber/red states are the only thing that pops.
+// Colors come from semantic tokens (attn/block) so they auto-swap light/dark.
 const props = defineProps<{ level: string; note?: string }>();
 
 interface Style {
@@ -14,13 +14,25 @@ interface Style {
 }
 
 const styles: Record<string, Style> = {
-  ok: { label: 'OK', cls: 'bg-emerald-700 text-emerald-50', dot: 'bg-emerald-300' },
-  attention: { label: 'Attention', cls: 'bg-amber-600 text-amber-50', dot: 'bg-amber-200' },
-  blocked: { label: 'Blocked', cls: 'bg-red-700 text-red-50', dot: 'bg-red-300' },
+  ok: {
+    label: 'OK',
+    cls: 'bg-transparent text-faint ring-1 ring-inset ring-line',
+    dot: 'bg-faint',
+  },
+  attention: {
+    label: 'Attention',
+    cls: 'bg-attn text-attn-fg',
+    dot: 'bg-attn-fg/80',
+  },
+  blocked: {
+    label: 'Blocked',
+    cls: 'bg-block text-block-fg',
+    dot: 'bg-block-fg/80',
+  },
 };
 
 const style = computed(
-  () => styles[props.level] ?? { label: props.level, cls: 'bg-subtle text-fg', dot: 'bg-faint' },
+  () => styles[props.level] ?? { label: props.level, cls: 'bg-transparent text-faint ring-1 ring-inset ring-line', dot: 'bg-faint' },
 );
 </script>
 

--- a/crates/loom/frontend/src/components/SessionActivity.vue
+++ b/crates/loom/frontend/src/components/SessionActivity.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { WeaverEvent } from '../types';
+
+// The Overview activity feed: de-noised to meaningful kinds (status, attention,
+// note, issue_*), newest first, capped at 6 with an "older →" reveal. High-volume
+// `hook` events are dropped — they never stream in live, but the initial GET /log
+// may include them, so filter defensively.
+const props = defineProps<{ events: WeaverEvent[]; format: (ev: WeaverEvent) => string }>();
+
+const MEANINGFUL = new Set([
+  'status',
+  'attention',
+  'note',
+  'issue_added',
+  'issue_closed',
+  'issue_reopened',
+]);
+
+const showAll = ref(false);
+const meaningfulEvents = computed(() =>
+  props.events.filter((e) => MEANINGFUL.has(e.kind)).slice().reverse(),
+);
+const visibleEvents = computed(() =>
+  showAll.value ? meaningfulEvents.value : meaningfulEvents.value.slice(0, 6),
+);
+</script>
+
+<template>
+  <div>
+    <div class="mb-2 text-xs font-medium uppercase tracking-wide text-faint">Recent activity</div>
+    <ul class="space-y-1 text-sm">
+      <li
+        v-for="(ev, i) in visibleEvents"
+        :key="ev.id"
+        class="stagger-in flex gap-2"
+        :style="{ '--i': i }"
+      >
+        <span class="shrink-0 font-mono text-xs text-faint">{{ ev.created_at.slice(11, 19) }}</span>
+        <span class="text-muted">{{ format(ev) }}</span>
+      </li>
+      <li v-if="!meaningfulEvents.length" class="text-xs text-faint">No activity yet.</li>
+    </ul>
+    <button
+      v-if="meaningfulEvents.length > 6"
+      class="mt-1 text-xs text-accent hover:underline"
+      @click="showAll = !showAll"
+    >
+      {{ showAll ? 'show less' : `${meaningfulEvents.length - 6} older →` }}
+    </button>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionDetailsPopover.vue
+++ b/crates/loom/frontend/src/components/SessionDetailsPopover.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import type { Session } from '../types';
+
+// The "⌄ details" popover for the page header: the low-frequency identity +
+// machine metadata trimmed out of the header run (id, branch, base, tmux,
+// worktree, github) plus the standalone Files-route affordance. Read-only; the
+// page owns open-state.
+const props = defineProps<{ ws: Session; open: boolean }>();
+const emit = defineEmits<{ 'update:open': [boolean] }>();
+
+function close() {
+  emit('update:open', false);
+}
+</script>
+
+<template>
+  <div v-if="open" class="relative">
+    <!-- Transparent backdrop dismisses on outside click — dependency-free. -->
+    <div class="fixed inset-0 z-10" @click="close"></div>
+    <div
+      data-testid="details-popover"
+      class="absolute right-0 z-20 mt-1 w-80 rounded border border-line bg-surface p-3 shadow-lg"
+    >
+      <dl class="space-y-2 text-xs">
+        <div class="flex gap-2">
+          <dt class="w-16 shrink-0 text-faint">id</dt>
+          <dd class="min-w-0 break-all font-mono text-muted">{{ ws.id }}</dd>
+        </div>
+        <div class="flex gap-2">
+          <dt class="w-16 shrink-0 text-faint">branch</dt>
+          <dd class="min-w-0 break-all font-mono text-muted">{{ ws.branch.branch }}</dd>
+        </div>
+        <div class="flex gap-2">
+          <dt class="w-16 shrink-0 text-faint">base</dt>
+          <dd class="min-w-0 break-all font-mono text-muted">base {{ ws.branch.base_branch }}</dd>
+        </div>
+        <div class="flex gap-2">
+          <dt class="w-16 shrink-0 text-faint">tmux</dt>
+          <dd class="min-w-0 break-all font-mono text-muted">{{ ws.tmux_session }}</dd>
+        </div>
+        <div class="flex gap-2">
+          <dt class="w-16 shrink-0 text-faint">worktree</dt>
+          <dd class="min-w-0 break-all font-mono text-muted">{{ ws.work_dir }}</dd>
+        </div>
+        <div v-if="ws.github_repo" class="flex gap-2">
+          <dt class="w-16 shrink-0 text-faint">github</dt>
+          <dd class="min-w-0 break-all font-mono text-muted">{{ ws.github_repo }}</dd>
+        </div>
+      </dl>
+      <div class="mt-3 border-t border-line pt-2">
+        <router-link
+          :to="`/s/${ws.id}/files`"
+          class="text-xs text-accent hover:underline"
+        >browse files →</router-link>
+      </div>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionIssues.vue
+++ b/crates/loom/frontend/src/components/SessionIssues.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { Issue } from '../types';
+
+// The Issues tab: the session's own claimed work plus the repo's unclaimed
+// backlog. Read-only here — both are managed with `weaver issue`.
+defineProps<{ issues: Issue[]; backlog: Issue[] }>();
+</script>
+
+<template>
+  <div class="space-y-5">
+    <section
+      v-if="issues.length"
+      class="rounded border border-line bg-surface p-4"
+      data-testid="issues-panel"
+    >
+      <div class="mb-2 flex items-center justify-between">
+        <span class="text-xs text-muted">
+          Open issues
+          <span class="text-faint">({{ issues.length }})</span>
+        </span>
+        <span class="text-xs text-faint">read-only · manage with <code>weaver issue</code></span>
+      </div>
+      <ul class="space-y-2 text-sm">
+        <li v-for="i in issues" :key="i.id" class="rounded bg-canvas/60 p-2">
+          <div class="flex items-baseline gap-2">
+            <span class="font-mono text-xs text-muted">#{{ i.id }}</span>
+            <span class="text-fg">{{ i.title }}</span>
+          </div>
+          <pre v-if="i.body" class="mt-1 whitespace-pre-wrap text-xs text-muted">{{ i.body }}</pre>
+        </li>
+      </ul>
+    </section>
+
+    <section
+      v-if="backlog.length"
+      class="rounded border border-line bg-surface p-4"
+      data-testid="backlog-panel"
+    >
+      <div class="mb-2 flex items-center justify-between">
+        <span class="text-xs text-muted">
+          Repo backlog
+          <span class="text-faint">({{ backlog.length }})</span>
+        </span>
+        <span class="text-xs text-faint">unclaimed · whole repo</span>
+      </div>
+      <ul class="space-y-1 text-sm">
+        <li
+          v-for="i in backlog"
+          :key="i.id"
+          class="flex items-baseline gap-2 rounded bg-canvas/60 p-2"
+        >
+          <span class="font-mono text-xs text-muted">#{{ i.id }}</span>
+          <span class="text-fg">{{ i.title }}</span>
+        </li>
+      </ul>
+    </section>
+
+    <p v-if="!issues.length && !backlog.length" class="text-sm text-faint">
+      No issues claimed, and the repo backlog is empty.
+    </p>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionOverview.vue
+++ b/crates/loom/frontend/src/components/SessionOverview.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import type { Session, WeaverEvent } from '../types';
+import SessionActivity from './SessionActivity.vue';
+import ScratchPanel from './ScratchPanel.vue';
+
+// The Overview tab: read-only context for a session, plus its lifecycle
+// actions. Goal and the status message are authored by the AGENT (the launch
+// prompt, `weaver set-status`) — shown here as prose, never as editable forms.
+// The only writes on this page are acknowledging attention (the status strip)
+// and lifecycle (Adopt / Archive / Remove, below).
+const props = defineProps<{
+  ws: Session;
+  events: WeaverEvent[];
+  format: (ev: WeaverEvent) => string;
+  busy: string;
+}>();
+
+const emit = defineEmits<{ adopt: []; archive: []; remove: [] }>();
+</script>
+
+<template>
+  <div class="space-y-5">
+    <!-- Goal — the agent's launch prompt. Read-only. -->
+    <section class="rounded border border-line bg-surface p-4">
+      <div class="mb-1 text-xs font-medium uppercase tracking-wide text-faint">Goal</div>
+      <p v-if="ws.branch.goal" class="whitespace-pre-wrap text-sm text-fg">{{ ws.branch.goal }}</p>
+      <p v-else class="text-sm text-faint">No goal set.</p>
+    </section>
+
+    <!-- Activity — de-noised event feed (read-only context). -->
+    <section class="rounded border border-line bg-surface p-4">
+      <SessionActivity :events="events" :format="format" />
+    </section>
+
+    <!-- Scratch files. -->
+    <ScratchPanel :id="ws.id" />
+
+    <!-- Lifecycle actions — neutral; only Remove reads danger. Adopt carries a
+         single suggested-action accent ring (it's the recovery path the strip
+         flags); Archive is plain neutral; Remove is a quiet block-token ghost,
+         loud only on hover. -->
+    <section class="flex flex-wrap gap-2 rounded border border-line bg-surface p-4">
+      <button
+        v-if="ws.status === 'orphaned'"
+        class="rounded bg-subtle px-3 py-1.5 text-sm text-accent ring-1 ring-inset ring-accent/30 hover:bg-subtle-hover"
+        :disabled="busy === 'adopt'"
+        @click="emit('adopt')"
+      >
+        {{ busy === 'adopt' ? 'Adopting…' : 'Adopt' }}
+      </button>
+      <button
+        v-if="ws.status !== 'archived'"
+        class="rounded bg-subtle px-3 py-1.5 text-sm text-fg hover:bg-subtle-hover"
+        :disabled="busy === 'archive'"
+        @click="emit('archive')"
+      >
+        {{ busy === 'archive' ? 'Archiving…' : 'Archive' }}
+      </button>
+      <button
+        class="ml-auto rounded bg-transparent px-3 py-1.5 text-sm text-block ring-1 ring-inset ring-block-line hover:bg-block-soft"
+        :disabled="busy === 'remove'"
+        @click="emit('remove')"
+      >
+        Remove
+      </button>
+    </section>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { ref, nextTick } from 'vue';
+import type { Session } from '../types';
+import { messageOf } from '../lib/sessionState';
+import StatusBadge from './StatusBadge.vue';
+import SessionDetailsPopover from './SessionDetailsPopover.vue';
+
+// The detail page header: a compact answer-zone.
+//   row 1  ← all · title (inline rename) · lifecycle badge
+//   row 2  the agent's current-state message as prose (the point of the page)
+//   row 3  one quiet repo/branch · agent line + a ⌄ details popover holding the
+//          low-frequency machine metadata (id, base, tmux, worktree, github)
+const props = defineProps<{ ws: Session }>();
+const emit = defineEmits<{ rename: [string] }>();
+
+const showDetails = ref(false);
+
+// Inline title rename — the title lives only here, no separate edit box. Click
+// the ✎ to edit; Enter/blur commits, Esc cancels. Title is the one branch field
+// a human authors; goal and status are agent-authored and read-only elsewhere.
+const editing = ref(false);
+const draft = ref('');
+const inputEl = ref<HTMLInputElement | null>(null);
+
+function current(): string {
+  return props.ws.branch.title || props.ws.branch.name;
+}
+
+async function startEdit() {
+  draft.value = current();
+  editing.value = true;
+  await nextTick();
+  inputEl.value?.focus();
+  inputEl.value?.select();
+}
+
+function commit() {
+  if (!editing.value) return;
+  editing.value = false;
+  const next = draft.value.trim();
+  if (next && next !== current()) emit('rename', next);
+}
+
+function cancel() {
+  editing.value = false;
+}
+
+// The short repo label is the last path segment of the worktree's repo root.
+function repoName(p: string): string {
+  return p.replace(/\/+$/, '').split('/').pop() || p;
+}
+</script>
+
+<template>
+  <header class="mb-3">
+    <!-- Row 1 — back link, title (inline rename), badges -->
+    <div class="flex items-center gap-3">
+      <router-link to="/" class="text-sm text-muted hover:text-fg">← all</router-link>
+      <input
+        v-if="editing"
+        ref="inputEl"
+        v-model="draft"
+        class="min-w-0 flex-1 rounded bg-input px-2 py-1 text-lg font-semibold outline-none focus:ring-1 ring-accent"
+        @keydown.enter.prevent="commit"
+        @keydown.esc.prevent="cancel"
+        @blur="commit"
+      />
+      <div v-else class="group flex min-w-0 items-center gap-1.5">
+        <h1 class="min-w-0 truncate text-lg font-semibold tracking-tight">
+          {{ ws.branch.title || ws.branch.name }}
+        </h1>
+        <button
+          type="button"
+          class="shrink-0 text-xs text-faint opacity-0 transition-opacity hover:text-fg group-hover:opacity-100"
+          title="Rename"
+          @click="startEdit"
+        >
+          ✎
+        </button>
+      </div>
+      <!-- Lifecycle only. The agent's attention signal lives in the status
+           strip below — one place, and it carries the acknowledge control — so
+           it is not duplicated as a badge here. -->
+      <StatusBadge class="ml-auto shrink-0" :status="ws.status" />
+    </div>
+
+    <!-- Row 2 — the current-state headline (the agent's "where am I"). Full
+         foreground — it's the point of the page, not chrome. -->
+    <p
+      v-if="messageOf(ws)"
+      class="mt-1 line-clamp-2 text-sm leading-snug text-fg"
+      data-testid="status-message"
+    >
+      {{ messageOf(ws) }}
+    </p>
+    <p v-else class="mt-1 text-sm text-faint">
+      No status yet — agent hasn't run <code>weaver set-status</code>.
+    </p>
+
+    <!-- Row 3 — one quiet meta line: repo/branch · agent, with everything else
+         (id, base, tmux, worktree, github) tucked behind ⌄ details. -->
+    <div class="mt-2 flex items-center gap-2 text-xs">
+      <span class="min-w-0 truncate font-mono text-muted">
+        {{ repoName(ws.branch.repo_root) }}/{{ ws.branch.name }}
+      </span>
+      <span class="text-faint">·</span>
+      <span class="text-muted">
+        {{ ws.agent_kind }}<template v-if="ws.model"> · {{ ws.model }}</template>
+      </span>
+      <div class="relative ml-auto shrink-0">
+        <button
+          type="button"
+          class="text-muted hover:text-fg"
+          @click="showDetails = !showDetails"
+        >
+          ⌄ details
+        </button>
+        <SessionDetailsPopover :ws="ws" v-model:open="showDetails" />
+      </div>
+    </div>
+  </header>
+</template>

--- a/crates/loom/frontend/src/components/SessionStatusStrip.vue
+++ b/crates/loom/frontend/src/components/SessionStatusStrip.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Session } from '../types';
+import { conversationState, levelOf, TONE_TEXT } from '../lib/sessionState';
+import { timeAgo } from '../lib/time';
+
+// The conversation-state strip: a derived STATE line (glyph + label), the one
+// human write on this page (Mark OK — acknowledge the agent's attention), and a
+// freshness stamp. Replaces the old verbatim "Waiting for input" prompt slab —
+// the prompt itself is live in the terminal one tab away.
+const props = defineProps<{ ws: Session }>();
+const emit = defineEmits<{ acknowledge: [] }>();
+
+// Mark OK only makes sense when the AGENT has actually raised its attention
+// level — acknowledging clears it back to 'ok'.
+const ackable = computed(() => levelOf(props.ws) !== 'ok');
+
+// The state line is derived from the agent's DECLARED attention level (set by
+// Claude's working/waiting/idle hooks and `weaver set-status`) plus lifecycle —
+// deliberately NOT from `pending_prompt`. That captured-pane snapshot is only
+// cleared by a `working` hook (an actual user submission), so it lingers on
+// watcher/loop sessions and after an acknowledge — it is not a reliable
+// "needs input now" signal, and treating it as one shows a phantom block.
+const conv = computed(() => conversationState(props.ws));
+const toneClass = computed(() => TONE_TEXT[conv.value.tone]);
+const lastActivity = computed(() => timeAgo(props.ws.last_activity_at));
+// Only true attention/blocked rows get the row wash + slow breath.
+const loud = computed(() => conv.value.tone === 'block' || conv.value.tone === 'attn');
+const washClass = computed(() =>
+  conv.value.tone === 'block'
+    ? 'border-l-2 border-block-line bg-block-soft'
+    : conv.value.tone === 'attn'
+      ? 'border-l-2 border-attn-line bg-attn-soft'
+      : 'border-l-2 border-transparent',
+);
+</script>
+
+<template>
+  <div
+    class="mb-4 flex items-center gap-2 rounded px-3 py-2 text-sm"
+    :class="[washClass, loud ? 'pulse-attention' : '']"
+  >
+    <span :class="toneClass">{{ conv.glyph }}</span>
+    <span :class="toneClass" class="font-medium" data-testid="conversation-state">{{ conv.label }}</span>
+    <div class="ml-auto flex items-center gap-3">
+      <button
+        v-if="ackable"
+        type="button"
+        data-testid="acknowledge"
+        class="rounded bg-surface px-2.5 py-1 text-xs font-semibold text-fg shadow-sm ring-1 ring-inset ring-line hover:bg-subtle"
+        @click="emit('acknowledge')"
+      >
+        Mark OK ✓
+      </button>
+      <span v-if="lastActivity" class="font-mono text-xs text-faint">
+        last activity {{ lastActivity }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionTabs.vue
+++ b/crates/loom/frontend/src/components/SessionTabs.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+// Work-area sub-nav. Terminal/Overview/Issues are component-local tabs (the
+// terminal must never unmount, so the parent flips a ref and v-shows it);
+// Files is a real route to FileBrowser (Monaco is heavy and mustn't load on
+// session-open). Neutral underline indicator — no loud fills; only the active
+// tab gets text-fg + an accent underline.
+type Tab = 'terminal' | 'overview' | 'issues' | 'files';
+
+const props = defineProps<{ tab: Tab; id: string; issueCount: number }>();
+defineEmits<{ select: [Exclude<Tab, 'files'>] }>();
+
+const LOCAL_TABS: { key: Exclude<Tab, 'files'>; label: string }[] = [
+  { key: 'terminal', label: 'Terminal' },
+  { key: 'overview', label: 'Overview' },
+  { key: 'issues', label: 'Issues' },
+];
+</script>
+
+<template>
+  <nav class="mb-3 flex items-center gap-1 border-b border-line text-sm">
+    <button
+      v-for="t in LOCAL_TABS"
+      :key="t.key"
+      type="button"
+      :data-tab="t.key"
+      class="-mb-px border-b-2 px-3 py-2"
+      :class="tab === t.key
+        ? 'border-accent text-fg font-medium'
+        : 'border-transparent text-muted hover:text-fg'"
+      @click="$emit('select', t.key)"
+    >
+      {{ t.label }}
+      <span v-if="t.key === 'issues' && issueCount" class="pill ml-1">{{ issueCount }}</span>
+    </button>
+    <router-link
+      :to="`/s/${id}/files`"
+      data-tab="files"
+      class="-mb-px border-b-2 px-3 py-2"
+      :class="tab === 'files'
+        ? 'border-accent text-fg font-medium'
+        : 'border-transparent text-muted hover:text-fg'"
+    >
+      Files
+    </router-link>
+  </nav>
+</template>

--- a/crates/loom/frontend/src/components/StatusBadge.vue
+++ b/crates/loom/frontend/src/components/StatusBadge.vue
@@ -3,26 +3,28 @@ import { computed } from 'vue';
 
 const props = defineProps<{ status: string }>();
 
-// Lifecycle (mechanical) status. How the agent is *doing* is the separate
-// attention axis — see AttentionBadge.vue.
+// Lifecycle (mechanical) status — deliberately NEUTRAL. Lifecycle is not the
+// loud signal; the attention axis (AttentionBadge) is. `running` keeps a faint
+// accent tint as the one live state worth a glance; everything else is muted
+// slate so attention stays the only chromatic thing on the page.
 const palette: Record<string, string> = {
-  created: 'bg-subtle text-fg',
-  launching: 'bg-sky-800 text-sky-100',
-  running: 'bg-accent text-accent-fg',
-  orphaned: 'bg-amber-900 text-amber-200',
-  done: 'bg-indigo-800 text-indigo-100',
-  error: 'bg-red-800 text-red-100',
-  archived: 'bg-subtle text-muted',
+  created: 'bg-subtle text-muted',
+  launching: 'bg-subtle text-fg',
+  running: 'bg-accent/10 text-accent ring-1 ring-inset ring-accent/30',
+  orphaned: 'bg-subtle text-muted',
+  done: 'bg-subtle text-muted',
+  error: 'bg-subtle text-fg',
+  archived: 'bg-subtle text-faint',
 };
 
-const cls = computed(() => palette[props.status] ?? 'bg-subtle text-fg');
+const cls = computed(() => palette[props.status] ?? 'bg-subtle text-muted');
 </script>
 
 <template>
   <span
     :class="cls"
     data-testid="status-badge"
-    class="inline-block rounded px-2 py-0.5 text-xs font-medium uppercase tracking-wide"
+    class="inline-block rounded px-2 py-0.5 text-[0.7rem] font-medium uppercase tracking-wide font-mono"
   >
     {{ status }}
   </span>

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -1,0 +1,54 @@
+import type { Session } from '../types';
+
+export type Attention = 'ok' | 'attention' | 'blocked';
+
+// Agent-declared attention, normalized. Archived sessions are forced quiet
+// (the agent is gone), and unset attention defaults to 'ok'. Mirrors the
+// backend; keeps stale/archived rows from shouting.
+export function levelOf(s: Session): Attention {
+  if (s.status === 'archived') return 'ok';
+  const a = s.branch.attention;
+  return a === 'attention' || a === 'blocked' ? a : 'ok';
+}
+
+// The current-state message (Branch.description). Suppressed for archived
+// sessions so torn-down workstreams don't show stale chatter.
+export function messageOf(s: Session): string {
+  if (s.status === 'archived') return '';
+  return s.branch.description ?? '';
+}
+
+// Compact conversation-state line for the detail header (#5): a derived
+// STATE, not verbatim agent chatter. Drives the line that replaces the old
+// "Waiting for input" slab. Returns a glyph + short label; glyphs are plain
+// unicode (offline-safe, no icon dependency).
+export interface ConvState {
+  glyph: string;   // ⏳ / ▶ / ✓ / ◦
+  label: string;   // e.g. "Blocked — needs input"
+  tone: 'block' | 'attn' | 'muted'; // which token family to color it with
+}
+
+export function conversationState(s: Session): ConvState {
+  // Lifecycle first for the unambiguous mechanical states.
+  if (s.status === 'archived') return { glyph: '◦', label: 'Archived', tone: 'muted' };
+  if (s.status === 'orphaned') return { glyph: '◦', label: 'Orphaned — detached', tone: 'muted' };
+  if (s.status === 'error') return { glyph: '◦', label: 'Error', tone: 'muted' };
+
+  // Then the agent-declared attention axis.
+  const level = levelOf(s);
+  if (level === 'blocked') return { glyph: '⏳', label: 'Blocked', tone: 'block' };
+  if (level === 'attention') return { glyph: '⏳', label: 'Needs attention', tone: 'attn' };
+
+  // Otherwise infer working vs idle from lifecycle. "Working"/"Idle" stay
+  // neutral so amber/red remains the sole loud signal.
+  if (s.status === 'running' || s.status === 'launching') return { glyph: '▶', label: 'Working', tone: 'muted' };
+  return { glyph: '✓', label: 'Idle', tone: 'muted' };
+}
+
+// Map ConvState.tone to a text-color token. Pages apply this; keeps motion/
+// color tokens out of the deriver.
+export const TONE_TEXT: Record<ConvState['tone'], string> = {
+  block: 'text-block',
+  attn: 'text-attn',
+  muted: 'text-muted',
+};

--- a/crates/loom/frontend/src/lib/time.ts
+++ b/crates/loom/frontend/src/lib/time.ts
@@ -1,0 +1,20 @@
+// Compact relative time for activity/metadata, e.g. "just now", "3m ago",
+// "2h ago", "4d ago". Foundation owns this; pages import it. Takes an ISO
+// timestamp (Session.last_activity_at, WeaverEvent.created_at) and an optional
+// reference "now" (for tests). Returns '' for empty/invalid input.
+export function timeAgo(iso: string | null | undefined, now: number = Date.now()): string {
+  if (!iso) return '';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '';
+  const secs = Math.max(0, Math.round((now - then) / 1000));
+  if (secs < 45) return 'just now';
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  const wks = Math.round(days / 7);
+  if (wks < 5) return `${wks}w ago`;
+  return `${Math.round(days / 30)}mo ago`;
+}

--- a/crates/loom/frontend/src/styles.css
+++ b/crates/loom/frontend/src/styles.css
@@ -24,6 +24,27 @@
   --color-accent-fg: var(--accent-fg);
   --color-code: var(--code);
   --color-code-fg: var(--code-fg);
+
+  /* Attention axis — the ONE reserved "needs a human" signal. Amber = wants
+     attention, red = blocked. These are the only loud hues in the UI; every
+     lifecycle/status surface stays neutral so this truly pops. */
+  --color-attn: var(--attn);
+  --color-attn-fg: var(--attn-fg);
+  --color-attn-soft: var(--attn-soft);
+  --color-attn-line: var(--attn-line);
+  --color-block: var(--block);
+  --color-block-fg: var(--block-fg);
+  --color-block-soft: var(--block-soft);
+  --color-block-line: var(--block-line);
+
+  /* Type. Dependency-free system stacks (no CDN/@fontsource — must work
+     offline). Sans for prose; a characterful mono for identifiers, refs,
+     ids, branch names, timestamps and all metadata. */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "Cascadia Mono", "SF Mono",
+    "JetBrains Mono", "Fira Code", "Roboto Mono", Menlo, Consolas,
+    "DejaVu Sans Mono", monospace;
 }
 
 /* Light palette (default). */
@@ -42,6 +63,16 @@
   --accent-fg: #ffffff;
   --code: #f1f5f9;          /* preformatted blocks (diffs, prompts) */
   --code-fg: #334155;       /* slate-700 */
+
+  /* Attention (amber) + Blocked (red) — the reserved loud signal. */
+  --attn: #b45309;          /* amber-700 — loud fill */
+  --attn-fg: #fffbeb;       /* amber-50  — text on fill */
+  --attn-soft: #fef3c7;     /* amber-100 — row wash */
+  --attn-line: #f59e0b;     /* amber-500 — left accent border */
+  --block: #b91c1c;         /* red-700 */
+  --block-fg: #fef2f2;      /* red-50 */
+  --block-soft: #fee2e2;    /* red-100 */
+  --block-line: #ef4444;    /* red-500 */
 }
 
 /* Dark palette — soft slate, not pure black. */
@@ -60,10 +91,101 @@
   --accent-fg: #ffffff;
   --code: #0f172a;          /* slate-900 */
   --code-fg: #cbd5e1;       /* slate-300 */
+
+  /* Attention (amber) + Blocked (red) — tuned for the slate-900 canvas. */
+  --attn: #d97706;          /* amber-600 */
+  --attn-fg: #fffbeb;       /* amber-50 */
+  --attn-soft: #78350f33;   /* amber-900 @ 20% — subtle row wash on dark */
+  --attn-line: #f59e0b;     /* amber-500 */
+  --block: #dc2626;         /* red-600 */
+  --block-fg: #fef2f2;      /* red-50 */
+  --block-soft: #7f1d1d33;  /* red-900 @ 20% */
+  --block-line: #ef4444;    /* red-500 */
 }
 
 html,
 body {
   margin: 0;
   background: var(--canvas);
+  font-family: var(--font-sans);
+}
+
+/* ── Motion ─────────────────────────────────────────────────────────────────
+   CSS-only. Reduced-motion users get the final state with no animation. */
+@media (prefers-reduced-motion: no-preference) {
+  /* One staggered list reveal on load. Each item sets --i to its index:
+       <tr class="stagger-in" :style="{ '--i': i }">
+     Delay is capped so long fleets don't crawl in. */
+  @keyframes loom-stagger-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .stagger-in {
+    opacity: 0;
+    animation: loom-stagger-in 0.28s ease-out forwards;
+    /* min(index, 12) * 30ms — caps cumulative delay at ~360ms. */
+    animation-delay: calc(min(var(--i, 0), 12) * 30ms);
+  }
+
+  /* Subtle, slow breath for rows that need a human. Pair with the amber/red
+     row wash (bg-attn-soft / border-l-2 border-attn-line). Not a flash. */
+  @keyframes loom-pulse-attention {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.72;
+    }
+  }
+
+  .pulse-attention {
+    animation: loom-pulse-attention 2.8s ease-in-out infinite;
+  }
+}
+
+/* Reduced motion: ensure staggered items are visible (no animation ran). */
+@media (prefers-reduced-motion: reduce) {
+  .stagger-in {
+    opacity: 1;
+  }
+}
+
+/* Reusable presentation primitives. Token-only, so they're auto light/dark
+   correct. Both pages use these instead of re-typing the class run. */
+
+/* Mono metadata chip — for ids, refs, agent/model, paths in the header run. */
+@utility meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 0.25rem;
+  background: var(--input);
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  padding: 0.0625rem 0.375rem;
+  white-space: nowrap;
+}
+
+/* Neutral pill — generic count/label pill (filter counts, issue counts,
+   the "N archived" reveal chip). Lifecycle StatusBadge keeps its own markup. */
+@utility pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  background: var(--subtle);
+  color: var(--muted);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  padding: 0.0625rem 0.5rem;
 }

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -34,7 +34,6 @@ export interface Session {
   model: string;
   /** Reasoning effort ('', 'low', 'medium', 'high', 'xhigh', 'max') — `--effort`. */
   effort: string;
-  pending_prompt: string;
   github_repo: string | null;
   last_activity_at: string;
   created_at: string;

--- a/crates/loom/frontend/src/views/FileBrowser.vue
+++ b/crates/loom/frontend/src/views/FileBrowser.vue
@@ -5,8 +5,18 @@ import { get } from '../api';
 import type { Session, FileTree, FileContent } from '../types';
 import { theme } from '../theme';
 import { loadMonaco, monacoTheme, languageForPath } from '../monaco';
+import { useRouter } from 'vue-router';
+import SessionTabs from '../components/SessionTabs.vue';
 
 const props = defineProps<{ id: string }>();
+const router = useRouter();
+
+// Selecting a non-Files tab from the file browser returns to the session page,
+// which always lands on its default (Terminal) surface — cross-surface tab
+// memory isn't worth a query param.
+function selectTab() {
+  router.push(`/s/${props.id}`);
+}
 
 // ---------------------------------------------------------------------------
 // Tree model — a flat path list from the API assembled into a folder tree.
@@ -358,13 +368,13 @@ onUnmounted(teardownEditors);
 
 <template>
   <div class="flex flex-col">
-    <!-- Header -->
+    <!-- Header — the shared session sub-nav (Files active) over the title row. -->
+    <SessionTabs :tab="'files'" :id="props.id" :issue-count="0" @select="selectTab" />
     <div class="flex items-center gap-3 mb-3">
-      <router-link :to="`/s/${props.id}`" class="text-muted hover:text-fg text-sm">← session</router-link>
       <h1 class="text-lg font-semibold truncate">
         {{ session?.branch.title || session?.branch.name || 'Files' }}
       </h1>
-      <span v-if="changedCount" class="text-xs text-amber-500">{{ changedCount }} changed</span>
+      <span v-if="changedCount" class="text-xs text-attn">{{ changedCount }} changed</span>
       <button
         class="ml-auto rounded bg-subtle hover:bg-subtle-hover px-2 py-1 text-xs"
         @click="refresh"

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import { get, post, patch, del } from '../api';
 import type { Session, WeaverEvent, Issue } from '../types';
-import StatusBadge from '../components/StatusBadge.vue';
-import AttentionBadge from '../components/AttentionBadge.vue';
 import AgentTerminal from '../components/AgentTerminal.vue';
-import ScratchPanel from '../components/ScratchPanel.vue';
+import SessionPageHeader from '../components/SessionPageHeader.vue';
+import SessionStatusStrip from '../components/SessionStatusStrip.vue';
+import SessionTabs from '../components/SessionTabs.vue';
+import SessionOverview from '../components/SessionOverview.vue';
+import SessionIssues from '../components/SessionIssues.vue';
 
 const props = defineProps<{ id: string }>();
 const router = useRouter();
+const route = useRoute();
 
 const ws = ref<Session | null>(null);
 const events = ref<WeaverEvent[]>([]);
@@ -18,24 +21,24 @@ const backlog = ref<Issue[]>([]);
 const error = ref('');
 const notice = ref('');
 
-const titleDraft = ref('');
-const goalDraft = ref('');
-// The agent's status: an attention level plus a current-state message. The two
-// are one signal (set together via `weaver set-status`), so the dashboard edits
-// them together too.
-const attnLevelDraft = ref('ok');
-const statusMsgDraft = ref('');
-
 const busy = ref('');
+
+// Work-area tab. Terminal is the default surface — "show me what it's doing" —
+// and stays mounted under v-show across all tabs (tearing down the
+// WebSocket/xterm/WebGL is the worst thing on a terminal-first page). Files is
+// a route, not a tab here, so Monaco never loads just because a session opened.
+// A `?tab=` query deep-links a tab (e.g. the list's open-issue link → issues).
+const initialTab = route.query.tab;
+const tab = ref<'terminal' | 'overview' | 'issues'>(
+  initialTab === 'overview' || initialTab === 'issues' ? initialTab : 'terminal',
+);
+
+const issueCount = computed(() => issues.value.length + backlog.value.length);
 
 let source: EventSource | null = null;
 
 async function loadSession() {
   ws.value = (await get(`/sessions/${props.id}`)) as Session;
-  titleDraft.value = ws.value.branch.title;
-  goalDraft.value = ws.value.branch.goal;
-  attnLevelDraft.value = ws.value.branch.attention || 'ok';
-  statusMsgDraft.value = ws.value.branch.description;
 }
 
 async function loadIssues() {
@@ -64,16 +67,6 @@ async function loadAll() {
     error.value = (e as Error).message;
   }
 }
-
-const saveStatus = () =>
-  act('status', async () => {
-    await patch(`/sessions/${props.id}`, {
-      attention: attnLevelDraft.value,
-      description: statusMsgDraft.value,
-    });
-    notice.value = 'Status updated.';
-    await loadSession();
-  });
 
 function openStream() {
   source = new EventSource(`/api/sessions/${props.id}/events`);
@@ -104,17 +97,22 @@ async function act(name: string, fn: () => Promise<void>) {
   }
 }
 
-const saveTitle = () =>
+// Title is the one branch field a human authors (a label for the workstream);
+// it is renamed inline from the header. Goal and the status message are written
+// by the AGENT (`weaver set-status`, the launch prompt) and are read-only here.
+const rename = (title: string) =>
   act('title', async () => {
-    await patch(`/sessions/${props.id}`, { title: titleDraft.value });
+    await patch(`/sessions/${props.id}`, { title });
     notice.value = 'Title saved.';
     await loadSession();
   });
 
-const saveGoal = () =>
-  act('goal', async () => {
-    await patch(`/sessions/${props.id}`, { goal: goalDraft.value });
-    notice.value = 'Goal saved.';
+// The only attention write a human makes: acknowledge the agent's signal by
+// clearing it back to `ok`. Leaves the current-state message untouched.
+const acknowledge = () =>
+  act('acknowledge', async () => {
+    await patch(`/sessions/${props.id}`, { attention: 'ok' });
+    notice.value = 'Marked OK.';
     await loadSession();
   });
 
@@ -167,213 +165,36 @@ onUnmounted(() => source?.close());
 
 <template>
   <div v-if="ws">
-    <div class="flex items-center gap-3 mb-1">
-      <router-link to="/" class="text-muted hover:text-muted text-sm">← all</router-link>
-      <h1 class="text-xl font-semibold">{{ ws.branch.title || ws.branch.name }}</h1>
-      <AttentionBadge :level="ws.branch.attention || 'ok'" :note="ws.branch.description" />
-      <StatusBadge :status="ws.status" />
-    </div>
-    <p
-      v-if="ws.branch.description"
-      class="text-sm text-muted mb-1"
-      data-testid="status-message"
-    >
-      {{ ws.branch.description }}
-    </p>
-    <div class="text-xs text-faint font-mono mb-1">
-      {{ ws.id }} · {{ ws.branch.branch }} (base {{ ws.branch.base_branch }}) ·
-      {{ ws.agent_kind }} · {{ ws.tmux_session }}
-      <span v-if="ws.github_repo"> · {{ ws.github_repo }}</span>
-    </div>
-    <div class="text-xs text-faint font-mono mb-4">
-      worktree: {{ ws.work_dir }} ·
-      <router-link :to="`/s/${props.id}/files`" class="text-accent hover:underline">browse files →</router-link>
-    </div>
+    <SessionPageHeader :ws="ws" @rename="rename" />
+    <SessionStatusStrip :ws="ws" @acknowledge="acknowledge" />
 
-    <p v-if="error" class="mb-3 text-sm text-red-400">{{ error }}</p>
+    <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
     <p v-if="notice" class="mb-3 text-sm text-accent">{{ notice }}</p>
 
-    <section
-      v-if="ws.pending_prompt"
-      class="mb-5 rounded border border-amber-700/60 bg-amber-950/40 p-4"
-    >
-      <div class="mb-2 text-xs font-medium text-amber-300">
-        Waiting for input — the agent is blocked on this prompt:
-      </div>
-      <pre
-        class="max-h-72 overflow-auto rounded bg-code p-3 text-xs leading-snug text-code-fg whitespace-pre-wrap"
-      >{{ ws.pending_prompt }}</pre>
-      <p class="mt-2 text-xs text-muted">
-        Answer it directly in the terminal below, or <code>loom attach {{ ws.id }}</code>.
-      </p>
+    <SessionTabs :tab="tab" :id="props.id" :issue-count="issueCount" @select="tab = $event" />
+
+    <!-- Terminal (default) — the full-width hero. v-show, NEVER v-if: keeping
+         the host in the DOM means AgentTerminal's zero-size guard skips the
+         bogus resize while hidden, and its ResizeObserver re-fits on return.
+         No wrapper chrome — the terminal IS the surface. -->
+    <section v-show="tab === 'terminal'">
+      <AgentTerminal :id="props.id" />
     </section>
 
-    <div class="grid gap-5 lg:grid-cols-3">
-      <!-- Left: title, goal, status, issues, actions -->
-      <div class="space-y-5 lg:col-span-1">
-        <section class="rounded border border-line bg-surface p-4">
-          <label class="block text-xs text-muted mb-1">Title</label>
-          <input
-            v-model="titleDraft"
-            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none"
-          />
-          <button
-            class="mt-2 rounded bg-subtle hover:bg-subtle-hover px-2 py-1 text-xs"
-            :disabled="busy === 'title'"
-            @click="saveTitle"
-          >
-            Save title
-          </button>
-        </section>
+    <!-- Overview — read-only context (goal, activity, scratch) + lifecycle. -->
+    <SessionOverview
+      v-if="tab === 'overview'"
+      :ws="ws"
+      :events="events"
+      :format="eventLine"
+      :busy="busy"
+      @adopt="adopt"
+      @archive="archive"
+      @remove="remove"
+    />
 
-        <section class="rounded border border-line bg-surface p-4">
-          <label class="block text-xs text-muted mb-1">
-            Goal — the agent's prompt (may be empty)
-          </label>
-          <textarea
-            v-model="goalDraft"
-            rows="3"
-            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none"
-          ></textarea>
-          <button
-            class="mt-2 rounded bg-subtle hover:bg-subtle-hover px-2 py-1 text-xs"
-            :disabled="busy === 'goal'"
-            @click="saveGoal"
-          >
-            Save goal
-          </button>
-        </section>
-
-        <section class="rounded border border-line bg-surface p-4">
-          <label class="block text-xs text-muted mb-1">
-            Status — the agent's signal, set via <code>weaver set-status</code>:
-            an attention level plus a current-state message
-          </label>
-          <select
-            v-model="attnLevelDraft"
-            data-testid="attention-select"
-            class="rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
-          >
-            <option value="ok">OK</option>
-            <option value="attention">Attention</option>
-            <option value="blocked">Blocked</option>
-          </select>
-          <textarea
-            v-model="statusMsgDraft"
-            rows="4"
-            placeholder="Wired up routes; tests pass. Remaining: update the docs."
-            class="mt-2 w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
-          ></textarea>
-          <button
-            class="mt-2 rounded bg-subtle hover:bg-subtle-hover px-2 py-1 text-xs"
-            :disabled="busy === 'status'"
-            @click="saveStatus"
-          >
-            Save status
-          </button>
-        </section>
-
-        <section
-          v-if="issues.length"
-          class="rounded border border-line bg-surface p-4"
-          data-testid="issues-panel"
-        >
-          <div class="flex items-center justify-between mb-2">
-            <span class="text-xs text-muted">
-              Open issues
-              <span class="text-faint">({{ issues.length }})</span>
-            </span>
-            <span class="text-xs text-faint">read-only · manage with <code>weaver issue</code></span>
-          </div>
-          <ul class="space-y-2 text-sm">
-            <li v-for="i in issues" :key="i.id" class="rounded bg-canvas/60 p-2">
-              <div class="flex items-baseline gap-2">
-                <span class="font-mono text-xs text-muted">#{{ i.id }}</span>
-                <span class="text-fg">{{ i.title }}</span>
-              </div>
-              <pre
-                v-if="i.body"
-                class="mt-1 whitespace-pre-wrap text-xs text-muted"
-              >{{ i.body }}</pre>
-            </li>
-          </ul>
-        </section>
-
-        <section
-          v-if="backlog.length"
-          class="rounded border border-line bg-surface p-4"
-          data-testid="backlog-panel"
-        >
-          <div class="flex items-center justify-between mb-2">
-            <span class="text-xs text-muted">
-              Repo backlog
-              <span class="text-faint">({{ backlog.length }})</span>
-            </span>
-            <span class="text-xs text-faint">unclaimed · whole repo</span>
-          </div>
-          <ul class="space-y-1 text-sm">
-            <li
-              v-for="i in backlog"
-              :key="i.id"
-              class="flex items-baseline gap-2 rounded bg-canvas/60 p-2"
-            >
-              <span class="font-mono text-xs text-muted">#{{ i.id }}</span>
-              <span class="text-fg">{{ i.title }}</span>
-            </li>
-          </ul>
-        </section>
-
-        <ScratchPanel :id="props.id" />
-
-        <section class="rounded border border-line bg-surface p-4 flex gap-2">
-          <button
-            v-if="ws.status === 'orphaned'"
-            class="rounded bg-amber-700 hover:bg-amber-600 px-3 py-1.5 text-sm"
-            :disabled="busy === 'adopt'"
-            @click="adopt"
-          >
-            {{ busy === 'adopt' ? 'Adopting…' : 'Adopt' }}
-          </button>
-          <button
-            v-if="ws.status !== 'archived'"
-            class="rounded bg-indigo-700 hover:bg-indigo-600 px-3 py-1.5 text-sm"
-            :disabled="busy === 'archive'"
-            @click="archive"
-          >
-            {{ busy === 'archive' ? 'Archiving…' : 'Archive' }}
-          </button>
-          <button
-            class="rounded bg-red-800 hover:bg-red-700 px-3 py-1.5 text-sm"
-            :disabled="busy === 'remove'"
-            @click="remove"
-          >
-            Remove
-          </button>
-        </section>
-      </div>
-
-      <!-- Right: live terminal, events -->
-      <div class="space-y-5 lg:col-span-2">
-        <section class="rounded border border-line bg-surface p-4">
-          <div class="text-xs text-muted mb-2">Terminal</div>
-          <AgentTerminal :id="props.id" />
-        </section>
-
-        <section class="rounded border border-line bg-surface p-4">
-          <div class="text-xs text-muted mb-2">Activity</div>
-          <ul class="space-y-1 text-sm max-h-60 overflow-auto">
-            <li v-for="ev in events" :key="ev.id" class="flex gap-2">
-              <span class="text-faint font-mono text-xs shrink-0">
-                {{ ev.created_at.slice(11, 19) }}
-              </span>
-              <span class="text-muted">{{ eventLine(ev) }}</span>
-            </li>
-            <li v-if="!events.length" class="text-faint">No activity yet.</li>
-          </ul>
-        </section>
-
-      </div>
-    </div>
+    <!-- Issues — claimed work + repo backlog. -->
+    <SessionIssues v-if="tab === 'issues'" :issues="issues" :backlog="backlog" />
   </div>
   <p v-else class="text-muted">Loading…</p>
 </template>

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -5,6 +5,8 @@ import type { Session, RecentRepo, RepoBranch } from '../types';
 import StatusBadge from '../components/StatusBadge.vue';
 import AttentionBadge from '../components/AttentionBadge.vue';
 import ScratchPicker from '../components/ScratchPicker.vue';
+import { timeAgo } from '../lib/time';
+import { levelOf, messageOf } from '../lib/sessionState';
 
 const sessions = ref<Session[]>([]);
 
@@ -12,36 +14,54 @@ const sessions = ref<Session[]>([]);
 type AttentionFilter = 'all' | 'attention' | 'ok';
 const filter = ref<AttentionFilter>('all');
 
-// The agent-declared attention level, with two guards: an unset value counts as
-// 'ok' (older rows), and an archived session is forced to 'ok' — its agent is
-// gone, so it can't need a human, regardless of any attention left on the
-// branch. Mirrors the backend, which clears attention when a session is
-// archived; this also keeps pre-existing archived rows quiet.
-function levelOf(s: Session): string {
-  if (s.status === 'archived') return 'ok';
-  return s.branch.attention || 'ok';
+// Archived sessions are torn-down workstreams: kept for reference but clutter
+// the live fleet view. Hide them by default; a reveal chip brings them back.
+// They still show when there's nothing else to look at (an all-archived fleet),
+// so the list never reads as empty while archived rows exist.
+const showArchived = ref(false);
+
+const archivedCount = computed(
+  () => sessions.value.filter((s) => s.status === 'archived').length,
+);
+
+// Attention rank: blocked and attention both "need a human" and pin to the top;
+// ok sinks below. Within a rank, preserve the server order (most-recent-first),
+// so the sort is stable and rows don't jitter between 3s polls.
+function rank(s: Session): number {
+  const lvl = levelOf(s);
+  if (lvl === 'blocked') return 0;
+  if (lvl === 'attention') return 1;
+  return 2;
 }
 
-// The agent's current-state message (set with the level via `weaver set-status`)
-// shown beside the attention badge — suppressed for archived sessions so a
-// torn-down workstream doesn't keep displaying a stale message.
-function messageOf(s: Session): string {
-  return s.status === 'archived' ? '' : s.branch.description;
-}
+// The ordered, archived-aware base list: attention pinned to the top, archived
+// hidden unless revealed (or unless every session is archived — see above).
+const ordered = computed<Session[]>(() => {
+  const all = sessions.value;
+  const live = all.filter((s) => s.status !== 'archived');
+  // Hide archived by default; reveal on toggle; always show if nothing else.
+  const base = showArchived.value || live.length === 0 ? all : live;
+  // Stable sort by attention rank (Array.prototype.sort is stable in modern JS).
+  return [...base].sort((a, b) => rank(a) - rank(b));
+});
 
+// Counts reflect the full fleet (NOT the archived-hidden view) so the filter
+// chips read the true picture; levelOf() already forces archived → ok, keeping
+// "needs attention" honest.
 const counts = computed(() => {
   const c = { all: sessions.value.length, attention: 0, ok: 0 };
   for (const s of sessions.value) {
     if (levelOf(s) === 'ok') c.ok += 1;
-    else c.attention += 1; // 'attention' and 'blocked' both "need me"
+    else c.attention += 1; // 'attention' and 'blocked' both need a human
   }
   return c;
 });
 
+// Apply the attention filter on top of the ordered/archived-aware base list.
 const filteredSessions = computed(() => {
-  if (filter.value === 'all') return sessions.value;
-  if (filter.value === 'ok') return sessions.value.filter((s) => levelOf(s) === 'ok');
-  return sessions.value.filter((s) => levelOf(s) !== 'ok');
+  if (filter.value === 'all') return ordered.value;
+  if (filter.value === 'ok') return ordered.value.filter((s) => levelOf(s) === 'ok');
+  return ordered.value.filter((s) => levelOf(s) !== 'ok');
 });
 const recentRepos = ref<RecentRepo[]>([]);
 const error = ref('');
@@ -371,7 +391,7 @@ onUnmounted(() => clearInterval(timer));
             spellcheck="false"
             class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
           />
-          <p v-if="branchesError" class="mt-1 text-xs text-red-400">{{ branchesError }}</p>
+          <p v-if="branchesError" class="mt-1 text-xs text-block">{{ branchesError }}</p>
           <ul
             v-if="branchFocused && branchMatches.length"
             data-testid="branch-options"
@@ -409,88 +429,121 @@ onUnmounted(() => clearInterval(timer));
       </button>
     </form>
 
-    <p v-if="error" class="mb-4 text-sm text-red-400">{{ error }}</p>
+    <p v-if="error" class="mb-4 text-sm text-block">{{ error }}</p>
 
     <p v-if="!sessions.length" class="text-muted text-sm">
       No sessions yet.
     </p>
 
-    <!-- Attention filter: jump straight to the sessions that need a human. -->
-    <div v-if="sessions.length" class="mb-3 inline-flex rounded border border-line text-xs overflow-hidden">
+    <div v-if="sessions.length" class="mb-3 flex items-center gap-3">
+      <!-- Attention filter: jump straight to the sessions that need a human. -->
+      <div class="inline-flex rounded border border-line text-xs overflow-hidden">
+        <button
+          v-for="opt in (['all', 'attention', 'ok'] as const)"
+          :key="opt"
+          type="button"
+          :data-testid="`filter-${opt}`"
+          :class="[
+            'px-3 py-1 border-l border-line first:border-l-0',
+            filter === opt ? 'bg-accent text-accent-fg' : 'bg-input text-muted hover:bg-subtle',
+          ]"
+          @click="filter = opt"
+        >
+          {{ opt === 'all' ? 'All' : opt === 'attention' ? 'Needs attention' : 'OK' }}
+          <span class="opacity-70">{{ counts[opt] }}</span>
+        </button>
+      </div>
+
+      <!-- Archived live below the fold: a quiet chip reveals/hides them. -->
       <button
-        v-for="opt in (['all', 'attention', 'ok'] as const)"
-        :key="opt"
+        v-if="archivedCount"
         type="button"
-        :data-testid="`filter-${opt}`"
+        :aria-pressed="showArchived"
         :class="[
-          'px-3 py-1 border-l border-line first:border-l-0',
-          filter === opt ? 'bg-accent text-accent-fg' : 'bg-input text-muted hover:bg-subtle',
+          'pill transition-colors',
+          showArchived ? 'ring-1 ring-inset ring-line text-fg' : 'hover:bg-subtle-hover',
         ]"
-        @click="filter = opt"
+        @click="showArchived = !showArchived"
       >
-        {{ opt === 'all' ? 'All' : opt === 'attention' ? 'Needs attention' : 'OK' }}
-        <span class="opacity-70">{{ counts[opt] }}</span>
+        {{ showArchived ? 'Hide' : 'Show' }} {{ archivedCount }} archived
       </button>
     </div>
 
     <!--
-      Two orthogonal status axes, one column each, no stacking:
-        · Status — the agent's single "does this need me?" signal: the
-          attention level plus its current-state message (weaver set-status)
-        · State  — the mechanical lifecycle: is the session working or not
-      Session (title + goal) describes the work itself.
+      One signal row per session. Left→right: the agent's single attention
+      signal, the dominant title, its muted current-state line, a neutral
+      lifecycle pill, and the mono branch ref pushed far-right. Attention rows
+      pin to the top (sort in script) and get a left accent-border + slow pulse;
+      ok rows stay quiet. Staggered reveal on load via --i.
     -->
-    <div v-if="sessions.length" class="overflow-x-auto rounded border border-line">
-      <table class="w-full border-collapse text-sm">
-        <thead>
-          <tr class="border-b border-line bg-surface text-left text-xs uppercase tracking-wide text-muted">
-            <th class="px-3 py-2 font-medium">Status</th>
-            <th class="px-3 py-2 font-medium">State</th>
-            <th class="px-3 py-2 font-medium">Session</th>
-            <th class="px-3 py-2 font-medium">Ref</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            v-for="s in filteredSessions"
-            :key="s.id"
-            data-testid="session-card"
-            :data-session-id="s.id"
-            class="border-b border-line last:border-0 hover:bg-surface cursor-pointer"
-            @click="$router.push(`/s/${s.id}`)"
+    <ul v-if="sessions.length" class="overflow-hidden rounded border border-line bg-surface">
+      <li
+        v-for="(s, i) in filteredSessions"
+        :key="s.id"
+        data-testid="session-card"
+        :data-session-id="s.id"
+        :style="{ '--i': i }"
+        :class="[
+          'stagger-in group flex cursor-pointer items-start gap-3 border-b border-line px-3 py-3 last:border-0',
+          'min-h-[3.25rem] transition-colors hover:bg-subtle',
+          levelOf(s) === 'blocked'
+            ? 'border-l-2 border-l-block-line bg-block-soft pulse-attention'
+            : levelOf(s) === 'attention'
+              ? 'border-l-2 border-l-attn-line bg-attn-soft pulse-attention'
+              : '',
+        ]"
+        @click="$router.push(`/s/${s.id}`)"
+      >
+        <!-- Signal: the one reserved loud axis. -->
+        <div class="shrink-0 pt-0.5">
+          <AttentionBadge :level="levelOf(s)" :note="messageOf(s)" />
+        </div>
+
+        <!-- Title + current-state (the work, in prose). -->
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <router-link
+              :to="`/s/${s.id}`"
+              class="truncate text-base font-semibold text-fg hover:text-accent"
+              @click.stop
+            >
+              {{ s.branch.title || s.branch.name }}
+            </router-link>
+            <!-- Lifecycle: demoted, neutral, mono pill (StatusBadge). -->
+            <StatusBadge :status="s.status" class="shrink-0" />
+          </div>
+
+          <!-- Current-state headline (agent's set-status message), else the goal. -->
+          <p
+            v-if="messageOf(s)"
+            class="mt-0.5 truncate text-sm text-muted"
           >
-            <td class="px-3 py-2 align-top">
-              <AttentionBadge :level="levelOf(s)" :note="messageOf(s)" />
-              <span v-if="messageOf(s)" class="mt-1 block max-w-[22rem] truncate text-xs text-muted">
-                {{ messageOf(s) }}
-              </span>
-            </td>
-            <td class="px-3 py-2 align-top">
-              <StatusBadge :status="s.status" />
-            </td>
-            <td class="px-3 py-2 align-top">
-              <router-link
-                :to="`/s/${s.id}`"
-                class="block max-w-[24rem] truncate font-medium text-fg hover:text-accent"
-                @click.stop
-              >
-                {{ s.branch.title || s.branch.name }}
-              </router-link>
-              <span v-if="s.branch.goal" class="block max-w-[24rem] truncate text-xs text-muted">
-                {{ s.branch.goal }}
-              </span>
-            </td>
-            <td class="px-3 py-2 align-top">
-              <div class="font-mono text-xs text-faint">
-                <span class="block truncate">{{ s.branch.branch }}</span>
-                <span v-if="s.branch.open_issue_count" class="text-muted">
-                  {{ s.branch.open_issue_count }} open issue{{ s.branch.open_issue_count === 1 ? '' : 's' }}
-                </span>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            {{ messageOf(s) }}
+          </p>
+          <p
+            v-if="s.branch.goal"
+            class="mt-0.5 truncate text-xs text-faint"
+          >
+            {{ s.branch.goal }}
+          </p>
+        </div>
+
+        <!-- Ref: machine identity, mono, pushed far-right and receding. -->
+        <div class="shrink-0 text-right">
+          <span class="block truncate font-mono text-xs text-faint">{{ s.branch.branch }}</span>
+          <router-link
+            v-if="s.branch.open_issue_count"
+            :to="`/s/${s.id}?tab=issues`"
+            class="font-mono text-xs text-muted hover:text-accent"
+            @click.stop
+          >
+            {{ s.branch.open_issue_count }} open issue{{ s.branch.open_issue_count === 1 ? '' : 's' }}
+          </router-link>
+          <span v-if="s.last_activity_at" class="mt-0.5 block text-xs text-faint">
+            {{ timeAgo(s.last_activity_at) }}
+          </span>
+        </div>
+      </li>
+    </ul>
   </div>
 </template>

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -611,13 +611,6 @@ fn print_session(ws: &Value) {
         }
     }
     println!("  activity: {}", str_field(ws, "last_activity_at"));
-    let prompt = str_field(ws, "pending_prompt");
-    if !prompt.is_empty() {
-        println!("  waiting on:");
-        for line in prompt.lines() {
-            println!("    {line}");
-        }
-    }
 }
 
 async fn cmd_attach(key: String) -> Result<()> {

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -25,7 +25,6 @@ CREATE TABLE IF NOT EXISTS sessions (
     model              TEXT NOT NULL DEFAULT '',
     effort             TEXT NOT NULL DEFAULT '',
     status             TEXT NOT NULL,
-    pending_prompt     TEXT NOT NULL DEFAULT '',
     github_repo        TEXT,
     last_activity_at   TEXT,
     created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -86,7 +86,6 @@ pub async fn run(state: AppState) {
                         "tmux session ended; marking orphaned"
                     );
                     let _ = session_mod::set_status(&state.db, &session.id, "orphaned").await;
-                    let _ = session_mod::set_pending_prompt(&state.db, &session.id, "").await;
                     let _ = events::record(
                         &state.db,
                         &state.bus,
@@ -127,24 +126,17 @@ pub async fn run(state: AppState) {
 /// (this also promotes a freshly-`launching` session). Beyond that:
 ///
 /// * `working` (a prompt was submitted — the user is engaged) clears attention
-///   back to `ok` and drops any pending prompt.
+///   back to `ok`.
 /// * `waiting` (Claude is blocked asking the user) raises attention to
-///   `attention` and snapshots the pane as the pending prompt.
+///   `attention`.
 /// * `idle` (a turn ended) leaves attention untouched — a finished-but-fine
 ///   agent must not be mistaken for one that needs the user. If it actually
 ///   needs something it will have said so via `weaver set-status`.
 async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64> {
-    enum Prompt {
-        Capture,
-        Clear,
-        Leave,
-    }
-    let (attention, prompt): (Option<&str>, Prompt) = match kind {
-        "working" => (Some("ok"), Prompt::Clear),
-        // The captured pane (the pending prompt) is what conveys "waiting for
-        // input"; the hook just raises the level.
-        "waiting" => (Some("attention"), Prompt::Capture),
-        "idle" => (None, Prompt::Leave),
+    let attention: Option<&str> = match kind {
+        "working" => Some("ok"),
+        "waiting" => Some("attention"),
+        "idle" => None,
         // `session-start` and anything unknown carry no status signal.
         _ => return None,
     };
@@ -160,20 +152,6 @@ async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64
         let _ = session_mod::set_status(&state.db, &session.id, "running").await;
     }
     let _ = session_mod::touch(&state.db, &session.id).await;
-
-    match prompt {
-        Prompt::Capture => {
-            let p = tmux::capture(&session.tmux_session, 0)
-                .await
-                .map(|s| s.trim().to_string())
-                .unwrap_or_default();
-            let _ = session_mod::set_pending_prompt(&state.db, &session.id, &p).await;
-        }
-        Prompt::Clear => {
-            let _ = session_mod::set_pending_prompt(&state.db, &session.id, "").await;
-        }
-        Prompt::Leave => {}
-    }
 
     // Attention, only when the hook carries a signal and the level differs.
     let mut attention_changed: Option<&str> = None;

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -20,7 +20,6 @@ pub struct Session {
     /// Reasoning effort ('', 'low', 'medium', 'high', 'xhigh', 'max') — `--effort`.
     pub effort: String,
     pub status: String,
-    pub pending_prompt: String,
     pub github_repo: Option<String>,
     pub last_activity_at: Option<String>,
     pub created_at: String,
@@ -151,15 +150,6 @@ pub async fn set_status(db: &Db, id: &str, status: &str) -> Result<()> {
 pub async fn touch(db: &Db, id: &str) -> Result<()> {
     sqlx::query("UPDATE sessions SET last_activity_at = ? WHERE id = ?")
         .bind(now_iso())
-        .bind(id)
-        .execute(db)
-        .await?;
-    Ok(())
-}
-
-pub async fn set_pending_prompt(db: &Db, id: &str, prompt: &str) -> Result<()> {
-    sqlx::query("UPDATE sessions SET pending_prompt = ? WHERE id = ?")
-        .bind(prompt)
         .bind(id)
         .execute(db)
         .await?;

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -31,7 +31,6 @@
 //!   "work_dir": "/path/to/.worktrees/foo",
 //!   "tmux_session": "weaver-abcd1234",
 //!   "agent_kind": "claude",
-//!   "pending_prompt": "",
 //!   "github_repo": null,
 //!   "last_activity_at": "...",
 //!   "created_at": "...",
@@ -221,7 +220,6 @@ pub struct SessionView {
     pub agent_kind: String,
     pub model: String,
     pub effort: String,
-    pub pending_prompt: String,
     pub github_repo: Option<String>,
     pub last_activity_at: String,
     pub created_at: String,
@@ -240,7 +238,6 @@ impl SessionView {
             agent_kind: session.agent_kind.clone(),
             model: session.model.clone(),
             effort: session.effort.clone(),
-            pending_prompt: session.pending_prompt.clone(),
             github_repo: session.github_repo.clone(),
             last_activity_at: session
                 .last_activity_at
@@ -964,17 +961,12 @@ async fn archive_session(
     }
     session_mod::set_status(&st.db, &session.id, "archived").await?;
     // An archived session is finished with: its agent is gone, so it can no
-    // longer "need me". Clear any lingering attention (and the snapshotted
-    // pending prompt) so the dashboard stops flagging a torn-down workstream.
-    // Attention is the agent's live "does this need a human?" signal; nothing
-    // is live here any more. The history (goal, notes, description) is kept.
+    // longer "need me". Clear any lingering attention so the dashboard stops
+    // flagging a torn-down workstream. Attention is the agent's live "does this
+    // need a human?" signal; nothing is live here any more. The history (goal,
+    // notes, description) is kept.
     if branch.attention != branch_mod::DEFAULT_ATTENTION {
         branch_mod::set_attention(&st.db, &branch.id, branch_mod::DEFAULT_ATTENTION).await?;
-    }
-    if !session.pending_prompt.is_empty() {
-        session_mod::set_pending_prompt(&st.db, &session.id, "")
-            .await
-            .ok();
     }
     events::record(
         &st.db,

--- a/docs/browser-terminal.md
+++ b/docs/browser-terminal.md
@@ -22,8 +22,8 @@ an agent and they are both worse than a terminal:
   (degraded: line-at-a-time, no keys, no TUI, no feedback except the next
   screenshot).
 
-The structured/status data plane (working / waiting / idle / `pending_prompt`)
-already comes from the **weaver hooks → events → SSE** pipeline. The browser
+The structured/status data plane (working / waiting / idle → lifecycle +
+attention) already comes from the **weaver hooks → events → SSE** pipeline. The browser
 stream's *only* job is interacting with a PTY. So we collapse the two degraded
 input paths into one real one and delete the rest.
 

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -1,40 +1,50 @@
 import { test, expect } from '../fixtures/weaver';
 
 test.describe('session detail view', () => {
-  test('renders goal, description, status and branch', async ({ page, weaver }) => {
+  test('renders goal, status and identity metadata', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Render my details', name: 'detail-task' });
 
     await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
 
     await expect(page.getByRole('heading', { name: 'detail-task' })).toBeVisible();
-    // Goal textarea is the first textarea on the page.
-    await expect(page.locator('textarea').first()).toHaveValue('Render my details');
-    // Metadata line includes id, branch and base branch.
-    await expect(page.getByText(s.id, { exact: false })).toBeVisible();
-    await expect(page.getByText(s.branch.branch, { exact: false })).toBeVisible();
-    await expect(page.getByText(`base ${s.branch.base_branch}`, { exact: false })).toBeVisible();
-    // Status badge is present in the header.
+    // Status (lifecycle) badge is present in the header.
     await expect(page.getByTestId('status-badge').first()).toBeVisible();
+
+    // The goal is the agent's launch prompt — read-only prose on the Overview
+    // tab, not an editable field.
+    await page.getByRole('button', { name: 'Overview' }).click();
+    await expect(page.getByText('Render my details')).toBeVisible();
+
+    // Identity metadata (id, branch, base) lives behind the ⌄ details popover,
+    // not cluttering the header. Scope to the popover and match exactly so the
+    // id doesn't also match the `weaver-<id>` tmux line.
+    await page.getByRole('button', { name: 'details' }).click();
+    const details = page.getByTestId('details-popover');
+    await expect(details.getByText(s.id, { exact: true })).toBeVisible();
+    await expect(details.getByText(s.branch.branch, { exact: true })).toBeVisible();
+    await expect(details.getByText(`base ${s.branch.base_branch}`)).toBeVisible();
   });
 
-  test('editing the goal and saving persists across reload', async ({ page, weaver }) => {
-    const s = await weaver.seedSession({ goal: 'Original goal', name: 'edit-task' });
+  test('Mark OK acknowledges the agent’s attention', async ({ page, weaver }) => {
+    const s = await weaver.seedSession({ goal: 'Acknowledge me', name: 'ack-task' });
+    // The agent raises its attention; the human's only write here is to clear it.
+    await weaver.setStatus(s, 'attention', 'waiting on review');
 
     await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
 
-    const goalArea = page.locator('textarea').first();
-    await expect(goalArea).toHaveValue('Original goal');
-    await goalArea.fill('Updated goal text');
-    await page.getByRole('button', { name: 'Save goal' }).click();
-    await expect(page.getByText('Goal saved.')).toBeVisible();
+    // Attention is shown once, on the conversation-state strip, with the one
+    // human control beside it.
+    const conv = page.getByTestId('conversation-state');
+    await expect(conv).toHaveText(/needs attention/i);
 
-    // Server-side state changed.
+    await page.getByTestId('acknowledge').click();
+
+    // The strip clears (and the acknowledge control goes away)…
+    await expect(conv).not.toHaveText(/needs attention/i);
+    await expect(page.getByTestId('acknowledge')).toHaveCount(0);
+    // …and it's cleared server-side.
     const updated = await weaver.getSession(s.id);
-    expect(updated.branch.goal).toBe('Updated goal text');
-
-    // And it survives a full reload.
-    await page.reload();
-    await expect(page.locator('textarea').first()).toHaveValue('Updated goal text');
+    expect(updated.branch.attention).toBe('ok');
   });
 
   test('renders an interactive terminal that connects to the agent', async ({

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -66,6 +66,8 @@ test.describe('session list view', () => {
 
     await expect(page).toHaveURL(new RegExp(`#/s/${s.id}$`));
     await expect(page.getByRole('heading', { name: 'nav-task' })).toBeVisible();
-    await expect(page.locator('textarea').first()).toHaveValue('Navigate to me');
+    // The goal is read-only prose on the Overview tab (agent-authored).
+    await page.getByRole('button', { name: 'Overview' }).click();
+    await expect(page.getByText('Navigate to me')).toBeVisible();
   });
 });

--- a/e2e/tests/remove.spec.ts
+++ b/e2e/tests/remove.spec.ts
@@ -10,6 +10,9 @@ test.describe('removing a session', () => {
     await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
     await expect(page.getByRole('heading', { name: 'remove-task' })).toBeVisible();
 
+    // Lifecycle actions live on the Overview tab, off the terminal-first default.
+    await page.getByRole('button', { name: 'Overview' }).click();
+
     // Remove uses a native confirm() dialog — accept it.
     page.once('dialog', (dialog) => {
       expect(dialog.type()).toBe('confirm');
@@ -31,6 +34,7 @@ test.describe('removing a session', () => {
     const s = await weaver.seedSession({ goal: 'Keep me', name: 'keep-task' });
 
     await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    await page.getByRole('button', { name: 'Overview' }).click();
 
     page.once('dialog', (dialog) => dialog.dismiss());
     await page.getByRole('button', { name: 'Remove' }).click();

--- a/e2e/tests/status-hook.spec.ts
+++ b/e2e/tests/status-hook.spec.ts
@@ -6,7 +6,8 @@ test.describe('status reflects hook and attention events', () => {
 
     await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
     const status = page.getByTestId('status-badge').first();
-    const attention = page.getByTestId('attention-badge').first();
+    // The agent's attention is shown once, on the conversation-state strip.
+    const conv = page.getByTestId('conversation-state');
     await expect(status).toBeVisible();
 
     // Any hook means the agent process is alive → lifecycle `running`.
@@ -15,18 +16,18 @@ test.describe('status reflects hook and attention events', () => {
 
     // A `waiting` hook (Claude blocked on the user) raises the attention axis.
     await weaver.hook(s, 'waiting');
-    await expect(attention).toHaveText(/attention/i);
+    await expect(conv).toHaveText(/needs attention/i);
   });
 
   test('detail view: weaver set-status sets level + message via SSE', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Declare my status', name: 'status-detail' });
 
     await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
-    const attention = page.getByTestId('attention-badge').first();
-    await expect(attention).toBeVisible();
+    const conv = page.getByTestId('conversation-state');
+    await expect(conv).toBeVisible();
 
     await weaver.setStatus(s, 'blocked', 'tests failing, need help');
-    await expect(attention).toHaveText(/blocked/i);
+    await expect(conv).toHaveText(/blocked/i);
     await expect(page.getByTestId('status-message')).toHaveText(/tests failing, need help/i);
   });
 


### PR DESCRIPTION
Reworks the loom dashboard around the terminal and the agent's own signals, plus a live-reload dev surface for iterating against a running server. All of this was built and verified live against the running backend.

## List / dashboard
- One **signal row** per session: attention · title · current-state · mono ref. **Archived hidden by default** (reveal chip); attention **pinned to the top** with a subtle pulse.
- **Colour discipline**: a single reserved accent for "needs a human"; lifecycle badges demoted to neutral tokens. New `attn`/`block` semantic tokens + CSS-only `stagger-in`/`pulse-attention` utilities (reduced-motion safe).

## Session detail
- **Tabbed work area** — Terminal / Overview / Issues / Files. The **terminal is a chrome-free full-width hero** and the default tab.
- **Goal and the status message are agent-authored → read-only** (on the Overview tab). The only human writes are **inline title rename** (header ✎), **attention acknowledge** (`Mark OK`), and lifecycle (Adopt/Archive/Remove).
- Header collapsed to one quiet `repo/branch · agent` line; `id`/`branch`/`base`/`tmux`/`worktree` moved behind a `⌄ details` popover.
- **Attention is shown once** — on the conversation-state strip (removed the duplicate header badge), with `Mark OK` beside it.

## `pending_prompt` removal
The captured tmux pane (`pending_prompt`) was an unreliable "needs input" signal: it's only cleared by a `working` hook, so it lingered on watcher/loop sessions and after an acknowledge, producing **phantom "Blocked — needs input"** states. Removed end to end — monitor capture, `Session` struct/setter, DB column, API field, CLI `waiting on:` line, and docs. The agent's **declared attention level** (hooks / `weaver set-status`) is the signal; the live prompt is read straight from the terminal.

## Dev server
`npm run dev` (`rspack serve`) gives Vue **HMR**, proxying `/api` (REST + SSE + the terminal **WebSocket**) to the running loom backend — with an **Origin rewrite** so the backend's CSWSH guard accepts the proxied terminal handshake. The production build path is unchanged.

## Verification
- `cargo build` ✓ · `cargo test -p loom` ✓
- Playwright e2e suite **17/17** (specs updated to the read-only model: goal read-only in Overview, identity in the popover, `Mark OK` acknowledge replacing the goal-edit test, lifecycle reached via the Overview tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)