### PR TITLE
loom launch: a tracking issue the launcher can poll or block on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | Method + path | What it does |
 |---|---|
 | `GET /api/health` | liveness probe |
-| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]`) |
+| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]` and `parent_branch`; opens a tracking issue and returns its id as `tracking_issue`) |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description, attention) |
 | `POST /api/sessions/{id}/{note,archive,adopt}` | actions |
 | `GET POST DELETE /api/sessions/{id}/scratch` | list / drop / remove worktree `scratch/` reference files |
@@ -157,7 +157,8 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 `SessionView` (`/api/sessions[/...]`) returns session-specific fields
 top-level (`id`, `status`, `work_dir`, `tmux_session`, `agent_kind`, `model`,
 `effort`, `pending_prompt`, `github_repo`, `last_activity_at`,
-`created_at`, `updated_at`) plus a nested `branch: BranchView`
+`created_at`, `updated_at`, and — on the create response only —
+`tracking_issue`) plus a nested `branch: BranchView`
 (`id`, `name`, `title`, `goal`, `description`, `attention`,
 `repo_root`, `branch`, `base_branch`, `created_at`, `updated_at`,
 `open_issue_count`).
@@ -265,6 +266,8 @@ weaver issue add "Audit the logger" --repo  # unclaimed repo backlog item
 weaver issue ls                         # this branch's work + unclaimed backlog
 weaver issue ls --mine --all            # just this branch, including closed
 weaver issue ls --repo                  # whole repo, grouped by branch
+weaver issue show 7                     # an issue + the live status of the branch working it
+weaver issue wait 7 --timeout 600       # block until a sub-tree closes #7 or raises attention
 weaver issue close 7
 weaver where                            # debug: print resolved repo / branch / branch-id
 weaver log --limit 50                   # recent events for the current branch

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ weaver issue ls                       # this branch's work + the repo backlog
 weaver issue ls --mine                # just this branch's claimed issues
 weaver issue ls --repo                # the whole repo, grouped by branch
 weaver issue close 7
+weaver issue show 7                   # an issue + the live status of the branch working it
+weaver issue wait 7                   # block until a sub-session finishes or needs you
 weaver set-status                     # read: goal + status + open-issue count
 weaver where                          # debug: print resolved repo / branch / branch-id
 weaver log --limit 50                 # recent events for the current branch
@@ -81,6 +83,17 @@ GitHub issue (via the `gh` CLI), `loom launch --claim 7` takes them from an
 existing weaver issue and moves it out of the repo backlog, and `loom launch
 --branch <name>` resumes an existing branch. `loom issues` prints the repo's
 board across branches.
+
+Every launch opens a **tracking issue** claimed by the new branch — the task as
+a weaver issue — and `loom launch` prints its number. That number is the handle
+for following the session: `weaver issue show <n>` reports the issue plus the
+live `set-status` of the branch working it, and `weaver issue wait <n>` blocks
+until the issue closes or that branch raises its attention. The launched agent
+is told to keep its status current and close the issue when the work is done.
+When an agent already inside a weaver session runs `loom launch`, the tracking
+issue is attributed to it (`source_branch`), so its sub-trees show up under
+"Delegated by this branch" in `weaver issue ls` — agents can fan work out into
+parallel sub-sessions and poll or block on them the same way a human does.
 
 `loom launch --model <haiku|sonnet|opus> --effort <low|medium|high|xhigh|max>`
 (both also selectors in the web create form) pin the session's Claude model

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -39,6 +39,9 @@ export interface Session {
   last_activity_at: string;
   created_at: string;
   updated_at: string;
+  /** The tracking issue opened for this session's task at launch (the handle
+   *  the launcher follows). Only set on the create response. */
+  tracking_issue: number | null;
   branch: Branch;
 }
 

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -448,6 +448,12 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
     } = a;
     let client = Client::new();
     let cwd = std::env::current_dir()?;
+    // When an agent in a weaver session runs `loom launch`, `$WEAVER_BRANCH` is
+    // its own branch id — pass it so the tracking issue is attributed to the
+    // launching (parent) agent. A human shell launch leaves it unset.
+    let parent_branch = std::env::var("WEAVER_BRANCH")
+        .ok()
+        .filter(|s| !s.is_empty());
     let ws = client
         .post(
             "/api/sessions",
@@ -461,6 +467,7 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
                 "existing_branch": branch,
                 "issue": issue,
                 "claim_issue": claim,
+                "parent_branch": parent_branch,
                 "model": model,
                 "effort": effort,
             }),
@@ -488,6 +495,11 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
         println!("  effort: {effort}");
     }
     println!("  dir:    {}", str_field(&ws, "work_dir"));
+    if let Some(n) = ws.get("tracking_issue").and_then(Value::as_i64) {
+        // The handle the caller uses to follow this sub-tree: poll it with
+        // `weaver issue show <n>`, or block on it with `weaver issue wait <n>`.
+        println!("  track:  weaver issue #{n}  (weaver issue show {n} | wait {n})");
+    }
     println!("  attach: loom attach {id}");
     Ok(())
 }

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -226,6 +226,10 @@ pub struct SessionView {
     pub last_activity_at: String,
     pub created_at: String,
     pub updated_at: String,
+    /// The tracking issue opened for this session's task at launch (the handle
+    /// handed back to whoever launched it). Only populated on the create
+    /// response; `None` on the list/get/patch paths, which don't recompute it.
+    pub tracking_issue: Option<i64>,
     pub branch: BranchView,
 }
 
@@ -248,6 +252,7 @@ impl SessionView {
                 .unwrap_or_else(|| branch.updated_at.clone()),
             created_at: session.created_at.clone(),
             updated_at: branch.updated_at.clone(),
+            tracking_issue: None,
             branch: bv,
         })
     }
@@ -422,6 +427,13 @@ struct CreateReq {
     claim_issue: Option<i64>,
     #[serde(default)]
     existing_branch: Option<String>,
+    /// The branch (id or name) of the agent launching this session, when it is
+    /// itself a weaver session delegating work. Recorded as the tracking
+    /// issue's `source_branch` so the parent's sub-trees are attributable. The
+    /// `loom` CLI fills this from `$WEAVER_BRANCH`; a human/dashboard launch
+    /// leaves it unset.
+    #[serde(default)]
+    parent_branch: Option<String>,
     /// Model tier ('haiku' | 'sonnet' | 'opus'); blank/absent inherits the
     /// configured `agent.claude_args`.
     #[serde(default)]
@@ -655,21 +667,55 @@ async fn create_session(
         .await?
         .ok_or_else(|| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, "branch vanished"))?;
 
+    // Open this session's tracking issue before the launch prompt is written,
+    // so the agent can be told its issue number. When an agent delegated this
+    // work (`parent_branch`), the parent becomes the issue's `source_branch`.
+    let parent_branch_name = match req
+        .parent_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(key) => branch_mod::resolve_key(&st.db, key)
+            .await?
+            .map(|b| b.branch)
+            .filter(|name| name != &branch.branch),
+        None => None,
+    };
+    let tracking_issue = create_tracking_issue(
+        &st,
+        &branch,
+        parent_branch_name.as_deref(),
+        &title,
+        &goal,
+        &description,
+        github_repo.as_deref(),
+        github_issue,
+        claimed_issue_id,
+    )
+    .await?;
+
     let session_id = branch_mod::new_id();
     let run_dir = db::run_dir(&session_id);
     tokio::fs::create_dir_all(&run_dir).await?;
 
     // Drop any attached reference files into the worktree before the agent
     // launches, then tell the agent they are there. The branch goal stays the
-    // clean text the user typed; the scratch note rides on the launch prompt
-    // (goal.txt) only, so it reaches the agent without cluttering the dashboard.
+    // clean text the user typed; the scratch and tracking notes ride on the
+    // launch prompt (goal.txt) only, so they reach the agent without cluttering
+    // the dashboard.
     let scratch_names = write_initial_scratch(&work_dir, &req.scratch).await?;
-    let launch_prompt = match (goal.is_empty(), scratch_note(&scratch_names)) {
-        (true, None) => String::new(),
-        (false, None) => goal.clone(),
-        (true, Some(note)) => note,
-        (false, Some(note)) => format!("{goal}\n\n{note}"),
-    };
+    let mut prompt_parts: Vec<String> = Vec::new();
+    if !goal.is_empty() {
+        prompt_parts.push(goal.clone());
+    }
+    if let Some(note) = scratch_note(&scratch_names) {
+        prompt_parts.push(note);
+    }
+    if let Some(id) = tracking_issue {
+        prompt_parts.push(tracking_note(id));
+    }
+    let launch_prompt = prompt_parts.join("\n\n");
     let goal_file = if launch_prompt.is_empty() {
         None
     } else {
@@ -717,40 +763,6 @@ async fn create_session(
     )
     .await?;
 
-    // Track a seeding GitHub issue as a claimed issue row on this branch.
-    if let Some(number) = github_issue {
-        weaver_core::issue::add(
-            &st.db,
-            &weaver_core::issue::NewIssue {
-                repo_root: branch.repo_root.clone(),
-                github_repo: github_repo.clone(),
-                source_branch: Some(branch.branch.clone()),
-                claimed_branch: Some(branch.branch.clone()),
-                title: title.clone(),
-                body: description.clone(),
-                github_issue: Some(number),
-            },
-        )
-        .await
-        .ok();
-    }
-
-    // Fan-out pickup: a pre-existing weaver issue this session is claiming.
-    if let Some(issue_id) = claimed_issue_id {
-        weaver_core::issue::set_claim(&st.db, issue_id, Some(&branch.branch))
-            .await
-            .ok();
-        events::record(
-            &st.db,
-            &st.bus,
-            &branch.id,
-            "issue_claimed",
-            json!({ "id": issue_id }),
-        )
-        .await
-        .ok();
-    }
-
     if let Err(e) = repo::record_use(&st.db, &branch.repo_root).await {
         tracing::warn!(branch = %branch.id, error = %e, "failed to record recent repo");
     }
@@ -771,7 +783,123 @@ async fn create_session(
         "session created"
     );
 
-    Ok(Json(SessionView::build(&st.db, &session, &branch).await?))
+    let mut view = SessionView::build(&st.db, &session, &branch).await?;
+    view.tracking_issue = tracking_issue;
+    Ok(Json(view))
+}
+
+/// A line appended to a session's launch prompt telling the agent which weaver
+/// issue tracks its task, so it keeps the issue up to date and closes it when
+/// done. Mirrors [`scratch_note`]: it rides on the prompt only, never the
+/// stored goal.
+fn tracking_note(issue_id: i64) -> String {
+    format!(
+        "This session is tracked as weaver issue #{issue_id}. Keep your status \
+         current with `weaver set-status <level> \"<message>\"` as you work, and \
+         run `weaver issue close {issue_id}` once the task is complete (e.g. the \
+         PR is open) so whoever launched you knows you are done."
+    )
+}
+
+/// Open (or adopt) the tracking issue for a freshly-launched session: the one
+/// issue, claimed by the new branch, that represents its task. Whoever launched
+/// the session follows progress through it.
+///
+/// `--claim <id>` and `--issue <n>` (GitHub) reuse the issue they already
+/// imply, so a launch never opens a duplicate; a plain launch opens a fresh one
+/// from the task. An empty worktree with no task at all is untracked (`None`).
+/// `source_branch` records provenance — the parent branch when an agent
+/// delegated this work, else the new branch itself.
+#[allow(clippy::too_many_arguments)]
+async fn create_tracking_issue(
+    st: &AppState,
+    branch: &Branch,
+    parent_branch: Option<&str>,
+    title: &str,
+    goal: &str,
+    description: &str,
+    github_repo: Option<&str>,
+    github_issue: Option<i64>,
+    claim_issue: Option<i64>,
+) -> ApiResult<Option<i64>> {
+    let source = parent_branch.unwrap_or(&branch.branch).to_string();
+
+    // Claiming an existing weaver issue: that issue *is* the tracker.
+    if let Some(id) = claim_issue {
+        weaver_core::issue::set_claim(&st.db, id, Some(&branch.branch))
+            .await
+            .ok();
+        events::record(
+            &st.db,
+            &st.bus,
+            &branch.id,
+            "issue_claimed",
+            json!({ "id": id }),
+        )
+        .await
+        .ok();
+        return Ok(Some(id));
+    }
+
+    // A GitHub-seeded launch tracks the imported issue row.
+    if let Some(number) = github_issue {
+        let issue = weaver_core::issue::add(
+            &st.db,
+            &weaver_core::issue::NewIssue {
+                repo_root: branch.repo_root.clone(),
+                github_repo: github_repo.map(str::to_string),
+                source_branch: Some(source),
+                claimed_branch: Some(branch.branch.clone()),
+                title: title.to_string(),
+                body: description.to_string(),
+                github_issue: Some(number),
+            },
+        )
+        .await?;
+        events::record(
+            &st.db,
+            &st.bus,
+            &branch.id,
+            "issue_added",
+            json!({ "id": issue.id, "title": issue.title }),
+        )
+        .await
+        .ok();
+        return Ok(Some(issue.id));
+    }
+
+    // No task to track (e.g. an empty `--agent shell` worktree).
+    if goal.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let body = if description.trim().is_empty() {
+        goal
+    } else {
+        description
+    };
+    let issue = weaver_core::issue::add(
+        &st.db,
+        &weaver_core::issue::NewIssue {
+            repo_root: branch.repo_root.clone(),
+            source_branch: Some(source),
+            claimed_branch: Some(branch.branch.clone()),
+            title: title.to_string(),
+            body: body.to_string(),
+            ..Default::default()
+        },
+    )
+    .await?;
+    events::record(
+        &st.db,
+        &st.bus,
+        &branch.id,
+        "issue_added",
+        json!({ "id": issue.id, "title": issue.title }),
+    )
+    .await
+    .ok();
+    Ok(Some(issue.id))
 }
 
 #[derive(Debug, Deserialize)]
@@ -1839,6 +1967,101 @@ mod tests {
 
     fn b64(s: &str) -> String {
         base64::engine::general_purpose::STANDARD.encode(s)
+    }
+
+    #[tokio::test]
+    async fn create_tracking_issue_sources_parent_and_reuses_claims() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let st = AppState {
+            db: db.clone(),
+            bus: crate::events::EventBus::new(),
+            addr: "127.0.0.1:0".to_string(),
+        };
+        let child = branch_mod::upsert(&db, "/r", "weaver/child", "main")
+            .await
+            .unwrap();
+
+        // A delegated launch names the parent as the issue's source.
+        let id = create_tracking_issue(
+            &st,
+            &child,
+            Some("weaver/parent"),
+            "do it",
+            "do it in detail",
+            "",
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .expect("a fresh tracking issue");
+        let issue = weaver_core::issue::get(&db, id).await.unwrap().unwrap();
+        assert_eq!(issue.claimed_branch.as_deref(), Some("weaver/child"));
+        assert_eq!(
+            issue.source_branch.as_deref(),
+            Some("weaver/parent"),
+            "a delegated launch is sourced from the parent"
+        );
+
+        // A non-delegated launch is self-sourced (matches a hand-authored issue).
+        let id2 =
+            create_tracking_issue(&st, &child, None, "solo", "solo task", "", None, None, None)
+                .await
+                .unwrap()
+                .unwrap();
+        let issue2 = weaver_core::issue::get(&db, id2).await.unwrap().unwrap();
+        assert_eq!(issue2.source_branch.as_deref(), Some("weaver/child"));
+
+        // No task at all → nothing to track.
+        let none = create_tracking_issue(&st, &child, None, "", "", "", None, None, None)
+            .await
+            .unwrap();
+        assert!(none.is_none(), "an empty task opens no tracking issue");
+
+        // Claiming an existing issue reuses it rather than opening a duplicate.
+        let existing = weaver_core::issue::add(
+            &db,
+            &weaver_core::issue::NewIssue {
+                repo_root: "/r".to_string(),
+                title: "preexisting".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let claimed = create_tracking_issue(
+            &st,
+            &child,
+            None,
+            "x",
+            "x",
+            "",
+            None,
+            None,
+            Some(existing.id),
+        )
+        .await
+        .unwrap();
+        assert_eq!(claimed, Some(existing.id), "a claim reuses the issue id");
+        let reclaimed = weaver_core::issue::get(&db, existing.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            reclaimed.claimed_branch.as_deref(),
+            Some("weaver/child"),
+            "claiming stamps the new branch"
+        );
+    }
+
+    #[test]
+    fn tracking_note_names_the_issue_and_how_to_close_it() {
+        let note = tracking_note(42);
+        assert!(note.contains("weaver issue #42"));
+        // It tells the agent exactly how to signal "done".
+        assert!(note.contains("weaver issue close 42"));
+        assert!(note.contains("weaver set-status"));
     }
 
     #[test]

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -678,6 +678,10 @@ async fn create_session(
     {
         Some(key) => branch_mod::resolve_key(&st.db, key)
             .await?
+            // Only attribute to a parent in *this* repo. `resolve_key` searches
+            // globally, and a stray `$WEAVER_BRANCH` from a checkout elsewhere
+            // must not misattribute `source_branch` to an unrelated branch.
+            .filter(|b| b.repo_root == branch.repo_root)
             .map(|b| b.branch)
             .filter(|name| name != &branch.branch),
         None => None,
@@ -824,11 +828,11 @@ async fn create_tracking_issue(
 ) -> ApiResult<Option<i64>> {
     let source = parent_branch.unwrap_or(&branch.branch).to_string();
 
-    // Claiming an existing weaver issue: that issue *is* the tracker.
+    // Claiming an existing weaver issue: that issue *is* the tracker, so the
+    // claim must actually land — otherwise we'd hand back a tracking id for an
+    // issue this branch never claimed. Propagate failures rather than swallow.
     if let Some(id) = claim_issue {
-        weaver_core::issue::set_claim(&st.db, id, Some(&branch.branch))
-            .await
-            .ok();
+        weaver_core::issue::set_claim(&st.db, id, Some(&branch.branch)).await?;
         events::record(
             &st.db,
             &st.bus,

--- a/crates/loom/tests/integration.rs
+++ b/crates/loom/tests/integration.rs
@@ -178,6 +178,11 @@ async fn session_lifecycle() {
         ws["branch"]["title"], "integration test goal",
         "title derived from goal"
     );
+    // The launch hands back a tracking issue id — the caller's handle on it.
+    assert!(
+        ws["tracking_issue"].as_i64().is_some(),
+        "launch returns a tracking issue id, got {ws}"
+    );
     assert!(tmux::has_session(&session).await, "tmux session missing");
 
     let list = client.get("/api/sessions").await.unwrap();
@@ -463,7 +468,26 @@ async fn session_lifecycle() {
     let arr = branches.as_array().unwrap();
     assert_eq!(arr.len(), 1, "one branch tracked");
     assert_eq!(arr[0]["branch"], "weaver/integration-test-goal");
-    assert_eq!(arr[0]["open_issue_count"], 0);
+    // The launch opened one tracking issue, claimed by the new branch. With no
+    // parent agent it is self-sourced (source_branch == claimed_branch).
+    assert_eq!(
+        arr[0]["open_issue_count"], 1,
+        "launch opens a tracking issue"
+    );
+    let tracking = client
+        .get(&format!("/api/branches/{branch_id}/issues"))
+        .await
+        .unwrap();
+    let tracking = tracking.as_array().unwrap();
+    assert_eq!(tracking.len(), 1, "exactly the tracking issue");
+    assert_eq!(
+        tracking[0]["claimed_branch"],
+        "weaver/integration-test-goal"
+    );
+    assert_eq!(
+        tracking[0]["source_branch"], "weaver/integration-test-goal",
+        "self-sourced when no parent launched it"
+    );
 
     // Branch issues are claimed by the branch; the repo-wide board lives at
     // /api/repos/issues.
@@ -484,18 +508,22 @@ async fn session_lifecycle() {
         .get(&format!("/api/branches/{branch_id}/issues"))
         .await
         .unwrap();
-    assert_eq!(listed.as_array().unwrap().len(), 1);
+    assert_eq!(
+        listed.as_array().unwrap().len(),
+        2,
+        "the tracking issue plus the hand-created one"
+    );
     let branch_view = client
         .get(&format!("/api/branches/{branch_id}"))
         .await
         .unwrap();
-    assert_eq!(branch_view["open_issue_count"], 1);
-    // The repo board sees the claimed issue; the unclaimed backlog does not.
+    assert_eq!(branch_view["open_issue_count"], 2);
+    // The repo board sees both claimed issues; the unclaimed backlog does not.
     let board = client
         .get(&format!("/api/repos/issues?repo_root={repo_root}"))
         .await
         .unwrap();
-    assert_eq!(board.as_array().unwrap().len(), 1);
+    assert_eq!(board.as_array().unwrap().len(), 2);
     let backlog = client
         .get(&format!(
             "/api/repos/issues?repo_root={repo_root}&scope=backlog"
@@ -747,18 +775,24 @@ async fn session_lifecycle() {
     let list = client.get("/api/sessions").await.unwrap();
     assert_eq!(list.as_array().unwrap().len(), 0);
 
-    // The claimed issue is repo-owned: it outlives its session, returning to
-    // the unclaimed backlog rather than being deleted with the branch.
+    // Issues are repo-owned: they outlive their sessions, returning to the
+    // unclaimed backlog rather than being deleted with the branch. Every launch
+    // with a task sourced a tracking issue (integration-test-goal, feature/x,
+    // feature/y, archive-me — the bare no-goal session opens none), plus the
+    // "fix it" issue created by hand: five in all, every claim released.
     let board = client
         .get(&format!("/api/repos/issues?repo_root={repo_root}&all=true"))
         .await
         .unwrap();
     let board = board.as_array().unwrap();
-    assert_eq!(board.len(), 1, "issue survived teardown");
-    assert_eq!(board[0]["id"].as_i64().unwrap(), issue_id);
+    assert_eq!(board.len(), 5, "tracking + manual issues survived teardown");
     assert!(
-        board[0]["claimed_branch"].is_null(),
-        "claim was released on teardown"
+        board.iter().all(|i| i["claimed_branch"].is_null()),
+        "every claim was released on teardown"
+    );
+    assert!(
+        board.iter().any(|i| i["id"].as_i64() == Some(issue_id)),
+        "the hand-created issue survived"
     );
 
     let recent = client.get("/api/repos/recent").await.unwrap();

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -20,10 +20,48 @@ It is on your `PATH`. From anywhere in the worktree you can run:
   files it in the shared repo backlog instead).
 - `weaver issue ls` — this branch's tasks plus the unclaimed repo backlog
   (`--mine` for just yours, `--repo` for the whole repo). `weaver issue close N`.
+- `weaver issue show N` — an issue plus the live status of the branch working
+  it; `weaver issue wait N` blocks until it closes or that branch needs you
+  (see "Launching and tracking sub-sessions" below).
 - `weaver set-status` — with no argument, show the goal, status, and open-issue
   count.
 
 These talk directly to the weaver database — no daemon required.
+
+## Your tracking issue
+
+This branch has a **tracking issue** — a weaver issue claimed by your branch
+that represents the task you were launched for. `weaver issue ls --mine` shows
+it. It is how the agent (or human) that launched you watches your progress
+without reading this terminal:
+
+- Keep your status honest with `weaver set-status` as you work — that is the
+  live signal whoever launched you polls.
+- When the task is genuinely complete (the PR is open, the work is done), run
+  `weaver issue close <id>` on the tracking issue. Closing it is the
+  unambiguous "this sub-tree is finished" signal; leaving it open means "still
+  in flight". Do not close it early.
+
+## Launching and tracking sub-sessions
+
+You can fan work out into its own detached session — a parallel sub-tree on its
+own branch and worktree — and track it the same way someone tracks you:
+
+- `loom launch "<what the sub-agent should do>"` — spawn a sub-session. It
+  prints the new branch and a **tracking issue number** for the task; that
+  issue is your handle on the sub-tree.
+- `weaver issue show <id>` — poll the sub-tree: its tracking issue's
+  open/closed state plus the sub-agent's live `set-status` (attention +
+  current-state message).
+- `weaver issue wait <id>` — block until the sub-tree finishes (its tracking
+  issue closes) or needs you (the sub-agent raises its attention to
+  `attention`/`blocked`). Takes `--timeout <secs>`; prints why it woke.
+- `weaver issue ls` lists the sub-tasks you have delegated under
+  "Delegated by this branch", each with its sub-agent's current status.
+
+This duplicates some of a coding agent's builtin sub-agents, but a weaver
+sub-session is fully decoupled: it survives independently, has its own git
+history, and you can hand it off or revisit it later.
 
 ## Signalling your status
 

--- a/crates/weaver-core/src/issue.rs
+++ b/crates/weaver-core/src/issue.rs
@@ -107,6 +107,32 @@ pub async fn list_for_branch(
     Ok(rows)
 }
 
+/// Issues this branch **delegated**: created from `branch` (it is the
+/// `source_branch`) but claimed by a *different* branch — i.e. the tracking
+/// issues a parent agent opened when it launched sub-sessions. This is the
+/// parent's view of its parallel sub-trees.
+pub async fn list_delegated_by(
+    db: &Db,
+    repo_root: &str,
+    branch: &str,
+    include_closed: bool,
+) -> Result<Vec<Issue>> {
+    let sql = format!(
+        "SELECT * FROM issues
+         WHERE repo_root = ? AND source_branch = ?
+           AND claimed_branch IS NOT NULL AND claimed_branch != ?{}
+         ORDER BY id ASC",
+        status_clause(include_closed)
+    );
+    let rows = sqlx::query_as::<_, Issue>(&sql)
+        .bind(repo_root)
+        .bind(branch)
+        .bind(branch)
+        .fetch_all(db)
+        .await?;
+    Ok(rows)
+}
+
 /// The unclaimed repo backlog (`claimed_branch IS NULL`).
 pub async fn list_backlog(db: &Db, repo_root: &str, include_closed: bool) -> Result<Vec<Issue>> {
     let sql = format!(
@@ -314,6 +340,37 @@ mod tests {
         );
         assert_eq!(list_backlog(&db, "/r", false).await.unwrap().len(), 2);
         assert_eq!(list_for_repo(&db, "/r", false).await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delegated_lists_sub_trees_only() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        // `parent` delegated a task to `child` (source=parent, claimed=child).
+        let delegated = add(
+            &db,
+            &NewIssue {
+                repo_root: "/r".to_string(),
+                source_branch: Some("parent".to_string()),
+                claimed_branch: Some("child".to_string()),
+                title: "do the sub-task".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        // A self-claimed issue on `parent` is its own work, not a delegation.
+        add(&db, &claimed("/r", "parent", "my own work"))
+            .await
+            .unwrap();
+
+        let mine = list_delegated_by(&db, "/r", "parent", false).await.unwrap();
+        assert_eq!(mine.len(), 1, "only the cross-branch issue is delegated");
+        assert_eq!(mine[0].id, delegated.id);
+        // The child sees nothing delegated *by* it.
+        assert!(list_delegated_by(&db, "/r", "child", false)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -103,8 +103,26 @@ enum IssueCmd {
         #[arg(long)]
         branch: Option<String>,
     },
-    /// Show one issue.
+    /// Show one issue, including the live status of the branch working it.
     Show { id: i64 },
+    /// Block until an issue finishes or its sub-tree needs you.
+    ///
+    /// Polls the issue until it closes (the sub-agent's "done" signal) or — unless
+    /// `--closed-only` — until the branch working it raises its attention to
+    /// `attention`/`blocked` (it wants you). Prints why it woke. Exits non-zero
+    /// if `--timeout` elapses first with the issue still open.
+    Wait {
+        id: i64,
+        /// Give up after this many seconds (0 = wait indefinitely).
+        #[arg(long, default_value = "1800")]
+        timeout: u64,
+        /// Seconds between polls.
+        #[arg(long, default_value = "3")]
+        interval: u64,
+        /// Wake only when the issue closes; ignore the sub-agent's attention.
+        #[arg(long)]
+        closed_only: bool,
+    },
     /// Close an issue.
     Close { id: i64 },
     /// Reopen a closed issue.
@@ -357,6 +375,12 @@ async fn cmd_issue(cmd: IssueCmd) -> Result<()> {
                 "  claimed: {}",
                 i.claimed_branch.as_deref().unwrap_or("(backlog)")
             );
+            // Surface the live status of the branch working this issue — what
+            // makes `issue show` a poll of a delegated sub-tree, not just a
+            // record lookup.
+            if let Some(progress) = working_branch_status(&db, &i).await {
+                println!("  working: {progress}");
+            }
             if let Some(src) = &i.source_branch {
                 println!("  from:    {src}");
             }
@@ -371,6 +395,14 @@ async fn cmd_issue(cmd: IssueCmd) -> Result<()> {
                 println!();
                 println!("{}", i.body);
             }
+        }
+        IssueCmd::Wait {
+            id,
+            timeout,
+            interval,
+            closed_only,
+        } => {
+            cmd_issue_wait(&db, &b.repo_root, id, timeout, interval.max(1), closed_only).await?;
         }
         IssueCmd::Close { id } => {
             ensure_issue_in_repo(&db, id, &b.repo_root).await?;
@@ -417,6 +449,19 @@ async fn cmd_issue_ls_default(
         println!("On this branch ({}):", working.len());
         for i in &working {
             println!("  {}", issue_line(i));
+        }
+        printed = true;
+    }
+    // Sub-trees this branch launched: tracking issues it sourced but another
+    // branch is working. Each carries its sub-agent's live status.
+    let delegated = issue::list_delegated_by(db, repo_root, target, all).await?;
+    if !delegated.is_empty() {
+        println!("Delegated by this branch ({}):", delegated.len());
+        for i in &delegated {
+            let status = working_branch_status(db, i)
+                .await
+                .unwrap_or_else(|| i.claimed_branch.clone().unwrap_or_else(|| "?".to_string()));
+            println!("  {}  → {status}", issue_line(i));
         }
         printed = true;
     }
@@ -501,6 +546,80 @@ async fn ensure_issue_in_repo(db: &db::Db, id: i64, repo_root: &str) -> Result<i
         bail!("issue #{id} belongs to a different repo");
     }
     Ok(i)
+}
+
+/// The live status of the branch working `issue`, as `"<branch> · <attention>
+/// — <message>"`, or `None` when the issue is unclaimed or its branch row is
+/// gone. This is what turns an issue lookup into a poll of a delegated sub-tree.
+async fn working_branch_status(db: &db::Db, issue: &issue::Issue) -> Option<String> {
+    let claimed = issue.claimed_branch.as_deref()?;
+    let row = branch::find_by_repo_branch(db, &issue.repo_root, claimed)
+        .await
+        .ok()
+        .flatten()?;
+    let status = if row.description.is_empty() {
+        row.attention.clone()
+    } else {
+        format!("{} — {}", row.attention, row.description)
+    };
+    Some(format!("{claimed} · {status}"))
+}
+
+/// Block until issue `id` finishes (closes) or — unless `closed_only` — its
+/// claiming branch raises attention above `ok`. Polls every `interval` seconds;
+/// exits the process non-zero if `timeout` (when non-zero) elapses first.
+async fn cmd_issue_wait(
+    db: &db::Db,
+    repo_root: &str,
+    id: i64,
+    timeout: u64,
+    interval: u64,
+    closed_only: bool,
+) -> Result<()> {
+    let issue = ensure_issue_in_repo(db, id, repo_root).await?;
+    if issue.status != "open" {
+        println!("issue #{id} is {} — nothing to wait for", issue.status);
+        return Ok(());
+    }
+    match working_branch_status(db, &issue).await {
+        Some(s) => println!("waiting on #{id} ({}) — {s}", issue.title),
+        None => println!("waiting on #{id} ({})", issue.title),
+    }
+
+    let deadline =
+        (timeout > 0).then(|| std::time::Instant::now() + std::time::Duration::from_secs(timeout));
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
+        let cur = issue::get(db, id)
+            .await?
+            .ok_or_else(|| anyhow!("issue #{id} disappeared while waiting"))?;
+        if cur.status != "open" {
+            println!("issue #{id} closed — sub-tree finished");
+            return Ok(());
+        }
+        if !closed_only {
+            if let Some(name) = cur.claimed_branch.as_deref() {
+                if let Some(row) = branch::find_by_repo_branch(db, repo_root, name).await? {
+                    if row.attention != branch::DEFAULT_ATTENTION {
+                        let msg = if row.description.is_empty() {
+                            row.attention.clone()
+                        } else {
+                            format!("{} — {}", row.attention, row.description)
+                        };
+                        println!("issue #{id} needs you — {name} is {msg}");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+            let progress = working_branch_status(db, &cur)
+                .await
+                .unwrap_or_else(|| "open".to_string());
+            println!("timed out after {timeout}s — #{id} still open ({progress})");
+            std::process::exit(1);
+        }
+    }
 }
 
 /// The WEAVER.md to inject at session start: the repo's own copy when it ships

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -586,10 +586,17 @@ async fn cmd_issue_wait(
         None => println!("waiting on #{id} ({})", issue.title),
     }
 
+    let interval = std::time::Duration::from_secs(interval);
     let deadline =
         (timeout > 0).then(|| std::time::Instant::now() + std::time::Duration::from_secs(timeout));
     loop {
-        tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
+        // Never nap past the deadline: a long `--interval` must not stretch a
+        // short `--timeout`.
+        let nap = match deadline {
+            Some(d) => interval.min(d.saturating_duration_since(std::time::Instant::now())),
+            None => interval,
+        };
+        tokio::time::sleep(nap).await;
         let cur = issue::get(db, id)
             .await?
             .ok_or_else(|| anyhow!("issue #{id} disappeared while waiting"))?;
@@ -612,12 +619,14 @@ async fn cmd_issue_wait(
                 }
             }
         }
+        // Timing out is a real "not done" outcome: report it as an error so the
+        // process exits non-zero (callers branch on it) without an ad-hoc
+        // `process::exit` that bypasses normal error handling.
         if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
             let progress = working_branch_status(db, &cur)
                 .await
                 .unwrap_or_else(|| "open".to_string());
-            println!("timed out after {timeout}s — #{id} still open ({progress})");
-            std::process::exit(1);
+            bail!("timed out after {timeout}s — #{id} still open ({progress})");
         }
     }
 }

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -201,8 +201,9 @@ fn issue_wait_times_out_on_an_open_issue() {
         !out.status.success(),
         "an unmet wait should exit non-zero so callers can branch on it"
     );
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("timed out"), "stdout: {stdout}");
+    // The timeout is reported through the normal error path (stderr).
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("timed out"), "stderr: {stderr}");
 }
 
 /// A tracking issue sourced from this branch but claimed by another shows up

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -151,6 +151,126 @@ fn issue_ls_separates_branch_work_from_repo_backlog() {
     assert!(out.contains("open issues: 1"), "status: {out}");
 }
 
+/// `issue show` surfaces the live status of the branch working the issue, which
+/// is what lets a parent agent poll a delegated sub-tree.
+#[test]
+fn issue_show_includes_the_working_branch_status() {
+    let env = setup();
+    run(&env, &["issue", "add", "the", "sub-task"]);
+    // The current branch claims it; give the branch a live status.
+    run(&env, &["set-status", "blocked", "build", "is", "broken"]);
+    let out = run(&env, &["issue", "show", "1"]);
+    assert!(
+        out.contains("working:"),
+        "show should report progress: {out}"
+    );
+    assert!(
+        out.contains("blocked — build is broken"),
+        "show should surface the claiming branch's status: {out}"
+    );
+}
+
+/// `issue wait` returns immediately (success) when the issue is already closed,
+/// and reports a closed issue rather than hanging.
+#[test]
+fn issue_wait_returns_when_already_closed() {
+    let env = setup();
+    run(&env, &["issue", "add", "done", "already"]);
+    run(&env, &["issue", "close", "1"]);
+    let out = run(&env, &["issue", "wait", "1", "--timeout", "1"]);
+    assert!(
+        out.contains("nothing to wait for"),
+        "wait on a closed issue should return at once: {out}"
+    );
+}
+
+/// `issue wait` on a still-open issue gives up at the timeout with a non-zero
+/// exit, so a caller can tell "still running" from "finished".
+#[test]
+fn issue_wait_times_out_on_an_open_issue() {
+    let env = setup();
+    run(&env, &["issue", "add", "still", "going"]);
+    let out = Command::new(weaver_bin())
+        .args(["issue", "wait", "1", "--timeout", "1", "--interval", "1"])
+        .current_dir(&env.repo_path)
+        .env("WEAVER_HOME", &env.home_path)
+        .env("WEAVER_API", "http://127.0.0.1:1")
+        .output()
+        .expect("failed to spawn weaver");
+    assert!(
+        !out.status.success(),
+        "an unmet wait should exit non-zero so callers can branch on it"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("timed out"), "stdout: {stdout}");
+}
+
+/// A tracking issue sourced from this branch but claimed by another shows up
+/// under "Delegated by this branch", with the sub-agent's status.
+#[test]
+fn issue_ls_shows_delegated_sub_trees() {
+    let env = setup();
+    // Simulate a delegation: an issue this branch (feature-test) sourced, now
+    // claimed by a child branch with a live status. We seed it straight into
+    // the db the same way the launcher would.
+    seed_delegated_issue(&env, "feature-test", "weaver/child", "attention", "ready");
+
+    let out = run(&env, &["issue", "ls"]);
+    assert!(
+        out.contains("Delegated by this branch"),
+        "ls should list delegated sub-trees: {out}"
+    );
+    assert!(out.contains("weaver/child"), "ls: {out}");
+    assert!(
+        out.contains("attention — ready"),
+        "delegated rows show the sub-agent status: {out}"
+    );
+}
+
+/// Insert a delegated tracking issue (sourced by `parent`, claimed by `child`)
+/// and give `child` a branch row with the supplied attention/description —
+/// reproducing the state a `loom launch` from inside `parent` would create.
+fn seed_delegated_issue(env: &Env, parent: &str, child: &str, attention: &str, description: &str) {
+    let db_path = env.home_path.join("weaver.db");
+    // Make sure the parent branch row exists first (a write resolves it).
+    run(env, &["goal", "parent", "goal"]);
+    let repo_root = canonical_repo_root(&env.repo_path);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let db = weaver_core::db::connect(&db_path).await.unwrap();
+        let child_id = weaver_core::branch::new_id();
+        weaver_core::branch::insert(&db, &child_id, &repo_root, child, "main")
+            .await
+            .unwrap();
+        weaver_core::branch::set_attention(&db, &child_id, attention)
+            .await
+            .unwrap();
+        weaver_core::branch::set_description(&db, &child_id, description)
+            .await
+            .unwrap();
+        weaver_core::issue::add(
+            &db,
+            &weaver_core::issue::NewIssue {
+                repo_root: repo_root.clone(),
+                source_branch: Some(parent.to_string()),
+                claimed_branch: Some(child.to_string()),
+                title: "the delegated task".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    });
+}
+
+/// The canonical repo_root weaver keys on (matches `branch::resolve_from_path`).
+fn canonical_repo_root(repo: &Path) -> String {
+    repo.canonicalize()
+        .unwrap_or_else(|_| repo.to_path_buf())
+        .display()
+        .to_string()
+}
+
 #[test]
 fn note_writes_an_event() {
     let env = setup();


### PR DESCRIPTION
`loom launch` now translates each task into a **branch-level weaver issue** in the new branch and hands the issue number back to the caller, so a launching agent (or human) can track the sub-session's progress — and block or poll on a parallel sub-tree.

## How it works

- **Every launch opens a tracking issue** claimed by the new branch, representing the task. Its id is returned as `SessionView.tracking_issue` and printed by `loom launch`:
  ```
  track:  weaver issue #1  (weaver issue show 1 | wait 1)
  ```
- **The launched agent is instructed** — in its opening prompt and generically in `WEAVER.md` — to keep `weaver set-status` current and to `weaver issue close <id>` when the work is done. Closing it is the unambiguous "this sub-tree is finished" signal.
- **Delegation is attributed.** When an agent already inside a weaver session runs `loom launch`, the CLI passes its `$WEAVER_BRANCH` as `parent_branch`; the tracking issue records the parent as `source_branch`, and the sub-tree appears under a new **"Delegated by this branch"** section in `weaver issue ls`.
- **No duplicates.** A GitHub `--issue` or weaver `--claim` launch reuses the issue it already implies; a task-less `--agent shell` worktree opens none.

## Poll / block primitives (agent-facing, daemon-less)

- `weaver issue show <id>` now surfaces the **live status** (attention + current-state message) of the branch working the issue — a poll of the sub-tree, not just a record lookup.
- `weaver issue wait <id>` **blocks** until the issue closes *or* that branch raises its attention above `ok` (it needs you), with `--timeout` / `--interval` / `--closed-only`. Exits non-zero on timeout so callers can branch on it.

Closes #6.
