### PR TITLE
feat(overlooker): make builtin:status a script — no privileged native programs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
     # build/lint/test jobs, so it can't affect them. The live round-trip test is
     # opt-in (WEAVER_PY_LIVE) and stays out of CI; the server-free gating suite —
     # the capability enforcement contract — is the coverage here.
+    #
+    # The pure-Python weaver_loom suite (stdlib-only, no build step) rides the
+    # same job: its conftest puts the source tree on sys.path, so a bare pytest
+    # over python/weaver-loom/tests is the whole invocation.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -101,4 +105,4 @@ jobs:
       - run: pip install maturin pytest
       - run: maturin build --release --manifest-path crates/weaver-py/Cargo.toml --out dist
       - run: pip install --find-links dist weaver-py
-      - run: pytest crates/weaver-py/tests -v
+      - run: pytest crates/weaver-py/tests python/weaver-loom/tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ e2e/test-results/
 *.pyc
 python/weaver-loom/dist/
 __pycache__/
+python/weaver-loom/.venv/
+python/weaver-loom/uv.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,12 @@ Diagram and module-by-module map: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 cargo build              # backend + Vue SPA (build.rs drives npm/rspack)
 cargo test --workspace   # backend unit + integration (needs git, tmux)
 cd e2e && npm test       # Playwright UI suite against a real loom
+cd python/weaver-loom && uv run pytest   # weaver_loom + builtin overlooker program logic (server-free)
 ```
+
+Test placement: pure program/module logic lives in pytest
+(`python/weaver-loom/tests/`, `crates/weaver-py/tests/`); Rust integration
+tests prove wiring against a live server — don't duplicate logic across them.
 
 Run `./scripts/pre-commit.sh` before committing — the fmt + clippy gate CI
 enforces, plus an [agent lint review](docs/lint.md): a headless `claude`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ name = "weaver-api"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -318,17 +318,16 @@ export interface OverlookerRunResult {
 }
 
 /** One program an overlooker can run, served by `GET /api/overlookers/programs`.
- *  Builtin programs ship inside the loom binary: a `native` one is implemented
- *  in Rust, a `script` one is an embedded Python file whose `source` the panel
- *  renders read-only. `defaults` is the suggested starting config a create form
- *  prefills. Mirrors `ProgramView` in weaver-api. */
+ *  Builtin programs are Python scripts that ship inside the loom binary; the
+ *  embedded `source` is rendered read-only in the panel. `defaults` is the
+ *  suggested starting config a create form prefills. Mirrors `ProgramView` in
+ *  weaver-api. */
 export interface ProgramView {
   /** The reference an overlooker's `program` field uses, e.g. `builtin:status`. */
   program: string;
   title: string;
   description: string;
-  kind: 'native' | 'script';
-  source: string | null;
+  source: string;
   defaults: {
     trigger?: OverlookerTrigger;
     scope?: OverlookerScope;

--- a/crates/loom/frontend/src/views/OverlookerDetail.vue
+++ b/crates/loom/frontend/src/views/OverlookerDetail.vue
@@ -334,8 +334,8 @@ onMounted(() => {
               {{ showSource ? 'hide source' : 'view source' }}
             </button>
             <p v-if="programInfo" class="mt-0.5 text-xs text-faint">
-              {{ programInfo.title }} — a builtin {{ programInfo.kind }} shipped
-              with loom<span v-if="programInfo.source">; the source is read-only</span>.
+              {{ programInfo.title }} — a builtin script shipped with loom;
+              the source is read-only.
             </p>
             <pre
               v-if="showSource && programInfo?.source"

--- a/crates/loom/frontend/src/views/Overlookers.vue
+++ b/crates/loom/frontend/src/views/Overlookers.vue
@@ -535,11 +535,9 @@ onMounted(() => {
         >
           <div class="flex items-center gap-2 flex-wrap">
             <span class="font-mono text-sm font-semibold">{{ p.program }}</span>
-            <span class="meta-chip">{{ p.kind }}</span>
             <span class="text-sm text-muted">{{ p.title }}</span>
             <div class="ml-auto flex shrink-0 items-center gap-2">
               <button
-                v-if="p.source"
                 type="button"
                 data-testid="program-source-toggle"
                 class="rounded bg-subtle hover:bg-subtle-hover px-2.5 py-1 text-xs font-medium"
@@ -559,7 +557,7 @@ onMounted(() => {
           </div>
           <p class="mt-1 text-xs text-faint">{{ p.description }}</p>
           <pre
-            v-if="expandedSource === p.program && p.source"
+            v-if="expandedSource === p.program"
             data-testid="program-source"
             class="mt-2 max-h-80 overflow-auto rounded bg-input p-3 text-xs font-mono"
           >{{ p.source }}</pre>

--- a/crates/loom/overlookers/status.py
+++ b/crates/loom/overlookers/status.py
@@ -1,0 +1,109 @@
+"""status — survey the scoped fleet and stamp a triage mark on each session.
+
+The judgement is best-effort-LLM with a deterministic fallback, so the round
+works fully without a real agent:
+
+* when a prompt is configured (params.prompt), ask the daemon's one-shot
+  agent for a level + note from the session's screen preview (parsed
+  leniently via parse_judgement);
+* otherwise — or when the agent is absent or unparseable — fall back to a
+  rule that mirrors the session's own `attention` tag as the mark.
+
+An `ok` judgement returns the triage axis to calm (clears the tag) rather
+than marking. With the `nudge` capability, a freshly marked session is also
+nudged with the note. Honours dry_run: would-be marks are logged as
+`{would: "mark"}` actions and nothing mutates.
+"""
+
+from weaver_loom import Round, WeaverError, parse_judgement
+
+#: The storable triage values; `ok` is the absence of the tag.
+STORABLE = ("attention", "blocked")
+
+
+def attention_value(session):
+    """The session's own `attention` tag value — `ok` when absent (calm)."""
+    for tag in (session.get("branch") or {}).get("tags") or []:
+        if tag.get("key") == "attention":
+            return tag.get("value") or "ok"
+    return "ok"
+
+
+def judge(rnd, session):
+    """Decide a (level, note) for one session: best-effort LLM judgement when
+    a prompt is configured, else mirror the agent's self-reported attention."""
+    prompt = rnd.params.get("prompt") or ""
+    if prompt:
+        try:
+            screen = rnd.client.preview(session["id"], 200)
+        except WeaverError:
+            screen = ""
+        out = rnd.client.agent(
+            f"{prompt}\n\nSession screen:\n{screen}\n", rnd.model, rnd.effort
+        )
+        judged = parse_judgement(out) if out else None
+        if judged:
+            return judged
+
+    attention = attention_value(session)
+    level = attention if attention in STORABLE else "ok"
+    return level, f"attention is {attention}"
+
+
+def main():
+    rnd = Round()
+    can_mark = rnd.can("mark")
+    can_nudge = rnd.can("nudge")
+    marked = 0
+    counts = {}
+
+    for session in rnd.sessions():
+        level, note = judge(rnd, session)
+
+        # An `ok` judgement returns the triage axis to calm rather than
+        # marking: clear the tag (the server records the cleared-tag event —
+        # the audit rule). The dry-run path mutates nothing.
+        if level not in STORABLE:
+            if can_mark and not rnd.dry_run:
+                rnd.client.mark(session["id"], "ok", by=rnd.name)
+            continue
+
+        if not can_mark:
+            rnd.did("observe", session=session["id"], level=level, note=note)
+            continue
+
+        marked += 1
+        counts[level] = counts.get(level, 0) + 1
+        if rnd.dry_run:
+            rnd.would("mark", session=session["id"], level=level, note=note)
+            continue
+
+        rnd.client.mark(session["id"], level, note, by=rnd.name)
+        rnd.did("mark", session=session["id"], level=level, note=note)
+
+        # The nudge rung of the intervention ladder: only when capability-
+        # granted. Best-effort; a session with no live tmux just no-ops.
+        if can_nudge:
+            text = f"[overlooker {rnd.name}] {note}"
+            try:
+                rnd.client.nudge(session["id"], text, by=rnd.name)
+                rnd.did("nudge", session=session["id"], text=text)
+            except WeaverError:
+                pass
+
+    if rnd.surveyed == 0:
+        rnd.finish("surveyed 0 sessions in scope", outcome="noop")
+        return
+
+    breakdown = ", ".join(f"{n} {level}" for level, n in sorted(counts.items()))
+    dry = " (dry run, no marks applied)" if rnd.dry_run else ""
+    verb = "would mark" if rnd.dry_run else "marked"
+    if breakdown:
+        summary = f"surveyed {rnd.surveyed}, {verb} {marked} ({breakdown}){dry}"
+    else:
+        summary = f"surveyed {rnd.surveyed}, {verb} 0{dry}"
+    rnd.finish(summary, outcome="ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -1,4 +1,6 @@
-//! Launching coding agents into tmux panes and installing status hooks.
+//! Launching coding agents into tmux panes and installing status hooks, plus
+//! the **one-shot headless agent** (`POST /api/agent/oneshot`) — a fresh,
+//! env-stripped `claude -p` run for a judgement call.
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -175,6 +177,78 @@ pub async fn install_hooks(work_dir: &Path, weaver_bin: &str) -> Result<()> {
     tokio::fs::write(&path, serde_json::to_string_pretty(&root)?).await?;
     tracing::debug!(path = %path.display(), "claude hooks installed");
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The one-shot headless agent
+// ---------------------------------------------------------------------------
+
+/// Markers of a *calling* Claude Code session, stripped before spawning a
+/// subprocess so it runs fresh and isolated (the lint-review precedent).
+/// Mirrors `scripts/lint-review.py`'s `STRIPPED_ENV`. Shared by the one-shot
+/// agent here and the overlooker script executor.
+pub const STRIPPED_ENV: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_EXECPATH",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_CODE_SSE_PORT",
+];
+
+/// Spawn a one-shot headless agent: write `prompt` to its stdin, capture
+/// stdout, strip the calling session's env markers. Best-effort: returns
+/// `None` when the agent is absent, errors, or exceeds `timeout` — callers
+/// must degrade gracefully, so a missing `claude` never breaks them.
+///
+/// The command is `WEAVER_OVERLOOKER_AGENT_CMD` (default `claude -p`); a
+/// non-empty `model`/`effort` is appended as `--model`/`--effort`.
+pub async fn run_oneshot(
+    prompt: &str,
+    model: &str,
+    effort: &str,
+    timeout: std::time::Duration,
+) -> Option<String> {
+    let cmd_str =
+        std::env::var("WEAVER_OVERLOOKER_AGENT_CMD").unwrap_or_else(|_| "claude -p".to_string());
+    let mut parts = cmd_str.split_whitespace();
+    let program = parts.next()?;
+    let mut args: Vec<String> = parts.map(str::to_string).collect();
+    if !model.trim().is_empty() {
+        args.push("--model".to_string());
+        args.push(model.trim().to_string());
+    }
+    if !effort.trim().is_empty() {
+        args.push("--effort".to_string());
+        args.push(effort.trim().to_string());
+    }
+
+    let mut command = tokio::process::Command::new(program);
+    command
+        .args(&args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+    for key in STRIPPED_ENV {
+        command.env_remove(key);
+    }
+
+    let mut child = command.spawn().ok()?; // agent not on PATH → None, caller degrades.
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        let _ = stdin.write_all(prompt.as_bytes()).await;
+        // Drop stdin so the agent sees EOF and proceeds.
+        drop(stdin);
+    }
+
+    let out = tokio::time::timeout(timeout, child.wait_with_output()).await;
+    match out {
+        Ok(Ok(output)) if output.status.success() => {
+            Some(String::from_utf8_lossy(&output.stdout).to_string())
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1239,18 +1239,14 @@ async fn cmd_overlooker_programs(source: Option<String>) -> Result<()> {
         let Some(row) = row else {
             bail!("no builtin program '{want}' — `loom overlooker programs` lists them");
         };
-        match row.get("source").and_then(Value::as_str) {
-            Some(src) => print!("{src}"),
-            None => bail!("'{want}' is a native (in-Rust) program with no script source"),
-        }
+        print!("{}", str_field(row, "source"));
         return Ok(());
     }
-    println!("{:<26}  {:<8}  TITLE", "PROGRAM", "KIND");
+    println!("{:<26}  TITLE", "PROGRAM");
     for p in rows {
         println!(
-            "{:<26}  {:<8}  {}",
+            "{:<26}  {}",
             str_field(&p, "program"),
-            str_field(&p, "kind"),
             str_field(&p, "title"),
         );
     }

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -2,15 +2,14 @@
 //! the loom binary and that an overlooker's `program` field names as
 //! `builtin:<name>`.
 //!
-//! Two kinds share the registry:
-//!
-//! * **native** — implemented in Rust inside the engine (`builtin:status`).
-//! * **script** — a real Python file under `crates/loom/overlookers/`,
-//!   embedded here with `include_str!` and run by the engine's script
-//!   executor ([`crate::overlooker`]) exactly like a user's custom program
-//!   file. Living in the repo makes each one diffable, reviewable, and the
-//!   working example of the program contract; the panel shows the source
-//!   read-only.
+//! Every builtin is a **script**: a real Python file under
+//! `crates/loom/overlookers/`, embedded here with `include_str!` and run by
+//! the engine's script executor ([`crate::overlooker`]) exactly like a user's
+//! custom program file. Living in the repo makes each one diffable,
+//! reviewable, and the working example of the program contract; the panel
+//! shows the source read-only. There is deliberately no privileged in-Rust
+//! program shape — everything a builtin does, it does through the loom REST
+//! API a custom program also sees.
 //!
 //! `GET /api/overlookers/programs` serves this table (as [`ProgramView`]s) so
 //! the panel and the `loom overlooker programs` CLI list one source of truth.
@@ -25,16 +24,16 @@ use weaver_api::ProgramView;
 pub const PYTHON_MODULE: &str =
     include_str!("../../../python/weaver-loom/src/weaver_loom/__init__.py");
 
-/// One stock program: its identity, its embedded source (for a script), and
-/// the suggested starting config a create form prefills. The JSON-bearing
-/// defaults are stored as text so the table stays a flat `const`.
+/// One stock program: its identity, its embedded source, and the suggested
+/// starting config a create form prefills. The JSON-bearing defaults are
+/// stored as text so the table stays a flat `const`.
 pub struct BuiltinProgram {
     /// The short name; the program reference is `builtin:<name>`.
     pub name: &'static str,
     pub title: &'static str,
     pub description: &'static str,
-    /// The embedded Python source, or `None` for a native (in-Rust) program.
-    pub source: Option<&'static str>,
+    /// The embedded Python source.
+    pub source: &'static str,
     pub default_trigger: &'static str,
     pub default_scope: &'static str,
     pub default_params: &'static str,
@@ -47,10 +46,10 @@ pub const BUILTINS: &[BuiltinProgram] = &[
         name: "status",
         title: "Status check",
         description: "Survey the scoped fleet and stamp a triage mark on each \
-                      session — judgement via the configured prompt (a one-shot \
-                      agent when available), else mirroring the agent's own \
-                      attention tag.",
-        source: None,
+                      session — judgement via the configured prompt (the \
+                      daemon's one-shot agent when available), else mirroring \
+                      the agent's own attention tag.",
+        source: include_str!("../overlookers/status.py"),
         default_trigger: r#"{"cron":"0 * * * *"}"#,
         default_scope: r#"{"attention":"!ok"}"#,
         default_params: "{}",
@@ -63,7 +62,7 @@ pub const BUILTINS: &[BuiltinProgram] = &[
                       label (params.label, default 'weaver'), so PRs born from \
                       sessions are identifiable on GitHub. Read-only: it \
                       reports would-label actions.",
-        source: Some(include_str!("../overlookers/pr_label.py")),
+        source: include_str!("../overlookers/pr_label.py"),
         default_trigger: r#"{"every":"15m"}"#,
         default_scope: "{}",
         default_params: r#"{"label":"weaver"}"#,
@@ -77,7 +76,7 @@ pub const BUILTINS: &[BuiltinProgram] = &[
                       Read-only: it reports would-archive actions (the \
                       github.archive_on_merge setting still performs the \
                       archive).",
-        source: Some(include_str!("../overlookers/archive_merged.py")),
+        source: include_str!("../overlookers/archive_merged.py"),
         default_trigger: r#"{"every":"5m"}"#,
         default_scope: "{}",
         default_params: "{}",
@@ -98,13 +97,7 @@ impl BuiltinProgram {
             program: self.program(),
             title: self.title.to_string(),
             description: self.description.to_string(),
-            kind: if self.source.is_some() {
-                "script"
-            } else {
-                "native"
-            }
-            .to_string(),
-            source: self.source.map(str::to_string),
+            source: self.source.to_string(),
             defaults: json!({
                 "trigger": parse(self.default_trigger),
                 "scope": parse(self.default_scope),
@@ -169,10 +162,10 @@ mod tests {
                     b.name
                 );
             }
-            // The wire view: kind tracks the presence of source.
+            // The wire view: every builtin serves its embedded source.
             let v = b.view();
             assert!(v.program.starts_with("builtin:"));
-            assert_eq!(v.kind == "script", v.source.is_some());
+            assert!(!v.source.is_empty(), "{}: source is embedded", b.name);
         }
     }
 
@@ -187,7 +180,7 @@ mod tests {
         }
         let scripts = BUILTINS
             .iter()
-            .filter_map(|b| Some((b.name, b.source?)))
+            .map(|b| (b.name, b.source))
             .chain([("weaver_loom", PYTHON_MODULE)]);
         for (name, source) in scripts {
             let dir = tempfile::tempdir().unwrap();

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -28,11 +28,11 @@
 //! never "handles" the specific event, so firing twice is idempotent. The round
 //! runs a **program** under the non-optional guardrails — no-overlap, cooldown,
 //! timeout, no-recursion — and records every mutating action as both an
-//! `overlooker_runs` action entry and an `events` row (the audit rule). Three
-//! program shapes share that one substrate ([`run_program`]): the native
-//! `builtin:status` stock program (in-process Rust), the builtin **scripts**
-//! embedded from [`crate::builtins`], and custom program files — the last two
-//! run by the same subprocess executor ([`run_script`]).
+//! `overlooker_runs` action entry and an `events` row (the audit rule). Two
+//! program shapes share that one substrate ([`run_program`]): the builtin
+//! **scripts** embedded from [`crate::builtins`] and custom program files —
+//! both run by the same subprocess executor ([`run_script`]), reaching the
+//! fleet only through the loom REST API.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -42,13 +42,12 @@ use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
-use crate::session::{self as session_mod, Session};
+use crate::events;
+use crate::session as session_mod;
 use crate::web::AppState;
-use crate::{events, tmux};
-use weaver_core::branch::{self as branch_mod, Branch};
+use weaver_core::branch as branch_mod;
 use weaver_core::config as core_config;
 use weaver_core::overlooker::{self as ov, Overlooker};
-use weaver_core::tags::{self, TRIAGE_KEY};
 
 /// How often the engine wakes to drain new events and check the timer. Matches
 /// the monitor's cadence closely enough that a reactive event is acted on
@@ -58,7 +57,7 @@ const TICK: Duration = Duration::from_millis(1500);
 /// Read an integer setting, falling back to `default` on absence or parse
 /// failure. `weaver_core::config` has bool/string getters but no int getter, so
 /// the engine parses the raw value itself.
-async fn get_int(db: &crate::Db, key: &str, default: i64) -> i64 {
+pub(crate) async fn get_int(db: &crate::Db, key: &str, default: i64) -> i64 {
     core_config::get(db, key)
         .await
         .and_then(|v| v.trim().parse::<i64>().ok())
@@ -438,7 +437,7 @@ async fn record_skipped(
 }
 
 // ---------------------------------------------------------------------------
-// The program substrate (T5) + the stock `builtin:status` program (T11)
+// The program substrate — the subprocess script executor
 // ---------------------------------------------------------------------------
 
 /// The result of running a program: an outcome, a one-line human summary, and the
@@ -449,19 +448,16 @@ struct RoundResult {
     actions: Value,
 }
 
-/// Dispatch to the program the overlooker names: the native `builtin:status`
-/// stock program, a builtin **script** embedded from [`crate::builtins`], or a
-/// custom program file (an absolute path, conventionally under
-/// `~/.weaver/overlookers/`) — the scripts both run on [`run_script`].
+/// Dispatch to the program the overlooker names: a builtin **script**
+/// embedded from [`crate::builtins`], or a custom program file (an absolute
+/// path, conventionally under `~/.weaver/overlookers/`) — both run on
+/// [`run_script`].
 async fn run_program(
     state: &AppState,
     o: &Overlooker,
     dry_run: bool,
 ) -> anyhow::Result<RoundResult> {
-    if o.program == "builtin:status" {
-        return builtin_status(state, o, dry_run).await;
-    }
-    if let Some(source) = crate::builtins::find(&o.program).and_then(|b| b.source) {
+    if let Some(source) = crate::builtins::find(&o.program).map(|b| b.source) {
         let file_name = program_file_name(&o.program);
         return run_script(
             state,
@@ -523,10 +519,11 @@ async fn uv_available() -> bool {
 }
 
 /// Run a **script program**: an env-stripped subprocess (the lint-review
-/// precedent, like [`run_agent`]) that reaches the fleet only through the loom
-/// REST API. `$WEAVER_API` carries the daemon's own address and
-/// `$WEAVER_OVERLOOKER` the round config (`{id, name, program, params, scope,
-/// capabilities, dry_run}`); the vendored `weaver_loom` module rides
+/// precedent, like [`crate::agent::run_oneshot`]) that reaches the fleet only
+/// through the loom REST API. `$WEAVER_API` carries the daemon's own address
+/// and `$WEAVER_OVERLOOKER` the round config (`{id, name, program, params,
+/// scope, capabilities, model, effort, dry_run}`); the vendored `weaver_loom`
+/// module rides
 /// `PYTHONPATH` so every program can import the API layer with no install
 /// step. The contract is to print one JSON object — `{outcome, summary,
 /// actions}` — as the final stdout line; a non-zero exit or unparseable
@@ -581,6 +578,8 @@ async fn run_script(
         "params": o.params(),
         "scope": serde_json::to_value(o.scope()).unwrap_or(Value::Null),
         "capabilities": o.capabilities(),
+        "model": o.model,
+        "effort": o.effort,
         "dry_run": dry_run,
     });
 
@@ -602,7 +601,7 @@ async fn run_script(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
-    for key in STRIPPED_ENV {
+    for key in crate::agent::STRIPPED_ENV {
         command.env_remove(key);
     }
 
@@ -691,332 +690,6 @@ fn tail(s: &str, n: usize) -> String {
         .map(|(i, _)| i)
         .unwrap_or(0);
     format!("…{}", &s[start..])
-}
-
-/// The set of every overlooker's warm session id — the sessions a round must
-/// never survey or act on (no-recursion: watchers don't watch watchers). The
-/// survey already reads the *visible* fleet (managed sessions excluded), so this
-/// is the secondary guard for a warm session referenced by `warm_session_id`
-/// that is not yet marked `managed_by`.
-async fn warm_session_ids(state: &AppState) -> HashSet<String> {
-    ov::list(&state.db)
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|o| o.warm_session_id)
-        .collect()
-}
-
-/// The declarative stock program: survey the scoped, non-terminal fleet and
-/// stamp a triage mark on each in-scope session.
-///
-/// The judgement is best-effort-LLM with a deterministic fallback, so the engine
-/// works fully without a real `claude`:
-/// * when a prompt is configured *and* `claude` is on PATH, ask it for a level +
-///   note from the session's screen preview (parsed leniently);
-/// * otherwise — or on any parse/skip — fall back to a **rule** that mirrors the
-///   session's own `attention` as the mark, with a derived note.
-///
-/// `dry_run` performs no mutation: each would-be mark is logged as a
-/// `{would:"mark", …}` action instead, so an operator can repeat a dry round
-/// safely.
-async fn builtin_status(
-    state: &AppState,
-    o: &Overlooker,
-    dry_run: bool,
-) -> anyhow::Result<RoundResult> {
-    let scope = o.scope();
-    let warm = warm_session_ids(state).await;
-    let can_mark = o.has_capability("mark");
-    let can_nudge = o.has_capability("nudge");
-
-    // The survey scope is the *visible* fleet: engine-managed (warm) sessions
-    // are excluded at the source, so no round ever surveys a watcher's own
-    // session (the no-recursion guarantee, enforced for every overlooker, not
-    // just the one that owns the session). `warm_session_ids` below is a belt-
-    // and-braces check for any warm session not yet marked `managed_by`.
-    let sessions = session_mod::list_visible(&state.db).await?;
-    let mut actions: Vec<Value> = Vec::new();
-    let mut surveyed = 0usize;
-    let mut marked = 0usize;
-    let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
-
-    for session in sessions {
-        // no-recursion: never survey an overlooker's own warm session.
-        if warm.contains(&session.id) {
-            continue;
-        }
-        if session_mod::is_terminal(&session.status) {
-            continue;
-        }
-        let Some(branch) = branch_mod::get(&state.db, &session.branch_id).await? else {
-            continue;
-        };
-        // The scope's attention filter matches the resolved `attention` tag
-        // value; an absent tag is the calm `ok` state.
-        let attention = attention_value(state, &branch).await;
-        if !scope.admits(&attention, &branch.repo_root) {
-            continue;
-        }
-        surveyed += 1;
-
-        let (level, note) = judge(state, o, &session, &branch).await;
-        // A non-storable level (an `ok`/clear decision) returns the triage axis to
-        // calm rather than marking: clear the tag and log a `tag` event with an
-        // empty value (the audit rule — every mutating action is also an events
-        // row). The dry-run path mutates nothing.
-        if !tags::is_valid_value(TRIAGE_KEY, &level) {
-            if can_mark && !dry_run {
-                tags::clear(&state.db, &branch.id, TRIAGE_KEY).await?;
-                events::record_tag(
-                    &state.db, &state.bus, &branch.id, TRIAGE_KEY, "", "", &o.name,
-                )
-                .await
-                .ok();
-            }
-            continue;
-        }
-
-        if !can_mark {
-            actions.push(json!({
-                "session": session.id,
-                "action": "observe",
-                "level": level,
-                "note": note,
-            }));
-            continue;
-        }
-
-        if dry_run {
-            actions.push(json!({
-                "session": session.id,
-                "would": "mark",
-                "level": level,
-                "note": note,
-            }));
-            marked += 1;
-            *counts.entry(level.clone()).or_default() += 1;
-            continue;
-        }
-
-        // Apply the mark: write the `triage` tag and record the `tag` event so
-        // the fleet badge updates and the monitor re-broadcasts it (the audit
-        // rule — every mutating action is also an events row).
-        tags::set(&state.db, &branch.id, TRIAGE_KEY, &level, &note, &o.name).await?;
-        events::record_tag(
-            &state.db, &state.bus, &branch.id, TRIAGE_KEY, &level, &note, &o.name,
-        )
-        .await
-        .ok();
-        actions.push(json!({
-            "session": session.id,
-            "action": "mark",
-            "level": level,
-            "note": note,
-        }));
-        marked += 1;
-        *counts.entry(level.clone()).or_default() += 1;
-
-        // The nudge rung of the intervention ladder: only when capability-granted
-        // and the mark is not `ok`. Best-effort; a missing tmux just no-ops.
-        if can_nudge && level != "ok" && tmux::has_session(&session.tmux_session).await {
-            let text = format!("[overlooker {}] {note}", o.name);
-            if dry_run {
-                actions.push(json!({ "session": session.id, "would": "nudge", "text": text }));
-            } else {
-                let _ = tmux::send_literal(&session.tmux_session, &text).await;
-                let _ = tmux::send_enter(&session.tmux_session).await;
-                events::record(
-                    &state.db,
-                    &state.bus,
-                    &branch.id,
-                    "nudge",
-                    json!({ "by": o.name, "text": text }),
-                )
-                .await
-                .ok();
-                actions.push(json!({ "session": session.id, "action": "nudge", "text": text }));
-            }
-        }
-    }
-
-    if surveyed == 0 {
-        return Ok(RoundResult {
-            outcome: "noop".to_string(),
-            summary: "surveyed 0 sessions in scope".to_string(),
-            actions: Value::Array(actions),
-        });
-    }
-
-    let breakdown = counts
-        .iter()
-        .map(|(level, n)| format!("{n} {level}"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let dry = if dry_run {
-        " (dry run, no marks applied)"
-    } else {
-        ""
-    };
-    let verb = if dry_run { "would mark" } else { "marked" };
-    let summary = if breakdown.is_empty() {
-        format!("surveyed {surveyed}, {verb} 0{dry}")
-    } else {
-        format!("surveyed {surveyed}, {verb} {marked} ({breakdown}){dry}")
-    };
-
-    Ok(RoundResult {
-        outcome: "ok".to_string(),
-        summary,
-        actions: Value::Array(actions),
-    })
-}
-
-/// Decide a `(level, note)` for one session. Best-effort LLM judgement when a
-/// prompt is configured and `claude` is reachable; otherwise the deterministic
-/// rule — mirror the agent's own `attention` as the mark with a derived note —
-/// so a round always produces a testable result without a real agent.
-async fn judge(
-    state: &AppState,
-    o: &Overlooker,
-    session: &Session,
-    branch: &Branch,
-) -> (String, String) {
-    let prompt = o
-        .params()
-        .get("prompt")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .unwrap_or_default();
-
-    if !prompt.is_empty() {
-        let screen = tmux::capture(&session.tmux_session, 200)
-            .await
-            .unwrap_or_default();
-        let full = format!("{prompt}\n\nSession screen:\n{screen}\n");
-        if let Some(out) = run_agent(state, o, &full).await {
-            if let Some(judged) = parse_judgement(&out) {
-                return judged;
-            }
-        }
-    }
-
-    // Rule fallback: mirror the agent's self-reported attention as the mark. The
-    // agent's `attention` tag value (absent ⇒ calm `ok`) is the candidate level;
-    // a non-storable value (`ok`) makes the caller clear the triage tag instead.
-    let attention = attention_value(state, branch).await;
-    let level = if tags::is_valid_value(TRIAGE_KEY, &attention) {
-        attention.clone()
-    } else {
-        "ok".to_string()
-    };
-    let note = format!("attention is {attention}");
-    (level, note)
-}
-
-/// The resolved value of a branch's `attention` tag — the agent's self-report —
-/// or `ok` when the tag is absent (absence is the calm state).
-async fn attention_value(state: &AppState, branch: &Branch) -> String {
-    tags::get(&state.db, &branch.id, tags::ATTENTION_KEY)
-        .await
-        .ok()
-        .flatten()
-        .map(|t| t.value)
-        .unwrap_or_else(|| "ok".to_string())
-}
-
-/// The levels an agent judgement may name. The two storable triage values plus
-/// the calm `ok` — recognising `ok` lets a judgement explicitly return the axis
-/// to calm (the caller then clears the tag rather than marking).
-const JUDGED_LEVELS: &[&str] = &["ok", "attention", "blocked"];
-
-/// Parse an agent judgement into `(level, note)`. Lenient by design: the first
-/// recognised triage word is the level; the rest of that line (or the next
-/// non-empty line) is the note. Returns `None` when no level is found, so the
-/// caller falls back to the rule.
-fn parse_judgement(out: &str) -> Option<(String, String)> {
-    for line in out.lines() {
-        let lower = line.to_ascii_lowercase();
-        for level in JUDGED_LEVELS {
-            if lower
-                .split(|c: char| !c.is_ascii_alphabetic())
-                .any(|w| w == *level)
-            {
-                let note = line
-                    .split_once([':', '-'])
-                    .map(|x| x.1.trim())
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or(line.trim())
-                    .to_string();
-                return Some((level.to_string(), note));
-            }
-        }
-    }
-    None
-}
-
-// ---------------------------------------------------------------------------
-// run_agent — a fresh, env-stripped headless `claude -p` for judgement
-// ---------------------------------------------------------------------------
-
-/// Markers of the *calling* Claude Code session, stripped before spawning the
-/// sub-agent so it runs fresh and isolated (the lint-review precedent). Mirrors
-/// `scripts/lint-review.py`'s `STRIPPED_ENV`.
-const STRIPPED_ENV: &[&str] = &[
-    "ANTHROPIC_API_KEY",
-    "CLAUDECODE",
-    "CLAUDE_CODE_ENTRYPOINT",
-    "CLAUDE_CODE_EXECPATH",
-    "CLAUDE_CODE_SESSION_ID",
-    "CLAUDE_CODE_SSE_PORT",
-];
-
-/// Spawn a one-shot headless agent for a judgement call: write `prompt` to its
-/// stdin, capture stdout, strip the calling session's env markers. Best-effort:
-/// returns `None` when the agent is absent, errors, or times out — the round
-/// must work fully without it, so a missing `claude` never breaks a round.
-///
-/// The command is `WEAVER_OVERLOOKER_AGENT_CMD` (default `claude -p`); a model
-/// configured on the overlooker is appended as `--model`.
-async fn run_agent(state: &AppState, o: &Overlooker, prompt: &str) -> Option<String> {
-    let cmd_str =
-        std::env::var("WEAVER_OVERLOOKER_AGENT_CMD").unwrap_or_else(|_| "claude -p".to_string());
-    let mut parts = cmd_str.split_whitespace();
-    let program = parts.next()?;
-    let mut args: Vec<String> = parts.map(str::to_string).collect();
-    if !o.model.is_empty() {
-        args.push("--model".to_string());
-        args.push(o.model.clone());
-    }
-
-    let mut command = tokio::process::Command::new(program);
-    command
-        .args(&args)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null());
-    for key in STRIPPED_ENV {
-        command.env_remove(key);
-    }
-
-    let mut child = command.spawn().ok()?; // claude not on PATH → None, round falls back.
-    if let Some(mut stdin) = child.stdin.take() {
-        use tokio::io::AsyncWriteExt;
-        let _ = stdin.write_all(prompt.as_bytes()).await;
-        // Drop stdin so the agent sees EOF and proceeds.
-        drop(stdin);
-    }
-
-    let budget = get_int(&state.db, "overlooker.default_timeout_secs", 600)
-        .await
-        .max(1) as u64;
-    let out = tokio::time::timeout(Duration::from_secs(budget), child.wait_with_output()).await;
-    match out {
-        Ok(Ok(output)) if output.status.success() => {
-            Some(String::from_utf8_lossy(&output.stdout).to_string())
-        }
-        _ => None,
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1340,17 +1013,5 @@ rnd.finish("name=%s label=%s dry=%s api=%s" % (
             "the stderr tail names the failure: {}",
             run.summary
         );
-    }
-
-    #[test]
-    fn parse_judgement_finds_level_and_note() {
-        let (level, note) = parse_judgement("blocked: stuck retrying the same test").unwrap();
-        assert_eq!(level, "blocked");
-        assert_eq!(note, "stuck retrying the same test");
-        // No recognised level → None (caller falls back to the rule).
-        assert!(parse_judgement("looks fine to me, carry on").is_none());
-        // 'ok' is recognised even without a separator.
-        let (level, _) = parse_judgement("ok").unwrap();
-        assert_eq!(level, "ok");
     }
 }

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -839,6 +839,15 @@ async fn create_tracking_issue(
     Ok(Some(issue.id))
 }
 
+/// The author of a mutation: the trimmed `by`, or `manual` when absent or
+/// all-whitespace (an empty author never reaches the audit trail).
+fn author_or_manual(by: Option<&str>) -> String {
+    by.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("manual")
+        .to_string()
+}
+
 /// Set (upsert) a tag on a session's branch: validate `value` against the key's
 /// ladder, write the tag, and broadcast a `tag` event. The well-known keys are
 /// `attention` (the agent's self-report) and `triage` (an overlooker's, or a
@@ -861,7 +870,7 @@ async fn set_session_tag(
             format!("invalid value '{value}' for '{tag_key}' — must be non-empty")
         }));
     }
-    let by = req.by.as_deref().unwrap_or("manual").trim().to_string();
+    let by = author_or_manual(req.by.as_deref());
     let note = req.note.trim();
     tags::set(&st.db, &branch.id, &tag_key, value, note, &by).await?;
     events::record_tag(&st.db, &st.bus, &branch.id, &tag_key, value, note, &by)
@@ -882,7 +891,7 @@ async fn clear_session_tag(
     Query(q): Query<ByQuery>,
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
-    let by = q.by.as_deref().unwrap_or("manual").trim().to_string();
+    let by = author_or_manual(q.by.as_deref());
     tags::clear(&st.db, &branch.id, &tag_key).await?;
     events::record_tag(&st.db, &st.bus, &branch.id, &tag_key, "", "", &by)
         .await
@@ -1857,7 +1866,7 @@ async fn send_session(
             .await
             .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
-    let by = req.by.as_deref().unwrap_or("manual").trim().to_string();
+    let by = author_or_manual(req.by.as_deref());
     events::record(
         &st.db,
         &st.bus,
@@ -2129,14 +2138,7 @@ async fn set_issue_tag(
             "invalid value for '{key}' — must be non-empty (clear the tag to remove it)"
         )));
     }
-    // An all-whitespace author is treated the same as a missing one.
-    let by = req
-        .by
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .unwrap_or("manual")
-        .to_string();
+    let by = author_or_manual(req.by.as_deref());
     let note = req.note.trim();
     weaver_core::issue::set_tag(&st.db, id, key, value, note, &by).await?;
     if let Some(branch_id) = issue_event_branch(&st.db, &issue).await {

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -88,10 +88,10 @@ use crate::events::{Event, EventBus};
 use crate::session::{self as session_mod, NewSession, Session};
 use crate::{agent, config, db, events, git, github, overlooker as ov_engine, repo, tmux};
 use weaver_api::{
-    BranchView, CreateIssueReq, CreateOverlookerReq, CreateRepoIssueReq, CreateReq, IssueView,
-    OverlookerRunView, OverlookerView, PatchIssueReq, PatchOverlookerReq, PatchSessionReq,
-    PlanTaskView, PlanView, ProgramView, RunOverlookerReq, ScratchUpload, SendReq, SessionView,
-    TagReq,
+    AgentOneshotReq, BranchView, CreateIssueReq, CreateOverlookerReq, CreateRepoIssueReq,
+    CreateReq, IssueView, OverlookerRunView, OverlookerView, PatchIssueReq, PatchOverlookerReq,
+    PatchSessionReq, PlanTaskView, PlanView, ProgramView, RunOverlookerReq, ScratchUpload, SendReq,
+    SessionView, TagReq,
 };
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::Branch;
@@ -330,6 +330,9 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/overlookers/{id}/run", post(run_overlooker))
         .route("/overlookers/{id}/runs", get(overlooker_runs))
+        // The one-shot headless agent — the judgement primitive overlooker
+        // programs (and any script) call through the daemon.
+        .route("/agent/oneshot", post(agent_oneshot))
         // Scratch uploads can carry images / logs; lift the default 2 MB cap.
         .layer(DefaultBodyLimit::max(64 * 1024 * 1024))
         .with_state(state);
@@ -347,11 +350,23 @@ pub fn router(state: AppState) -> Router {
 
 async fn list_sessions(State(st): State<AppState>) -> ApiResult<Json<Vec<SessionView>>> {
     // The fleet listing shows work, not infrastructure: engine-managed (warm)
-    // sessions are excluded here, so the dashboard never renders a watcher's own
-    // session. Internal liveness/adopt paths use `session::list` instead.
+    // sessions are excluded here, so neither the dashboard nor an overlooker
+    // round's survey (scripts read this route) ever sees a watcher's own
+    // session — the no-recursion guarantee. `list_visible` drops `managed_by`
+    // rows; the `warm_session_id` check below is belt-and-braces for a warm
+    // session not yet stamped. Internal liveness/adopt paths use
+    // `session::list` instead.
+    let warm: std::collections::HashSet<String> = ov::list(&st.db)
+        .await?
+        .into_iter()
+        .filter_map(|o| o.warm_session_id)
+        .collect();
     let sessions = session_mod::list_visible(&st.db).await?;
     let mut views: Vec<SessionView> = Vec::with_capacity(sessions.len());
     for s in sessions {
+        if warm.contains(&s.id) {
+            continue;
+        }
         if let Some(branch) = branch_mod::get(&st.db, &s.branch_id).await? {
             views.push(session_view(&st.db, &s, &branch).await?);
         }
@@ -858,19 +873,29 @@ async fn set_session_tag(
 
 /// Clear a tag on a session's branch — delete the row and broadcast a `tag`
 /// event with an empty value (the cleared signal). How a loud axis returns to
-/// calm (`ok`). A no-op when the tag is already absent. DELETE carries no body,
-/// so the author is recorded as `manual`.
+/// calm (`ok`). A no-op when the tag is already absent. DELETE carries no
+/// body, so the author rides the `by` query parameter (an overlooker name),
+/// defaulting to `manual`.
 async fn clear_session_tag(
     State(st): State<AppState>,
     Path((key, tag_key)): Path<(String, String)>,
+    Query(q): Query<ByQuery>,
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
+    let by = q.by.as_deref().unwrap_or("manual").trim().to_string();
     tags::clear(&st.db, &branch.id, &tag_key).await?;
-    events::record_tag(&st.db, &st.bus, &branch.id, &tag_key, "", "", "manual")
+    events::record_tag(&st.db, &st.bus, &branch.id, &tag_key, "", "", &by)
         .await
         .ok();
     let (session, branch) = require_session(&st.db, &session.id).await?;
     Ok(Json(session_view(&st.db, &session, &branch).await?))
+}
+
+/// Query string carrying the author of a body-less mutation (a tag DELETE).
+#[derive(Debug, Deserialize)]
+struct ByQuery {
+    #[serde(default)]
+    by: Option<String>,
 }
 
 async fn patch_session(
@@ -1814,13 +1839,15 @@ async fn require_live_tmux(session: &Session) -> ApiResult<()> {
 }
 
 /// Type a message into a session's agent pane and, by default, submit it with
-/// Enter to trigger an agent round.
+/// Enter to trigger an agent round. Every send is also a `nudge` events row
+/// (the audit rule — every mutating action is an events row), attributed to
+/// `by` (an overlooker name, or `manual` when absent).
 async fn send_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
     Json(req): Json<SendReq>,
 ) -> ApiResult<Json<Value>> {
-    let (session, _) = require_session(&st.db, &key).await?;
+    let (session, branch) = require_session(&st.db, &key).await?;
     require_live_tmux(&session).await?;
     tmux::send_literal(&session.tmux_session, &req.text)
         .await
@@ -1830,6 +1857,16 @@ async fn send_session(
             .await
             .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
+    let by = req.by.as_deref().unwrap_or("manual").trim().to_string();
+    events::record(
+        &st.db,
+        &st.bus,
+        &branch.id,
+        "nudge",
+        json!({ "by": by, "text": req.text }),
+    )
+    .await
+    .ok();
     Ok(Json(json!({ "sent": true, "submitted": req.submit })))
 }
 
@@ -2547,6 +2584,32 @@ async fn run_overlooker(
         "outcome": outcome,
         "summary": summary,
     })))
+}
+
+/// Run a one-shot headless agent and return `{output}` — the judgement
+/// primitive overlooker programs call. The daemon owns the agent command
+/// (`WEAVER_OVERLOOKER_AGENT_CMD`, default `claude -p`) and the timeout
+/// budget. Best-effort by contract: an absent or failing agent returns
+/// `{output: null}` rather than an error, so callers degrade to their
+/// deterministic fallback.
+async fn agent_oneshot(
+    State(st): State<AppState>,
+    Json(req): Json<AgentOneshotReq>,
+) -> ApiResult<Json<Value>> {
+    if req.prompt.trim().is_empty() {
+        return Err(AppError::bad_request("prompt must be non-empty"));
+    }
+    let budget = ov_engine::get_int(&st.db, "overlooker.default_timeout_secs", 600)
+        .await
+        .max(1) as u64;
+    let output = agent::run_oneshot(
+        &req.prompt,
+        &req.model,
+        &req.effort,
+        std::time::Duration::from_secs(budget),
+    )
+    .await;
+    Ok(Json(json!({ "output": output })))
 }
 
 async fn overlooker_runs(

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -102,6 +102,11 @@ impl TestServer {
         tokio::spawn(server::serve(state, listener));
 
         std::env::set_var("WEAVER_API", format!("http://{addr}"));
+        // Pin the one-shot agent to a fast no-op: `true` exits 0 with empty
+        // output, so a judgement degrades to the deterministic fallback
+        // rather than spawning a real (slow, environment-dependent) claude.
+        // A test exercising the agent path overrides this itself.
+        std::env::set_var("WEAVER_OVERLOOKER_AGENT_CMD", "true");
         let client = client::default();
         for _ in 0..60 {
             if client.get("/api/health").await.is_ok() {

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -1,6 +1,11 @@
-//! The Overlooker engine: the dispatcher's event→trigger matching (T4), a stock
-//! `builtin:status` round landing a mark and its audit row (T5/T11), and the
-//! guardrails (cooldown / no-overlap → `skipped`).
+//! The Overlooker engine's **wiring**: the dispatcher's event→trigger
+//! matching, rounds landing marks and audit rows against the live server, and
+//! the guardrails (cooldown / no-overlap → `skipped`).
+//!
+//! Test placement: a builtin program's *decision logic* is covered
+//! server-free by pytest (`python/weaver-loom/tests/`); these cases prove the
+//! plumbing — the script runs under the engine, reaches the fleet over REST,
+//! and its mutations land with attribution. Don't re-test program logic here.
 //!
 //! These cases drive the engine **directly** on the test server's isolated db
 //! rather than through the spawned background loop: the `overlooker.enabled`
@@ -292,12 +297,16 @@ async fn stale_session_emits_one_event_and_wakes_a_reactive_overlooker() {
         .unwrap();
 }
 
-/// T5 / T11: a `builtin:status` round over a non-ok session lands a triage mark
-/// (rule path, no real claude) and records the action in the run; a `dry_run`
-/// round makes no mark but records a `would`-action.
+/// The status program's wiring proof: a round over a non-ok session lands an
+/// attributed triage mark on the live server and records the action on the
+/// run row. The program's decision logic (judge fallback, dry-run, capability
+/// branches, summaries) is covered server-free in
+/// `python/weaver-loom/tests/test_status_program.py`; dry-run flag
+/// propagation through the executor is covered by the lib test
+/// `run_script_round_trips_the_contract`.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn builtin_status_marks_a_session_and_dry_run_is_safe() {
+async fn builtin_status_round_lands_an_attributed_mark() {
     if !python3_available() {
         eprintln!("skipping: python3 not on PATH");
         return;
@@ -359,40 +368,6 @@ async fn builtin_status_marks_a_session_and_dry_run_is_safe() {
         arr.iter()
             .any(|a| a["action"] == "mark" && a["session"] == session_id.as_str()),
         "the run records a mark action: {actions}"
-    );
-
-    // Clear the mark, then a dry run must NOT re-apply it — it records a `would`.
-    ts.client
-        .delete(&format!("/api/sessions/{session_id}/tags/triage"))
-        .await
-        .unwrap();
-    let dry_run_id = overlooker::fire_now(&state, &o.name, true, "manual")
-        .await
-        .unwrap();
-    let view = ts
-        .client
-        .get(&format!("/api/sessions/{session_id}"))
-        .await
-        .unwrap();
-    assert!(
-        branch_tag(&view, "triage").is_none(),
-        "a dry run applies no mark"
-    );
-    let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
-    let dry = runs.iter().find(|r| r.id == dry_run_id).unwrap();
-    let actions: serde_json::Value = serde_json::from_str(&dry.actions).unwrap();
-    assert!(
-        actions
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|a| a["would"] == "mark" && a["session"] == session_id.as_str()),
-        "a dry run logs a would-mark instead of marking: {actions}"
-    );
-    assert!(
-        dry.summary.contains("dry run"),
-        "the dry-run summary says so: {}",
-        dry.summary
     );
 
     ts.client
@@ -976,11 +951,11 @@ async fn status_judgement_uses_the_oneshot_agent_when_prompted() {
         "blocked",
         "the agent judgement (not the calm attention mirror) lands as the mark"
     );
-    let tag = branch_tag(&view, "triage").unwrap();
-    assert_eq!(tag["set_by"], "judge-watch");
+    // (Judgement parsing detail — level/note extraction — is pytest-covered in
+    // weaver_loom; here only the through-the-stack outcome matters.)
     assert_eq!(
-        tag["note"], "the judge says so",
-        "the note is the judgement line after its separator"
+        branch_tag(&view, "triage").unwrap()["set_by"],
+        "judge-watch"
     );
 
     // Restore the fixture's no-op agent for the tests that follow.

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -65,6 +65,10 @@ async fn enabled_overlooker(state: &AppState, new: ov::NewOverlooker) -> ov::Ove
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dispatcher_matches_trigger_with_repo_filter_and_is_idempotent() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
     let ts = TestServer::start().await;
     let state = engine_state(&ts).await;
     let (session_id, branch_id, repo_root) = make_session(&ts, "watch me").await;
@@ -174,6 +178,10 @@ async fn dispatcher_matches_trigger_with_repo_filter_and_is_idempotent() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stale_session_emits_one_event_and_wakes_a_reactive_overlooker() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
     let ts = TestServer::start().await;
     let state = engine_state(&ts).await;
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "go stale").await;
@@ -290,6 +298,10 @@ async fn stale_session_emits_one_event_and_wakes_a_reactive_overlooker() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn builtin_status_marks_a_session_and_dry_run_is_safe() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
     let ts = TestServer::start().await;
     let state = engine_state(&ts).await;
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "status me").await;
@@ -395,6 +407,10 @@ async fn builtin_status_marks_a_session_and_dry_run_is_safe() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn timer_emits_cron_tick_for_a_due_overlooker_and_dispatches_it() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
     let ts = TestServer::start().await;
     let state = engine_state(&ts).await;
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "tick me").await;
@@ -479,6 +495,10 @@ async fn timer_emits_cron_tick_for_a_due_overlooker_and_dispatches_it() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cooldown_and_overlap_refire_are_refused() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
     let ts = TestServer::start().await;
     let state = engine_state(&ts).await;
     let (session_id, branch_id, repo_root) = make_session(&ts, "cool down").await;
@@ -558,6 +578,10 @@ async fn cooldown_and_overlap_refire_are_refused() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rest_overlooker_lifecycle_and_validation() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
     let ts = TestServer::start().await;
     // A non-ok session so the dry-run round has something in scope to "would-mark".
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "rest me").await;
@@ -738,12 +762,11 @@ async fn rest_lists_builtin_programs_and_validates_program_refs() {
         assert!(names.contains(&expected), "{expected} missing: {names:?}");
     }
 
-    // A script program ships its source and suggested defaults…
+    // Every builtin is a script: it ships its source and suggested defaults.
     let archive = arr
         .iter()
         .find(|p| p["program"] == "builtin:archive-merged")
         .unwrap();
-    assert_eq!(archive["kind"], "script");
     assert!(
         archive["source"]
             .as_str()
@@ -753,13 +776,14 @@ async fn rest_lists_builtin_programs_and_validates_program_refs() {
     );
     assert!(archive["defaults"]["trigger"]["every"].is_string());
     assert_eq!(archive["defaults"]["capabilities"][0], "observe");
-    // …a native program has no source to show.
     let status = arr
         .iter()
         .find(|p| p["program"] == "builtin:status")
         .unwrap();
-    assert_eq!(status["kind"], "native");
-    assert!(status["source"].is_null());
+    assert!(
+        status["source"].as_str().unwrap().contains("triage"),
+        "the status program is a script like every other builtin"
+    );
 
     // An unknown builtin is rejected at create time; a known script accepted.
     let bad = ts
@@ -889,6 +913,84 @@ async fn builtin_scripts_report_merged_and_unlabelled_prs() {
     }
 }
 
+/// The LLM judgement path end to end: with a prompt configured and the
+/// one-shot agent stubbed (`WEAVER_OVERLOOKER_AGENT_CMD=cat` echoes the
+/// prompt back), the status script calls the daemon's `POST /api/agent/oneshot`
+/// and parses the level + note out of the reply — the mark carries the
+/// agent's judgement, not the attention mirror. Also drives the endpoint
+/// directly: a stubbed agent echoes, and an empty prompt is rejected.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn status_judgement_uses_the_oneshot_agent_when_prompted() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
+    let ts = TestServer::start().await;
+    // `cat` echoes the composed prompt (prompt + screen) straight back, so the
+    // judgement parser sees the prompt's own first line.
+    std::env::set_var("WEAVER_OVERLOOKER_AGENT_CMD", "cat");
+
+    // The endpoint itself: output echoes the prompt; an empty prompt 400s.
+    let reply = ts
+        .client
+        .post("/api/agent/oneshot", json!({ "prompt": "ping" }))
+        .await
+        .unwrap();
+    assert_eq!(reply["output"], "ping", "the stub agent echoes the prompt");
+    assert!(
+        ts.client
+            .post("/api/agent/oneshot", json!({ "prompt": "" }))
+            .await
+            .is_err(),
+        "an empty prompt is rejected"
+    );
+
+    // A calm session (no attention tag): the fallback rule would clear, so a
+    // `blocked` mark proves the agent judgement was used.
+    let state = engine_state(&ts).await;
+    let (session_id, _branch_id, _repo_root) = make_session(&ts, "judge me").await;
+    let o = enabled_overlooker(
+        &state,
+        ov::NewOverlooker {
+            name: "judge-watch".to_string(),
+            trigger_spec: json!({ "cron": "0 * * * *" }).to_string(),
+            program: "builtin:status".to_string(),
+            params: json!({ "prompt": "blocked - the judge says so" }).to_string(),
+            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            ..Default::default()
+        },
+    )
+    .await;
+    overlooker::fire_now(&state, &o.name, false, "manual")
+        .await
+        .unwrap();
+
+    let view = ts
+        .client
+        .get(&format!("/api/sessions/{session_id}"))
+        .await
+        .unwrap();
+    assert_eq!(
+        branch_tag_value(&view, "triage"),
+        "blocked",
+        "the agent judgement (not the calm attention mirror) lands as the mark"
+    );
+    let tag = branch_tag(&view, "triage").unwrap();
+    assert_eq!(tag["set_by"], "judge-watch");
+    assert_eq!(
+        tag["note"], "the judge says so",
+        "the note is the judgement line after its separator"
+    );
+
+    // Restore the fixture's no-op agent for the tests that follow.
+    std::env::set_var("WEAVER_OVERLOOKER_AGENT_CMD", "true");
+    ts.client
+        .delete(&format!("/api/sessions/{session_id}"))
+        .await
+        .unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // T12 — Warm-session lifecycle
 // ---------------------------------------------------------------------------
@@ -943,6 +1045,10 @@ async fn insert_managed_session(
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn warm_session_is_hidden_from_fleet_and_survey() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
     let ts = TestServer::start().await;
     let state = engine_state(&ts).await;
 

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -64,9 +64,35 @@ async fn enabled_overlooker(state: &AppState, new: ov::NewOverlooker) -> ov::Ove
     ov::get(&state.db, &o.id).await.unwrap().unwrap()
 }
 
+/// The test-owned **survey fixture program** (`programs/survey.py`): records
+/// one `survey` action per surveyed session and mutates nothing. Engine-
+/// mechanics tests run it so they can assert "a round ran over exactly these
+/// sessions" from the run row alone, with no dependency on any builtin
+/// program's behavior (that logic is pytest-owned).
+fn survey_program() -> String {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/integration/programs/survey.py"
+    )
+    .to_string()
+}
+
+/// The session ids a run's recorded `survey` actions name.
+fn surveyed_ids(run: &ov::OverlookerRun) -> Vec<String> {
+    serde_json::from_str::<serde_json::Value>(&run.actions)
+        .ok()
+        .and_then(|v| v.as_array().cloned())
+        .unwrap_or_default()
+        .iter()
+        .filter(|a| a["action"] == "survey")
+        .filter_map(|a| a["session"].as_str().map(str::to_string))
+        .collect()
+}
+
 /// T4: a reactive event whose trigger matches fires the right overlooker exactly
 /// once and lands a run row; a repo filter excludes another repo's event; and
-/// re-firing the same event is idempotent (the mark converges, no contradiction).
+/// re-firing the same event is idempotent (a fresh re-survey, never a second
+/// "handling" of the event).
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dispatcher_matches_trigger_with_repo_filter_and_is_idempotent() {
@@ -88,16 +114,16 @@ async fn dispatcher_matches_trigger_with_repo_filter_and_is_idempotent() {
         .await
         .unwrap();
 
-    // An overlooker reacting to `attention` events in *this* repo, marking the
-    // scoped (non-ok) fleet.
+    // An overlooker reacting to `attention` events in *this* repo, surveying
+    // the scoped (non-ok) fleet via the test-owned fixture program.
     let o = enabled_overlooker(
         &state,
         ov::NewOverlooker {
             name: "blocked-watch".to_string(),
             trigger_spec: json!({ "event": "attention", "repo": repo_root }).to_string(),
             scope: json!({ "attention": "!ok" }).to_string(),
-            program: "builtin:status".to_string(),
-            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            program: survey_program(),
+            capabilities: vec!["observe".to_string()],
             ..Default::default()
         },
     )
@@ -117,38 +143,26 @@ async fn dispatcher_matches_trigger_with_repo_filter_and_is_idempotent() {
     };
     overlooker::dispatch(&state, &in_flight, &ev).await;
 
-    // Exactly one run, and it marked the session.
+    // Exactly one run, and its run row records the survey of the in-scope
+    // session — the engine-observable proof the round ran.
     let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
     assert_eq!(runs.len(), 1, "one matching event fires exactly one round");
     assert_eq!(runs[0].outcome, "ok");
-    let view = ts
-        .client
-        .get(&format!("/api/sessions/{session_id}"))
-        .await
-        .unwrap();
     assert_eq!(
-        branch_tag_value(&view, "triage"),
-        "blocked",
-        "the rule mirrors the agent's attention onto the mark"
-    );
-    assert_eq!(
-        branch_tag(&view, "triage").unwrap()["set_by"],
-        "blocked-watch"
+        surveyed_ids(&runs[0]),
+        vec![session_id.clone()],
+        "the round surveyed exactly the in-scope session"
     );
 
-    // Re-firing the identical event is idempotent: it converges on the same mark
-    // (a fresh run, but no contradictory state). Level-triggered: the round
-    // re-surveys rather than "handling" the event again.
+    // Re-firing the identical event is idempotent: level-triggered, the round
+    // just re-surveys the current fleet — a fresh run row, same survey.
     overlooker::dispatch(&state, &in_flight, &ev).await;
-    let view2 = ts
-        .client
-        .get(&format!("/api/sessions/{session_id}"))
-        .await
-        .unwrap();
+    let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
+    assert_eq!(runs.len(), 2, "a re-fire is a fresh round");
     assert_eq!(
-        branch_tag_value(&view2, "triage"),
-        "blocked",
-        "re-firing converges on the same mark, not a contradiction"
+        surveyed_ids(&runs[0]),
+        vec![session_id.clone()],
+        "the re-fired round re-surveys, it does not 'handle' the event again"
     );
 
     // The repo filter excludes an event from another repo: same kind/level but a
@@ -191,8 +205,8 @@ async fn stale_session_emits_one_event_and_wakes_a_reactive_overlooker() {
     let state = engine_state(&ts).await;
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "go stale").await;
 
-    // The session reports `attention` about itself so the stock round's rule
-    // produces a non-ok mark when the overlooker fires (proving it ran).
+    // The session reports `attention` about itself so it falls inside the
+    // overlooker's `!ok` scope (the survey will name it, proving it ran).
     ts.client
         .put(
             &format!("/api/sessions/{session_id}/tags/attention"),
@@ -208,8 +222,8 @@ async fn stale_session_emits_one_event_and_wakes_a_reactive_overlooker() {
             name: "stale-watch".to_string(),
             trigger_spec: json!({ "event": "stale" }).to_string(),
             scope: json!({ "attention": "!ok" }).to_string(),
-            program: "builtin:status".to_string(),
-            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            program: survey_program(),
+            capabilities: vec!["observe".to_string()],
             ..Default::default()
         },
     )
@@ -252,24 +266,16 @@ async fn stale_session_emits_one_event_and_wakes_a_reactive_overlooker() {
         "a stale event is branch-scoped so its repo resolves for repo-filtering"
     );
 
-    // The dispatcher consumes the stale tick and fires the reactive round.
+    // The dispatcher consumes the stale tick and fires the reactive round; the
+    // run row records the survey of the in-scope stale session.
     let in_flight = overlooker::new_in_flight();
     overlooker::dispatch(&state, &in_flight, stale_ev).await;
     let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
     assert_eq!(runs.len(), 1, "the stale event fires exactly one round");
-    let view = ts
-        .client
-        .get(&format!("/api/sessions/{session_id}"))
-        .await
-        .unwrap();
     assert_eq!(
-        branch_tag_value(&view, "triage"),
-        "attention",
-        "the woken round marked the in-scope stale session"
-    );
-    assert_eq!(
-        branch_tag(&view, "triage").unwrap()["set_by"],
-        "stale-watch"
+        surveyed_ids(&runs[0]),
+        vec![session_id.clone()],
+        "the woken round surveyed the in-scope stale session"
     );
 
     // Once activity resumes (a non-stale pass clears the session from `seen`),
@@ -404,8 +410,8 @@ async fn timer_emits_cron_tick_for_a_due_overlooker_and_dispatches_it() {
             trigger_spec: json!({ "every": "30m" }).to_string(),
             name: "hourly".to_string(),
             scope: json!({ "attention": "!ok" }).to_string(),
-            program: "builtin:status".to_string(),
-            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            program: survey_program(),
+            capabilities: vec!["observe".to_string()],
             ..Default::default()
         },
     )
@@ -442,20 +448,16 @@ async fn timer_emits_cron_tick_for_a_due_overlooker_and_dispatches_it() {
         "next_run_at moved forward off the past due time"
     );
 
-    // The dispatcher consumes that cron tick and runs the scheduled round.
+    // The dispatcher consumes that cron tick and runs the scheduled round; the
+    // run row records the survey of the in-scope session.
     let in_flight = overlooker::new_in_flight();
     overlooker::dispatch(&state, &in_flight, cron).await;
     let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
     assert_eq!(runs.len(), 1, "the cron tick fires exactly one round");
-    let view = ts
-        .client
-        .get(&format!("/api/sessions/{session_id}"))
-        .await
-        .unwrap();
     assert_eq!(
-        branch_tag_value(&view, "triage"),
-        "attention",
-        "the scheduled round marked the in-scope session"
+        surveyed_ids(&runs[0]),
+        vec![session_id.clone()],
+        "the scheduled round surveyed the in-scope session"
     );
 
     ts.client
@@ -494,8 +496,8 @@ async fn cooldown_and_overlap_refire_are_refused() {
             name: "cooldown-watch".to_string(),
             trigger_spec: json!({ "event": "attention", "repo": repo_root }).to_string(),
             scope: json!({ "attention": "!ok" }).to_string(),
-            program: "builtin:status".to_string(),
-            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            program: survey_program(),
+            capabilities: vec!["observe".to_string()],
             cooldown_secs: 3600,
             ..Default::default()
         },
@@ -1044,8 +1046,8 @@ async fn warm_session_is_hidden_from_fleet_and_survey() {
             name: "warm-watch".to_string(),
             trigger_spec: json!({ "cron": "0 * * * *" }).to_string(),
             scope: json!({ "attention": "!ok" }).to_string(),
-            program: "builtin:status".to_string(),
-            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            program: survey_program(),
+            capabilities: vec!["observe".to_string()],
             ..Default::default()
         },
     )
@@ -1058,8 +1060,8 @@ async fn warm_session_is_hidden_from_fleet_and_survey() {
         "/tmp/warm-hidden",
     )
     .await;
-    // The warm session reports non-ok too, so the only thing keeping it out of a
-    // mark is the visibility filter, not the scope predicate.
+    // The warm session reports non-ok too, so the only thing keeping it out of
+    // the survey is the visibility filter, not the scope predicate.
     let warm = session_mod::get(&state.db, &warm_id)
         .await
         .unwrap()
@@ -1092,30 +1094,21 @@ async fn warm_session_is_hidden_from_fleet_and_survey() {
         "fleet hides the warm session: {ids:?}"
     );
 
-    // A round surveys the ordinary session (marks it) but never the warm one.
-    overlooker::fire_now(&state, &o.name, false, "manual")
+    // A round surveys the ordinary session but never the warm one — asserted
+    // on the run row the engine records, not on any program side-effect.
+    let run_id = overlooker::fire_now(&state, &o.name, false, "manual")
         .await
         .unwrap();
-    let visible_view = ts
-        .client
-        .get(&format!("/api/sessions/{visible_id}"))
-        .await
-        .unwrap();
-    assert_eq!(
-        branch_tag_value(&visible_view, "triage"),
-        "attention",
-        "the round marked the in-scope ordinary session"
-    );
-    let warm_after = session_mod::with_branch(&state.db, &warm_id)
-        .await
-        .unwrap()
-        .unwrap();
+    let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
+    let run = runs.iter().find(|r| r.id == run_id).unwrap();
+    let surveyed = surveyed_ids(run);
     assert!(
-        weaver_core::tags::get(&state.db, &warm_after.1.id, weaver_core::tags::TRIAGE_KEY)
-            .await
-            .unwrap()
-            .is_none(),
-        "the round never surveyed (or marked) the warm session"
+        surveyed.contains(&visible_id),
+        "the round surveyed the ordinary session: {surveyed:?}"
+    );
+    assert!(
+        !surveyed.contains(&warm_id),
+        "the round never surveyed the warm session: {surveyed:?}"
     );
 
     ts.client
@@ -1152,7 +1145,7 @@ async fn warm_session_is_re_adopted_across_restart_independent_of_auto_adopt() {
             trigger_spec: json!({ "cron": "0 * * * *" }).to_string(),
             scope: json!({ "repo": repo_root }).to_string(),
             params: json!({ "warm": true }).to_string(),
-            program: "builtin:status".to_string(),
+            program: survey_program(),
             ..Default::default()
         },
     )
@@ -1264,7 +1257,7 @@ async fn ensure_warm_session_reuses_the_same_session() {
             trigger_spec: json!({ "cron": "0 * * * *" }).to_string(),
             scope: json!({ "repo": repo_root }).to_string(),
             params: json!({ "warm": true }).to_string(),
-            program: "builtin:status".to_string(),
+            program: survey_program(),
             ..Default::default()
         },
     )

--- a/crates/loom/tests/integration/programs/survey.py
+++ b/crates/loom/tests/integration/programs/survey.py
@@ -1,0 +1,14 @@
+"""Test fixture program: record one `survey` action per surveyed session.
+
+Owned by the engine-mechanics integration tests (`tests/integration/
+overlookers.rs`): it mutates nothing, so a test can assert "a round ran over
+exactly these sessions" from the run row alone — no dependency on any
+builtin program's behavior.
+"""
+
+from weaver_loom import Round
+
+rnd = Round()
+for session in rnd.sessions():
+    rnd.did("survey", session=session["id"])
+rnd.finish(f"surveyed {rnd.surveyed}")

--- a/crates/weaver-api/Cargo.toml
+++ b/crates/weaver-api/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 weaver-core = { path = "../weaver-core" }
 anyhow = "1"
+percent-encoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -165,10 +165,24 @@ impl Client {
     }
 
     /// Clear a tag on a session (`DELETE /api/sessions/{key}/tags/{tag_key}`) —
-    /// how a loud axis returns to calm (`ok`).
-    pub async fn clear_tag(&self, key: &str, tag_key: &str) -> Result<SessionView> {
+    /// how a loud axis returns to calm (`ok`). `by` attributes the clear on
+    /// the audit event (an overlooker name); the server defaults `manual`.
+    pub async fn clear_tag(
+        &self,
+        key: &str,
+        tag_key: &str,
+        by: Option<&str>,
+    ) -> Result<SessionView> {
+        let query = by
+            .map(|b| {
+                format!(
+                    "?by={}",
+                    percent_encoding::utf8_percent_encode(b, percent_encoding::NON_ALPHANUMERIC)
+                )
+            })
+            .unwrap_or_default();
         let value = self
-            .delete(&format!("/api/sessions/{key}/tags/{tag_key}"))
+            .delete(&format!("/api/sessions/{key}/tags/{tag_key}{query}"))
             .await?;
         serde_json::from_value(value)
             .map_err(|e| anyhow!("decoding response from /api/sessions/{key}/tags/{tag_key}: {e}"))
@@ -186,7 +200,7 @@ impl Client {
         by: Option<&str>,
     ) -> Result<SessionView> {
         if level.is_empty() || level == "ok" {
-            self.clear_tag(key, weaver_core::tags::TRIAGE_KEY).await
+            self.clear_tag(key, weaver_core::tags::TRIAGE_KEY, by).await
         } else {
             self.set_tag(key, weaver_core::tags::TRIAGE_KEY, level, note, by)
                 .await

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -315,9 +315,8 @@ impl From<OverlookerRun> for OverlookerRunView {
 }
 
 /// One **program** an overlooker can run, as `GET /api/overlookers/programs`
-/// exposes it. Builtin programs ship inside the loom binary: a `native` one is
-/// implemented in Rust, a `script` one is an embedded Python file whose source
-/// is returned for a read-only view in the panel.
+/// exposes it. Builtin programs are Python scripts that ship inside the loom
+/// binary; the embedded source is returned for a read-only view in the panel.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProgramView {
     /// The reference an overlooker's `program` field names it by, e.g.
@@ -325,11 +324,9 @@ pub struct ProgramView {
     pub program: String,
     pub title: String,
     pub description: String,
-    /// `native` (in-Rust) or `script` (an embedded Python program).
-    pub kind: String,
-    /// A `script` program's source. Read-only — it ships with the binary;
-    /// `null` for a native program.
-    pub source: Option<String>,
+    /// The program's embedded Python source. Read-only — it ships with the
+    /// binary.
+    pub source: String,
     /// Suggested starting config for a new overlooker running this program:
     /// `{trigger, scope, params, capabilities}` — what a create form prefills.
     pub defaults: Value,
@@ -432,6 +429,10 @@ pub struct SendReq {
     /// agent round). Defaults to true; pass false to stage input unsubmitted.
     #[serde(default = "default_submit")]
     pub submit: bool,
+    /// Who is sending (an overlooker name or `manual`) — recorded on the
+    /// `nudge` audit event; the server defaults a missing author.
+    #[serde(default)]
+    pub by: Option<String>,
 }
 
 fn default_submit() -> bool {
@@ -444,8 +445,26 @@ impl SendReq {
         Self {
             text: text.into(),
             submit: true,
+            by: None,
         }
     }
+}
+
+/// Body for `POST /api/agent/oneshot`: run a fresh, env-stripped one-shot
+/// headless agent (`claude -p`) with `prompt` on stdin and return its stdout
+/// as `{output}` (`null` when the agent is absent or fails — callers degrade
+/// gracefully). The judgement primitive overlooker programs reach through the
+/// daemon, which owns the agent command and timeout configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentOneshotReq {
+    pub prompt: String,
+    /// Model tier override (`haiku` | `sonnet` | `opus` | `fable`); empty
+    /// inherits the agent's default.
+    #[serde(default)]
+    pub model: String,
+    /// Reasoning effort override; empty inherits.
+    #[serde(default)]
+    pub effort: String,
 }
 
 /// Body for `POST /api/branches/{id}/issues`: create an issue claimed by a

--- a/crates/weaver-py/Cargo.lock
+++ b/crates/weaver-py/Cargo.lock
@@ -1544,6 +1544,7 @@ name = "weaver-api"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/weaver-py/src/lib.rs
+++ b/crates/weaver-py/src/lib.rs
@@ -214,11 +214,22 @@ impl Client {
     }
 
     /// Clear a tag on a session (needs `mark`) — how a loud axis returns to
-    /// calm. Returns the updated session.
-    fn clear_tag(&self, py: Python<'_>, key: &str, tag_key: &str) -> PyResult<Py<PyAny>> {
+    /// calm. `by` attributes the clear on the audit event. Returns the
+    /// updated session.
+    #[pyo3(signature = (key, tag_key, by=None))]
+    fn clear_tag(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        tag_key: &str,
+        by: Option<String>,
+    ) -> PyResult<Py<PyAny>> {
         self.gate("mark")?;
         let view = py
-            .detach(|| self.rt.block_on(self.inner.clear_tag(key, tag_key)))
+            .detach(|| {
+                self.rt
+                    .block_on(self.inner.clear_tag(key, tag_key, by.as_deref()))
+            })
             .map_err(api_err)?;
         to_py(py, &view)
     }
@@ -248,13 +259,22 @@ impl Client {
 
     /// Type a message into a session's agent pane (needs `nudge`). `submit`
     /// presses Enter to start a turn; pass `False` to stage input unsubmitted.
-    /// Returns the raw `{sent, submitted}` reply.
-    #[pyo3(signature = (key, text, submit=true))]
-    fn nudge(&self, py: Python<'_>, key: &str, text: &str, submit: bool) -> PyResult<Py<PyAny>> {
+    /// `by` attributes the recorded `nudge` audit event. Returns the raw
+    /// `{sent, submitted}` reply.
+    #[pyo3(signature = (key, text, submit=true, by=None))]
+    fn nudge(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        text: &str,
+        submit: bool,
+        by: Option<String>,
+    ) -> PyResult<Py<PyAny>> {
         self.gate("nudge")?;
         let req = SendReq {
             text: text.to_string(),
             submit,
+            by,
         };
         let value = py
             .detach(|| self.rt.block_on(self.inner.nudge(key, &req)))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ needing the daemon to be reachable.
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
 | `crates/loom/src/overlooker.rs` | the overlooker engine: cron timer + event dispatcher + the round executor (the script subprocess executor every program runs on) |
 | `crates/loom/src/builtins.rs` | the builtin overlooker program registry; the script programs are real Python files in `crates/loom/overlookers/`, embedded into the binary |
-| `python/weaver-loom/` | the pure-Python layer over the loom REST API (`weaver_loom`: client + overlooker round context); stdlib-only, uv-buildable, vendored onto every script's `PYTHONPATH` by the engine |
+| `python/weaver-loom/` | the pure-Python layer over the loom REST API (`weaver_loom`: client + overlooker round context); stdlib-only, uv-buildable, vendored onto every script's `PYTHONPATH` by the engine; server-free contract tests in `tests/` (`uv run pytest`, CI's `python-binding` job) |
 | `crates/loom/src/agent.rs` | launching agents into tmux + installing `.claude/settings.local.json` hooks + the one-shot headless agent behind `POST /api/agent/oneshot` |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
 | `crates/loom/src/tmux.rs` | `tmux new-session / capture-pane / kill-session / attach` (exact-match `=name:` targets) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,10 +48,10 @@ needing the daemon to be reachable.
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
-| `crates/loom/src/overlooker.rs` | the overlooker engine: cron timer + event dispatcher + the round executor (the native `builtin:status` program and the script subprocess executor) |
+| `crates/loom/src/overlooker.rs` | the overlooker engine: cron timer + event dispatcher + the round executor (the script subprocess executor every program runs on) |
 | `crates/loom/src/builtins.rs` | the builtin overlooker program registry; the script programs are real Python files in `crates/loom/overlookers/`, embedded into the binary |
 | `python/weaver-loom/` | the pure-Python layer over the loom REST API (`weaver_loom`: client + overlooker round context); stdlib-only, uv-buildable, vendored onto every script's `PYTHONPATH` by the engine |
-| `crates/loom/src/agent.rs` | launching agents into tmux + installing `.claude/settings.local.json` hooks |
+| `crates/loom/src/agent.rs` | launching agents into tmux + installing `.claude/settings.local.json` hooks + the one-shot headless agent behind `POST /api/agent/oneshot` |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
 | `crates/loom/src/tmux.rs` | `tmux new-session / capture-pane / kill-session / attach` (exact-match `=name:` targets) |
 | `crates/loom/src/terminal.rs` | WebSocket ⇄ PTY bridge: xterm.js ⇄ `tmux attach` (the live terminal) |
@@ -388,27 +388,29 @@ scope, and acts within an explicit capability set. The design of record is
 
 A round runs the **program** the overlooker names:
 
-- **`builtin:status`** — the native (in-Rust) stock program: stamps a `triage`
-  mark on each in-scope session, judging via the configured `prompt` (a
-  one-shot env-stripped `claude -p` when available) or mirroring the agent's
-  own `attention` tag.
 - **Builtin scripts** — real Python files in `crates/loom/overlookers/`,
   embedded into the binary and registered in `loom::builtins`:
+  `builtin:status` (stamp a `triage` mark on each in-scope session, judging
+  via the configured `prompt` through the daemon's one-shot agent when
+  available, else mirroring the agent's own `attention` tag),
   `builtin:pr-label` (flag sessions whose open PR lacks the loom label) and
-  `builtin:archive-merged` (flag live sessions whose PR has merged). Both are
-  **read-only**: they record `would:` actions and mutate nothing — the actual
-  archive is still `github.archive_on_merge`, above. The Overlooker panel and
-  `loom overlooker programs` list the registry; script sources render
-  read-only (they ship with the binary).
+  `builtin:archive-merged` (flag live sessions whose PR has merged). The last
+  two are **read-only**: they record `would:` actions and mutate nothing — the
+  actual archive is still `github.archive_on_merge`, above. The Overlooker
+  panel and `loom overlooker programs` list the registry; script sources
+  render read-only (they ship with the binary).
 - **A custom program file** — an absolute path, conventionally
   `~/.weaver/overlookers/<name>.py` (`loom overlooker new` scaffolds one).
 
 Builtin scripts and custom files run on one executor: an env-stripped
 subprocess that reaches the fleet only through the loom REST API — everything
-loom can do is an HTTP route, and Python is purely a convenience layer on top.
+loom can do is an HTTP route (including one-shot agent judgement, at
+`POST /api/agent/oneshot`), and Python is purely a convenience layer on top.
+There is deliberately no privileged in-Rust program shape: a builtin sees
+exactly the API a custom program sees.
 The contract: `$WEAVER_API` carries the daemon's base URL, `$WEAVER_OVERLOOKER`
-the round's config (`{id, name, program, params, scope, capabilities,
-dry_run}`), and the script prints one JSON object — `{outcome, summary,
+the round's config (`{id, name, program, params, scope, capabilities, model,
+effort, dry_run}`), and the script prints one JSON object — `{outcome, summary,
 actions}` — as its final stdout line. A non-zero exit, no result object, or a
 blown round budget records the round as an `error`. A mutating program must
 honor `dry_run` (record `{would: …}` actions instead of acting) and stay inside
@@ -433,4 +435,5 @@ builtins are stdlib-only and need neither).
 | `WEAVER_API` | loom URL (both sides — server binds, CLI talks) | `http://127.0.0.1:7878` |
 | `WEAVER_BRANCH` | override the branch resolver (set by `loom session launch` in the worktree) | — |
 | `WEAVER_TMUX_SOCKET` | pin tmux to a dedicated server (`tmux -L <name>`) so ops can't touch real sessions; set by the test harnesses | unset → default socket |
+| `WEAVER_OVERLOOKER_AGENT_CMD` | the one-shot headless agent command behind `POST /api/agent/oneshot` (judgement calls) | `claude -p` |
 | `RUST_LOG` / `EnvFilter` | tracing filter | `loom=info,weaver_core=info,tower_http=warn` |

--- a/e2e/tests/overlookers.spec.ts
+++ b/e2e/tests/overlookers.spec.ts
@@ -143,15 +143,17 @@ test.describe('overlooker panel', () => {
       await expect(section).toContainText(name);
     }
 
-    // A script program's source is viewable read-only; the native status
-    // program has no source to show.
+    // Every builtin is a script whose source is viewable read-only.
     const archive = rows.filter({ hasText: 'builtin:archive-merged' });
     await archive.getByTestId('program-source-toggle').click();
     await expect(archive.getByTestId('program-source')).toContainText(
       'flag sessions whose pull request has merged',
     );
     const status = rows.filter({ hasText: 'builtin:status' });
-    await expect(status.getByTestId('program-source-toggle')).toHaveCount(0);
+    await status.getByTestId('program-source-toggle').click();
+    await expect(status.getByTestId('program-source')).toContainText(
+      'stamp a triage mark',
+    );
 
     // "Use" opens the create form prefilled with the program and a name.
     await archive.getByTestId('program-use').click();

--- a/python/weaver-loom/pyproject.toml
+++ b/python/weaver-loom/pyproject.toml
@@ -11,3 +11,8 @@ dependencies = []
 [build-system]
 requires = ["uv_build>=0.6,<0.9"]
 build-backend = "uv_build"
+
+[dependency-groups]
+# `uv run pytest` from this directory runs the server-free contract suite in
+# tests/; CI runs the same suite in the python-binding job.
+dev = ["pytest"]

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -35,6 +35,7 @@ from the weaver repo with ``uv pip install -e python/weaver-loom``.
 import json
 import os
 import urllib.error
+import urllib.parse
 import urllib.request
 
 DEFAULT_BASE = "http://127.0.0.1:7878"
@@ -44,6 +45,29 @@ CAPABILITIES = ["observe", "mark", "escalate", "nudge", "interrupt", "launch"]
 
 #: Lifecycle states with no live session behind them.
 TERMINAL_STATUSES = {"done", "error", "archived"}
+
+#: The levels an agent judgement may name: the two storable triage values plus
+#: the calm ``ok`` — recognising ``ok`` lets a judgement explicitly return the
+#: axis to calm (the caller then clears the tag rather than marking).
+JUDGED_LEVELS = ("ok", "attention", "blocked")
+
+
+def parse_judgement(text):
+    """Parse an agent judgement into ``(level, note)``, or ``None``.
+
+    Lenient by design: the first line containing a recognised triage word
+    yields the level; the rest of that line (after a ``:`` or ``-``) is the
+    note. ``None`` means no level was found — the caller falls back to its
+    deterministic rule.
+    """
+    for line in (text or "").splitlines():
+        words = "".join(c if c.isalpha() else " " for c in line.lower()).split()
+        for level in JUDGED_LEVELS:
+            if level in words:
+                cuts = [i for i in (line.find(":"), line.find("-")) if i >= 0]
+                note = line[min(cuts) + 1 :].strip() if cuts else ""
+                return level, note or line.strip()
+    return None
 
 
 class WeaverError(RuntimeError):
@@ -123,6 +147,18 @@ class Client:
         """The builtin overlooker program registry."""
         return self._request("GET", "/overlookers/programs")
 
+    def agent(self, prompt, model="", effort=""):
+        """Run a one-shot headless agent in the daemon and return its stdout,
+        or ``None`` when the agent is absent or failed (degrade gracefully —
+        the daemon never errors a missing agent). A judgement primitive: pair
+        with :func:`parse_judgement`."""
+        reply = self._request(
+            "POST",
+            "/agent/oneshot",
+            {"prompt": prompt, "model": model or "", "effort": effort or ""},
+        )
+        return (reply or {}).get("output")
+
     # -- Writes (capability-gated) --------------------------------------------
 
     def set_tag(self, key, tag_key, value, note="", by=None):
@@ -133,24 +169,28 @@ class Client:
             body["by"] = by
         return self._request("PUT", f"/sessions/{key}/tags/{tag_key}", body)
 
-    def clear_tag(self, key, tag_key):
-        """Clear a tag — how a loud axis returns to calm; needs ``mark``."""
+    def clear_tag(self, key, tag_key, by=None):
+        """Clear a tag — how a loud axis returns to calm; needs ``mark``.
+        ``by`` attributes the clear (an overlooker name)."""
         self._gate("mark")
-        return self._request("DELETE", f"/sessions/{key}/tags/{tag_key}")
+        query = f"?by={urllib.parse.quote(by)}" if by else ""
+        return self._request("DELETE", f"/sessions/{key}/tags/{tag_key}{query}")
 
     def mark(self, key, level, note="", by=None):
         """Stamp the overlooker's ``triage`` mark; needs ``mark``. A ``level``
         of ``attention``/``blocked`` sets it; empty or ``ok`` clears it."""
         if not level or level == "ok":
-            return self.clear_tag(key, "triage")
+            return self.clear_tag(key, "triage", by)
         return self.set_tag(key, "triage", level, note, by)
 
-    def nudge(self, key, text, submit=True):
-        """Type a message into the session's agent pane; needs ``nudge``."""
+    def nudge(self, key, text, submit=True, by=None):
+        """Type a message into the session's agent pane; needs ``nudge``.
+        ``by`` attributes the recorded ``nudge`` audit event."""
         self._gate("nudge")
-        return self._request(
-            "POST", f"/sessions/{key}/send", {"text": text, "submit": submit}
-        )
+        body = {"text": text, "submit": submit}
+        if by is not None:
+            body["by"] = by
+        return self._request("POST", f"/sessions/{key}/send", body)
 
     def interrupt(self, key):
         """Send a break (Escape) to stop the current turn; needs ``interrupt``."""
@@ -162,10 +202,10 @@ class Round:
     """One overlooker round, as the engine runs it.
 
     Reads the round config from ``$WEAVER_OVERLOOKER`` (``{id, name, program,
-    params, scope, capabilities, dry_run}``), builds a :class:`Client` granted
-    that round's capabilities, accumulates the action log, and prints the
-    result the engine parses. A mutating program must check :attr:`dry_run`
-    (record a :meth:`would` action instead of acting).
+    params, scope, capabilities, model, effort, dry_run}``), builds a
+    :class:`Client` granted that round's capabilities, accumulates the action
+    log, and prints the result the engine parses. A mutating program must
+    check :attr:`dry_run` (record a :meth:`would` action instead of acting).
     """
 
     def __init__(self, config=None, client=None):
@@ -175,6 +215,10 @@ class Round:
         self.name = config.get("name", "")
         self.params = config.get("params") or {}
         self.scope = config.get("scope") or {}
+        #: The overlooker's configured agent model / reasoning effort — pass
+        #: these to :meth:`Client.agent` so judgement honours the config.
+        self.model = config.get("model", "")
+        self.effort = config.get("effort", "")
         self.dry_run = bool(config.get("dry_run"))
         self.client = client or Client(capabilities=config.get("capabilities") or [])
         self.actions = []

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -173,7 +173,7 @@ class Client:
         """Clear a tag — how a loud axis returns to calm; needs ``mark``.
         ``by`` attributes the clear (an overlooker name)."""
         self._gate("mark")
-        query = f"?by={urllib.parse.quote(by)}" if by else ""
+        query = f"?by={urllib.parse.quote(by, safe='')}" if by else ""
         return self._request("DELETE", f"/sessions/{key}/tags/{tag_key}{query}")
 
     def mark(self, key, level, note="", by=None):

--- a/python/weaver-loom/tests/conftest.py
+++ b/python/weaver-loom/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Make the package importable straight from the source tree, so the suite
+runs with a bare `pytest` (CI and local) — no install step, matching how the
+loom engine itself vendors the module onto PYTHONPATH."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))

--- a/python/weaver-loom/tests/test_status_program.py
+++ b/python/weaver-loom/tests/test_status_program.py
@@ -1,0 +1,184 @@
+"""The builtin status program's decision logic, with no server required.
+
+Loads `crates/loom/overlookers/status.py` straight from the repo and drives
+it with stubbed clients: the judge's prompt/fallback split, the ok-clears
+rule, the capability branches, and the summary format all live here. The
+Rust integration suite keeps only the wiring proof — that the script runs
+under the engine against a live loom and its marks/audit rows land.
+
+pr-label and archive-merged carry no logic beyond a one-line predicate over
+the PR snapshot, so their coverage stays in the Rust end-to-end test
+(`builtin_scripts_report_merged_and_unlabelled_prs`) — a pytest double of a
+one-liner would be duplication, not coverage.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+from weaver_loom import Round, WeaverError
+
+OVERLOOKERS = Path(__file__).resolve().parents[3] / "crates" / "loom" / "overlookers"
+
+
+def load_program(name):
+    spec = importlib.util.spec_from_file_location(name, OVERLOOKERS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+status = load_program("status")
+
+
+class StubClient:
+    """The slice of Client the status program touches, scripted per test."""
+
+    def __init__(self, capabilities=None, sessions=None, agent_reply=None,
+                 screen="the pane", nudge_fails=False):
+        self.capabilities = capabilities or []
+        self._sessions = sessions or []
+        self.agent_reply = agent_reply
+        self.screen = screen
+        self.nudge_fails = nudge_fails
+        self.calls = []
+
+    def can(self, cap):
+        return cap == "observe" or cap in self.capabilities
+
+    def sessions(self):
+        return self._sessions
+
+    def preview(self, key, lines=0):
+        self.calls.append(("preview", key))
+        return self.screen
+
+    def agent(self, prompt, model="", effort=""):
+        self.calls.append(("agent", prompt, model, effort))
+        return self.agent_reply
+
+    def mark(self, key, level, note="", by=None):
+        self.calls.append(("mark", key, level, note, by))
+
+    def nudge(self, key, text, submit=True, by=None):
+        if self.nudge_fails:
+            raise WeaverError("no live tmux")
+        self.calls.append(("nudge", key, text, by))
+
+
+def session(id, attention=None):
+    tags = [{"key": "attention", "value": attention}] if attention else []
+    return {"id": id, "status": "running", "branch": {"tags": tags, "repo_root": "/r"}}
+
+
+def make_round(client, **config):
+    return Round(config={"name": "watch", **config}, client=client)
+
+
+def run_main(client, capsys, **config):
+    """Drive main() with a stubbed round; return the parsed result line."""
+    rnd = make_round(client, capabilities=client.capabilities, **config)
+    orig = status.Round
+    status.Round = lambda: rnd
+    try:
+        status.main()
+    finally:
+        status.Round = orig
+    return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+
+
+# -- judge: fallback rule vs prompt path ---------------------------------------
+
+
+def test_judge_mirrors_attention_without_a_prompt():
+    rnd = make_round(StubClient())
+    assert status.judge(rnd, session("s", "blocked")) == ("blocked", "attention is blocked")
+    assert status.judge(rnd, session("s")) == ("ok", "attention is ok")
+
+
+def test_judge_prompt_path_asks_the_agent_with_screen_and_model():
+    client = StubClient(agent_reply="blocked: stuck on a test")
+    rnd = make_round(client, params={"prompt": "stuck?"}, model="haiku", effort="low")
+    assert status.judge(rnd, session("s")) == ("blocked", "stuck on a test")
+    kind, prompt, model, effort = client.calls[-1]
+    assert (kind, model, effort) == ("agent", "haiku", "low")
+    assert prompt.startswith("stuck?") and "the pane" in prompt
+
+
+def test_judge_falls_back_when_agent_is_absent_or_unparseable():
+    for reply in (None, "no verdict here"):
+        rnd = make_round(StubClient(agent_reply=reply), params={"prompt": "stuck?"})
+        assert status.judge(rnd, session("s", "attention")) == (
+            "attention",
+            "attention is attention",
+        )
+
+
+def test_judge_survives_a_dead_pane():
+    class NoPane(StubClient):
+        def preview(self, key, lines=0):
+            raise WeaverError("409 no live tmux")
+
+    rnd = make_round(NoPane(agent_reply="ok - all quiet"), params={"prompt": "stuck?"})
+    assert status.judge(rnd, session("s")) == ("ok", "all quiet")
+
+
+# -- main: marking, clearing, capabilities, dry-run, summary --------------------
+
+
+def test_marks_loud_sessions_and_clears_calm_ones(capsys):
+    client = StubClient(
+        capabilities=["mark"],
+        sessions=[session("loud", "blocked"), session("calm")],
+    )
+    result = run_main(client, capsys)
+    assert ("mark", "loud", "blocked", "attention is blocked", "watch") in client.calls
+    assert ("mark", "calm", "ok", "", "watch") in client.calls  # ok ⇒ clear
+    assert result["outcome"] == "ok"
+    assert result["summary"] == "surveyed 2, marked 1 (1 blocked)"
+    assert result["actions"] == [
+        {"action": "mark", "session": "loud", "level": "blocked",
+         "note": "attention is blocked"}
+    ]
+
+
+def test_without_mark_capability_only_observes(capsys):
+    client = StubClient(sessions=[session("loud", "attention")])
+    result = run_main(client, capsys)
+    assert client.calls == []  # no mutation attempted
+    assert result["actions"] == [
+        {"action": "observe", "session": "loud", "level": "attention",
+         "note": "attention is attention"}
+    ]
+
+
+def test_dry_run_mutates_nothing_and_says_so(capsys):
+    client = StubClient(capabilities=["mark"],
+                        sessions=[session("loud", "blocked"), session("calm")])
+    result = run_main(client, capsys, dry_run=True)
+    assert client.calls == []
+    assert result["actions"] == [
+        {"would": "mark", "session": "loud", "level": "blocked",
+         "note": "attention is blocked"}
+    ]
+    assert result["summary"] == "surveyed 2, would mark 1 (1 blocked) (dry run, no marks applied)"
+
+
+def test_nudge_follows_a_mark_and_a_dead_pane_no_ops(capsys):
+    client = StubClient(capabilities=["mark", "nudge"],
+                        sessions=[session("loud", "blocked")])
+    result = run_main(client, capsys)
+    assert ("nudge", "loud", "[overlooker watch] attention is blocked", "watch") in client.calls
+    assert {"action": "nudge", "session": "loud",
+            "text": "[overlooker watch] attention is blocked"} in result["actions"]
+
+    dead = StubClient(capabilities=["mark", "nudge"],
+                      sessions=[session("loud", "blocked")], nudge_fails=True)
+    result = run_main(dead, capsys)
+    assert not any(a.get("action") == "nudge" for a in result["actions"])
+
+
+def test_empty_scope_is_a_noop(capsys):
+    result = run_main(StubClient(capabilities=["mark"]), capsys)
+    assert result == {"outcome": "noop", "summary": "surveyed 0 sessions in scope",
+                      "actions": []}

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -1,0 +1,235 @@
+"""The weaver_loom contract, with no server required.
+
+These run in CI (the `python-binding` job). They cover the pure logic every
+overlooker program leans on — judgement parsing, the survey's scope filter,
+capability gating, mark routing, and the round-result stdout contract — by
+stubbing the HTTP layer; the live end-to-end coverage is the Rust integration
+suite (`crates/loom/tests/integration/overlookers.rs`), which runs the real
+builtin scripts against a real loom.
+"""
+
+import json
+
+import pytest
+from weaver_loom import (
+    CAPABILITIES,
+    CapabilityDenied,
+    Client,
+    Round,
+    parse_judgement,
+)
+
+
+class StubClient(Client):
+    """A Client whose requests are recorded instead of sent."""
+
+    def __init__(self, capabilities=None, replies=None):
+        super().__init__(base="http://stub", capabilities=capabilities)
+        self.requests = []
+        self.replies = replies or {}
+
+    def _request(self, method, path, body=None):
+        self.requests.append((method, path, body))
+        return self.replies.get(path)
+
+
+def session(id, status="running", tags=None, repo_root="/repo"):
+    return {
+        "id": id,
+        "status": status,
+        "branch": {"tags": tags or [], "repo_root": repo_root},
+    }
+
+
+def attention(value):
+    return [{"key": "attention", "value": value}]
+
+
+# -- parse_judgement ---------------------------------------------------------
+
+
+def test_parse_judgement_finds_level_and_note():
+    assert parse_judgement("blocked: stuck retrying the same test") == (
+        "blocked",
+        "stuck retrying the same test",
+    )
+    # The earliest separator wins, mirroring the engine's old parser.
+    assert parse_judgement("attention - waiting: on review") == (
+        "attention",
+        "waiting: on review",
+    )
+    # 'ok' is recognised even without a separator; the whole line is the note.
+    assert parse_judgement("ok") == ("ok", "ok")
+    # The level word is matched on word boundaries, not substrings.
+    assert parse_judgement("blockedness everywhere") is None
+
+
+def test_parse_judgement_scans_lines_and_degrades_to_none():
+    assert parse_judgement("preamble\nBlocked - cannot push") == (
+        "blocked",
+        "cannot push",
+    )
+    assert parse_judgement("looks fine to me, carry on") is None
+    assert parse_judgement("") is None
+    assert parse_judgement(None) is None
+
+
+# -- the survey's scope filter -------------------------------------------------
+
+
+def make_round(scope=None, sessions=None, capabilities=None, **config):
+    client = StubClient(
+        capabilities=capabilities or [], replies={"/sessions": sessions or []}
+    )
+    return Round(
+        config={"name": "t", "scope": scope or {}, **config},
+        client=client,
+    )
+
+
+def test_sessions_skips_terminal_and_counts_surveyed():
+    rnd = make_round(
+        sessions=[
+            session("live"),
+            session("done", status="done"),
+            session("archived", status="archived"),
+        ]
+    )
+    assert [s["id"] for s in rnd.sessions()] == ["live"]
+    assert rnd.surveyed == 1
+
+
+def test_scope_attention_filter_matches_exact_and_negated():
+    fleet = [
+        session("calm"),
+        session("loud", tags=attention("attention")),
+        session("stuck", tags=attention("blocked")),
+    ]
+    not_ok = make_round(scope={"attention": "!ok"}, sessions=fleet)
+    assert [s["id"] for s in not_ok.sessions()] == ["loud", "stuck"]
+    only_blocked = make_round(scope={"attention": "blocked"}, sessions=fleet)
+    assert [s["id"] for s in only_blocked.sessions()] == ["stuck"]
+    # An absent tag is the calm `ok` state.
+    only_ok = make_round(scope={"attention": "ok"}, sessions=fleet)
+    assert [s["id"] for s in only_ok.sessions()] == ["calm"]
+
+
+def test_scope_repo_pin_excludes_other_repos():
+    fleet = [session("here"), session("there", repo_root="/elsewhere")]
+    rnd = make_round(scope={"repo": "/repo"}, sessions=fleet)
+    assert [s["id"] for s in rnd.sessions()] == ["here"]
+
+
+# -- capability gating ---------------------------------------------------------
+
+
+def test_observe_is_implicit_and_writes_are_gated():
+    c = StubClient()
+    assert c.can("observe")
+    c.sessions()  # a read never gates
+    for call in (
+        lambda: c.set_tag("s", "triage", "blocked"),
+        lambda: c.clear_tag("s", "triage"),
+        lambda: c.mark("s", "blocked"),
+        lambda: c.nudge("s", "hello"),
+        lambda: c.interrupt("s"),
+    ):
+        with pytest.raises(CapabilityDenied):
+            call()
+    # The gate fires before any request leaves the process.
+    assert c.requests == [("GET", "/sessions", None)]
+
+
+def test_capabilities_constant_matches_the_ladder():
+    assert CAPABILITIES == [
+        "observe",
+        "mark",
+        "escalate",
+        "nudge",
+        "interrupt",
+        "launch",
+    ]
+
+
+# -- mark routing & attribution -------------------------------------------------
+
+
+def test_mark_sets_a_loud_level_with_attribution():
+    c = StubClient(capabilities=["mark"])
+    c.mark("s1", "blocked", "stuck", by="watch")
+    assert c.requests == [
+        (
+            "PUT",
+            "/sessions/s1/tags/triage",
+            {"value": "blocked", "note": "stuck", "by": "watch"},
+        )
+    ]
+
+
+def test_mark_ok_clears_via_delete_with_by_query():
+    c = StubClient(capabilities=["mark"])
+    c.mark("s1", "ok", by="watch")
+    c.mark("s1", "")
+    assert c.requests == [
+        ("DELETE", "/sessions/s1/tags/triage?by=watch", None),
+        ("DELETE", "/sessions/s1/tags/triage", None),
+    ]
+
+
+def test_nudge_carries_by_for_the_audit_event():
+    c = StubClient(capabilities=["nudge"])
+    c.nudge("s1", "hello", by="watch")
+    c.nudge("s1", "staged", submit=False)
+    assert c.requests == [
+        ("POST", "/sessions/s1/send", {"text": "hello", "submit": True, "by": "watch"}),
+        ("POST", "/sessions/s1/send", {"text": "staged", "submit": False}),
+    ]
+
+
+def test_agent_returns_output_or_none():
+    c = StubClient(replies={"/agent/oneshot": {"output": "blocked: judged"}})
+    assert c.agent("look", model="haiku", effort="low") == "blocked: judged"
+    assert c.requests[-1] == (
+        "POST",
+        "/agent/oneshot",
+        {"prompt": "look", "model": "haiku", "effort": "low"},
+    )
+    # A degraded daemon reply ({output: null}) reads as None, not an error.
+    absent = StubClient(replies={"/agent/oneshot": {"output": None}})
+    assert absent.agent("look") is None
+
+
+# -- the round-result contract ---------------------------------------------------
+
+
+def test_round_reads_config_and_finish_prints_the_contract(capsys):
+    rnd = make_round(
+        params={"prompt": "stuck?"},
+        model="haiku",
+        effort="low",
+        dry_run=True,
+        capabilities=["mark"],
+    )
+    assert rnd.params == {"prompt": "stuck?"}
+    assert (rnd.model, rnd.effort, rnd.dry_run) == ("haiku", "low", True)
+    assert rnd.can("mark") and not rnd.can("nudge")
+
+    rnd.would("mark", session="s1", level="blocked")
+    rnd.did("observe", session="s2")
+    rnd.finish("surveyed 2")
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == {
+        "outcome": "ok",
+        "summary": "surveyed 2",
+        "actions": [
+            {"would": "mark", "session": "s1", "level": "blocked"},
+            {"action": "observe", "session": "s2"},
+        ],
+    }
+
+
+def test_finish_defaults_to_noop_without_actions(capsys):
+    make_round().finish("nothing in scope")
+    result = json.loads(capsys.readouterr().out.strip())
+    assert result["outcome"] == "noop"
+    assert result["actions"] == []


### PR DESCRIPTION
The status check was the only in-Rust overlooker program — a historical artifact: it predates the script substrate (#44), and the script environment couldn't express what it needed. This closes those gaps as REST/API primitives and ports the program to crates/loom/overlookers/status.py, embedded and registered like every other builtin. The native program shape is gone, and with it the native/script kind split in ProgramView, the panel, the CLI listing, and the tests: a builtin now sees exactly the API a custom program sees.

What the script environment gained, and why each is API-shaped rather than a hack:

- One-shot agent judgement. The env-stripped headless agent (claude -p, WEAVER_OVERLOOKER_AGENT_CMD, model/effort flags, config-driven timeout) moved from the engine into loom::agent and is exposed as POST /api/agent/oneshot. The daemon stays the single owner of agent configuration; scripts call it like any other route. weaver_loom grows Client.agent() plus a parse_judgement() helper mirroring the engine's lenient level/note parser.
- Model and effort in the round config. $WEAVER_OVERLOOKER now carries the overlooker's model and effort so a script can honour the configured judgement model.
- Audit attribution over REST. DELETE /sessions/{key}/tags/{tag} accepts ?by= (clears were always attributed 'manual' before), and POST /sessions/{key}/send accepts by and records the nudge events row the native program used to write directly — the every-mutation-is-an-events-row audit rule now holds through the API.
- No-recursion for every survey. GET /api/sessions excludes warm_session_id-referenced sessions (belt-and-braces beyond the managed_by filter), so a script's survey can never see a watcher's own session; the engine-private warm-session check is gone.

The status program's behaviour is unchanged: prompt-configured LLM judgement over a 200-line screen preview when the agent is available, falling back to mirroring the session's own attention tag; ok judgements clear the triage tag; marks and nudges are attributed to the overlooker; dry runs record would-mark actions and mutate nothing.

Tests: the integration suite drives the script end to end against the live test server (with python3-absent skips); a new case stubs WEAVER_OVERLOOKER_AGENT_CMD to exercise the full judgement path through the oneshot endpoint; the fixture pins the agent command to a no-op so rounds stay deterministic. The e2e program-registry spec now expects source on all three builtins.

Part of #41.