### PR TITLE
feat(weaver): replay a concise summary after compaction; add `weaver readme`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ needing the daemon to be reachable.
 | Path | What's in it |
 |---|---|
 | `crates/weaver-core/` | lib: `branches`, `issues`, `notes`, `events`, `db`, `git`, `config`, `plan` (parser + reconcile), `repo_config` (`.weaver/config.toml`), agent helpers. Pure logic; used by both binaries. |
-| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `note`, `set-status` [read or set level + message], `issue …`, `where`, `log`, `hook`, `config`) |
+| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `readme`, `note`, `set-status` [read or set level + message], `issue …`, `where`, `log`, `hook`, `config`) |
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
@@ -266,7 +266,7 @@ block into the worktree's `.claude/settings.local.json` (see
 
 | Claude hook event | shells out to |
 |---|---|
-| `SessionStart` | `weaver hook --event session-start` (also injects the repo's `WEAVER.md`, or the builtin [[crates/weaver-core/WEAVER.md]], as `additionalContext`) |
+| `SessionStart` | `weaver hook --event session-start` (also injects `additionalContext`: the repo's `WEAVER.md`, or the builtin [[crates/weaver-core/WEAVER.md]], on a genuine start/resume/clear; after a **compaction** — `source: "compact"` on the hook's stdin — a concise `weaver summary` re-orientation instead, so the agent isn't re-fed the whole guide. `weaver readme` pulls the full guide back on demand) |
 | `UserPromptSubmit` | `weaver hook --event working` |
 | `Notification` | `weaver hook --event waiting` |
 | `Stop` | `weaver hook --event idle` |
@@ -347,6 +347,7 @@ When working inside a worktree the agent can run, with no daemon required:
 weaver goal "ship the feature"          # set the branch's goal
 weaver goal                             # print the goal
 weaver summary                          # goal + outstanding tasks + next-step hints
+weaver readme                           # print the full weaver workflow guide (WEAVER.md)
 weaver note   "blocked on the DB schema"
 weaver set-status attention "ready for review"   # level + current-state message
 weaver set-status ok "waiting on PR review feedback"

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -12,7 +12,11 @@ It is on your `PATH`. From anywhere in the worktree you can run:
 - `weaver goal` — print the task this branch was created for.
 - `weaver summary` — a quick catch-up on the branch: the goal, your current
   status, the outstanding tasks, and a hint or two for what to do next. Run it
-  when you pick up or resume a branch.
+  when you pick up or resume a branch. After a context compaction weaver replays
+  this catch-up for you automatically, so you don't lose track of where you are.
+- `weaver readme` — print this guide (the full weaver workflow). Re-read it when
+  you need the rules back — e.g. after a compaction, when only the concise
+  catch-up was replayed.
 - `weaver note "<text>"` — append a progress note, or a decision and its
   rationale, to the branch log.
 - `weaver set-status <level> "<message>"` — tell the dashboard how you are

--- a/crates/weaver-core/src/agent.rs
+++ b/crates/weaver-core/src/agent.rs
@@ -38,15 +38,17 @@ pub fn builtin_weaver_md() -> &'static str {
     BUILTIN_WEAVER_MD
 }
 
-/// Context injected at SessionStart (via the `session-start` weaver hook): a
-/// WEAVER.md telling the agent it is in a weaver session and how it is expected
-/// to behave. `weaver_md` is the repo's own WEAVER.md when present, else
-/// [`builtin_weaver_md`].
-pub fn session_primer(weaver_md: &str) -> String {
+/// Wrap `context` as the JSON a SessionStart hook prints to inject it into the
+/// agent's context (`hookSpecificOutput.additionalContext`). On a genuine
+/// start/resume/clear this carries the full WEAVER.md primer (the repo's own
+/// when present, else [`builtin_weaver_md`]); after a compaction the weaver hook
+/// passes a concise re-orientation instead, so the agent isn't re-fed the whole
+/// guide every time its context is summarized.
+pub fn session_primer(context: &str) -> String {
     json!({
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
-            "additionalContext": weaver_md,
+            "additionalContext": context,
         }
     })
     .to_string()

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -53,6 +53,14 @@ enum Cmd {
     /// issues and any open sub-trees it delegated), and a line or two of hints
     /// for what to do next. Read-only; derived straight from the database.
     Summary,
+    /// Print the full weaver workflow guide (the WEAVER.md for this branch).
+    ///
+    /// The same primer injected at session start — how a weaver session works
+    /// and what is expected of the agent. Re-read it when you need the full
+    /// rules back (e.g. after a context compaction, when only the concise
+    /// catch-up was replayed). Uses the repo's own `WEAVER.md` when it ships
+    /// one, else the builtin.
+    Readme,
     /// Manage the current branch's issue list.
     Issue {
         #[command(subcommand)]
@@ -194,6 +202,7 @@ async fn run() -> Result<()> {
         Cmd::SetStatus { level, message } => cmd_set_status(level, message.join(" ")).await,
         Cmd::Note { text } => cmd_note(text.join(" ")).await,
         Cmd::Summary => cmd_summary().await,
+        Cmd::Readme => cmd_readme().await,
         Cmd::Issue { cmd } => cmd_issue(cmd).await,
         Cmd::Plan { cmd } => cmd_plan(cmd).await,
         Cmd::Where => cmd_where().await,
@@ -258,6 +267,16 @@ const SUMMARY_TASK_CAP: usize = 10;
 async fn cmd_summary() -> Result<()> {
     let db = open_db().await?;
     let b = branch::resolve(&db).await?;
+    print!("{}", render_summary(&db, &b).await?);
+    Ok(())
+}
+
+/// Render the `weaver summary` catch-up as a string (see [`cmd_summary`]). Kept
+/// separate from the printing so the post-compaction hook can replay the same
+/// text into the agent's context as `additionalContext` (see [`cmd_hook`]).
+async fn render_summary(db: &db::Db, b: &branch::Branch) -> Result<String> {
+    use std::fmt::Write as _;
+    let mut out = String::new();
 
     // Each section trails the command that drills into it, so the summary
     // doubles as a map of where to look next.
@@ -268,69 +287,86 @@ async fn cmd_summary() -> Result<()> {
     } else {
         "(none set)".to_string()
     };
-    println!("Goal:    {goal}  (weaver goal)");
+    let _ = writeln!(out, "Goal:    {goal}  (weaver goal)");
 
     let status = if b.description.is_empty() {
         b.attention.clone()
     } else {
         format!("{} — {}", b.attention, b.description)
     };
-    println!("Status:  {status}  (weaver set-status)");
+    let _ = writeln!(out, "Status:  {status}  (weaver set-status)");
 
     // Plans on this branch — large multi-session efforts. Status comes from the
     // plan file itself, so this stays a cheap read (no issue join).
-    let plans = read_plans(&plan_dir(&b));
+    let plans = read_plans(&plan_dir(b));
     match plans.as_slice() {
-        [] => println!("Plan:    none  (weaver plan new \"<title>\")"),
-        [p] => println!(
-            "Plan:    {} [{}]  (weaver plan show {})",
-            p.slug, p.status, p.slug
-        ),
+        [] => {
+            let _ = writeln!(out, "Plan:    none  (weaver plan new \"<title>\")");
+        }
+        [p] => {
+            let _ = writeln!(
+                out,
+                "Plan:    {} [{}]  (weaver plan show {})",
+                p.slug, p.status, p.slug
+            );
+        }
         many => {
             let slugs = many.iter().map(|p| p.slug.as_str()).collect::<Vec<_>>();
-            println!("Plan:    {}  (weaver plan ls)", slugs.join(", "));
+            let _ = writeln!(out, "Plan:    {}  (weaver plan ls)", slugs.join(", "));
         }
     }
 
     // Outstanding work: this branch's own open issues, then any open sub-trees
     // it delegated (each carrying its sub-agent's live status).
-    let open = issue::list_for_branch(&db, &b.repo_root, &b.branch, false).await?;
-    let delegated = issue::list_delegated_by(&db, &b.repo_root, &b.branch, false).await?;
-    println!();
+    let open = issue::list_for_branch(db, &b.repo_root, &b.branch, false).await?;
+    let delegated = issue::list_delegated_by(db, &b.repo_root, &b.branch, false).await?;
+    out.push('\n');
     if open.is_empty() && delegated.is_empty() {
-        println!("Outstanding: none  (weaver issue ls)");
+        let _ = writeln!(out, "Outstanding: none  (weaver issue ls)");
     } else {
         let total = open.len() + delegated.len();
-        println!("Outstanding ({total}):  (weaver issue ls)");
+        let _ = writeln!(out, "Outstanding ({total}):  (weaver issue ls)");
         // Cap the whole list (own issues first, then delegated sub-trees) so a
         // branch that delegated many sub-trees can't blow the summary up; the
         // overflow collapses into one trailing line.
         let mut shown = 0;
         for i in open.iter().take(SUMMARY_TASK_CAP) {
-            println!("  #{:<4} {}", i.id, i.title);
+            let _ = writeln!(out, "  #{:<4} {}", i.id, i.title);
             shown += 1;
         }
         for i in delegated.iter().take(SUMMARY_TASK_CAP - shown) {
-            let who = working_branch_status(&db, i)
+            let who = working_branch_status(db, i)
                 .await
                 .unwrap_or_else(|| i.claimed_branch.clone().unwrap_or_else(|| "?".to_string()));
-            println!("  #{:<4} {}  → {who} (delegated)", i.id, i.title);
+            let _ = writeln!(out, "  #{:<4} {}  → {who} (delegated)", i.id, i.title);
             shown += 1;
         }
         if total > shown {
-            println!("  (+{} more — weaver issue ls)", total - shown);
+            let _ = writeln!(out, "  (+{} more — weaver issue ls)", total - shown);
         }
     }
 
     // Hints for next steps: the most recent note (where work was left off) plus
     // a generated next-action drawn from the open work.
-    println!();
-    println!("Next steps:  (weaver log · weaver note)");
-    let notes = note::list_for_branch(&db, &b.id).await?;
+    out.push('\n');
+    let _ = writeln!(out, "Next steps:  (weaver log · weaver note)");
+    let notes = note::list_for_branch(db, &b.id).await?;
     if let Some(last) = notes.last() {
-        println!("  - last note: {}", truncate(&last.text, 100));
+        let _ = writeln!(out, "  - last note: {}", truncate(&last.text, 100));
     }
-    println!("  - {}", next_action_hint(&open, &delegated));
+    let _ = writeln!(out, "  - {}", next_action_hint(&open, &delegated));
+    Ok(out)
+}
+
+/// Print the full weaver workflow guide for this branch (the repo's own
+/// `WEAVER.md` when it ships one, else the builtin). The same primer injected at
+/// session start; `weaver readme` lets the agent pull it back on demand — most
+/// usefully after a context compaction, when only the concise catch-up was
+/// replayed.
+async fn cmd_readme() -> Result<()> {
+    let db = open_db().await?;
+    let b = branch::resolve(&db).await?;
+    print!("{}", weaver_md_for_branch(&b));
     Ok(())
 }
 
@@ -1032,15 +1068,76 @@ fn weaver_md_for_branch(branch: &branch::Branch) -> String {
     weaver_core::agent::builtin_weaver_md().to_string()
 }
 
+/// Read the `source` field a SessionStart hook receives as JSON on stdin
+/// (`startup` | `resume` | `clear` | `compact`). Returns `None` when stdin is a
+/// terminal (a human running the hook by hand), empty, or unparseable — callers
+/// then fall back to the full-primer behaviour, which is always safe.
+fn read_hook_source() -> Option<String> {
+    use std::io::{IsTerminal, Read};
+    let mut stdin = std::io::stdin();
+    if stdin.is_terminal() {
+        return None;
+    }
+    let mut buf = String::new();
+    stdin.read_to_string(&mut buf).ok()?;
+    let v: Value = serde_json::from_str(buf.trim()).ok()?;
+    v.get("source")?.as_str().map(str::to_owned)
+}
+
+/// The concise weaver re-orientation replayed after a context compaction: a
+/// short reminder that this is still a weaver session, the `weaver summary`
+/// catch-up, and the load-bearing rules an agent must not lose (status, no
+/// blocking TUI prompts, PR-not-merge, close the tracking issue). The full guide
+/// is one `weaver readme` away.
+fn compact_replay(b: &branch::Branch, summary: &str) -> String {
+    format!(
+        "Context was just compacted — you are still in a **weaver session** on branch \
+         `{branch}` (a detached agent workstream in a git worktree; the user reviews \
+         asynchronously via the loom dashboard, not this terminal). Re-orientation:\n\n\
+         {summary}\n\
+         Reminders: keep your status honest with `weaver set-status <ok|attention|blocked> \
+         \"<message>\"`; never block on an interactive TUI prompt — state the question as plain \
+         text and raise `weaver set-status attention`; finish by opening a PR (`gh pr create`) \
+         rather than merging, and `weaver issue close <id>` your tracking issue when the work is \
+         done. Run `weaver readme` for the full weaver workflow guide.\n",
+        branch = b.branch,
+    )
+}
+
 async fn cmd_hook(event: String) -> Result<()> {
     // Hooks must never break the agent: best-effort, swallow errors.
     let result: Result<()> = (async {
         let db = open_db().await?;
         let b = branch::resolve(&db).await?;
-        events::record_local(&db, &b.id, "hook", json!({ "event": event })).await?;
-        if event == "session-start" {
-            let weaver_md = weaver_md_for_branch(&b);
-            print!("{}", weaver_core::agent::session_primer(&weaver_md));
+        // SessionStart carries a `source` on stdin (startup|resume|clear|compact);
+        // we only read it for that event so other hooks don't touch stdin.
+        let is_session_start = event == "session-start";
+        let source = if is_session_start {
+            read_hook_source()
+        } else {
+            None
+        };
+        let is_compact = source.as_deref() == Some("compact");
+        events::record_local(
+            &db,
+            &b.id,
+            "hook",
+            json!({ "event": event, "source": source }),
+        )
+        .await?;
+        if is_session_start {
+            // After a compaction the agent has lost its working context but the
+            // session is unchanged — replay a concise re-orientation (the
+            // `weaver summary` catch-up) rather than the full WEAVER.md, which it
+            // can pull back with `weaver readme` if it needs the full rules. On a
+            // genuine start/resume/clear, inject the full primer.
+            let context = if is_compact {
+                let summary = render_summary(&db, &b).await.unwrap_or_default();
+                compact_replay(&b, &summary)
+            } else {
+                weaver_md_for_branch(&b)
+            };
+            print!("{}", weaver_core::agent::session_primer(&context));
         }
         Ok(())
     })

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -1090,16 +1090,9 @@ fn read_hook_source() -> Option<String> {
 /// blocking TUI prompts, PR-not-merge, close the tracking issue). The full guide
 /// is one `weaver readme` away.
 fn compact_replay(b: &branch::Branch, summary: &str) -> String {
+    let summary = summary.trim_end();
     format!(
-        "Context was just compacted — you are still in a **weaver session** on branch \
-         `{branch}` (a detached agent workstream in a git worktree; the user reviews \
-         asynchronously via the loom dashboard, not this terminal). Re-orientation:\n\n\
-         {summary}\n\
-         Reminders: keep your status honest with `weaver set-status <ok|attention|blocked> \
-         \"<message>\"`; never block on an interactive TUI prompt — state the question as plain \
-         text and raise `weaver set-status attention`; finish by opening a PR (`gh pr create`) \
-         rather than merging, and `weaver issue close <id>` your tracking issue when the work is \
-         done. Run `weaver readme` for the full weaver workflow guide.\n",
+        "Context was just compacted — you are still in a **weaver session** on branch `{branch}` (a detached agent workstream in a git worktree; the user reviews asynchronously via the loom dashboard, not this terminal). Re-orientation:\n\n{summary}\n\nReminders: keep your status honest with `weaver set-status <ok|attention|blocked> \"<message>\"`; never block on an interactive TUI prompt — state the question as plain text and raise `weaver set-status attention`; finish by opening a PR (`gh pr create`) rather than merging, and `weaver issue close <id>` your tracking issue when the work is done. Run `weaver readme` for the full weaver workflow guide.\n",
         branch = b.branch,
     )
 }

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -3,8 +3,9 @@
 //! These drive the `weaver` binary directly (`cargo run -- ...`) inside a
 //! scratch git repo and assert on stdout and the resulting sqlite rows.
 
+use std::io::Write;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn sh(dir: &Path, program: &str, args: &[&str]) {
     let status = Command::new(program)
@@ -362,6 +363,127 @@ fn hook_writes_an_event_row() {
     assert!(
         log.contains("working"),
         "log should mention the event name: {log}"
+    );
+}
+
+/// Run the weaver binary with `stdin` piped in, returning captured stdout. Used
+/// to drive the SessionStart hook, which reads its `source` from a JSON payload
+/// on stdin.
+fn run_with_stdin(env: &Env, args: &[&str], stdin: &str) -> String {
+    let mut child = Command::new(weaver_bin())
+        .args(args)
+        .current_dir(&env.repo_path)
+        .env("WEAVER_HOME", &env.home_path)
+        .env("WEAVER_API", "http://127.0.0.1:1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn weaver");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("weaver did not exit");
+    assert!(
+        out.status.success(),
+        "weaver {args:?} failed: {} / {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// `weaver readme` prints the full weaver workflow guide so an agent can pull
+/// the rules back on demand (e.g. after a compaction replayed only the catch-up).
+#[test]
+fn readme_prints_the_full_weaver_guide() {
+    let env = setup();
+    let out = run(&env, &["readme"]);
+    assert!(
+        out.contains("weaver session"),
+        "readme should print the WEAVER.md guide: {out}"
+    );
+    assert!(
+        out.contains("weaver set-status"),
+        "readme should describe the weaver CLI: {out}"
+    );
+}
+
+/// On a genuine start/resume/clear (no `compact` source), the session-start hook
+/// injects the full WEAVER.md primer as `additionalContext`.
+#[test]
+fn session_start_hook_injects_the_full_primer() {
+    let env = setup();
+    let payload = r#"{"hook_event_name":"SessionStart","source":"startup"}"#;
+    let out = run_with_stdin(&env, &["hook", "--event", "session-start"], payload);
+    assert!(
+        out.contains("\"hookEventName\":\"SessionStart\""),
+        "hook should emit SessionStart additionalContext JSON: {out}"
+    );
+    // The full guide — not the compact catch-up.
+    assert!(
+        out.contains("review progress asynchronously"),
+        "startup should replay the full WEAVER.md: {out}"
+    );
+    assert!(
+        !out.contains("Context was just compacted"),
+        "startup must not use the compaction replay: {out}"
+    );
+}
+
+/// After a context compaction (`source: "compact"`), the hook replays a concise
+/// re-orientation — the `weaver summary` catch-up plus the load-bearing rules and
+/// a pointer to `weaver readme` — instead of the whole WEAVER.md.
+#[test]
+fn session_start_hook_after_compaction_replays_the_concise_summary() {
+    let env = setup();
+    run(&env, &["goal", "ship", "the", "feature"]);
+    run(&env, &["issue", "add", "wire", "up", "routes"]);
+    run(&env, &["set-status", "ok", "routes", "wired"]);
+
+    let payload = r#"{"hook_event_name":"SessionStart","source":"compact"}"#;
+    let out = run_with_stdin(&env, &["hook", "--event", "session-start"], payload);
+
+    // Still a SessionStart context injection.
+    assert!(
+        out.contains("\"hookEventName\":\"SessionStart\""),
+        "compact replay should still be SessionStart additionalContext: {out}"
+    );
+    // The concise catch-up: framing, the live branch state, and how-to pointers.
+    assert!(
+        out.contains("Context was just compacted"),
+        "compact replay should re-orient the agent: {out}"
+    );
+    assert!(
+        out.contains("ship the feature"),
+        "replay omits the goal: {out}"
+    );
+    assert!(
+        out.contains("ok — routes wired"),
+        "replay omits the live status: {out}"
+    );
+    assert!(
+        out.contains("wire up routes"),
+        "replay omits the outstanding work: {out}"
+    );
+    assert!(
+        out.contains("weaver readme"),
+        "replay should point at the full guide: {out}"
+    );
+    // It must stay concise — not re-feed the whole WEAVER.md.
+    assert!(
+        !out.contains("review progress asynchronously"),
+        "compact replay must not dump the full WEAVER.md: {out}"
+    );
+
+    // The hook still records the lifecycle event (with its source) for the monitor.
+    let log = run(&env, &["log"]);
+    assert!(
+        log.contains("session-start"),
+        "the hook should record a session-start event: {log}"
     );
 }
 


### PR DESCRIPTION
## What

After a context compaction, the SessionStart hook used to re-inject the **full 127-line `WEAVER.md`** — heavy, and not what an agent most needs back at that moment. This wires the hook to be compaction-aware:

- `weaver hook --event session-start` now reads the hook's **`source`** from stdin (`startup` | `resume` | `clear` | `compact`).
- On **`compact`** it replays a **concise re-orientation** as `additionalContext`: a one-line "you're still in a weaver session" frame, the `weaver summary` catch-up (goal, status, outstanding work — each line trailing the command that drills into it), the load-bearing rules an agent must not lose (status reporting, no blocking TUI prompts, PR-not-merge, close the tracking issue), and a pointer to the full guide.
- On a genuine **start/resume/clear** it injects the full primer, exactly as before.

## Why

This is the "replay weaver hints after compaction" task. The full guide every time is wasteful and crowds out the dynamic state (goal/status/issues) the agent actually loses on a compaction. The concise replay reuses the existing `weaver summary` content, which already reads as a "map of where to look next".

## Changes

- **Reuse, not reinvent:** refactor `cmd_summary` → reusable `render_summary`, shared by the CLI and the hook, so the replay *is* the same catch-up an agent reads on pickup.
- **`weaver readme`** (new command): print the full `WEAVER.md` on demand, so an agent that only got the concise replay can pull the complete rules back.
- Record the SessionStart `source` on the hook event row (additive — the monitor still keys on `event`, so liveness/attention handling is unchanged).
- Docs: `WEAVER.md` and `AGENTS.md` describe `weaver readme` and the compaction replay.

## Hook contract notes

`SessionStart` fires after both manual `/compact` and auto-compaction with `source: "compact"`; `additionalContext` on stdout is the post-compaction injection mechanism (`PreCompact` runs *before* and can't inject into the post-compact window). The hook reads `source` from stdin rather than relying on a matcher, so the installed hook config is unchanged. Reading stdin is guarded (`IsTerminal` + parse-failure → `None`) so a hand-run hook or missing payload safely falls back to the full primer.

## Testing

- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `cargo test -p weaver -p weaver-core`: pass (20 `agent_cli` integration + 41 core).
- 3 new integration tests: compact replay (concise, includes goal/status/work + `weaver readme`, **not** the full guide), full-primer default on startup, and `weaver readme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)