### PR TITLE
loom: poll GitHub for PR/review status and archive on merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ needing the daemon to be reachable.
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
 | `crates/loom/src/tmux.rs` | `tmux new-session / capture-pane / kill-session / attach` (exact-match `=name:` targets) |
 | `crates/loom/src/terminal.rs` | WebSocket ⇄ PTY bridge: xterm.js ⇄ `tmux attach` (the live terminal) |
-| `crates/loom/src/github.rs` | `gh` CLI shell-out for issue seeding |
+| `crates/loom/src/github.rs` | `gh` CLI shell-out: issue seeding, PR opening, and the PR-status poll loop (snapshots each branch's PR; archives on merge) |
 | `crates/loom/src/client.rs` | HTTP client used by the `loom` CLI to talk to its own daemon |
 | `crates/loom/src/bin/loom.rs` | the orchestrator CLI (`serve`, `launch`, `ps`, `attach`, …) |
 | `crates/loom/frontend/` | Vue 3 SPA, rspack, Tailwind. `api.ts` + views in `views/` |
@@ -124,8 +124,8 @@ the PR, not integrating it yourself (see the builtin
   shared by `weaver` and `loom`. WAL mode handles concurrency.
   - Core tables (`weaver-core/src/db.rs`): `branches`, `issues`, `notes`,
     `events`, `settings`.
-  - Loom tables (`crates/loom/src/db.rs`): `sessions`, `summaries`,
-    `recent_repos`.
+  - Loom tables (`crates/loom/src/db.rs`): `sessions`, `recent_repos`,
+    `branch_github` (per-branch PR snapshot).
 - **`server.json`** in `$WEAVER_HOME`: pid + bound addr, written when `loom`
   comes up. The `loom` CLI uses it to find the daemon when `WEAVER_API` is
   unset.
@@ -144,6 +144,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]`) |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description, attention) |
 | `POST /api/sessions/{id}/{note,archive,adopt}` | actions |
+| `POST /api/sessions/{id}/github` | re-poll the branch's GitHub PR now and return the updated session |
 | `GET POST DELETE /api/sessions/{id}/scratch` | list / drop / remove worktree `scratch/` reference files |
 | `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ PTY ⇄ tmux (the interaction surface) |
@@ -160,7 +161,12 @@ top-level (`id`, `status`, `work_dir`, `tmux_session`, `agent_kind`, `model`,
 `created_at`, `updated_at`) plus a nested `branch: BranchView`
 (`id`, `name`, `title`, `goal`, `description`, `attention`,
 `repo_root`, `branch`, `base_branch`, `created_at`, `updated_at`,
-`open_issue_count`).
+`open_issue_count`, `github`).
+
+`BranchView::github` is the branch's latest GitHub pull-request snapshot
+(`pr_number`, `pr_url`, `pr_state`, `pr_title`, `is_draft`, `review_decision`,
+`checks`, `mergeable`, `merged_at`, `fetched_at`), or `null` when GitHub polling
+is off, there is no PR, or `gh` is unavailable. See "GitHub integration" below.
 
 Status is two orthogonal axes. The session's `status` is the **lifecycle**
 (orchestrator-owned, mechanical): `created` / `launching` / `running` /
@@ -247,6 +253,41 @@ session as `ok` regardless of a stale attention value left on the branch.
 
 Orphan detection is independent: if `tmux has-session` says no, the session
 becomes `orphaned` and is eligible for `loom adopt`.
+
+## GitHub integration
+
+When the `gh` CLI is installed and authenticated, loom keeps a per-branch
+pull-request snapshot alongside the session. A second background loop
+(`github::poll`, sibling of the monitor, spawned in `server::serve`) ticks every
+30s and, for each active session, runs `gh pr view <branch> --json …` from the
+repo root. The result — PR number, URL, state (`OPEN`/`CLOSED`/`MERGED`), draft
+flag, `reviewDecision`, a rolled-up `checks` verdict (`passing`/`failing`/
+`pending`), and mergeability — is written to the loom-owned `branch_github`
+table (one row per branch, keyed `branch_id`) and served as `BranchView.github`.
+The dashboard renders it on the session list and overview; `POST
+/api/sessions/{id}/github` forces an immediate re-poll.
+
+The loop self-gates and degrades quietly: it is always spawned but does nothing
+while the `github.poll` setting is off, `gh` is missing (probed once, cached via
+`gh_available`), or the repo has no GitHub remote (a per-branch `gh` error that
+is logged at debug and skipped). So it is a no-op on non-GitHub repos rather
+than a failure.
+
+**Archive on merge.** When a poll finds a branch's PR has merged and
+`github.archive_on_merge` is on (the default), loom archives the session
+automatically — the same teardown as the Archive button (`web::archive`, shared
+code): tmux killed, worktree removed, branch and weaver history kept. The
+worktree is removed with `--force`, so any uncommitted work in it is discarded;
+a merged PR is taken to mean the workstream is done. Turn the behaviour off with
+`weaver config set github.archive_on_merge false` (or in the settings pane).
+Both settings live in `weaver-core::config::registry()` under the **GitHub**
+group.
+
+`gh`-touching logic lives in `crate::github`: `fetch_pr` (the shell-out +
+JSON parse + check rollup), `refresh` (fetch → store → announce → maybe
+archive, behind both the poller and the refresh endpoint), and `poll` (the
+loop). The merge-archive decision is split into `apply_snapshot` so it is
+testable without invoking `gh`.
 
 ## Agent-facing commands
 

--- a/README.md
+++ b/README.md
@@ -136,13 +136,36 @@ automatically on startup (off by default):
 weaver config set server.auto_adopt true
 ```
 
+## GitHub
+
+With the `gh` CLI installed and authenticated, loom tracks each active session's
+pull request. A background loop polls `gh pr view` for the branch every 30s and
+surfaces the result on the dashboard: a link straight to the PR, its state
+(open / draft / merged / closed), the review decision (approved / changes
+requested / review required), and a rolled-up CI verdict (checks passing /
+failing / pending). The session's Overview tab has a **Refresh** button to
+re-poll on demand.
+
+Once a branch's PR merges, loom archives the session automatically — tearing
+down its tmux and worktree while keeping the branch and its weaver history, the
+same as the Archive button. Turn either behaviour off in **Settings** or from
+the CLI:
+
+```sh
+weaver config set github.archive_on_merge false   # keep the worktree after merge
+weaver config set github.poll false               # stop polling GitHub entirely
+```
+
+Polling is a quiet no-op for repositories without a GitHub remote, or wherever
+`gh` is not installed — nothing to configure to opt out there.
+
 ## REST API (brief)
 
 Loom serves a JSON API under `/api`; the Vue SPA is the primary consumer.
 
 - `GET /api/health`
 - `GET POST /api/sessions`, `GET PATCH DELETE /api/sessions/{id}`,
-  `POST /api/sessions/{id}/{note,summarize,archive,adopt}`,
+  `POST /api/sessions/{id}/{note,archive,adopt,github}`,
   `GET /api/sessions/{id}/{diff,log,events}`,
   `GET /api/sessions/{id}/terminal` (WebSocket: xterm.js ⇄ PTY ⇄ tmux)
 - `GET /api/branches`, `GET PATCH /api/branches/{id}`,
@@ -184,6 +207,10 @@ Notable settings:
 - `agent.claude_args` — extra arguments spliced into the Claude TUI launch,
   e.g. `--model claude-opus-4-7`.
 - `server.auto_adopt` — adopt every recoverable session on daemon startup.
+- `github.poll` — poll GitHub (via `gh`) for each session's PR, review, and
+  check status (on by default; a no-op without `gh` or a GitHub remote).
+- `github.archive_on_merge` — archive a session automatically once its PR
+  merges (on by default).
 
 ## Building
 

--- a/crates/loom/frontend/src/components/GithubStatus.vue
+++ b/crates/loom/frontend/src/components/GithubStatus.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { GithubStatus } from '../types';
+
+// A branch's GitHub pull-request snapshot, fetched server-side via `gh`. Tints
+// stay restrained — text color only, never a loud fill — so GitHub info never
+// competes with the attention axis (the one reserved loud signal in the UI).
+// Tokens are semantic (text-accent / text-block / text-muted) so they swap with
+// the light/dark theme.
+const props = defineProps<{ gh: GithubStatus; compact?: boolean }>();
+
+interface Chip {
+  label: string;
+  cls: string;
+}
+
+// `draft` reads as its own state while the PR is open; merged/closed win out.
+const stateChip = computed<Chip>(() => {
+  const draft = props.gh.is_draft && props.gh.pr_state === 'OPEN';
+  const key = draft ? 'DRAFT' : props.gh.pr_state;
+  const tint: Record<string, string> = {
+    OPEN: 'text-fg',
+    MERGED: 'text-accent',
+    CLOSED: 'text-faint',
+    DRAFT: 'text-faint',
+  };
+  return { label: key.toLowerCase(), cls: tint[key] ?? 'text-muted' };
+});
+
+const reviewChip = computed<Chip | null>(() => {
+  const r = props.gh.review_decision;
+  if (!r) return null;
+  const map: Record<string, Chip> = {
+    APPROVED: { label: 'approved', cls: 'text-accent' },
+    CHANGES_REQUESTED: { label: 'changes requested', cls: 'text-block' },
+    REVIEW_REQUIRED: { label: 'review required', cls: 'text-muted' },
+  };
+  return map[r] ?? { label: r.toLowerCase().replace(/_/g, ' '), cls: 'text-muted' };
+});
+
+const checksChip = computed<Chip | null>(() => {
+  const c = props.gh.checks;
+  if (!c) return null;
+  const map: Record<string, Chip> = {
+    passing: { label: 'checks passing', cls: 'text-accent' },
+    failing: { label: 'checks failing', cls: 'text-block' },
+    pending: { label: 'checks pending', cls: 'text-muted' },
+  };
+  return map[c] ?? { label: `checks ${c}`, cls: 'text-muted' };
+});
+
+// Only surface mergeability when it's a problem — a clean PR needn't say so.
+const conflicting = computed(() => props.gh.mergeable === 'CONFLICTING');
+</script>
+
+<template>
+  <!-- Compact: a single tight line for the dashboard's far-right column. -->
+  <span v-if="compact" class="inline-flex items-center gap-1.5 text-xs" data-testid="github-compact">
+    <a
+      :href="gh.pr_url"
+      target="_blank"
+      rel="noopener"
+      class="font-mono text-accent hover:underline"
+      @click.stop
+    >PR #{{ gh.pr_number }}</a>
+    <span :class="stateChip.cls" class="font-mono uppercase tracking-wide">{{ stateChip.label }}</span>
+    <span v-if="checksChip" :class="checksChip.cls" class="font-mono" title="CI checks">●</span>
+  </span>
+
+  <!-- Full: a labelled block for the session overview. -->
+  <div v-else class="space-y-2" data-testid="github-full">
+    <a
+      :href="gh.pr_url"
+      target="_blank"
+      rel="noopener"
+      class="block text-sm text-accent hover:underline"
+    >
+      <span class="font-mono">#{{ gh.pr_number }}</span>
+      <span class="text-fg">{{ gh.pr_title }}</span>
+    </a>
+    <div class="flex flex-wrap items-center gap-2">
+      <span
+        v-for="chip in [stateChip, reviewChip, checksChip].filter(Boolean)"
+        :key="(chip as Chip).label"
+        :class="(chip as Chip).cls"
+        class="rounded bg-subtle px-1.5 py-0.5 text-[0.7rem] font-medium font-mono uppercase tracking-wide"
+      >
+        {{ (chip as Chip).label }}
+      </span>
+      <span
+        v-if="conflicting"
+        class="rounded bg-subtle px-1.5 py-0.5 text-[0.7rem] font-medium font-mono uppercase tracking-wide text-block"
+      >
+        conflicts
+      </span>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionOverview.vue
+++ b/crates/loom/frontend/src/components/SessionOverview.vue
@@ -2,12 +2,14 @@
 import type { Session, WeaverEvent } from '../types';
 import SessionActivity from './SessionActivity.vue';
 import ScratchPanel from './ScratchPanel.vue';
+import GithubStatus from './GithubStatus.vue';
+import { timeAgo } from '../lib/time';
 
 // The Overview tab: read-only context for a session, plus its lifecycle
 // actions. Goal and the status message are authored by the AGENT (the launch
 // prompt, `weaver set-status`) — shown here as prose, never as editable forms.
-// The only writes on this page are acknowledging attention (the status strip)
-// and lifecycle (Adopt / Archive / Remove, below).
+// The only writes on this page are acknowledging attention (the status strip),
+// refreshing the GitHub snapshot, and lifecycle (Adopt / Archive / Remove).
 const props = defineProps<{
   ws: Session;
   events: WeaverEvent[];
@@ -15,7 +17,7 @@ const props = defineProps<{
   busy: string;
 }>();
 
-const emit = defineEmits<{ adopt: []; archive: []; remove: [] }>();
+const emit = defineEmits<{ adopt: []; archive: []; remove: []; refreshGithub: [] }>();
 </script>
 
 <template>
@@ -25,6 +27,31 @@ const emit = defineEmits<{ adopt: []; archive: []; remove: [] }>();
       <div class="mb-1 text-xs font-medium uppercase tracking-wide text-faint">Goal</div>
       <p v-if="ws.branch.goal" class="whitespace-pre-wrap text-sm text-fg">{{ ws.branch.goal }}</p>
       <p v-else class="text-sm text-faint">No goal set.</p>
+    </section>
+
+    <!-- GitHub — the branch's PR snapshot, polled server-side via `gh`. Shown
+         only once a snapshot exists; the Refresh button forces a re-poll. -->
+    <section class="rounded border border-line bg-surface p-4">
+      <div class="mb-2 flex items-center justify-between">
+        <div class="text-xs font-medium uppercase tracking-wide text-faint">GitHub</div>
+        <button
+          class="rounded bg-subtle px-2 py-1 text-xs text-muted hover:bg-subtle-hover disabled:opacity-50"
+          :disabled="busy === 'refreshGithub'"
+          @click="emit('refreshGithub')"
+        >
+          {{ busy === 'refreshGithub' ? 'Refreshing…' : 'Refresh' }}
+        </button>
+      </div>
+      <template v-if="ws.branch.github">
+        <GithubStatus :gh="ws.branch.github" />
+        <p class="mt-2 text-xs text-faint">
+          Snapshot {{ timeAgo(ws.branch.github.fetched_at) }}.
+        </p>
+      </template>
+      <p v-else class="text-sm text-faint">
+        No pull request found for this branch yet. loom polls automatically while
+        the session is active.
+      </p>
     </section>
 
     <!-- Activity — de-noised event feed (read-only context). -->

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -20,6 +20,29 @@ export interface Branch {
   created_at: string;
   updated_at: string;
   open_issue_count: number;
+  /** Latest GitHub pull-request snapshot for the branch, or null when GitHub
+   *  polling is off, there's no PR, or `gh` is unavailable. Maintained
+   *  server-side by loom's poll loop. */
+  github: GithubStatus | null;
+}
+
+/** A point-in-time GitHub snapshot of a branch's pull request: its link plus
+ *  the review and check rollups loom read via the `gh` CLI. */
+export interface GithubStatus {
+  pr_number: number;
+  pr_url: string;
+  /** 'OPEN' | 'CLOSED' | 'MERGED'. */
+  pr_state: string;
+  pr_title: string;
+  is_draft: boolean;
+  /** 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null. */
+  review_decision: string | null;
+  /** Rolled-up checks: 'passing' | 'failing' | 'pending' | null (no checks). */
+  checks: string | null;
+  /** 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null. */
+  mergeable: string | null;
+  merged_at: string | null;
+  fetched_at: string;
 }
 
 /** A session is loom's view: one tmux + one running agent attached to a

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -70,7 +70,7 @@ async function loadAll() {
 
 function openStream() {
   source = new EventSource(`/api/sessions/${props.id}/events`);
-  for (const kind of ['status', 'attention', 'note']) {
+  for (const kind of ['status', 'attention', 'note', 'github']) {
     source.addEventListener(kind, (e) => {
       const ev = JSON.parse((e as MessageEvent).data) as WeaverEvent;
       events.value.push(ev);
@@ -144,12 +144,21 @@ const adopt = () =>
     await loadSession();
   });
 
+const refreshGithub = () =>
+  act('refreshGithub', async () => {
+    await post(`/sessions/${props.id}/github`);
+    notice.value = 'GitHub status refreshed.';
+    await loadSession();
+  });
+
 function eventLine(ev: WeaverEvent): string {
   const d = ev.data || {};
   if (ev.kind === 'status') return `status → ${d.status ?? '?'}`;
   if (ev.kind === 'attention')
     return `status → ${d.level ?? '?'}${d.note ? ` (${d.note})` : ''}`;
   if (ev.kind === 'note') return String(d.text ?? '');
+  if (ev.kind === 'github')
+    return `PR #${d.pr ?? '?'} → ${d.state ?? '?'}${d.checks ? ` · checks ${d.checks}` : ''}`;
   if (ev.kind === 'issue_added') return `issue added: ${d.title ?? ''}`;
   if (ev.kind === 'issue_closed') return `issue closed: #${d.id ?? '?'}`;
   if (ev.kind === 'issue_reopened') return `issue reopened: #${d.id ?? '?'}`;
@@ -191,6 +200,7 @@ onUnmounted(() => source?.close());
       @adopt="adopt"
       @archive="archive"
       @remove="remove"
+      @refresh-github="refreshGithub"
     />
 
     <!-- Issues — claimed work + repo backlog. -->

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -4,6 +4,7 @@ import { get, post } from '../api';
 import type { Session, RecentRepo, RepoBranch } from '../types';
 import StatusBadge from '../components/StatusBadge.vue';
 import AttentionBadge from '../components/AttentionBadge.vue';
+import GithubStatus from '../components/GithubStatus.vue';
 import ScratchPicker from '../components/ScratchPicker.vue';
 import { timeAgo } from '../lib/time';
 import { levelOf, messageOf } from '../lib/sessionState';
@@ -531,10 +532,12 @@ onUnmounted(() => clearInterval(timer));
         <!-- Ref: machine identity, mono, pushed far-right and receding. -->
         <div class="shrink-0 text-right">
           <span class="block truncate font-mono text-xs text-faint">{{ s.branch.branch }}</span>
+          <!-- PR snapshot (if any) — a quiet link straight to the GitHub PR. -->
+          <GithubStatus v-if="s.branch.github" :gh="s.branch.github" compact class="mt-0.5 justify-end" />
           <router-link
             v-if="s.branch.open_issue_count"
             :to="`/s/${s.id}?tab=issues`"
-            class="font-mono text-xs text-muted hover:text-accent"
+            class="block font-mono text-xs text-muted hover:text-accent"
             @click.stop
           >
             {{ s.branch.open_issue_count }} open issue{{ s.branch.open_issue_count === 1 ? '' : 's' }}

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -610,6 +610,26 @@ fn print_session(ws: &Value) {
             println!("  github:   {repo}");
         }
     }
+    // The branch's PR snapshot, when loom has polled one (see `loom::github`).
+    if let Some(gh) = ws.get("branch").and_then(|b| b.get("github")) {
+        if let Some(url) = gh.get("pr_url").and_then(Value::as_str) {
+            let number = gh.get("pr_number").and_then(Value::as_i64).unwrap_or(0);
+            let state = gh
+                .get("pr_state")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_lowercase();
+            let mut bits = vec![state];
+            if let Some(review) = gh.get("review_decision").and_then(Value::as_str) {
+                bits.push(review.to_lowercase().replace('_', " "));
+            }
+            if let Some(checks) = gh.get("checks").and_then(Value::as_str) {
+                bits.push(format!("checks {checks}"));
+            }
+            let bits: Vec<String> = bits.into_iter().filter(|b| !b.is_empty()).collect();
+            println!("  pr:       #{number} {url} ({})", bits.join(", "));
+        }
+    }
     println!("  activity: {}", str_field(ws, "last_activity_at"));
 }
 

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -36,6 +36,27 @@ CREATE TABLE IF NOT EXISTS recent_repos (
     repo_root    TEXT PRIMARY KEY,
     last_used_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
+
+-- The latest GitHub snapshot for a branch: the pull request loom found for it
+-- (via the `gh` CLI) plus its review/check rollup. One row per branch, replaced
+-- on each poll; it is optional context, gone the moment the branch row is.
+CREATE TABLE IF NOT EXISTS branch_github (
+    branch_id        TEXT PRIMARY KEY REFERENCES branches(id) ON DELETE CASCADE,
+    pr_number        INTEGER,
+    pr_url           TEXT,
+    -- 'OPEN' | 'CLOSED' | 'MERGED'.
+    pr_state         TEXT,
+    pr_title         TEXT,
+    is_draft         INTEGER NOT NULL DEFAULT 0,
+    -- 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | NULL.
+    review_decision  TEXT,
+    -- Rolled-up checks: 'passing' | 'failing' | 'pending' | NULL (no checks).
+    checks           TEXT,
+    -- 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | NULL.
+    mergeable        TEXT,
+    merged_at        TEXT,
+    fetched_at       TEXT NOT NULL
+);
 "#;
 
 /// Open the shared database and apply loom's additional tables on top of the

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -1,10 +1,31 @@
 //! Optional GitHub integration via the `gh` CLI. All functions degrade
 //! gracefully — callers treat errors as "GitHub unavailable".
+//!
+//! Two responsibilities live here:
+//!
+//! * **Issue seeding** ([`fetch_issue`], [`repo_slug`]) and PR opening
+//!   ([`create_pr`]) — one-shot shell-outs used when a session is created.
+//! * **PR status polling** ([`poll`], [`refresh`], [`fetch_pr`]) — the
+//!   background loop that snapshots each active session's pull request (link,
+//!   review decision, check rollup) into the `branch_github` table, and
+//!   archives a session once its PR merges. The snapshot rides along on
+//!   `BranchView`; the dashboard renders it.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
-use serde::Deserialize;
-use std::path::Path;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sqlx::FromRow;
 use tokio::process::Command;
+use tokio::sync::OnceCell;
+
+use crate::db::{now_iso, Db};
+use crate::session::{self as session_mod, Session};
+use crate::web::AppState;
+use crate::{branch as branch_mod, config, events, note};
+use weaver_core::branch::Branch;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Issue {
@@ -82,4 +103,579 @@ pub async fn create_pr(work_dir: &Path, base: &str, title: &str, body: &str) -> 
         ],
     )
     .await
+}
+
+// ---------------------------------------------------------------------------
+// PR status snapshots
+//
+// The latest pull-request snapshot loom found for a branch, persisted in the
+// `branch_github` table (one row per branch) and served inside `BranchView`.
+// The background `poll` loop keeps it fresh; `refresh` does one branch on
+// demand. Everything degrades to "no snapshot" when `gh` is missing or the repo
+// has no GitHub remote.
+// ---------------------------------------------------------------------------
+
+const POLL_TICK: Duration = Duration::from_secs(30);
+
+/// The fields requested from `gh pr view --json`. Kept in one place so the parse
+/// struct and the query can't drift.
+const PR_FIELDS: &str =
+    "number,url,state,title,isDraft,reviewDecision,mergeable,mergedAt,statusCheckRollup";
+
+/// A branch's pull-request snapshot, as stored and as served under
+/// `BranchView::github`. `pr_state` is `OPEN` / `CLOSED` / `MERGED`; `checks` is
+/// the rolled-up `passing` / `failing` / `pending` (or `null` when the PR has no
+/// checks); `review_decision` is GitHub's `APPROVED` / `CHANGES_REQUESTED` /
+/// `REVIEW_REQUIRED` (or `null` when review isn't required).
+#[derive(Debug, Clone, Serialize, FromRow)]
+pub struct GithubStatus {
+    pub pr_number: i64,
+    pub pr_url: String,
+    pub pr_state: String,
+    pub pr_title: String,
+    pub is_draft: bool,
+    pub review_decision: Option<String>,
+    pub checks: Option<String>,
+    pub mergeable: Option<String>,
+    pub merged_at: Option<String>,
+    pub fetched_at: String,
+}
+
+impl GithubStatus {
+    /// The fields whose change is worth announcing on the activity feed — PR
+    /// identity and the human-meaningful state. `mergeable` and timestamps are
+    /// deliberately excluded: they flap (e.g. `UNKNOWN` ⇄ `MERGEABLE`) without
+    /// telling the user anything.
+    fn signature(&self) -> (i64, String, Option<String>, Option<String>, bool) {
+        (
+            self.pr_number,
+            self.pr_state.clone(),
+            self.review_decision.clone(),
+            self.checks.clone(),
+            self.is_draft,
+        )
+    }
+
+    /// Payload for the `github` event the poller records when the snapshot
+    /// changes — enough for a dashboard to summarize without re-fetching.
+    pub fn event_data(&self) -> Value {
+        json!({
+            "pr": self.pr_number,
+            "url": self.pr_url,
+            "state": self.pr_state,
+            "review": self.review_decision,
+            "checks": self.checks,
+            "draft": self.is_draft,
+        })
+    }
+}
+
+/// The shape of one `gh pr view --json` record. Internal — callers see
+/// [`GithubStatus`].
+#[derive(Debug, Deserialize)]
+struct PrJson {
+    number: i64,
+    url: String,
+    state: String,
+    title: String,
+    #[serde(rename = "isDraft", default)]
+    is_draft: bool,
+    #[serde(rename = "reviewDecision", default)]
+    review_decision: Option<String>,
+    #[serde(default)]
+    mergeable: Option<String>,
+    #[serde(rename = "mergedAt", default)]
+    merged_at: Option<String>,
+    #[serde(rename = "statusCheckRollup", default)]
+    status_check_rollup: Option<Vec<CheckJson>>,
+}
+
+/// One entry in `statusCheckRollup`. The array is a union of GitHub's CheckRun
+/// (carries `status` + `conclusion`) and StatusContext (carries `state`); we
+/// accept whichever fields are present.
+#[derive(Debug, Deserialize)]
+struct CheckJson {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+}
+
+impl PrJson {
+    fn into_status(self) -> GithubStatus {
+        let nonempty = |s: Option<String>| s.filter(|v| !v.is_empty());
+        GithubStatus {
+            pr_number: self.number,
+            pr_url: self.url,
+            pr_state: self.state,
+            pr_title: self.title,
+            is_draft: self.is_draft,
+            review_decision: nonempty(self.review_decision),
+            checks: rollup_checks(self.status_check_rollup.as_deref().unwrap_or(&[])),
+            mergeable: nonempty(self.mergeable),
+            merged_at: nonempty(self.merged_at),
+            fetched_at: now_iso(),
+        }
+    }
+}
+
+/// Roll a PR's individual checks up to a single verdict, the way `gh pr checks`
+/// does: any failure ⇒ `failing`, else anything still running ⇒ `pending`, else
+/// `passing`. `None` when the PR has no checks at all.
+fn rollup_checks(items: &[CheckJson]) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    let mut any_pending = false;
+    let mut any_fail = false;
+    for it in items {
+        if let Some(status) = it.status.as_deref() {
+            // CheckRun: only COMPLETED runs have a meaningful conclusion.
+            if status != "COMPLETED" {
+                any_pending = true;
+                continue;
+            }
+            match it.conclusion.as_deref().unwrap_or("") {
+                "SUCCESS" | "NEUTRAL" | "SKIPPED" => {}
+                "" => any_pending = true,
+                _ => any_fail = true, // FAILURE / CANCELLED / TIMED_OUT / ACTION_REQUIRED / …
+            }
+        } else if let Some(state) = it.state.as_deref() {
+            // StatusContext (legacy commit statuses).
+            match state {
+                "SUCCESS" => {}
+                "PENDING" | "EXPECTED" => any_pending = true,
+                _ => any_fail = true, // FAILURE / ERROR
+            }
+        }
+    }
+    Some(
+        if any_fail {
+            "failing"
+        } else if any_pending {
+            "pending"
+        } else {
+            "passing"
+        }
+        .to_string(),
+    )
+}
+
+/// Whether the `gh` CLI is usable on this machine. Probed once and cached — a
+/// missing `gh` is the common "GitHub integration off" case and shouldn't cost a
+/// process spawn on every poll.
+pub async fn gh_available() -> bool {
+    static AVAILABLE: OnceCell<bool> = OnceCell::const_new();
+    *AVAILABLE
+        .get_or_init(|| async {
+            let ok = Command::new("gh")
+                .arg("--version")
+                .output()
+                .await
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+            if ok {
+                tracing::info!("gh CLI detected — GitHub PR polling available");
+            } else {
+                tracing::info!("gh CLI not found — GitHub PR polling disabled");
+            }
+            ok
+        })
+        .await
+}
+
+/// Fetch the pull request for `branch` (its remote head ref) from `repo_root`.
+/// `Ok(None)` means there is simply no PR for the branch yet; `Err` is a real
+/// failure (no GitHub remote, auth, `gh` missing) the caller logs and skips.
+pub async fn fetch_pr(repo_root: &Path, branch: &str) -> Result<Option<GithubStatus>> {
+    let out = Command::new("gh")
+        .args(["pr", "view", branch, "--json", PR_FIELDS])
+        .current_dir(repo_root)
+        .output()
+        .await
+        .context("failed to spawn gh (is the GitHub CLI installed?)")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        // gh exits non-zero when the branch has no PR; that's not an error.
+        if stderr.to_lowercase().contains("no pull requests found")
+            || stderr.to_lowercase().contains("no open pull requests")
+        {
+            return Ok(None);
+        }
+        bail!("gh pr view {branch} failed: {}", stderr.trim());
+    }
+    let raw: PrJson = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
+        .context("parsing gh pr JSON")?;
+    Ok(Some(raw.into_status()))
+}
+
+/// The stored snapshot for a branch, if one has been fetched.
+pub async fn get_status(db: &Db, branch_id: &str) -> Result<Option<GithubStatus>> {
+    let row = sqlx::query_as::<_, GithubStatus>(
+        "SELECT pr_number, pr_url, pr_state, pr_title, is_draft, review_decision,
+                checks, mergeable, merged_at, fetched_at
+         FROM branch_github WHERE branch_id = ?",
+    )
+    .bind(branch_id)
+    .fetch_optional(db)
+    .await?;
+    Ok(row)
+}
+
+/// Persist (replacing) the snapshot for a branch.
+pub async fn upsert_status(db: &Db, branch_id: &str, s: &GithubStatus) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO branch_github
+           (branch_id, pr_number, pr_url, pr_state, pr_title, is_draft,
+            review_decision, checks, mergeable, merged_at, fetched_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(branch_id) DO UPDATE SET
+           pr_number = excluded.pr_number, pr_url = excluded.pr_url,
+           pr_state = excluded.pr_state, pr_title = excluded.pr_title,
+           is_draft = excluded.is_draft, review_decision = excluded.review_decision,
+           checks = excluded.checks, mergeable = excluded.mergeable,
+           merged_at = excluded.merged_at, fetched_at = excluded.fetched_at",
+    )
+    .bind(branch_id)
+    .bind(s.pr_number)
+    .bind(&s.pr_url)
+    .bind(&s.pr_state)
+    .bind(&s.pr_title)
+    .bind(s.is_draft)
+    .bind(&s.review_decision)
+    .bind(&s.checks)
+    .bind(&s.mergeable)
+    .bind(&s.merged_at)
+    .bind(&s.fetched_at)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Fetch a branch's PR, store the snapshot, announce a meaningful change on the
+/// activity feed, and — when `archive_on_merge` is set and the PR has merged —
+/// archive the still-live session. Returns the fresh snapshot, or `None` when
+/// the branch has no PR. The single code path behind both the poller and the
+/// on-demand refresh endpoint.
+pub async fn refresh(
+    state: &AppState,
+    session: &Session,
+    branch: &Branch,
+    archive_on_merge: bool,
+) -> Result<Option<GithubStatus>> {
+    let snap = match fetch_pr(&PathBuf::from(&branch.repo_root), &branch.branch).await? {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+    apply_snapshot(state, session, branch, &snap, archive_on_merge).await?;
+    Ok(Some(snap))
+}
+
+/// Persist a freshly-fetched snapshot, announce a meaningful change on the
+/// activity feed, and archive a still-live session whose PR has merged (when
+/// `archive_on_merge` is set). Split from [`refresh`] so the storage and
+/// merge-archive behaviour is testable without invoking `gh`.
+async fn apply_snapshot(
+    state: &AppState,
+    session: &Session,
+    branch: &Branch,
+    snap: &GithubStatus,
+    archive_on_merge: bool,
+) -> Result<()> {
+    let prev = get_status(&state.db, &branch.id).await?;
+    upsert_status(&state.db, &branch.id, snap).await?;
+    let changed = prev.as_ref().map(GithubStatus::signature) != Some(snap.signature());
+    if changed {
+        events::record(
+            &state.db,
+            &state.bus,
+            &branch.id,
+            "github",
+            snap.event_data(),
+        )
+        .await
+        .ok();
+    }
+
+    if archive_on_merge && snap.pr_state == "MERGED" && !session_mod::is_terminal(&session.status) {
+        let msg = format!("PR #{} merged — archiving the worktree.", snap.pr_number);
+        note::add(&state.db, &branch.id, &msg).await.ok();
+        match crate::web::archive(state, session, branch).await {
+            Ok(_) => tracing::info!(
+                branch = %branch.branch,
+                pr = snap.pr_number,
+                "archived session after PR merge"
+            ),
+            Err(e) => tracing::warn!(
+                branch = %branch.branch,
+                error = %e.message(),
+                "archive-on-merge failed"
+            ),
+        }
+    }
+    Ok(())
+}
+
+/// Background loop: snapshot every active session's PR on a fixed cadence. A
+/// no-op while `github.poll` is off or `gh` is unavailable, so it is always safe
+/// to spawn. Sibling of the [`crate::monitor`] loop.
+pub async fn poll(state: AppState) {
+    tracing::info!(tick_s = POLL_TICK.as_secs(), "github poll loop started");
+    loop {
+        tokio::time::sleep(POLL_TICK).await;
+        if !config::get_bool(&state.db, "github.poll", config::DEFAULT_GITHUB_POLL).await {
+            continue;
+        }
+        if !gh_available().await {
+            continue;
+        }
+        if let Err(e) = poll_once(&state).await {
+            tracing::warn!(error = %e, "github poll tick failed");
+        }
+    }
+}
+
+async fn poll_once(state: &AppState) -> Result<()> {
+    let archive_on_merge = config::get_bool(
+        &state.db,
+        "github.archive_on_merge",
+        config::DEFAULT_GITHUB_ARCHIVE_ON_MERGE,
+    )
+    .await;
+    // One active session per branch (enforced by a unique index), so iterating
+    // sessions visits each candidate branch once.
+    for session in session_mod::list(&state.db).await? {
+        if session_mod::is_terminal(&session.status) {
+            continue;
+        }
+        let Some(branch) = branch_mod::get(&state.db, &session.branch_id).await? else {
+            continue;
+        };
+        if let Err(e) = refresh(state, &session, &branch, archive_on_merge).await {
+            tracing::debug!(branch = %branch.branch, error = %e, "github refresh failed");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check(status: Option<&str>, conclusion: Option<&str>, state: Option<&str>) -> CheckJson {
+        CheckJson {
+            status: status.map(str::to_string),
+            conclusion: conclusion.map(str::to_string),
+            state: state.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn rollup_none_when_empty() {
+        assert_eq!(rollup_checks(&[]), None);
+    }
+
+    #[test]
+    fn rollup_passing_when_all_succeed() {
+        let items = [
+            check(Some("COMPLETED"), Some("SUCCESS"), None),
+            check(Some("COMPLETED"), Some("SKIPPED"), None),
+            check(None, None, Some("SUCCESS")),
+        ];
+        assert_eq!(rollup_checks(&items).as_deref(), Some("passing"));
+    }
+
+    #[test]
+    fn rollup_pending_beats_passing_but_not_failing() {
+        let pending = [
+            check(Some("COMPLETED"), Some("SUCCESS"), None),
+            check(Some("IN_PROGRESS"), None, None),
+        ];
+        assert_eq!(rollup_checks(&pending).as_deref(), Some("pending"));
+
+        let failing = [
+            check(Some("IN_PROGRESS"), None, None),
+            check(Some("COMPLETED"), Some("FAILURE"), None),
+        ];
+        assert_eq!(rollup_checks(&failing).as_deref(), Some("failing"));
+    }
+
+    #[test]
+    fn parse_pr_json_normalizes_empty_strings() {
+        let json = r#"{
+            "number": 7, "url": "https://x/pr/7", "state": "OPEN", "title": "T",
+            "isDraft": false, "reviewDecision": "", "mergeable": "MERGEABLE",
+            "mergedAt": null, "statusCheckRollup": []
+        }"#;
+        let status = serde_json::from_str::<PrJson>(json).unwrap().into_status();
+        assert_eq!(status.pr_number, 7);
+        assert_eq!(status.pr_state, "OPEN");
+        // Empty reviewDecision and null mergedAt collapse to None.
+        assert_eq!(status.review_decision, None);
+        assert_eq!(status.merged_at, None);
+        // Empty rollup means "no checks", not "passing".
+        assert_eq!(status.checks, None);
+        assert_eq!(status.mergeable.as_deref(), Some("MERGEABLE"));
+    }
+
+    // ---- apply_snapshot: storage + archive-on-merge --------------------------
+
+    use std::path::Path;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn snapshot(state: &str) -> GithubStatus {
+        GithubStatus {
+            pr_number: 5,
+            pr_url: "https://example/pr/5".to_string(),
+            pr_state: state.to_string(),
+            pr_title: "Add the thing".to_string(),
+            is_draft: false,
+            review_decision: Some("APPROVED".to_string()),
+            checks: Some("passing".to_string()),
+            mergeable: Some("MERGEABLE".to_string()),
+            merged_at: (state == "MERGED").then(now_iso),
+            fetched_at: now_iso(),
+        }
+    }
+
+    /// A real git repo with a `weaver/feat` worktree, an in-memory db, and a
+    /// running session on that branch — the minimum to exercise `apply_snapshot`
+    /// (including the worktree teardown the archive path performs).
+    struct Fixture {
+        _repo: tempfile::TempDir,
+        state: AppState,
+        session: Session,
+        branch: Branch,
+        work_dir: std::path::PathBuf,
+    }
+
+    async fn fixture() -> Fixture {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path().canonicalize().unwrap();
+        git(&root, &["init", "-b", "main"]);
+        git(&root, &["config", "user.email", "t@example.com"]);
+        git(&root, &["config", "user.name", "Tester"]);
+        git(&root, &["commit", "--allow-empty", "-m", "init"]);
+        let work_dir = root.join(".worktrees/feat");
+        git(
+            &root,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "weaver/feat",
+                work_dir.to_str().unwrap(),
+                "main",
+            ],
+        );
+
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let branch = branch_mod::upsert(&db, &root.display().to_string(), "weaver/feat", "main")
+            .await
+            .unwrap();
+        let session = session_mod::insert(
+            &db,
+            &crate::session::NewSession {
+                id: "ghsess1".to_string(),
+                branch_id: branch.id.clone(),
+                work_dir: work_dir.display().to_string(),
+                tmux_session: format!("weaver-ghtest-{}", std::process::id()),
+                agent_kind: "shell".to_string(),
+                model: String::new(),
+                effort: String::new(),
+                status: "running".to_string(),
+                github_repo: None,
+            },
+        )
+        .await
+        .unwrap();
+        let state = AppState {
+            db,
+            bus: events::EventBus::new(),
+            addr: "127.0.0.1:0".to_string(),
+        };
+        Fixture {
+            _repo: repo,
+            state,
+            session,
+            branch,
+            work_dir,
+        }
+    }
+
+    #[tokio::test]
+    async fn open_pr_is_stored_but_not_archived() {
+        let f = fixture().await;
+        apply_snapshot(&f.state, &f.session, &f.branch, &snapshot("OPEN"), true)
+            .await
+            .unwrap();
+
+        // The snapshot round-trips out of the table…
+        let stored = get_status(&f.state.db, &f.branch.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.pr_number, 5);
+        assert_eq!(stored.pr_state, "OPEN");
+        assert_eq!(stored.checks.as_deref(), Some("passing"));
+        // …and an open PR leaves the live session (and its worktree) alone.
+        let session = session_mod::get(&f.state.db, &f.session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "running");
+        assert!(f.work_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn merged_pr_archives_the_session_and_removes_the_worktree() {
+        let f = fixture().await;
+        apply_snapshot(&f.state, &f.session, &f.branch, &snapshot("MERGED"), true)
+            .await
+            .unwrap();
+
+        let session = session_mod::get(&f.state.db, &f.session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "archived");
+        // The worktree is torn down — that's the "archive the worktree" promise.
+        assert!(!f.work_dir.exists());
+        // The merged snapshot is still queryable for the archived session.
+        let stored = get_status(&f.state.db, &f.branch.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.pr_state, "MERGED");
+    }
+
+    #[tokio::test]
+    async fn merged_pr_is_left_alone_when_archive_on_merge_is_off() {
+        let f = fixture().await;
+        apply_snapshot(&f.state, &f.session, &f.branch, &snapshot("MERGED"), false)
+            .await
+            .unwrap();
+
+        let session = session_mod::get(&f.state.db, &f.session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "running");
+        assert!(f.work_dir.exists());
+    }
 }

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -11,7 +11,7 @@ use tokio::net::TcpListener;
 use crate::events::EventBus;
 use crate::session as session_mod;
 use crate::web::AppState;
-use crate::{config, db, monitor, tmux, web};
+use crate::{config, db, github, monitor, tmux, web};
 use weaver_core::branch as branch_mod;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -114,7 +114,11 @@ async fn reconcile_sessions(state: &AppState) {
 
 pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
     tokio::spawn(monitor::run(state.clone()));
-    tracing::debug!("background tasks spawned (monitor)");
+    // The GitHub poller is always spawned; it self-gates on the `github.poll`
+    // setting and on `gh` being available, so it idles cheaply when GitHub
+    // integration is off or unavailable.
+    tokio::spawn(github::poll(state.clone()));
+    tracing::debug!("background tasks spawned (monitor, github poll)");
     axum::serve(listener, web::router(state))
         .with_graceful_shutdown(shutdown_signal())
         .await?;

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -176,6 +176,11 @@ pub struct BranchView {
     pub created_at: String,
     pub updated_at: String,
     pub open_issue_count: i64,
+    /// The branch's latest GitHub pull-request snapshot (link, review decision,
+    /// check rollup), or `null` when GitHub polling is off, the repo has no
+    /// remote PR, or `gh` is unavailable. Maintained by the poll loop in
+    /// [`crate::github`].
+    pub github: Option<github::GithubStatus>,
 }
 
 impl BranchView {
@@ -184,10 +189,16 @@ impl BranchView {
         let open = weaver_core::issue::open_count_for_branch(db, &branch.repo_root, &branch.branch)
             .await
             .unwrap_or(0);
-        Ok(Self::from_parts(branch, open))
+        // Best-effort: a missing/erroring snapshot just renders as no GitHub info.
+        let github = github::get_status(db, &branch.id).await.ok().flatten();
+        Ok(Self::from_parts(branch, open, github))
     }
 
-    fn from_parts(branch: &Branch, open_issue_count: i64) -> Self {
+    fn from_parts(
+        branch: &Branch,
+        open_issue_count: i64,
+        github: Option<github::GithubStatus>,
+    ) -> Self {
         let name = branch
             .branch
             .strip_prefix("weaver/")
@@ -206,6 +217,7 @@ impl BranchView {
             created_at: branch.created_at.clone(),
             updated_at: branch.updated_at.clone(),
             open_issue_count,
+            github,
         }
     }
 }
@@ -337,6 +349,7 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{id}/note", post(note_session))
         .route("/sessions/{id}/archive", post(archive_session))
         .route("/sessions/{id}/adopt", post(adopt_session))
+        .route("/sessions/{id}/github", post(refresh_github_session))
         .route("/sessions/{id}/tree", get(tree_session))
         .route("/sessions/{id}/file", get(file_session))
         .route("/sessions/{id}/raw", get(raw_session))
@@ -943,11 +956,15 @@ async fn note_session(
 /// This is the "I'm done with this workstream" action — unlike delete, the
 /// weaver/loom record is preserved for future reference, and the git branch is
 /// left intact so the work can be revisited or a worktree recreated later.
-async fn archive_session(
-    State(st): State<AppState>,
-    Path(key): Path<String>,
-) -> ApiResult<Json<Value>> {
-    let (session, branch) = require_session(&st.db, &key).await?;
+///
+/// Extracted from the route handler so the GitHub poller can archive a session
+/// the moment its PR merges (see [`crate::github::refresh`]). Returns any
+/// non-fatal teardown warnings.
+pub async fn archive(
+    st: &AppState,
+    session: &Session,
+    branch: &Branch,
+) -> Result<Vec<String>, AppError> {
     let mut warnings: Vec<String> = Vec::new();
 
     tmux::kill_session(&session.tmux_session).await.ok();
@@ -980,9 +997,39 @@ async fn archive_session(
     if !warnings.is_empty() {
         tracing::warn!(branch = %branch.id, warnings = warnings.len(), "session archived with warnings");
     }
+    Ok(warnings)
+}
+
+async fn archive_session(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<Value>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    let warnings = archive(&st, &session, &branch).await?;
     Ok(Json(
         json!({ "archived": true, "branch": branch.branch, "warnings": warnings }),
     ))
+}
+
+/// Refresh a session's GitHub PR snapshot on demand (the dashboard's "refresh"
+/// affordance) and return the updated session. Manual refresh never
+/// auto-archives — that surprise is reserved for the background poller, which
+/// will pick a freshly-merged PR up within a tick.
+async fn refresh_github_session(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<SessionView>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    if !github::gh_available().await {
+        return Err(AppError::bad_request(
+            "the GitHub CLI (`gh`) is not available on the server",
+        ));
+    }
+    github::refresh(&st, &session, &branch, false)
+        .await
+        .map_err(|e| AppError::new(StatusCode::BAD_GATEWAY, format!("gh: {e}")))?;
+    let (session, branch) = require_session(&st.db, &session.id).await?;
+    Ok(Json(SessionView::build(&st.db, &session, &branch).await?))
 }
 
 /// Recreate an orphaned session's tmux and resume its agent.

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -17,6 +17,12 @@ pub const DEFAULT_AGENT: &str = "claude";
 /// Whether the server adopts orphaned sessions on startup. Off by default:
 /// the operator opts in via `weaver config set server.auto_adopt true`.
 pub const DEFAULT_AUTO_ADOPT: bool = false;
+/// Whether loom polls GitHub (via the `gh` CLI) for each session's PR, review,
+/// and check status. On by default, but a no-op wherever `gh` is missing.
+pub const DEFAULT_GITHUB_POLL: bool = true;
+/// Whether loom archives a session automatically once its pull request merges.
+/// On by default — a merged branch's worktree has served its purpose.
+pub const DEFAULT_GITHUB_ARCHIVE_ON_MERGE: bool = true;
 
 // ---------------------------------------------------------------------------
 // Setting registry
@@ -87,6 +93,29 @@ pub const REGISTRY: &[SettingSpec] = &[
         kind: SettingKind::Bool,
         default: "false",
         group: "Server",
+    },
+    SettingSpec {
+        key: "github.poll",
+        label: "Poll GitHub for PR status",
+        description: "When enabled, loom uses the `gh` CLI to fetch each \
+            active session's pull request — its link, review decision, and \
+            check rollup — and surfaces it on the dashboard. A no-op for \
+            repositories without a GitHub remote, or wherever `gh` is not \
+            installed.",
+        kind: SettingKind::Bool,
+        default: "true",
+        group: "GitHub",
+    },
+    SettingSpec {
+        key: "github.archive_on_merge",
+        label: "Archive on PR merge",
+        description: "When enabled, loom archives a session automatically once \
+            its pull request is merged — tearing down the tmux session and \
+            removing the worktree, while keeping the branch and its history. \
+            Requires GitHub polling.",
+        kind: SettingKind::Bool,
+        default: "true",
+        group: "GitHub",
     },
 ];
 


### PR DESCRIPTION
Adds optional GitHub integration to loom. When the `gh` CLI is installed and authenticated, loom tracks each active session's pull request and surfaces it on the dashboard, and archives a session automatically once its PR merges.

## How it works

- A background poll loop (`github::poll`, a sibling of the monitor, spawned in `server::serve`) runs every 30s. For each active session it runs `gh pr view <branch> --json …` from the repo root and writes the result — PR number/URL, state (`OPEN`/`CLOSED`/`MERGED`), draft flag, `reviewDecision`, a rolled-up `checks` verdict (`passing`/`failing`/`pending`), and mergeability — into a new loom-owned `branch_github` table (one row per branch).
- The snapshot rides along on `BranchView.github`, so the SPA and CLI get it for free. `POST /api/sessions/{id}/github` forces an immediate re-poll (the Overview tab's **Refresh** button).
- **Archive on merge:** when a poll finds a branch's PR merged and `github.archive_on_merge` is on (default), loom archives the session — the same teardown as the Archive button (`web::archive`, now shared): tmux killed, worktree removed (`--force`), branch + weaver history kept.
- The loop self-gates: always spawned, but a no-op while `github.poll` is off, `gh` is missing (`gh_available`, probed once and cached), or the repo has no GitHub remote (a per-branch `gh` error logged at debug and skipped). So it degrades quietly on non-GitHub repos rather than failing.

## Settings (registry, **GitHub** group)

- `github.poll` (default `true`) — poll GitHub for PR/review/check status.
- `github.archive_on_merge` (default `true`) — archive a session once its PR merges.

## UI

- New `GithubStatus.vue`: a quiet PR link + restrained chips for state / review / checks. Tints are text-only (accent / block / muted) so GitHub info never competes with the attention axis.
- Surfaced compactly on the session list and as a labelled section (with Refresh) on the session Overview. `github` SSE events refresh the detail view.