### PR TITLE
feat(config): configurable in-browser terminal theme (dark/light)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,411 +1,84 @@
 # AGENTS.md
 
-Engineer-facing notes for hacking on weaver itself. For user-facing docs read
-[README.md](README.md); for the prompt the in-workspace agent sees, read the
-builtin [crates/weaver-core/WEAVER.md](crates/weaver-core/WEAVER.md) (a repo can
-ship its own `WEAVER.md` to override it).
+How to hack on weaver itself. **Read this whole file before you start** — it's
+short on purpose. Depth lives elsewhere, pull it in when you need it:
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) (internals: module map, REST API,
+storage, status model, GitHub integration), [README.md](README.md) (user docs),
+and [crates/weaver-core/WEAVER.md](crates/weaver-core/WEAVER.md) (the prompt the
+in-workspace agent sees). Run `weaver readme` for the agent workflow commands.
 
-## Mental model
+## What weaver is
 
-weaver ships **two binaries** and a **shared sqlite database**:
+Two binaries over one shared sqlite db (`~/.weaver/weaver.db`, WAL):
 
-- **`weaver`** is the **agent-facing CLI**: database-direct (no daemon, no
-  HTTP), resolving "the current branch" from `$WEAVER_BRANCH` else the git
-  checkout under cwd. Cold start is sub-50ms; it carries no `axum` / `reqwest` /
-  SPA dependencies. Agents call it to read and update the goal, report status,
-  add and triage issues, and emit hook events. It **works whether or not `loom`
-  is running** — that decoupling is the point of the split.
+- **`weaver`** — the daemon-less agent CLI: goal, status, issues, hook events.
+  Works with or without loom.
+- **`loom`** — the optional orchestrator: REST + SSE server, Vue SPA, per-branch
+  tmux + agent process, the monitor, and `git worktree` / `tmux` shell-outs.
 
-- **`loom`** is the **optional orchestrator**. It runs the REST + SSE server,
-  hosts the Vue web UI, owns the per-branch tmux + agent process via the
-  `sessions` table, runs the background monitor, and shells out to
-  `git worktree` / `tmux`. Without loom, branches and issues still work; tmux
-  orchestration, the dashboard, and the live screen do not.
-
-```
-weaver CLI ──sqlite──┐
-                     ├─ ~/.weaver/weaver.db   (shared, WAL)
-loom serve  ─────────┘    │
-  │                       │
-  ├─ axum REST + SSE      │
-  ├─ tmux + git wrappers  │
-  ├─ agent launcher       │
-  ├─ monitor (consumes    │
-  │   `events` rows that  │
-  │   `weaver hook` wrote)│
-  └─ Vue SPA              │
-                          │
-  Vue SPA ──REST + SSE────┘
-```
-
-Both binaries open the sqlite file directly. The monitor watches the `events`
-table for new `hook` rows — that is how `weaver hook` reports status without
-needing the daemon to be reachable.
-
-## Layout
-
-| Path | What's in it |
-|---|---|
-| `crates/weaver-core/` | lib: `branches`, `issues`, `events`, `db`, `migrations` (ordered SQL + `schema_migrations` indicator), `git`, `config`, `plan` (parser + reconcile), `repo_config` (`.weaver/config.toml`), agent helpers. Pure logic; used by both binaries. |
-| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `readme`, `set-status` [read or set level + message], `issue …`, `where`, `log`, `hook`, `config`) |
-| `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** |
-| `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
-| `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
-| `crates/loom/src/agent.rs` | launching agents into tmux + installing `.claude/settings.local.json` hooks |
-| `crates/loom/src/session.rs` | `Session` row + sqlx queries |
-| `crates/loom/src/tmux.rs` | `tmux new-session / capture-pane / kill-session / attach` (exact-match `=name:` targets) |
-| `crates/loom/src/terminal.rs` | WebSocket ⇄ PTY bridge: xterm.js ⇄ `tmux attach` (the live terminal) |
-| `crates/loom/src/github.rs` | `gh` CLI shell-out: issue seeding, PR opening, and the PR-status poll loop (snapshots each branch's PR; archives on merge) |
-| `crates/loom/src/client.rs` | HTTP client used by the `loom` CLI to talk to its own daemon |
-| `crates/loom/src/bin/loom.rs` | the orchestrator CLI (`serve`, `launch`, `ps`, `attach`, …) |
-| `crates/loom/frontend/` | Vue 3 SPA, rspack, Tailwind. `api.ts` + views in `views/` |
-| `crates/loom/static/dist/` | Build output (placeholder; real build overwrites) |
-| `crates/loom/tests/` | integration tests: `integration/` (server suites) + `hook_monitor.rs`; need `git` + `tmux` |
-| `e2e/` | Playwright; talks to a real `loom serve`. Separate `package.json` |
-| `crates/loom/build.rs` | Builds the SPA into `static/dist` (npm + rspack); writes a placeholder when Node is unavailable |
+Diagram and module-by-module map: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Build & test
 
 ```sh
-cargo build                              # builds the backend + the Vue SPA (needs Node + npm)
-cargo test --workspace                   # backend unit + integration tests (git, tmux)
-cd crates/loom/frontend && npm run dev   # live-reloading SPA against `loom serve`
-cd e2e && npm test                       # frontend end-to-end tests (Playwright)
+cargo build              # backend + Vue SPA (build.rs drives npm/rspack)
+cargo test --workspace   # backend unit + integration (needs git, tmux)
+cd e2e && npm test       # Playwright UI suite against a real loom
 ```
 
-`cargo build` builds the SPA into `static/dist` via `build.rs`; loom serves it
-from there at runtime (`web::static_dir`). `rerun-if-changed` makes the SPA build
-a no-op when no frontend source changed, so backend-only edits don't re-run
-rspack; a Node-less checkout still builds (the backend) and serves a placeholder.
-There is no skip flag — backend and frontend are separated at the **test** level
-(`cargo test` for the backend, the Playwright `e2e/` suite for the frontend), not
-the build level.
+Run `./scripts/pre-commit.sh` before committing — it is the fmt + clippy gate CI
+enforces (wire it up with `git config core.hooksPath .githooks`). Build/test
+internals and the Playwright setup live in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
-The integration tests shell out to real `git` and `tmux`. If one hangs, look
-for stray `weaver-test-*` tmux sessions.
+## Don't disturb the user's live loom
 
-### Pre-commit checks
-
-Run `./scripts/pre-commit.sh` before committing; it runs the same fmt + clippy
-gate the CI `lint` job enforces. Enable it as an automatic hook with `git config
-core.hooksPath .githooks`.
-
-### Don't spin up your own `loom` — it shares the user's tmux + db
-
-A real `loom serve` and the sessions it owns are **machine-global**: one default
-tmux server (the `weaver-<id>` sessions) and one `~/.weaver/weaver.db`. The user
-is normally running loom there with live agents inside it — including the one
-running *you*. So, unless the user explicitly asks:
+A real `loom serve` is **machine-global**: one default tmux server and one
+`~/.weaver/weaver.db`, normally running the user's agents — including the one
+running *you*. So unless the user explicitly asks:
 
 - **Don't** start your own `loom serve` / `loom launch`, create or kill
   `weaver-*` tmux sessions on the default socket, or run broad tmux cleanup
-  (`tmux kill-server`, `pkill -f weaver-…`, `tmux -L 'weaver*' kill-server`).
-  Each tears down the user's running agents at a stroke.
-- **If a task seems to need a live loom session, ask the user first.**
+  (`tmux kill-server`, `pkill -f weaver`). Each wipes the user's agents at a
+  stroke.
+- **If a task seems to need a live loom, ask first.**
 
-To exercise loom or tmux behaviour, use the test infrastructure instead. Both
-suites pin tmux to a throwaway server via `WEAVER_TMUX_SOCKET` (→ `tmux -L
-<name>`, see `tmux::socket_args`) and a temp `WEAVER_HOME`, so they can never
-see — let alone kill — the user's real sessions: the Rust integration tests
-(`crates/loom/tests/`) and the Playwright `e2e/` suite each use a private
-socket. Extend them rather than driving a real server by hand. If you must run
-loom ad-hoc, isolate it the same way:
+To exercise loom/tmux behaviour, extend the test suites — they isolate via a
+private `WEAVER_TMUX_SOCKET` + a temp `WEAVER_HOME`. If you must run loom by
+hand, isolate it the same way:
 
 ```sh
 WEAVER_TMUX_SOCKET=loom-dev-$$ WEAVER_HOME=$(mktemp -d) loom serve --addr 127.0.0.1:0
 ```
 
-### End-to-end (Playwright)
-
-The `e2e/` suite drives the real UI against a real server. It boots **one**
-`loom serve` per Playwright *worker* (not per test) on a random port, each with
-its own `WEAVER_HOME` / sqlite db, a private tmux socket (`WEAVER_TMUX_SOCKET`,
-reaped on teardown), and a throwaway git repo (see `e2e/fixtures/weaver.ts`),
-using the deterministic `shell` agent. The per-test `weaver` fixture wipes every
-session (branch + worktree) between tests, so each starts from a clean slate and
-count-based assertions hold regardless of order. Workers are fully isolated, so
-the suite runs in parallel (`fullyParallel`, `workers > 1`) and — because every
-session it touches is scoped to a worker's private socket and db — can't disturb
-a long-running dev server or your `~/.weaver` sessions. A `globalSetup` runs
-`cargo build` once up front so workers never race on the build.
-
-```sh
-cd e2e
-npm install            # first run only; also fetches the browser (see below)
-npx playwright install chromium
-npm test               # runs the suite; rebuilds loom + the SPA if stale
-```
-
-On a Linux distro Playwright doesn't ship a prebuilt browser for (e.g.
-`ubuntu26.04`, where `playwright install` errors with "does not support
-chromium"), force the nearest supported fallback build with
-`PLAYWRIGHT_HOST_PLATFORM_OVERRIDE`, and set it for the test run too so the same
-binary is launched:
-
-```sh
-PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npx playwright install chromium
-PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
-```
-
 ## Landing changes
 
-**Open a pull request by default.** Don't push to or merge into `main`
-directly. Work on a branch, run the checks above (`./scripts/pre-commit.sh` for
-fmt + clippy, then `cargo test --workspace`), make them pass, then `gh pr
-create`. This holds for every change — features, fixes, docs, refactors —
-unless the user tells you to commit straight to the base branch. A weaver
-worktree is already on its own branch; finishing the work means committing and
-opening the PR, not integrating it yourself (see the builtin
-[crates/weaver-core/WEAVER.md](crates/weaver-core/WEAVER.md)).
-
-**Don't credit yourself.** Write commit messages and PR descriptions in the
-project's voice — no "Generated with …", "Co-Authored-By: <tool>", or similar
-self-attribution.
-
-Then drive the PR to a mergeable state — don't open it and walk away:
-
-- **Keep it current with `main`.** When the branch falls behind or conflicts,
-  rebase or merge `main` (whichever keeps the history sane) and resolve the
-  conflicts yourself.
-- **Watch CI and review comments.** Poll the PR's checks and comments; fix
-  failing checks and address feedback as they land. Use your own judgement on
-  the response, and when a call is genuinely unclear, flag the user —
-  `weaver set-status attention "<question>"` — rather than guessing.
-
-## Storage & state
-
-- **SQLite** at `$WEAVER_HOME/weaver.db` (default `~/.weaver/weaver.db`),
-  shared by `weaver` and `loom`. WAL mode handles concurrency.
-  - Core tables: `branches`, `issues`, `events`, `settings`.
-  - Loom tables (`crates/loom/src/db.rs`): `sessions`, `recent_repos`,
-    `branch_github` (per-branch PR snapshot).
-  - **Schema migrations** (`weaver-core/src/migrations.rs`): ordered SQL files
-    under `crates/weaver-core/migrations/` (`NNNN_name.sql`, embedded with
-    `include_str!`), applied at startup and recorded in a `schema_migrations`
-    indicator table so each runs once. Add a change as a new numbered file plus
-    a row in `MIGRATIONS`; never edit one that has shipped. A pre-framework
-    database is brought to the baseline by a one-time `legacy_bootstrap` on
-    first run.
-- **`server.json`** in `$WEAVER_HOME`: pid + bound addr, written when `loom`
-  comes up. The `loom` CLI uses it to find the daemon when `WEAVER_API` is
-  unset.
-- **Settings** live in the `settings` table; each key is declared in
-  `weaver-core::config::registry()`. Both binaries read it. This is the
-  **global** (machine/user) store; **per-repo** conventions instead live in a
-  committed `.weaver/config.toml` read by `weaver-core::repo_config` (today just
-  `[plan].dir`, default `docs/plans`) — distinct from the settings table, and
-  resolved repo-file → builtin-default like a repo's own `WEAVER.md`.
-- **Worktrees** live under `<repo>/.worktrees/<slug>` on `weaver/<slug>`
-  (unless `--branch` reused an existing branch).
-
-## REST API
-
-All routes live under `/api`. The Vue SPA is the primary consumer.
-
-| Method + path | What it does |
-|---|---|
-| `GET /api/health` | liveness probe |
-| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]` and `parent_branch`; opens a tracking issue and returns its id as `tracking_issue`) |
-| `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description, attention) |
-| `POST /api/sessions/{id}/{archive,adopt}` | actions |
-| `POST /api/sessions/{id}/github` | re-poll the branch's GitHub PR now and return the updated session |
-| `GET POST DELETE /api/sessions/{id}/scratch` | list / drop / remove worktree `scratch/` reference files |
-| `PUT /api/sessions/{id}/file?path=…` | write raw bytes to a worktree file (the editor save primitive) |
-| `GET /api/sessions/{id}/plan` | a [structured project plan](../docs/structured-projects.md), parsed + task status joined from issues |
-| `POST /api/sessions/{id}/plan/sync` | reconcile a plan against the issue ledger (`apply` to write) |
-| `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
-| `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ PTY ⇄ tmux (the interaction surface) |
-| `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |
-| `GET POST /api/branches/{id}/issues` | issues claimed by the branch / create one |
-| `GET PATCH DELETE /api/issues/{id}` | per-issue CRUD |
-| `GET POST /api/repos/issues?repo_root=…` | repo-wide board (`scope=repo\|backlog`) / create a backlog item |
-| `GET /api/repos/recent` / `GET /api/repos/branches?cwd=…` | recent repos / branches in a repo |
-| `GET PATCH /api/settings` | settings registry |
-
-`SessionView` (`/api/sessions[/...]`) returns session-specific fields
-top-level (`id`, `status`, `work_dir`, `tmux_session`, `agent_kind`, `model`,
-`effort`, `pending_prompt`, `github_repo`, `last_activity_at`,
-`created_at`, `updated_at`, and — on the create response only —
-`tracking_issue`) plus a nested `branch: BranchView`
-(`id`, `name`, `title`, `goal`, `description`, `attention`,
-`repo_root`, `branch`, `base_branch`, `created_at`, `updated_at`,
-`open_issue_count`, `github`).
-
-`BranchView::github` is the branch's latest GitHub pull-request snapshot
-(`pr_number`, `pr_url`, `pr_state`, `pr_title`, `is_draft`, `review_decision`,
-`checks`, `mergeable`, `merged_at`, `fetched_at`), or `null` when GitHub polling
-is off, there is no PR, or `gh` is unavailable. See "GitHub integration" below.
-
-Status is two orthogonal axes. The session's `status` is the **lifecycle**
-(orchestrator-owned, mechanical): `created` / `launching` / `running` /
-`orphaned` / `done` / `error`. The branch's `attention` (level) plus its
-`description` (a one-line current-state message) are the **agent-declared**
-"does this need me?" signal: `ok` / `attention` / `blocked`, both set via
-`weaver set-status`. The dashboard filters on `attention`.
-
-There is **no** `/api/hook` endpoint — see "Status detection" below.
-
-**Scratch files** are reference material dropped into the worktree's `scratch/`
-directory (git-ignored, so it never enters the agent's diff). They can be added
-to a live session via `POST /api/sessions/{id}/scratch`, or attached up-front in
-the New Session form: those ride in the create request as `scratch` and are
-written *before* the agent launches, with a note appended to the launch prompt
-so a fresh agent knows the files are there. The stored branch goal stays the
-clean text the user typed.
+- **Open a PR; never push to or merge `main`.** Branch → `./scripts/pre-commit.sh`
+  + `cargo test --workspace` pass → `gh pr create`. A weaver worktree is already
+  on its own branch; finishing means opening the PR, not integrating it yourself.
+  Holds for every change unless the user says otherwise.
+- **Write in the project's voice** — no self-attribution in commits or PRs
+  ("Generated with…", "Co-Authored-By: <tool>", and the like).
+- **Keep the branch synced with `main`** when it falls behind or conflicts.
+- **Drive the PR to green, then hand off — local green is not CI green.** Opening
+  the PR starts this step; it doesn't end it. CI runs more than the local gate
+  (the Playwright `e2e/` suite, CodeQL, a clean-checkout SPA build), so passing
+  locally proves nothing about CI. After pushing: block on
+  `gh pr checks <n> --watch --fail-fast`, read feedback (`gh pr view <n> --json
+  reviews,comments` and `gh api repos/<owner>/<repo>/pulls/<n>/comments`), then
+  fix failures and address comments — replying in-thread — until it's green.
+  Only **then** raise `weaver set-status attention "ready for review"`; while CI
+  is running you are `ok`, not done. When a review call is genuinely unclear, ask
+  via `weaver set-status attention "<question>"` rather than guessing.
 
 ## Conventions
 
-- **API-first.** New features land as a REST endpoint in `web.rs` first; the
-  SPA and the `loom` CLI both consume it. Don't put business logic in
-  `bin/loom.rs` or in the Vue layer.
-- **Errors:** the server returns `AppError` (status + message + optional
-  `details` map of per-field reasons); the `loom` CLI uses `anyhow` and prints
-  `error: {e:#}`.
-- **Async:** tokio everywhere on the server side. Long-running subprocesses
-  (tmux, git, gh, the agent) go through `tokio::process::Command`. The
-  `weaver` CLI is synchronous-feeling (just a few `sqlx` calls per command).
-- **Events:** state changes flow through `EventBus`; the SSE handler in
-  `web.rs` fans them out. `weaver hook` writes directly to the `events`
-  table, and loom's monitor tick promotes the new row into a session status
-  change and a fresh `EventBus` notification.
-- **No tracking-branch state in the server:** loom can be killed and restarted
-  at any time. tmux sessions and worktrees survive; "orphaned" is a
-  first-class status, recovered via `loom adopt` (or the Adopt button in the
-  UI).
-
-## Status & attention
-
-Two distinct axes (see the SessionView note above): the mechanical **lifecycle**
-`sessions.status`, and the agent-declared **attention** on the branch.
-
-**Lifecycle** is driven by Claude Code hooks. `loom launch` merges a `hooks`
-block into the worktree's `.claude/settings.local.json` (see
-`loom::agent::install_hooks` and `weaver_core::agent::hooks_json`):
-
-| Claude hook event | shells out to |
-|---|---|
-| `SessionStart` | `weaver hook --event session-start` (also injects `additionalContext`: the repo's `WEAVER.md`, or the builtin [[crates/weaver-core/WEAVER.md]], on a genuine start/resume/clear; after a **compaction** — `source: "compact"` on the hook's stdin — a concise `weaver summary` re-orientation instead, so the agent isn't re-fed the whole guide. `weaver readme` pulls the full guide back on demand) |
-| `UserPromptSubmit` | `weaver hook --event working` |
-| `Notification` | `weaver hook --event waiting` |
-| `Stop` | `weaver hook --event idle` |
-
-`weaver hook` writes an `events` row keyed on the branch resolved from
-`$WEAVER_BRANCH` (set by the launcher) — no HTTP. Loom's monitor (`apply_hook`)
-consumes new `hook` rows on its next tick. Any hook means the agent process is
-alive, so all three set `status = running` (this also promotes a freshly
-`launching` session). Liveness is all a hook proves, so that is all the
-orchestrator tracks — it does not infer working/waiting/idle from stillness.
-
-The hooks also nudge the **attention** level where they carry a genuine signal:
-`working` clears it to `ok` and drops any pending prompt (the user is engaged);
-`waiting` raises it to `attention` and snapshots the tmux pane into
-`pending_prompt` (Claude is blocked asking the user — the snapshot conveys what
-it's waiting on, so no separate note is stored); `idle` (a turn ending) leaves
-attention untouched, so a finished-but-fine agent isn't mistaken for one that
-needs you.
-
-**Attention** is otherwise the agent's own call, set via `weaver set-status
-<level> ["<message>"]`. That writes the branch's `attention` level (and, when a
-message is given, the `description`) directly (daemon-less) and an `attention`
-event the monitor re-broadcasts over SSE. A bare `weaver set-status <level>`
-changes only the level and keeps the last message. Last write wins, so an
-explicit declaration overrides the hook-inferred default. The PATCH
-`/api/sessions/{id}` and `/api/branches/{id}` routes accept `attention` (and
-`description`) too, for the UI.
-
-Archiving a session clears its attention back to `ok` (and drops any snapshotted
-`pending_prompt`): the agent is gone, so a torn-down workstream can't still "need
-me", and the dashboard stops flagging it. The UI also treats any `archived`
-session as `ok` regardless of a stale attention value left on the branch.
-
-Orphan detection is independent: if `tmux has-session` says no, the session
-becomes `orphaned` and is eligible for `loom adopt`.
-
-## GitHub integration
-
-When the `gh` CLI is installed and authenticated, loom keeps a per-branch
-pull-request snapshot alongside the session. A second background loop
-(`github::poll`, sibling of the monitor, spawned in `server::serve`) ticks every
-30s and, for each active session, runs `gh pr view <branch> --json …` from the
-repo root. The result — PR number, URL, state (`OPEN`/`CLOSED`/`MERGED`), draft
-flag, `reviewDecision`, a rolled-up `checks` verdict (`passing`/`failing`/
-`pending`), and mergeability — is written to the loom-owned `branch_github`
-table (one row per branch, keyed `branch_id`) and served as `BranchView.github`.
-The dashboard renders it on the session list and overview; `POST
-/api/sessions/{id}/github` forces an immediate re-poll.
-
-The loop self-gates and degrades quietly: it is always spawned but does nothing
-while the `github.poll` setting is off, `gh` is missing (probed once, cached via
-`gh_available`), or the repo has no GitHub remote (a per-branch `gh` error that
-is logged at debug and skipped). So it is a no-op on non-GitHub repos rather
-than a failure.
-
-**Archive on merge.** When a poll finds a branch's PR has merged and
-`github.archive_on_merge` is on (the default), loom archives the session
-automatically — the same teardown as the Archive button (`web::archive`, shared
-code): tmux killed, worktree removed, branch and weaver history kept. The
-worktree is removed with `--force`, so any uncommitted work in it is discarded;
-a merged PR is taken to mean the workstream is done. Turn the behaviour off with
-`weaver config set github.archive_on_merge false` (or in the settings pane).
-Both settings live in `weaver-core::config::registry()` under the **GitHub**
-group.
-
-`gh`-touching logic lives in `crate::github`: `fetch_pr` (the shell-out +
-JSON parse + check rollup), `refresh` (fetch → store → announce → maybe
-archive, behind both the poller and the refresh endpoint), and `poll` (the
-loop). The merge-archive decision is split into `apply_snapshot` so it is
-testable without invoking `gh`.
-
-## Agent-facing commands
-
-When working inside a worktree the agent can run, with no daemon required:
-
-```sh
-weaver goal "ship the feature"          # set the branch's goal
-weaver goal                             # print the goal
-weaver summary                          # goal + outstanding tasks + next-step hints
-weaver readme                           # print the full weaver workflow guide (WEAVER.md)
-weaver set-status attention "ready for review"   # level + current-state message
-weaver set-status ok "waiting on PR review feedback"
-weaver set-status blocked                # change level only; keep the last message
-weaver set-status                        # read: goal + status + open issues
-weaver issue add "Backfill old rows" --body "ETA after the schema change"
-weaver issue add "Audit the logger" --repo  # unclaimed repo backlog item
-weaver issue ls                         # this branch's work + unclaimed backlog
-weaver issue ls --mine --all            # just this branch, including closed
-weaver issue ls --repo                  # whole repo, grouped by branch
-weaver issue show 7                     # an issue + the live status of the branch working it
-weaver issue wait 7 --timeout 600       # block until a sub-tree closes #7 or raises attention
-weaver issue close 7
-weaver plan new "Search rewrite"        # scaffold docs/plans/<slug>.md (large efforts)
-weaver plan ls                          # plans on this branch
-weaver plan show search-rewrite         # tasks + status projected from issues
-weaver plan sync search-rewrite --apply # reconcile plan tasks ↔ issue ledger
-weaver where                            # debug: print resolved repo / branch / branch-id
-weaver log --limit 50                   # recent events for the current branch
-weaver hook --event working             # (used by Claude Code hooks)
-```
-
-These are all `weaver-core` calls against the sqlite database. They write
-`events` rows so that loom (if running) can react on its next monitor tick.
-
-## Frontend notes
-
-- Vue 3 + `<script setup>` + Vue Router. Tailwind v4 via PostCSS.
-- All server calls go through `crates/loom/frontend/src/api.ts`. Don't fetch
-  inline in components.
-- Types in `frontend/src/types.ts` mirror the serde structs in `web.rs` —
-  keep them in sync by hand (no codegen).
-- The SPA is a thin client of the REST API ([[ui-built-on-rest-api]]). Don't
-  invent browser-local features the `loom` CLI cannot observe.
-
-## Environment
-
-| Var | Purpose | Default |
-|---|---|---|
-| `WEAVER_HOME` | state directory | `~/.weaver` |
-| `WEAVER_DB` | sqlite path | `$WEAVER_HOME/weaver.db` |
-| `WEAVER_API` | loom URL (both sides — server binds, CLI talks) | `http://127.0.0.1:7878` |
-| `WEAVER_BRANCH` | override the branch resolver (set by `loom launch` in the worktree) | — |
-| `WEAVER_TMUX_SOCKET` | pin tmux to a dedicated server (`tmux -L <name>`) so ops can't touch real sessions; set by the test harnesses | unset → default socket |
-| `RUST_LOG` / `EnvFilter` | tracing filter | `loom=info,weaver_core=info,tower_http=warn` |
+- **API-first.** A new feature is a `web.rs` REST route first; the SPA and the
+  `loom` CLI both consume it. No business logic in `bin/loom.rs` or the Vue layer.
+- **The frontend is a thin REST client** ([[ui-built-on-rest-api]]): every call
+  goes through `frontend/src/api.ts` (no inline `fetch`), and
+  `frontend/src/types.ts` mirrors the serde structs in `web.rs` by hand (no
+  codegen — keep them in sync). Don't invent browser-local features the `loom`
+  CLI can't observe.
+- Errors, async, the event bus, orphan recovery, and the rest of the runtime
+  model: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Notable settings:
   check status (on by default; a no-op without `gh` or a GitHub remote).
 - `github.archive_on_merge` — archive a session automatically once its PR
   merges (on by default).
+- `terminal.theme` — colour palette for the in-browser terminal: `dark` (the
+  classic black background, default) or `light`.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Loom serves a JSON API under `/api`; the Vue SPA is the primary consumer.
   `GET POST /api/repos/issues?repo_root=…` (the repo-wide board / backlog)
 - `GET PATCH /api/settings`
 
-See `AGENTS.md` for the shape of `SessionView`.
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the shape of `SessionView`.
 
 ## Server address
 

--- a/crates/loom/frontend/src/components/AgentTerminal.vue
+++ b/crates/loom/frontend/src/components/AgentTerminal.vue
@@ -74,9 +74,16 @@ function themeFor(name: string | undefined): ITheme {
   return name === 'light' ? LIGHT_THEME : DARK_THEME;
 }
 
+// How long to wait for the theme fetch before opening the terminal with the
+// dark default anyway. Same-origin localhost answers in single-digit ms; this
+// ceiling only matters if the request stalls, so the terminal never hangs
+// closed waiting on it.
+const THEME_FETCH_TIMEOUT_MS = 1000;
+
 // Best-effort fetch of the configured terminal theme. Any failure (offline,
-// stale server without the setting) falls back to the dark default rather than
-// blocking the terminal from opening.
+// stale server without the setting) falls back to the dark default. The caller
+// races this against a timeout so a *slow* (not just failed) request can't hold
+// the terminal closed either.
 async function loadTheme(): Promise<ITheme> {
   try {
     const res = (await get('/settings')) as { settings?: SettingView[] };
@@ -189,8 +196,15 @@ function onVisible() {
 onMounted(async () => {
   if (!host.value) return;
   // Resolve the configured palette before constructing the terminal so it
-  // paints in the right theme from the first frame (no dark→light flash).
-  const theme = await loadTheme();
+  // paints in the right theme from the first frame (no dark→light flash on the
+  // common fast path). But never let a slow/stalled request hold the terminal
+  // closed: race the fetch against a short timeout, open with the dark default
+  // if it loses, and upgrade to the configured palette once it lands.
+  const themePromise = loadTheme();
+  const initialTheme = await Promise.race([
+    themePromise,
+    new Promise<ITheme>((resolve) => setTimeout(() => resolve(DARK_THEME), THEME_FETCH_TIMEOUT_MS)),
+  ]);
   if (disposed || !host.value) return; // unmounted while the fetch was in flight
   term = new Terminal({
     convertEol: false,
@@ -198,7 +212,7 @@ onMounted(async () => {
     fontSize: 13,
     scrollback: 5000,
     allowProposedApi: true, // required to activate the unicode11 addon
-    theme,
+    theme: initialTheme,
     // Constrain agent-supplied OSC 8 hyperlinks to http(s); reject
     // javascript:/data:/file: which an untrusted agent could otherwise emit.
     linkHandler: {
@@ -215,6 +229,14 @@ onMounted(async () => {
     },
   });
   term.open(host.value);
+
+  // If the timeout won the race above, apply the real palette once the fetch
+  // resolves. Reference equality holds because the palettes are module-level
+  // singletons, so a no-op (configured theme === fallback) doesn't churn the
+  // renderer.
+  themePromise.then((t) => {
+    if (!disposed && term && t !== initialTheme) term.options.theme = t;
+  });
 
   fit = new FitAddon();
   term.loadAddon(fit);

--- a/crates/loom/frontend/src/components/AgentTerminal.vue
+++ b/crates/loom/frontend/src/components/AgentTerminal.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue';
-import { Terminal } from '@xterm/xterm';
+import { Terminal, type ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebglAddon } from '@xterm/addon-webgl';
 import '@xterm/xterm/css/xterm.css';
+import { get } from '../api';
+import type { SettingView } from '../types';
 
 // A real terminal in the browser: xterm.js bridged over a WebSocket to a
 // server-owned PTY running `tmux attach`. The PTY is the single interaction
@@ -36,6 +38,54 @@ let lastRows = 0;
 
 const OP_INPUT = 0x00;
 const OP_RESIZE = 0x01;
+
+// Terminal palettes, selected by the `terminal.theme` server setting. The dark
+// palette is the long-standing default — a black background with xterm's own
+// ANSI colours, which already assume a dark terminal — so it stays minimal to
+// preserve the exact prior appearance. The light palette (Solarized Light) must
+// supply its own foreground, cursor, and full 16-colour set, because xterm's
+// defaults are unreadable on a light background.
+const DARK_THEME: ITheme = { background: '#000000' };
+const LIGHT_THEME: ITheme = {
+  background: '#fdf6e3',
+  foreground: '#586e75',
+  cursor: '#586e75',
+  cursorAccent: '#fdf6e3',
+  selectionBackground: '#eee8d5',
+  black: '#073642',
+  red: '#dc322f',
+  green: '#859900',
+  yellow: '#b58900',
+  blue: '#268bd2',
+  magenta: '#d33682',
+  cyan: '#2aa198',
+  white: '#eee8d5',
+  brightBlack: '#002b36',
+  brightRed: '#cb4b16',
+  brightGreen: '#586e75',
+  brightYellow: '#657b83',
+  brightBlue: '#839496',
+  brightMagenta: '#6c71c4',
+  brightCyan: '#93a1a1',
+  brightWhite: '#fdf6e3',
+};
+
+function themeFor(name: string | undefined): ITheme {
+  return name === 'light' ? LIGHT_THEME : DARK_THEME;
+}
+
+// Best-effort fetch of the configured terminal theme. Any failure (offline,
+// stale server without the setting) falls back to the dark default rather than
+// blocking the terminal from opening.
+async function loadTheme(): Promise<ITheme> {
+  try {
+    const res = (await get('/settings')) as { settings?: SettingView[] };
+    const s = res?.settings?.find((x) => x.key === 'terminal.theme');
+    return themeFor(s?.value);
+  } catch {
+    return DARK_THEME;
+  }
+}
 
 function wsUrl(): string {
   // http→ws / https→wss on the page origin.
@@ -136,15 +186,19 @@ function onVisible() {
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   if (!host.value) return;
+  // Resolve the configured palette before constructing the terminal so it
+  // paints in the right theme from the first frame (no dark→light flash).
+  const theme = await loadTheme();
+  if (disposed || !host.value) return; // unmounted while the fetch was in flight
   term = new Terminal({
     convertEol: false,
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
     fontSize: 13,
     scrollback: 5000,
     allowProposedApi: true, // required to activate the unicode11 addon
-    theme: { background: '#000000' },
+    theme,
     // Constrain agent-supplied OSC 8 hyperlinks to http(s); reject
     // javascript:/data:/file: which an untrusted agent could otherwise emit.
     linkHandler: {

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -194,7 +194,7 @@ export interface FileContent {
   bytes: number;
 }
 
-export type SettingKind = 'string' | 'int' | 'bool';
+export type SettingKind = 'string' | 'int' | 'bool' | 'enum';
 
 /** One configurable setting: its registry metadata plus its current value. */
 export interface SettingView {
@@ -204,6 +204,8 @@ export interface SettingView {
   kind: SettingKind;
   default: string;
   group: string;
+  /** Allowed values for an `enum` setting, in display order; empty otherwise. */
+  options: string[];
   value: string;
   is_default: boolean;
 }

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -136,6 +136,14 @@ onMounted(load);
                 drafts[s.key] === 'true' ? 'Enabled' : 'Disabled'
               }}</span>
             </label>
+            <select
+              v-else-if="s.kind === 'enum'"
+              :id="s.key"
+              v-model="drafts[s.key]"
+              class="flex-1 rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
+            >
+              <option v-for="opt in s.options" :key="opt" :value="opt">{{ opt }}</option>
+            </select>
             <input
               v-else
               :id="s.key"

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -63,7 +63,7 @@ pub struct SettingSpec {
     pub default: &'static str,
     /// Heading the setting is grouped under in the UI.
     pub group: &'static str,
-    /// The allowed values for an [`SettingKind::Enum`] setting, in display
+    /// The allowed values for a [`SettingKind::Enum`] setting, in display
     /// order. Empty for every other kind.
     pub options: &'static [&'static str],
 }

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -23,6 +23,9 @@ pub const DEFAULT_GITHUB_POLL: bool = true;
 /// Whether loom archives a session automatically once its pull request merges.
 /// On by default — a merged branch's worktree has served its purpose.
 pub const DEFAULT_GITHUB_ARCHIVE_ON_MERGE: bool = true;
+/// The palette the browser terminal (xterm.js) renders with. `dark` keeps the
+/// classic black background; `light` swaps in a light, readable palette.
+pub const DEFAULT_TERMINAL_THEME: &str = "dark";
 
 // ---------------------------------------------------------------------------
 // Setting registry
@@ -39,6 +42,9 @@ pub enum SettingKind {
     Int,
     /// A boolean — stored as `true`/`false`.
     Bool,
+    /// A choice from a fixed set of strings ([`SettingSpec::options`]). Renders
+    /// as a dropdown; validated against the allowed values.
+    Enum,
 }
 
 /// A statically declared setting: everything the UI and validator need to know
@@ -57,6 +63,9 @@ pub struct SettingSpec {
     pub default: &'static str,
     /// Heading the setting is grouped under in the UI.
     pub group: &'static str,
+    /// The allowed values for an [`SettingKind::Enum`] setting, in display
+    /// order. Empty for every other kind.
+    pub options: &'static [&'static str],
 }
 
 /// Every setting weaver knows about. Adding a row here is all it takes to make
@@ -72,6 +81,7 @@ pub const REGISTRY: &[SettingSpec] = &[
         kind: SettingKind::String,
         default: DEFAULT_AGENT,
         group: "Agents",
+        options: &[],
     },
     SettingSpec {
         key: "agent.claude_args",
@@ -83,6 +93,7 @@ pub const REGISTRY: &[SettingSpec] = &[
         kind: SettingKind::String,
         default: "",
         group: "Agents",
+        options: &[],
     },
     SettingSpec {
         key: "server.auto_adopt",
@@ -93,6 +104,7 @@ pub const REGISTRY: &[SettingSpec] = &[
         kind: SettingKind::Bool,
         default: "false",
         group: "Server",
+        options: &[],
     },
     SettingSpec {
         key: "github.poll",
@@ -105,6 +117,7 @@ pub const REGISTRY: &[SettingSpec] = &[
         kind: SettingKind::Bool,
         default: "true",
         group: "GitHub",
+        options: &[],
     },
     SettingSpec {
         key: "github.archive_on_merge",
@@ -116,6 +129,18 @@ pub const REGISTRY: &[SettingSpec] = &[
         kind: SettingKind::Bool,
         default: "true",
         group: "GitHub",
+        options: &[],
+    },
+    SettingSpec {
+        key: "terminal.theme",
+        label: "Terminal theme",
+        description: "Colour palette for the in-browser terminal. `dark` is \
+            the classic black background; `light` swaps in a light, readable \
+            palette. Takes effect the next time a terminal is opened.",
+        kind: SettingKind::Enum,
+        default: DEFAULT_TERMINAL_THEME,
+        group: "Appearance",
+        options: &["dark", "light"],
     },
 ];
 
@@ -143,6 +168,16 @@ pub fn validate(key: &str, value: &str) -> std::result::Result<(), String> {
             "true" | "1" | "yes" | "on" | "false" | "0" | "no" | "off" => Ok(()),
             _ => Err(format!("expects true or false, got '{value}'")),
         },
+        SettingKind::Enum => {
+            if spec.options.contains(&value.trim()) {
+                Ok(())
+            } else {
+                Err(format!(
+                    "expects one of {}, got '{value}'",
+                    spec.options.join(", ")
+                ))
+            }
+        }
     }
 }
 
@@ -293,6 +328,53 @@ mod tests {
         assert!(validate("server.auto_adopt", "maybe").is_err());
         // Unregistered keys are free-form.
         assert!(validate("some.future.key", "anything").is_ok());
+    }
+
+    #[test]
+    fn validate_enum_accepts_only_listed_options() {
+        assert!(validate("terminal.theme", "dark").is_ok());
+        assert!(validate("terminal.theme", "light").is_ok());
+        // Surrounding whitespace is tolerated, like the other kinds.
+        assert!(validate("terminal.theme", " light ").is_ok());
+        // Anything outside the option set is rejected, and the error lists them.
+        let err = validate("terminal.theme", "solarized").unwrap_err();
+        assert!(err.contains("dark"), "error should list the options: {err}");
+        assert!(
+            err.contains("light"),
+            "error should list the options: {err}"
+        );
+    }
+
+    #[test]
+    fn enum_kind_iff_options_present() {
+        // The two are coupled: an Enum must declare its choices, and only an
+        // Enum may. This keeps the dropdown and validator in lockstep.
+        for s in REGISTRY {
+            let is_enum = s.kind == SettingKind::Enum;
+            assert_eq!(
+                is_enum,
+                !s.options.is_empty(),
+                "'{}': options must be non-empty iff kind is Enum",
+                s.key
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn describe_serializes_enum_kind_and_options_for_the_frontend() {
+        // The settings pane keys off `kind` and `options` to render a dropdown,
+        // so guard the JSON shape the API hands it.
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let views = describe(&db).await.unwrap();
+        let theme = views
+            .iter()
+            .find(|v| v.spec.key == "terminal.theme")
+            .expect("terminal.theme should be registered");
+        let json = serde_json::to_value(theme).unwrap();
+        assert_eq!(json["kind"], "enum");
+        assert_eq!(json["options"], serde_json::json!(["dark", "light"]));
+        assert_eq!(json["value"], "dark");
+        assert_eq!(json["is_default"], true);
     }
 
     #[tokio::test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,303 @@
+# Architecture
+
+Deep reference for weaver's internals. [AGENTS.md](../AGENTS.md) is the short
+how-to-work guide and links here; this file is for when you need the full map.
+
+## Mental model
+
+weaver ships **two binaries** over a **shared sqlite database**:
+
+- **`weaver`** — the **agent-facing CLI**: database-direct (no daemon, no HTTP),
+  resolving "the current branch" from `$WEAVER_BRANCH` else the git checkout
+  under cwd. Cold start is sub-50ms; it carries no `axum` / `reqwest` / SPA
+  dependencies. Agents call it to read and update the goal, report status, add
+  and triage issues, and emit hook events. It **works whether or not `loom` is
+  running** — that decoupling is the point of the split.
+- **`loom`** — the **optional orchestrator**: the REST + SSE server, the Vue web
+  UI, the per-branch tmux + agent process (via the `sessions` table), the
+  background monitor, and the `git worktree` / `tmux` shell-outs. Without loom,
+  branches and issues still work; tmux orchestration, the dashboard, and the
+  live screen do not.
+
+```
+weaver CLI ──sqlite──┐
+                     ├─ ~/.weaver/weaver.db   (shared, WAL)
+loom serve  ─────────┘    │
+  │                       │
+  ├─ axum REST + SSE      │
+  ├─ tmux + git wrappers  │
+  ├─ agent launcher       │
+  ├─ monitor (consumes    │
+  │   `events` rows that  │
+  │   `weaver hook` wrote)│
+  └─ Vue SPA              │
+                          │
+  Vue SPA ──REST + SSE────┘
+```
+
+Both binaries open the sqlite file directly. The monitor watches the `events`
+table for new `hook` rows — that is how `weaver hook` reports status without
+needing the daemon to be reachable.
+
+## Module layout
+
+| Path | What's in it |
+|---|---|
+| `crates/weaver-core/` | lib: `branches`, `issues`, `events`, `db`, `migrations` (ordered SQL + `schema_migrations` indicator), `git`, `config`, `plan` (parser + reconcile), `repo_config` (`.weaver/config.toml`), agent helpers. Pure logic; used by both binaries. |
+| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `readme`, `set-status` [read or set level + message], `issue …`, `where`, `log`, `hook`, `config`) |
+| `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** |
+| `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
+| `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
+| `crates/loom/src/agent.rs` | launching agents into tmux + installing `.claude/settings.local.json` hooks |
+| `crates/loom/src/session.rs` | `Session` row + sqlx queries |
+| `crates/loom/src/tmux.rs` | `tmux new-session / capture-pane / kill-session / attach` (exact-match `=name:` targets) |
+| `crates/loom/src/terminal.rs` | WebSocket ⇄ PTY bridge: xterm.js ⇄ `tmux attach` (the live terminal) |
+| `crates/loom/src/github.rs` | `gh` CLI shell-out: issue seeding, PR opening, and the PR-status poll loop (snapshots each branch's PR; archives on merge) |
+| `crates/loom/src/client.rs` | HTTP client used by the `loom` CLI to talk to its own daemon |
+| `crates/loom/src/bin/loom.rs` | the orchestrator CLI (`serve`, `launch`, `ps`, `attach`, …) |
+| `crates/loom/frontend/` | Vue 3 SPA, rspack, Tailwind. `api.ts` + views in `views/` |
+| `crates/loom/static/dist/` | Build output (placeholder; real build overwrites) |
+| `crates/loom/tests/` | integration tests: `integration/` (server suites) + `hook_monitor.rs`; need `git` + `tmux` |
+| `e2e/` | Playwright; talks to a real `loom serve`. Separate `package.json` |
+| `crates/loom/build.rs` | Builds the SPA into `static/dist` (npm + rspack); writes a placeholder when Node is unavailable |
+
+## Build internals
+
+`cargo build` builds the SPA into `static/dist` via `build.rs`; loom serves it
+from there at runtime (`web::static_dir`). `rerun-if-changed` makes the SPA build
+a no-op when no frontend source changed, so backend-only edits don't re-run
+rspack; a Node-less checkout still builds (the backend) and serves a placeholder.
+There is no skip flag — backend and frontend are separated at the **test** level
+(`cargo test` for the backend, the Playwright `e2e/` suite for the frontend), not
+the build level.
+
+The integration tests shell out to real `git` and `tmux`. If one hangs, look
+for stray `weaver-test-*` tmux sessions.
+
+### End-to-end (Playwright)
+
+The `e2e/` suite drives the real UI against a real server. It boots **one**
+`loom serve` per Playwright *worker* (not per test) on a random port, each with
+its own `WEAVER_HOME` / sqlite db, a private tmux socket (`WEAVER_TMUX_SOCKET`,
+reaped on teardown), and a throwaway git repo (see `e2e/fixtures/weaver.ts`),
+using the deterministic `shell` agent. The per-test `weaver` fixture wipes every
+session (branch + worktree) between tests, so each starts from a clean slate and
+count-based assertions hold regardless of order. Workers are fully isolated, so
+the suite runs in parallel (`fullyParallel`, `workers > 1`) and — because every
+session it touches is scoped to a worker's private socket and db — can't disturb
+a long-running dev server or your `~/.weaver` sessions. A `globalSetup` runs
+`cargo build` once up front so workers never race on the build.
+
+```sh
+cd e2e
+npm install            # first run only; also fetches the browser (see below)
+npx playwright install chromium
+npm test               # runs the suite; rebuilds loom + the SPA if stale
+```
+
+On a Linux distro Playwright doesn't ship a prebuilt browser for (e.g.
+`ubuntu26.04`, where `playwright install` errors with "does not support
+chromium"), force the nearest supported fallback build with
+`PLAYWRIGHT_HOST_PLATFORM_OVERRIDE`, and set it for the test run too so the same
+binary is launched:
+
+```sh
+PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npx playwright install chromium
+PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
+```
+
+## Storage & state
+
+- **SQLite** at `$WEAVER_HOME/weaver.db` (default `~/.weaver/weaver.db`),
+  shared by `weaver` and `loom`. WAL mode handles concurrency.
+  - Core tables: `branches`, `issues`, `events`, `settings`.
+  - Loom tables (`crates/loom/src/db.rs`): `sessions`, `recent_repos`,
+    `branch_github` (per-branch PR snapshot).
+  - **Schema migrations** (`weaver-core/src/migrations.rs`): ordered SQL files
+    under `crates/weaver-core/migrations/` (`NNNN_name.sql`, embedded with
+    `include_str!`), applied at startup and recorded in a `schema_migrations`
+    indicator table so each runs once. Add a change as a new numbered file plus
+    a row in `MIGRATIONS`; never edit one that has shipped. A pre-framework
+    database is brought to the baseline by a one-time `legacy_bootstrap` on
+    first run.
+- **`server.json`** in `$WEAVER_HOME`: pid + bound addr, written when `loom`
+  comes up. The `loom` CLI uses it to find the daemon when `WEAVER_API` is
+  unset.
+- **Settings** live in the `settings` table; each key is declared in
+  `weaver-core::config::registry()`. Both binaries read it. This is the
+  **global** (machine/user) store; **per-repo** conventions instead live in a
+  committed `.weaver/config.toml` read by `weaver-core::repo_config` (today just
+  `[plan].dir`, default `docs/plans`) — distinct from the settings table, and
+  resolved repo-file → builtin-default like a repo's own `WEAVER.md`.
+- **Worktrees** live under `<repo>/.worktrees/<slug>` on `weaver/<slug>`
+  (unless `--branch` reused an existing branch).
+
+## REST API
+
+All routes live under `/api`. The Vue SPA is the primary consumer.
+
+| Method + path | What it does |
+|---|---|
+| `GET /api/health` | liveness probe |
+| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]` and `parent_branch`; opens a tracking issue and returns its id as `tracking_issue`) |
+| `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description, attention) |
+| `POST /api/sessions/{id}/{archive,adopt}` | actions |
+| `POST /api/sessions/{id}/github` | re-poll the branch's GitHub PR now and return the updated session |
+| `GET POST DELETE /api/sessions/{id}/scratch` | list / drop / remove worktree `scratch/` reference files |
+| `PUT /api/sessions/{id}/file?path=…` | write raw bytes to a worktree file (the editor save primitive) |
+| `GET /api/sessions/{id}/plan` | a [structured project plan](structured-projects.md), parsed + task status joined from issues |
+| `POST /api/sessions/{id}/plan/sync` | reconcile a plan against the issue ledger (`apply` to write) |
+| `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
+| `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ PTY ⇄ tmux (the interaction surface) |
+| `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |
+| `GET POST /api/branches/{id}/issues` | issues claimed by the branch / create one |
+| `GET PATCH DELETE /api/issues/{id}` | per-issue CRUD |
+| `GET POST /api/repos/issues?repo_root=…` | repo-wide board (`scope=repo\|backlog`) / create a backlog item |
+| `GET /api/repos/recent` / `GET /api/repos/branches?cwd=…` | recent repos / branches in a repo |
+| `GET PATCH /api/settings` | settings registry |
+
+`SessionView` (`/api/sessions[/...]`) returns session-specific fields
+top-level (`id`, `status`, `work_dir`, `tmux_session`, `agent_kind`, `model`,
+`effort`, `pending_prompt`, `github_repo`, `last_activity_at`,
+`created_at`, `updated_at`, and — on the create response only —
+`tracking_issue`) plus a nested `branch: BranchView`
+(`id`, `name`, `title`, `goal`, `description`, `attention`,
+`repo_root`, `branch`, `base_branch`, `created_at`, `updated_at`,
+`open_issue_count`, `github`).
+
+`BranchView::github` is the branch's latest GitHub pull-request snapshot
+(`pr_number`, `pr_url`, `pr_state`, `pr_title`, `is_draft`, `review_decision`,
+`checks`, `mergeable`, `merged_at`, `fetched_at`), or `null` when GitHub polling
+is off, there is no PR, or `gh` is unavailable. See [GitHub
+integration](#github-integration).
+
+Status is two orthogonal axes. The session's `status` is the **lifecycle**
+(orchestrator-owned, mechanical): `created` / `launching` / `running` /
+`orphaned` / `done` / `error`. The branch's `attention` (level) plus its
+`description` (a one-line current-state message) are the **agent-declared**
+"does this need me?" signal: `ok` / `attention` / `blocked`, both set via
+`weaver set-status`. The dashboard filters on `attention`.
+
+There is **no** `/api/hook` endpoint — see [Status & attention](#status--attention).
+
+**Scratch files** are reference material dropped into the worktree's `scratch/`
+directory (git-ignored, so it never enters the agent's diff). They can be added
+to a live session via `POST /api/sessions/{id}/scratch`, or attached up-front in
+the New Session form: those ride in the create request as `scratch` and are
+written *before* the agent launches, with a note appended to the launch prompt
+so a fresh agent knows the files are there. The stored branch goal stays the
+clean text the user typed.
+
+## Runtime conventions
+
+- **API-first.** New features land as a REST endpoint in `web.rs` first; the
+  SPA and the `loom` CLI both consume it. Don't put business logic in
+  `bin/loom.rs` or in the Vue layer.
+- **Errors:** the server returns `AppError` (status + message + optional
+  `details` map of per-field reasons); the `loom` CLI uses `anyhow` and prints
+  `error: {e:#}`.
+- **Async:** tokio everywhere on the server side. Long-running subprocesses
+  (tmux, git, gh, the agent) go through `tokio::process::Command`. The
+  `weaver` CLI is synchronous-feeling (just a few `sqlx` calls per command).
+- **Events:** state changes flow through `EventBus`; the SSE handler in
+  `web.rs` fans them out. `weaver hook` writes directly to the `events`
+  table, and loom's monitor tick promotes the new row into a session status
+  change and a fresh `EventBus` notification.
+- **No tracking-branch state in the server:** loom can be killed and restarted
+  at any time. tmux sessions and worktrees survive; "orphaned" is a
+  first-class status, recovered via `loom adopt` (or the Adopt button in the
+  UI).
+
+## Status & attention
+
+Two distinct axes (see the SessionView note above): the mechanical **lifecycle**
+`sessions.status`, and the agent-declared **attention** on the branch.
+
+**Lifecycle** is driven by Claude Code hooks. `loom launch` merges a `hooks`
+block into the worktree's `.claude/settings.local.json` (see
+`loom::agent::install_hooks` and `weaver_core::agent::hooks_json`):
+
+| Claude hook event | shells out to |
+|---|---|
+| `SessionStart` | `weaver hook --event session-start` (also injects `additionalContext`: the repo's `WEAVER.md`, or the builtin [crates/weaver-core/WEAVER.md](../crates/weaver-core/WEAVER.md), on a genuine start/resume/clear; after a **compaction** — `source: "compact"` on the hook's stdin — a concise `weaver summary` re-orientation instead, so the agent isn't re-fed the whole guide. `weaver readme` pulls the full guide back on demand) |
+| `UserPromptSubmit` | `weaver hook --event working` |
+| `Notification` | `weaver hook --event waiting` |
+| `Stop` | `weaver hook --event idle` |
+
+`weaver hook` writes an `events` row keyed on the branch resolved from
+`$WEAVER_BRANCH` (set by the launcher) — no HTTP. Loom's monitor (`apply_hook`)
+consumes new `hook` rows on its next tick. Any hook means the agent process is
+alive, so all three set `status = running` (this also promotes a freshly
+`launching` session). Liveness is all a hook proves, so that is all the
+orchestrator tracks — it does not infer working/waiting/idle from stillness.
+
+The hooks also nudge the **attention** level where they carry a genuine signal:
+`working` clears it to `ok` and drops any pending prompt (the user is engaged);
+`waiting` raises it to `attention` and snapshots the tmux pane into
+`pending_prompt` (Claude is blocked asking the user — the snapshot conveys what
+it's waiting on, so no separate note is stored); `idle` (a turn ending) leaves
+attention untouched, so a finished-but-fine agent isn't mistaken for one that
+needs you.
+
+**Attention** is otherwise the agent's own call, set via `weaver set-status
+<level> ["<message>"]`. That writes the branch's `attention` level (and, when a
+message is given, the `description`) directly (daemon-less) and an `attention`
+event the monitor re-broadcasts over SSE. A bare `weaver set-status <level>`
+changes only the level and keeps the last message. Last write wins, so an
+explicit declaration overrides the hook-inferred default. The PATCH
+`/api/sessions/{id}` and `/api/branches/{id}` routes accept `attention` (and
+`description`) too, for the UI.
+
+Archiving a session clears its attention back to `ok` (and drops any snapshotted
+`pending_prompt`): the agent is gone, so a torn-down workstream can't still "need
+me", and the dashboard stops flagging it. The UI also treats any `archived`
+session as `ok` regardless of a stale attention value left on the branch.
+
+Orphan detection is independent: if `tmux has-session` says no, the session
+becomes `orphaned` and is eligible for `loom adopt`.
+
+## GitHub integration
+
+When the `gh` CLI is installed and authenticated, loom keeps a per-branch
+pull-request snapshot alongside the session. A second background loop
+(`github::poll`, sibling of the monitor, spawned in `server::serve`) ticks every
+30s and, for each active session, runs `gh pr view <branch> --json …` from the
+repo root. The result — PR number, URL, state (`OPEN`/`CLOSED`/`MERGED`), draft
+flag, `reviewDecision`, a rolled-up `checks` verdict (`passing`/`failing`/
+`pending`), and mergeability — is written to the loom-owned `branch_github`
+table (one row per branch, keyed `branch_id`) and served as `BranchView.github`.
+The dashboard renders it on the session list and overview; `POST
+/api/sessions/{id}/github` forces an immediate re-poll.
+
+The loop self-gates and degrades quietly: it is always spawned but does nothing
+while the `github.poll` setting is off, `gh` is missing (probed once, cached via
+`gh_available`), or the repo has no GitHub remote (a per-branch `gh` error that
+is logged at debug and skipped). So it is a no-op on non-GitHub repos rather
+than a failure.
+
+**Archive on merge.** When a poll finds a branch's PR has merged and
+`github.archive_on_merge` is on (the default), loom archives the session
+automatically — the same teardown as the Archive button (`web::archive`, shared
+code): tmux killed, worktree removed, branch and weaver history kept. The
+worktree is removed with `--force`, so any uncommitted work in it is discarded;
+a merged PR is taken to mean the workstream is done. Turn the behaviour off with
+`weaver config set github.archive_on_merge false` (or in the settings pane).
+Both settings live in `weaver-core::config::registry()` under the **GitHub**
+group.
+
+`gh`-touching logic lives in `crate::github`: `fetch_pr` (the shell-out +
+JSON parse + check rollup), `refresh` (fetch → store → announce → maybe
+archive, behind both the poller and the refresh endpoint), and `poll` (the
+loop). The merge-archive decision is split into `apply_snapshot` so it is
+testable without invoking `gh`.
+
+## Environment
+
+| Var | Purpose | Default |
+|---|---|---|
+| `WEAVER_HOME` | state directory | `~/.weaver` |
+| `WEAVER_DB` | sqlite path | `$WEAVER_HOME/weaver.db` |
+| `WEAVER_API` | loom URL (both sides — server binds, CLI talks) | `http://127.0.0.1:7878` |
+| `WEAVER_BRANCH` | override the branch resolver (set by `loom launch` in the worktree) | — |
+| `WEAVER_TMUX_SOCKET` | pin tmux to a dedicated server (`tmux -L <name>`) so ops can't touch real sessions; set by the test harnesses | unset → default socket |
+| `RUST_LOG` / `EnvFilter` | tracing filter | `loom=info,weaver_core=info,tower_http=warn` |


### PR DESCRIPTION
## What

Users can now switch the in-browser terminal between a **dark** (default) and **light** palette, configured as a DB-backed setting so it's shared by `loom` and the `weaver` CLI.

Previously the xterm.js terminal background was hard-coded to black (`theme: { background: '#000000' }`) with no way to change it.

## How

- **New setting `terminal.theme`** (group *Appearance*, enum `dark`/`light`, default `dark`) added to the config registry in `weaver-core/src/config.rs`. Being registry-backed, it's editable from both the **Settings** pane and `weaver config set terminal.theme light`.
- **New `Enum` `SettingKind`** with a fixed `options` list on each `SettingSpec`. The validator (and CLI) accept only the listed values; the settings pane renders enums as a `<select>` dropdown instead of a free-text box. Existing settings are unaffected (`options: &[]`).
- **`AgentTerminal.vue`** fetches `terminal.theme` before constructing the terminal so it paints in the right palette from the first frame (no dark→light flash), falling back to dark on any fetch failure. The light palette is Solarized Light — a full 16-colour set plus foreground/cursor, since xterm's defaults assume a dark background and are unreadable on light.

## Scope note

This themes the **xterm.js terminal palette** (the visible "default dark version" the request referred to), not tmux's own status-bar styling — weaver sets no tmux theme today, and doing so would collide with a user's own `tmux.conf`. The terminal-background layer is the right place to configure this.

## Testing

- `cargo test --workspace` — green (incl. new config unit tests: enum validation, the enum⇔options invariant, and the JSON shape the frontend consumes).
- `cargo fmt` + `cargo clippy -D warnings` clean (pre-commit gate).
- `rspack build` of the SPA compiles.