### PR TITLE
feat(loom): ETags, Cache-Control, and zstd/gzip/brotli compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,33 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -81,6 +102,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "atoi"
@@ -186,6 +219,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +258,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -288,6 +344,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +401,15 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "croner"
@@ -525,6 +610,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -979,6 +1074,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1218,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1593,6 +1708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2113,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
  "futures-core",
@@ -2663,3 +2785,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/loom/Cargo.toml
+++ b/crates/loom/Cargo.toml
@@ -35,7 +35,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
-tower-http = { version = "0.6", features = ["cors", "fs"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "compression-full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 croner = "3"

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -61,13 +61,16 @@
 //! through `PUT /api/sessions/{id}/tags/{key}` and cleared through `DELETE`.
 //! Absence is the calm state; there is no stored `ok` tag.
 
+use std::collections::hash_map::DefaultHasher;
 use std::convert::Infallible;
+use std::hash::{Hash, Hasher};
 use std::path::{Component, PathBuf};
 
 use axum::{
     body::Bytes,
     extract::{DefaultBodyLimit, Path, Query, State},
-    http::{header, StatusCode},
+    http::{header, Request, StatusCode},
+    middleware::Next,
     response::{
         sse::{self, KeepAlive, Sse},
         IntoResponse, Response,
@@ -80,6 +83,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::services::{ServeDir, ServeFile};
 
@@ -243,6 +247,95 @@ async fn require_branch(db: &Db, key: &str) -> ApiResult<Branch> {
 }
 
 // ---------------------------------------------------------------------------
+// Caching middleware
+// ---------------------------------------------------------------------------
+
+/// Add `ETag` + `Cache-Control: no-cache` to JSON API GET responses and serve
+/// `304 Not Modified` when the client's `If-None-Match` matches.
+///
+/// Skips non-200 responses, SSE streams, and WebSocket upgrades so they pass
+/// through untouched.
+pub async fn api_etag_middleware(request: Request<axum::body::Body>, next: Next) -> Response {
+    let if_none_match = request.headers().get(header::IF_NONE_MATCH).cloned();
+    let response = next.run(request).await;
+
+    if response.status() != StatusCode::OK {
+        return response;
+    }
+    // Skip streaming responses (SSE, WebSocket upgrades).
+    if let Some(ct) = response.headers().get(header::CONTENT_TYPE) {
+        if ct.as_bytes().starts_with(b"text/event-stream") {
+            return response;
+        }
+    }
+    if response.headers().contains_key(header::UPGRADE) {
+        return response;
+    }
+
+    let (mut parts, body) = response.into_parts();
+    let bytes = match axum::body::to_bytes(body, 16 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => return Response::from_parts(parts, axum::body::Body::empty()),
+    };
+
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    let etag = format!("\"loom-{:016x}\"", hasher.finish());
+    let etag_val: axum::http::HeaderValue = etag.parse().unwrap();
+
+    parts.headers.insert(header::ETAG, etag_val.clone());
+    parts
+        .headers
+        .entry(header::CACHE_CONTROL)
+        .or_insert_with(|| "no-cache".parse().unwrap());
+
+    if if_none_match.is_some_and(|v| v == etag_val) {
+        parts.status = StatusCode::NOT_MODIFIED;
+        return Response::from_parts(parts, axum::body::Body::empty());
+    }
+
+    Response::from_parts(parts, axum::body::Body::from(bytes))
+}
+
+/// Set `Cache-Control` on static asset responses:
+/// - Content-hashed assets (filename contains an 8-hex-char segment, e.g.
+///   `app.a1b2c3d4.js`) get `max-age=31536000, immutable` — the hash guarantees
+///   the content never changes for that URL.
+/// - Everything else (`index.html`, fonts, etc.) gets `no-cache` so browsers
+///   always revalidate; `ServeDir` provides `ETag`/`Last-Modified` for fast 304s.
+pub async fn static_cache_middleware(request: Request<axum::body::Body>, next: Next) -> Response {
+    let path = request.uri().path().to_owned();
+    let response = next.run(request).await;
+
+    if response.status() != StatusCode::OK {
+        return response;
+    }
+
+    let cache_control = if is_immutable_asset(&path) {
+        "max-age=31536000, immutable"
+    } else {
+        "no-cache"
+    };
+
+    let (mut parts, body) = response.into_parts();
+    parts
+        .headers
+        .entry(header::CACHE_CONTROL)
+        .or_insert_with(|| cache_control.parse().unwrap());
+    Response::from_parts(parts, body)
+}
+
+/// True for content-hashed static assets produced by rspack.
+/// Matches filenames like `app.a1b2c3d4.js` — any path component that is
+/// exactly 8 lowercase hex characters surrounded by dots.
+fn is_immutable_asset(path: &str) -> bool {
+    let filename = path.rsplit('/').next().unwrap_or("");
+    filename
+        .split('.')
+        .any(|seg| seg.len() == 8 && seg.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
+// ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
@@ -335,12 +428,15 @@ pub fn router(state: AppState) -> Router {
         .route("/agent/oneshot", post(agent_oneshot))
         // Scratch uploads can carry images / logs; lift the default 2 MB cap.
         .layer(DefaultBodyLimit::max(64 * 1024 * 1024))
+        .layer(axum::middleware::from_fn(api_etag_middleware))
         .with_state(state);
 
     let index = static_dir().join("index.html");
     Router::new()
         .nest("/api", api)
         .fallback_service(ServeDir::new(static_dir()).fallback(ServeFile::new(index)))
+        .layer(axum::middleware::from_fn(static_cache_middleware))
+        .layer(CompressionLayer::new())
         .layer(CorsLayer::permissive())
 }
 
@@ -2800,5 +2896,22 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn is_immutable_asset_matches_rspack_content_hashed_files() {
+        assert!(is_immutable_asset("/app.a1b2c3d4.js"));
+        assert!(is_immutable_asset("/chunk.00ff1234.js"));
+        assert!(is_immutable_asset("/styles.deadbeef.css"));
+    }
+
+    #[test]
+    fn is_immutable_asset_rejects_non_hashed_paths() {
+        assert!(!is_immutable_asset("/index.html"));
+        assert!(!is_immutable_asset("/app.js"));
+        assert!(!is_immutable_asset("/favicon.ico"));
+        // Hash segment must be exactly 8 hex chars.
+        assert!(!is_immutable_asset("/app.abc.js"));
+        assert!(!is_immutable_asset("/app.abc123def.js")); // 9 chars
     }
 }


### PR DESCRIPTION
- **CompressionLayer** (zstd, gzip, brotli, deflate) on all responses — encoding negotiated via `Accept-Encoding`
- **ETag middleware** on `/api` routes: hashes JSON response bodies, returns `304 Not Modified` on `If-None-Match` match; transparently skips SSE streams and WebSocket upgrades
- **Cache-Control middleware** on static files: `max-age=31536000, immutable` for rspack content-hashed assets (e.g. `app.a1b2c3d4.js`), `no-cache` for `index.html` and other non-hashed files; `ServeDir`'s built-in `ETag`/`Last-Modified` support handles fast 304 revalidation