### PR TITLE
feat(weaver): `weaver summary` + shared fmt/clippy pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# weaver pre-commit hook — block commits that fail `cargo fmt` or `clippy`.
+#
+# Enable it (once per clone):  git config core.hooksPath .githooks
+# Bypass it for one commit:     git commit --no-verify
+#
+# The actual checks live in scripts/pre-commit.sh, shared with CI.
+exec "$(git rev-parse --show-toplevel)/scripts/pre-commit.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: crates/loom/frontend/package-lock.json
-      - run: cargo fmt --all --check
-      - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      # Same fmt + clippy gate developers run locally via the pre-commit hook
+      # (.githooks/pre-commit), so "passes locally" means "passes CI".
+      - run: ./scripts/pre-commit.sh
 
   test:
     name: test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ needing the daemon to be reachable.
 | Path | What's in it |
 |---|---|
 | `crates/weaver-core/` | lib: `branches`, `issues`, `notes`, `events`, `db`, `git`, `config`, `plan` (parser + reconcile), `repo_config` (`.weaver/config.toml`), agent helpers. Pure logic; used by both binaries. |
-| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `note`, `set-status` [read or set level + message], `issue …`, `where`, `log`, `hook`, `config`) |
+| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `note`, `set-status` [read or set level + message], `issue …`, `where`, `log`, `hook`, `config`) |
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
@@ -84,6 +84,12 @@ the build level.
 
 The integration tests shell out to real `git` and `tmux`. If one hangs, look
 for stray `weaver-test-*` tmux sessions.
+
+### Pre-commit checks
+
+Run `./scripts/pre-commit.sh` before committing; it runs the same fmt + clippy
+gate the CI `lint` job enforces. Enable it as an automatic hook with `git config
+core.hooksPath .githooks`.
 
 ### Don't spin up your own `loom` — it shares the user's tmux + db
 
@@ -340,6 +346,7 @@ When working inside a worktree the agent can run, with no daemon required:
 ```sh
 weaver goal "ship the feature"          # set the branch's goal
 weaver goal                             # print the goal
+weaver summary                          # goal + outstanding tasks + next-step hints
 weaver note   "blocked on the DB schema"
 weaver set-status attention "ready for review"   # level + current-state message
 weaver set-status ok "waiting on PR review feedback"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ loom open                             # open the web UI
 # Agent-facing (run from inside the worktree, no daemon required)
 weaver goal "ship the feature"
 weaver goal                           # print the current goal
+weaver summary                        # goal + outstanding tasks + next-step hints
 weaver note    "blocked on the DB schema"
 weaver set-status attention "ready for review"   # level (ok|attention|blocked) + current-state message
 weaver issue add "Backfill old rows" --body "ETA after the schema change"

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -10,6 +10,9 @@ This document describes how to work *with weaver*. It is distinct from any
 It is on your `PATH`. From anywhere in the worktree you can run:
 
 - `weaver goal` — print the task this branch was created for.
+- `weaver summary` — a quick catch-up on the branch: the goal, your current
+  status, the outstanding tasks, and a hint or two for what to do next. Run it
+  when you pick up or resume a branch.
 - `weaver note "<text>"` — append a progress note, or a decision and its
   rationale, to the branch log.
 - `weaver set-status <level> "<message>"` — tell the dashboard how you are

--- a/crates/weaver-core/src/plan.rs
+++ b/crates/weaver-core/src/plan.rs
@@ -203,9 +203,7 @@ fn strip_separators(raw: &str) -> String {
 fn parse_deps(raw: &str) -> Vec<String> {
     raw.split(',')
         .map(str::trim)
-        .filter(|s| {
-            !s.is_empty() && !matches!(*s, "—" | "–" | "-" | "none" | "None" | "NONE")
-        })
+        .filter(|s| !s.is_empty() && !matches!(*s, "—" | "–" | "-" | "none" | "None" | "NONE"))
         .map(str::to_string)
         .collect()
 }
@@ -524,7 +522,7 @@ Just do it now.
         let with = scaffold("p", "P", "  Rewrite search to use the new index  ");
         assert!(with.contains("Rewrite search to use the new index"));
         assert!(!with.contains("What are we building")); // prompt replaced
-        // Empty goal keeps the prompt.
+                                                         // Empty goal keeps the prompt.
         assert!(scaffold("p", "P", "   ").contains("What are we building"));
     }
 

--- a/crates/weaver-core/src/plan.rs
+++ b/crates/weaver-core/src/plan.rs
@@ -522,7 +522,8 @@ Just do it now.
         let with = scaffold("p", "P", "  Rewrite search to use the new index  ");
         assert!(with.contains("Rewrite search to use the new index"));
         assert!(!with.contains("What are we building")); // prompt replaced
-                                                         // Empty goal keeps the prompt.
+
+        // An empty goal keeps the prompt.
         assert!(scaffold("p", "P", "   ").contains("What are we building"));
     }
 

--- a/crates/weaver-core/src/repo_config.rs
+++ b/crates/weaver-core/src/repo_config.rs
@@ -116,12 +116,7 @@ mod tests {
     #[test]
     fn escaping_dir_falls_back_to_default() {
         // A hostile committed config must not steer reads outside the worktree.
-        for bad in [
-            "../../etc",
-            "/etc/passwd",
-            "foo/../../bar",
-            "./docs/plans",
-        ] {
+        for bad in ["../../etc", "/etc/passwd", "foo/../../bar", "./docs/plans"] {
             let tmp = tempfile::tempdir().unwrap();
             write_config(tmp.path(), &format!("[plan]\ndir = \"{bad}\"\n"));
             assert_eq!(
@@ -136,10 +131,7 @@ mod tests {
     fn nested_relative_dir_is_allowed() {
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), "[plan]\ndir = \"design/specs/plans\"\n");
-        assert_eq!(
-            plan_dir(&[tmp.path().to_path_buf()]),
-            "design/specs/plans"
-        );
+        assert_eq!(plan_dir(&[tmp.path().to_path_buf()]), "design/specs/plans");
     }
 
     #[test]

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -259,21 +259,38 @@ async fn cmd_summary() -> Result<()> {
     let db = open_db().await?;
     let b = branch::resolve(&db).await?;
 
+    // Each section trails the command that drills into it, so the summary
+    // doubles as a map of where to look next.
     let goal = if !b.goal.is_empty() {
         b.goal.clone()
     } else if !b.title.is_empty() {
         b.title.clone()
     } else {
-        "(none set — `weaver goal \"…\"`)".to_string()
+        "(none set)".to_string()
     };
-    println!("Goal:   {goal}");
+    println!("Goal:    {goal}  (weaver goal)");
 
     let status = if b.description.is_empty() {
         b.attention.clone()
     } else {
         format!("{} — {}", b.attention, b.description)
     };
-    println!("Status: {status}");
+    println!("Status:  {status}  (weaver set-status)");
+
+    // Plans on this branch — large multi-session efforts. Status comes from the
+    // plan file itself, so this stays a cheap read (no issue join).
+    let plans = read_plans(&plan_dir(&b));
+    match plans.as_slice() {
+        [] => println!("Plan:    none  (weaver plan new \"<title>\")"),
+        [p] => println!(
+            "Plan:    {} [{}]  (weaver plan show {})",
+            p.slug, p.status, p.slug
+        ),
+        many => {
+            let slugs = many.iter().map(|p| p.slug.as_str()).collect::<Vec<_>>();
+            println!("Plan:    {}  (weaver plan ls)", slugs.join(", "));
+        }
+    }
 
     // Outstanding work: this branch's own open issues, then any open sub-trees
     // it delegated (each carrying its sub-agent's live status).
@@ -281,9 +298,12 @@ async fn cmd_summary() -> Result<()> {
     let delegated = issue::list_delegated_by(&db, &b.repo_root, &b.branch, false).await?;
     println!();
     if open.is_empty() && delegated.is_empty() {
-        println!("Outstanding: none");
+        println!("Outstanding: none  (weaver issue ls)");
     } else {
-        println!("Outstanding ({}):", open.len() + delegated.len());
+        println!(
+            "Outstanding ({}):  (weaver issue ls)",
+            open.len() + delegated.len()
+        );
         for i in open.iter().take(SUMMARY_TASK_CAP) {
             println!("  #{:<4} {}", i.id, i.title);
         }
@@ -304,7 +324,7 @@ async fn cmd_summary() -> Result<()> {
     // Hints for next steps: the most recent note (where work was left off) plus
     // a generated next-action drawn from the open work.
     println!();
-    println!("Next steps:");
+    println!("Next steps:  (weaver log · weaver note)");
     let notes = note::list_for_branch(&db, &b.id).await?;
     if let Some(last) = notes.last() {
         println!("  - last note: {}", truncate(&last.text, 100));

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -300,24 +300,25 @@ async fn cmd_summary() -> Result<()> {
     if open.is_empty() && delegated.is_empty() {
         println!("Outstanding: none  (weaver issue ls)");
     } else {
-        println!(
-            "Outstanding ({}):  (weaver issue ls)",
-            open.len() + delegated.len()
-        );
+        let total = open.len() + delegated.len();
+        println!("Outstanding ({total}):  (weaver issue ls)");
+        // Cap the whole list (own issues first, then delegated sub-trees) so a
+        // branch that delegated many sub-trees can't blow the summary up; the
+        // overflow collapses into one trailing line.
+        let mut shown = 0;
         for i in open.iter().take(SUMMARY_TASK_CAP) {
             println!("  #{:<4} {}", i.id, i.title);
+            shown += 1;
         }
-        if open.len() > SUMMARY_TASK_CAP {
-            println!(
-                "  (+{} more — weaver issue ls)",
-                open.len() - SUMMARY_TASK_CAP
-            );
-        }
-        for i in &delegated {
+        for i in delegated.iter().take(SUMMARY_TASK_CAP - shown) {
             let who = working_branch_status(&db, i)
                 .await
                 .unwrap_or_else(|| i.claimed_branch.clone().unwrap_or_else(|| "?".to_string()));
             println!("  #{:<4} {}  → {who} (delegated)", i.id, i.title);
+            shown += 1;
+        }
+        if total > shown {
+            println!("  (+{} more — weaver issue ls)", total - shown);
         }
     }
 

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -46,6 +46,13 @@ enum Cmd {
     },
     /// Append a note to the current branch.
     Note { text: Vec<String> },
+    /// Print a quick orientation for the current branch.
+    ///
+    /// A one-shot catch-up for an agent picking up (or resuming) a branch: the
+    /// goal, the current status, the outstanding tasks (this branch's open
+    /// issues and any open sub-trees it delegated), and a line or two of hints
+    /// for what to do next. Read-only; derived straight from the database.
+    Summary,
     /// Manage the current branch's issue list.
     Issue {
         #[command(subcommand)]
@@ -186,6 +193,7 @@ async fn run() -> Result<()> {
         Cmd::Goal { text } => cmd_goal(text.join(" ")).await,
         Cmd::SetStatus { level, message } => cmd_set_status(level, message.join(" ")).await,
         Cmd::Note { text } => cmd_note(text.join(" ")).await,
+        Cmd::Summary => cmd_summary().await,
         Cmd::Issue { cmd } => cmd_issue(cmd).await,
         Cmd::Plan { cmd } => cmd_plan(cmd).await,
         Cmd::Where => cmd_where().await,
@@ -235,6 +243,95 @@ async fn cmd_note(text: String) -> Result<()> {
     events::record_local(&db, &b.id, "note", json!({ "text": text })).await?;
     println!("noted");
     Ok(())
+}
+
+/// How many outstanding tasks `weaver summary` lists before collapsing the rest.
+const SUMMARY_TASK_CAP: usize = 10;
+
+/// Print a quick orientation for the current branch: the goal, the current
+/// status, the outstanding tasks, and a hint or two for what to do next.
+///
+/// This is the catch-up an agent reads when it picks up a branch. Everything is
+/// pulled straight from the database — no LLM, no daemon. It overlaps `set-status`
+/// (read), but where that shows an open-issue *count*, summary lists the actual
+/// tasks and points at the next action.
+async fn cmd_summary() -> Result<()> {
+    let db = open_db().await?;
+    let b = branch::resolve(&db).await?;
+
+    let goal = if !b.goal.is_empty() {
+        b.goal.clone()
+    } else if !b.title.is_empty() {
+        b.title.clone()
+    } else {
+        "(none set — `weaver goal \"…\"`)".to_string()
+    };
+    println!("Goal:   {goal}");
+
+    let status = if b.description.is_empty() {
+        b.attention.clone()
+    } else {
+        format!("{} — {}", b.attention, b.description)
+    };
+    println!("Status: {status}");
+
+    // Outstanding work: this branch's own open issues, then any open sub-trees
+    // it delegated (each carrying its sub-agent's live status).
+    let open = issue::list_for_branch(&db, &b.repo_root, &b.branch, false).await?;
+    let delegated = issue::list_delegated_by(&db, &b.repo_root, &b.branch, false).await?;
+    println!();
+    if open.is_empty() && delegated.is_empty() {
+        println!("Outstanding: none");
+    } else {
+        println!("Outstanding ({}):", open.len() + delegated.len());
+        for i in open.iter().take(SUMMARY_TASK_CAP) {
+            println!("  #{:<4} {}", i.id, i.title);
+        }
+        if open.len() > SUMMARY_TASK_CAP {
+            println!(
+                "  (+{} more — weaver issue ls)",
+                open.len() - SUMMARY_TASK_CAP
+            );
+        }
+        for i in &delegated {
+            let who = working_branch_status(&db, i)
+                .await
+                .unwrap_or_else(|| i.claimed_branch.clone().unwrap_or_else(|| "?".to_string()));
+            println!("  #{:<4} {}  → {who} (delegated)", i.id, i.title);
+        }
+    }
+
+    // Hints for next steps: the most recent note (where work was left off) plus
+    // a generated next-action drawn from the open work.
+    println!();
+    println!("Next steps:");
+    let notes = note::list_for_branch(&db, &b.id).await?;
+    if let Some(last) = notes.last() {
+        println!("  - last note: {}", truncate(&last.text, 100));
+    }
+    println!("  - {}", next_action_hint(&open, &delegated));
+    Ok(())
+}
+
+/// A single suggested next action for `weaver summary`, derived from the open
+/// work: pick up the first open task, else poll a delegated sub-tree, else
+/// (nothing open) wrap up and open a PR.
+fn next_action_hint(open: &[issue::Issue], delegated: &[issue::Issue]) -> String {
+    if let Some(first) = open.first() {
+        format!(
+            "pick up #{} ({}); `weaver issue ls` for the rest",
+            first.id,
+            truncate(&first.title, 60)
+        )
+    } else if !delegated.is_empty() {
+        format!(
+            "{} delegated sub-tree(s) still open — `weaver issue show <id>` to poll",
+            delegated.len()
+        )
+    } else {
+        "no open tasks — wrap up and open a PR (`gh pr create`), or `weaver issue add` to track more"
+            .to_string()
+    }
 }
 
 async fn cmd_where() -> Result<()> {
@@ -587,8 +684,12 @@ fn plan_dir(b: &branch::Branch) -> std::path::PathBuf {
 /// Parse the plan at `<dir>/<slug>.md`, or a helpful error if it's missing.
 fn load_plan(dir: &std::path::Path, slug: &str) -> Result<plan::Plan> {
     let path = dir.join(format!("{slug}.md"));
-    let src = std::fs::read_to_string(&path)
-        .map_err(|_| anyhow!("no plan '{slug}' at {} — see `weaver plan ls`", path.display()))?;
+    let src = std::fs::read_to_string(&path).map_err(|_| {
+        anyhow!(
+            "no plan '{slug}' at {} — see `weaver plan ls`",
+            path.display()
+        )
+    })?;
     Ok(plan::parse(slug, &src))
 }
 
@@ -664,7 +765,10 @@ async fn cmd_plan(cmd: PlanCmd) -> Result<()> {
                 let who = if owners.is_empty() {
                     String::new()
                 } else {
-                    format!(" (materialized on {})", owners.into_iter().collect::<Vec<_>>().join(", "))
+                    format!(
+                        " (materialized on {})",
+                        owners.into_iter().collect::<Vec<_>>().join(", ")
+                    )
                 };
                 bail!(
                     "plan slug '{slug}' is already in use in this repo{who} — \
@@ -774,7 +878,9 @@ fn print_delta(delta: &plan::SyncPlan) {
     for action in &delta.actions {
         match action {
             Create { task, title } => println!("  + create issue for {task}: {title}"),
-            Close { task, issue_id } => println!("  - close #{issue_id} ({task} removed from plan)"),
+            Close { task, issue_id } => {
+                println!("  - close #{issue_id} ({task} removed from plan)")
+            }
             UpdateTitle {
                 task,
                 issue_id,

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -308,6 +308,29 @@ fn summary_orients_an_agent_on_the_branch() {
     }
 }
 
+/// The outstanding list is capped (across own issues *and* delegated sub-trees)
+/// so a branch with lots of work can't blow up the summary; the overflow
+/// collapses into a single "(+N more)" line.
+#[test]
+fn summary_caps_a_long_outstanding_list() {
+    let env = setup();
+    for n in 0..13 {
+        let title = format!("task{n}");
+        run(&env, &["issue", "add", title.as_str()]);
+    }
+    let out = run(&env, &["summary"]);
+    assert!(out.contains("Outstanding (13):"), "summary: {out}");
+    // Cap is 10 → the last 3 collapse into one line, not three rows.
+    assert!(
+        out.contains("(+3 more"),
+        "summary should collapse the overflow: {out}"
+    );
+    assert!(
+        !out.contains("task12"),
+        "capped tasks should not be printed individually: {out}"
+    );
+}
+
 /// With nothing open, summary flips its hint to "wrap up / open a PR".
 #[test]
 fn summary_with_no_open_tasks_suggests_wrapping_up() {

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -284,8 +284,8 @@ fn summary_orients_an_agent_on_the_branch() {
     run(&env, &["note", "left", "off", "mid-refactor"]);
 
     let out = run(&env, &["summary"]);
-    assert!(out.contains("Goal:   ship the feature"), "summary: {out}");
-    assert!(out.contains("Status: ok — routes wired"), "summary: {out}");
+    assert!(out.contains("ship the feature"), "summary: {out}");
+    assert!(out.contains("ok — routes wired"), "summary: {out}");
     // Outstanding lists the tasks themselves, not just a count.
     assert!(out.contains("Outstanding (2):"), "summary: {out}");
     assert!(out.contains("#1    wire up routes"), "summary: {out}");
@@ -296,6 +296,16 @@ fn summary_orients_an_agent_on_the_branch() {
         "summary: {out}"
     );
     assert!(out.contains("pick up #1"), "summary: {out}");
+    // Every section advertises the command that drills into it.
+    for hint in [
+        "(weaver goal)",
+        "(weaver set-status)",
+        "(weaver issue ls)",
+        "weaver plan",
+        "weaver log",
+    ] {
+        assert!(out.contains(hint), "summary should surface `{hint}`: {out}");
+    }
 }
 
 /// With nothing open, summary flips its hint to "wrap up / open a PR".

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -272,6 +272,43 @@ fn canonical_repo_root(repo: &Path) -> String {
         .to_string()
 }
 
+/// `summary` is the agent catch-up: it surfaces the goal, the current status,
+/// the actual list of outstanding tasks, and a generated next-step hint.
+#[test]
+fn summary_orients_an_agent_on_the_branch() {
+    let env = setup();
+    run(&env, &["goal", "ship", "the", "feature"]);
+    run(&env, &["issue", "add", "wire", "up", "routes"]);
+    run(&env, &["issue", "add", "add", "tests"]);
+    run(&env, &["set-status", "ok", "routes", "wired"]);
+    run(&env, &["note", "left", "off", "mid-refactor"]);
+
+    let out = run(&env, &["summary"]);
+    assert!(out.contains("Goal:   ship the feature"), "summary: {out}");
+    assert!(out.contains("Status: ok — routes wired"), "summary: {out}");
+    // Outstanding lists the tasks themselves, not just a count.
+    assert!(out.contains("Outstanding (2):"), "summary: {out}");
+    assert!(out.contains("#1    wire up routes"), "summary: {out}");
+    assert!(out.contains("#2    add tests"), "summary: {out}");
+    // Hints: the most recent note plus a next-action pointing at the first task.
+    assert!(
+        out.contains("last note: left off mid-refactor"),
+        "summary: {out}"
+    );
+    assert!(out.contains("pick up #1"), "summary: {out}");
+}
+
+/// With nothing open, summary flips its hint to "wrap up / open a PR".
+#[test]
+fn summary_with_no_open_tasks_suggests_wrapping_up() {
+    let env = setup();
+    run(&env, &["goal", "tidy", "up"]);
+    let out = run(&env, &["summary"]);
+    assert!(out.contains("Outstanding: none"), "summary: {out}");
+    assert!(out.contains("no open tasks"), "summary: {out}");
+    assert!(out.contains("open a PR"), "summary: {out}");
+}
+
 #[test]
 fn note_writes_an_event() {
     let env = setup();

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Shared pre-commit / CI gate: formatting and lints must both pass.
+#
+# This is the single source of truth for "is the tree clean?". It is run by:
+#   - the git pre-commit hook (.githooks/pre-commit), enabled per-clone with
+#     `git config core.hooksPath .githooks` (see AGENTS.md); and
+#   - the CI `lint` job (.github/workflows/ci.yml),
+# so a commit that passes locally passes CI. Bypass the hook for one commit with
+# `git commit --no-verify`.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "▶ cargo fmt --all --check"
+if ! cargo fmt --all --check; then
+  echo >&2
+  echo "✗ formatting check failed — run \`cargo fmt --all\`, then re-stage and commit." >&2
+  exit 1
+fi
+
+echo "▶ cargo clippy --workspace --all-targets --locked -- -D warnings"
+cargo clippy --workspace --all-targets --locked -- -D warnings
+
+echo "✓ fmt + clippy clean"


### PR DESCRIPTION
## `weaver summary`

A one-shot catch-up an agent can run when it picks up or resumes a branch:

- the **goal**,
- the current **status** (attention level + message),
- any **plan** on the branch,
- the **outstanding tasks** — this branch's open issues plus any open sub-trees it delegated, and
- a line or two of **next-step hints**: the most recent note (where work was left off), then a generated next action (pick up the first open task / poll a delegated sub-tree / wrap up and open a PR).

Read-only and derived straight from the SQLite db — no LLM, no daemon. It complements `set-status` (read), which only reports an open-issue *count*; `summary` lists the actual tasks and points at the next action. Every section trails the command that drills into it, so the summary doubles as a map of where to look next.

```
Goal:    Add a weaver summary command  (weaver goal)
Status:  ok — Routes wired; tests pending  (weaver set-status)
Plan:    none  (weaver plan new "<title>")

Outstanding (2):  (weaver issue ls)
  #1    Wire up the routes
  #2    Add tests

Next steps:  (weaver log · weaver note)
  - last note: Decided to derive hints from the most recent note plus a generated next-action
  - pick up #1 (Wire up the routes); `weaver issue ls` for the rest
```

Docs updated: `WEAVER.md`, `README.md`, `AGENTS.md`. Two new tests in `agent_cli.rs`.

## Shared fmt + clippy pre-commit gate

While here, the working tree turned up formatting drift: `plan.rs`/`repo_config.rs` were no longer clean under current stable `rustfmt`, so the existing CI `lint` job's `cargo fmt --all --check` would now fail. To catch this before CI:

- `scripts/pre-commit.sh` — single source of truth (`cargo fmt --all --check` + `clippy -D warnings`).
- `.githooks/pre-commit` — tracked hook that runs it; enable with `git config core.hooksPath .githooks`.
- The CI `lint` job now invokes the same script, so the local hook and CI can't drift.
- Reformatted the two drifted files so the gate is green.

## Testing

- `cargo test --workspace` — all suites pass.
- `./scripts/pre-commit.sh` passes; verified the hook blocks a deliberately mis-formatted commit and fires on real `git commit`s (it caught a long match arm in this very change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)