### PR TITLE
Fix diff viewer picking up unrelated upstream changes

### DIFF
--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -89,12 +89,15 @@ export interface ScratchFile {
 }
 
 /** The worktree file tree: a flat list of repo-relative paths plus a
- *  `path → status` map of changes vs the base branch. Assembled into a tree
- *  client-side. Returned by `/api/sessions/{id}/tree`. */
+ *  `path → status` map of changes vs the chosen baseline. Assembled into a tree
+ *  client-side. Returned by `/api/sessions/{id}/tree`; the optional `base`
+ *  query param ("branch" | "uncommitted") selects the baseline, echoed back. */
 export interface FileTree {
   files: string[];
   /** status is one of "added" | "modified" | "deleted" | "renamed" | "copied". */
   changed: Record<string, string>;
+  /** The baseline these changes are measured against: "branch" | "uncommitted". */
+  base: string;
 }
 
 /** A single file's content for the editor. For binary or oversized files the

--- a/crates/loom/frontend/src/views/FileBrowser.vue
+++ b/crates/loom/frontend/src/views/FileBrowser.vue
@@ -38,6 +38,26 @@ const loadError = ref('');
 const showChanges = ref(true);
 const showFiles = ref(true);
 
+// Which baseline "changed" is measured against. `branch` (default) is the
+// branch's fork point — everything it introduced; `uncommitted` is just what
+// hasn't been committed yet (vs HEAD). The server resolves the actual ref (and
+// for `branch` picks the up-to-date base so a stale local mainline doesn't drag
+// unrelated upstream commits into the diff).
+type DiffBase = 'branch' | 'uncommitted';
+const baseOptions: { value: DiffBase; label: string; title: string }[] = [
+  {
+    value: 'branch',
+    label: 'Branch',
+    title: 'Everything this branch changed since it forked from its base',
+  },
+  {
+    value: 'uncommitted',
+    label: 'Uncommitted',
+    title: "Only changes that haven't been committed yet (vs HEAD)",
+  },
+];
+const diffBase = ref<DiffBase>('branch');
+
 const session = ref<Session | null>(null);
 
 function buildTree(t: FileTree): Node {
@@ -186,10 +206,12 @@ function rawUrl(path: string): string {
 }
 
 async function getFile(path: string, ref?: 'base'): Promise<FileContent> {
-  const suffix = ref === 'base' ? '&ref=base' : '';
-  return (await get(
-    `/sessions/${props.id}/file?path=${encodeURIComponent(path)}${suffix}`,
-  )) as FileContent;
+  const params = new URLSearchParams({ path });
+  if (ref === 'base') {
+    params.set('ref', 'base');
+    params.set('base', diffBase.value);
+  }
+  return (await get(`/sessions/${props.id}/file?${params.toString()}`)) as FileContent;
 }
 
 function disposeModels() {
@@ -363,12 +385,20 @@ function setMode(m: ViewMode) {
 
 async function loadTree() {
   try {
-    tree.value = (await get(`/sessions/${props.id}/tree`)) as FileTree;
+    tree.value = (await get(`/sessions/${props.id}/tree?base=${diffBase.value}`)) as FileTree;
     autoExpand();
     loadError.value = '';
   } catch (e) {
     loadError.value = (e as Error).message;
   }
+}
+
+// Switch the diff baseline: reload the change set and re-render the open file
+// (its diff is now taken against the new base).
+async function setDiffBase(v: DiffBase) {
+  if (diffBase.value === v) return;
+  diffBase.value = v;
+  await refresh();
 }
 
 // Open folders that contain changes (and every top-level folder) so the tree
@@ -425,8 +455,21 @@ onUnmounted(teardownEditors);
         {{ session?.branch.title || session?.branch.name || 'Files' }}
       </h1>
       <span v-if="changedCount" class="text-xs text-attn">{{ changedCount }} changed</span>
+      <!-- Diff baseline: branch-since-fork (default) vs uncommitted-only. -->
+      <div class="ml-auto flex items-center overflow-hidden rounded border border-line text-xs">
+        <button
+          v-for="opt in baseOptions"
+          :key="opt.value"
+          class="px-2 py-1"
+          :class="diffBase === opt.value ? 'bg-subtle text-fg' : 'text-muted hover:bg-subtle/60'"
+          :title="opt.title"
+          @click="setDiffBase(opt.value)"
+        >
+          {{ opt.label }}
+        </button>
+      </div>
       <button
-        class="ml-auto rounded bg-subtle hover:bg-subtle-hover px-2 py-1 text-xs"
+        class="rounded bg-subtle hover:bg-subtle-hover px-2 py-1 text-xs"
         @click="refresh"
       >
         Refresh

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -1056,12 +1056,22 @@ async fn adopt_session(
 /// of MB the browser editor stops being useful and starts being a memory hog.
 const MAX_TEXT_BYTES: usize = 2 * 1024 * 1024;
 
+/// `base` selects the diff baseline: `branch` (default, the branch's fork point)
+/// or `uncommitted` (vs `HEAD`). Shared by the tree and file endpoints; absent
+/// or unknown values fall back to `branch` (see [`git::DiffBase::from_query`]).
+#[derive(Debug, Deserialize)]
+struct TreeQuery {
+    base: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct FileQuery {
     path: String,
-    /// `working` (default, read from disk) or `base` (read from the merge-base).
+    /// `working` (default, read from disk) or `base` (read from the diff base).
     #[serde(rename = "ref")]
     reference: Option<String>,
+    /// Which baseline the `base` ref resolves to — see [`TreeQuery`].
+    base: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1120,13 +1130,15 @@ fn content_type_for(path: &str) -> &'static str {
 async fn tree_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
+    Query(q): Query<TreeQuery>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
     let work_dir = PathBuf::from(&session.work_dir);
+    let mode = git::DiffBase::from_query(q.base.as_deref());
     let files = git::list_files(&work_dir).await?;
     // A missing/odd base shouldn't sink the whole tree — just show no badges.
-    let changed = match git::merge_base(&work_dir, &branch.base_branch).await {
-        Ok(base) => git::changed_files(&work_dir, &base)
+    let changed = match git::diff_since(&work_dir, &branch.base_branch, mode).await {
+        Ok(since) => git::changed_files(&work_dir, &since)
             .await
             .unwrap_or_default(),
         Err(_) => Vec::new(),
@@ -1135,7 +1147,9 @@ async fn tree_session(
         .into_iter()
         .map(|c| (c.path, Value::String(c.status)))
         .collect();
-    Ok(Json(json!({ "files": files, "changed": changed })))
+    Ok(Json(
+        json!({ "files": files, "changed": changed, "base": mode.as_str() }),
+    ))
 }
 
 /// Text content of a single worktree file for the editor. Binary and oversized
@@ -1152,8 +1166,9 @@ async fn file_session(
     let rel = rel_path(&q.path)?;
 
     let bytes: Vec<u8> = if q.reference.as_deref() == Some("base") {
-        match git::merge_base(&work_dir, &branch.base_branch).await {
-            Ok(base) => git::read_blob(&work_dir, &base, &rel)
+        let mode = git::DiffBase::from_query(q.base.as_deref());
+        match git::diff_since(&work_dir, &branch.base_branch, mode).await {
+            Ok(since) => git::read_blob(&work_dir, &since, &rel)
                 .await?
                 .unwrap_or_default(),
             // No base means nothing to compare against; treat as empty original.

--- a/crates/loom/tests/integration.rs
+++ b/crates/loom/tests/integration.rs
@@ -456,6 +456,61 @@ async fn session_lifecycle() {
             .await
             .unwrap();
         assert_eq!(bad.status().as_u16(), 400, "absolute raw path rejected");
+
+        // Diff baseline selector: commit the current edits, then make one more
+        // uncommitted change. `base=branch` (the default) shows everything the
+        // branch introduced; `base=uncommitted` shows only what's not committed.
+        let wt = Path::new(&work_dir);
+        sh(wt, "git", &["add", "-A"]);
+        sh(wt, "git", &["commit", "-q", "-m", "branch work"]);
+        std::fs::write(wt.join("README.md"), "hello world again\n").unwrap();
+
+        let branch_scope = client
+            .get(&format!("/api/sessions/{id}/tree?base=branch"))
+            .await
+            .unwrap();
+        let changed = branch_scope["changed"].as_object().unwrap();
+        assert_eq!(branch_scope["base"], "branch");
+        assert_eq!(changed["README.md"], "modified");
+        assert_eq!(
+            changed["new.txt"], "added",
+            "branch scope still shows the committed addition"
+        );
+
+        let uncommitted = client
+            .get(&format!("/api/sessions/{id}/tree?base=uncommitted"))
+            .await
+            .unwrap();
+        let changed = uncommitted["changed"].as_object().unwrap();
+        assert_eq!(uncommitted["base"], "uncommitted");
+        assert_eq!(changed["README.md"], "modified");
+        assert!(
+            !changed.contains_key("new.txt"),
+            "uncommitted scope hides the already-committed addition, got {changed:?}"
+        );
+
+        // The `base` ref read honours the scope too: vs HEAD the original is the
+        // committed README; vs the branch fork point it's the pre-branch one.
+        let head_side = client
+            .get(&format!(
+                "/api/sessions/{id}/file?path=README.md&ref=base&base=uncommitted"
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            head_side["content"], "hello world\n",
+            "uncommitted base reads the committed (HEAD) version"
+        );
+        let fork_side = client
+            .get(&format!(
+                "/api/sessions/{id}/file?path=README.md&ref=base&base=branch"
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            fork_side["content"], "hello\n",
+            "branch base reads the fork-point version"
+        );
     }
 
     // Branches endpoint lists this branch with the right metadata.

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -179,6 +179,80 @@ pub async fn merge_base(work_dir: &Path, base: &str) -> Result<String> {
     git(work_dir, &["merge-base", base, "HEAD"]).await
 }
 
+/// Is `a` an ancestor of `b`? (`git merge-base --is-ancestor` exits 0 when so.)
+async fn is_ancestor(work_dir: &Path, a: &str, b: &str) -> bool {
+    git(work_dir, &["merge-base", "--is-ancestor", a, b])
+        .await
+        .is_ok()
+}
+
+/// Merge-base of `HEAD` with the branch's base, choosing between the local
+/// `<base>` ref and its `origin/<base>` tracking counterpart whichever sits
+/// *closer to* `HEAD`.
+///
+/// A weaver branch is forked from the local `<base>` at creation, but that local
+/// ref then often falls behind `origin/<base>` (nobody checks `main` out to pull
+/// it) while the branch itself gets rebased onto the remote. Diffing against the
+/// stale local ref would then replay every intervening upstream commit as a
+/// spurious change — the "cruft from unrelated upstream changes" a long-lived
+/// branch accumulates. Taking the more recent of the two merge-bases keeps the
+/// diff to the branch's own work whichever ref it actually tracks.
+pub async fn merge_base_fresh(work_dir: &Path, base: &str) -> Result<String> {
+    let remote = format!("origin/{base}");
+    let mut best: Option<String> = None;
+    for cand in [base, remote.as_str()] {
+        let Ok(mb) = git(work_dir, &["merge-base", cand, "HEAD"]).await else {
+            continue; // ref doesn't resolve (no such branch / no remote) — skip it
+        };
+        best = Some(match best {
+            None => mb,
+            // Prefer the merge-base nearer HEAD: if the previous pick is an
+            // ancestor of this one, this one is the more recent fork point.
+            Some(prev) if is_ancestor(work_dir, &prev, &mb).await => mb,
+            Some(prev) => prev,
+        });
+    }
+    best.ok_or_else(|| anyhow!("no merge-base between HEAD and {base} or origin/{base}"))
+}
+
+/// Which baseline a worktree diff is taken against. The string values are the
+/// wire form carried by the file-viewer's `base` query parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffBase {
+    /// The branch's fork point — everything the branch introduced. The default.
+    Branch,
+    /// `HEAD` — only changes not yet committed.
+    Uncommitted,
+}
+
+impl DiffBase {
+    /// Parse the `base` query value; anything unrecognized (or absent) is `Branch`.
+    pub fn from_query(s: Option<&str>) -> Self {
+        match s {
+            Some("uncommitted") => DiffBase::Uncommitted,
+            _ => DiffBase::Branch,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DiffBase::Branch => "branch",
+            DiffBase::Uncommitted => "uncommitted",
+        }
+    }
+}
+
+/// Resolve the git revision a worktree diff should compare against for `mode`:
+/// the freshest merge-base with `base` for [`DiffBase::Branch`], or plain `HEAD`
+/// for [`DiffBase::Uncommitted`]. Feed the result to [`changed_files`],
+/// [`diff`], or [`read_blob`] as `since`.
+pub async fn diff_since(work_dir: &Path, base: &str, mode: DiffBase) -> Result<String> {
+    match mode {
+        DiffBase::Branch => merge_base_fresh(work_dir, base).await,
+        DiffBase::Uncommitted => Ok("HEAD".to_string()),
+    }
+}
+
 async fn git_with_index(work_dir: &Path, index: &Path, args: &[&str]) -> Result<String> {
     tracing::debug!(
         ?args,
@@ -375,5 +449,93 @@ pub async fn read_blob(work_dir: &Path, rev: &str, path: &str) -> Result<Option<
         Ok(Some(out.stdout))
     } else {
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn run(dir: &Path, args: &[&str]) -> String {
+        git(dir, args).await.unwrap()
+    }
+
+    async fn commit(dir: &Path, msg: &str) -> String {
+        run(dir, &["commit", "--allow-empty", "-q", "-m", msg]).await;
+        run(dir, &["rev-parse", "HEAD"]).await
+    }
+
+    /// A stale local `main` left behind at the fork point must not drag the
+    /// upstream commits the branch was rebased onto into its diff. The freshest
+    /// merge-base (here `origin/main`) keeps the diff to the branch's own work.
+    #[tokio::test]
+    async fn merge_base_fresh_prefers_up_to_date_remote() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        run(dir, &["init", "-q", "-b", "main"]).await;
+        run(dir, &["config", "user.email", "t@t.t"]).await;
+        run(dir, &["config", "user.name", "t"]).await;
+
+        let t0 = commit(dir, "T0").await;
+        // Two upstream commits the branch will be rebased onto.
+        std::fs::write(dir.join("SKILL.md"), "s\n").unwrap();
+        run(dir, &["add", "-A"]).await;
+        commit(dir, "U1 upstream").await;
+        std::fs::write(dir.join("dependabot.yml"), "d\n").unwrap();
+        run(dir, &["add", "-A"]).await;
+        let upstream = commit(dir, "U2 upstream").await;
+        // origin/main tracks the up-to-date upstream tip.
+        run(dir, &["update-ref", "refs/remotes/origin/main", &upstream]).await;
+
+        // The branch forks from the up-to-date remote and adds one real change.
+        run(dir, &["checkout", "-q", "-b", "feature", &upstream]).await;
+        std::fs::write(dir.join("mine.txt"), "m\n").unwrap();
+        run(dir, &["add", "-A"]).await;
+        commit(dir, "my real change").await;
+
+        // Local `main` is left stale at the original fork point.
+        run(dir, &["update-ref", "refs/heads/main", &t0]).await;
+
+        // Plain merge-base against the stale local ref is the bug: it predates
+        // the upstream commits, so the diff replays them as cruft.
+        assert_eq!(merge_base(dir, "main").await.unwrap(), t0);
+        let crufty = changed_files(dir, &t0).await.unwrap();
+        let names: Vec<&str> = crufty.iter().map(|c| c.path.as_str()).collect();
+        assert!(names.contains(&"SKILL.md") && names.contains(&"dependabot.yml"));
+
+        // The fresh resolution snaps to origin/main, dropping the upstream churn.
+        let since = diff_since(dir, "main", DiffBase::Branch).await.unwrap();
+        assert_eq!(since, upstream, "should diff against the up-to-date remote");
+        let clean = changed_files(dir, &since).await.unwrap();
+        assert_eq!(clean.len(), 1);
+        assert_eq!(clean[0].path, "mine.txt");
+    }
+
+    /// `DiffBase::Uncommitted` scopes to working-tree changes vs `HEAD`, ignoring
+    /// everything the branch has already committed.
+    #[tokio::test]
+    async fn diff_since_uncommitted_is_vs_head() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        run(dir, &["init", "-q", "-b", "main"]).await;
+        run(dir, &["config", "user.email", "t@t.t"]).await;
+        run(dir, &["config", "user.name", "t"]).await;
+        commit(dir, "T0").await;
+        std::fs::write(dir.join("committed.txt"), "c\n").unwrap();
+        run(dir, &["add", "-A"]).await;
+        commit(dir, "committed work").await;
+
+        // An as-yet-uncommitted edit.
+        std::fs::write(dir.join("scratchpad.txt"), "wip\n").unwrap();
+
+        assert_eq!(
+            diff_since(dir, "main", DiffBase::Uncommitted)
+                .await
+                .unwrap(),
+            "HEAD"
+        );
+        let changed = changed_files(dir, "HEAD").await.unwrap();
+        assert_eq!(changed.len(), 1, "only the uncommitted file");
+        assert_eq!(changed[0].path, "scratchpad.txt");
     }
 }


### PR DESCRIPTION
## Problem

The Files tab could show a wildly inflated change set — the report had **457 changed files**, most of them unrelated upstream churn (`SKILL.md`, `dependabot.yml`, …):

The tree diffed the worktree against `merge-base(<local base branch>, HEAD)`. When the local mainline ref (`main`) lags `origin/main` — the common case, since nobody checks `main` out just to pull it — while the branch was forked from or rebased onto the up-to-date remote, that merge-base sits *before* the upstream commits. Every intervening upstream change then replays as a spurious "change".

## Fix

**Freshest base resolution.** `git::merge_base_fresh` considers both the local `<base>` ref and its `origin/<base>` tracking counterpart and takes the merge-base nearer `HEAD`. The diff stays scoped to the branch's own work whichever ref it actually tracks. Falls back to the old behaviour when there's no remote (merge-base against the local ref).

**A simple scope selector** in the Files header (the user asked for "the most natural set by default, plus a simple selector if there are reasonable options"):
- **Branch** (default) — everything the branch introduced since its fork point.
- **Uncommitted** — only working-tree changes not yet committed (vs `HEAD`).

## Implementation

- `crates/weaver-core/src/git.rs`: `merge_base_fresh`, `diff_since`, and the `DiffBase` enum (+ unit tests reproducing the exact stale-`main` cruft scenario and the uncommitted scope).
- `crates/loom/src/web.rs`: `/tree` and `/file` take a `base` query param (`branch` | `uncommitted`, default `branch`); the resolved base is echoed back.
- `crates/loom/frontend/`: a segmented control mirroring the existing diff mode toggle; `FileTree.base` added to keep types in sync.
- `crates/loom/tests/integration.rs`: end-to-end coverage of both scopes through the real server, including the `ref=base` reads.

## Verification

`WEAVER_SKIP_FRONTEND=1 cargo test --workspace` passes; `cargo clippy --workspace --all-targets` clean; frontend builds and type-checks. Verified live against a repo reproducing the failure mode: with a stale local `main`, the default **Branch** scope dropped from the upstream cruft to just the branch's own file, and **Uncommitted** showed only the working-tree edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)