### PR TITLE
loom UI: drop SPA hash routing for clean HTML5 paths

### DIFF
--- a/crates/loom/frontend/rspack.config.js
+++ b/crates/loom/frontend/rspack.config.js
@@ -20,6 +20,10 @@ module.exports = (_env, argv) => {
     output: {
       path: path.resolve(__dirname, '../static/dist'),
       filename: isDev ? 'app.js' : 'app.[contenthash:8].js',
+      // Absolute so assets resolve from any route depth. With HTML5 history
+      // routing a deep link like /s/abc/files must still load /app.xxxx.js, not
+      // /s/abc/app.xxxx.js — the default 'auto' would emit a relative src.
+      publicPath: '/',
       clean: !isDev,
     },
     resolve: {
@@ -47,7 +51,8 @@ module.exports = (_env, argv) => {
       hot: true,
       // Don't gzip; it buffers the `/api/.../events` SSE stream.
       compress: false,
-      // SPA deep links (the app uses hash routing, but keep this for safety).
+      // Serve index.html for SPA deep links (HTML5 history routing) so a
+      // hard refresh on /s/abc doesn't 404.
       historyApiFallback: true,
       client: {
         overlay: { errors: true, warnings: false },

--- a/crates/loom/frontend/src/main.ts
+++ b/crates/loom/frontend/src/main.ts
@@ -1,5 +1,5 @@
 import { createApp } from 'vue';
-import { createRouter, createWebHashHistory } from 'vue-router';
+import { createRouter, createWebHistory } from 'vue-router';
 import App from './App.vue';
 import SessionList from './views/SessionList.vue';
 import SessionDetail from './views/SessionDetail.vue';
@@ -8,7 +8,7 @@ import Settings from './views/Settings.vue';
 import './styles.css';
 
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHistory(),
   routes: [
     { path: '/', component: SessionList },
     { path: '/s/:id', component: SessionDetail, props: true },

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -4,7 +4,7 @@ test.describe('session detail view', () => {
   test('renders goal, status and identity metadata', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Render my details', name: 'detail-task' });
 
-    await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
 
     await expect(page.getByRole('heading', { name: 'detail-task' })).toBeVisible();
     // Status (lifecycle) badge is present in the header.
@@ -30,7 +30,7 @@ test.describe('session detail view', () => {
     // The agent raises its attention; the human's only write here is to clear it.
     await weaver.setStatus(s, 'attention', 'waiting on review');
 
-    await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
 
     // Attention is shown once, on the conversation-state strip, with the one
     // human control beside it.
@@ -53,7 +53,7 @@ test.describe('session detail view', () => {
   }) => {
     const s = await weaver.seedSession({ goal: 'Receive a command', name: 'term-task' });
 
-    await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
 
     // The xterm.js terminal mounts.
     await expect(page.locator('.xterm')).toBeVisible();

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -64,7 +64,7 @@ test.describe('session list view', () => {
     await page.goto(weaver.baseUrl);
     await page.locator(`[data-session-id="${s.id}"]`).click();
 
-    await expect(page).toHaveURL(new RegExp(`#/s/${s.id}$`));
+    await expect(page).toHaveURL(new RegExp(`/s/${s.id}$`));
     await expect(page.getByRole('heading', { name: 'nav-task' })).toBeVisible();
     // The goal is read-only prose on the Overview tab (agent-authored).
     await page.getByRole('button', { name: 'Overview' }).click();

--- a/e2e/tests/remove.spec.ts
+++ b/e2e/tests/remove.spec.ts
@@ -7,7 +7,7 @@ test.describe('removing a session', () => {
   }) => {
     const s = await weaver.seedSession({ goal: 'Delete me', name: 'remove-task' });
 
-    await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
     await expect(page.getByRole('heading', { name: 'remove-task' })).toBeVisible();
 
     // Lifecycle actions live on the Overview tab, off the terminal-first default.
@@ -21,7 +21,7 @@ test.describe('removing a session', () => {
     await page.getByRole('button', { name: 'Remove' }).click();
 
     // Router pushes back to the list.
-    await expect(page).toHaveURL(/#\/$/);
+    await expect(page).toHaveURL(/\/$/);
     await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
     await expect(page.getByText('No sessions yet.')).toBeVisible();
 
@@ -33,14 +33,14 @@ test.describe('removing a session', () => {
   test('dismissing the confirm dialog keeps the session', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Keep me', name: 'keep-task' });
 
-    await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
     await page.getByRole('button', { name: 'Overview' }).click();
 
     page.once('dialog', (dialog) => dialog.dismiss());
     await page.getByRole('button', { name: 'Remove' }).click();
 
     // Still on the detail page, still present server-side.
-    await expect(page).toHaveURL(new RegExp(`#/s/${s.id}$`));
+    await expect(page).toHaveURL(new RegExp(`/s/${s.id}$`));
     const all = await weaver.listSessions();
     expect(all).toHaveLength(1);
   });

--- a/e2e/tests/status-hook.spec.ts
+++ b/e2e/tests/status-hook.spec.ts
@@ -4,7 +4,7 @@ test.describe('status reflects hook and attention events', () => {
   test('detail view: hooks drive lifecycle + attention via SSE', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Watch my status', name: 'hook-detail' });
 
-    await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
     const status = page.getByTestId('status-badge').first();
     // The agent's attention is shown once, on the conversation-state strip.
     const conv = page.getByTestId('conversation-state');
@@ -22,7 +22,7 @@ test.describe('status reflects hook and attention events', () => {
   test('detail view: weaver set-status sets level + message via SSE', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Declare my status', name: 'status-detail' });
 
-    await page.goto(`${weaver.baseUrl}/#/s/${s.id}`);
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
     const conv = page.getByTestId('conversation-state');
     await expect(conv).toBeVisible();
 


### PR DESCRIPTION
## What

Switch the loom UI from hash routing (`http://localhost:7878/#/s/<id>`) to clean HTML5 history paths (`http://localhost:7878/s/<id>`).

The hash structure was legacy — the app already had everything unhashed history mode needs:

- The API is namespaced under `/api`, so there are no route collisions.
- The loom server already serves `index.html` as a fallback for any unmatched non-`/api` path (`web.rs:378`), so deep links and hard refreshes resolve.
- The dev server already sets `historyApiFallback: true`.
- Every internal link is router-relative (`:to="/s/..."`), so they simply stop emitting the leading `#`.

## Changes

- **`main.ts`** — `createWebHashHistory()` → `createWebHistory()`.
- **`rspack.config.js`** — set `output.publicPath: '/'` so assets resolve from any route depth. (The one real gotcha: with the default `'auto'`, a deep link like `/s/abc/files` would request a relative `/s/abc/app.xxxx.js` and 404. Absolute `/app.xxxx.js` fixes it.) Also refreshed two stale "hash routing" comments.
- **e2e specs** — navigate to `/s/:id` instead of `/#/s/:id` and match unhashed URLs.

URLs are now `/`, `/s/<id>`, `/s/<id>/files`, `/settings`.

## Verification

- Frontend builds clean; emitted `index.html` references absolute `/app.*.js` / `/app.*.css`.
- Full Playwright suite **17/17 passing**, including the deep-link `goto(.../s/<id>)` tests (hard load → server fallback → router + absolute assets) and the `toHaveURL` URL-shape assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)