### PR TITLE
fix(loom): stop Chrome autofilling the new-session form as an ID card

### DIFF
--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -254,6 +254,7 @@ onUnmounted(() => clearInterval(timer));
     <form
       v-if="showForm"
       class="mb-5 rounded border border-line bg-surface p-4 space-y-3"
+      autocomplete="off"
       @submit.prevent="create"
     >
       <div class="relative">
@@ -303,6 +304,7 @@ onUnmounted(() => clearInterval(timer));
         <input
           v-model="title"
           placeholder="Health endpoint"
+          autocomplete="off"
           class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
         />
       </div>
@@ -314,6 +316,7 @@ onUnmounted(() => clearInterval(timer));
           v-model="goal"
           rows="4"
           placeholder="Add a /health endpoint that returns 200"
+          autocomplete="off"
           class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent resize-y"
         ></textarea>
       </div>
@@ -322,6 +325,7 @@ onUnmounted(() => clearInterval(timer));
           <label class="block text-xs text-muted mb-1">Model</label>
           <select
             v-model="model"
+            autocomplete="off"
             class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
           >
             <option value="">Default</option>
@@ -334,6 +338,7 @@ onUnmounted(() => clearInterval(timer));
           <label class="block text-xs text-muted mb-1">Effort</label>
           <select
             v-model="effort"
+            autocomplete="off"
             class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
           >
             <option value="">Default</option>
@@ -382,6 +387,8 @@ onUnmounted(() => clearInterval(timer));
               v-model="name"
               @input="nameEdited = true"
               placeholder="health-endpoint"
+              autocomplete="off"
+              spellcheck="false"
               class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
             />
           </div>


### PR DESCRIPTION
## Problem

Chrome consistently misclassified the **New session** form as a contact /
ID-card profile. Its heuristic autofill keys off field labels, and the form has
a **Title** field (read as an honorific) next to a **Name** field (read as a
person's name) — a strong "fill this with my identity" signal. The result was an
autofill icon and irrelevant suggestions on a form that has nothing to do with
personal data.

The repo/base/branch inputs already set `autocomplete="off"`, but the
identity-shaped fields (Title, Name) and the rest did not, so the form as a
whole still tripped the classifier.

## Fix

Opt the form out of autofill explicitly:

- `autocomplete="off"` on the `<form>` element, and
- `autocomplete="off"` on every field that lacked it — Title, Goal, Model,
  Effort, and Name — bringing them in line with the repo/base/branch inputs.
- `spellcheck="false"` on Name too, matching the other `font-mono` identifier
  inputs.

Purely additive HTML attributes; no behaviour, selectors, or test hooks change.

## Verification

- `npm run build` (rspack SPA build) compiles cleanly.
- `./scripts/pre-commit.sh` — fmt + clippy clean, agent lint no findings.
- The `e2e/tests/create.spec.ts` selectors target placeholders / roles /
  testids, none of which were touched.
