### PR TITLE
loom UI tune-up — polish + the larger cleanups

### DIFF
--- a/crates/loom/frontend/src/components/AgentTerminal.vue
+++ b/crates/loom/frontend/src/components/AgentTerminal.vue
@@ -296,8 +296,8 @@ onUnmounted(() => {
     <div
       v-if="state !== 'open'"
       data-testid="term-status"
-      class="absolute right-2 top-2 rounded px-2 py-1 text-xs"
-      :class="state === 'error' ? 'bg-red-950/90 text-red-300' : 'bg-input/90 text-amber-300'"
+      class="absolute right-2 top-2 rounded px-2 py-1 text-xs font-medium"
+      :class="state === 'error' ? 'bg-block text-block-fg' : 'bg-attn text-attn-fg'"
     >
       <span v-if="state === 'connecting'">connecting…</span>
       <span v-else-if="state === 'reconnecting'">reconnecting…</span>

--- a/crates/loom/frontend/src/components/MarkdownView.vue
+++ b/crates/loom/frontend/src/components/MarkdownView.vue
@@ -66,7 +66,7 @@ function onClick(e: MouseEvent) {
 
 <template>
   <div class="h-full w-full overflow-auto bg-surface">
-    <p v-if="error" class="m-4 rounded border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-400">
+    <p v-if="error" class="m-4 rounded border border-block-line bg-block-soft p-3 text-sm text-block">
       {{ error }}
     </p>
     <article ref="body" class="markdown-body mx-auto max-w-3xl px-6 py-5" @click="onClick"></article>

--- a/crates/loom/frontend/src/components/ScratchPicker.vue
+++ b/crates/loom/frontend/src/components/ScratchPicker.vue
@@ -76,7 +76,7 @@ function remove(name: string) {
         </span>
         <button
           type="button"
-          class="shrink-0 rounded px-1.5 py-0.5 text-xs text-muted hover:text-red-400 hover:bg-subtle"
+          class="shrink-0 rounded px-1.5 py-0.5 text-xs text-muted hover:text-block hover:bg-subtle"
           title="Remove"
           @click.stop="remove(f.name)"
         >

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -161,14 +161,14 @@ const washClass = computed(() =>
                 </button>
                 <button
                   v-if="ws.status !== 'archived'"
-                  class="rounded bg-subtle px-3 py-1.5 text-xs text-fg hover:bg-subtle-hover"
+                  class="btn-secondary px-3 py-1.5 text-xs"
                   :disabled="busy === 'archive'"
                   @click="archive"
                 >
                   {{ busy === 'archive' ? 'Archiving…' : 'Archive' }}
                 </button>
                 <button
-                  class="ml-auto rounded bg-transparent px-3 py-1.5 text-xs text-block ring-1 ring-inset ring-block-line hover:bg-block-soft"
+                  class="btn-danger ml-auto px-3 py-1.5 text-xs"
                   :disabled="busy === 'remove'"
                   @click="remove"
                 >

--- a/crates/loom/frontend/src/components/SessionPlan.vue
+++ b/crates/loom/frontend/src/components/SessionPlan.vue
@@ -80,14 +80,31 @@ function statusOf(t: PlanTask): Status {
   return { label: t.exec, cls: 'text-faint', glyph: '·' };
 }
 
-// The rendered plan document, minus its leading YAML frontmatter (`---\n…\n---`).
-// The frontmatter (`plan:`, `status:`) is already surfaced as the header title +
-// status pill; left in, markdown-it renders it as a stray `<hr>` + "plan: …"
-// paragraph at the top of the prose. Only a frontmatter block at the very start
-// is stripped, so a `---` rule elsewhere in the doc is untouched.
-const renderedContent = computed(() =>
-  (plan.value?.content ?? '').replace(/^﻿?---\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/, ''),
-);
+// The rendered plan document, minus its leading YAML frontmatter (`---\n…\n---`)
+// AND its `## Tasks` section. The frontmatter (`plan:`, `status:`) is already
+// surfaced as the header title + status pill; left in, markdown-it renders it as
+// a stray `<hr>` + "plan: …" paragraph at the top of the prose. Only a
+// frontmatter block at the very start is stripped, so a `---` rule elsewhere in
+// the doc is untouched. The `## Tasks` section (its heading, preamble, and every
+// `### T<n>` block) restates the projected task list above, so it's dropped from
+// the prose: a line-based scan removes everything from `## Task[s]` up to — but
+// not including — the next `^## ` heading (or end of doc). Display-only: the raw
+// `plan.content` still drives parsing, the graph, reconcile, and saving.
+const renderedContent = computed(() => {
+  const body = (plan.value?.content ?? '').replace(/^﻿?---\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/, '');
+  let inTasks = false;
+  return body
+    .split('\n')
+    .filter((line) => {
+      if (/^## +tasks?\s*$/i.test(line)) {
+        inTasks = true; // enter the Tasks section — drop this and following lines
+        return false;
+      }
+      if (inTasks && /^## /.test(line)) inTasks = false; // next level-2 heading ends it
+      return !inTasks;
+    })
+    .join('\n');
+});
 
 const valueRank: Record<string, number> = { high: 0, med: 1, medium: 1, low: 2 };
 const tasksByValue = computed(() =>
@@ -145,6 +162,10 @@ async function edit() {
   delta.value = null;
   await nextTick();
   await mountEditor();
+  // Land the user on the editor: it's the only thing shown in edit mode, but the
+  // page may be scrolled to the read-first projections above it.
+  editor?.focus();
+  host.value?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 }
 
 function cancel() {
@@ -226,7 +247,7 @@ onUnmounted(teardownEditor);
         <div class="ml-auto flex gap-1.5">
           <template v-if="!editing">
             <button
-              class="rounded bg-subtle px-2.5 py-1 text-xs text-fg hover:bg-subtle-hover"
+              class="btn-secondary px-2.5 py-1 text-xs"
               @click="edit"
             >
               Edit
@@ -241,14 +262,14 @@ onUnmounted(teardownEditor);
           </template>
           <template v-else>
             <button
-              class="rounded bg-accent px-2.5 py-1 text-xs text-accent-fg hover:bg-accent-hover"
+              class="btn-primary px-2.5 py-1 text-xs"
               :disabled="busy === 'save'"
               @click="save"
             >
               {{ busy === 'save' ? 'Saving…' : 'Save' }}
             </button>
             <button
-              class="rounded bg-subtle px-2.5 py-1 text-xs text-fg hover:bg-subtle-hover"
+              class="btn-secondary px-2.5 py-1 text-xs"
               @click="cancel"
             >
               Cancel
@@ -284,13 +305,13 @@ onUnmounted(teardownEditor);
       </ul>
       <div class="mt-2.5 flex gap-1.5">
         <button
-          class="rounded bg-accent px-2.5 py-1 text-xs text-accent-fg hover:bg-accent-hover"
+          class="btn-primary px-2.5 py-1 text-xs"
           :disabled="busy === 'apply'"
           @click="applyDelta"
         >
           {{ busy === 'apply' ? 'Applying…' : `Apply ${delta.actions.length} change(s)` }}
         </button>
-        <button class="rounded bg-subtle px-2.5 py-1 text-xs text-fg hover:bg-subtle-hover" @click="delta = null">
+        <button class="btn-secondary px-2.5 py-1 text-xs" @click="delta = null">
           Dismiss
         </button>
       </div>
@@ -298,8 +319,9 @@ onUnmounted(teardownEditor);
 
     <div v-if="plan">
       <!-- Task list — the live projection: status comes from the issue ledger,
-           sorted so the highest-value work surfaces first. -->
-      <ul v-if="plan.tasks.length" class="divide-y divide-line">
+           sorted so the highest-value work surfaces first. Hidden while editing,
+           so Monaco is the only thing on screen. -->
+      <ul v-if="plan.tasks.length" v-show="!editing" data-testid="plan-tasks" class="divide-y divide-line">
         <li v-for="t in tasksByValue" :key="t.id" class="flex items-baseline gap-2 px-4 py-1.5 text-sm">
           <span class="font-mono text-xs text-faint">{{ t.id }}</span>
           <span :class="statusOf(t).cls" :title="statusOf(t).label">{{ statusOf(t).glyph }}</span>
@@ -310,8 +332,8 @@ onUnmounted(teardownEditor);
         </li>
       </ul>
 
-      <!-- Dependency graph (only when there are edges). -->
-      <div v-if="graphSource" class="border-t border-line">
+      <!-- Dependency graph (only when there are edges). Hidden while editing. -->
+      <div v-if="graphSource" v-show="!editing" class="border-t border-line">
         <MarkdownView :id="props.id" :path="plan.path" :source="graphSource" />
       </div>
 

--- a/crates/loom/frontend/src/components/SessionPlan.vue
+++ b/crates/loom/frontend/src/components/SessionPlan.vue
@@ -80,6 +80,15 @@ function statusOf(t: PlanTask): Status {
   return { label: t.exec, cls: 'text-faint', glyph: '·' };
 }
 
+// The rendered plan document, minus its leading YAML frontmatter (`---\n…\n---`).
+// The frontmatter (`plan:`, `status:`) is already surfaced as the header title +
+// status pill; left in, markdown-it renders it as a stray `<hr>` + "plan: …"
+// paragraph at the top of the prose. Only a frontmatter block at the very start
+// is stripped, so a `---` rule elsewhere in the doc is untouched.
+const renderedContent = computed(() =>
+  (plan.value?.content ?? '').replace(/^﻿?---\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/, ''),
+);
+
 const valueRank: Record<string, number> = { high: 0, med: 1, medium: 1, low: 2 };
 const tasksByValue = computed(() =>
   [...(plan.value?.tasks ?? [])].sort((a, b) => {
@@ -310,7 +319,7 @@ onUnmounted(teardownEditor);
            host stays mounted (v-show) so its ref survives the mode flip. -->
       <div v-show="editing" ref="host" class="h-[60vh] w-full border-t border-line"></div>
       <div v-show="!editing" class="border-t border-line">
-        <MarkdownView :id="props.id" :path="plan.path" :source="plan.content" />
+        <MarkdownView :id="props.id" :path="plan.path" :source="renderedContent" />
       </div>
     </div>
   </section>

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -23,7 +23,8 @@ export function messageOf(s: Session): string {
 // "Waiting for input" slab. Returns a glyph + short label; glyphs are plain
 // unicode (offline-safe, no icon dependency).
 export interface ConvState {
-  glyph: string;   // ⏳ / ▶ / ✓ / ◦
+  glyph: string;   // ● / ▶ / ✓ / ◦ — BMP geometric chars only (emoji like the
+                   // hourglass render as tofu in the system sans/mono stacks)
   label: string;   // e.g. "Blocked — needs input"
   tone: 'block' | 'attn' | 'muted'; // which token family to color it with
 }
@@ -36,8 +37,8 @@ export function conversationState(s: Session): ConvState {
 
   // Then the agent-declared attention axis.
   const level = levelOf(s);
-  if (level === 'blocked') return { glyph: '⏳', label: 'Blocked', tone: 'block' };
-  if (level === 'attention') return { glyph: '⏳', label: 'Needs attention', tone: 'attn' };
+  if (level === 'blocked') return { glyph: '●', label: 'Blocked', tone: 'block' };
+  if (level === 'attention') return { glyph: '●', label: 'Needs attention', tone: 'attn' };
 
   // Otherwise infer working vs idle from lifecycle. "Working"/"Idle" stay
   // neutral so amber/red remains the sole loud signal.

--- a/crates/loom/frontend/src/markdown.ts
+++ b/crates/loom/frontend/src/markdown.ts
@@ -175,6 +175,32 @@ export async function renderMarkdown(src: string, ctx: RenderContext): Promise<s
 
 let mermaidSeq = 0;
 
+// Mermaid's stock `default`/`dark` themes paint nodes lavender-purple, which
+// clashes with loom's neutral-slate + single-blue palette. Drive mermaid's
+// `base` theme with loom's own tokens instead so diagrams read as part of the
+// same UI in both palettes. Hexes mirror the slate/blue values in styles.css.
+function mermaidThemeVariables(dark: boolean): Record<string, string> {
+  return dark
+    ? {
+        background: '#1e293b', // surface (slate-800)
+        primaryColor: '#0f172a', // canvas (slate-900) — node fill
+        primaryBorderColor: '#475569', // slate-600
+        primaryTextColor: '#f1f5f9', // slate-100
+        lineColor: '#64748b', // slate-500 — edges
+        secondaryColor: '#334155', // slate-700
+        tertiaryColor: '#0f172a',
+      }
+    : {
+        background: '#ffffff',
+        primaryColor: '#f1f5f9', // slate-100 — node fill
+        primaryBorderColor: '#cbd5e1', // slate-300
+        primaryTextColor: '#0f172a', // slate-900
+        lineColor: '#94a3b8', // slate-400 — edges
+        secondaryColor: '#e2e8f0', // slate-200
+        tertiaryColor: '#f8fafc',
+      };
+}
+
 /** Turn every `<pre class="mermaid">` placeholder under `root` into a rendered
  *  SVG diagram. Mermaid runs with `securityLevel: 'strict'` (it sanitises its
  *  own SVG); a diagram that fails to parse is left as its source text with an
@@ -188,7 +214,8 @@ export async function renderMermaid(root: HTMLElement, dark: boolean): Promise<v
   mermaid.initialize({
     startOnLoad: false,
     securityLevel: 'strict',
-    theme: dark ? 'dark' : 'default',
+    theme: 'base',
+    themeVariables: mermaidThemeVariables(dark),
     fontFamily: 'inherit',
   });
 

--- a/crates/loom/frontend/src/styles.css
+++ b/crates/loom/frontend/src/styles.css
@@ -62,8 +62,8 @@
   --faint: #94a3b8;         /* slate-400 — tertiary text */
   --subtle: #e2e8f0;        /* slate-200 — secondary buttons */
   --subtle-hover: #cbd5e1;  /* slate-300 */
-  --tree-line: #cbd5e1;     /* slate-300 — session-tree guides (a step up from
-                               --line so threading reads on white) */
+  --tree-line: #94a3b8;     /* slate-400 — session-tree guides; well above --line
+                               so the threading connectors read clearly on white */
   --accent: #2563eb;        /* blue-600  — primary action */
   --accent-hover: #1d4ed8;  /* blue-700 */
   --accent-fg: #ffffff;
@@ -92,7 +92,8 @@
   --faint: #64748b;         /* slate-500 */
   --subtle: #334155;        /* slate-700 */
   --subtle-hover: #475569;  /* slate-600 */
-  --tree-line: #475569;     /* slate-600 — session-tree guides on the dark canvas */
+  --tree-line: #64748b;     /* slate-500 — session-tree guides; lifted off the
+                               dark canvas so the connectors read clearly */
   --accent: #3b82f6;        /* blue-500 */
   --accent-hover: #2563eb;  /* blue-600 */
   --accent-fg: #ffffff;
@@ -208,7 +209,7 @@ body {
 
 .tree-col {
   position: relative;
-  width: 1.05rem;
+  width: 1.5rem; /* per-depth indent — wide enough that nesting reads at a glance */
 }
 
 /* Vertical line, centered in the column. `through`/`tee` run the full height
@@ -259,4 +260,67 @@ body {
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.0625rem 0.5rem;
+}
+
+/* ── Buttons ─────────────────────────────────────────────────────────────────
+   Three shared button treatments, token-only so they stay light/dark correct
+   like `pill`/`meta-chip`. Each bakes shape + colour + hover + disabled; call
+   sites add only size (px/py/text), weight, and any layout. `primary` is the
+   accent call-to-action, `secondary` the neutral companion, `danger` the ghost
+   destructive. The segmented filter/branch toggles and the few bespoke
+   accent-ring buttons (Reconcile, Adopt, Mark OK) keep their own markup. */
+@utility btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border-radius: 0.25rem;
+  background: var(--accent);
+  color: var(--accent-fg);
+  transition: background-color 0.15s ease;
+  cursor: pointer;
+  &:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+@utility btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border-radius: 0.25rem;
+  background: var(--subtle);
+  color: var(--fg);
+  transition: background-color 0.15s ease;
+  cursor: pointer;
+  &:hover:not(:disabled) {
+    background: var(--subtle-hover);
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+@utility btn-danger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--block);
+  box-shadow: inset 0 0 0 1px var(--block-line);
+  transition: background-color 0.15s ease;
+  cursor: pointer;
+  &:hover:not(:disabled) {
+    background: var(--block-soft);
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
 }

--- a/crates/loom/frontend/src/views/FileBrowser.vue
+++ b/crates/loom/frontend/src/views/FileBrowser.vue
@@ -158,16 +158,19 @@ const changedList = computed(() => {
 // Status → single-letter badge + colour class.
 function badge(status: string): { letter: string; cls: string } {
   switch (status) {
+    // Conventional diff colours, but routed through loom's semantic tokens so
+    // they theme light/dark with the rest of the UI. (Added keeps a literal
+    // green — the palette has no positive/added token.)
     case 'added':
       return { letter: 'A', cls: 'text-green-600 dark:text-green-400' };
     case 'deleted':
-      return { letter: 'D', cls: 'text-red-500' };
+      return { letter: 'D', cls: 'text-block' };
     case 'renamed':
-      return { letter: 'R', cls: 'text-blue-500' };
+      return { letter: 'R', cls: 'text-accent' };
     case 'copied':
-      return { letter: 'C', cls: 'text-blue-500' };
+      return { letter: 'C', cls: 'text-accent' };
     default:
-      return { letter: 'M', cls: 'text-amber-500' };
+      return { letter: 'M', cls: 'text-attn' };
   }
 }
 
@@ -656,7 +659,7 @@ onUnmounted(teardownEditors);
 
           <div
             v-else-if="kind === 'error'"
-            class="flex h-full w-full items-center justify-center p-4 text-sm text-red-400"
+            class="flex h-full w-full items-center justify-center p-4 text-sm text-block"
           >
             {{ viewError }}
           </div>

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -285,8 +285,16 @@ onUnmounted(() => clearInterval(timer));
   <div>
     <div class="flex items-center justify-between mb-4">
       <h1 class="text-xl font-semibold">Sessions</h1>
+      <!-- Toggles the create form. Closed → primary (accent) call-to-action;
+           open → a neutral "Cancel" so it never reads as a second primary
+           action competing with the form's own Create button. -->
       <button
-        class="rounded bg-accent hover:bg-accent-hover px-3 py-1.5 text-sm font-medium"
+        :class="[
+          'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+          showForm
+            ? 'bg-subtle text-fg hover:bg-subtle-hover'
+            : 'bg-accent text-accent-fg hover:bg-accent-hover',
+        ]"
         @click="showForm = !showForm"
       >
         {{ showForm ? 'Cancel' : 'New session' }}
@@ -497,7 +505,7 @@ onUnmounted(() => clearInterval(timer));
       <button
         type="submit"
         :disabled="creating"
-        class="rounded bg-accent hover:bg-accent-hover px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+        class="rounded bg-accent text-accent-fg hover:bg-accent-hover px-3 py-1.5 text-sm font-medium disabled:opacity-50"
       >
         {{ creating ? 'Creating…' : 'Create' }}
       </button>
@@ -510,21 +518,30 @@ onUnmounted(() => clearInterval(timer));
     </p>
 
     <div v-if="sessions.length" class="mb-3 flex items-center gap-3">
-      <!-- Attention filter: jump straight to the sessions that need a human. -->
-      <div class="inline-flex rounded border border-line text-xs overflow-hidden">
+      <!-- Attention filter: jump straight to the sessions that need a human.
+           Each segment pairs a label with its count in a small pill so the
+           number reads as a count, not a suffix glued to the word. -->
+      <div class="inline-flex rounded-md border border-line text-xs overflow-hidden">
         <button
           v-for="opt in (['all', 'attention', 'ok'] as const)"
           :key="opt"
           type="button"
           :data-testid="`filter-${opt}`"
           :class="[
-            'px-3 py-1 border-l border-line first:border-l-0',
-            filter === opt ? 'bg-accent text-accent-fg' : 'bg-input text-muted hover:bg-subtle',
+            'flex items-center gap-1.5 px-3 py-1.5 font-medium border-l border-line first:border-l-0 transition-colors',
+            filter === opt
+              ? 'bg-accent text-accent-fg'
+              : 'bg-input text-muted hover:bg-subtle hover:text-fg',
           ]"
           @click="filter = opt"
         >
           {{ opt === 'all' ? 'All' : opt === 'attention' ? 'Needs attention' : 'OK' }}
-          <span class="opacity-70">{{ counts[opt] }}</span>
+          <span
+            :class="[
+              'rounded-full px-1.5 text-[0.7rem] leading-5 tabular-nums',
+              filter === opt ? 'bg-accent-fg/20 text-accent-fg' : 'bg-subtle text-faint',
+            ]"
+          >{{ counts[opt] }}</span>
         </button>
       </div>
 

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -28,8 +28,9 @@ const archivedCount = computed(
 // The archived-aware, filtered set to display (membership only — the tree below
 // imposes the order). Archived rows are hidden by default; a reveal chip brings
 // them back, and they always show when there's nothing else, so the list never
-// reads empty while archived rows exist. Attention is no longer pinned to the
-// top — threading groups related work instead — but attention rows still get
+// reads empty while archived rows exist. Individual attention rows aren't pinned
+// to the top — threading keeps related work grouped — but a whole thread that
+// contains attention floats up (see treeRows), and attention rows still get
 // their loud row wash + pulse, so they stay easy to spot.
 const visibleSessions = computed<Session[]>(() => {
   const all = sessions.value;
@@ -65,9 +66,12 @@ interface TreeRow {
 
 // Group the visible sessions into threads: each hangs under the session that
 // launched it (`parent_id`, a branch id), with top-level sessions under an
-// implicit root. Siblings sort by launch time (newest first) and a parent always
-// sits directly above its children. A parent that's filtered/archived out of the
-// visible set (or was never tracked) drops its orphaned children to the top.
+// implicit root. A parent always sits directly above its children. Threads stay
+// grouped, but a thread containing attention floats to the top: roots and
+// siblings sort by their subtree's urgency first (blocked above attention above
+// ok), then newest-first within the same urgency — so a blocked/attention child
+// can never sink to the bottom of the fleet. A parent that's filtered/archived
+// out of the visible set (or was never tracked) drops its orphaned children up.
 const treeRows = computed<TreeRow[]>(() => {
   const list = visibleSessions.value;
   const present = new Set(list.map((s) => s.branch.id));
@@ -83,9 +87,37 @@ const treeRows = computed<TreeRow[]>(() => {
       roots.push(s);
     }
   }
+  // Attention rank for a single session: blocked is louder than attention is
+  // louder than ok. Used to float urgent threads to the top.
+  const rankOf = (s: Session): number => {
+    const lvl = levelOf(s);
+    return lvl === 'blocked' ? 2 : lvl === 'attention' ? 1 : 0;
+  };
+  // Memoized max attention rank across a session's whole subtree (itself + all
+  // descendants), so a thread surfaces at the urgency of its loudest member.
+  // The cycle guard mirrors walk()'s: a parent link loop can't spin us forever.
+  const rankCache = new Map<string, number>();
+  const ranking = new Set<string>();
+  const subtreeRank = (s: Session): number => {
+    const cached = rankCache.get(s.branch.id);
+    if (cached !== undefined) return cached;
+    if (ranking.has(s.branch.id)) return rankOf(s); // mid-cycle: just self
+    ranking.add(s.branch.id);
+    let max = rankOf(s);
+    for (const kid of children.get(s.branch.id) ?? []) {
+      max = Math.max(max, subtreeRank(kid));
+    }
+    ranking.delete(s.branch.id);
+    rankCache.set(s.branch.id, max);
+    return max;
+  };
   // Newest-first within a sibling group, matching the dashboard's default feel.
   const byNewest = (a: Session, b: Session) =>
     b.created_at < a.created_at ? -1 : b.created_at > a.created_at ? 1 : 0;
+  // Urgent subtree first, then newest-first as the tie-break. When no session
+  // carries attention every rank is 0 and this collapses to plain byNewest.
+  const byUrgencyThenNewest = (a: Session, b: Session) =>
+    subtreeRank(b) - subtreeRank(a) || byNewest(a, b);
 
   const rows: TreeRow[] = [];
   const seen = new Set<string>(); // guard against any cycle in the parent links
@@ -93,7 +125,7 @@ const treeRows = computed<TreeRow[]>(() => {
     if (seen.has(node.branch.id)) return;
     seen.add(node.branch.id);
     rows.push({ session: node, depth, verticals, isLast });
-    const kids = [...(children.get(node.branch.id) ?? [])].sort(byNewest);
+    const kids = [...(children.get(node.branch.id) ?? [])].sort(byUrgencyThenNewest);
     kids.forEach((kid, i) => {
       const last = i === kids.length - 1;
       // The implicit root isn't a drawn column, so a top-level node's children
@@ -102,7 +134,7 @@ const treeRows = computed<TreeRow[]>(() => {
       walk(kid, depth + 1, childVerticals, last);
     });
   };
-  const sortedRoots = [...roots].sort(byNewest);
+  const sortedRoots = [...roots].sort(byUrgencyThenNewest);
   sortedRoots.forEach((r, i) => walk(r, 0, [], i === sortedRoots.length - 1));
   return rows;
 });
@@ -223,6 +255,24 @@ async function loadRecentRepos() {
   }
 }
 
+// Clear the form back to its initial state and hide it. Shared by the create()
+// success path and the Cancel button so the two can't drift apart. The repo path
+// is intentionally left as-is (kept out of create()'s reset) — it's the most
+// reused field across sessions, so a fresh form pre-keeps the last repo typed.
+function resetForm() {
+  title.value = '';
+  goal.value = '';
+  model.value = '';
+  effort.value = '';
+  name.value = '';
+  base.value = '';
+  existingBranch.value = '';
+  scratchFiles.value = [];
+  nameEdited.value = false;
+  branchMode.value = 'new';
+  showForm.value = false;
+}
+
 async function create() {
   // A session needs a repo and at least a title or a goal; the goal alone is
   // optional (an empty goal just starts the agent unprompted).
@@ -253,17 +303,7 @@ async function create() {
       );
     }
     await post('/sessions', body);
-    title.value = '';
-    goal.value = '';
-    model.value = '';
-    effort.value = '';
-    name.value = '';
-    base.value = '';
-    existingBranch.value = '';
-    scratchFiles.value = [];
-    nameEdited.value = false;
-    branchMode.value = 'new';
-    showForm.value = false;
+    resetForm();
     await load();
     await loadRecentRepos();
   } catch (e) {
@@ -290,10 +330,8 @@ onUnmounted(() => clearInterval(timer));
            action competing with the form's own Create button. -->
       <button
         :class="[
-          'rounded px-3 py-1.5 text-sm font-medium transition-colors',
-          showForm
-            ? 'bg-subtle text-fg hover:bg-subtle-hover'
-            : 'bg-accent text-accent-fg hover:bg-accent-hover',
+          'px-3 py-1.5 text-sm font-medium',
+          showForm ? 'btn-secondary' : 'btn-primary',
         ]"
         @click="showForm = !showForm"
       >
@@ -301,214 +339,256 @@ onUnmounted(() => clearInterval(timer));
       </button>
     </div>
 
+    <!--
+      Grouped into labeled sections so the ~9-field form scans instead of
+      reading as one flat stack: Repository, What to build, Agent, Branch, and
+      Scratch files. The treatment is deliberately light — a small uppercase
+      section label and a hairline top divider per group, no heavy boxes — so it
+      stays consistent with the rest of the app's quiet surfaces.
+    -->
     <form
       v-if="showForm"
-      class="mb-5 rounded border border-line bg-surface p-4 space-y-3"
+      class="mb-5 rounded border border-line bg-surface p-4 space-y-5"
       autocomplete="off"
       @submit.prevent="create"
     >
-      <div class="relative">
-        <label class="block text-xs text-muted mb-1">
-          Repository path (on the server)
-          <span v-if="recentRepos.length" class="text-faint">— or pick a recent one</span>
-        </label>
-        <input
-          v-model="repo"
-          @focus="repoFocused = true"
-          @input="repoFocused = true"
-          @blur="repoFocused = false"
-          placeholder="/home/you/code/project"
-          autocomplete="off"
-          spellcheck="false"
-          class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
-        />
-        <ul
-          v-if="repoFocused && repoMatches.length"
-          data-testid="recent-repos"
-          class="absolute left-0 right-0 z-10 mt-1 max-h-56 overflow-auto rounded border border-line bg-input shadow-lg"
-        >
-          <li v-for="r in repoMatches" :key="r.repo_root">
-            <button
-              type="button"
-              data-testid="recent-repo"
-              @mousedown.prevent="pickRepo(r.repo_root)"
-              class="flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left hover:bg-subtle"
-            >
-              <span class="min-w-0">
-                <span class="block truncate text-sm">{{ repoName(r.repo_root) }}</span>
-                <span class="block truncate text-xs text-muted font-mono">{{ r.repo_root }}</span>
-              </span>
-              <span
-                v-if="r.active_branches"
-                :title="`${r.active_branches} tracked branch(es)`"
-                class="shrink-0 rounded bg-subtle px-1.5 py-0.5 text-xs text-muted"
-              >
-                {{ r.active_branches }}
-              </span>
-            </button>
-          </li>
-        </ul>
-      </div>
-      <div>
-        <label class="block text-xs text-muted mb-1">Title</label>
-        <input
-          v-model="title"
-          placeholder="Health endpoint"
-          autocomplete="off"
-          class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
-        />
-      </div>
-      <div>
-        <label class="block text-xs text-muted mb-1">
-          Goal — optional; leave blank to start the agent with no prompt
-        </label>
-        <textarea
-          v-model="goal"
-          rows="4"
-          placeholder="Add a /health endpoint that returns 200"
-          autocomplete="off"
-          class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent resize-y"
-        ></textarea>
-      </div>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <label class="block text-xs text-muted mb-1">Model</label>
-          <select
-            v-model="model"
-            autocomplete="off"
-            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
-          >
-            <option value="">Default</option>
-            <option value="haiku">Haiku</option>
-            <option value="sonnet">Sonnet</option>
-            <option value="opus">Opus</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-xs text-muted mb-1">Effort</label>
-          <select
-            v-model="effort"
-            autocomplete="off"
-            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
-          >
-            <option value="">Default</option>
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-            <option value="xhigh">X-High</option>
-            <option value="max">Max</option>
-          </select>
-        </div>
-        <p class="col-span-2 -mt-1 text-xs text-faint">
-          Model tier and reasoning effort for the Claude agent. Leave as Default
-          to inherit the configured launch args.
-        </p>
-      </div>
-      <div>
-        <div class="inline-flex rounded border border-line text-xs overflow-hidden mb-2">
-          <button
-            type="button"
-            :class="[
-              'px-3 py-1',
-              branchMode === 'new' ? 'bg-accent text-white' : 'bg-input text-muted hover:bg-subtle',
-            ]"
-            @click="branchMode = 'new'"
-          >
-            New branch
-          </button>
-          <button
-            type="button"
-            :class="[
-              'px-3 py-1 border-l border-line',
-              branchMode === 'existing' ? 'bg-accent text-white' : 'bg-input text-muted hover:bg-subtle',
-            ]"
-            @click="branchMode = 'existing'"
-          >
-            Existing branch
-          </button>
-        </div>
-        <div v-if="branchMode === 'new'" class="space-y-2">
-          <div>
-            <label class="block text-xs text-muted mb-1">
-              Name — the worktree (<code>.worktrees/&lt;name&gt;</code>) and branch
-              (<code>weaver/&lt;name&gt;</code>)
-            </label>
-            <input
-              v-model="name"
-              @input="nameEdited = true"
-              placeholder="health-endpoint"
-              autocomplete="off"
-              spellcheck="false"
-              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
-            />
-          </div>
-          <div>
-            <label class="block text-xs text-muted mb-1">
-              Base branch — fork point (optional)
-            </label>
-            <input
-              v-model="base"
-              placeholder="origin/main (freshly fetched)"
-              autocomplete="off"
-              spellcheck="false"
-              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
-            />
-            <p class="mt-1 text-xs text-faint">
-              Leave blank to fork from a freshly-fetched
-              <code>origin/&lt;default branch&gt;</code>.
-            </p>
-          </div>
-        </div>
-        <div v-else class="relative">
+      <!-- Repository: where the work lives, with a recent-repos shortcut. -->
+      <section class="space-y-3">
+        <h2 class="text-xs font-medium uppercase tracking-wide text-faint">Repository</h2>
+        <div class="relative">
           <label class="block text-xs text-muted mb-1">
-            Existing branch — weaver reuses its worktree if one is checked out
+            Repository path (on the server)
+            <span v-if="recentRepos.length" class="text-faint">— or pick a recent one</span>
           </label>
           <input
-            v-model="existingBranch"
-            @focus="branchFocused = true"
-            @input="branchFocused = true"
-            @blur="branchFocused = false"
-            placeholder="feature/foo"
+            v-model="repo"
+            @focus="repoFocused = true"
+            @input="repoFocused = true"
+            @blur="repoFocused = false"
+            placeholder="/home/you/code/project"
             autocomplete="off"
             spellcheck="false"
-            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
           />
-          <p v-if="branchesError" class="mt-1 text-xs text-block">{{ branchesError }}</p>
           <ul
-            v-if="branchFocused && branchMatches.length"
-            data-testid="branch-options"
+            v-if="repoFocused && repoMatches.length"
+            data-testid="recent-repos"
             class="absolute left-0 right-0 z-10 mt-1 max-h-56 overflow-auto rounded border border-line bg-input shadow-lg"
           >
-            <li v-for="b in branchMatches" :key="b.name">
+            <li v-for="r in repoMatches" :key="r.repo_root">
               <button
                 type="button"
-                data-testid="branch-option"
-                @mousedown.prevent="pickBranch(b)"
+                data-testid="recent-repo"
+                @mousedown.prevent="pickRepo(r.repo_root)"
                 class="flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left hover:bg-subtle"
               >
                 <span class="min-w-0">
-                  <span class="block truncate text-sm font-mono">
-                    {{ b.name }}
-                    <span v-if="b.current" class="ml-1 text-xs text-accent">(current)</span>
-                  </span>
-                  <span
-                    v-if="b.worktree"
-                    class="block truncate text-xs text-muted font-mono"
-                  >→ {{ b.worktree }}</span>
+                  <span class="block truncate text-sm">{{ repoName(r.repo_root) }}</span>
+                  <span class="block truncate text-xs text-muted font-mono">{{ r.repo_root }}</span>
+                </span>
+                <span
+                  v-if="r.active_branches"
+                  :title="`${r.active_branches} tracked branch(es)`"
+                  class="shrink-0 rounded bg-subtle px-1.5 py-0.5 text-xs text-muted"
+                >
+                  {{ r.active_branches }}
                 </span>
               </button>
             </li>
           </ul>
         </div>
+      </section>
+
+      <!-- What to build: the human-facing intent — a short title and the goal. -->
+      <section class="space-y-3 border-t border-line pt-3">
+        <h2 class="text-xs font-medium uppercase tracking-wide text-faint">What to build</h2>
+        <div>
+          <label class="block text-xs text-muted mb-1">Title</label>
+          <input
+            v-model="title"
+            placeholder="Health endpoint"
+            autocomplete="off"
+            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
+          />
+        </div>
+        <div>
+          <label class="block text-xs text-muted mb-1">
+            Goal — optional; leave blank to start the agent with no prompt
+          </label>
+          <textarea
+            v-model="goal"
+            rows="4"
+            placeholder="Add a /health endpoint that returns 200"
+            autocomplete="off"
+            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent resize-y"
+          ></textarea>
+        </div>
+      </section>
+
+      <!-- Agent: which Claude tier and how hard it reasons. -->
+      <section class="space-y-3 border-t border-line pt-3">
+        <h2 class="text-xs font-medium uppercase tracking-wide text-faint">Agent</h2>
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <label class="block text-xs text-muted mb-1">Model</label>
+            <select
+              v-model="model"
+              autocomplete="off"
+              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
+            >
+              <option value="">Default</option>
+              <option value="haiku">Haiku</option>
+              <option value="sonnet">Sonnet</option>
+              <option value="opus">Opus</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-xs text-muted mb-1">Effort</label>
+            <select
+              v-model="effort"
+              autocomplete="off"
+              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
+            >
+              <option value="">Default</option>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+              <option value="xhigh">X-High</option>
+              <option value="max">Max</option>
+            </select>
+          </div>
+          <p class="col-span-2 -mt-1 text-xs text-faint">
+            Model tier and reasoning effort for the Claude agent. Leave as Default
+            to inherit the configured launch args.
+          </p>
+        </div>
+      </section>
+
+      <!-- Branch: fork a fresh branch or reuse an existing one. -->
+      <section class="space-y-3 border-t border-line pt-3">
+        <h2 class="text-xs font-medium uppercase tracking-wide text-faint">Branch</h2>
+        <div>
+          <div class="inline-flex rounded border border-line text-xs overflow-hidden mb-2">
+            <button
+              type="button"
+              :class="[
+                'px-3 py-1',
+                branchMode === 'new' ? 'bg-accent text-white' : 'bg-input text-muted hover:bg-subtle',
+              ]"
+              @click="branchMode = 'new'"
+            >
+              New branch
+            </button>
+            <button
+              type="button"
+              :class="[
+                'px-3 py-1 border-l border-line',
+                branchMode === 'existing' ? 'bg-accent text-white' : 'bg-input text-muted hover:bg-subtle',
+              ]"
+              @click="branchMode = 'existing'"
+            >
+              Existing branch
+            </button>
+          </div>
+          <div v-if="branchMode === 'new'" class="space-y-2">
+            <div>
+              <label class="block text-xs text-muted mb-1">
+                Name — the worktree (<code>.worktrees/&lt;name&gt;</code>) and branch
+                (<code>weaver/&lt;name&gt;</code>)
+              </label>
+              <input
+                v-model="name"
+                @input="nameEdited = true"
+                placeholder="health-endpoint"
+                autocomplete="off"
+                spellcheck="false"
+                class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+              />
+            </div>
+            <div>
+              <label class="block text-xs text-muted mb-1">
+                Base branch — fork point (optional)
+              </label>
+              <input
+                v-model="base"
+                placeholder="origin/main (freshly fetched)"
+                autocomplete="off"
+                spellcheck="false"
+                class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+              />
+              <p class="mt-1 text-xs text-faint">
+                Leave blank to fork from a freshly-fetched
+                <code>origin/&lt;default branch&gt;</code>.
+              </p>
+            </div>
+          </div>
+          <div v-else class="relative">
+            <label class="block text-xs text-muted mb-1">
+              Existing branch — weaver reuses its worktree if one is checked out
+            </label>
+            <input
+              v-model="existingBranch"
+              @focus="branchFocused = true"
+              @input="branchFocused = true"
+              @blur="branchFocused = false"
+              placeholder="feature/foo"
+              autocomplete="off"
+              spellcheck="false"
+              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+            />
+            <p v-if="branchesError" class="mt-1 text-xs text-block">{{ branchesError }}</p>
+            <ul
+              v-if="branchFocused && branchMatches.length"
+              data-testid="branch-options"
+              class="absolute left-0 right-0 z-10 mt-1 max-h-56 overflow-auto rounded border border-line bg-input shadow-lg"
+            >
+              <li v-for="b in branchMatches" :key="b.name">
+                <button
+                  type="button"
+                  data-testid="branch-option"
+                  @mousedown.prevent="pickBranch(b)"
+                  class="flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left hover:bg-subtle"
+                >
+                  <span class="min-w-0">
+                    <span class="block truncate text-sm font-mono">
+                      {{ b.name }}
+                      <span v-if="b.current" class="ml-1 text-xs text-accent">(current)</span>
+                    </span>
+                    <span
+                      v-if="b.worktree"
+                      class="block truncate text-xs text-muted font-mono"
+                    >→ {{ b.worktree }}</span>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- Scratch files: reference material staged into the new worktree. -->
+      <section class="space-y-3 border-t border-line pt-3">
+        <h2 class="text-xs font-medium uppercase tracking-wide text-faint">Scratch files</h2>
+        <ScratchPicker v-model="scratchFiles" />
+      </section>
+
+      <!-- Action row: Create leads (primary), Cancel discards + closes the form. -->
+      <div class="flex items-center gap-2 border-t border-line pt-3">
+        <button
+          type="submit"
+          :disabled="creating"
+          class="btn-primary px-3 py-1.5 text-sm font-medium"
+        >
+          {{ creating ? 'Creating…' : 'Create' }}
+        </button>
+        <button
+          type="button"
+          class="btn-secondary px-3 py-1.5 text-sm font-medium"
+          @click="resetForm"
+        >
+          Cancel
+        </button>
       </div>
-      <ScratchPicker v-model="scratchFiles" />
-      <button
-        type="submit"
-        :disabled="creating"
-        class="rounded bg-accent text-accent-fg hover:bg-accent-hover px-3 py-1.5 text-sm font-medium disabled:opacity-50"
-      >
-        {{ creating ? 'Creating…' : 'Create' }}
-      </button>
     </form>
 
     <p v-if="error" class="mb-4 text-sm text-block">{{ error }}</p>
@@ -563,10 +643,11 @@ onUnmounted(() => clearInterval(timer));
     <!--
       One signal row per session. Left→right: an optional tree gutter threading
       child sessions under their launcher, the agent's single attention signal,
-      the dominant title, its muted current-state line, a neutral lifecycle pill,
-      and the mono branch ref pushed far-right. Rows are grouped into threads
-      (build in script) rather than attention-sorted; attention rows still get a
-      left accent-border + slow pulse so they stand out. Staggered reveal via --i.
+      the dominant title, its muted current-state line, a neutral lifecycle pill
+      (shown only for off-nominal states — running is the silent default), and
+      the mono branch ref pushed far-right. Rows are grouped into threads (built
+      in script), with attention-carrying threads floated up; attention rows also
+      get a left accent-border + slow pulse so they stand out. Stagger via --i.
     -->
     <ul v-if="sessions.length" data-testid="session-list" class="overflow-hidden rounded border border-line bg-surface">
       <li
@@ -614,8 +695,10 @@ onUnmounted(() => clearInterval(timer));
             >
               {{ s.branch.title || s.branch.name }}
             </router-link>
-            <!-- Lifecycle: demoted, neutral, mono pill (StatusBadge). -->
-            <StatusBadge :status="s.status" class="shrink-0" />
+            <!-- Lifecycle: demoted, neutral, mono pill (StatusBadge). Hidden for
+                 the running state — nearly every live row is running, so the pill
+                 would just be repeated noise; only off-nominal states show one. -->
+            <StatusBadge v-if="s.status !== 'running'" :status="s.status" class="shrink-0" />
           </div>
 
           <!-- Current-state headline (agent's set-status message), else the goal. -->

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -154,14 +154,14 @@ onMounted(load);
               :class="{ 'font-mono': s.kind === 'string' }"
             />
             <button
-              class="rounded bg-accent text-accent-fg hover:bg-accent-hover px-3 py-1.5 text-sm disabled:opacity-40"
+              class="btn-primary px-3 py-1.5 text-sm"
               :disabled="busy === s.key || !dirty(s)"
               @click="save(s)"
             >
               Save
             </button>
             <button
-              class="rounded bg-subtle hover:bg-subtle-hover px-3 py-1.5 text-sm disabled:opacity-40"
+              class="btn-secondary px-3 py-1.5 text-sm"
               :disabled="busy === s.key || s.is_default"
               :title="`Reset to default: ${s.default || '(empty)'}`"
               @click="reset(s)"

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -100,7 +100,7 @@ onMounted(load);
       (<code>weaver config</code>).
     </p>
 
-    <p v-if="error" class="mb-3 text-sm text-red-400">{{ error }}</p>
+    <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
     <p v-if="notice" class="mb-3 text-sm text-accent">{{ notice }}</p>
 
     <div v-for="g in groups" :key="g.name" class="mb-6">
@@ -154,7 +154,7 @@ onMounted(load);
               :class="{ 'font-mono': s.kind === 'string' }"
             />
             <button
-              class="rounded bg-accent hover:bg-accent-hover px-3 py-1.5 text-sm disabled:opacity-40"
+              class="rounded bg-accent text-accent-fg hover:bg-accent-hover px-3 py-1.5 text-sm disabled:opacity-40"
               :disabled="busy === s.key || !dirty(s)"
               @click="save(s)"
             >
@@ -170,9 +170,9 @@ onMounted(load);
             </button>
           </div>
           <p class="mt-1.5 text-xs text-faint">
-            <span v-if="s.is_default">Using the default</span>
+            <span v-if="s.is_default">Using the default:</span>
             <span v-else>Customized · default is</span>
-            <code>{{ s.default || '(empty)' }}</code>
+            <code class="ml-1">{{ s.default || '(empty)' }}</code>
           </p>
         </section>
       </div>

--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -83,7 +83,9 @@ test.describe('creating a session via the UI form', () => {
     await page.goto(weaver.baseUrl);
     await page.getByRole('button', { name: 'New session' }).click();
     await expect(page.getByPlaceholder('Add a /health endpoint')).toBeVisible();
-    await page.getByRole('button', { name: 'Cancel' }).click();
+    // There are now two "Cancel" buttons — the top toggle and the form's own
+    // bottom action. Scope to the form so this targets the bottom one uniquely.
+    await page.locator('form').getByRole('button', { name: 'Cancel' }).click();
     await expect(page.getByPlaceholder('Add a /health endpoint')).toBeHidden();
   });
 });

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -20,23 +20,28 @@ test.describe('session list view', () => {
     const cardA = page.locator(`[data-session-id="${a.id}"]`);
     await expect(cardA).toContainText('alpha-task');
     await expect(cardA).toContainText('Add a health endpoint');
-    await expect(cardA.getByTestId('status-badge')).toBeVisible();
+    // A live session is `running`, and the list omits the lifecycle badge for
+    // that state — nearly every row is running, so the pill would just be
+    // repeated noise. Non-running states still show it (see the archived test).
+    await expect(cardA.getByTestId('status-badge')).toHaveCount(0);
 
     const cardB = page.locator(`[data-session-id="${b.id}"]`);
     await expect(cardB).toContainText('beta-task');
     await expect(cardB).toContainText('Fix the login bug');
   });
 
-  test('attention and lifecycle live in separate columns', async ({ page, weaver }) => {
+  test('attention is its own badge, separate from the lifecycle axis', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Refactor auth', name: 'auth' });
     await weaver.setStatus(s, 'attention', 'ready for review');
 
     await page.goto(weaver.baseUrl);
     const card = page.locator(`[data-session-id="${s.id}"]`);
-    // The agent's single signal (attention) and the mechanical lifecycle are
-    // each their own badge — not stacked in one cell.
+    // The agent's single signal (attention) is its own badge — never merged into
+    // the lifecycle cell. The session is running, so the lifecycle pill is
+    // omitted from the row (declutter), leaving attention to stand alone; the two
+    // axes co-rendering as distinct badges is covered by the archived test below.
     await expect(card.getByTestId('attention-badge')).toHaveAttribute('data-level', 'attention');
-    await expect(card.getByTestId('status-badge')).toBeVisible();
+    await expect(card.getByTestId('status-badge')).toHaveCount(0);
     await expect(card).toContainText('ready for review');
   });
 

--- a/e2e/tests/plan.spec.ts
+++ b/e2e/tests/plan.spec.ts
@@ -47,10 +47,13 @@ test.describe('plan on the overview tab', () => {
     await expect(plan.getByText('Feature plan', { exact: true })).toBeVisible();
 
     // The task list projects status from the ledger; before reconcile the
-    // materializing tasks are "planned" (no issue yet).
-    await expect(plan.getByText('Build the API')).toBeVisible();
-    await expect(plan.getByText('Build the UI')).toBeVisible();
-    await expect(plan.getByText('planned').first()).toBeVisible();
+    // materializing tasks are "planned" (no issue yet). Scope to the task list:
+    // the task titles also appear in the dependency-graph's mermaid source, so a
+    // plan-wide getByText would be ambiguous (and races mermaid's SVG render).
+    const tasks = plan.getByTestId('plan-tasks');
+    await expect(tasks.getByText('Build the API')).toBeVisible();
+    await expect(tasks.getByText('Build the UI')).toBeVisible();
+    await expect(tasks.getByText('planned').first()).toBeVisible();
 
     // Both the architecture diagram and the dependency graph render to SVG.
     await expect(plan.locator('.mermaid-diagram svg').first()).toBeVisible();


### PR DESCRIPTION
Set up the loom dev frontend and reviewed every surface in both light and dark
themes (driven through an isolated Playwright loom, screenshotting each screen).
This PR lands both the quick-win papercuts **and** the larger structural cleanups
from that review. The one deferred item is the terminal palette (#87) — it's
user-selectable in Settings, so it's left as-is per the maintainer's call.

## Quick wins (first pass)

- **Primary buttons were dark-on-blue in light mode** ("New session", "Create",
  Settings "Save") — added the missing `text-accent-fg`.
- **"Cancel" was the same blue as "Create"** — the create-form toggle turns
  neutral when the form is open.
- **The "OK" / "Needs attention" filter** — refined into a segmented control
  with the count in its own pill.
- **Plan frontmatter leaked** into the rendered doc — stripped.
- **Mermaid diagrams were lavender** — re-themed to loom's slate/blue tokens.
- **Settings helper text ran words together** ("Using the defaultdark") — fixed.
- **Raw Tailwind colors** in 5 components → semantic `attn`/`block`/`accent`
  tokens so they theme correctly.
- **The conversation-state glyph rendered as tofu** — swapped for a BMP dot.

## Larger cleanups (this pass)

- **#88 — Plan Overview tripled its content.** The rendered doc dropped the
  `## Tasks` section (it restated the projected task list); design, the
  architecture diagram, and open questions stay. Display-only — the raw plan
  file still drives parsing, the dependency graph, reconcile, and Edit.
- **#91 — Plan Edit mounted Monaco below the projections.** Edit mode now shows
  only the editor, focused and scrolled into view.
- **#89 — Urgent rows could sink to the bottom.** Threads containing
  attention/blocked now float to the top (blocked above attention); threads stay
  grouped and calm ones sink, so an urgent child can't hide at the bottom.
- **#90 — Tree threading was too subtle.** Stronger guide color (slate-400/500)
  and a wider per-depth indent, so nesting reads at a glance.
- **#92 — The create form was long and monotone.** Grouped into labeled sections
  (Repository / What to build / Agent / Branch / Scratch files), with a Cancel
  beside Create at the bottom.
- **#93 — The RUNNING pill repeated on nearly every row.** Hidden in list rows
  (non-running states still show it; the single-session detail header is
  unchanged), so attention is the only thing competing for the eye.
- **#94 — Button system.** Added shared `btn-primary`/`btn-secondary`/`btn-danger`
  utilities (like the existing `pill`/`meta-chip`) and swept the
  primary/secondary/danger buttons onto them; bespoke accent-ring buttons
  (Reconcile, Adopt, Mark OK) keep their own markup.

## Deferred

- **#87 — Terminal palette vs. the page theme.** The terminal has its own
  light/dark palette selectable in Settings (`terminal.theme`); left as-is.

## Verification

All 22 Playwright e2e specs pass; `cargo fmt` + `clippy` clean; agent lint review
clean. Each surface was screenshot-verified in both themes. e2e specs were
updated where the design intentionally changed: plan task assertions scoped to
the task list (this also de-flakes a latent strict-mode match against the
dependency-graph's mermaid source); the list status-badge assertions reflect the
running-row declutter (the archived test still covers the lifecycle badge
rendering); and create's Cancel is scoped to the form now that there are two.