### PR TITLE
feat(overlooker): builtin script programs — pr-label + archive-merged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules/
 .bot/
 e2e/test-results/
 *.pyc
+python/weaver-loom/dist/
+__pycache__/

--- a/crates/loom/Cargo.toml
+++ b/crates/loom/Cargo.toml
@@ -29,6 +29,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "derive"] }
+# The overlooker engine materializes embedded builtin scripts to a scratch file
+# before running them; the tests reuse it for fixtures.
+tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
@@ -38,7 +41,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 croner = "3"
 
 [dev-dependencies]
-tempfile = "3"
 # WebSocket client for the terminal round-trip integration test. 0.29 matches
 # axum 0.8's own tokio-tungstenite, so the two speak the same protocol stack.
 tokio-tungstenite = "0.29"

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -313,6 +313,26 @@ export interface OverlookerRunResult {
   summary: string;
 }
 
+/** One program an overlooker can run, served by `GET /api/overlookers/programs`.
+ *  Builtin programs ship inside the loom binary: a `native` one is implemented
+ *  in Rust, a `script` one is an embedded Python file whose `source` the panel
+ *  renders read-only. `defaults` is the suggested starting config a create form
+ *  prefills. Mirrors `ProgramView` in weaver-api. */
+export interface ProgramView {
+  /** The reference an overlooker's `program` field uses, e.g. `builtin:status`. */
+  program: string;
+  title: string;
+  description: string;
+  kind: 'native' | 'script';
+  source: string | null;
+  defaults: {
+    trigger?: OverlookerTrigger;
+    scope?: OverlookerScope;
+    params?: Record<string, unknown>;
+    capabilities?: string[];
+  };
+}
+
 export type SettingKind = 'string' | 'int' | 'bool' | 'enum';
 
 /** One configurable setting: its registry metadata plus its current value. */

--- a/crates/loom/frontend/src/views/OverlookerDetail.vue
+++ b/crates/loom/frontend/src/views/OverlookerDetail.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { get, post, patch, del } from '../api';
-import type { Overlooker, OverlookerRun, OverlookerRunResult } from '../types';
+import type { Overlooker, OverlookerRun, OverlookerRunResult, ProgramView } from '../types';
 import OutcomeBadge from '../components/OutcomeBadge.vue';
 import AgentTerminal from '../components/AgentTerminal.vue';
 import { timeAgo } from '../lib/time';
@@ -163,9 +163,26 @@ async function remove() {
 // The capability set as a readable, ordered chip list (observe is implicit).
 const grantedCaps = computed(() => ov.value?.capabilities ?? []);
 
+// The builtin program registry, to label this overlooker's program and render
+// a builtin script's source read-only (it ships inside the loom binary).
+const programs = ref<ProgramView[]>([]);
+const showSource = ref(false);
+const programInfo = computed(
+  () => programs.value.find((p) => p.program === ov.value?.program) ?? null,
+);
+
+async function loadPrograms() {
+  try {
+    programs.value = (await get('/overlookers/programs')) as ProgramView[];
+  } catch {
+    // Supplementary: without the registry the program still shows as its ref.
+  }
+}
+
 onMounted(() => {
   loadOverlooker();
   loadRuns();
+  loadPrograms();
 });
 </script>
 
@@ -305,7 +322,27 @@ onMounted(() => {
             📁 {{ repoLabel(ov.trigger.repo) }}
           </dd>
           <dt class="text-faint">Program</dt>
-          <dd class="font-mono">{{ ov.program }}</dd>
+          <dd>
+            <span class="font-mono">{{ ov.program }}</span>
+            <button
+              v-if="programInfo?.source"
+              type="button"
+              data-testid="program-source-toggle"
+              class="ml-2 text-xs text-accent hover:underline"
+              @click="showSource = !showSource"
+            >
+              {{ showSource ? 'hide source' : 'view source' }}
+            </button>
+            <p v-if="programInfo" class="mt-0.5 text-xs text-faint">
+              {{ programInfo.title }} — a builtin {{ programInfo.kind }} shipped
+              with loom<span v-if="programInfo.source">; the source is read-only</span>.
+            </p>
+            <pre
+              v-if="showSource && programInfo?.source"
+              data-testid="program-source"
+              class="mt-2 max-h-80 overflow-auto rounded bg-input p-3 text-xs font-mono"
+            >{{ programInfo.source }}</pre>
+          </dd>
 
           <dt class="text-faint pt-1">Capabilities</dt>
           <dd>

--- a/crates/loom/frontend/src/views/Overlookers.vue
+++ b/crates/loom/frontend/src/views/Overlookers.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, reactive, onMounted } from 'vue';
 import { get, post, patch } from '../api';
-import type { Overlooker, OverlookerRunResult } from '../types';
+import type { Overlooker, OverlookerRunResult, ProgramView } from '../types';
 import OutcomeBadge from '../components/OutcomeBadge.vue';
 import { timeAgo } from '../lib/time';
 import {
@@ -31,6 +31,20 @@ async function load() {
     error.value = (e as Error).message;
   } finally {
     loaded.value = true;
+  }
+}
+
+// The builtin program registry — what the create form offers and the "Builtin
+// programs" section lists (script sources shown read-only).
+const programs = ref<ProgramView[]>([]);
+// The program whose script source is expanded in the registry section.
+const expandedSource = ref('');
+
+async function loadPrograms() {
+  try {
+    programs.value = (await get('/overlookers/programs')) as ProgramView[];
+  } catch (e) {
+    error.value = (e as Error).message;
   }
 }
 
@@ -80,7 +94,10 @@ const form = reactive({
   every: '30m',
   event: 'attention',
   level: 'blocked',
+  // A builtin reference from the registry, or the literal 'custom' to free-type
+  // a program file path into `customProgram`.
   program: 'builtin:status',
+  customProgram: '',
   prompt: '',
   scopeAttention: '!ok',
   repo: '',
@@ -95,10 +112,41 @@ function resetForm() {
   form.event = 'attention';
   form.level = 'blocked';
   form.program = 'builtin:status';
+  form.customProgram = '';
   form.prompt = '';
   form.scopeAttention = '!ok';
   form.repo = '';
   form.capabilities = { mark: true, escalate: true, nudge: false, interrupt: false, launch: false };
+}
+
+// Prefill the form from a builtin's suggested defaults (trigger cadence, scope,
+// capability grants) — the registry's starting point, freely editable after.
+function applyProgramDefaults(programRef: string) {
+  const p = programs.value.find((x) => x.program === programRef);
+  if (!p) return;
+  const t = p.defaults?.trigger ?? {};
+  if (t.cron) {
+    form.triggerKind = 'cron';
+    form.cron = t.cron;
+  } else if (t.every) {
+    form.triggerKind = 'every';
+    form.every = t.every;
+  } else if (t.event) {
+    form.triggerKind = 'event';
+    form.event = t.event;
+    form.level = t.level ?? '';
+  }
+  form.scopeAttention = p.defaults?.scope?.attention ?? '';
+  const granted = p.defaults?.capabilities ?? [];
+  for (const c of GRANTABLE_CAPABILITIES) form.capabilities[c] = granted.includes(c);
+}
+
+// "Use" on a registry row: open the create form prefilled with that program.
+function useProgram(p: ProgramView) {
+  form.program = p.program;
+  applyProgramDefaults(p.program);
+  if (!form.name.trim()) form.name = p.program.replace(/^builtin:/, '');
+  showForm.value = true;
 }
 
 async function create() {
@@ -122,12 +170,20 @@ async function create() {
     // `observe` is implicit; ship the explicitly-ticked grants on top of it.
     const capabilities = capabilitiesFrom(form.capabilities);
 
+    const programRef =
+      form.program === 'custom' ? form.customProgram.trim() : form.program;
+    // Start from the program's suggested params (e.g. pr-label's label), with
+    // the prompt — the form's one explicit param — layered on top.
+    const chosen = programs.value.find((p) => p.program === programRef);
+    const params: Record<string, unknown> = { ...(chosen?.defaults?.params ?? {}) };
+    if (form.prompt.trim()) params.prompt = form.prompt.trim();
+
     const body: Record<string, unknown> = {
       name: form.name.trim(),
       trigger,
       scope,
-      program: form.program.trim() || 'builtin:status',
-      params: form.prompt.trim() ? { prompt: form.prompt.trim() } : {},
+      program: programRef || 'builtin:status',
+      params,
       capabilities,
     };
     await post('/overlookers', body);
@@ -141,7 +197,10 @@ async function create() {
   }
 }
 
-onMounted(load);
+onMounted(() => {
+  load();
+  loadPrograms();
+});
 </script>
 
 <template>
@@ -246,12 +305,25 @@ onMounted(load);
       <div class="grid grid-cols-2 gap-3">
         <div>
           <label class="block text-xs text-muted mb-1">Program</label>
-          <input
+          <select
             v-model="form.program"
-            placeholder="builtin:status"
+            data-testid="overlooker-program"
+            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+            @change="applyProgramDefaults(form.program)"
+          >
+            <option v-for="p in programs" :key="p.program" :value="p.program">
+              {{ p.program }}
+            </option>
+            <option value="custom">custom path…</option>
+          </select>
+          <input
+            v-if="form.program === 'custom'"
+            v-model="form.customProgram"
+            data-testid="overlooker-custom-program"
+            placeholder="/home/you/.weaver/overlookers/my-watch.py"
             autocomplete="off"
             spellcheck="false"
-            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+            class="mt-2 w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
           />
         </div>
         <div>
@@ -441,5 +513,58 @@ onMounted(load);
         </div>
       </li>
     </ul>
+
+    <!-- Builtin programs — the stock programs that ship with loom. Script
+         sources are read-only (they live in the weaver repo); "Use" opens the
+         create form prefilled with the program's suggested defaults. -->
+    <section v-if="programs.length" class="mt-8" data-testid="builtin-programs">
+      <h2 class="text-sm font-semibold text-muted uppercase tracking-wide mb-1">
+        Builtin programs
+      </h2>
+      <p class="text-xs text-faint mb-2">
+        Stock programs shipped with loom — pick one as a new overlooker's
+        program. Sources are read-only; start a custom one from a copy with
+        <code>loom overlooker new &lt;name&gt;</code>.
+      </p>
+      <ul class="overflow-hidden rounded border border-line bg-surface">
+        <li
+          v-for="p in programs"
+          :key="p.program"
+          data-testid="program-row"
+          class="border-b border-line px-4 py-3 last:border-0"
+        >
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="font-mono text-sm font-semibold">{{ p.program }}</span>
+            <span class="meta-chip">{{ p.kind }}</span>
+            <span class="text-sm text-muted">{{ p.title }}</span>
+            <div class="ml-auto flex shrink-0 items-center gap-2">
+              <button
+                v-if="p.source"
+                type="button"
+                data-testid="program-source-toggle"
+                class="rounded bg-subtle hover:bg-subtle-hover px-2.5 py-1 text-xs font-medium"
+                @click="expandedSource = expandedSource === p.program ? '' : p.program"
+              >
+                {{ expandedSource === p.program ? 'Hide source' : 'View source' }}
+              </button>
+              <button
+                type="button"
+                data-testid="program-use"
+                class="rounded bg-accent hover:bg-accent-hover px-2.5 py-1 text-xs font-medium text-accent-fg"
+                @click="useProgram(p)"
+              >
+                Use
+              </button>
+            </div>
+          </div>
+          <p class="mt-1 text-xs text-faint">{{ p.description }}</p>
+          <pre
+            v-if="expandedSource === p.program && p.source"
+            data-testid="program-source"
+            class="mt-2 max-h-80 overflow-auto rounded bg-input p-3 text-xs font-mono"
+          >{{ p.source }}</pre>
+        </li>
+      </ul>
+    </section>
   </div>
 </template>

--- a/crates/loom/overlookers/archive_merged.py
+++ b/crates/loom/overlookers/archive_merged.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""archive-merged — flag sessions whose pull request has merged.
+
+A builtin loom overlooker program (`builtin:archive-merged`). Each round it
+surveys the in-scope fleet over the loom REST API and reports every live
+session whose latest PR snapshot says the pull request is merged — work that is
+integrated and only waiting for its session to be archived.
+
+This builtin is **read-only**: it records a `would: archive` action per merged
+session and mutates nothing. (Today the `github.archive_on_merge` setting
+performs the actual archive; this program is the scripted home for that
+workflow.)
+
+The program contract (shared by every script the engine runs):
+
+* `WEAVER_API` — base URL of the loom REST API (e.g. `http://127.0.0.1:7878`).
+* `WEAVER_OVERLOOKER` — JSON config for this round:
+  `{id, name, program, params, scope, capabilities, dry_run}`.
+* Print one JSON object to stdout: `{"outcome": "ok"|"noop", "summary": str,
+  "actions": [...]}`. A non-zero exit (or unparseable stdout) records the
+  round as an error.
+"""
+
+import json
+import os
+import urllib.request
+
+# Lifecycle states with no live session left to archive.
+TERMINAL = {"done", "error", "archived"}
+
+
+def api_get(path):
+    base = os.environ.get("WEAVER_API", "http://127.0.0.1:7878").rstrip("/")
+    if not base.startswith("http"):
+        base = "http://" + base
+    with urllib.request.urlopen(base + "/api" + path) as resp:
+        return json.load(resp)
+
+
+def attention_of(branch):
+    """The branch's `attention` tag value; absence is the calm `ok`."""
+    for tag in branch.get("tags") or []:
+        if tag.get("key") == "attention":
+            return tag.get("value") or "ok"
+    return "ok"
+
+
+def in_scope(scope, session):
+    """Apply the overlooker's fleet query: an `attention` filter (`!ok` or an
+    exact level) and an optional `repo` pin."""
+    branch = session.get("branch") or {}
+    want = scope.get("attention")
+    if want:
+        have = attention_of(branch)
+        matched = have != want[1:] if want.startswith("!") else have == want
+        if not matched:
+            return False
+    repo = scope.get("repo")
+    if repo and branch.get("repo_root") != repo:
+        return False
+    return True
+
+
+def main():
+    cfg = json.loads(os.environ.get("WEAVER_OVERLOOKER", "{}"))
+    scope = cfg.get("scope") or {}
+
+    surveyed = 0
+    actions = []
+    for session in api_get("/sessions"):
+        if session.get("status") in TERMINAL or not in_scope(scope, session):
+            continue
+        surveyed += 1
+        github = (session.get("branch") or {}).get("github") or {}
+        if github.get("pr_state") != "MERGED":
+            continue
+        pr = github.get("pr_number")
+        actions.append(
+            {
+                "session": session["id"],
+                "would": "archive",
+                "pr": pr,
+                "note": f"PR #{pr} is merged — the session can be archived",
+            }
+        )
+
+    summary = f"surveyed {surveyed}, {len(actions)} with a merged PR"
+    print(
+        json.dumps(
+            {
+                "outcome": "ok" if actions else "noop",
+                "summary": summary,
+                "actions": actions,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/loom/overlookers/archive_merged.py
+++ b/crates/loom/overlookers/archive_merged.py
@@ -1,20 +1,7 @@
-#!/usr/bin/env python3
 """archive-merged — flag sessions whose pull request has merged.
 
-A builtin loom overlooker program (`builtin:archive-merged`). Each round it
-surveys the in-scope fleet over the loom REST API and reports every live
-session whose latest PR snapshot says the pull request is merged — work that is
-integrated and only waiting for its session to be archived.
-
-This builtin is **read-only**: it records a `would: archive` action per merged
-session and mutates nothing. (Today the `github.archive_on_merge` setting
-performs the actual archive; this program is the scripted home for that
-workflow.)
-
-Written against `weaver_loom`, the Python layer over the loom REST API — the
-engine vendors that module onto PYTHONPATH for every script it runs. The
-program contract (env in, one result JSON object on stdout) is documented in
-docs/ARCHITECTURE.md (Overlookers).
+Read-only: records a would-archive action per merged PR (the
+github.archive_on_merge setting still performs the actual archive).
 """
 
 from weaver_loom import Round

--- a/crates/loom/overlookers/archive_merged.py
+++ b/crates/loom/overlookers/archive_merged.py
@@ -11,89 +11,29 @@ session and mutates nothing. (Today the `github.archive_on_merge` setting
 performs the actual archive; this program is the scripted home for that
 workflow.)
 
-The program contract (shared by every script the engine runs):
-
-* `WEAVER_API` — base URL of the loom REST API (e.g. `http://127.0.0.1:7878`).
-* `WEAVER_OVERLOOKER` — JSON config for this round:
-  `{id, name, program, params, scope, capabilities, dry_run}`.
-* Print one JSON object to stdout: `{"outcome": "ok"|"noop", "summary": str,
-  "actions": [...]}`. A non-zero exit (or unparseable stdout) records the
-  round as an error.
+Written against `weaver_loom`, the Python layer over the loom REST API — the
+engine vendors that module onto PYTHONPATH for every script it runs. The
+program contract (env in, one result JSON object on stdout) is documented in
+docs/ARCHITECTURE.md (Overlookers).
 """
 
-import json
-import os
-import urllib.request
-
-# Lifecycle states with no live session left to archive.
-TERMINAL = {"done", "error", "archived"}
-
-
-def api_get(path):
-    base = os.environ.get("WEAVER_API", "http://127.0.0.1:7878").rstrip("/")
-    if not base.startswith("http"):
-        base = "http://" + base
-    with urllib.request.urlopen(base + "/api" + path) as resp:
-        return json.load(resp)
-
-
-def attention_of(branch):
-    """The branch's `attention` tag value; absence is the calm `ok`."""
-    for tag in branch.get("tags") or []:
-        if tag.get("key") == "attention":
-            return tag.get("value") or "ok"
-    return "ok"
-
-
-def in_scope(scope, session):
-    """Apply the overlooker's fleet query: an `attention` filter (`!ok` or an
-    exact level) and an optional `repo` pin."""
-    branch = session.get("branch") or {}
-    want = scope.get("attention")
-    if want:
-        have = attention_of(branch)
-        matched = have != want[1:] if want.startswith("!") else have == want
-        if not matched:
-            return False
-    repo = scope.get("repo")
-    if repo and branch.get("repo_root") != repo:
-        return False
-    return True
+from weaver_loom import Round
 
 
 def main():
-    cfg = json.loads(os.environ.get("WEAVER_OVERLOOKER", "{}"))
-    scope = cfg.get("scope") or {}
-
-    surveyed = 0
-    actions = []
-    for session in api_get("/sessions"):
-        if session.get("status") in TERMINAL or not in_scope(scope, session):
-            continue
-        surveyed += 1
+    rnd = Round()
+    for session in rnd.sessions():
         github = (session.get("branch") or {}).get("github") or {}
         if github.get("pr_state") != "MERGED":
             continue
         pr = github.get("pr_number")
-        actions.append(
-            {
-                "session": session["id"],
-                "would": "archive",
-                "pr": pr,
-                "note": f"PR #{pr} is merged — the session can be archived",
-            }
+        rnd.would(
+            "archive",
+            session=session["id"],
+            pr=pr,
+            note=f"PR #{pr} is merged — the session can be archived",
         )
-
-    summary = f"surveyed {surveyed}, {len(actions)} with a merged PR"
-    print(
-        json.dumps(
-            {
-                "outcome": "ok" if actions else "noop",
-                "summary": summary,
-                "actions": actions,
-            }
-        )
-    )
+    rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} with a merged PR")
 
 
 if __name__ == "__main__":

--- a/crates/loom/overlookers/pr_label.py
+++ b/crates/loom/overlookers/pr_label.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""pr-label — flag sessions whose open PR lacks the loom label.
+
+A builtin loom overlooker program (`builtin:pr-label`). Each round it surveys
+the in-scope fleet over the loom REST API and, for every live session with an
+open pull request, checks (via a `gh` read) that the PR carries the configured
+label — so PRs born from loom sessions are identifiable on GitHub. Sessions
+whose PR already has the label are skipped.
+
+This builtin is **read-only**: it records a `would: label` action per
+unlabelled PR and mutates nothing. When `gh` is unavailable (or the labels
+can't be read) it still reports the ensure-label action, noting the labels
+were unreadable.
+
+Params: `{"label": "<name>"}` — the label to ensure; defaults to `weaver`.
+
+The program contract (shared by every script the engine runs):
+
+* `WEAVER_API` — base URL of the loom REST API (e.g. `http://127.0.0.1:7878`).
+* `WEAVER_OVERLOOKER` — JSON config for this round:
+  `{id, name, program, params, scope, capabilities, dry_run}`.
+* Print one JSON object to stdout: `{"outcome": "ok"|"noop", "summary": str,
+  "actions": [...]}`. A non-zero exit (or unparseable stdout) records the
+  round as an error.
+"""
+
+import json
+import os
+import subprocess
+import urllib.request
+
+# Lifecycle states with no live session behind the PR.
+TERMINAL = {"done", "error", "archived"}
+
+DEFAULT_LABEL = "weaver"
+
+
+def api_get(path):
+    base = os.environ.get("WEAVER_API", "http://127.0.0.1:7878").rstrip("/")
+    if not base.startswith("http"):
+        base = "http://" + base
+    with urllib.request.urlopen(base + "/api" + path) as resp:
+        return json.load(resp)
+
+
+def attention_of(branch):
+    """The branch's `attention` tag value; absence is the calm `ok`."""
+    for tag in branch.get("tags") or []:
+        if tag.get("key") == "attention":
+            return tag.get("value") or "ok"
+    return "ok"
+
+
+def in_scope(scope, session):
+    """Apply the overlooker's fleet query: an `attention` filter (`!ok` or an
+    exact level) and an optional `repo` pin."""
+    branch = session.get("branch") or {}
+    want = scope.get("attention")
+    if want:
+        have = attention_of(branch)
+        matched = have != want[1:] if want.startswith("!") else have == want
+        if not matched:
+            return False
+    repo = scope.get("repo")
+    if repo and branch.get("repo_root") != repo:
+        return False
+    return True
+
+
+def pr_labels(repo_root, pr_number):
+    """The PR's current label names via a `gh` read, or None when unreadable
+    (gh missing, unauthenticated, no GitHub remote, ...)."""
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "labels"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if out.returncode != 0:
+            return None
+        labels = json.loads(out.stdout).get("labels") or []
+        return [label.get("name", "") for label in labels]
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def main():
+    cfg = json.loads(os.environ.get("WEAVER_OVERLOOKER", "{}"))
+    scope = cfg.get("scope") or {}
+    label = (cfg.get("params") or {}).get("label") or DEFAULT_LABEL
+
+    surveyed = 0
+    actions = []
+    for session in api_get("/sessions"):
+        if session.get("status") in TERMINAL or not in_scope(scope, session):
+            continue
+        surveyed += 1
+        branch = session.get("branch") or {}
+        github = branch.get("github") or {}
+        if github.get("pr_state") != "OPEN":
+            continue
+        pr = github.get("pr_number")
+        labels = pr_labels(branch.get("repo_root"), pr)
+        if labels is not None and label in labels:
+            continue
+        note = (
+            f"PR #{pr} lacks label '{label}'"
+            if labels is not None
+            else f"PR #{pr}: labels unreadable via gh — would ensure '{label}'"
+        )
+        actions.append(
+            {
+                "session": session["id"],
+                "would": "label",
+                "pr": pr,
+                "label": label,
+                "note": note,
+            }
+        )
+
+    summary = f"surveyed {surveyed}, {len(actions)} open PR(s) missing '{label}'"
+    print(
+        json.dumps(
+            {
+                "outcome": "ok" if actions else "noop",
+                "summary": summary,
+                "actions": actions,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/loom/overlookers/pr_label.py
+++ b/crates/loom/overlookers/pr_label.py
@@ -1,34 +1,31 @@
-#!/usr/bin/env python3
 """pr-label — flag sessions whose open PR lacks the loom label.
 
-A builtin loom overlooker program (`builtin:pr-label`). Each round it surveys
-the in-scope fleet over the loom REST API and, for every live session with an
-open pull request, checks (via a `gh` read) that the PR carries the configured
-label — so PRs born from loom sessions are identifiable on GitHub. Sessions
-whose PR already has the label are skipped.
-
-This builtin is **read-only**: it records a `would: label` action per
-unlabelled PR and mutates nothing. When `gh` is unavailable (or the labels
-can't be read) it still reports the ensure-label action, noting the labels
-were unreadable.
-
-Params: `{"label": "<name>"}` — the label to ensure; defaults to `weaver`.
-
-Written against `weaver_loom`, the Python layer over the loom REST API — the
-engine vendors that module onto PYTHONPATH for every script it runs. The
-program contract (env in, one result JSON object on stdout) is documented in
-docs/ARCHITECTURE.md (Overlookers).
+Read-only: records a would-label action per open PR missing the label
+(params.label, default 'weaver'). Labels are read via the gh CLI.
 """
 
-from weaver_loom import Round, gh
+import json
+import subprocess
+
+from weaver_loom import Round
 
 DEFAULT_LABEL = "weaver"
 
 
 def pr_labels(repo_root, pr_number):
-    """The PR's current label names, or None when unreadable."""
-    reply = gh(["pr", "view", str(pr_number), "--json", "labels"], cwd=repo_root)
-    if reply is None:
+    """The PR's current label names via gh, or None when unreadable."""
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "labels"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if out.returncode != 0:
+            return None
+        reply = json.loads(out.stdout)
+    except (OSError, subprocess.SubprocessError, ValueError):
         return None
     return [label.get("name", "") for label in reply.get("labels") or []]
 

--- a/crates/loom/overlookers/pr_label.py
+++ b/crates/loom/overlookers/pr_label.py
@@ -14,89 +14,29 @@ were unreadable.
 
 Params: `{"label": "<name>"}` — the label to ensure; defaults to `weaver`.
 
-The program contract (shared by every script the engine runs):
-
-* `WEAVER_API` — base URL of the loom REST API (e.g. `http://127.0.0.1:7878`).
-* `WEAVER_OVERLOOKER` — JSON config for this round:
-  `{id, name, program, params, scope, capabilities, dry_run}`.
-* Print one JSON object to stdout: `{"outcome": "ok"|"noop", "summary": str,
-  "actions": [...]}`. A non-zero exit (or unparseable stdout) records the
-  round as an error.
+Written against `weaver_loom`, the Python layer over the loom REST API — the
+engine vendors that module onto PYTHONPATH for every script it runs. The
+program contract (env in, one result JSON object on stdout) is documented in
+docs/ARCHITECTURE.md (Overlookers).
 """
 
-import json
-import os
-import subprocess
-import urllib.request
-
-# Lifecycle states with no live session behind the PR.
-TERMINAL = {"done", "error", "archived"}
+from weaver_loom import Round, gh
 
 DEFAULT_LABEL = "weaver"
 
 
-def api_get(path):
-    base = os.environ.get("WEAVER_API", "http://127.0.0.1:7878").rstrip("/")
-    if not base.startswith("http"):
-        base = "http://" + base
-    with urllib.request.urlopen(base + "/api" + path) as resp:
-        return json.load(resp)
-
-
-def attention_of(branch):
-    """The branch's `attention` tag value; absence is the calm `ok`."""
-    for tag in branch.get("tags") or []:
-        if tag.get("key") == "attention":
-            return tag.get("value") or "ok"
-    return "ok"
-
-
-def in_scope(scope, session):
-    """Apply the overlooker's fleet query: an `attention` filter (`!ok` or an
-    exact level) and an optional `repo` pin."""
-    branch = session.get("branch") or {}
-    want = scope.get("attention")
-    if want:
-        have = attention_of(branch)
-        matched = have != want[1:] if want.startswith("!") else have == want
-        if not matched:
-            return False
-    repo = scope.get("repo")
-    if repo and branch.get("repo_root") != repo:
-        return False
-    return True
-
-
 def pr_labels(repo_root, pr_number):
-    """The PR's current label names via a `gh` read, or None when unreadable
-    (gh missing, unauthenticated, no GitHub remote, ...)."""
-    try:
-        out = subprocess.run(
-            ["gh", "pr", "view", str(pr_number), "--json", "labels"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if out.returncode != 0:
-            return None
-        labels = json.loads(out.stdout).get("labels") or []
-        return [label.get("name", "") for label in labels]
-    except (OSError, subprocess.SubprocessError, ValueError):
+    """The PR's current label names, or None when unreadable."""
+    reply = gh(["pr", "view", str(pr_number), "--json", "labels"], cwd=repo_root)
+    if reply is None:
         return None
+    return [label.get("name", "") for label in reply.get("labels") or []]
 
 
 def main():
-    cfg = json.loads(os.environ.get("WEAVER_OVERLOOKER", "{}"))
-    scope = cfg.get("scope") or {}
-    label = (cfg.get("params") or {}).get("label") or DEFAULT_LABEL
-
-    surveyed = 0
-    actions = []
-    for session in api_get("/sessions"):
-        if session.get("status") in TERMINAL or not in_scope(scope, session):
-            continue
-        surveyed += 1
+    rnd = Round()
+    label = rnd.params.get("label") or DEFAULT_LABEL
+    for session in rnd.sessions():
         branch = session.get("branch") or {}
         github = branch.get("github") or {}
         if github.get("pr_state") != "OPEN":
@@ -110,26 +50,8 @@ def main():
             if labels is not None
             else f"PR #{pr}: labels unreadable via gh — would ensure '{label}'"
         )
-        actions.append(
-            {
-                "session": session["id"],
-                "would": "label",
-                "pr": pr,
-                "label": label,
-                "note": note,
-            }
-        )
-
-    summary = f"surveyed {surveyed}, {len(actions)} open PR(s) missing '{label}'"
-    print(
-        json.dumps(
-            {
-                "outcome": "ok" if actions else "noop",
-                "summary": summary,
-                "actions": actions,
-            }
-        )
-    )
+        rnd.would("label", session=session["id"], pr=pr, label=label, note=note)
+    rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} open PR(s) missing '{label}'")
 
 
 if __name__ == "__main__":

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1157,36 +1157,14 @@ fn scaffold_template(name: &str) -> String {
 # requires-python = ">=3.9"
 # dependencies = []
 # ///
-"""__NAME__ — a weaver overlooker program (a periodic / triggered watch over the fleet).
+"""__NAME__ — a weaver overlooker program.
 
-The loom engine runs this file as an env-stripped subprocess — via `uv run
---script` when uv is installed (the PEP 723 block above declares any
-third-party dependencies), else plain `python3`. The `weaver_loom` module —
-the Python layer over the loom REST API — is vendored onto PYTHONPATH by the
-engine; for standalone runs install it from the weaver repo with
-`uv pip install -e python/weaver-loom`.
+The engine runs this as a subprocess with WEAVER_API (the loom REST base URL)
+and WEAVER_OVERLOOKER (the round config JSON) set; `weaver_loom` is on
+PYTHONPATH. `Round.finish` prints the result the engine reads from stdout.
 
-The contract:
-
-* `WEAVER_API` — base URL of the loom REST API.
-* `WEAVER_OVERLOOKER` — JSON config for this round:
-  {"id", "name", "program", "params", "scope", "capabilities", "dry_run"}.
-* Print one JSON object as the final stdout line: {"outcome": "ok"|"noop",
-  "summary": str, "actions": [...]} — `Round.finish` does this for you. A
-  non-zero exit (or no result object) records the round as an error.
-
-A mutating program must honor dry_run (record `rnd.would(...)` instead of
-acting) and stay inside its granted capabilities. The builtin programs are
-working examples: `loom overlooker programs --source builtin:archive-merged`.
-
-Register this file once you're happy with it:
-
-    loom overlooker add __NAME__ --program __PATH__ \
-        --every 15m --capabilities observe
-
-Iterate safely — every mutating action is stubbed under --dry-run:
-
-    loom overlooker run __NAME__ --dry-run
+Register:   loom overlooker add __NAME__ --program __PATH__ --every 15m
+Try it:     loom overlooker run __NAME__ --dry-run
 """
 
 from weaver_loom import Round
@@ -1195,14 +1173,9 @@ from weaver_loom import Round
 def main():
     rnd = Round()
     for session in rnd.sessions():
-        # A round is level-triggered: survey the *current* fleet and reconcile,
-        # rather than reacting to the one event that woke you. Decide here —
-        # e.g. read session["branch"]["github"] or its tags — and record an
-        # action per finding:
-        #
+        # Decide per session and record findings, e.g.:
         #     rnd.would("mark", session=session["id"], note="one line on why")
         pass
-
     rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} finding(s)")
 
 

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1147,27 +1147,36 @@ async fn cmd_open() -> Result<()> {
 // ---------------------------------------------------------------------------
 
 /// The starter program a `loom overlooker new` scaffolds: a small, runnable
-/// template against the program contract the engine speaks — the same contract
-/// the builtin scripts implement (`loom overlooker programs --source <name>`
-/// prints one as a fuller example). Plain `replace` rather than `format!`, so
-/// the template's literal braces (JSON, f-strings) stay readable.
+/// template against the `weaver_loom` API layer and the program contract the
+/// engine speaks — the same shape the builtin scripts implement
+/// (`loom overlooker programs --source <name>` prints one as a fuller
+/// example). Plain `replace` rather than `format!`, so the template's literal
+/// braces (JSON, f-strings) stay readable.
 fn scaffold_template(name: &str) -> String {
-    const TEMPLATE: &str = r##""""__NAME__ — a weaver overlooker program (a periodic / triggered watch over the fleet).
+    const TEMPLATE: &str = r##"# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""__NAME__ — a weaver overlooker program (a periodic / triggered watch over the fleet).
 
-The loom engine runs this file as an env-stripped `python3` subprocess. The
-contract:
+The loom engine runs this file as an env-stripped subprocess — via `uv run
+--script` when uv is installed (the PEP 723 block above declares any
+third-party dependencies), else plain `python3`. The `weaver_loom` module —
+the Python layer over the loom REST API — is vendored onto PYTHONPATH by the
+engine; for standalone runs install it from the weaver repo with
+`uv pip install -e python/weaver-loom`.
 
-* `WEAVER_API` — base URL of the loom REST API; drive the fleet through it
-  (plain urllib works; the `weaver_py` binding wraps the same surface, typed
-  and capability-gated).
+The contract:
+
+* `WEAVER_API` — base URL of the loom REST API.
 * `WEAVER_OVERLOOKER` — JSON config for this round:
   {"id", "name", "program", "params", "scope", "capabilities", "dry_run"}.
-* Print one JSON object to stdout: {"outcome": "ok"|"noop", "summary": str,
-  "actions": [...]}. A non-zero exit (or unparseable stdout) records the
-  round as an error.
+* Print one JSON object as the final stdout line: {"outcome": "ok"|"noop",
+  "summary": str, "actions": [...]} — `Round.finish` does this for you. A
+  non-zero exit (or no result object) records the round as an error.
 
-A mutating program must honor dry_run (record {"would": ...} actions instead
-of acting) and stay inside its granted capabilities. The builtin programs are
+A mutating program must honor dry_run (record `rnd.would(...)` instead of
+acting) and stay inside its granted capabilities. The builtin programs are
 working examples: `loom overlooker programs --source builtin:archive-merged`.
 
 Register this file once you're happy with it:
@@ -1180,39 +1189,21 @@ Iterate safely — every mutating action is stubbed under --dry-run:
     loom overlooker run __NAME__ --dry-run
 """
 
-import json
-import os
-import urllib.request
-
-
-def api_get(path):
-    base = os.environ.get("WEAVER_API", "http://127.0.0.1:7878").rstrip("/")
-    with urllib.request.urlopen(base + "/api" + path) as resp:
-        return json.load(resp)
+from weaver_loom import Round
 
 
 def main():
-    cfg = json.loads(os.environ.get("WEAVER_OVERLOOKER", "{}"))
-
-    surveyed = 0
-    actions = []
-    for session in api_get("/sessions"):
-        if session.get("status") in ("done", "error", "archived"):
-            continue
-        surveyed += 1
+    rnd = Round()
+    for session in rnd.sessions():
         # A round is level-triggered: survey the *current* fleet and reconcile,
         # rather than reacting to the one event that woke you. Decide here —
-        # e.g. read session["branch"]["github"] or its tags — and append an
+        # e.g. read session["branch"]["github"] or its tags — and record an
         # action per finding:
         #
-        #     actions.append({"session": session["id"], "would": "mark",
-        #                     "note": "one line on why"})
+        #     rnd.would("mark", session=session["id"], note="one line on why")
+        pass
 
-    print(json.dumps({
-        "outcome": "ok" if actions else "noop",
-        "summary": f"surveyed {surveyed}, {len(actions)} finding(s)",
-        "actions": actions,
-    }))
+    rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} finding(s)")
 
 
 if __name__ == "__main__":
@@ -1761,17 +1752,19 @@ mod tests {
         }
     }
 
-    /// The scaffolded program carries the pieces an author starts from: a
-    /// module docstring and the env/stdout program contract.
+    /// The scaffolded program carries the pieces an author starts from: the
+    /// PEP 723 block (uv-runnable), a docstring documenting the contract, and
+    /// the `weaver_loom` round context.
     #[test]
     fn scaffold_template_is_well_formed() {
         let out = scaffold_template("test-watch");
+        assert!(out.starts_with("# /// script"), "PEP 723 block leads");
         // The docstring opens with exactly three quotes (a malformed `""` would
         // be the most likely raw-string bug).
-        assert!(out.starts_with("\"\"\"test-watch"), "got: {}", &out[..16]);
-        // It documents and implements the program contract.
+        assert!(out.contains("\"\"\"test-watch — "));
+        // It documents the program contract and uses the API layer.
         assert!(out.contains("WEAVER_OVERLOOKER"));
-        assert!(out.contains("import urllib.request"));
+        assert!(out.contains("from weaver_loom import Round"));
         assert!(out.contains("loom overlooker add test-watch"));
     }
 
@@ -1786,7 +1779,7 @@ mod tests {
         let path = home.path().join("overlookers").join("scaffolded.py");
         assert!(path.exists(), "the program file was written");
         let body = std::fs::read_to_string(&path).unwrap();
-        assert!(body.starts_with("\"\"\"scaffolded — "));
+        assert!(body.contains("\"\"\"scaffolded — "));
         // A second `new` of the same name refuses rather than clobbering.
         assert!(cmd_overlooker_new("scaffolded".to_string()).await.is_err());
         std::env::remove_var("WEAVER_HOME");

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -61,6 +61,7 @@ enum Cmd {
     /// escalating to you. Author one as a plain file an agent can edit, then
     /// register it and iterate with `--dry-run`:
     ///
+    ///     loom overlooker programs                 # the builtin programs that ship with loom
     ///     loom overlooker new test-watch          # scaffold ~/.weaver/overlookers/test-watch.py
     ///     loom overlooker add status --cron "0 * * * *" --capabilities observe,mark,escalate
     ///     loom overlooker run status --dry-run     # simulate; mutating actions are stubbed
@@ -177,12 +178,20 @@ enum SessionCmd {
 enum OverlookerCmd {
     /// Scaffold a starter program file at `~/.weaver/overlookers/<name>.py`.
     ///
-    /// Writes a commented Python template using the `weaver` module decorators,
-    /// then prints the path. Edit it, then register it with
+    /// Writes a commented Python template against the program contract (the
+    /// fleet over `$WEAVER_API`, round config in `$WEAVER_OVERLOOKER`, result
+    /// JSON on stdout), then prints the path. Edit it, then register it with
     /// `loom overlooker add <name> --program <path>`.
     New {
         /// The overlooker name; also the file stem (`<name>.py`).
         name: String,
+    },
+    /// List the builtin programs that ship with loom (GET /api/overlookers/programs).
+    Programs {
+        /// Print one program's script source instead of the table, e.g.
+        /// `--source builtin:archive-merged` — a working example to start from.
+        #[arg(long)]
+        source: Option<String>,
     },
     /// Register an overlooker from flags (POST /api/overlookers).
     Add(Box<AddOpts>),
@@ -395,6 +404,7 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
 async fn run_overlooker(cmd: OverlookerCmd) -> Result<()> {
     match cmd {
         OverlookerCmd::New { name } => cmd_overlooker_new(name).await,
+        OverlookerCmd::Programs { source } => cmd_overlooker_programs(source).await,
         OverlookerCmd::Add(opts) => cmd_overlooker_add(*opts).await,
         OverlookerCmd::Rm { name } => cmd_overlooker_rm(name).await,
         OverlookerCmd::Enable { name } => cmd_overlooker_set_enabled(name, true).await,
@@ -1136,56 +1146,81 @@ async fn cmd_open() -> Result<()> {
 // Overlooker commands (the operator + authoring surface)
 // ---------------------------------------------------------------------------
 
-/// The starter program a `loom overlooker new` scaffolds. A small commented
-/// template against the `weaver` module decorators — the file convention an
-/// agent edits. The `{name}` placeholder is the overlooker's name.
+/// The starter program a `loom overlooker new` scaffolds: a small, runnable
+/// template against the program contract the engine speaks — the same contract
+/// the builtin scripts implement (`loom overlooker programs --source <name>`
+/// prints one as a fuller example). Plain `replace` rather than `format!`, so
+/// the template's literal braces (JSON, f-strings) stay readable.
 fn scaffold_template(name: &str) -> String {
-    format!(
-        r##""""{name} — a weaver overlooker (a periodic / triggered watch over the fleet).
+    const TEMPLATE: &str = r##""""__NAME__ — a weaver overlooker program (a periodic / triggered watch over the fleet).
 
-This program is run by the loom overlooker engine as an env-stripped subprocess.
-It uses the `weaver` Python module — the PyO3 binding (`weaver-py`, shipped
-separately) that wraps the same loom REST API the `loom session ...` commands
-use. So the vocabulary you explore the fleet with on the CLI is the vocabulary
-you call here: `ov.sessions(...)`, `s.preview()`, `s.mark(...)`, `s.nudge(...)`.
+The loom engine runs this file as an env-stripped `python3` subprocess. The
+contract:
+
+* `WEAVER_API` — base URL of the loom REST API; drive the fleet through it
+  (plain urllib works; the `weaver_py` binding wraps the same surface, typed
+  and capability-gated).
+* `WEAVER_OVERLOOKER` — JSON config for this round:
+  {"id", "name", "program", "params", "scope", "capabilities", "dry_run"}.
+* Print one JSON object to stdout: {"outcome": "ok"|"noop", "summary": str,
+  "actions": [...]}. A non-zero exit (or unparseable stdout) records the
+  round as an error.
+
+A mutating program must honor dry_run (record {"would": ...} actions instead
+of acting) and stay inside its granted capabilities. The builtin programs are
+working examples: `loom overlooker programs --source builtin:archive-merged`.
 
 Register this file once you're happy with it:
 
-    loom overlooker add {name} --program {path} \
-        --cron "0 * * * *" --capabilities observe,mark,escalate
+    loom overlooker add __NAME__ --program __PATH__ \
+        --every 15m --capabilities observe
 
 Iterate safely — every mutating action is stubbed under --dry-run:
 
-    loom overlooker run {name} --dry-run
+    loom overlooker run __NAME__ --dry-run
 """
 
-import weaver
+import json
+import os
+import urllib.request
 
 
-@weaver.on_cron("0 * * * *")  # the trigger — a cron event source (hourly)
-def {ident}(ov):
-    # A round is level-triggered: survey the *current* scoped fleet and
-    # reconcile, rather than reacting to the one event that woke you.
-    for s in ov.sessions(attention="!ok"):
-        # Cheap mechanical rule — no model, no cost.
-        if s.idle_minutes() > 30 and s.pr_checks() == "failing":
-            s.mark("attention", "idle 30m with red CI")
+def api_get(path):
+    base = os.environ.get("WEAVER_API", "http://127.0.0.1:7878").rstrip("/")
+    with urllib.request.urlopen(base + "/api" + path) as resp:
+        return json.load(resp)
+
+
+def main():
+    cfg = json.loads(os.environ.get("WEAVER_OVERLOOKER", "{}"))
+
+    surveyed = 0
+    actions = []
+    for session in api_get("/sessions"):
+        if session.get("status") in ("done", "error", "archived"):
             continue
+        surveyed += 1
+        # A round is level-triggered: survey the *current* fleet and reconcile,
+        # rather than reacting to the one event that woke you. Decide here —
+        # e.g. read session["branch"]["github"] or its tags — and append an
+        # action per finding:
+        #
+        #     actions.append({"session": session["id"], "would": "mark",
+        #                     "note": "one line on why"})
 
-        # …or a fresh agent for the judgement call.
-        verdict = ov.run_agent(
-            f"Is this session stuck? Screen:\n{{s.preview(200)}}"
-        )
-        s.mark(verdict.level, verdict.note)
+    print(json.dumps({
+        "outcome": "ok" if actions else "noop",
+        "summary": f"surveyed {surveyed}, {len(actions)} finding(s)",
+        "actions": actions,
+    }))
 
-        # The nudge rung of the intervention ladder — capability-gated.
-        if verdict.level != "ok" and ov.can("nudge"):
-            s.nudge(verdict.suggestion)
-"##,
-        name = name,
-        ident = name.replace(['-', '.', ' '], "_"),
-        path = overlooker_path(name).display(),
-    )
+
+if __name__ == "__main__":
+    main()
+"##;
+    TEMPLATE
+        .replace("__NAME__", name)
+        .replace("__PATH__", &overlooker_path(name).display().to_string())
 }
 
 /// The conventional path for an overlooker's program file:
@@ -1221,6 +1256,40 @@ async fn cmd_overlooker_new(name: String) -> Result<()> {
         "    loom overlooker add {name} --program {} --cron \"0 * * * *\"",
         path.display()
     );
+    Ok(())
+}
+
+/// `loom overlooker programs` — list the builtin programs that ship with loom
+/// (the registry the panel offers), or print one program's script source with
+/// `--source` as a working example to start a custom program from.
+async fn cmd_overlooker_programs(source: Option<String>) -> Result<()> {
+    let client = client::default();
+    let rows = client
+        .get("/api/overlookers/programs")
+        .await?
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    if let Some(want) = source {
+        let row = rows.iter().find(|p| str_field(p, "program") == want);
+        let Some(row) = row else {
+            bail!("no builtin program '{want}' — `loom overlooker programs` lists them");
+        };
+        match row.get("source").and_then(Value::as_str) {
+            Some(src) => print!("{src}"),
+            None => bail!("'{want}' is a native (in-Rust) program with no script source"),
+        }
+        return Ok(());
+    }
+    println!("{:<26}  {:<8}  TITLE", "PROGRAM", "KIND");
+    for p in rows {
+        println!(
+            "{:<26}  {:<8}  {}",
+            str_field(&p, "program"),
+            str_field(&p, "kind"),
+            str_field(&p, "title"),
+        );
+    }
     Ok(())
 }
 
@@ -1536,6 +1605,34 @@ mod tests {
         Cli::command().debug_assert();
     }
 
+    /// The scaffold must honor the contract it documents — at minimum, be
+    /// valid Python with the placeholders filled in. Skips without `python3`
+    /// (the same degradation the engine applies).
+    #[test]
+    fn scaffold_template_is_valid_python() {
+        if !loom::builtins::python3_available() {
+            eprintln!("skipping: python3 not on PATH");
+            return;
+        }
+        let rendered = scaffold_template("test-watch");
+        assert!(rendered.contains("test-watch"), "the name is filled in");
+        assert!(!rendered.contains("__NAME__"), "no placeholder survives");
+        assert!(!rendered.contains("__PATH__"), "no placeholder survives");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-watch.py");
+        std::fs::write(&path, rendered).unwrap();
+        let out = std::process::Command::new("python3")
+            .args(["-m", "py_compile"])
+            .arg(&path)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "the scaffold does not compile: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
     #[test]
     fn terminal_statuses_match_the_session_model() {
         for s in ["done", "error", "archived"] {
@@ -1664,17 +1761,17 @@ mod tests {
         }
     }
 
-    /// The scaffolded program is valid Python: a module docstring, the
-    /// `import weaver`, and a cron-decorated round whose name is a safe ident.
+    /// The scaffolded program carries the pieces an author starts from: a
+    /// module docstring and the env/stdout program contract.
     #[test]
     fn scaffold_template_is_well_formed() {
         let out = scaffold_template("test-watch");
         // The docstring opens with exactly three quotes (a malformed `""` would
         // be the most likely raw-string bug).
         assert!(out.starts_with("\"\"\"test-watch"), "got: {}", &out[..16]);
-        assert!(out.contains("import weaver"));
-        // `-` in the name becomes `_` so the function name is a valid ident.
-        assert!(out.contains("def test_watch(ov):"));
+        // It documents and implements the program contract.
+        assert!(out.contains("WEAVER_OVERLOOKER"));
+        assert!(out.contains("import urllib.request"));
         assert!(out.contains("loom overlooker add test-watch"));
     }
 
@@ -1689,7 +1786,7 @@ mod tests {
         let path = home.path().join("overlookers").join("scaffolded.py");
         assert!(path.exists(), "the program file was written");
         let body = std::fs::read_to_string(&path).unwrap();
-        assert!(body.contains("def scaffolded(ov):"));
+        assert!(body.starts_with("\"\"\"scaffolded — "));
         // A second `new` of the same name refuses rather than clobbering.
         assert!(cmd_overlooker_new("scaffolded".to_string()).await.is_err());
         std::env::remove_var("WEAVER_HOME");

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -1,0 +1,199 @@
+//! The **builtin overlooker programs** — the stock programs that ship inside
+//! the loom binary and that an overlooker's `program` field names as
+//! `builtin:<name>`.
+//!
+//! Two kinds share the registry:
+//!
+//! * **native** — implemented in Rust inside the engine (`builtin:status`).
+//! * **script** — a real Python file under `crates/loom/overlookers/`,
+//!   embedded here with `include_str!` and run by the engine's script
+//!   executor ([`crate::overlooker`]) exactly like a user's custom program
+//!   file. Living in the repo makes each one diffable, reviewable, and the
+//!   working example of the program contract; the panel shows the source
+//!   read-only.
+//!
+//! `GET /api/overlookers/programs` serves this table (as [`ProgramView`]s) so
+//! the panel and the `loom overlooker programs` CLI list one source of truth.
+
+use serde_json::{json, Value};
+use weaver_api::ProgramView;
+
+/// One stock program: its identity, its embedded source (for a script), and
+/// the suggested starting config a create form prefills. The JSON-bearing
+/// defaults are stored as text so the table stays a flat `const`.
+pub struct BuiltinProgram {
+    /// The short name; the program reference is `builtin:<name>`.
+    pub name: &'static str,
+    pub title: &'static str,
+    pub description: &'static str,
+    /// The embedded Python source, or `None` for a native (in-Rust) program.
+    pub source: Option<&'static str>,
+    pub default_trigger: &'static str,
+    pub default_scope: &'static str,
+    pub default_params: &'static str,
+    pub default_capabilities: &'static [&'static str],
+}
+
+/// Every builtin program, in the order the panel lists them.
+pub const BUILTINS: &[BuiltinProgram] = &[
+    BuiltinProgram {
+        name: "status",
+        title: "Status check",
+        description: "Survey the scoped fleet and stamp a triage mark on each \
+                      session — judgement via the configured prompt (a one-shot \
+                      agent when available), else mirroring the agent's own \
+                      attention tag.",
+        source: None,
+        default_trigger: r#"{"cron":"0 * * * *"}"#,
+        default_scope: r#"{"attention":"!ok"}"#,
+        default_params: "{}",
+        default_capabilities: &["observe", "mark", "escalate"],
+    },
+    BuiltinProgram {
+        name: "pr-label",
+        title: "PR labeller",
+        description: "Flag sessions whose open pull request lacks the loom \
+                      label (params.label, default 'weaver'), so PRs born from \
+                      sessions are identifiable on GitHub. Read-only: it \
+                      reports would-label actions.",
+        source: Some(include_str!("../overlookers/pr_label.py")),
+        default_trigger: r#"{"every":"15m"}"#,
+        default_scope: "{}",
+        default_params: r#"{"label":"weaver"}"#,
+        default_capabilities: &["observe"],
+    },
+    BuiltinProgram {
+        name: "archive-merged",
+        title: "Archive merged",
+        description: "Flag live sessions whose pull request has merged — \
+                      integrated work whose session is ready to archive. \
+                      Read-only: it reports would-archive actions (the \
+                      github.archive_on_merge setting still performs the \
+                      archive).",
+        source: Some(include_str!("../overlookers/archive_merged.py")),
+        default_trigger: r#"{"every":"5m"}"#,
+        default_scope: "{}",
+        default_params: "{}",
+        default_capabilities: &["observe"],
+    },
+];
+
+impl BuiltinProgram {
+    /// The reference an overlooker's `program` field uses: `builtin:<name>`.
+    pub fn program(&self) -> String {
+        format!("builtin:{}", self.name)
+    }
+
+    /// The wire view: defaults parsed into structured JSON, source attached.
+    pub fn view(&self) -> ProgramView {
+        let parse = |s: &str| serde_json::from_str::<Value>(s).unwrap_or_else(|_| json!({}));
+        ProgramView {
+            program: self.program(),
+            title: self.title.to_string(),
+            description: self.description.to_string(),
+            kind: if self.source.is_some() {
+                "script"
+            } else {
+                "native"
+            }
+            .to_string(),
+            source: self.source.map(str::to_string),
+            defaults: json!({
+                "trigger": parse(self.default_trigger),
+                "scope": parse(self.default_scope),
+                "params": parse(self.default_params),
+                "capabilities": self.default_capabilities,
+            }),
+        }
+    }
+}
+
+/// Resolve a `builtin:<name>` program reference against the registry. Any
+/// other shape (a file path, an unknown builtin) is `None`.
+pub fn find(program: &str) -> Option<&'static BuiltinProgram> {
+    let name = program.strip_prefix("builtin:")?;
+    BUILTINS.iter().find(|b| b.name == name)
+}
+
+/// Whether `python3` is on PATH — whether script programs can run here. The
+/// engine itself degrades per-round (a missing interpreter errors that round
+/// with a clear message); this probe is for the call sites that want to know
+/// up front, e.g. tests that skip rather than fail without an interpreter.
+pub fn python3_available() -> bool {
+    std::process::Command::new("python3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_resolves_builtin_refs_only() {
+        assert_eq!(find("builtin:status").unwrap().name, "status");
+        assert_eq!(find("builtin:pr-label").unwrap().name, "pr-label");
+        assert!(find("builtin:nope").is_none());
+        assert!(find("/abs/path.py").is_none());
+        assert!(find("status").is_none());
+    }
+
+    #[test]
+    fn registry_is_well_formed() {
+        for b in BUILTINS {
+            // The default consts must be real JSON objects — parsed strictly
+            // here, so a typo'd const fails the test rather than silently
+            // becoming the `{}` fallback `view()` applies.
+            for (field, raw) in [
+                ("trigger", b.default_trigger),
+                ("scope", b.default_scope),
+                ("params", b.default_params),
+            ] {
+                let parsed: Value = serde_json::from_str(raw)
+                    .unwrap_or_else(|e| panic!("{}: default {field} is not JSON: {e}", b.name));
+                assert!(parsed.is_object(), "{}: default {field}", b.name);
+            }
+            for cap in b.default_capabilities {
+                assert!(
+                    weaver_core::overlooker::CAPABILITIES.contains(cap),
+                    "{}: unknown capability {cap}",
+                    b.name
+                );
+            }
+            // The wire view: kind tracks the presence of source.
+            let v = b.view();
+            assert!(v.program.starts_with("builtin:"));
+            assert_eq!(v.kind == "script", v.source.is_some());
+        }
+    }
+
+    /// Every embedded script must at least be valid Python — `py_compile` is
+    /// the cheap structural gate. Skips when `python3` is absent (the same
+    /// graceful degradation the engine applies at run time).
+    #[test]
+    fn embedded_scripts_compile() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not on PATH");
+            return;
+        }
+        for b in BUILTINS {
+            let Some(source) = b.source else { continue };
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join(format!("{}.py", b.name));
+            std::fs::write(&path, source).unwrap();
+            let out = std::process::Command::new("python3")
+                .args(["-m", "py_compile"])
+                .arg(&path)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "builtin:{} does not compile: {}",
+                b.name,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+    }
+}

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -18,6 +18,13 @@
 use serde_json::{json, Value};
 use weaver_api::ProgramView;
 
+/// The `weaver_loom` Python module — the API layer over the loom REST API that
+/// overlooker programs import. Vendored into the binary so the engine can
+/// place it on every script's `PYTHONPATH` (no install step); the source of
+/// truth (and the installable package) is `python/weaver-loom/`.
+pub const PYTHON_MODULE: &str =
+    include_str!("../../../python/weaver-loom/src/weaver_loom/__init__.py");
+
 /// One stock program: its identity, its embedded source (for a script), and
 /// the suggested starting config a create form prefills. The JSON-bearing
 /// defaults are stored as text so the table stays a flat `const`.
@@ -178,10 +185,13 @@ mod tests {
             eprintln!("skipping: python3 not on PATH");
             return;
         }
-        for b in BUILTINS {
-            let Some(source) = b.source else { continue };
+        let scripts = BUILTINS
+            .iter()
+            .filter_map(|b| Some((b.name, b.source?)))
+            .chain([("weaver_loom", PYTHON_MODULE)]);
+        for (name, source) in scripts {
             let dir = tempfile::tempdir().unwrap();
-            let path = dir.path().join(format!("{}.py", b.name));
+            let path = dir.path().join(format!("{name}.py"));
             std::fs::write(&path, source).unwrap();
             let out = std::process::Command::new("python3")
                 .args(["-m", "py_compile"])
@@ -190,8 +200,7 @@ mod tests {
                 .unwrap();
             assert!(
                 out.status.success(),
-                "builtin:{} does not compile: {}",
-                b.name,
+                "{name} does not compile: {}",
                 String::from_utf8_lossy(&out.stderr)
             );
         }

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -6,6 +6,7 @@
 //! purely additive.
 
 pub mod agent;
+pub mod builtins;
 pub mod client;
 pub mod db;
 pub mod endpoint;

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -462,18 +462,18 @@ async fn run_program(
         return builtin_status(state, o, dry_run).await;
     }
     if let Some(source) = crate::builtins::find(&o.program).and_then(|b| b.source) {
-        // Materialize the embedded source to a scratch file so a traceback
-        // carries a real file/line; the dir is removed when the round ends.
-        let dir = tempfile::tempdir().map_err(|e| anyhow::anyhow!("creating scratch dir: {e}"))?;
-        let path = dir.path().join(program_file_name(&o.program));
-        tokio::fs::write(&path, source)
-            .await
-            .map_err(|e| anyhow::anyhow!("writing {}: {e}", path.display()))?;
-        return run_script(state, o, dry_run, &path).await;
+        let file_name = program_file_name(&o.program);
+        return run_script(
+            state,
+            o,
+            dry_run,
+            ScriptSource::Embedded { file_name, source },
+        )
+        .await;
     }
     let path = std::path::PathBuf::from(&o.program);
     if path.is_absolute() {
-        return run_script(state, o, dry_run, &path).await;
+        return run_script(state, o, dry_run, ScriptSource::File(path)).await;
     }
     Err(anyhow::anyhow!(
         "unknown overlooker program '{}' — expected 'builtin:<name>' or an absolute path",
@@ -487,21 +487,93 @@ fn program_file_name(program: &str) -> String {
     format!("{}.py", program.strip_prefix("builtin:").unwrap_or(program))
 }
 
-/// Run a **script program**: an env-stripped `python3` subprocess (the
-/// lint-review precedent, like [`run_agent`]). The script reaches the fleet
-/// only through the loom REST API — `$WEAVER_API` carries the daemon's own
-/// address — and reads its round config from `$WEAVER_OVERLOOKER`
-/// (`{id, name, program, params, scope, capabilities, dry_run}`). Its contract
-/// is to print one JSON object, `{outcome, summary, actions}`, to stdout; a
-/// non-zero exit or unparseable stdout errors the round. The wall-clock budget
-/// in [`fire`] bounds it, and `kill_on_drop` reaps the subprocess when that
-/// budget cancels the future.
+/// Where a script program's code comes from: embedded in the binary (a
+/// builtin) or a file on disk (a custom program).
+enum ScriptSource {
+    Embedded {
+        file_name: String,
+        source: &'static str,
+    },
+    File(std::path::PathBuf),
+}
+
+/// Whether a script opts into PEP 723 inline metadata (`# /// script`). Such a
+/// script declares its own dependencies, so the engine prefers `uv run
+/// --script` — which resolves them — when `uv` is installed; a plain script
+/// runs under `python3` directly.
+fn has_pep723(source: &str) -> bool {
+    source.lines().any(|l| l.trim() == "# /// script")
+}
+
+/// Whether the `uv` CLI is usable. Probed once and cached, like
+/// [`crate::github::gh_available`] — absence is normal and shouldn't cost a
+/// process spawn every round.
+async fn uv_available() -> bool {
+    static AVAILABLE: tokio::sync::OnceCell<bool> = tokio::sync::OnceCell::const_new();
+    *AVAILABLE
+        .get_or_init(|| async {
+            tokio::process::Command::new("uv")
+                .arg("--version")
+                .output()
+                .await
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .await
+}
+
+/// Run a **script program**: an env-stripped subprocess (the lint-review
+/// precedent, like [`run_agent`]) that reaches the fleet only through the loom
+/// REST API. `$WEAVER_API` carries the daemon's own address and
+/// `$WEAVER_OVERLOOKER` the round config (`{id, name, program, params, scope,
+/// capabilities, dry_run}`); the vendored `weaver_loom` module rides
+/// `PYTHONPATH` so every program can import the API layer with no install
+/// step. The contract is to print one JSON object — `{outcome, summary,
+/// actions}` — as the final stdout line; a non-zero exit or unparseable
+/// stdout errors the round. The wall-clock budget in [`fire`] bounds it, and
+/// `kill_on_drop` reaps the subprocess when that budget cancels the future.
+///
+/// The interpreter is `python3`, or `uv run --script` when the script declares
+/// PEP 723 inline metadata and `uv` is installed (so a custom program can
+/// declare third-party dependencies; the builtins are stdlib-only).
 async fn run_script(
     state: &AppState,
     o: &Overlooker,
     dry_run: bool,
-    script: &std::path::Path,
+    src: ScriptSource,
 ) -> anyhow::Result<RoundResult> {
+    // One scratch dir per round: the vendored module always lands here (for
+    // PYTHONPATH), an embedded builtin's source too (so a traceback carries a
+    // real file/line). Removed when the round ends.
+    let scratch = tempfile::tempdir().map_err(|e| anyhow::anyhow!("creating scratch dir: {e}"))?;
+    let module = scratch.path().join("weaver_loom.py");
+    tokio::fs::write(&module, crate::builtins::PYTHON_MODULE)
+        .await
+        .map_err(|e| anyhow::anyhow!("writing {}: {e}", module.display()))?;
+
+    let (script_path, source) = match &src {
+        ScriptSource::Embedded { file_name, source } => {
+            let path = scratch.path().join(file_name);
+            tokio::fs::write(&path, source)
+                .await
+                .map_err(|e| anyhow::anyhow!("writing {}: {e}", path.display()))?;
+            (path, source.to_string())
+        }
+        // The source is read only to detect PEP 723 metadata; a missing file
+        // surfaces as the spawn error below, with the path in it.
+        ScriptSource::File(path) => (
+            path.clone(),
+            tokio::fs::read_to_string(path).await.unwrap_or_default(),
+        ),
+    };
+
+    let pythonpath = match std::env::var("PYTHONPATH") {
+        Ok(existing) if !existing.is_empty() => {
+            format!("{}:{existing}", scratch.path().display())
+        }
+        _ => scratch.path().display().to_string(),
+    };
+
     let config = json!({
         "id": o.id,
         "name": o.name,
@@ -512,11 +584,20 @@ async fn run_script(
         "dry_run": dry_run,
     });
 
-    let mut command = tokio::process::Command::new("python3");
+    let interpreter = if has_pep723(&source) && uv_available().await {
+        "uv"
+    } else {
+        "python3"
+    };
+    let mut command = tokio::process::Command::new(interpreter);
+    if interpreter == "uv" {
+        command.args(["run", "--quiet", "--script"]);
+    }
     command
-        .arg(script)
+        .arg(&script_path)
         .env("WEAVER_API", api_base(&state.addr))
         .env("WEAVER_OVERLOOKER", config.to_string())
+        .env("PYTHONPATH", pythonpath)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -527,7 +608,7 @@ async fn run_script(
 
     let out = command.output().await.map_err(|e| {
         anyhow::anyhow!(
-            "spawning python3 for '{}' failed: {e} (is python3 installed?)",
+            "spawning {interpreter} for '{}' failed: {e} (is {interpreter} installed?)",
             o.program
         )
     })?;
@@ -561,12 +642,19 @@ fn api_base(addr: &str) -> String {
     format!("http://{dialable}")
 }
 
-/// Parse a script's stdout into a [`RoundResult`]. The stdout must be one JSON
-/// object; the fields are read leniently — a missing/unknown `outcome` reads as
-/// `ok`, a missing `summary` as empty, a missing/non-array `actions` as none —
-/// so a minimal script stays minimal.
+/// Parse a script's stdout into a [`RoundResult`]: the whole stdout as one
+/// JSON object, or — so a script may log progress lines first — the **last**
+/// stdout line that is one. The fields are read leniently: a missing/unknown
+/// `outcome` reads as `ok`, a missing `summary` as empty, a missing/non-array
+/// `actions` as none — so a minimal script stays minimal.
 fn parse_round_result(stdout: &str) -> Option<RoundResult> {
-    let v: Value = serde_json::from_str(stdout.trim()).ok()?;
+    let trimmed = stdout.trim();
+    parse_result_object(trimmed).or_else(|| trimmed.lines().rev().find_map(parse_result_object))
+}
+
+/// One candidate result line → [`RoundResult`], if it is a JSON object.
+fn parse_result_object(text: &str) -> Option<RoundResult> {
+    let v: Value = serde_json::from_str(text.trim()).ok()?;
     let obj = v.as_object()?;
     let outcome = obj
         .get("outcome")
@@ -1114,10 +1202,28 @@ mod tests {
         assert_eq!(r.summary, "");
         assert_eq!(r.actions, Value::Array(vec![]));
 
-        // Anything that isn't one JSON object is a contract violation.
+        // A script may log progress lines first; the result is the last JSON
+        // object line on stdout.
+        let r = parse_round_result(
+            "surveying...\n3 sessions seen\n{\"outcome\":\"ok\",\"summary\":\"done\"}\n",
+        )
+        .unwrap();
+        assert_eq!(r.summary, "done");
+
+        // Anything without a JSON object is a contract violation.
         assert!(parse_round_result("").is_none());
         assert!(parse_round_result("not json").is_none());
         assert!(parse_round_result("[1, 2]").is_none());
+    }
+
+    #[test]
+    fn has_pep723_detects_the_inline_metadata_block() {
+        assert!(has_pep723(
+            "# /// script\n# dependencies = []\n# ///\nprint()"
+        ));
+        assert!(has_pep723("#!/usr/bin/env python3\n# /// script\n# ///\n"));
+        assert!(!has_pep723("import weaver_loom\n"));
+        assert!(!has_pep723("# script\n# ///\n"));
     }
 
     #[test]
@@ -1159,9 +1265,11 @@ mod tests {
         (state, o)
     }
 
-    /// A custom script file round-trips the whole contract: it reads its round
-    /// config from `$WEAVER_OVERLOOKER` (params and the dry-run flag included)
-    /// and its printed `{outcome, summary, actions}` lands on the run row.
+    /// A custom script file round-trips the whole contract **through the
+    /// vendored `weaver_loom` module**: the engine puts the API layer on
+    /// PYTHONPATH, the `Round` context exposes the `$WEAVER_OVERLOOKER` config
+    /// (params and the dry-run flag included), and `finish()`'s printed
+    /// `{outcome, summary, actions}` lands on the run row.
     #[tokio::test]
     async fn run_script_round_trips_the_contract() {
         if !python3_available() {
@@ -1173,15 +1281,12 @@ mod tests {
         std::fs::write(
             &script,
             r#"
-import json, os
-cfg = json.loads(os.environ["WEAVER_OVERLOOKER"])
-print(json.dumps({
-    "outcome": "ok",
-    "summary": "name=%s label=%s dry=%s api=%s" % (
-        cfg["name"], cfg["params"]["label"], json.dumps(cfg["dry_run"]),
-        os.environ["WEAVER_API"]),
-    "actions": [{"would": "label", "note": "from the script"}],
-}))
+import json
+from weaver_loom import Round
+rnd = Round()
+rnd.would("label", note="from the script")
+rnd.finish("name=%s label=%s dry=%s api=%s" % (
+    rnd.name, rnd.params["label"], json.dumps(rnd.dry_run), rnd.client.base))
 "#,
         )
         .unwrap();
@@ -1196,11 +1301,11 @@ print(json.dumps({
             .into_iter()
             .find(|r| r.id == run_id)
             .unwrap();
-        assert_eq!(run.outcome, "ok");
+        assert_eq!(run.outcome, "ok", "summary: {}", run.summary);
         assert!(
             run.summary
                 .contains("name=script-test label=weaver dry=true api=http://127.0.0.1:0"),
-            "the script saw its config: {}",
+            "the script saw its config through the module: {}",
             run.summary
         );
         let actions: Value = serde_json::from_str(&run.actions).unwrap();

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -26,10 +26,13 @@
 //! A **round** is one execution ([`fire`]). It is **level-triggered**: the event
 //! that woke it is only a nudge to re-survey the *current* scoped fleet — it
 //! never "handles" the specific event, so firing twice is idempotent. The round
-//! runs a **program** (the declarative `builtin:status` stock program here)
-//! under the non-optional guardrails — no-overlap, cooldown, timeout,
-//! no-recursion — and records every mutating action as both an
-//! `overlooker_runs` action entry and an `events` row (the audit rule).
+//! runs a **program** under the non-optional guardrails — no-overlap, cooldown,
+//! timeout, no-recursion — and records every mutating action as both an
+//! `overlooker_runs` action entry and an `events` row (the audit rule). Three
+//! program shapes share that one substrate ([`run_program`]): the native
+//! `builtin:status` stock program (in-process Rust), the builtin **scripts**
+//! embedded from [`crate::builtins`], and custom program files — the last two
+//! run by the same subprocess executor ([`run_script`]).
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -446,20 +449,160 @@ struct RoundResult {
     actions: Value,
 }
 
-/// Dispatch to the program the overlooker names. Today only the declarative
-/// `builtin:status` stock program exists; a custom file path would route to a
-/// Python-subprocess executor (a follow-up, see the module docs).
+/// Dispatch to the program the overlooker names: the native `builtin:status`
+/// stock program, a builtin **script** embedded from [`crate::builtins`], or a
+/// custom program file (an absolute path, conventionally under
+/// `~/.weaver/overlookers/`) — the scripts both run on [`run_script`].
 async fn run_program(
     state: &AppState,
     o: &Overlooker,
     dry_run: bool,
 ) -> anyhow::Result<RoundResult> {
-    match o.program.as_str() {
-        "builtin:status" => builtin_status(state, o, dry_run).await,
-        other => Err(anyhow::anyhow!(
-            "unknown overlooker program '{other}' (only builtin:status is implemented)"
-        )),
+    if o.program == "builtin:status" {
+        return builtin_status(state, o, dry_run).await;
     }
+    if let Some(source) = crate::builtins::find(&o.program).and_then(|b| b.source) {
+        // Materialize the embedded source to a scratch file so a traceback
+        // carries a real file/line; the dir is removed when the round ends.
+        let dir = tempfile::tempdir().map_err(|e| anyhow::anyhow!("creating scratch dir: {e}"))?;
+        let path = dir.path().join(program_file_name(&o.program));
+        tokio::fs::write(&path, source)
+            .await
+            .map_err(|e| anyhow::anyhow!("writing {}: {e}", path.display()))?;
+        return run_script(state, o, dry_run, &path).await;
+    }
+    let path = std::path::PathBuf::from(&o.program);
+    if path.is_absolute() {
+        return run_script(state, o, dry_run, &path).await;
+    }
+    Err(anyhow::anyhow!(
+        "unknown overlooker program '{}' — expected 'builtin:<name>' or an absolute path",
+        o.program
+    ))
+}
+
+/// A scratch file name for an embedded builtin: `builtin:pr-label` →
+/// `pr-label.py`, so its tracebacks read like the program they came from.
+fn program_file_name(program: &str) -> String {
+    format!("{}.py", program.strip_prefix("builtin:").unwrap_or(program))
+}
+
+/// Run a **script program**: an env-stripped `python3` subprocess (the
+/// lint-review precedent, like [`run_agent`]). The script reaches the fleet
+/// only through the loom REST API — `$WEAVER_API` carries the daemon's own
+/// address — and reads its round config from `$WEAVER_OVERLOOKER`
+/// (`{id, name, program, params, scope, capabilities, dry_run}`). Its contract
+/// is to print one JSON object, `{outcome, summary, actions}`, to stdout; a
+/// non-zero exit or unparseable stdout errors the round. The wall-clock budget
+/// in [`fire`] bounds it, and `kill_on_drop` reaps the subprocess when that
+/// budget cancels the future.
+async fn run_script(
+    state: &AppState,
+    o: &Overlooker,
+    dry_run: bool,
+    script: &std::path::Path,
+) -> anyhow::Result<RoundResult> {
+    let config = json!({
+        "id": o.id,
+        "name": o.name,
+        "program": o.program,
+        "params": o.params(),
+        "scope": serde_json::to_value(o.scope()).unwrap_or(Value::Null),
+        "capabilities": o.capabilities(),
+        "dry_run": dry_run,
+    });
+
+    let mut command = tokio::process::Command::new("python3");
+    command
+        .arg(script)
+        .env("WEAVER_API", api_base(&state.addr))
+        .env("WEAVER_OVERLOOKER", config.to_string())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    for key in STRIPPED_ENV {
+        command.env_remove(key);
+    }
+
+    let out = command.output().await.map_err(|e| {
+        anyhow::anyhow!(
+            "spawning python3 for '{}' failed: {e} (is python3 installed?)",
+            o.program
+        )
+    })?;
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if !out.status.success() {
+        anyhow::bail!(
+            "script exited with {}: {}",
+            out.status.code().unwrap_or(-1),
+            tail(&stderr, 400)
+        );
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    parse_round_result(&stdout).ok_or_else(|| {
+        anyhow::anyhow!(
+            "script printed no result JSON object ({{outcome, summary, actions}}); stdout: {}; stderr: {}",
+            tail(&stdout, 200),
+            tail(&stderr, 200)
+        )
+    })
+}
+
+/// The REST base URL a script subprocess targets — the daemon's own bound
+/// address. A wildcard bind (`0.0.0.0` / `[::]`) is mapped to loopback, since
+/// "every interface" is not a dialable host.
+fn api_base(addr: &str) -> String {
+    let dialable = addr
+        .strip_prefix("0.0.0.0:")
+        .or_else(|| addr.strip_prefix("[::]:"))
+        .map(|port| format!("127.0.0.1:{port}"))
+        .unwrap_or_else(|| addr.to_string());
+    format!("http://{dialable}")
+}
+
+/// Parse a script's stdout into a [`RoundResult`]. The stdout must be one JSON
+/// object; the fields are read leniently — a missing/unknown `outcome` reads as
+/// `ok`, a missing `summary` as empty, a missing/non-array `actions` as none —
+/// so a minimal script stays minimal.
+fn parse_round_result(stdout: &str) -> Option<RoundResult> {
+    let v: Value = serde_json::from_str(stdout.trim()).ok()?;
+    let obj = v.as_object()?;
+    let outcome = obj
+        .get("outcome")
+        .and_then(Value::as_str)
+        .filter(|o| ov::OUTCOMES.contains(o))
+        .unwrap_or("ok");
+    let summary = obj
+        .get("summary")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let actions = obj
+        .get("actions")
+        .filter(|a| a.is_array())
+        .cloned()
+        .unwrap_or_else(|| Value::Array(vec![]));
+    Some(RoundResult {
+        outcome: outcome.to_string(),
+        summary: summary.to_string(),
+        actions,
+    })
+}
+
+/// The last `n` bytes-ish of a process stream (on a char boundary), so an
+/// error summary carries the end of a traceback without unbounded length.
+fn tail(s: &str, n: usize) -> String {
+    let s = s.trim();
+    if s.chars().count() <= n {
+        return s.to_string();
+    }
+    let start = s
+        .char_indices()
+        .rev()
+        .nth(n - 1)
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    format!("…{}", &s[start..])
 }
 
 /// The set of every overlooker's warm session id — the sessions a round must
@@ -951,6 +1094,147 @@ mod tests {
         assert_eq!(iso(next), "2026-06-08T11:00:00.000Z");
         // A malformed expression never schedules.
         assert!(next_cron("not a cron", from).is_none());
+    }
+
+    #[test]
+    fn parse_round_result_is_lenient_but_requires_an_object() {
+        // The full contract round-trips.
+        let r = parse_round_result(
+            r#"{"outcome":"noop","summary":"all calm","actions":[{"would":"mark"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(r.outcome, "noop");
+        assert_eq!(r.summary, "all calm");
+        assert_eq!(r.actions.as_array().unwrap().len(), 1);
+
+        // A minimal object gets the lenient defaults; an unknown outcome
+        // clamps to `ok` rather than inventing a new state.
+        let r = parse_round_result(r#"{"outcome":"sideways"}"#).unwrap();
+        assert_eq!(r.outcome, "ok");
+        assert_eq!(r.summary, "");
+        assert_eq!(r.actions, Value::Array(vec![]));
+
+        // Anything that isn't one JSON object is a contract violation.
+        assert!(parse_round_result("").is_none());
+        assert!(parse_round_result("not json").is_none());
+        assert!(parse_round_result("[1, 2]").is_none());
+    }
+
+    #[test]
+    fn api_base_maps_wildcard_binds_to_loopback() {
+        assert_eq!(api_base("127.0.0.1:7878"), "http://127.0.0.1:7878");
+        assert_eq!(api_base("0.0.0.0:7878"), "http://127.0.0.1:7878");
+        assert_eq!(api_base("[::]:7878"), "http://127.0.0.1:7878");
+    }
+
+    #[test]
+    fn tail_keeps_the_end_of_long_streams() {
+        assert_eq!(tail("short", 10), "short");
+        assert_eq!(tail("a long traceback line", 4), "…line");
+        // Multi-byte chars stay on a boundary.
+        assert_eq!(tail("héllo wörld", 4), "…örld");
+    }
+
+    use crate::builtins::python3_available;
+
+    /// An `AppState` over a fresh in-memory db plus an overlooker registered on
+    /// `program` — the minimum for a [`fire`] round to run a script end to end.
+    async fn script_fixture(program: &str) -> (AppState, Overlooker) {
+        let state = AppState {
+            db: crate::db::connect_in_memory().await.unwrap(),
+            bus: events::EventBus::new(),
+            addr: "127.0.0.1:0".to_string(),
+        };
+        let o = ov::create(
+            &state.db,
+            &ov::NewOverlooker {
+                name: "script-test".to_string(),
+                program: program.to_string(),
+                params: r#"{"label":"weaver"}"#.to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        (state, o)
+    }
+
+    /// A custom script file round-trips the whole contract: it reads its round
+    /// config from `$WEAVER_OVERLOOKER` (params and the dry-run flag included)
+    /// and its printed `{outcome, summary, actions}` lands on the run row.
+    #[tokio::test]
+    async fn run_script_round_trips_the_contract() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not on PATH");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("echo_config.py");
+        std::fs::write(
+            &script,
+            r#"
+import json, os
+cfg = json.loads(os.environ["WEAVER_OVERLOOKER"])
+print(json.dumps({
+    "outcome": "ok",
+    "summary": "name=%s label=%s dry=%s api=%s" % (
+        cfg["name"], cfg["params"]["label"], json.dumps(cfg["dry_run"]),
+        os.environ["WEAVER_API"]),
+    "actions": [{"would": "label", "note": "from the script"}],
+}))
+"#,
+        )
+        .unwrap();
+
+        let (state, o) = script_fixture(&script.display().to_string()).await;
+        let run_id = fire(&state, &new_in_flight(), &o, "manual", true)
+            .await
+            .unwrap();
+        let run = ov::recent_runs(&state.db, &o.id, 10)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|r| r.id == run_id)
+            .unwrap();
+        assert_eq!(run.outcome, "ok");
+        assert!(
+            run.summary
+                .contains("name=script-test label=weaver dry=true api=http://127.0.0.1:0"),
+            "the script saw its config: {}",
+            run.summary
+        );
+        let actions: Value = serde_json::from_str(&run.actions).unwrap();
+        assert_eq!(actions[0]["would"], "label");
+    }
+
+    /// A failing script errors the round with the stderr tail in the summary,
+    /// and a missing program file errors rather than wedging.
+    #[tokio::test]
+    async fn run_script_failures_are_recorded_as_errors() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not on PATH");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("boom.py");
+        std::fs::write(&script, "raise RuntimeError('kaboom')\n").unwrap();
+
+        let (state, o) = script_fixture(&script.display().to_string()).await;
+        let run_id = fire(&state, &new_in_flight(), &o, "manual", false)
+            .await
+            .unwrap();
+        let run = ov::recent_runs(&state.db, &o.id, 10)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|r| r.id == run_id)
+            .unwrap();
+        assert_eq!(run.outcome, "error");
+        assert!(
+            run.summary.contains("kaboom"),
+            "the stderr tail names the failure: {}",
+            run.summary
+        );
     }
 
     #[test]

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -90,7 +90,8 @@ use crate::{agent, config, db, events, git, github, overlooker as ov_engine, rep
 use weaver_api::{
     BranchView, CreateIssueReq, CreateOverlookerReq, CreateRepoIssueReq, CreateReq, IssueView,
     OverlookerRunView, OverlookerView, PatchIssueReq, PatchOverlookerReq, PatchSessionReq,
-    PlanTaskView, PlanView, RunOverlookerReq, ScratchUpload, SendReq, SessionView, TagReq,
+    PlanTaskView, PlanView, ProgramView, RunOverlookerReq, ScratchUpload, SendReq, SessionView,
+    TagReq,
 };
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::Branch;
@@ -312,6 +313,9 @@ pub fn router(state: AppState) -> Router {
             "/overlookers",
             get(list_overlookers).post(create_overlooker),
         )
+        // The static segment wins over the `{id}` capture below, so a program
+        // named "programs" can't shadow this listing.
+        .route("/overlookers/programs", get(list_programs))
         .route(
             "/overlookers/{id}",
             get(get_overlooker)
@@ -2281,17 +2285,36 @@ fn validate_capabilities(caps: &[String]) -> ApiResult<()> {
     Ok(())
 }
 
-/// A program reference must be a stock `builtin:*` program or an absolute path
-/// (a file under `~/.weaver/overlookers/`); a bare relative path is rejected so
-/// the engine never resolves it against an ambiguous cwd.
+/// A program reference must be a known `builtin:<name>` program or an absolute
+/// path (a file under `~/.weaver/overlookers/`). An unknown builtin is rejected
+/// here, naming the registry, rather than erroring every round; a bare relative
+/// path is rejected so the engine never resolves it against an ambiguous cwd.
 fn validate_program(program: &str) -> ApiResult<()> {
-    let ok = program.starts_with("builtin:") || PathBuf::from(program).is_absolute();
-    if !ok {
+    if program.starts_with("builtin:") {
+        if crate::builtins::find(program).is_none() {
+            let known = crate::builtins::BUILTINS
+                .iter()
+                .map(|b| b.program())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(AppError::bad_request(format!(
+                "unknown builtin program '{program}' — expected one of {known}"
+            )));
+        }
+        return Ok(());
+    }
+    if !PathBuf::from(program).is_absolute() {
         return Err(AppError::bad_request(format!(
             "invalid program '{program}' — expected 'builtin:<name>' or an absolute path"
         )));
     }
     Ok(())
+}
+
+/// `GET /api/overlookers/programs` — the builtin program registry: what the
+/// create form offers and the panel's read-only script viewer renders.
+async fn list_programs() -> Json<Vec<ProgramView>> {
+    Json(crate::builtins::BUILTINS.iter().map(|b| b.view()).collect())
 }
 
 /// Resolve an overlooker (by id or name) or 404.

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -698,6 +698,198 @@ async fn rest_overlooker_lifecycle_and_validation() {
 }
 
 // ---------------------------------------------------------------------------
+// Builtin script programs
+// ---------------------------------------------------------------------------
+
+use loom::builtins::python3_available;
+
+/// A stored PR snapshot for a branch, as the GitHub poll loop would write it.
+fn pr_snapshot(state: &str, number: i64) -> weaver_core::github::GithubStatus {
+    weaver_core::github::GithubStatus {
+        pr_number: number,
+        pr_url: format!("https://example/pr/{number}"),
+        pr_state: state.to_string(),
+        pr_title: "the change".to_string(),
+        is_draft: false,
+        review_decision: None,
+        checks: Some("passing".to_string()),
+        mergeable: None,
+        merged_at: (state == "MERGED").then(db::now_iso),
+        fetched_at: db::now_iso(),
+    }
+}
+
+/// The registry over REST: every builtin carries its defaults, script programs
+/// carry their read-only source, and `validate_program` rejects an unknown
+/// builtin at create time (naming the registry) while accepting a known one.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rest_lists_builtin_programs_and_validates_program_refs() {
+    let ts = TestServer::start().await;
+
+    let programs = ts.client.get("/api/overlookers/programs").await.unwrap();
+    let arr = programs.as_array().unwrap();
+    let names: Vec<&str> = arr.iter().map(|p| p["program"].as_str().unwrap()).collect();
+    for expected in [
+        "builtin:status",
+        "builtin:pr-label",
+        "builtin:archive-merged",
+    ] {
+        assert!(names.contains(&expected), "{expected} missing: {names:?}");
+    }
+
+    // A script program ships its source and suggested defaults…
+    let archive = arr
+        .iter()
+        .find(|p| p["program"] == "builtin:archive-merged")
+        .unwrap();
+    assert_eq!(archive["kind"], "script");
+    assert!(
+        archive["source"]
+            .as_str()
+            .unwrap()
+            .contains("archive-merged"),
+        "the embedded source is served"
+    );
+    assert!(archive["defaults"]["trigger"]["every"].is_string());
+    assert_eq!(archive["defaults"]["capabilities"][0], "observe");
+    // …a native program has no source to show.
+    let status = arr
+        .iter()
+        .find(|p| p["program"] == "builtin:status")
+        .unwrap();
+    assert_eq!(status["kind"], "native");
+    assert!(status["source"].is_null());
+
+    // An unknown builtin is rejected at create time; a known script accepted.
+    let bad = ts
+        .client
+        .post(
+            "/api/overlookers",
+            json!({ "name": "bad", "program": "builtin:nope" }),
+        )
+        .await;
+    assert!(bad.is_err(), "an unknown builtin program is rejected");
+    let ok = ts
+        .client
+        .post(
+            "/api/overlookers",
+            json!({ "name": "good", "program": "builtin:archive-merged" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ok["program"], "builtin:archive-merged");
+}
+
+/// The embedded builtin scripts end to end: each runs as a real `python3`
+/// subprocess against the live test server's REST API. `archive-merged` flags
+/// the session whose stored PR snapshot is merged; `pr-label` flags the one
+/// with an open PR (the fixture repo has no GitHub remote, so the label read
+/// degrades to the ensure-label report). Both are read-only — the fleet is
+/// untouched afterward.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn builtin_scripts_report_merged_and_unlabelled_prs() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
+    let ts = TestServer::start().await;
+    let state = engine_state(&ts).await;
+    let (merged_id, merged_branch, _repo) = make_session(&ts, "merged work").await;
+    let (open_id, open_branch, _repo) = make_session(&ts, "open work").await;
+    loom::github::upsert_status(&state.db, &merged_branch, &pr_snapshot("MERGED", 41))
+        .await
+        .unwrap();
+    loom::github::upsert_status(&state.db, &open_branch, &pr_snapshot("OPEN", 42))
+        .await
+        .unwrap();
+
+    // archive-merged: exactly the merged session is reported, as a would-do.
+    enabled_overlooker(
+        &state,
+        ov::NewOverlooker {
+            name: "archive-watch".to_string(),
+            program: "builtin:archive-merged".to_string(),
+            capabilities: vec!["observe".to_string()],
+            ..Default::default()
+        },
+    )
+    .await;
+    let run_id = overlooker::fire_now(&state, "archive-watch", false, "manual")
+        .await
+        .unwrap();
+    let runs = ts
+        .client
+        .get("/api/overlookers/archive-watch/runs?limit=10")
+        .await
+        .unwrap();
+    let run = runs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["id"] == run_id)
+        .unwrap()
+        .clone();
+    assert_eq!(run["outcome"], "ok", "summary: {}", run["summary"]);
+    let actions = run["actions"].as_array().unwrap();
+    assert_eq!(
+        actions.len(),
+        1,
+        "only the merged PR is flagged: {actions:?}"
+    );
+    assert_eq!(actions[0]["would"], "archive");
+    assert_eq!(actions[0]["session"], merged_id.as_str());
+    assert_eq!(actions[0]["pr"], 41);
+
+    // pr-label: exactly the open PR is reported, with the default label.
+    enabled_overlooker(
+        &state,
+        ov::NewOverlooker {
+            name: "label-watch".to_string(),
+            program: "builtin:pr-label".to_string(),
+            capabilities: vec!["observe".to_string()],
+            ..Default::default()
+        },
+    )
+    .await;
+    let run_id = overlooker::fire_now(&state, "label-watch", false, "manual")
+        .await
+        .unwrap();
+    let runs = ts
+        .client
+        .get("/api/overlookers/label-watch/runs?limit=10")
+        .await
+        .unwrap();
+    let run = runs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["id"] == run_id)
+        .unwrap()
+        .clone();
+    assert_eq!(run["outcome"], "ok", "summary: {}", run["summary"]);
+    let actions = run["actions"].as_array().unwrap();
+    assert_eq!(actions.len(), 1, "only the open PR is flagged: {actions:?}");
+    assert_eq!(actions[0]["would"], "label");
+    assert_eq!(actions[0]["session"], open_id.as_str());
+    assert_eq!(actions[0]["label"], "weaver");
+
+    // Read-only: neither session was archived or otherwise mutated.
+    for id in [&merged_id, &open_id] {
+        let view = ts.client.get(&format!("/api/sessions/{id}")).await.unwrap();
+        assert_ne!(view["status"], "archived", "builtin scripts mutate nothing");
+    }
+
+    for id in [merged_id, open_id] {
+        ts.client
+            .delete(&format!("/api/sessions/{id}"))
+            .await
+            .unwrap();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // T12 — Warm-session lifecycle
 // ---------------------------------------------------------------------------
 

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -300,6 +300,27 @@ impl From<OverlookerRun> for OverlookerRunView {
     }
 }
 
+/// One **program** an overlooker can run, as `GET /api/overlookers/programs`
+/// exposes it. Builtin programs ship inside the loom binary: a `native` one is
+/// implemented in Rust, a `script` one is an embedded Python file whose source
+/// is returned for a read-only view in the panel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgramView {
+    /// The reference an overlooker's `program` field names it by, e.g.
+    /// `builtin:status` or `builtin:archive-merged`.
+    pub program: String,
+    pub title: String,
+    pub description: String,
+    /// `native` (in-Rust) or `script` (an embedded Python program).
+    pub kind: String,
+    /// A `script` program's source. Read-only — it ships with the binary;
+    /// `null` for a native program.
+    pub source: Option<String>,
+    /// Suggested starting config for a new overlooker running this program:
+    /// `{trigger, scope, params, capabilities}` — what a create form prefills.
+    pub defaults: Value,
+}
+
 // ---------------------------------------------------------------------------
 // Request payloads
 // ---------------------------------------------------------------------------

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,6 +48,8 @@ needing the daemon to be reachable.
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
+| `crates/loom/src/overlooker.rs` | the overlooker engine: cron timer + event dispatcher + the round executor (the native `builtin:status` program and the script subprocess executor) |
+| `crates/loom/src/builtins.rs` | the builtin overlooker program registry; the script programs are real Python files in `crates/loom/overlookers/`, embedded into the binary |
 | `crates/loom/src/agent.rs` | launching agents into tmux + installing `.claude/settings.local.json` hooks |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
 | `crates/loom/src/tmux.rs` | `tmux new-session / capture-pane / kill-session / attach` (exact-match `=name:` targets) |
@@ -186,6 +188,9 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET POST /api/repos/issues?repo_root=…` | repo-wide board (`scope=repo\|backlog`) / create a backlog item |
 | `GET /api/repos/recent` / `GET /api/repos/branches?cwd=…` | recent repos / branches in a repo |
 | `GET PATCH /api/settings` | settings registry |
+| `GET POST /api/overlookers` / `GET PATCH DELETE /api/overlookers/{id}` | overlooker CRUD (see [Overlookers](#overlookers)) |
+| `GET /api/overlookers/programs` | the builtin program registry: titles, suggested defaults, read-only script sources |
+| `POST /api/overlookers/{id}/run` / `GET /api/overlookers/{id}/runs` | fire a round now (`{dry_run}` stubs mutations) / the round-history audit |
 
 `SessionView` (`/api/sessions[/...]`) returns session-specific fields
 top-level (`id`, `status`, `work_dir`, `tmux_session`, `agent_kind`, `model`,
@@ -366,6 +371,43 @@ JSON parse + check rollup), `refresh` (fetch → store → announce → maybe
 archive, behind both the poller and the refresh endpoint), and `poll` (the
 loop). The merge-archive decision is split into `apply_snapshot` so it is
 testable without invoking `gh`.
+
+## Overlookers
+
+An **overlooker** is a periodic / triggered watch program over the fleet: it
+wakes on a trigger (a cron tick or a session event), surveys the sessions in
+scope, and acts within an explicit capability set. The design of record is
+[docs/plans/overlooker.md](plans/overlooker.md). The engine
+(`loom::overlooker`, spawned in `server::serve`, self-gated on the
+`overlooker.enabled` setting) runs each **round** under non-optional guardrails
+— no-overlap, cooldown, a wall-clock timeout, no-recursion — and records it in
+`overlooker_runs`, the audit trail the panel's round history renders.
+
+A round runs the **program** the overlooker names:
+
+- **`builtin:status`** — the native (in-Rust) stock program: stamps a `triage`
+  mark on each in-scope session, judging via the configured `prompt` (a
+  one-shot env-stripped `claude -p` when available) or mirroring the agent's
+  own `attention` tag.
+- **Builtin scripts** — real Python files in `crates/loom/overlookers/`,
+  embedded into the binary and registered in `loom::builtins`:
+  `builtin:pr-label` (flag sessions whose open PR lacks the loom label) and
+  `builtin:archive-merged` (flag live sessions whose PR has merged). Both are
+  **read-only**: they record `would:` actions and mutate nothing — the actual
+  archive is still `github.archive_on_merge`, above. The Overlooker panel and
+  `loom overlooker programs` list the registry; script sources render
+  read-only (they ship with the binary).
+- **A custom program file** — an absolute path, conventionally
+  `~/.weaver/overlookers/<name>.py` (`loom overlooker new` scaffolds one).
+
+Builtin scripts and custom files run on one executor: an env-stripped `python3`
+subprocess that reaches the fleet only through the loom REST API. The contract:
+`$WEAVER_API` carries the daemon's base URL, `$WEAVER_OVERLOOKER` the round's
+config (`{id, name, program, params, scope, capabilities, dry_run}`), and the
+script prints one JSON object — `{outcome, summary, actions}` — to stdout. A
+non-zero exit, unparseable stdout, or a blown round budget records the round as
+an `error`. A mutating program must honor `dry_run` (record `{would: …}`
+actions instead of acting) and stay inside its granted capabilities.
 
 ## Environment
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,6 +50,7 @@ needing the daemon to be reachable.
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
 | `crates/loom/src/overlooker.rs` | the overlooker engine: cron timer + event dispatcher + the round executor (the native `builtin:status` program and the script subprocess executor) |
 | `crates/loom/src/builtins.rs` | the builtin overlooker program registry; the script programs are real Python files in `crates/loom/overlookers/`, embedded into the binary |
+| `python/weaver-loom/` | the pure-Python layer over the loom REST API (`weaver_loom`: client + overlooker round context); stdlib-only, uv-buildable, vendored onto every script's `PYTHONPATH` by the engine |
 | `crates/loom/src/agent.rs` | launching agents into tmux + installing `.claude/settings.local.json` hooks |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
 | `crates/loom/src/tmux.rs` | `tmux new-session / capture-pane / kill-session / attach` (exact-match `=name:` targets) |
@@ -400,14 +401,26 @@ A round runs the **program** the overlooker names:
 - **A custom program file** — an absolute path, conventionally
   `~/.weaver/overlookers/<name>.py` (`loom overlooker new` scaffolds one).
 
-Builtin scripts and custom files run on one executor: an env-stripped `python3`
-subprocess that reaches the fleet only through the loom REST API. The contract:
-`$WEAVER_API` carries the daemon's base URL, `$WEAVER_OVERLOOKER` the round's
-config (`{id, name, program, params, scope, capabilities, dry_run}`), and the
-script prints one JSON object — `{outcome, summary, actions}` — to stdout. A
-non-zero exit, unparseable stdout, or a blown round budget records the round as
-an `error`. A mutating program must honor `dry_run` (record `{would: …}`
-actions instead of acting) and stay inside its granted capabilities.
+Builtin scripts and custom files run on one executor: an env-stripped
+subprocess that reaches the fleet only through the loom REST API — everything
+loom can do is an HTTP route, and Python is purely a convenience layer on top.
+The contract: `$WEAVER_API` carries the daemon's base URL, `$WEAVER_OVERLOOKER`
+the round's config (`{id, name, program, params, scope, capabilities,
+dry_run}`), and the script prints one JSON object — `{outcome, summary,
+actions}` — as its final stdout line. A non-zero exit, no result object, or a
+blown round budget records the round as an `error`. A mutating program must
+honor `dry_run` (record `{would: …}` actions instead of acting) and stay inside
+its granted capabilities.
+
+That convenience layer is **`weaver_loom`** (`python/weaver-loom/`, stdlib-only):
+a capability-gated `Client` over the REST routes plus the `Round` context
+(config, scope-filtered survey, action log, result emission). The engine vendors
+the module onto every script's `PYTHONPATH`, so programs import it with no
+install step; for standalone iteration it installs with
+`uv pip install -e python/weaver-loom`. The interpreter is `python3`, or
+`uv run --script` when the script declares PEP 723 inline metadata and `uv` is
+installed — so a custom program can declare third-party dependencies (the
+builtins are stdlib-only and need neither).
 
 ## Environment
 

--- a/e2e/tests/overlookers.spec.ts
+++ b/e2e/tests/overlookers.spec.ts
@@ -129,6 +129,49 @@ test.describe('overlooker panel', () => {
     await expect(page.getByTestId('overlooker-warm-off')).toHaveCount(0);
   });
 
+  test('lists builtin programs with read-only source and prefills the form', async ({
+    page,
+    weaver,
+  }) => {
+    await page.goto(`${weaver.baseUrl}/overlookers`);
+
+    // The registry section lists the stock programs that ship with loom.
+    const rows = page.getByTestId('program-row');
+    await expect(rows).toHaveCount(3);
+    const section = page.getByTestId('builtin-programs');
+    for (const name of ['builtin:status', 'builtin:pr-label', 'builtin:archive-merged']) {
+      await expect(section).toContainText(name);
+    }
+
+    // A script program's source is viewable read-only; the native status
+    // program has no source to show.
+    const archive = rows.filter({ hasText: 'builtin:archive-merged' });
+    await archive.getByTestId('program-source-toggle').click();
+    await expect(archive.getByTestId('program-source')).toContainText(
+      'flag sessions whose pull request has merged',
+    );
+    const status = rows.filter({ hasText: 'builtin:status' });
+    await expect(status.getByTestId('program-source-toggle')).toHaveCount(0);
+
+    // "Use" opens the create form prefilled with the program and a name.
+    await archive.getByTestId('program-use').click();
+    await expect(page.getByTestId('overlooker-form')).toBeVisible();
+    await expect(page.getByTestId('overlooker-program')).toHaveValue('builtin:archive-merged');
+    await expect(page.getByTestId('overlooker-name')).toHaveValue('archive-merged');
+    await page.getByTestId('overlooker-create').click();
+
+    const row = page.getByTestId('overlooker-row');
+    await expect(row).toHaveCount(1);
+    await expect(row).toContainText('builtin:archive-merged');
+
+    // The detail page renders the same script source, read-only.
+    await row.getByTestId('overlooker-name-link').click();
+    await page.getByTestId('program-source-toggle').click();
+    await expect(page.getByTestId('program-source')).toContainText(
+      'flag sessions whose pull request has merged',
+    );
+  });
+
   test('deletes an overlooker from the detail page', async ({ page, weaver }) => {
     const o = await weaver.seedOverlooker({ name: 'doomed' });
 

--- a/python/weaver-loom/README.md
+++ b/python/weaver-loom/README.md
@@ -1,0 +1,25 @@
+# weaver-loom
+
+The Python layer over the loom REST API: fleet reads, capability-gated actions
+(the intervention ladder), and the overlooker round context. Stdlib-only —
+everything loom can do is exposed over HTTP, and this package is purely a
+convenience layer on top.
+
+Overlooker programs don't need to install it: the loom engine vendors the
+module onto `PYTHONPATH` for every script it runs. For standalone iteration:
+
+```sh
+uv pip install -e python/weaver-loom
+```
+
+```python
+from weaver_loom import Round
+
+rnd = Round()  # reads $WEAVER_API + $WEAVER_OVERLOOKER
+for session in rnd.sessions():
+    ...
+rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} findings")
+```
+
+The builtin programs under `crates/loom/overlookers/` are working examples;
+the program contract is documented in `docs/ARCHITECTURE.md` (Overlookers).

--- a/python/weaver-loom/pyproject.toml
+++ b/python/weaver-loom/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "weaver-loom"
+version = "0.2.0"
+description = "Python layer over the loom REST API: fleet reads, capability-gated actions, and the overlooker round context."
+readme = "README.md"
+requires-python = ">=3.9"
+# Stdlib-only on purpose: the loom engine vendors this module onto PYTHONPATH
+# for every overlooker script it runs, so a script needs no install step.
+dependencies = []
+
+[build-system]
+requires = ["uv_build>=0.6,<0.9"]
+build-backend = "uv_build"

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -1,0 +1,260 @@
+"""weaver_loom — the Python layer over the loom REST API.
+
+Everything loom can do is exposed over HTTP (`crates/loom/src/web.rs`); this
+module is a convenience layer on top, nothing more. It holds no state the API
+doesn't, and a script could always speak HTTP directly — the loom daemon stays
+the single owner of the live runtime either way.
+
+Two pieces:
+
+* :class:`Client` — a thin, capability-gated wrapper over the REST routes.
+  DTOs cross as plain dicts (the shapes `frontend/types.ts` documents);
+  mutating calls check the granted capability set *before* issuing a request,
+  mirroring the intervention-ladder contract of the `weaver-py` binding.
+* :class:`Round` — the overlooker program context: the round config the engine
+  passes in ``$WEAVER_OVERLOOKER``, a client granted that round's
+  capabilities, the scope-filtered fleet survey, and the
+  ``{outcome, summary, actions}`` result the engine reads from stdout.
+
+A minimal program::
+
+    from weaver_loom import Round
+
+    rnd = Round()
+    for session in rnd.sessions():
+        github = (session.get("branch") or {}).get("github") or {}
+        if github.get("pr_state") == "MERGED":
+            rnd.would("archive", session=session["id"], note="PR merged")
+    rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} findings")
+
+The loom engine vendors this module onto ``PYTHONPATH`` for every script it
+runs, so a program needs no install step; for standalone iteration, install it
+from the weaver repo with ``uv pip install -e python/weaver-loom``.
+"""
+
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+
+DEFAULT_BASE = "http://127.0.0.1:7878"
+
+#: The intervention ladder, calm → loud. ``observe`` is implicit.
+CAPABILITIES = ["observe", "mark", "escalate", "nudge", "interrupt", "launch"]
+
+#: Lifecycle states with no live session behind them.
+TERMINAL_STATUSES = {"done", "error", "archived"}
+
+
+class WeaverError(RuntimeError):
+    """A failed request or an unreachable loom server."""
+
+
+class CapabilityDenied(WeaverError):
+    """A mutating call attempted without the capability it requires."""
+
+
+def _base_url(base=None):
+    """Resolve a base URL: the argument, else ``$WEAVER_API``, else the loom
+    default. A bare ``host:port`` is accepted."""
+    base = (base or os.environ.get("WEAVER_API") or DEFAULT_BASE).strip().rstrip("/")
+    if not base.startswith(("http://", "https://")):
+        base = "http://" + base
+    return base
+
+
+class Client:
+    """A capability-gated client for one loom server.
+
+    ``observe`` is implicit, so read methods always work; each mutating method
+    raises :class:`CapabilityDenied` when its capability wasn't granted at
+    construction. Sessions and branches cross as plain dicts.
+    """
+
+    def __init__(self, base=None, capabilities=None):
+        self.base = _base_url(base)
+        self.capabilities = list(capabilities or [])
+
+    def can(self, cap):
+        """Whether this client holds ``cap`` (``observe`` is always held)."""
+        return cap == "observe" or cap in self.capabilities
+
+    def _gate(self, cap):
+        if not self.can(cap):
+            raise CapabilityDenied(
+                f"capability '{cap}' not granted (granted: {self.capabilities or ['observe']})"
+            )
+
+    def _request(self, method, path, body=None):
+        url = self.base + "/api" + path
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {"Content-Type": "application/json"} if data else {}
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                raw = resp.read()
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode("utf-8", errors="replace").strip()
+            raise WeaverError(f"{method} {path}: HTTP {e.code}: {detail}") from None
+        except urllib.error.URLError as e:
+            raise WeaverError(f"{method} {path}: {e.reason}") from None
+        return json.loads(raw) if raw else None
+
+    # -- Reads (observe) ----------------------------------------------------
+
+    def sessions(self):
+        """Every active session (``GET /api/sessions``)."""
+        return self._request("GET", "/sessions")
+
+    def session(self, key):
+        """One session by id, branch id, branch name, or ``repo:branch``."""
+        return self._request("GET", f"/sessions/{key}")
+
+    def preview(self, key, lines=0):
+        """The session's tmux pane as text, with ``lines`` of scrollback."""
+        reply = self._request("GET", f"/sessions/{key}/preview?lines={lines}")
+        return (reply or {}).get("screen", "")
+
+    def diff(self, key):
+        """The worktree file tree + change map vs the diff base."""
+        return self._request("GET", f"/sessions/{key}/tree")
+
+    def programs(self):
+        """The builtin overlooker program registry."""
+        return self._request("GET", "/overlookers/programs")
+
+    # -- Writes (capability-gated) --------------------------------------------
+
+    def set_tag(self, key, tag_key, value, note="", by=None):
+        """Set (upsert) a tag on a session; needs ``mark``."""
+        self._gate("mark")
+        body = {"value": value, "note": note}
+        if by is not None:
+            body["by"] = by
+        return self._request("PUT", f"/sessions/{key}/tags/{tag_key}", body)
+
+    def clear_tag(self, key, tag_key):
+        """Clear a tag — how a loud axis returns to calm; needs ``mark``."""
+        self._gate("mark")
+        return self._request("DELETE", f"/sessions/{key}/tags/{tag_key}")
+
+    def mark(self, key, level, note="", by=None):
+        """Stamp the overlooker's ``triage`` mark; needs ``mark``. A ``level``
+        of ``attention``/``blocked`` sets it; empty or ``ok`` clears it."""
+        if not level or level == "ok":
+            return self.clear_tag(key, "triage")
+        return self.set_tag(key, "triage", level, note, by)
+
+    def nudge(self, key, text, submit=True):
+        """Type a message into the session's agent pane; needs ``nudge``."""
+        self._gate("nudge")
+        return self._request(
+            "POST", f"/sessions/{key}/send", {"text": text, "submit": submit}
+        )
+
+    def interrupt(self, key):
+        """Send a break (Escape) to stop the current turn; needs ``interrupt``."""
+        self._gate("interrupt")
+        return self._request("POST", f"/sessions/{key}/interrupt", {})
+
+
+class Round:
+    """One overlooker round, as the engine runs it.
+
+    Reads the round config from ``$WEAVER_OVERLOOKER`` (``{id, name, program,
+    params, scope, capabilities, dry_run}``), builds a :class:`Client` granted
+    that round's capabilities, accumulates the action log, and prints the
+    result the engine parses. A mutating program must check :attr:`dry_run`
+    (record a :meth:`would` action instead of acting).
+    """
+
+    def __init__(self, config=None, client=None):
+        if config is None:
+            config = json.loads(os.environ.get("WEAVER_OVERLOOKER", "{}"))
+        self.config = config
+        self.name = config.get("name", "")
+        self.params = config.get("params") or {}
+        self.scope = config.get("scope") or {}
+        self.dry_run = bool(config.get("dry_run"))
+        self.client = client or Client(capabilities=config.get("capabilities") or [])
+        self.actions = []
+        #: How many live sessions the last :meth:`sessions` survey admitted.
+        self.surveyed = 0
+
+    def can(self, cap):
+        """Whether this round holds ``cap`` (``observe`` is always held)."""
+        return self.client.can(cap)
+
+    def sessions(self):
+        """The round's survey: the live fleet, scope-filtered.
+
+        Terminal sessions are skipped; the overlooker's scope applies its
+        ``attention`` filter (``!ok`` or an exact level; an absent tag is the
+        calm ``ok``) and its ``repo`` pin. Sets :attr:`surveyed`.
+        """
+        admitted = []
+        for session in self.client.sessions():
+            if session.get("status") in TERMINAL_STATUSES:
+                continue
+            if not self._admits(session):
+                continue
+            admitted.append(session)
+        self.surveyed = len(admitted)
+        return admitted
+
+    def _admits(self, session):
+        branch = session.get("branch") or {}
+        want = self.scope.get("attention")
+        if want:
+            have = "ok"
+            for tag in branch.get("tags") or []:
+                if tag.get("key") == "attention":
+                    have = tag.get("value") or "ok"
+            matched = have != want[1:] if want.startswith("!") else have == want
+            if not matched:
+                return False
+        repo = self.scope.get("repo")
+        if repo and branch.get("repo_root") != repo:
+            return False
+        return True
+
+    def would(self, action, **fields):
+        """Record a stubbed would-do action — a read-only or dry-run finding."""
+        self.actions.append({"would": action, **fields})
+
+    def did(self, action, **fields):
+        """Record an action the round actually performed."""
+        self.actions.append({"action": action, **fields})
+
+    def finish(self, summary, outcome=None):
+        """Print the round result the engine reads from stdout. ``outcome``
+        defaults to ``ok`` when any action was recorded, else ``noop``."""
+        print(
+            json.dumps(
+                {
+                    "outcome": outcome or ("ok" if self.actions else "noop"),
+                    "summary": summary,
+                    "actions": self.actions,
+                }
+            )
+        )
+
+
+def gh(args, cwd=None, timeout=30):
+    """A `gh` CLI read, degrading to ``None`` when unavailable (gh missing,
+    unauthenticated, no GitHub remote, bad JSON). For loom-adjacent workflows
+    GitHub state isn't in the loom API yet; keep these calls read-only."""
+    try:
+        out = subprocess.run(
+            ["gh", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if out.returncode != 0:
+            return None
+        return json.loads(out.stdout)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -34,7 +34,6 @@ from the weaver repo with ``uv pip install -e python/weaver-loom``.
 
 import json
 import os
-import subprocess
 import urllib.error
 import urllib.request
 
@@ -239,22 +238,3 @@ class Round:
                 }
             )
         )
-
-
-def gh(args, cwd=None, timeout=30):
-    """A `gh` CLI read, degrading to ``None`` when unavailable (gh missing,
-    unauthenticated, no GitHub remote, bad JSON). For loom-adjacent workflows
-    GitHub state isn't in the loom API yet; keep these calls read-only."""
-    try:
-        out = subprocess.run(
-            ["gh", *args],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-        if out.returncode != 0:
-            return None
-        return json.loads(out.stdout)
-    except (OSError, subprocess.SubprocessError, ValueError):
-        return None


### PR DESCRIPTION
Closes the deferred half of the overlooker program substrate and uses it to move loom's session workflows into **builtin scripts**: real Python files that live in this repo, ship inside the binary, and show up in the Overlooker tab.

## What's here

**The script executor** (`loom::overlooker::run_script`). A `builtin:<name>` script program or a custom program file now runs as an env-stripped subprocess (the lint-review precedent) that reaches the fleet only through the loom REST API. The contract: `$WEAVER_API` carries the daemon's base URL, `$WEAVER_OVERLOOKER` the round config (`{id, name, program, params, scope, capabilities, dry_run}`), and the script prints one `{outcome, summary, actions}` JSON object as the last line of stdout (earlier lines may be logs). Non-zero exit / unparseable stdout / a blown round budget records the round as an `error`; `kill_on_drop` reaps the subprocess when the timeout cancels it. Previously `run_program` knew only `builtin:status` and a program file path was an error at run time.

**`weaver_loom` — the Python layer over the REST API** (`python/weaver-loom/`). All actions are exposed through the HTTP API; the Python module is purely a convenience layer on top of it. `Round` reads the engine handshake, surveys the scoped fleet (terminal-status + scope filtering), records `would`/`did` actions, and prints the result contract; `Client` wraps the REST endpoints (sessions, preview, diff, tags/mark, nudge, interrupt) behind a capability gate that raises `CapabilityDenied` before any un-granted write. Stdlib-only by design — the engine **vendors the module onto `PYTHONPATH` for every script round**, so programs just `from weaver_loom import Round` with no install step. For standalone authoring it's a real package (`uv pip install -e python/weaver-loom`, `uv_build` backend).

**uv-aware execution.** Scripts carrying PEP 723 inline metadata (`# /// script`) run through `uv run --script` when `uv` is on PATH (declared deps resolve automatically), else `python3` as before. The `loom overlooker new` scaffold emits the PEP 723 header and builds on `weaver_loom`.

**The builtin registry** (`loom::builtins`, scripts in `crates/loom/overlookers/`). Embedded via `include_str!`, each with a title, description, and suggested defaults; served at `GET /api/overlookers/programs`, listed in the Overlooker panel (read-only source view, "Use" prefills the create form), and mirrored on the CLI by `loom overlooker programs [--source <ref>]`. `validate_program` now rejects an unknown `builtin:` reference at create time instead of erroring every round.

**The workflows, as scripts** — read-only for now, per the brief; both record `would:` actions and mutate nothing:

- `builtin:archive-merged` — flags live sessions whose PR snapshot says the pull request merged. This is the scripted home of the hard-coded archive-on-merge workflow (`github.rs::apply_snapshot`); the `github.archive_on_merge` setting **still performs the actual archive**, so removing the hard-coded path waits until scripts get a mutation path (follow-up filed).
- `builtin:pr-label` — flags sessions whose open PR lacks the loom label (`params.label`, default `weaver`), checking current labels via a `gh` read with graceful degradation. Worth noting: while the brief listed this as an existing workflow, it doesn't exist anywhere in the codebase, GitHub Actions, or as labels on past PRs — so this script *defines* it rather than ports it.

**Honest scaffold.** `loom overlooker new` previously scaffolded an aspirational decorator API (`@weaver.on_cron`) the engine never implemented; it now scaffolds the real contract, and a test `py_compile`s it.

## Surveyed and deliberately not moved

The other background automations are event *sources* feeding overlooker triggers, not workflows: stale detection (`monitor.rs`), `pr_red` edge detection and the PR snapshot poll (`github.rs`), hook reflection. They stay as engine substrate.

## Tests

- Unit: registry integrity (strict-parsed defaults, capability vocabulary, `py_compile` of every embedded script and the vendored module), executor round-trip + error paths (incl. last-line result parsing and PEP 723 detection), scaffold validity.
- Integration (`TestServer`): the registry over REST + program validation; both builtin scripts end-to-end as real subprocesses against the live server — merged PR flagged by `archive-merged`, open PR flagged by `pr-label`, fleet untouched after.
- e2e (Playwright): builtin programs section, read-only source view, create-form prefill, detail-page source.

`./scripts/pre-commit.sh` clean (fmt + clippy + agent lint), `cargo test --workspace` green, `e2e` overlooker suite 8/8, `uv build` + the engine-style `uv run --script` path verified by hand.
