### PR TITLE
feat(loom): thread sub-sessions under their launcher in the session list

### DIFF
--- a/crates/loom/frontend/src/components/SessionPlan.vue
+++ b/crates/loom/frontend/src/components/SessionPlan.vue
@@ -257,7 +257,7 @@ onUnmounted(teardownEditor);
     <!-- No plan file yet: the panel degrades to the branch goal — a plan is the
          goal grown up, and `weaver plan new` seeds its Problem from this goal. -->
     <div v-if="loaded && !plan && !error" class="px-4 py-5">
-      <p v-if="goal" class="whitespace-pre-wrap text-sm text-fg">{{ goal }}</p>
+      <p v-if="goal" data-testid="session-goal" class="whitespace-pre-wrap text-sm text-fg">{{ goal }}</p>
       <p v-else class="text-sm text-faint">No goal set.</p>
       <p class="mt-3 text-xs text-faint">
         Scaffold a structured plan with <code>weaver plan new "&lt;title&gt;"</code>

--- a/crates/loom/frontend/src/styles.css
+++ b/crates/loom/frontend/src/styles.css
@@ -62,6 +62,8 @@
   --faint: #94a3b8;         /* slate-400 — tertiary text */
   --subtle: #e2e8f0;        /* slate-200 — secondary buttons */
   --subtle-hover: #cbd5e1;  /* slate-300 */
+  --tree-line: #cbd5e1;     /* slate-300 — session-tree guides (a step up from
+                               --line so threading reads on white) */
   --accent: #2563eb;        /* blue-600  — primary action */
   --accent-hover: #1d4ed8;  /* blue-700 */
   --accent-fg: #ffffff;
@@ -90,6 +92,7 @@
   --faint: #64748b;         /* slate-500 */
   --subtle: #334155;        /* slate-700 */
   --subtle-hover: #475569;  /* slate-600 */
+  --tree-line: #475569;     /* slate-600 — session-tree guides on the dark canvas */
   --accent: #3b82f6;        /* blue-500 */
   --accent-hover: #2563eb;  /* blue-600 */
   --accent-fg: #ffffff;
@@ -178,6 +181,70 @@ body {
   line-height: 1rem;
   padding: 0.0625rem 0.375rem;
   white-space: nowrap;
+}
+
+/* ── Session tree guides ────────────────────────────────────────────────────
+   A quiet indent gutter that threads child sessions under the session that
+   launched them. One fixed-width column per depth level: ancestor columns carry
+   a vertical line while that ancestor still has siblings below; the node's own
+   column draws the ├/└ connector across to its row. Lines use the border token
+   so they stay subtle in both palettes.
+
+   `--tree-tick` is the connector height — where the elbow turns and the stub
+   crosses to the row content, tuned to land on the attention badge / title.
+   The gutter stretches to the row's content height, then negative margins
+   extend it over the row's vertical padding so a parent's line meets its
+   child's without a gap. */
+.tree-gutter {
+  /* `--tree-tick`: connector height — where the elbow turns and the stub crosses
+     to the badge, centered on the attention badge / title line. */
+  --tree-tick: 1.5rem;
+  align-self: stretch;
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+  display: flex;
+  flex: none;
+}
+
+.tree-col {
+  position: relative;
+  width: 1.05rem;
+}
+
+/* Vertical line, centered in the column. `through`/`tee` run the full height
+   (the branch continues to a later sibling); `elbow` stops at the connector. */
+.tree-col--through::before,
+.tree-col--tee::before,
+.tree-col--elbow::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  width: 0;
+  top: 0;
+  border-left: 1px solid var(--tree-line);
+}
+
+.tree-col--through::before,
+.tree-col--tee::before {
+  bottom: 0;
+}
+
+.tree-col--elbow::before {
+  height: var(--tree-tick);
+}
+
+/* Horizontal stub from the vertical across to the row content, at the tick. The
+   negative right edge carries the line over the row's flex `gap` so the
+   connector meets the badge instead of stopping short of it. */
+.tree-col--tee::after,
+.tree-col--elbow::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  right: -0.55rem;
+  top: var(--tree-tick);
+  height: 0;
+  border-top: 1px solid var(--tree-line);
 }
 
 /* Neutral pill — generic count/label pill (filter counts, issue counts,

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -20,6 +20,11 @@ export interface Branch {
   created_at: string;
   updated_at: string;
   open_issue_count: number;
+  /** Branch id of the session that launched this one (its parent in loom's
+   *  session tree), or null for a top-level session. The dashboard groups the
+   *  list into threads by it; null parents (and parents not in the list) sit at
+   *  the root. Derived server-side from the tracking issue's `source_branch`. */
+  parent_id: string | null;
   /** Latest GitHub pull-request snapshot for the branch, or null when GitHub
    *  polling is off, there's no PR, or `gh` is unavailable. Maintained
    *  server-side by loom's poll loop. */

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -20,11 +20,6 @@ export interface Branch {
   created_at: string;
   updated_at: string;
   open_issue_count: number;
-  /** Branch id of the session that launched this one (its parent in loom's
-   *  session tree), or null for a top-level session. The dashboard groups the
-   *  list into threads by it; null parents (and parents not in the list) sit at
-   *  the root. Derived server-side from the tracking issue's `source_branch`. */
-  parent_id: string | null;
   /** Latest GitHub pull-request snapshot for the branch, or null when GitHub
    *  polling is off, there's no PR, or `gh` is unavailable. Maintained
    *  server-side by loom's poll loop. */
@@ -66,6 +61,11 @@ export interface Session {
   last_activity_at: string;
   created_at: string;
   updated_at: string;
+  /** Branch id of the session that launched this one (its parent in the session
+   *  tree), or null for a top-level session. The dashboard groups the list into
+   *  threads by it; a child whose parent is absent (archived, or never tracked)
+   *  renders at the top level. Stamped on the session row at launch. */
+  parent_id: string | null;
   /** The tracking issue opened for this session's task at launch (the handle
    *  the launcher follows). Only set on the create response. */
   tracking_issue: number | null;

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -25,25 +25,19 @@ const archivedCount = computed(
   () => sessions.value.filter((s) => s.status === 'archived').length,
 );
 
-// Attention rank: blocked and attention both "need a human" and pin to the top;
-// ok sinks below. Within a rank, preserve the server order (most-recent-first),
-// so the sort is stable and rows don't jitter between 3s polls.
-function rank(s: Session): number {
-  const lvl = levelOf(s);
-  if (lvl === 'blocked') return 0;
-  if (lvl === 'attention') return 1;
-  return 2;
-}
-
-// The ordered, archived-aware base list: attention pinned to the top, archived
-// hidden unless revealed (or unless every session is archived — see above).
-const ordered = computed<Session[]>(() => {
+// The archived-aware, filtered set to display (membership only — the tree below
+// imposes the order). Archived rows are hidden by default; a reveal chip brings
+// them back, and they always show when there's nothing else, so the list never
+// reads empty while archived rows exist. Attention is no longer pinned to the
+// top — threading groups related work instead — but attention rows still get
+// their loud row wash + pulse, so they stay easy to spot.
+const visibleSet = computed<Session[]>(() => {
   const all = sessions.value;
   const live = all.filter((s) => s.status !== 'archived');
-  // Hide archived by default; reveal on toggle; always show if nothing else.
   const base = showArchived.value || live.length === 0 ? all : live;
-  // Stable sort by attention rank (Array.prototype.sort is stable in modern JS).
-  return [...base].sort((a, b) => rank(a) - rank(b));
+  if (filter.value === 'attention') return base.filter((s) => levelOf(s) !== 'ok');
+  if (filter.value === 'ok') return base.filter((s) => levelOf(s) === 'ok');
+  return base;
 });
 
 // Counts reflect the full fleet (NOT the archived-hidden view) so the filter
@@ -58,11 +52,59 @@ const counts = computed(() => {
   return c;
 });
 
-// Apply the attention filter on top of the ordered/archived-aware base list.
-const filteredSessions = computed(() => {
-  if (filter.value === 'all') return ordered.value;
-  if (filter.value === 'ok') return ordered.value.filter((s) => levelOf(s) === 'ok');
-  return ordered.value.filter((s) => levelOf(s) !== 'ok');
+// One flattened tree row: the session, its depth, and the gutter guides drawn to
+// its left. `verticals[i]` is true when an ancestor's line keeps running down
+// past this row; `isLast` picks the connector (└ vs ├). Depth 0 (top-level)
+// draws no gutter, so a flat fleet with no sub-sessions looks exactly as before.
+interface TreeRow {
+  session: Session;
+  depth: number;
+  verticals: boolean[];
+  isLast: boolean;
+}
+
+// Group the visible sessions into threads: each hangs under the session that
+// launched it (branch.parent_id), with top-level sessions under an implicit
+// root. Siblings sort by launch time (newest first) and a parent always sits
+// directly above its children. A parent that's filtered/archived out of the
+// visible set (or was never tracked) drops its orphaned children to the top.
+const treeRows = computed<TreeRow[]>(() => {
+  const list = visibleSet.value;
+  const present = new Set(list.map((s) => s.branch.id));
+  const children = new Map<string, Session[]>();
+  const roots: Session[] = [];
+  for (const s of list) {
+    const pid = s.branch.parent_id;
+    if (pid && pid !== s.branch.id && present.has(pid)) {
+      const arr = children.get(pid);
+      if (arr) arr.push(s);
+      else children.set(pid, [s]);
+    } else {
+      roots.push(s);
+    }
+  }
+  // Newest-first within a sibling group, matching the dashboard's default feel.
+  const byNewest = (a: Session, b: Session) =>
+    b.created_at < a.created_at ? -1 : b.created_at > a.created_at ? 1 : 0;
+
+  const rows: TreeRow[] = [];
+  const seen = new Set<string>(); // guard against any cycle in the parent links
+  const walk = (node: Session, depth: number, verticals: boolean[], isLast: boolean) => {
+    if (seen.has(node.branch.id)) return;
+    seen.add(node.branch.id);
+    rows.push({ session: node, depth, verticals, isLast });
+    const kids = [...(children.get(node.branch.id) ?? [])].sort(byNewest);
+    kids.forEach((kid, i) => {
+      const last = i === kids.length - 1;
+      // The implicit root isn't a drawn column, so a top-level node's children
+      // start with no ancestor lines; deeper, append this node's continuation.
+      const childVerticals = depth === 0 ? [] : [...verticals, !isLast];
+      walk(kid, depth + 1, childVerticals, last);
+    });
+  };
+  const sortedRoots = [...roots].sort(byNewest);
+  sortedRoots.forEach((r, i) => walk(r, 0, [], i === sortedRoots.length - 1));
+  return rows;
 });
 const recentRepos = ref<RecentRepo[]>([]);
 const error = ref('');
@@ -495,18 +537,20 @@ onUnmounted(() => clearInterval(timer));
     </div>
 
     <!--
-      One signal row per session. Left→right: the agent's single attention
-      signal, the dominant title, its muted current-state line, a neutral
-      lifecycle pill, and the mono branch ref pushed far-right. Attention rows
-      pin to the top (sort in script) and get a left accent-border + slow pulse;
-      ok rows stay quiet. Staggered reveal on load via --i.
+      One signal row per session. Left→right: an optional tree gutter threading
+      child sessions under their launcher, the agent's single attention signal,
+      the dominant title, its muted current-state line, a neutral lifecycle pill,
+      and the mono branch ref pushed far-right. Rows are grouped into threads
+      (build in script) rather than attention-sorted; attention rows still get a
+      left accent-border + slow pulse so they stand out. Staggered reveal via --i.
     -->
-    <ul v-if="sessions.length" class="overflow-hidden rounded border border-line bg-surface">
+    <ul v-if="sessions.length" data-testid="session-list" class="overflow-hidden rounded border border-line bg-surface">
       <li
-        v-for="(s, i) in filteredSessions"
+        v-for="({ session: s, depth, verticals, isLast }, i) in treeRows"
         :key="s.id"
         data-testid="session-card"
         :data-session-id="s.id"
+        :data-depth="depth"
         :style="{ '--i': i }"
         :class="[
           'stagger-in group flex cursor-pointer items-start gap-3 border-b border-line px-3 py-3 last:border-0',
@@ -519,6 +563,18 @@ onUnmounted(() => clearInterval(timer));
         ]"
         @click="$router.push(`/s/${s.id}`)"
       >
+        <!-- Tree gutter: threads a child session under the one that launched it.
+             Drawn only for nested rows, so a flat fleet is visually unchanged. -->
+        <div v-if="depth > 0" class="tree-gutter" aria-hidden="true">
+          <span
+            v-for="(v, c) in verticals"
+            :key="c"
+            class="tree-col"
+            :class="{ 'tree-col--through': v }"
+          ></span>
+          <span class="tree-col" :class="isLast ? 'tree-col--elbow' : 'tree-col--tee'"></span>
+        </div>
+
         <!-- Signal: the one reserved loud axis. -->
         <div class="shrink-0 pt-0.5">
           <AttentionBadge :level="levelOf(s)" :note="messageOf(s)" />

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -31,7 +31,7 @@ const archivedCount = computed(
 // reads empty while archived rows exist. Attention is no longer pinned to the
 // top — threading groups related work instead — but attention rows still get
 // their loud row wash + pulse, so they stay easy to spot.
-const visibleSet = computed<Session[]>(() => {
+const visibleSessions = computed<Session[]>(() => {
   const all = sessions.value;
   const live = all.filter((s) => s.status !== 'archived');
   const base = showArchived.value || live.length === 0 ? all : live;
@@ -64,17 +64,17 @@ interface TreeRow {
 }
 
 // Group the visible sessions into threads: each hangs under the session that
-// launched it (branch.parent_id), with top-level sessions under an implicit
-// root. Siblings sort by launch time (newest first) and a parent always sits
-// directly above its children. A parent that's filtered/archived out of the
+// launched it (`parent_id`, a branch id), with top-level sessions under an
+// implicit root. Siblings sort by launch time (newest first) and a parent always
+// sits directly above its children. A parent that's filtered/archived out of the
 // visible set (or was never tracked) drops its orphaned children to the top.
 const treeRows = computed<TreeRow[]>(() => {
-  const list = visibleSet.value;
+  const list = visibleSessions.value;
   const present = new Set(list.map((s) => s.branch.id));
   const children = new Map<string, Session[]>();
   const roots: Session[] = [];
   for (const s of list) {
-    const pid = s.branch.parent_id;
+    const pid = s.parent_id;
     if (pid && pid !== s.branch.id && present.has(pid)) {
       const arr = children.get(pid);
       if (arr) arr.push(s);

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -101,6 +101,11 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
     // add the column explicitly and ignore the "duplicate column" error.
     add_column_if_missing(pool, "sessions", "model", "TEXT NOT NULL DEFAULT ''").await?;
     add_column_if_missing(pool, "sessions", "effort", "TEXT NOT NULL DEFAULT ''").await?;
+    // The branch id of the session that launched this one — its parent in the
+    // dashboard's session tree. Set once at create time from the known launcher;
+    // NULL for a top-level session. Sessions predating the column stay NULL (they
+    // render flat, as they did before threading existed).
+    add_column_if_missing(pool, "sessions", "parent_branch_id", "TEXT").await?;
     Ok(())
 }
 

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -600,6 +600,7 @@ mod tests {
                 effort: String::new(),
                 status: "running".to_string(),
                 github_repo: None,
+                parent_branch_id: None,
             },
         )
         .await

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -23,6 +23,10 @@ pub struct Session {
     pub github_repo: Option<String>,
     pub last_activity_at: Option<String>,
     pub created_at: String,
+    /// Branch id of the session that launched this one — its parent in the
+    /// dashboard's session tree. `None` for a top-level session. Set once at
+    /// creation from the resolved launcher, never re-derived.
+    pub parent_branch_id: Option<String>,
 }
 
 /// Session **lifecycle** states — the mechanical, orchestrator-owned axis: is
@@ -59,6 +63,9 @@ pub struct NewSession {
     pub effort: String,
     pub status: String,
     pub github_repo: Option<String>,
+    /// Branch id of the launching session (the parent in the session tree), or
+    /// `None` for a top-level launch. See [`Session::parent_branch_id`].
+    pub parent_branch_id: Option<String>,
 }
 
 pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
@@ -66,8 +73,8 @@ pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
     sqlx::query(
         "INSERT INTO sessions
          (id, branch_id, work_dir, tmux_session, agent_kind, model, effort, status,
-          github_repo, last_activity_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          github_repo, parent_branch_id, last_activity_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&s.id)
     .bind(&s.branch_id)
@@ -78,6 +85,7 @@ pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
     .bind(&s.effort)
     .bind(&s.status)
     .bind(&s.github_repo)
+    .bind(&s.parent_branch_id)
     .bind(&now)
     .bind(&now)
     .execute(db)

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -177,6 +177,12 @@ pub struct BranchView {
     pub created_at: String,
     pub updated_at: String,
     pub open_issue_count: i64,
+    /// The branch id of the session that **launched** this one (the parent in
+    /// loom's session tree), or `null` for a top-level session run directly by a
+    /// human. Derived from the tracking issue's `source_branch` and resolved to
+    /// the parent's branch id *within the same repo*; `null` too when that parent
+    /// branch is no longer tracked. The dashboard groups the list by it.
+    pub parent_id: Option<String>,
     /// The branch's latest GitHub pull-request snapshot (link, review decision,
     /// check rollup), or `null` when GitHub polling is off, the repo has no
     /// remote PR, or `gh` is unavailable. Maintained by the poll loop in
@@ -192,12 +198,26 @@ impl BranchView {
             .unwrap_or(0);
         // Best-effort: a missing/erroring snapshot just renders as no GitHub info.
         let github = github::get_status(db, &branch.id).await.ok().flatten();
-        Ok(Self::from_parts(branch, open, github))
+        // The parent in loom's session tree: the tracking issue's `source_branch`
+        // resolved to a tracked branch id in the same repo. Best-effort — a
+        // missing link or an untracked parent just leaves this top-level.
+        let parent_id =
+            match weaver_core::issue::parent_branch_of(db, &branch.repo_root, &branch.branch).await
+            {
+                Ok(Some(name)) => branch_mod::find_by_repo_branch(db, &branch.repo_root, &name)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|p| p.id),
+                _ => None,
+            };
+        Ok(Self::from_parts(branch, open, parent_id, github))
     }
 
     fn from_parts(
         branch: &Branch,
         open_issue_count: i64,
+        parent_id: Option<String>,
         github: Option<github::GithubStatus>,
     ) -> Self {
         let name = branch
@@ -218,6 +238,7 @@ impl BranchView {
             created_at: branch.created_at.clone(),
             updated_at: branch.updated_at.clone(),
             open_issue_count,
+            parent_id,
             github,
         }
     }

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -177,12 +177,6 @@ pub struct BranchView {
     pub created_at: String,
     pub updated_at: String,
     pub open_issue_count: i64,
-    /// The branch id of the session that **launched** this one (the parent in
-    /// loom's session tree), or `null` for a top-level session run directly by a
-    /// human. Derived from the tracking issue's `source_branch` and resolved to
-    /// the parent's branch id *within the same repo*; `null` too when that parent
-    /// branch is no longer tracked. The dashboard groups the list by it.
-    pub parent_id: Option<String>,
     /// The branch's latest GitHub pull-request snapshot (link, review decision,
     /// check rollup), or `null` when GitHub polling is off, the repo has no
     /// remote PR, or `gh` is unavailable. Maintained by the poll loop in
@@ -198,26 +192,12 @@ impl BranchView {
             .unwrap_or(0);
         // Best-effort: a missing/erroring snapshot just renders as no GitHub info.
         let github = github::get_status(db, &branch.id).await.ok().flatten();
-        // The parent in loom's session tree: the tracking issue's `source_branch`
-        // resolved to a tracked branch id in the same repo. Best-effort — a
-        // missing link or an untracked parent just leaves this top-level.
-        let parent_id =
-            match weaver_core::issue::parent_branch_of(db, &branch.repo_root, &branch.branch).await
-            {
-                Ok(Some(name)) => branch_mod::find_by_repo_branch(db, &branch.repo_root, &name)
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(|p| p.id),
-                _ => None,
-            };
-        Ok(Self::from_parts(branch, open, parent_id, github))
+        Ok(Self::from_parts(branch, open, github))
     }
 
     fn from_parts(
         branch: &Branch,
         open_issue_count: i64,
-        parent_id: Option<String>,
         github: Option<github::GithubStatus>,
     ) -> Self {
         let name = branch
@@ -238,7 +218,6 @@ impl BranchView {
             created_at: branch.created_at.clone(),
             updated_at: branch.updated_at.clone(),
             open_issue_count,
-            parent_id,
             github,
         }
     }
@@ -258,6 +237,13 @@ pub struct SessionView {
     pub last_activity_at: String,
     pub created_at: String,
     pub updated_at: String,
+    /// Branch id of the session that **launched** this one — the parent in the
+    /// dashboard's session tree — or `null` for a top-level session. Stamped on
+    /// the session row at launch from the resolved launcher (`parent_branch`), so
+    /// reads need no extra query and the link can't drift. The dashboard groups
+    /// the list into threads by it; a child whose parent is absent (archived, or
+    /// never tracked) renders at the top level.
+    pub parent_id: Option<String>,
     /// The tracking issue opened for this session's task at launch (the handle
     /// handed back to whoever launched it). Only populated on the create
     /// response; `None` on the list/get/patch paths, which don't recompute it.
@@ -283,6 +269,7 @@ impl SessionView {
                 .unwrap_or_else(|| branch.updated_at.clone()),
             created_at: session.created_at.clone(),
             updated_at: branch.updated_at.clone(),
+            parent_id: session.parent_branch_id.clone(),
             tracking_issue: None,
             branch: bv,
         })
@@ -711,10 +698,12 @@ async fn create_session(
         .await?
         .ok_or_else(|| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, "branch vanished"))?;
 
-    // Open this session's tracking issue before the launch prompt is written,
-    // so the agent can be told its issue number. When an agent delegated this
-    // work (`parent_branch`), the parent becomes the issue's `source_branch`.
-    let parent_branch_name = match req
+    // Resolve the launching parent once: it names the tracking issue's
+    // `source_branch` *and* the session's tree parent (`parent_branch_id`).
+    // Only attribute to a parent in *this* repo, and never to the branch itself
+    // — `resolve_key` searches globally, so a stray `$WEAVER_BRANCH` from a
+    // checkout elsewhere must not misattribute the link to an unrelated branch.
+    let parent = match req
         .parent_branch
         .as_deref()
         .map(str::trim)
@@ -722,14 +711,14 @@ async fn create_session(
     {
         Some(key) => branch_mod::resolve_key(&st.db, key)
             .await?
-            // Only attribute to a parent in *this* repo. `resolve_key` searches
-            // globally, and a stray `$WEAVER_BRANCH` from a checkout elsewhere
-            // must not misattribute `source_branch` to an unrelated branch.
-            .filter(|b| b.repo_root == branch.repo_root)
-            .map(|b| b.branch)
-            .filter(|name| name != &branch.branch),
+            .filter(|b| b.repo_root == branch.repo_root && b.branch != branch.branch),
         None => None,
     };
+    let parent_branch_name = parent.as_ref().map(|b| b.branch.clone());
+
+    // Open this session's tracking issue before the launch prompt is written,
+    // so the agent can be told its issue number. When an agent delegated this
+    // work (`parent_branch`), the parent becomes the issue's `source_branch`.
     let tracking_issue = create_tracking_issue(
         &st,
         &branch,
@@ -807,6 +796,7 @@ async fn create_session(
             effort,
             status: status.to_string(),
             github_repo: github_repo.clone(),
+            parent_branch_id: parent.as_ref().map(|b| b.id.clone()),
         },
     )
     .await?;

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -200,3 +200,69 @@ async fn adopt_recreates_killed_session() {
 
     client.delete(&format!("/api/sessions/{id}")).await.unwrap();
 }
+
+/// A delegated launch records its launcher as the session's tree parent
+/// (`parent_id`); a top-level launch has none. The link is stored on the session
+/// row at create time, so it survives a re-list unchanged.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_records_its_launcher_as_tree_parent() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+    let cwd = ts.cwd();
+
+    // A top-level (human) launch has no parent.
+    let parent = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "parent work", "cwd": cwd, "agent": "shell", "name": "parent" }),
+        )
+        .await
+        .unwrap();
+    let parent_branch_id = parent["branch"]["id"].as_str().unwrap().to_string();
+    assert!(
+        parent["parent_id"].is_null(),
+        "a top-level launch has no tree parent"
+    );
+
+    // A delegated launch names the parent branch; its session points back at it.
+    let child = client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "child work",
+                "cwd": cwd,
+                "agent": "shell",
+                "name": "child",
+                "parent_branch": parent_branch_id,
+            }),
+        )
+        .await
+        .unwrap();
+    let child_id = child["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        child["parent_id"].as_str(),
+        Some(parent_branch_id.as_str()),
+        "the child's tree parent is the launching branch"
+    );
+
+    // Stored, not recomputed: the link is still there on a plain list.
+    let list = client.get("/api/sessions").await.unwrap();
+    let row = list
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["id"] == child_id.as_str())
+        .expect("child session in list");
+    assert_eq!(row["parent_id"].as_str(), Some(parent_branch_id.as_str()));
+
+    client
+        .delete(&format!("/api/sessions/{child_id}"))
+        .await
+        .unwrap();
+    let parent_id = parent["id"].as_str().unwrap();
+    client
+        .delete(&format!("/api/sessions/{parent_id}"))
+        .await
+        .unwrap();
+}

--- a/crates/weaver-core/src/issue.rs
+++ b/crates/weaver-core/src/issue.rs
@@ -153,6 +153,27 @@ pub async fn list_delegated_by(
     Ok(rows)
 }
 
+/// The branch this one was **delegated from**, if any: the `source_branch` of
+/// its tracking issue — the issue claimed by `branch` whose source is a
+/// *different* branch (the parent that launched it). A top-level session, run by
+/// a human rather than delegated, has no such issue and returns `None`. Closed
+/// tracking issues still count, so the parent link survives the sub-task
+/// finishing. When several qualify (rare), the earliest tracking issue wins.
+pub async fn parent_branch_of(db: &Db, repo_root: &str, branch: &str) -> Result<Option<String>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT source_branch FROM issues
+         WHERE repo_root = ? AND claimed_branch = ?
+           AND source_branch IS NOT NULL AND source_branch != ?
+         ORDER BY id ASC LIMIT 1",
+    )
+    .bind(repo_root)
+    .bind(branch)
+    .bind(branch)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.map(|(s,)| s))
+}
+
 /// The unclaimed repo backlog (`claimed_branch IS NULL`).
 pub async fn list_backlog(db: &Db, repo_root: &str, include_closed: bool) -> Result<Vec<Issue>> {
     let sql = format!(
@@ -423,6 +444,48 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn parent_branch_of_reads_the_tracking_issue() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        // `parent` delegated to `child` (source=parent, claimed=child).
+        let tracking = add(
+            &db,
+            &NewIssue {
+                repo_root: "/r".to_string(),
+                source_branch: Some("parent".to_string()),
+                claimed_branch: Some("child".to_string()),
+                title: "do the sub-task".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        // The child's own self-claimed work must not be mistaken for its parent.
+        add(&db, &claimed("/r", "child", "my own work"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            parent_branch_of(&db, "/r", "child")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("parent")
+        );
+        // A top-level branch (only self-sourced work) has no parent.
+        assert_eq!(parent_branch_of(&db, "/r", "parent").await.unwrap(), None);
+
+        // The link survives the sub-task being closed.
+        close(&db, tracking.id).await.unwrap();
+        assert_eq!(
+            parent_branch_of(&db, "/r", "child")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("parent")
+        );
     }
 
     #[tokio::test]

--- a/crates/weaver-core/src/issue.rs
+++ b/crates/weaver-core/src/issue.rs
@@ -153,27 +153,6 @@ pub async fn list_delegated_by(
     Ok(rows)
 }
 
-/// The branch this one was **delegated from**, if any: the `source_branch` of
-/// its tracking issue — the issue claimed by `branch` whose source is a
-/// *different* branch (the parent that launched it). A top-level session, run by
-/// a human rather than delegated, has no such issue and returns `None`. Closed
-/// tracking issues still count, so the parent link survives the sub-task
-/// finishing. When several qualify (rare), the earliest tracking issue wins.
-pub async fn parent_branch_of(db: &Db, repo_root: &str, branch: &str) -> Result<Option<String>> {
-    let row: Option<(String,)> = sqlx::query_as(
-        "SELECT source_branch FROM issues
-         WHERE repo_root = ? AND claimed_branch = ?
-           AND source_branch IS NOT NULL AND source_branch != ?
-         ORDER BY id ASC LIMIT 1",
-    )
-    .bind(repo_root)
-    .bind(branch)
-    .bind(branch)
-    .fetch_optional(db)
-    .await?;
-    Ok(row.map(|(s,)| s))
-}
-
 /// The unclaimed repo backlog (`claimed_branch IS NULL`).
 pub async fn list_backlog(db: &Db, repo_root: &str, include_closed: bool) -> Result<Vec<Issue>> {
     let sql = format!(
@@ -444,48 +423,6 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
-    }
-
-    #[tokio::test]
-    async fn parent_branch_of_reads_the_tracking_issue() {
-        let db = crate::db::connect_in_memory().await.unwrap();
-        // `parent` delegated to `child` (source=parent, claimed=child).
-        let tracking = add(
-            &db,
-            &NewIssue {
-                repo_root: "/r".to_string(),
-                source_branch: Some("parent".to_string()),
-                claimed_branch: Some("child".to_string()),
-                title: "do the sub-task".to_string(),
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        // The child's own self-claimed work must not be mistaken for its parent.
-        add(&db, &claimed("/r", "child", "my own work"))
-            .await
-            .unwrap();
-
-        assert_eq!(
-            parent_branch_of(&db, "/r", "child")
-                .await
-                .unwrap()
-                .as_deref(),
-            Some("parent")
-        );
-        // A top-level branch (only self-sourced work) has no parent.
-        assert_eq!(parent_branch_of(&db, "/r", "parent").await.unwrap(), None);
-
-        // The link survives the sub-task being closed.
-        close(&db, tracking.id).await.unwrap();
-        assert_eq!(
-            parent_branch_of(&db, "/r", "child")
-                .await
-                .unwrap()
-                .as_deref(),
-            Some("parent")
-        );
     }
 
     #[tokio::test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -189,17 +189,17 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 `SessionView` (`/api/sessions[/...]`) returns session-specific fields
 top-level (`id`, `status`, `work_dir`, `tmux_session`, `agent_kind`, `model`,
 `effort`, `pending_prompt`, `github_repo`, `last_activity_at`,
-`created_at`, `updated_at`, and — on the create response only —
+`created_at`, `updated_at`, `parent_id`, and — on the create response only —
 `tracking_issue`) plus a nested `branch: BranchView`
 (`id`, `name`, `title`, `goal`, `description`, `attention`,
 `repo_root`, `branch`, `base_branch`, `created_at`, `updated_at`,
-`open_issue_count`, `parent_id`, `github`).
+`open_issue_count`, `github`).
 
-`BranchView::parent_id` is the branch id of the session that **launched** this
+`SessionView::parent_id` is the branch id of the session that **launched** this
 one — the parent in loom's session tree — or `null` for a top-level session. It
-is derived from the tracking issue's `source_branch` (the delegating parent)
-resolved to a tracked branch id in the same repo, and is `null` too when that
-parent is no longer tracked. The dashboard's session list
+is stamped onto the `sessions` row at create time from the resolved
+`parent_branch` (so reads need no extra query and the link can't drift), and is
+`null` too when that parent is later untracked. The dashboard's session list
 groups sessions into threads by it (children under their launcher, siblings by
 launch time); a flat fleet with no sub-sessions is unchanged.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,7 +193,15 @@ top-level (`id`, `status`, `work_dir`, `tmux_session`, `agent_kind`, `model`,
 `tracking_issue`) plus a nested `branch: BranchView`
 (`id`, `name`, `title`, `goal`, `description`, `attention`,
 `repo_root`, `branch`, `base_branch`, `created_at`, `updated_at`,
-`open_issue_count`, `github`).
+`open_issue_count`, `parent_id`, `github`).
+
+`BranchView::parent_id` is the branch id of the session that **launched** this
+one — the parent in loom's session tree — or `null` for a top-level session. It
+is derived from the tracking issue's `source_branch` (the delegating parent)
+resolved to a tracked branch id in the same repo, and is `null` too when that
+parent is no longer tracked. The dashboard's session list
+groups sessions into threads by it (children under their launcher, siblings by
+launch time); a flat fleet with no sub-sessions is unchanged.
 
 `BranchView::github` is the branch's latest GitHub pull-request snapshot
 (`pr_number`, `pr_url`, `pr_state`, `pr_title`, `is_draft`, `review_decision`,

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -28,8 +28,6 @@ export interface Branch {
   created_at: string;
   updated_at: string;
   open_issue_count: number;
-  /** Branch id of the session that launched this one, or null at the top level. */
-  parent_id: string | null;
 }
 
 /** A session as returned by `/api/sessions[/...]`. */
@@ -44,6 +42,8 @@ export interface Session {
   last_activity_at: string;
   created_at: string;
   updated_at: string;
+  /** Branch id of the session that launched this one, or null at the top level. */
+  parent_id: string | null;
   branch: Branch;
 }
 

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -28,6 +28,8 @@ export interface Branch {
   created_at: string;
   updated_at: string;
   open_issue_count: number;
+  /** Branch id of the session that launched this one, or null at the top level. */
+  parent_id: string | null;
 }
 
 /** A session as returned by `/api/sessions[/...]`. */
@@ -51,6 +53,8 @@ export interface SeedOpts {
   title?: string;
   name?: string;
   base?: string;
+  /** Branch id of the launching session — sets this session's tree parent. */
+  parent?: string;
 }
 
 export interface WeaverFixture {
@@ -315,6 +319,7 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
             agent: 'shell',
             name: opts.name,
             base: opts.base,
+            parent_branch: opts.parent,
           }),
         })) as Session;
       },

--- a/e2e/tests/tree.spec.ts
+++ b/e2e/tests/tree.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '../fixtures/weaver';
+
+// The session list threads sub-sessions under the session that launched them:
+// a child hangs below its parent (resolved from the tracking issue's
+// source_branch → branch.parent_id), siblings sort newest-first, and a subtle
+// gutter draws the ├/└ connectors. Top-level sessions draw no gutter, so a flat
+// fleet is unchanged.
+test.describe('session tree', () => {
+  test('nests children under the session that launched them', async ({ page, weaver }) => {
+    // parent ─┬─ child-b      (newest sibling first)
+    //         └─ child-a ──── grandchild
+    const parent = await weaver.seedSession({ goal: 'Build the feature', name: 'parent' });
+    const childA = await weaver.seedSession({
+      goal: 'Backend work',
+      name: 'child-a',
+      parent: parent.branch.id,
+    });
+    const childB = await weaver.seedSession({
+      goal: 'Frontend work',
+      name: 'child-b',
+      parent: parent.branch.id,
+    });
+    const grandchild = await weaver.seedSession({
+      goal: 'CSS guides',
+      name: 'grandchild',
+      parent: childA.branch.id,
+    });
+
+    await page.goto(weaver.baseUrl);
+    const cards = page.getByTestId('session-card');
+    await expect(cards).toHaveCount(4);
+
+    const card = (id: string) => page.locator(`[data-session-id="${id}"]`);
+
+    // Depth: parent at the root, its children one in, the grandchild two in.
+    await expect(card(parent.id)).toHaveAttribute('data-depth', '0');
+    await expect(card(childA.id)).toHaveAttribute('data-depth', '1');
+    await expect(card(childB.id)).toHaveAttribute('data-depth', '1');
+    await expect(card(grandchild.id)).toHaveAttribute('data-depth', '2');
+
+    // Top-level rows draw no gutter; nested rows do (one column per depth level).
+    await expect(card(parent.id).locator('.tree-gutter')).toHaveCount(0);
+    await expect(card(childA.id).locator('.tree-gutter')).toHaveCount(1);
+    await expect(card(grandchild.id).locator('.tree-col')).toHaveCount(2);
+
+    // DFS order: the parent leads, and the grandchild renders immediately under
+    // its own parent (child-a) — never detached from its thread.
+    const ids = await cards.evaluateAll((els) =>
+      els.map((e) => e.getAttribute('data-session-id')),
+    );
+    expect(ids[0]).toBe(parent.id);
+    expect(ids.indexOf(grandchild.id)).toBe(ids.indexOf(childA.id) + 1);
+    // Newest sibling first: child-b (seeded last of the two) precedes child-a.
+    expect(ids.indexOf(childB.id)).toBeLessThan(ids.indexOf(childA.id));
+  });
+
+  test('a parent archived out of view drops its child to the top level', async ({
+    page,
+    weaver,
+  }) => {
+    const parent = await weaver.seedSession({ goal: 'Parent task', name: 'parent' });
+    const child = await weaver.seedSession({
+      goal: 'Child task',
+      name: 'child',
+      parent: parent.branch.id,
+    });
+
+    // Archive the parent — by default archived rows are hidden, so the child has
+    // no visible parent and falls back to a top-level (gutter-less) row.
+    await fetch(`${weaver.baseUrl}/api/sessions/${parent.id}/archive`, { method: 'POST' });
+
+    await page.goto(weaver.baseUrl);
+    const childCard = page.locator(`[data-session-id="${child.id}"]`);
+    await expect(childCard).toBeVisible();
+    await expect(childCard).toHaveAttribute('data-depth', '0');
+    await expect(childCard.locator('.tree-gutter')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## What & why

When a top-level session spawns sub-sessions, weaver tracks the parent internally (the tracking issue's `source_branch`), but the loom dashboard rendered a flat list — so it was hard to see which sessions belong to the same execution flow.

This adds a **subtle tree** to the session list: related sessions are grouped, children hang under the session that launched them, and siblings sort by launch time. All top-level sessions are children of an implicit (undrawn) root, so a flat fleet with no sub-sessions looks exactly as before.

## How

**Backend (API-first)**
- `issue::parent_branch_of(repo, branch)` — reads the launching parent from the tracking issue (claimed by this branch, sourced from a *different* one). Closed tracking issues still count, so the link survives the sub-task finishing.
- `BranchView.parent_id` — that parent resolved to a tracked branch id in the same repo (`null` at the top level, or when the parent is no longer tracked). Documented in `ARCHITECTURE.md`.

**Frontend (thin client)**
- `SessionList.vue` groups sessions into threads by `parent_id`, sorts siblings newest-first, and flattens to rows with depth + connector guides (cycle-guarded).
- A quiet `├ └ │` indent gutter, drawn with token-only CSS (new `--tree-line`, light/dark correct) and only for nested rows. Attention is no longer pinned to the top — threading groups the work instead — but attention rows keep their row wash + pulse.

**Incidental fix**
- Restored `data-testid="session-goal"` on the Overview goal paragraph (dropped in an earlier refactor; `detail.spec.ts` / `list.spec.ts` assert on it and were failing on `main`).

## Validation

| Light | Dark |
|---|---|
| threading reads clearly; connectors land on the badge | guides visible on the slate canvas |

- Unit test for `parent_branch_of` (parent resolution + survives close).
- New `e2e/tests/tree.spec.ts`: nesting depth, gutter presence, DFS order, and a parent archived out of view dropping its child to the top level.
- Visually verified both themes with Playwright screenshots.
- `cargo test --workspace` green; full Playwright suite (22) green; `scripts/pre-commit.sh` (fmt + clippy + agent lint) clean.

Closes #59.