### PR TITLE
feat(loom): `loom session` group — drive child sessions uniformly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,14 @@ key decoupling — the agent CLI never speaks HTTP.
 ```sh
 # Orchestrator (optional)
 loom serve                            # run the daemon (REST + UI + tmux + monitor)
-loom launch "Add a /health endpoint"  # new worktree + tmux + agent, seeded with the task
-loom launch "Refactor the parser" --name parser-refactor   # override the branch slug
-loom launch "Big refactor" --model opus --effort high      # pick model tier + reasoning effort
+loom session launch "Add a /health endpoint"               # new worktree + tmux + agent, seeded with the task
+loom session launch "Refactor the parser" --name parser-refactor   # override the branch slug
+loom session launch "Big refactor" --model opus --effort high      # pick model tier + reasoning effort
+loom session poll <session>           # one-shot status (lifecycle + attention)
+loom session wait <session>           # block until it finishes or needs you
+loom session send <session> "try the curl again"   # type a message + Enter (trigger an agent round)
+loom session break <session>          # send Escape — interrupt the current turn
+loom session preview <session>        # print the recent tmux screen
 loom ps                               # list active sessions
 loom show <branch>                    # session detail
 loom attach <branch>                  # exec tmux attach (or use the browser terminal)
@@ -70,32 +75,41 @@ weaver where                          # debug: print resolved repo / branch / br
 weaver log --limit 50                 # recent events for the current branch
 ```
 
-`loom launch`'s positional argument is the **task**: it becomes the branch goal
-and the agent's opening prompt, and the `weaver/<slug>` branch name is derived
-from it (override with `--name`). The agent is `claude` unless you pass
-`--agent` or change `agent.default`, so the common case is just `loom launch
-"<what to do>"`. A `loom launch` with no task and nothing to pick up prints a
-usage hint and exits without launching.
+`loom session` is the uniform surface for driving a child session. `loom
+session launch`'s positional argument is the **task**: it becomes the branch
+goal and the agent's opening prompt, and the `weaver/<slug>` branch name is
+derived from it (override with `--name`). The agent is `claude` unless you pass
+`--agent` or change `agent.default`, so the common case is just `loom session
+launch "<what to do>"`. A launch with no task and nothing to pick up prints a
+usage hint and exits without launching. New branches fork from a
+freshly-fetched `origin/<default branch>` — the latest mainline — unless you
+pin a parent with `--base` (also a field in the web create form).
+
+Once a session is up, the other verbs interact with it: `loom session poll`
+reads its status, `loom session wait` blocks until it finishes or raises
+attention, `loom session send` types a message into the agent's pane (and
+submits it to trigger a round), `loom session break` sends Escape to interrupt
+the current turn, and `loom session preview` prints the recent tmux screen.
+Each takes a session key — an id, branch id, branch name, or `repo:branch`.
 
 Three flags seed the task from existing work instead of a fresh description:
-`loom launch --issue 123` takes the branch's title / goal / description from a
-GitHub issue (via the `gh` CLI), `loom launch --claim 7` takes them from an
-existing weaver issue and moves it out of the repo backlog, and `loom launch
---branch <name>` resumes an existing branch. `loom issues` prints the repo's
-board across branches.
+`loom session launch --issue 123` takes the branch's title / goal / description
+from a GitHub issue (via the `gh` CLI), `--claim 7` takes them from an existing
+weaver issue and moves it out of the repo backlog, and `--branch <name>` resumes
+an existing branch. `loom issues` prints the repo's board across branches.
 
 Every launch opens a **tracking issue** claimed by the new branch — the task as
-a weaver issue — and `loom launch` prints its number. That number is the handle
+a weaver issue — and the launch prints its number. That number is the handle
 for following the session: `weaver issue show <n>` reports the issue plus the
 live `set-status` of the branch working it, and `weaver issue wait <n>` blocks
 until the issue closes or that branch raises its attention. The launched agent
 is told to keep its status current and close the issue when the work is done.
-When an agent already inside a weaver session runs `loom launch`, the tracking
-issue is attributed to it (`source_branch`), so its sub-trees show up under
-"Delegated by this branch" in `weaver issue ls` — agents can fan work out into
-parallel sub-sessions and poll or block on them the same way a human does.
+When an agent already inside a weaver session runs `loom session launch`, the
+tracking issue is attributed to it (`source_branch`), so its sub-trees show up
+under "Delegated by this branch" in `weaver issue ls` — agents can fan work out
+into parallel sub-sessions and poll or block on them the same way a human does.
 
-`loom launch --model <haiku|sonnet|opus> --effort <low|medium|high|xhigh|max>`
+`loom session launch --model <haiku|sonnet|opus> --effort <low|medium|high|xhigh|max>`
 (both also selectors in the web create form) pin the session's Claude model
 tier and reasoning effort. They are orthogonal — any model runs at any effort —
 and spliced into the launch as `--model` / `--effort`. Both are stored per
@@ -110,7 +124,7 @@ The **lifecycle** (`session.status`) is mechanical and orchestrator-owned:
 `created`, `launching`, `running`, `orphaned`, `done`, or `error`. `done` and
 `error` are terminal; the rest, including `orphaned`, are recoverable. Claude-
 backed sessions drive it via Claude Code hooks installed into
-`.claude/settings.local.json` by `loom launch`. Each hook shells out to
+`.claude/settings.local.json` by `loom session launch`. Each hook shells out to
 `weaver hook --event {working|waiting|idle|session-start}`, writing an `events`
 row the monitor consumes on its next tick; any hook means the agent process is
 alive → `running`. When Claude blocks asking the user (the `waiting`/Notification
@@ -215,8 +229,8 @@ weaver config unset agent.claude_args
 
 Notable settings:
 
-- `agent.default` — agent kind launched for a new session when `loom launch`
-  is given no `--agent` (`claude`, `shell`, or a custom command).
+- `agent.default` — agent kind launched for a new session when `loom session
+  launch` is given no `--agent` (`claude`, `shell`, or a custom command).
 - `agent.claude_args` — extra arguments spliced into the Claude TUI launch,
   e.g. `--model claude-opus-4-7`.
 - `server.auto_adopt` — adopt every recoverable session on daemon startup.
@@ -246,4 +260,4 @@ tests are the Rust suites; the frontend's tests are the Playwright `e2e/` suite.
 - `WEAVER_HOME` — state directory (default `~/.weaver`)
 - `WEAVER_DB` — database path (default `$WEAVER_HOME/weaver.db`)
 - `WEAVER_API` — loom URL the `loom` CLI talks to (default `http://127.0.0.1:7878`)
-- `WEAVER_BRANCH` — override the branch resolver (set by `loom launch` in the worktree)
+- `WEAVER_BRANCH` — override the branch resolver (set by `loom session launch` in the worktree)

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -75,6 +75,9 @@ const model = ref('');
 const effort = ref('');
 const name = ref('');
 const nameEdited = ref(false);
+// Optional base/parent branch to fork a new session from. Blank means the
+// server default: a freshly-fetched `origin/<default branch>` (the mainline).
+const base = ref('');
 const creating = ref(false);
 // Reference files staged in the form; base64-encoded into the create request
 // so they land in the new worktree's scratch/ before the agent launches.
@@ -196,6 +199,8 @@ async function create() {
       body.existing_branch = existingBranch.value.trim();
     } else {
       body.name = name.value || undefined;
+      // Only a new branch has a base to fork from; blank = server default.
+      if (base.value.trim()) body.base = base.value.trim();
     }
     if (scratchFiles.value.length) {
       body.scratch = await Promise.all(
@@ -211,6 +216,7 @@ async function create() {
     model.value = '';
     effort.value = '';
     name.value = '';
+    base.value = '';
     existingBranch.value = '';
     scratchFiles.value = [];
     nameEdited.value = false;
@@ -366,17 +372,35 @@ onUnmounted(() => clearInterval(timer));
             Existing branch
           </button>
         </div>
-        <div v-if="branchMode === 'new'">
-          <label class="block text-xs text-muted mb-1">
-            Name — the worktree (<code>.worktrees/&lt;name&gt;</code>) and branch
-            (<code>weaver/&lt;name&gt;</code>)
-          </label>
-          <input
-            v-model="name"
-            @input="nameEdited = true"
-            placeholder="health-endpoint"
-            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
-          />
+        <div v-if="branchMode === 'new'" class="space-y-2">
+          <div>
+            <label class="block text-xs text-muted mb-1">
+              Name — the worktree (<code>.worktrees/&lt;name&gt;</code>) and branch
+              (<code>weaver/&lt;name&gt;</code>)
+            </label>
+            <input
+              v-model="name"
+              @input="nameEdited = true"
+              placeholder="health-endpoint"
+              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+            />
+          </div>
+          <div>
+            <label class="block text-xs text-muted mb-1">
+              Base branch — fork point (optional)
+            </label>
+            <input
+              v-model="base"
+              placeholder="origin/main (freshly fetched)"
+              autocomplete="off"
+              spellcheck="false"
+              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+            />
+            <p class="mt-1 text-xs text-faint">
+              Leave blank to fork from a freshly-fetched
+              <code>origin/&lt;default branch&gt;</code>.
+            </p>
+          </div>
         </div>
         <div v-else class="relative">
           <label class="block text-xs text-muted mb-1">

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -7,7 +7,7 @@
 //! other interaction surface).
 
 use anyhow::{anyhow, bail, Context, Result};
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 use serde_json::{json, Value};
 
 use loom::client::Client;
@@ -39,59 +39,24 @@ enum Cmd {
     /// Stop and re-start the loom daemon.
     Restart,
 
-    /// Launch a new session: worktree + tmux + agent, seeded with a task.
+    /// Manage sessions: launch, poll, wait, send, break, preview.
     ///
-    /// The positional argument is the task the agent should work on — it
-    /// becomes the branch goal and the agent's opening prompt:
+    /// A uniform surface for driving a child session — start one, watch it, and
+    /// interact with its agent pane:
     ///
-    ///     loom launch "Add a /health endpoint and a test for it"
-    ///
-    /// The branch name (`weaver/<slug>`) is derived from the task; override it
-    /// with `--name`. To pick up existing work instead of describing a new
-    /// task, use `--claim <id>`, `--issue <n>`, or `--branch <name>`.
-    Launch {
-        /// What the agent should do. Sets the branch goal and is fed to the
-        /// agent as its first prompt. Multiple words are joined, so quoting is
-        /// optional. Omit only when seeding from `--claim`/`--issue`/`--branch`.
-        task: Vec<String>,
-        /// Branch slug to create (`weaver/<name>`). Defaults to a slug derived
-        /// from the task. Mutually exclusive with `--branch`.
-        #[arg(long)]
-        name: Option<String>,
-        /// Agent to run: `claude` (the default), `shell` for a plain shell, or
-        /// any other command. Optional — omit to use the configured
-        /// `agent.default` (see `weaver config get agent.default`).
-        #[arg(long)]
-        agent: Option<String>,
-        /// Branch to fork the new worktree from. Defaults to the repo's current
-        /// branch.
-        #[arg(long)]
-        base: Option<String>,
-        /// One-line title shown on the dashboard. Defaults to a title derived
-        /// from the task.
-        #[arg(long)]
-        title: Option<String>,
-        /// Seed the task from a GitHub issue (by number, via the `gh` CLI):
-        /// fills in title, goal, and description.
-        #[arg(long)]
-        issue: Option<i64>,
-        /// Claim an existing weaver issue (by id) for this session: seeds the
-        /// goal from it and moves it out of the repo backlog.
-        #[arg(long)]
-        claim: Option<i64>,
-        /// Resume an existing branch rather than creating a new one. Mutually
-        /// exclusive with `--name`.
-        #[arg(long)]
-        branch: Option<String>,
-        /// Model tier: haiku, sonnet, or opus. Omit to inherit the configured
-        /// `agent.claude_args`.
-        #[arg(long)]
-        model: Option<String>,
-        /// Reasoning effort: low, medium, high, xhigh, or max. Omit to inherit
-        /// the configured `agent.claude_args`.
-        #[arg(long)]
-        effort: Option<String>,
+    ///     loom session launch "Add a /health endpoint and a test for it"
+    ///     loom session poll weaver/health      # one-shot status
+    ///     loom session wait weaver/health      # block until done / needs you
+    ///     loom session send weaver/health "try the curl again"
+    ///     loom session break weaver/health     # interrupt the current turn
+    ///     loom session preview weaver/health   # peek at the tmux screen
+    Session {
+        #[command(subcommand)]
+        cmd: SessionCmd,
     },
+    /// Deprecated alias for `loom session launch`.
+    #[command(hide = true)]
+    Launch(LaunchOpts),
     /// List active sessions.
     Ps,
     /// Show the repo's issue board (every issue across branches + backlog).
@@ -123,6 +88,121 @@ enum Cmd {
     Completions { shell: clap_complete::Shell },
 }
 
+/// Subcommands under `loom session` — the uniform way to drive a child session.
+#[derive(Subcommand)]
+enum SessionCmd {
+    /// Launch a new session: worktree + tmux + agent, seeded with a task.
+    ///
+    /// The positional argument is the task the agent should work on — it
+    /// becomes the branch goal and the agent's opening prompt:
+    ///
+    ///     loom session launch "Add a /health endpoint and a test for it"
+    ///
+    /// The branch name (`weaver/<slug>`) is derived from the task; override it
+    /// with `--name`. To pick up existing work instead of describing a new
+    /// task, use `--claim <id>`, `--issue <n>`, or `--branch <name>`.
+    Launch(LaunchOpts),
+    /// Poll a session's status: lifecycle + the agent's attention and message.
+    Poll {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+    },
+    /// Block until a session finishes or its agent needs you.
+    ///
+    /// Polls until the session reaches a terminal lifecycle state (`done` /
+    /// `error` / `archived`) or is lost (`orphaned`), or — unless
+    /// `--lifecycle-only` — until its agent raises attention to
+    /// `attention`/`blocked`. Prints why it woke. Exits non-zero if `--timeout`
+    /// elapses first.
+    Wait {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+        /// Give up after this many seconds (0 = wait indefinitely).
+        #[arg(long, default_value = "1800")]
+        timeout: u64,
+        /// Seconds between polls.
+        #[arg(long, default_value = "3")]
+        interval: u64,
+        /// Wake only on a lifecycle change; ignore the agent's attention.
+        #[arg(long)]
+        lifecycle_only: bool,
+    },
+    /// Type a message into a session's agent pane (and submit it to trigger an
+    /// agent round).
+    Send {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+        /// The message to type. Multiple words are joined, so quoting is
+        /// optional.
+        message: Vec<String>,
+        /// Type the message but don't press Enter — stage it without submitting.
+        #[arg(long)]
+        no_enter: bool,
+    },
+    /// Send a break (Escape) to a session — interrupt the agent's current turn.
+    Break {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+    },
+    /// Print a session's recent tmux screen.
+    #[command(alias = "sp")]
+    Preview {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+        /// Extra scrollback lines above the visible screen (0 = visible only).
+        #[arg(long, default_value = "0")]
+        lines: usize,
+    },
+}
+
+/// Shared `launch` options, used by both `loom session launch` and the
+/// deprecated top-level `loom launch` alias.
+#[derive(Args)]
+struct LaunchOpts {
+    /// What the agent should do. Sets the branch goal and is fed to the agent as
+    /// its first prompt. Multiple words are joined, so quoting is optional. Omit
+    /// only when seeding from `--claim`/`--issue`/`--branch`.
+    task: Vec<String>,
+    /// Branch slug to create (`weaver/<name>`). Defaults to a slug derived from
+    /// the task. Mutually exclusive with `--branch`.
+    #[arg(long)]
+    name: Option<String>,
+    /// Agent to run: `claude` (the default), `shell` for a plain shell, or any
+    /// other command. Optional — omit to use the configured `agent.default`
+    /// (see `weaver config get agent.default`).
+    #[arg(long)]
+    agent: Option<String>,
+    /// Branch to fork the new worktree from. Defaults to a freshly-fetched
+    /// `origin/<default branch>` (the repo's mainline), so new work starts from
+    /// the latest upstream rather than the launching checkout.
+    #[arg(long)]
+    base: Option<String>,
+    /// One-line title shown on the dashboard. Defaults to a title derived from
+    /// the task.
+    #[arg(long)]
+    title: Option<String>,
+    /// Seed the task from a GitHub issue (by number, via the `gh` CLI): fills in
+    /// title, goal, and description.
+    #[arg(long)]
+    issue: Option<i64>,
+    /// Claim an existing weaver issue (by id) for this session: seeds the goal
+    /// from it and moves it out of the repo backlog.
+    #[arg(long)]
+    claim: Option<i64>,
+    /// Resume an existing branch rather than creating a new one. Mutually
+    /// exclusive with `--name`.
+    #[arg(long)]
+    branch: Option<String>,
+    /// Model tier: haiku, sonnet, or opus. Omit to inherit the configured
+    /// `agent.claude_args`.
+    #[arg(long)]
+    model: Option<String>,
+    /// Reasoning effort: low, medium, high, xhigh, or max. Omit to inherit the
+    /// configured `agent.claude_args`.
+    #[arg(long)]
+    effort: Option<String>,
+}
+
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
@@ -143,31 +223,10 @@ async fn run() -> Result<()> {
         Cmd::Start => cmd_start().await,
         Cmd::Stop => cmd_stop().await,
         Cmd::Restart => cmd_restart().await,
-        Cmd::Launch {
-            task,
-            name,
-            agent,
-            base,
-            title,
-            issue,
-            claim,
-            branch,
-            model,
-            effort,
-        } => {
-            cmd_launch(LaunchArgs {
-                goal: task.join(" "),
-                name,
-                agent,
-                base,
-                title,
-                issue,
-                claim,
-                branch,
-                model,
-                effort,
-            })
-            .await
+        Cmd::Session { cmd } => run_session(cmd).await,
+        Cmd::Launch(opts) => {
+            eprintln!("note: `loom launch` is deprecated — use `loom session launch`");
+            cmd_launch(opts.into()).await
         }
         Cmd::Ps => cmd_ps().await,
         Cmd::Issues { all, backlog } => cmd_issues(all, backlog).await,
@@ -185,6 +244,27 @@ async fn run() -> Result<()> {
             clap_complete::generate(shell, &mut cmd, "loom", &mut std::io::stdout());
             Ok(())
         }
+    }
+}
+
+/// Dispatch the `loom session <verb>` subcommands.
+async fn run_session(cmd: SessionCmd) -> Result<()> {
+    match cmd {
+        SessionCmd::Launch(opts) => cmd_launch(opts.into()).await,
+        SessionCmd::Poll { session } => cmd_session_poll(session).await,
+        SessionCmd::Wait {
+            session,
+            timeout,
+            interval,
+            lifecycle_only,
+        } => cmd_session_wait(session, timeout, interval.max(1), lifecycle_only).await,
+        SessionCmd::Send {
+            session,
+            message,
+            no_enter,
+        } => cmd_session_send(session, message.join(" "), !no_enter).await,
+        SessionCmd::Break { session } => cmd_session_break(session).await,
+        SessionCmd::Preview { session, lines } => cmd_session_preview(session, lines).await,
     }
 }
 
@@ -394,8 +474,8 @@ async fn cmd_restart() -> Result<()> {
 // Session commands (HTTP)
 // ---------------------------------------------------------------------------
 
-/// Parsed `loom launch` inputs, after folding the positional task words into a
-/// single `goal` string.
+/// Parsed launch inputs, after folding the positional task words into a single
+/// `goal` string.
 struct LaunchArgs {
     goal: String,
     name: Option<String>,
@@ -409,7 +489,24 @@ struct LaunchArgs {
     effort: Option<String>,
 }
 
-/// A bare `loom launch` with nothing to work on — no task, no name, no title,
+impl From<LaunchOpts> for LaunchArgs {
+    fn from(o: LaunchOpts) -> Self {
+        LaunchArgs {
+            goal: o.task.join(" "),
+            name: o.name,
+            agent: o.agent,
+            base: o.base,
+            title: o.title,
+            issue: o.issue,
+            claim: o.claim,
+            branch: o.branch,
+            model: o.model,
+            effort: o.effort,
+        }
+    }
+}
+
+/// A bare `loom session launch` with nothing to work on — no task, no name, no title,
 /// and nothing to pick up (`--claim`/`--issue`/`--branch`). Launching anyway
 /// would spawn an agent with an empty goal that "starts unprompted", so we
 /// stop and point the user at the useful forms instead.
@@ -423,12 +520,12 @@ fn launch_underspecified(a: &LaunchArgs) -> bool {
 }
 
 const LAUNCH_HINT: &str = "nothing to do — give the agent a task or something to pick up:
-  loom launch \"<what the agent should do>\"   # the common case
-  loom launch --claim <id>                     # pick up a weaver issue
-  loom launch --issue <n>                      # seed from a GitHub issue
-  loom launch --branch <name>                  # resume an existing branch
-  loom launch --name <slug> --agent shell      # an empty named worktree (no task)
-See `loom launch --help` for all options.";
+  loom session launch \"<what the agent should do>\"   # the common case
+  loom session launch --claim <id>                     # pick up a weaver issue
+  loom session launch --issue <n>                      # seed from a GitHub issue
+  loom session launch --branch <name>                  # resume an existing branch
+  loom session launch --name <slug> --agent shell      # an empty named worktree (no task)
+See `loom session launch --help` for all options.";
 
 async fn cmd_launch(a: LaunchArgs) -> Result<()> {
     if launch_underspecified(&a) {
@@ -448,9 +545,10 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
     } = a;
     let client = Client::new();
     let cwd = std::env::current_dir()?;
-    // When an agent in a weaver session runs `loom launch`, `$WEAVER_BRANCH` is
-    // its own branch id — pass it so the tracking issue is attributed to the
-    // launching (parent) agent. A human shell launch leaves it unset.
+    // When an agent in a weaver session runs `loom session launch`,
+    // `$WEAVER_BRANCH` is its own branch id — pass it so the tracking issue is
+    // attributed to the launching (parent) agent. A human shell launch leaves it
+    // unset.
     let parent_branch = std::env::var("WEAVER_BRANCH")
         .ok()
         .filter(|s| !s.is_empty());
@@ -504,12 +602,167 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
     Ok(())
 }
 
+/// Resolve a session view by key, surfacing a clearer error than a bare 404 when
+/// the key matches no live session.
+async fn fetch_session(client: &Client, key: &str) -> Result<Value> {
+    client
+        .get(&format!("/api/sessions/{key}"))
+        .await
+        .with_context(|| format!("no live session for '{key}'"))
+}
+
+/// One-line attention summary: the level, plus its current-state message when set.
+fn attention_summary(ws: &Value) -> String {
+    let attention = branch_str(ws, "attention");
+    let message = branch_str(ws, "description");
+    if message.is_empty() {
+        attention.to_string()
+    } else {
+        format!("{attention} — {message}")
+    }
+}
+
+/// `loom session poll` — a one-shot status read: lifecycle + attention.
+async fn cmd_session_poll(key: String) -> Result<()> {
+    let client = Client::new();
+    let ws = fetch_session(&client, &key).await?;
+    println!(
+        "session {}  ({})",
+        str_field(&ws, "id"),
+        branch_str(&ws, "name")
+    );
+    println!("  status:    {}", str_field(&ws, "status"));
+    println!("  attention: {}", attention_summary(&ws));
+    if let Some(n) = ws.get("tracking_issue").and_then(Value::as_i64) {
+        println!("  track:     weaver issue #{n}");
+    }
+    println!("  activity:  {}", str_field(&ws, "last_activity_at"));
+    Ok(())
+}
+
+/// `loom session wait` — block until the session finishes, is lost, or (unless
+/// `lifecycle_only`) its agent raises attention. Mirrors `weaver issue wait`.
+async fn cmd_session_wait(
+    key: String,
+    timeout: u64,
+    interval: u64,
+    lifecycle_only: bool,
+) -> Result<()> {
+    let client = Client::new();
+    // Short-circuit if the session is already in a wake state at call time.
+    let ws = fetch_session(&client, &key).await?;
+    if let Some(reason) = wake_reason(&ws, &key, lifecycle_only) {
+        println!("{reason}");
+        return Ok(());
+    }
+    println!(
+        "waiting on {} ({}) — {}",
+        key,
+        branch_str(&ws, "name"),
+        str_field(&ws, "status")
+    );
+
+    let interval = std::time::Duration::from_secs(interval);
+    let deadline =
+        (timeout > 0).then(|| std::time::Instant::now() + std::time::Duration::from_secs(timeout));
+    loop {
+        // Never nap past the deadline: a long `--interval` must not stretch a
+        // short `--timeout`.
+        let nap = match deadline {
+            Some(d) => interval.min(d.saturating_duration_since(std::time::Instant::now())),
+            None => interval,
+        };
+        tokio::time::sleep(nap).await;
+        let ws = fetch_session(&client, &key).await?;
+        if let Some(reason) = wake_reason(&ws, &key, lifecycle_only) {
+            println!("{reason}");
+            return Ok(());
+        }
+        // Timing out is a real "not done" outcome: report it as an error so the
+        // process exits non-zero (callers branch on it).
+        if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+            bail!(
+                "timed out after {timeout}s — session {key} still {}",
+                str_field(&ws, "status")
+            );
+        }
+    }
+}
+
+/// Why a `wait` should stop watching `ws`, or `None` to keep waiting: a terminal
+/// or orphaned lifecycle, or — unless `lifecycle_only` — a raised attention.
+fn wake_reason(ws: &Value, key: &str, lifecycle_only: bool) -> Option<String> {
+    let status = str_field(ws, "status");
+    if is_terminal_status(status) {
+        return Some(format!("session {key} is {status} — finished"));
+    }
+    if status == "orphaned" {
+        return Some(format!(
+            "session {key} is orphaned — its tmux was lost (try `loom adopt {key}`)"
+        ));
+    }
+    if !lifecycle_only && branch_str(ws, "attention") != "ok" {
+        return Some(format!(
+            "session {key} needs you — {}",
+            attention_summary(ws)
+        ));
+    }
+    None
+}
+
+/// The terminal session lifecycle states (mirrors `session::is_terminal`).
+fn is_terminal_status(status: &str) -> bool {
+    matches!(status, "done" | "error" | "archived")
+}
+
+/// `loom session send` — type a message into the agent's pane, submitting it
+/// (Enter) unless `submit` is false.
+async fn cmd_session_send(key: String, message: String, submit: bool) -> Result<()> {
+    if message.trim().is_empty() {
+        bail!("nothing to send — provide a message");
+    }
+    let client = Client::new();
+    client
+        .post(
+            &format!("/api/sessions/{key}/send"),
+            json!({ "text": message, "submit": submit }),
+        )
+        .await?;
+    println!(
+        "sent to {key}{}",
+        if submit { "" } else { " (not submitted)" }
+    );
+    Ok(())
+}
+
+/// `loom session break` — send Escape to interrupt the agent's current turn.
+async fn cmd_session_break(key: String) -> Result<()> {
+    let client = Client::new();
+    client
+        .post(&format!("/api/sessions/{key}/interrupt"), json!({}))
+        .await?;
+    println!("sent break (Escape) to {key}");
+    Ok(())
+}
+
+/// `loom session preview` — print the session's recent tmux screen.
+async fn cmd_session_preview(key: String, lines: usize) -> Result<()> {
+    let client = Client::new();
+    let res = client
+        .get(&format!("/api/sessions/{key}/preview?lines={lines}"))
+        .await?;
+    print!("{}", str_field(&res, "screen"));
+    // The capture is right-trimmed server-side; ensure a clean final newline.
+    println!();
+    Ok(())
+}
+
 async fn cmd_ps() -> Result<()> {
     let client = Client::new();
     let list = client.get("/api/sessions").await?;
     let rows = list.as_array().cloned().unwrap_or_default();
     if rows.is_empty() {
-        println!("no sessions — start one with `loom launch \"<task>\"`");
+        println!("no sessions — start one with `loom session launch \"<task>\"`");
         return Ok(());
     }
     println!(
@@ -745,6 +998,50 @@ mod tests {
         assert_eq!(truncate("a very long string", 6), "a ver…");
     }
 
+    /// clap's own consistency check over the full command tree — catches a
+    /// malformed arg/subcommand (e.g. the nested `session` group) at test time
+    /// rather than on first run.
+    #[test]
+    fn cli_is_well_formed() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn terminal_statuses_match_the_session_model() {
+        for s in ["done", "error", "archived"] {
+            assert!(is_terminal_status(s), "{s} should be terminal");
+        }
+        for s in ["created", "launching", "running", "orphaned"] {
+            assert!(!is_terminal_status(s), "{s} should not be terminal");
+        }
+    }
+
+    fn view(status: &str, attention: &str, description: &str) -> Value {
+        json!({
+            "status": status,
+            "branch": { "attention": attention, "description": description },
+        })
+    }
+
+    #[test]
+    fn wake_reason_fires_on_terminal_orphan_and_attention() {
+        // A running, ok session keeps the wait blocked.
+        assert!(wake_reason(&view("running", "ok", ""), "s", false).is_none());
+
+        // Terminal and orphaned lifecycles always wake.
+        assert!(wake_reason(&view("done", "ok", ""), "s", false)
+            .unwrap()
+            .contains("finished"));
+        assert!(wake_reason(&view("orphaned", "ok", ""), "s", false)
+            .unwrap()
+            .contains("orphaned"));
+
+        // A raised attention wakes — and carries the message — unless lifecycle_only.
+        let needs = wake_reason(&view("running", "blocked", "build broken"), "s", false).unwrap();
+        assert!(needs.contains("needs you") && needs.contains("build broken"));
+        assert!(wake_reason(&view("running", "blocked", "build broken"), "s", true).is_none());
+    }
+
     fn empty_launch() -> LaunchArgs {
         LaunchArgs {
             goal: String::new(),
@@ -762,7 +1059,7 @@ mod tests {
 
     #[test]
     fn bare_launch_is_underspecified() {
-        // `loom launch` with nothing, or only an agent/model/effort/base
+        // `loom session launch` with nothing, or only an agent/model/effort/base
         // selector, has no actual task to run.
         assert!(launch_underspecified(&empty_launch()));
         let only_agent = LaunchArgs {

--- a/crates/loom/src/tmux.rs
+++ b/crates/loom/src/tmux.rs
@@ -116,6 +116,30 @@ pub async fn capture(name: &str, history: usize) -> Result<String> {
     run(&args).await
 }
 
+/// Send `text` to the session's pane as **literal** input (`send-keys -l`), so
+/// every character — including any that look like tmux key names — is typed
+/// verbatim. No trailing newline; pair with [`send_enter`] to submit.
+pub async fn send_literal(name: &str, text: &str) -> Result<()> {
+    let target = exact(name);
+    // `-l` is literal mode; `--` ends option parsing so a `text` that begins
+    // with `-` is still treated as input rather than a flag.
+    run(&["send-keys", "-t", &target, "-l", "--", text]).await?;
+    Ok(())
+}
+
+/// Send a single named key (e.g. `Enter`, `Escape`) to the session's pane.
+pub async fn send_key(name: &str, key: &str) -> Result<()> {
+    let target = exact(name);
+    run(&["send-keys", "-t", &target, key]).await?;
+    Ok(())
+}
+
+/// Submit the current pane input — a bare `Enter`. The agent-round trigger that
+/// follows a [`send_literal`].
+pub async fn send_enter(name: &str) -> Result<()> {
+    send_key(name, "Enter").await
+}
+
 /// Cleanly detach a single client identified by its controlling tty (e.g.
 /// `/dev/pts/5`). This is the principled way to end a `tmux attach`: the server
 /// tells that client to detach and the `tmux attach` process exits 0 on its own,

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -372,6 +372,10 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{id}/log", get(log_session))
         .route("/sessions/{id}/events", get(events_sse))
         .route("/sessions/{id}/terminal", get(crate::terminal::terminal_ws))
+        // Drive a session's tmux pane: type a message, interrupt, peek at it.
+        .route("/sessions/{id}/send", post(send_session))
+        .route("/sessions/{id}/interrupt", post(interrupt_session))
+        .route("/sessions/{id}/preview", get(preview_session))
         // Branches & issues
         .route("/branches", get(list_branches))
         .route("/branches/{id}", get(get_branch).patch(patch_branch))
@@ -597,9 +601,13 @@ async fn create_session(
         ));
     }
 
+    // Unless the caller pins a base, fork from a freshly-fetched `origin/<default
+    // branch>` so new work starts from the latest mainline, not the launching
+    // checkout's (possibly stale) current branch. `default_base` degrades to the
+    // current branch on a remote-less repo.
     let base = match req.base.clone() {
         Some(b) => b,
-        None => git::current_branch(&repo_root).await?,
+        None => git::default_base(&repo_root).await?,
     };
 
     let (branch_name, work_dir) = if let Some(existing_branch) = existing {
@@ -1787,6 +1795,98 @@ async fn events_sse(
             .unwrap_or_default()))
     });
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+// ---------------------------------------------------------------------------
+// Driving a session's tmux pane (send / interrupt / preview)
+//
+// One-shot HTTP primitives for an agent (or script) to drive a child session
+// uniformly, distinct from the interactive terminal WebSocket: type a message,
+// interrupt the current turn, or read back the pane.
+// ---------------------------------------------------------------------------
+
+/// Guard the pane-driving endpoints: the session must have a live tmux to type
+/// into or capture. An orphaned/torn-down session returns 409.
+async fn require_live_tmux(session: &Session) -> ApiResult<()> {
+    if tmux::has_session(&session.tmux_session).await {
+        Ok(())
+    } else {
+        Err(AppError::conflict(format!(
+            "session '{}' has no live tmux to drive",
+            session.id
+        )))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SendReq {
+    /// The text to type into the agent's pane.
+    text: String,
+    /// Whether to follow the text with Enter to submit it (and so trigger an
+    /// agent round). Defaults to true; pass false to stage input unsubmitted.
+    #[serde(default = "default_submit")]
+    submit: bool,
+}
+
+fn default_submit() -> bool {
+    true
+}
+
+/// Type a message into a session's agent pane and, by default, submit it with
+/// Enter to trigger an agent round.
+async fn send_session(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Json(req): Json<SendReq>,
+) -> ApiResult<Json<Value>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    require_live_tmux(&session).await?;
+    tmux::send_literal(&session.tmux_session, &req.text)
+        .await
+        .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if req.submit {
+        tmux::send_enter(&session.tmux_session)
+            .await
+            .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+    Ok(Json(json!({ "sent": true, "submitted": req.submit })))
+}
+
+/// Send a break/interrupt — `Escape`, the keystroke Claude Code reads as "stop
+/// the current turn" — to a session's agent pane.
+async fn interrupt_session(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<Value>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    require_live_tmux(&session).await?;
+    tmux::send_key(&session.tmux_session, "Escape")
+        .await
+        .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(json!({ "interrupted": true })))
+}
+
+#[derive(Debug, Deserialize)]
+struct PreviewQuery {
+    /// Extra scrollback lines to include above the visible screen (0 = just the
+    /// visible pane).
+    #[serde(default)]
+    lines: usize,
+}
+
+/// Capture the session's tmux pane as plain text — "what does the child look
+/// like right now". Returns `{ "screen": "<text>" }`.
+async fn preview_session(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Query(q): Query<PreviewQuery>,
+) -> ApiResult<Json<Value>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    require_live_tmux(&session).await?;
+    let screen = tmux::capture(&session.tmux_session, q.lines)
+        .await
+        .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(json!({ "screen": screen })))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -11,6 +11,7 @@ mod fixtures;
 mod archive;
 mod branches;
 mod files;
+mod pane;
 mod scratch;
 mod sessions;
 mod terminal;

--- a/crates/loom/tests/integration/pane.rs
+++ b/crates/loom/tests/integration/pane.rs
@@ -1,0 +1,182 @@
+//! Driving a session's tmux pane over REST: `send` types + submits a line,
+//! `preview` reads the pane back, `interrupt` injects a break, and all three
+//! refuse a session whose tmux is gone. These use `tmux send-keys`/`capture-pane`
+//! (no PTY), so unlike the terminal WebSocket suite they run everywhere.
+
+use std::time::Duration;
+
+use serde_json::json;
+use serial_test::serial;
+
+use loom::tmux;
+
+use crate::fixtures::TestServer;
+
+/// Poll `GET /preview` until the captured screen contains `marker`, or fail.
+async fn preview_until(ts: &TestServer, id: &str, marker: &str) -> String {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+    loop {
+        let res = ts
+            .client
+            .get(&format!("/api/sessions/{id}/preview"))
+            .await
+            .unwrap();
+        let screen = res["screen"].as_str().unwrap_or("").to_string();
+        if screen.contains(marker) {
+            return screen;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("marker {marker:?} never appeared in the pane; last capture:\n{screen}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// `send` (submit) runs a command in the shell; `preview` reads its output back.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_runs_a_command_and_preview_reads_it() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "pane test", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+
+    // Submit a command whose OUTPUT (the arithmetic result) differs from the
+    // text typed — so finding it proves the line was actually executed, not just
+    // echoed onto the prompt.
+    let sent = client
+        .post(
+            &format!("/api/sessions/{id}/send"),
+            json!({ "text": "echo PANE_$((6 * 7))" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(sent["submitted"], true, "submit defaults to true");
+
+    let screen = preview_until(&ts, &id, "PANE_42").await;
+    assert!(screen.contains("PANE_42"), "command output missing");
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// `send` with `submit:false` stages input without running it.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_without_submit_does_not_execute() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "pane test", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+
+    let sent = client
+        .post(
+            &format!("/api/sessions/{id}/send"),
+            json!({ "text": "echo STAGED_$((1 + 1))", "submit": false }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(sent["submitted"], false);
+
+    // Give the pane a beat, then confirm the arithmetic never ran: the literal
+    // text is on the prompt line, but the evaluated `STAGED_2` is not.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let res = client
+        .get(&format!("/api/sessions/{id}/preview"))
+        .await
+        .unwrap();
+    let screen = res["screen"].as_str().unwrap_or("");
+    assert!(
+        !screen.contains("STAGED_2"),
+        "unsubmitted input should not have executed; screen:\n{screen}"
+    );
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// `interrupt` injects an Escape and reports success.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupt_sends_a_break() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "pane test", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+
+    let res = client
+        .post(&format!("/api/sessions/{id}/interrupt"), json!({}))
+        .await
+        .unwrap();
+    assert_eq!(res["interrupted"], true);
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// All three pane endpoints 409 when the session has no live tmux.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pane_endpoints_reject_a_dead_session() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "pane test", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+    let session = ws["tmux_session"].as_str().unwrap().to_string();
+
+    // Kill the tmux out from under loom — the session is now orphaned.
+    tmux::kill_session(&session).await.unwrap();
+    assert!(!tmux::has_session(&session).await);
+
+    assert!(
+        client
+            .post(
+                &format!("/api/sessions/{id}/send"),
+                json!({ "text": "echo hi" })
+            )
+            .await
+            .is_err(),
+        "send should fail without a live tmux"
+    );
+    assert!(
+        client
+            .post(&format!("/api/sessions/{id}/interrupt"), json!({}))
+            .await
+            .is_err(),
+        "interrupt should fail without a live tmux"
+    );
+    assert!(
+        client
+            .get(&format!("/api/sessions/{id}/preview"))
+            .await
+            .is_err(),
+        "preview should fail without a live tmux"
+    );
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -6,7 +6,7 @@ use serial_test::serial;
 
 use loom::tmux;
 
-use crate::fixtures::TestServer;
+use crate::fixtures::{sh, TestServer};
 
 /// Creating a session provisions a worktree + tmux session and records the repo;
 /// deleting it tears the tmux session down and releases the repo's active count.
@@ -80,6 +80,46 @@ async fn create_lists_and_tears_down() {
     assert_eq!(recent.len(), 1, "recent repo should outlive its sessions");
     assert_eq!(recent[0]["repo_root"], repo_root);
     assert_eq!(recent[0]["active_branches"], 0);
+}
+
+/// With an `origin` remote present, a launch that doesn't pin `--base` forks the
+/// new branch from the freshly-fetched `origin/<default branch>`, recorded as
+/// the branch's base.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn launch_forks_from_fresh_origin_default() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+    let repo = ts.repo_path();
+
+    // Give the throwaway repo a bare `origin` and publish `main` to it, so the
+    // remote-tracking ref + origin/HEAD exist (what `default_base` resolves).
+    let remote = tempfile::tempdir().unwrap();
+    sh(
+        remote.path(),
+        "git",
+        &["init", "-q", "--bare", "-b", "main"],
+    );
+    let remote_url = remote.path().to_string_lossy().to_string();
+    sh(repo, "git", &["remote", "add", "origin", &remote_url]);
+    sh(repo, "git", &["push", "-q", "origin", "main"]);
+    sh(repo, "git", &["fetch", "-q", "origin"]);
+    sh(repo, "git", &["remote", "set-head", "origin", "main"]);
+
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "fork from fresh main", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        ws["branch"]["base_branch"], "origin/main",
+        "launch should fork from the fetched origin default, got {ws}"
+    );
+
+    let id = ws["id"].as_str().unwrap().to_string();
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
 }
 
 /// A session can be created with no goal at all — just a title.

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -62,9 +62,10 @@ without reading this terminal:
 You can fan work out into its own detached session — a parallel sub-tree on its
 own branch and worktree — and track it the same way someone tracks you:
 
-- `loom launch "<what the sub-agent should do>"` — spawn a sub-session. It
-  prints the new branch and a **tracking issue number** for the task; that
-  issue is your handle on the sub-tree.
+- `loom session launch "<what the sub-agent should do>"` — spawn a sub-session.
+  It prints the new branch and a **tracking issue number** for the task; that
+  issue is your handle on the sub-tree. The new branch forks from a
+  freshly-fetched `origin/<default branch>` unless you pass `--base <branch>`.
 - `weaver issue show <id>` — poll the sub-tree: its tracking issue's
   open/closed state plus the sub-agent's live `set-status` (attention +
   current-state message).
@@ -73,6 +74,20 @@ own branch and worktree — and track it the same way someone tracks you:
   `attention`/`blocked`). Takes `--timeout <secs>`; prints why it woke.
 - `weaver issue ls` lists the sub-tasks you have delegated under
   "Delegated by this branch", each with its sub-agent's current status.
+
+The tracking issue is the high-level handle; `loom session` also drives a child
+session's terminal directly, so you can nudge it without attaching:
+
+- `loom session poll <session>` — one-shot status (lifecycle + attention).
+- `loom session wait <session>` — block on the session itself (not its issue)
+  until it finishes, is lost, or raises attention. `--timeout <secs>`.
+- `loom session send <session> "<message>"` — type a message into the
+  sub-agent's pane and submit it, triggering an agent round (e.g. to answer a
+  question it asked or redirect it).
+- `loom session break <session>` — send Escape to interrupt its current turn.
+- `loom session preview <session>` — print its recent tmux screen, to see what
+  it's doing right now. A session key is an id, branch id, branch name, or
+  `repo:branch`.
 
 This duplicates some of a coding agent's builtin sub-agents, but a weaver
 sub-session is fully decoupled: it survives independently, has its own git

--- a/crates/weaver-core/src/branch.rs
+++ b/crates/weaver-core/src/branch.rs
@@ -303,7 +303,7 @@ fn primary_worktree(dir: &Path) -> PathBuf {
 }
 
 /// Resolve the branch the current process is operating on. Order:
-///   1. `$WEAVER_BRANCH` (an internal branch id, set by `loom launch`)
+///   1. `$WEAVER_BRANCH` (an internal branch id, set by `loom session launch`)
 ///   2. Walk up from `cwd` to find a git checkout, read `HEAD`, and look up
 ///      `(repo_root, branch)` in the `branches` table. Auto-creates the row
 ///      on first call.

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -109,6 +109,79 @@ pub async fn branch_exists(dir: &Path, branch: &str) -> bool {
     .is_ok()
 }
 
+/// Whether a remote named `name` is configured (`git remote get-url`).
+async fn has_remote(dir: &Path, name: &str) -> bool {
+    git(dir, &["remote", "get-url", name]).await.is_ok()
+}
+
+/// Whether `rev` resolves to a commit in this repo.
+async fn commit_exists(dir: &Path, rev: &str) -> bool {
+    git(
+        dir,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{rev}^{{commit}}"),
+        ],
+    )
+    .await
+    .is_ok()
+}
+
+/// The default branch on `origin` (e.g. `main`), resolved locally and cheaply:
+/// the recorded `origin/HEAD` symref, else a probe of the usual names against
+/// the existing remote-tracking refs. `None` when none of those resolve (a
+/// fresh clone with no `origin/HEAD` and no `main`/`master` tracking ref).
+async fn origin_default_branch(dir: &Path) -> Option<String> {
+    if let Ok(out) = git(
+        dir,
+        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+    )
+    .await
+    {
+        if let Some(name) = out.strip_prefix("origin/") {
+            if !name.is_empty() {
+                return Some(name.to_string());
+            }
+        }
+    }
+    for cand in ["main", "master"] {
+        if commit_exists(dir, &format!("origin/{cand}")).await {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+/// The base a freshly-launched session should fork from: the repo's default
+/// branch on `origin`, **fetched fresh**, so new work always starts from the
+/// latest mainline rather than whatever the launching checkout happens to have
+/// checked out (and possibly stale). Returns the `origin/<default>` ref, which
+/// the diff machinery already treats as a first-class base (see
+/// [`merge_base_fresh`]).
+///
+/// Degrades gracefully: with no `origin` remote (a local-only repo, or the test
+/// harness) it falls back to the local current branch, the historical default.
+/// A failed fetch (offline) is non-fatal — the existing `origin/<default>`
+/// tracking ref is used as-is; only if that ref doesn't resolve at all do we
+/// fall back to the current branch.
+pub async fn default_base(dir: &Path) -> Result<String> {
+    if !has_remote(dir, "origin").await {
+        return current_branch(dir).await;
+    }
+    if let Some(default) = origin_default_branch(dir).await {
+        // Best-effort: refresh the tracking ref so the fork point is current.
+        // Ignore network failures — a stale ref still beats the local branch.
+        let _ = git(dir, &["fetch", "origin", &default]).await;
+        let remote_ref = format!("origin/{default}");
+        if commit_exists(dir, &remote_ref).await {
+            return Ok(remote_ref);
+        }
+    }
+    current_branch(dir).await
+}
+
 /// Create a new worktree at `path` on a new `branch` forked from `base`.
 pub async fn worktree_add(repo_root: &Path, path: &Path, branch: &str, base: &str) -> Result<()> {
     let path = path.to_string_lossy();
@@ -509,6 +582,42 @@ mod tests {
         let clean = changed_files(dir, &since).await.unwrap();
         assert_eq!(clean.len(), 1);
         assert_eq!(clean[0].path, "mine.txt");
+    }
+
+    /// With no `origin` remote, the launch base degrades to the local current
+    /// branch — the historical behaviour, kept for remote-less repos.
+    #[tokio::test]
+    async fn default_base_without_remote_uses_current_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        run(dir, &["init", "-q", "-b", "main"]).await;
+        run(dir, &["config", "user.email", "t@t.t"]).await;
+        run(dir, &["config", "user.name", "t"]).await;
+        commit(dir, "T0").await;
+        assert_eq!(default_base(dir).await.unwrap(), "main");
+    }
+
+    /// With an `origin` remote, the launch base is the remote's default branch
+    /// (`origin/main`) so new work forks from the fetched mainline.
+    #[tokio::test]
+    async fn default_base_prefers_origin_default() {
+        let remote = tempfile::tempdir().unwrap();
+        run(remote.path(), &["init", "-q", "--bare", "-b", "main"]).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        run(dir, &["init", "-q", "-b", "main"]).await;
+        run(dir, &["config", "user.email", "t@t.t"]).await;
+        run(dir, &["config", "user.name", "t"]).await;
+        commit(dir, "T0").await;
+        let remote_url = remote.path().to_string_lossy().to_string();
+        run(dir, &["remote", "add", "origin", &remote_url]).await;
+        run(dir, &["push", "-q", "origin", "main"]).await;
+        // Populate the remote-tracking refs (origin/main, origin/HEAD).
+        run(dir, &["fetch", "-q", "origin"]).await;
+        run(dir, &["remote", "set-head", "origin", "main"]).await;
+
+        assert_eq!(default_base(dir).await.unwrap(), "origin/main");
     }
 
     /// `DiffBase::Uncommitted` scopes to working-tree changes vs `HEAD`, ignoring

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -231,7 +231,7 @@ fn issue_ls_shows_delegated_sub_trees() {
 
 /// Insert a delegated tracking issue (sourced by `parent`, claimed by `child`)
 /// and give `child` a branch row with the supplied attention/description —
-/// reproducing the state a `loom launch` from inside `parent` would create.
+/// reproducing the state a `loom session launch` from inside `parent` would create.
 fn seed_delegated_issue(env: &Env, parent: &str, child: &str, attention: &str, description: &str) {
     let db_path = env.home_path.join("weaver.db");
     // Make sure the parent branch row exists first (a write resolves it).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,6 +149,9 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `POST /api/sessions/{id}/plan/sync` | reconcile a plan against the issue ledger (`apply` to write) |
 | `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ PTY ⇄ tmux (the interaction surface) |
+| `POST /api/sessions/{id}/send` | type `{text}` into the agent's tmux pane; `submit` (default true) follows it with Enter to trigger a round |
+| `POST /api/sessions/{id}/interrupt` | send a break (Escape) to the pane — stop the current turn |
+| `GET /api/sessions/{id}/preview?lines=N` | capture the pane as `{screen}`; `lines` adds scrollback above the visible screen |
 | `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |
 | `GET POST /api/branches/{id}/issues` | issues claimed by the branch / create one |
 | `GET PATCH DELETE /api/issues/{id}` | per-issue CRUD |
@@ -188,6 +191,20 @@ written *before* the agent launches, with a note appended to the launch prompt
 so a fresh agent knows the files are there. The stored branch goal stays the
 clean text the user typed.
 
+**Launch base.** A new session's worktree forks from `base`. When the create
+request omits it, `git::default_base` resolves the repo's default branch on
+`origin` and fetches it, so the branch starts from a fresh `origin/<default>`
+rather than the launching checkout's current branch. A remote-less repo (no
+`origin`) degrades to the local current branch. The caller — the CLI's `--base`
+or the create form's base field — can pin any ref instead.
+
+**Driving the pane.** `send` / `interrupt` / `preview` are one-shot HTTP
+primitives over `tmux send-keys` and `capture-pane` (see `tmux::send_literal`,
+`send_key`, `capture`), distinct from the interactive terminal WebSocket: they
+let an agent or script type into, interrupt, or read back a child session
+uniformly. Each requires a live tmux (else 409). The CLI's `loom session
+{send,break,preview}` wrap them.
+
 ## Runtime conventions
 
 - **API-first.** New features land as a REST endpoint in `web.rs` first; the
@@ -213,7 +230,7 @@ clean text the user typed.
 Two distinct axes (see the SessionView note above): the mechanical **lifecycle**
 `sessions.status`, and the agent-declared **attention** on the branch.
 
-**Lifecycle** is driven by Claude Code hooks. `loom launch` merges a `hooks`
+**Lifecycle** is driven by Claude Code hooks. `loom session launch` merges a `hooks`
 block into the worktree's `.claude/settings.local.json` (see
 `loom::agent::install_hooks` and `weaver_core::agent::hooks_json`):
 
@@ -298,6 +315,6 @@ testable without invoking `gh`.
 | `WEAVER_HOME` | state directory | `~/.weaver` |
 | `WEAVER_DB` | sqlite path | `$WEAVER_HOME/weaver.db` |
 | `WEAVER_API` | loom URL (both sides — server binds, CLI talks) | `http://127.0.0.1:7878` |
-| `WEAVER_BRANCH` | override the branch resolver (set by `loom launch` in the worktree) | — |
+| `WEAVER_BRANCH` | override the branch resolver (set by `loom session launch` in the worktree) | — |
 | `WEAVER_TMUX_SOCKET` | pin tmux to a dedicated server (`tmux -L <name>`) so ops can't touch real sessions; set by the test harnesses | unset → default socket |
 | `RUST_LOG` / `EnvFilter` | tracing filter | `loom=info,weaver_core=info,tower_http=warn` |

--- a/docs/repo-scoped-issues.md
+++ b/docs/repo-scoped-issues.md
@@ -66,8 +66,8 @@ issue
   which is the least-surprising behavior; aggregate by `github_repo` in the UI
   if cross-clone grouping is ever wanted.
 - **`source_branch`** answers "where did this come from" (use case B).
-- **`claimed_branch`** answers "who is working it" (use case A). `loom launch`
-  stamps it when a session picks up an open repo issue; this is what turns a
+- **`claimed_branch`** answers "who is working it" (use case A). `loom session
+  launch` stamps it when a session picks up an open repo issue; this is what turns a
   repo-level backlog item into a session's working item.
 
 "Branch-scoped" then means `source_branch = me OR claimed_branch = me` — the

--- a/docs/structured-projects.md
+++ b/docs/structured-projects.md
@@ -20,7 +20,7 @@ The rest is the original design argument, kept as the rationale of record.
 
 ## The problem
 
-A single `loom launch "fix the bug"` is the easy case: one goal, one branch, one
+A single `loom session launch "fix the bug"` is the easy case: one goal, one branch, one
 agent, a handful of `weaver issue`s. It falls apart for the
 [marin #6178](https://github.com/marin-community/marin/issues/6178)-class task —
 a dozen interacting components, work that spans many sessions and days, where the
@@ -236,7 +236,7 @@ This is the missing front-end for the fan-out that
 [repo-scoped issues](repo-scoped-issues.md) was explicitly designed to enable —
 "create N issues up front, then launch one session per issue." Today a human
 hand-writes those N issues; the plan *generates* them from the design, keeps
-them linked, and gives the board something to group by. `loom launch --claim N`
+them linked, and gives the board something to group by. `loom session launch --claim N`
 already turns an issue into a session and stamps `claimed_branch`; nothing in
 that path changes. The plan just sits one level above it as the index and the
 source of the breakdown.
@@ -279,7 +279,7 @@ applies it.
 "Iterate on the design loop until satisfied, *then* break out into the working
 session." In weaver terms there is no special mode — a **planning session is
 just a normal session whose deliverable is the plan file.** You
-`loom launch "Plan the search rewrite" --plan search-rewrite`; the agent drafts
+`loom session launch "Plan the search rewrite" --plan search-rewrite`; the agent drafts
 `docs/plans/search-rewrite.md`, the user reviews it *through the dashboard*
 (rendered, with diagrams) and iterates — asynchronously, the way they already
 review everything. Because the agent never blocks on a TUI prompt (per
@@ -326,7 +326,7 @@ generalizes: the same file-write path makes the Files tab editable for free.
   plan becomes the single index into a sprawling fan-out — the thing that's
   missing today when ten sessions are in flight.
 - **Actions**: *Reconcile* (`plan sync`, show the delta), *Launch* (per ready
-  task → `loom launch --claim`).
+  task → `loom session launch --claim`).
 
 The one genuinely new backend piece is a **file-write endpoint** (today
 `/sessions/{id}/raw` and `/file` are read-only; Monaco is `readOnly: true`).
@@ -361,7 +361,7 @@ This is the field's unsolved problem, so be explicit: **the plan is opt-in and
 for large work only.** Heuristics — reach for a plan when the work will span
 multiple sessions/branches, has internal dependencies a diagram would clarify,
 or needs user sign-off on shape before code. Otherwise stay with the existing
-goal + issues; a typo fix must never cost a `requirements.md`. `loom launch`
+goal + issues; a typo fix must never cost a `requirements.md`. `loom session launch`
 stays single-goal by default; `--plan` is the deliberate escalation.
 
 ## Non-goals
@@ -394,7 +394,7 @@ stays single-goal by default; `--plan` is the deliberate escalation.
   tasks joined to issue status), `POST /api/sessions/{id}/plan/sync`, and a
   **file-write** endpoint (e.g. `PUT /api/sessions/{id}/file`) backing the Edit
   mode — the one new primitive, useful well beyond plans.
-- **Launch:** `loom launch --plan <slug>` (planning session);
+- **Launch:** `loom session launch --plan <slug>` (planning session);
   reuse `--claim` for the fan-out.
 
 ## Per-repo configuration


### PR DESCRIPTION
## What

Reworks `loom launch` into a uniform `loom session` command group so an agent has one consistent way to drive a child session — start it, watch it, and interact with its terminal.

### CLI — `loom session <verb>`
- **`launch`** — renamed from `loom launch` (worktree + tmux + agent, seeded with a task). `loom launch` stays as a **hidden deprecated alias** so in-flight agents and muscle memory keep working.
- **`send <session> "<msg>"`** — type a message into the agent's pane and submit it (Enter) to trigger a round. `--no-enter` stages without submitting.
- **`break <session>`** — send Escape to interrupt the current turn.
- **`preview <session>`** (alias `sp`) — print the recent tmux screen; `--lines N` adds scrollback.
- **`poll <session>`** — one-shot status (lifecycle + attention).
- **`wait <session>`** — block until the session finishes, is lost (`orphaned`), or — unless `--lifecycle-only` — its agent raises attention. `--timeout`/`--interval`, exits non-zero on timeout. Mirrors `weaver issue wait`.

A session key is an id, branch id, branch name, or `repo:branch`.

### REST (API-first)
- `POST /api/sessions/{id}/send` — `{text, submit?}` → `tmux send-keys -l` (+ Enter).
- `POST /api/sessions/{id}/interrupt` → Escape.
- `GET /api/sessions/{id}/preview?lines=N` → `{screen}` from `capture-pane`.

All three require a live tmux (else 409), and are distinct from the interactive terminal WebSocket.

### Launch base = fresh mainline
A new session's branch now forks from a **freshly-fetched `origin/<default branch>`** instead of the launching checkout's current branch, so sub-sessions start from the latest upstream. `git::default_base` resolves the remote default (via `origin/HEAD`, else `main`/`master`), fetches it, and degrades to the local current branch on a remote-less repo. Pin a parent explicitly with `--base` (CLI) or the new **Base branch** field in the web create form.

## Testing
- `cargo test --workspace` green (new: 4 pane integration tests, 1 origin-base launch test, 2 `default_base` unit tests, `wake_reason` + clap `debug_assert` unit tests).
- `./scripts/pre-commit.sh` (fmt + clippy) clean.
- Manual end-to-end smoke against an **isolated** loom (private tmux socket + temp `WEAVER_HOME`): launch → send (ran `echo`, output captured) → preview → poll → break → wait (timeout) → deprecated-alias path. Never touched the user's live loom.

Docs updated: README, ARCHITECTURE (REST table + launch-base/pane notes), WEAVER.md (sub-session guidance), structured-projects / repo-scoped-issues.