### PR TITLE
Surface the PR as a small link in the session header

### DIFF
--- a/crates/loom/frontend/src/components/SessionOverview.vue
+++ b/crates/loom/frontend/src/components/SessionOverview.vue
@@ -1,46 +1,25 @@
 <script setup lang="ts">
-import { ref } from 'vue';
-import { post } from '../api';
 import type { Session, WeaverEvent, Issue } from '../types';
 import SessionActivity from './SessionActivity.vue';
 import SessionIssues from './SessionIssues.vue';
 import SessionPlan from './SessionPlan.vue';
-import GithubStatus from './GithubStatus.vue';
-import { timeAgo } from '../lib/time';
 
 // The Overview tab: the read-only context for a session — the plan (the launch
-// goal at minimum, growing into tasks), the GitHub PR snapshot, claimed work +
-// repo backlog, and the de-noised activity feed.
+// goal at minimum, growing into tasks), claimed work + repo backlog, and the
+// de-noised activity feed. The PR snapshot now lives as a small link in the
+// session header rather than as a section here.
 // Everything here is authored by the AGENT (the launch prompt, `weaver
-// set-status`, `weaver issue`) or polled server-side (the PR snapshot); the
-// page's writes (acknowledge attention, rename, lifecycle) all live in the
-// header now, and the live working surface (terminal + scratch) is the Terminal
-// tab. This tab is purely "what is this session about, and what has it done".
-const props = defineProps<{
+// set-status`, `weaver issue`); the page's writes (acknowledge attention,
+// rename, lifecycle) all live in the header, and the live working surface
+// (terminal + scratch) is the Terminal tab. This tab is purely "what is this
+// session about, and what has it done".
+defineProps<{
   ws: Session;
   events: WeaverEvent[];
   format: (ev: WeaverEvent) => string;
   issues: Issue[];
   backlog: Issue[];
 }>();
-
-// A header/lifecycle write isn't owned here, but the GitHub snapshot is read-
-// only context that belongs with the rest of it — so this tab owns its own
-// re-poll and asks the page to reload the session when the snapshot changes.
-const emit = defineEmits<{ reload: [] }>();
-
-const refreshing = ref(false);
-async function refreshGithub() {
-  refreshing.value = true;
-  try {
-    await post(`/sessions/${props.ws.id}/github`);
-    emit('reload');
-  } catch {
-    // Best-effort — a failed poll leaves the last snapshot in place.
-  } finally {
-    refreshing.value = false;
-  }
-}
 </script>
 
 <template>
@@ -51,31 +30,8 @@ async function refreshGithub() {
          element carries `session-goal` for the detail/list specs. -->
     <SessionPlan :id="ws.id" :goal="ws.branch.goal" />
 
-    <!-- GitHub — the branch's PR snapshot, polled server-side via `gh`. Shown
-         for GitHub-backed repos; the Refresh button forces an immediate re-poll. -->
-    <section
-      v-if="ws.branch.github || ws.github_repo"
-      class="rounded border border-line bg-surface p-4"
-    >
-      <div class="mb-2 flex items-center justify-between">
-        <div class="text-xs font-medium uppercase tracking-wide text-faint">GitHub</div>
-        <button
-          class="rounded bg-subtle px-2 py-1 text-xs text-muted hover:bg-subtle-hover disabled:opacity-50"
-          :disabled="refreshing"
-          @click="refreshGithub"
-        >
-          {{ refreshing ? 'Refreshing…' : 'Refresh' }}
-        </button>
-      </div>
-      <template v-if="ws.branch.github">
-        <GithubStatus :gh="ws.branch.github" />
-        <p class="mt-2 text-xs text-faint">Snapshot {{ timeAgo(ws.branch.github.fetched_at) }}.</p>
-      </template>
-      <p v-else class="text-sm text-faint">
-        No pull request found for this branch yet. loom polls automatically while
-        the session is active.
-      </p>
-    </section>
+    <!-- The PR snapshot lives as a small link in the session header now (one
+         place you already look), not as a section down here. -->
 
     <!-- Issues — claimed work + repo backlog (only when there's something). -->
     <SessionIssues v-if="issues.length || backlog.length" :issues="issues" :backlog="backlog" />

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -6,6 +6,7 @@ import { timeAgo } from '../lib/time';
 import { useSessionActions } from '../lib/sessionActions';
 import StatusBadge from './StatusBadge.vue';
 import SessionDetailsPopover from './SessionDetailsPopover.vue';
+import GithubStatus from './GithubStatus.vue';
 
 // The session page header — one compact chrome block shared by both the detail
 // view and the file browser, so the "where am I / what is this" context never
@@ -14,7 +15,7 @@ import SessionDetailsPopover from './SessionDetailsPopover.vue';
 //   row 1  ← all · title (inline rename) · [attention chip + Mark OK]ⁱ
 //           · lifecycle badge · ⌄ details menu
 //   row 2  the agent's current-state message as prose (the point of the page)
-//   row 3  repo/branch · agent · the quiet conversation-state + freshness
+//   row 3  repo/branch · agent · PR link · the quiet conversation-state + freshness
 //
 // The old full-width "▶ Working … last activity" strip is gone: when the agent
 // is calm, its state is a quiet note on row 3; when it raises attention, the
@@ -204,6 +205,13 @@ const washClass = computed(() =>
       <span class="shrink-0 text-muted">
         {{ ws.agent_kind }}<template v-if="ws.model"> · {{ ws.model }}</template>
       </span>
+      <!-- The branch's PR, surfaced inline as a small link — the one place you
+           already look — rather than buried in the Overview tab. Compact mode is
+           the same tight glyphline the dashboard list uses. -->
+      <template v-if="ws.branch.github">
+        <span class="text-faint">·</span>
+        <GithubStatus :gh="ws.branch.github" compact class="min-w-0" />
+      </template>
       <div class="ml-auto flex shrink-0 items-center gap-1.5">
         <span v-if="!loud" data-testid="conversation-state" :class="toneClass">
           {{ conv.glyph }} {{ conv.label }}

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -121,7 +121,7 @@ onUnmounted(() => source?.close());
         <ScratchPanel :id="props.id" />
       </section>
 
-      <!-- Overview — read-only context (goal, GitHub, issues, activity). Scrolls
+      <!-- Overview — read-only context (goal, issues, activity). Scrolls
            within the work area so the header/tabs stay anchored. -->
       <div v-if="tab === 'overview'" class="h-full overflow-auto pb-1">
         <SessionOverview
@@ -130,7 +130,6 @@ onUnmounted(() => source?.close());
           :format="eventLine"
           :issues="issues"
           :backlog="backlog"
-          @reload="loadAll"
         />
       </div>
     </div>


### PR DESCRIPTION
## What

The GitHub PR snapshot sat at the bottom of the **Overview** tab, below the plan — out of the way of the one place you actually look. This moves it into the **session header's meta line** (row 3) as a compact PR link, reusing the same `GithubStatus` compact glyphline the dashboard list already uses.

Header row 3 now reads: `repo/branch · agent · PR #N open ●  …state · freshness`.

## Changes

- **`SessionPageHeader.vue`** — render `<GithubStatus compact>` inline on the meta line when the branch has a PR snapshot.
- **`SessionOverview.vue`** — drop the dedicated GitHub section and its manual *Refresh* button + re-poll logic. The snapshot already stays live via the existing `github` SSE event, which reloads the session.
- **`SessionDetail.vue`** — remove the now-unused `@reload` wiring and update the Overview comment.

## Notes

- The link only shows when a PR exists (the old "no PR found yet" placeholder is gone — decluttering intent).
- Manual *Refresh* is dropped; loom polls automatically while a session is active, and the `github` SSE event pushes updates into the header live.

## Checks

- `tsc --noEmit` and `rspack build` (production) both pass.
- fmt + clippy pre-commit hook clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)