### PR TITLE
feat(loom): authentication — API tokens, GitHub & password login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -102,6 +102,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
 
 [[package]]
 name = "async-compression"
@@ -198,6 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +226,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -274,6 +301,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -527,6 +560,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -574,7 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -748,14 +782,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -879,6 +928,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1156,6 +1221,7 @@ name = "loom"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "axum",
  "base64",
  "chrono",
@@ -1163,13 +1229,16 @@ dependencies = [
  "clap_complete",
  "croner",
  "futures-util",
+ "hex",
  "libc",
+ "percent-encoding",
  "portable-pty",
  "rand",
  "reqwest",
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "smartdoc",
  "sqlx",
  "tempfile",
@@ -1183,6 +1252,12 @@ dependencies = [
  "weaver-api",
  "weaver-core",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1239,7 +1314,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1250,7 +1325,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
 ]
 
@@ -1260,7 +1335,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1311,6 +1386,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1390,6 +1476,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1427,8 +1568,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1478,16 +1625,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1495,7 +1647,28 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1507,7 +1680,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1608,7 +1816,7 @@ checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1731,7 +1939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1881,6 +2089,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,7 +2135,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1984,6 +2198,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,7 +2226,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2009,6 +2238,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2212,6 +2451,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2433,6 +2678,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,12 +2779,159 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winreg"
@@ -2694,6 +3105,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/README.md
+++ b/README.md
@@ -259,6 +259,52 @@ different address. `loom serve --addr <host:port>` overrides `WEAVER_API`.
 The running daemon records the address it bound in `~/.weaver/server.json`,
 so the `loom` CLI finds it with no configuration in the common case.
 
+## Authentication
+
+loom can be exposed off `127.0.0.1` so the dashboard and the API are reachable
+without an SSH tunnel — `loom serve --addr 0.0.0.0:7878`, ideally behind a
+TLS-terminating reverse proxy. Access is then gated three ways:
+
+- **Local use needs nothing.** Requests from the loopback interface are trusted
+  as the machine owner, so the local `loom` CLI, the agent, and overlooker
+  scripts keep working with zero configuration. (Turn this off with
+  `auth.trust_loopback false` behind a *same-host* proxy — see below.)
+- **GitHub or password login** for the web UI. The login screen offers
+  "Continue with GitHub" once an OAuth app is configured, plus username/password.
+  A fresh install approves one user — **`rjpower`** on GitHub by default
+  (override with `LOOM_OWNER_GITHUB` at first run). Add more, set your password,
+  and configure GitHub sign-in under **Settings → Account**.
+- **API tokens** for automation — the `LOOM_TOKEN` a CI job or a remote `loom`
+  CLI presents as a bearer. Mint one under **Settings → Tokens** or:
+
+  ```sh
+  loom token create github-actions     # prints the secret once — store it now
+  ```
+
+  Then, from anywhere (e.g. a GitHub Actions step that kicks off a session in
+  response to a comment):
+
+  ```sh
+  export WEAVER_API=https://loom.example.com
+  export LOOM_TOKEN=loom_xxxxxxxx
+  loom session launch "Investigate the failing test in #123"
+  # or hit the API directly:
+  curl -H "Authorization: Bearer $LOOM_TOKEN" \
+       -H 'content-type: application/json' \
+       "$WEAVER_API/api/sessions" -d '{"cwd":"/srv/repo","goal":"..."}'
+  ```
+
+To configure **GitHub sign-in**: register an OAuth app on GitHub with the
+callback `https://loom.example.com/api/auth/github/callback`, then paste its
+client id and secret into Settings → Account (or set `LOOM_GITHUB_CLIENT_ID` /
+`LOOM_GITHUB_CLIENT_SECRET`).
+
+Behind a **same-host reverse proxy** the proxy's forwarded requests appear to
+come from loopback, so set `auth.trust_loopback false` and `auth.cookie_secure
+true`. Local automation keeps working: loom mints a machine-local token (at
+`~/.weaver/loom-token`, mode 0600) and hands it to its own subprocesses, so only
+genuinely remote callers need to present a token or log in.
+
 ## Configuration
 
 Settings live in the `settings` table of the sqlite database, shared by both
@@ -287,6 +333,12 @@ Notable settings:
   merges (on by default).
 - `terminal.theme` — colour palette for the in-browser terminal: `dark` (the
   classic black background, default) or `light`.
+- `auth.trust_loopback` — trust loopback requests as the machine owner (on by
+  default; turn off behind a same-host proxy). See [Authentication](#authentication).
+- `auth.cookie_secure` — mark the login cookie `Secure` (enable when served over
+  HTTPS).
+- `auth.base_url` — the public URL loom is reached at, used for the GitHub OAuth
+  callback (blank ⇒ derived from the request's Host header).
 
 ## Developing weaver
 
@@ -303,3 +355,6 @@ placeholder page), `cargo test --workspace` runs the backend suites, and `cd e2e
 - `WEAVER_DB` — database path (default `$WEAVER_HOME/weaver.db`)
 - `WEAVER_API` — loom URL the `loom` CLI talks to (default `http://127.0.0.1:7878`)
 - `WEAVER_BRANCH` — override the branch resolver (set by `loom session launch` in the worktree)
+- `LOOM_TOKEN` — bearer token the `loom` CLI / automation sends (see [Authentication](#authentication))
+- `LOOM_OWNER_GITHUB` — GitHub login seeded as the owner on a fresh database (default `rjpower`)
+- `LOOM_GITHUB_CLIENT_ID` / `LOOM_GITHUB_CLIENT_SECRET` — GitHub OAuth app credentials

--- a/crates/loom/Cargo.toml
+++ b/crates/loom/Cargo.toml
@@ -17,18 +17,29 @@ weaver-core = { path = "../weaver-core" }
 weaver-api = { path = "../weaver-api" }
 smartdoc = { path = "../smartdoc" }
 anyhow = "1"
+# Password hashing for the user/password login path (the OWASP-recommended KDF).
+argon2 = "0.5"
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 futures-util = "0.3"
+# Hex-encode the SHA-256 digests we store for API tokens and session cookies.
+hex = "0.4"
 libc = "0.2"
+percent-encoding = "2"
 portable-pty = "0.9"
 rand = "0.9"
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
+# `rustls-tls` is needed for the GitHub OAuth token/user calls over HTTPS — the
+# rest of loom's HTTP is loopback to its own daemon, but the OAuth dance reaches
+# github.com directly.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# SHA-256 for hashing API tokens / session ids at rest (high-entropy secrets, so
+# a fast digest is right — the slow KDF above is only for low-entropy passwords).
+sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "derive"] }
 # The overlooker engine materializes embedded builtin scripts to a scratch file
 # before running them; the tests reuse it for fixtures.

--- a/crates/loom/frontend/src/App.vue
+++ b/crates/loom/frontend/src/App.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import AppRail from './components/AppRail.vue';
 import StatusBar from './components/StatusBar.vue';
+import { me } from './auth';
 
 // The workbench shell (docs/loom-ui.md): nav rail on the left, a thin status
 // bar pinned to the bottom, and the view filling everything between — no top
 // app bar. `main` is a flex column so a full-height view (session detail,
 // file browser) can `flex-1 min-h-0` to fill it exactly, while list views
 // simply grow and let `main` scroll.
+//
+// Until the caller is authenticated we render the view bare (no rail/status
+// bar) — the router guard keeps that view on the login screen.
+const authed = computed(() => me.authenticated);
 </script>
 
 <template>
-  <div class="flex h-screen overflow-hidden bg-canvas font-sans text-fg">
+  <router-view v-if="!authed" />
+  <div v-else class="flex h-screen overflow-hidden bg-canvas font-sans text-fg">
     <AppRail />
     <div class="flex min-w-0 flex-1 flex-col">
       <main class="flex min-h-0 flex-1 flex-col overflow-auto">

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -1,8 +1,20 @@
+// A 401 on any non-auth route means the session lapsed (or was never there);
+// the app registers a handler that bounces to the login screen. Auth routes
+// (`/auth/...`) are exempt: a bad-password 401 must surface in the form, not
+// redirect.
+let onUnauthorized: (() => void) | null = null;
+export function setUnauthorizedHandler(fn: () => void): void {
+  onUnauthorized = fn;
+}
+
 async function request(path: string, opts: RequestInit = {}): Promise<unknown> {
   const res = await fetch('/api' + path, {
     headers: { 'content-type': 'application/json' },
     ...opts,
   });
+  if (res.status === 401 && !path.startsWith('/auth/')) {
+    onUnauthorized?.();
+  }
   if (!res.ok) {
     let message = res.statusText;
     try {
@@ -98,3 +110,58 @@ export const putArtifact = (id: string, name: string, body: ArtifactWriteBody) =
 /** Write a worktree file (the editor save primitive). Path is worktree-relative. */
 export const writeFile = (id: string, path: string, content: string) =>
   rawBody('PUT', `/sessions/${id}/file?path=${encodeURIComponent(path)}`, content);
+
+// --- Authentication --------------------------------------------------------
+
+import type { Me, Token, CreatedToken, User, GithubConfig } from './types';
+
+/** Who the caller is + which sign-in methods to offer. Never 401s. */
+export const getMe = () => get('/auth/me') as Promise<Me>;
+
+/** Username/password login; sets the session cookie on success. */
+export const login = (username: string, password: string) =>
+  post('/auth/login', { username, password });
+
+/** Drop the session and clear the cookie. */
+export const logout = () => post('/auth/logout');
+
+/** Begin GitHub OAuth — a full-page navigation (the server 302s to GitHub). */
+export const githubLoginUrl = '/api/auth/github/login';
+
+/** The user-managed API tokens. */
+export const listTokens = () => get('/auth/tokens') as Promise<Token[]>;
+
+/** Mint a token; the plaintext is in the reply once and never again. */
+export const createToken = (name: string, expiresInDays?: number | null) =>
+  post('/auth/tokens', { name, expires_in_days: expiresInDays ?? null }) as Promise<CreatedToken>;
+
+/** Revoke a token by id. */
+export const revokeToken = (id: string) => del(`/auth/tokens/${encodeURIComponent(id)}`);
+
+/** Set/change the caller's own password. */
+export const setPassword = (newPassword: string) =>
+  post('/auth/password', { new_password: newPassword });
+
+/** The approved-operator allowlist. */
+export const listUsers = () => get('/auth/users') as Promise<User[]>;
+
+/** Approve a new operator (GitHub login and/or password). */
+export const addUser = (username: string, githubLogin?: string, password?: string) =>
+  post('/auth/users', {
+    username,
+    github_login: githubLogin || null,
+    password: password || null,
+  }) as Promise<User>;
+
+/** Remove an approved operator. */
+export const removeUser = (username: string) => del(`/auth/users/${encodeURIComponent(username)}`);
+
+/** The GitHub OAuth app config (secret withheld). */
+export const getGithubConfig = () => get('/auth/github/config') as Promise<GithubConfig>;
+
+/** Set the OAuth client id, and optionally the secret (omit to leave it). */
+export const setGithubConfig = (clientId: string, clientSecret?: string) =>
+  put('/auth/github/config', {
+    client_id: clientId,
+    ...(clientSecret !== undefined ? { client_secret: clientSecret } : {}),
+  }) as Promise<GithubConfig>;

--- a/crates/loom/frontend/src/auth.ts
+++ b/crates/loom/frontend/src/auth.ts
@@ -1,0 +1,43 @@
+// The client-side identity store: one reactive `me` mirroring `GET /api/auth/me`.
+// Views read `me.authenticated` to decide chrome (App.vue) and the router guard
+// (main.ts) reads it to gate navigation. A loopback-trusted user comes back
+// authenticated with no login step; a remote user starts unauthenticated until
+// they sign in.
+import { reactive } from 'vue';
+import * as api from './api';
+import type { Me } from './types';
+
+const EMPTY: Me = {
+  authenticated: false,
+  username: null,
+  github_login: null,
+  via: null,
+  methods: { password: true, github: false },
+};
+
+export const me = reactive<Me>({ ...EMPTY });
+
+function assign(next: Me): void {
+  Object.assign(me, next);
+}
+
+/** Refresh identity from the server. Returns whether the caller is authenticated.
+ *  Never throws — a transport error reads as unauthenticated. */
+export async function loadMe(): Promise<boolean> {
+  try {
+    assign(await api.getMe());
+  } catch {
+    assign({ ...EMPTY });
+  }
+  return me.authenticated;
+}
+
+/** Log out: drop the server session, then the local identity. */
+export async function doLogout(): Promise<void> {
+  try {
+    await api.logout();
+  } catch {
+    /* clearing locally is enough even if the call fails */
+  }
+  assign({ ...EMPTY });
+}

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -1,0 +1,290 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import * as api from '../api';
+import { me, doLogout } from '../auth';
+import type { User, GithubConfig } from '../types';
+
+// Account + access management: who you are, your password, the approved-user
+// allowlist, and the GitHub OAuth app config that powers "Continue with GitHub".
+const router = useRouter();
+const error = ref('');
+const notice = ref('');
+const busy = ref(false);
+
+function ok(message: string) {
+  notice.value = message;
+  error.value = '';
+}
+function fail(e: unknown) {
+  error.value = (e as Error).message;
+  notice.value = '';
+}
+
+// -- Password ---------------------------------------------------------------
+const newPassword = ref('');
+const confirmPassword = ref('');
+
+async function savePassword() {
+  if (newPassword.value.length < 8) {
+    fail(new Error('Password must be at least 8 characters.'));
+    return;
+  }
+  if (newPassword.value !== confirmPassword.value) {
+    fail(new Error('Passwords do not match.'));
+    return;
+  }
+  busy.value = true;
+  try {
+    await api.setPassword(newPassword.value);
+    newPassword.value = '';
+    confirmPassword.value = '';
+    ok('Password updated.');
+  } catch (e) {
+    fail(e);
+  } finally {
+    busy.value = false;
+  }
+}
+
+// -- Approved users ---------------------------------------------------------
+const users = ref<User[]>([]);
+const newUser = ref('');
+const newUserGithub = ref('');
+const newUserPassword = ref('');
+
+async function loadUsers() {
+  try {
+    users.value = await api.listUsers();
+  } catch (e) {
+    fail(e);
+  }
+}
+
+async function addUser() {
+  if (!newUser.value.trim()) return;
+  busy.value = true;
+  try {
+    await api.addUser(
+      newUser.value.trim(),
+      newUserGithub.value.trim() || undefined,
+      newUserPassword.value || undefined,
+    );
+    newUser.value = '';
+    newUserGithub.value = '';
+    newUserPassword.value = '';
+    ok('User approved.');
+    await loadUsers();
+  } catch (e) {
+    fail(e);
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function removeUser(u: User) {
+  if (!confirm(`Remove approved user "${u.username}"? They will lose access.`)) return;
+  busy.value = true;
+  try {
+    await api.removeUser(u.username);
+    ok('User removed.');
+    await loadUsers();
+  } catch (e) {
+    fail(e);
+  } finally {
+    busy.value = false;
+  }
+}
+
+// -- GitHub OAuth app -------------------------------------------------------
+const gh = ref<GithubConfig | null>(null);
+const ghClientId = ref('');
+const ghClientSecret = ref('');
+
+async function loadGithub() {
+  try {
+    gh.value = await api.getGithubConfig();
+    ghClientId.value = gh.value.client_id;
+  } catch (e) {
+    fail(e);
+  }
+}
+
+async function saveGithub() {
+  busy.value = true;
+  try {
+    // Send the secret only when the field was filled, so an empty field leaves
+    // the stored secret intact.
+    gh.value = await api.setGithubConfig(
+      ghClientId.value.trim(),
+      ghClientSecret.value ? ghClientSecret.value : undefined,
+    );
+    ghClientSecret.value = '';
+    ok('GitHub sign-in updated.');
+  } catch (e) {
+    fail(e);
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function logout() {
+  await doLogout();
+  router.push('/login');
+}
+
+onMounted(() => {
+  loadUsers();
+  loadGithub();
+});
+</script>
+
+<template>
+  <div class="space-y-6">
+    <p v-if="error" class="text-sm text-block">{{ error }}</p>
+    <p v-if="notice" class="text-sm text-accent">{{ notice }}</p>
+
+    <!-- Identity -->
+    <section>
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">Signed in</h2>
+      <div class="flex items-center justify-between rounded-md border border-line bg-surface px-3 py-2.5">
+        <div>
+          <p class="text-sm font-medium">{{ me.username }}</p>
+          <p class="text-2xs text-faint">
+            <template v-if="me.github_login">GitHub: {{ me.github_login }} · </template>
+            via {{ me.via }}
+          </p>
+        </div>
+        <button class="btn-secondary px-2.5 py-1 text-xs" @click="logout">Sign out</button>
+      </div>
+    </section>
+
+    <!-- Password -->
+    <section>
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">Password</h2>
+      <div class="rounded-md border border-line bg-surface px-3 py-2.5">
+        <p class="text-xs text-muted mb-2">
+          Set a password to sign in without GitHub. At least 8 characters.
+        </p>
+        <div class="flex flex-wrap items-center gap-2">
+          <input
+            v-model="newPassword"
+            type="password"
+            autocomplete="new-password"
+            placeholder="New password"
+            class="flex-1 rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+          />
+          <input
+            v-model="confirmPassword"
+            type="password"
+            autocomplete="new-password"
+            placeholder="Confirm"
+            class="flex-1 rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+          />
+          <button
+            class="btn-primary px-3 py-1.5 text-xs"
+            :disabled="busy || !newPassword"
+            @click="savePassword"
+          >
+            Update
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- GitHub sign-in -->
+    <section>
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
+        GitHub sign-in
+      </h2>
+      <div class="rounded-md border border-line bg-surface px-3 py-2.5">
+        <p class="text-xs text-muted mb-2">
+          Register an OAuth app on GitHub with the callback
+          <code class="font-mono">{{ gh?.callback_path }}</code>, then paste its id and secret.
+          <span :class="gh?.configured ? 'text-accent' : 'text-faint'">
+            {{ gh?.configured ? 'Configured.' : 'Not configured.' }}
+          </span>
+        </p>
+        <div class="space-y-2">
+          <input
+            v-model="ghClientId"
+            placeholder="Client ID"
+            class="w-full rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+          />
+          <input
+            v-model="ghClientSecret"
+            type="password"
+            :placeholder="gh?.configured ? 'Client secret (leave blank to keep)' : 'Client secret'"
+            class="w-full rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+          />
+          <button
+            class="btn-primary px-3 py-1.5 text-xs"
+            :disabled="busy || !ghClientId.trim()"
+            @click="saveGithub"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Approved users -->
+    <section>
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
+        Approved users
+      </h2>
+      <div class="overflow-hidden rounded-md border border-line bg-surface">
+        <div
+          v-for="u in users"
+          :key="u.username"
+          class="flex items-center gap-3 border-b border-line px-3 py-2.5 last:border-0"
+        >
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-medium">{{ u.username }}</p>
+            <p class="text-2xs text-faint">
+              <template v-if="u.github_login">GitHub: {{ u.github_login }}</template>
+              <template v-else>no GitHub login</template>
+              · {{ u.has_password ? 'password set' : 'no password' }}
+            </p>
+          </div>
+          <button
+            v-if="u.username !== me.username"
+            class="btn-secondary px-2.5 py-1 text-xs"
+            :disabled="busy"
+            @click="removeUser(u)"
+          >
+            Remove
+          </button>
+          <span v-else class="text-2xs text-faint">you</span>
+        </div>
+      </div>
+
+      <div class="mt-2 flex flex-wrap items-end gap-2">
+        <input
+          v-model="newUser"
+          placeholder="Username"
+          class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+        />
+        <input
+          v-model="newUserGithub"
+          placeholder="GitHub login (optional)"
+          class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+        />
+        <input
+          v-model="newUserPassword"
+          type="password"
+          autocomplete="new-password"
+          placeholder="Password (optional)"
+          class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+        />
+        <button
+          class="btn-primary px-3 py-1.5 text-xs"
+          :disabled="busy || !newUser.trim()"
+          @click="addUser"
+        >
+          Approve user
+        </button>
+      </div>
+    </section>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/TokensPanel.vue
+++ b/crates/loom/frontend/src/components/TokensPanel.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import * as api from '../api';
+import type { Token, CreatedToken } from '../types';
+
+// Manage API tokens — the `LOOM_TOKEN` automation presents as a bearer. The
+// plaintext is shown once at creation; thereafter only metadata is listed.
+const tokens = ref<Token[]>([]);
+const error = ref('');
+const busy = ref(false);
+const name = ref('');
+const expiresDays = ref('');
+const created = ref<CreatedToken | null>(null);
+const copied = ref(false);
+
+async function load() {
+  try {
+    tokens.value = await api.listTokens();
+    error.value = '';
+  } catch (e) {
+    error.value = (e as Error).message;
+  }
+}
+
+async function create() {
+  if (!name.value.trim() || busy.value) return;
+  busy.value = true;
+  error.value = '';
+  created.value = null;
+  try {
+    const days = expiresDays.value.trim() ? Number(expiresDays.value) : null;
+    created.value = await api.createToken(name.value.trim(), days);
+    name.value = '';
+    expiresDays.value = '';
+    copied.value = false;
+    await load();
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function revoke(t: Token) {
+  if (!confirm(`Revoke "${t.name}"? Anything using this token will stop working.`)) return;
+  busy.value = true;
+  error.value = '';
+  try {
+    await api.revokeToken(t.id);
+    await load();
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function copy() {
+  if (!created.value) return;
+  try {
+    await navigator.clipboard.writeText(created.value.token);
+    copied.value = true;
+  } catch {
+    /* clipboard may be unavailable; the secret is still selectable */
+  }
+}
+
+const fmt = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : '—');
+
+onMounted(load);
+</script>
+
+<template>
+  <div>
+    <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">API tokens</h2>
+    <p class="text-xs text-faint mb-3">
+      A token authenticates automation and remote CLIs. Send it as
+      <code>Authorization: Bearer</code> or set it as <code>LOOM_TOKEN</code> (with
+      <code>WEAVER_API</code> pointing at this server).
+    </p>
+
+    <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
+
+    <!-- One-time secret: shown once, right after creation. -->
+    <div v-if="created" class="mb-4 rounded-md border border-accent bg-surface p-3" data-testid="new-token">
+      <p class="text-xs font-medium text-accent mb-1">
+        Copy this token now — it won't be shown again.
+      </p>
+      <div class="flex items-center gap-2">
+        <code class="flex-1 select-all break-all rounded bg-input px-2 py-1.5 font-mono text-xs">{{
+          created.token
+        }}</code>
+        <button class="btn-secondary px-2.5 py-1 text-xs" @click="copy">
+          {{ copied ? 'Copied' : 'Copy' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Create form. -->
+    <div class="mb-4 flex flex-wrap items-end gap-2">
+      <label class="flex flex-col gap-1">
+        <span class="text-2xs text-muted">Name</span>
+        <input
+          v-model="name"
+          placeholder="e.g. github-actions"
+          data-testid="token-name"
+          class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+          @keyup.enter="create"
+        />
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="text-2xs text-muted">Expires (days)</span>
+        <input
+          v-model="expiresDays"
+          type="number"
+          min="1"
+          placeholder="never"
+          class="w-28 rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+        />
+      </label>
+      <button
+        class="btn-primary px-3 py-1.5 text-xs"
+        :disabled="busy || !name.trim()"
+        data-testid="token-create"
+        @click="create"
+      >
+        Create token
+      </button>
+    </div>
+
+    <!-- Existing tokens. -->
+    <div v-if="tokens.length" class="overflow-hidden rounded-md border border-line bg-surface">
+      <div
+        v-for="t in tokens"
+        :key="t.id"
+        class="flex items-center gap-3 border-b border-line px-3 py-2.5 last:border-0"
+        data-testid="token-row"
+      >
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <span class="truncate text-sm font-medium">{{ t.name }}</span>
+            <code class="font-mono text-2xs text-faint">{{ t.prefix }}…</code>
+          </div>
+          <p class="text-2xs text-faint">
+            Created {{ fmt(t.created_at) }} · Last used {{ fmt(t.last_used_at) }}
+            <template v-if="t.expires_at"> · Expires {{ fmt(t.expires_at) }}</template>
+          </p>
+        </div>
+        <button
+          class="btn-secondary px-2.5 py-1 text-xs"
+          :disabled="busy"
+          data-testid="token-revoke"
+          @click="revoke(t)"
+        >
+          Revoke
+        </button>
+      </div>
+    </div>
+    <p v-else class="text-sm text-muted">No tokens yet.</p>
+  </div>
+</template>

--- a/crates/loom/frontend/src/main.ts
+++ b/crates/loom/frontend/src/main.ts
@@ -17,11 +17,15 @@ import Settings from './views/Settings.vue';
 import Issues from './views/Issues.vue';
 import Overlookers from './views/Overlookers.vue';
 import OverlookerDetail from './views/OverlookerDetail.vue';
+import Login from './views/Login.vue';
+import { me, loadMe } from './auth';
+import { setUnauthorizedHandler } from './api';
 import './styles.css';
 
 const router = createRouter({
   history: createWebHistory(),
   routes: [
+    { path: '/login', component: Login, meta: { public: true } },
     { path: '/', component: SessionList },
     { path: '/s/:id', component: SessionDetail, props: true },
     { path: '/s/:id/files', component: FileBrowser, props: true },
@@ -34,4 +38,25 @@ const router = createRouter({
   ],
 });
 
-createApp(App).use(router).mount('#app');
+// Gate every non-public route on an authenticated identity. A loopback-trusted
+// user resolves immediately; anyone else is bounced to the login screen.
+router.beforeEach(async (to) => {
+  if (to.meta.public) return true;
+  if (me.authenticated) return true;
+  if (await loadMe()) return true;
+  return { path: '/login', query: to.fullPath === '/' ? {} : { redirect: to.fullPath } };
+});
+
+// A 401 mid-session (an expired cookie) flips us back to the login screen.
+setUnauthorizedHandler(() => {
+  me.authenticated = false;
+  if (router.currentRoute.value.path !== '/login') {
+    router.push({ path: '/login' });
+  }
+});
+
+// Resolve identity once up front so the first paint picks the right chrome
+// (full shell vs. bare login), then mount.
+loadMe().finally(() => {
+  createApp(App).use(router).mount('#app');
+});

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -365,3 +365,54 @@ export interface SettingView {
   value: string;
   is_default: boolean;
 }
+
+// --- Authentication --------------------------------------------------------
+
+/** Which sign-in methods the login screen should offer. Mirrors weaver-api's
+ *  `AuthMethods`. */
+export interface AuthMethods {
+  password: boolean;
+  github: boolean;
+}
+
+/** Who the caller is + what the login screen needs (`GET /api/auth/me`).
+ *  `authenticated: false` means show the login view. Mirrors `MeView`. */
+export interface Me {
+  authenticated: boolean;
+  username: string | null;
+  github_login: string | null;
+  /** How they authenticated: `loopback` | `token` | `session` | null. */
+  via: string | null;
+  methods: AuthMethods;
+}
+
+/** One API token's non-secret metadata. Mirrors `TokenView`. */
+export interface Token {
+  id: string;
+  name: string;
+  prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+  expires_at: string | null;
+}
+
+/** The one-time create reply: the plaintext token plus its metadata (flattened).
+ *  Mirrors `CreatedTokenView`. */
+export interface CreatedToken extends Token {
+  token: string;
+}
+
+/** One approved operator. Mirrors `UserView`. */
+export interface User {
+  username: string;
+  github_login: string | null;
+  has_password: boolean;
+  created_at: string;
+}
+
+/** The GitHub OAuth app config (secret withheld). Mirrors `GithubConfigView`. */
+export interface GithubConfig {
+  configured: boolean;
+  client_id: string;
+  callback_path: string;
+}

--- a/crates/loom/frontend/src/views/Login.vue
+++ b/crates/loom/frontend/src/views/Login.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import * as api from '../api';
+import { me, loadMe } from '../auth';
+
+// The chrome-free sign-in screen (App.vue renders this bare, without the nav
+// rail, whenever the caller is unauthenticated). Offers GitHub sign-in when an
+// OAuth app is configured, plus username/password.
+const route = useRoute();
+const router = useRouter();
+
+const username = ref('');
+const password = ref('');
+const busy = ref(false);
+const error = ref('');
+
+// Friendly text for the codes the GitHub callback redirects back with.
+const OAUTH_ERRORS: Record<string, string> = {
+  'not-approved': 'That GitHub account is not on the approved list.',
+  'state-mismatch': 'The sign-in attempt expired or could not be verified. Try again.',
+  'missing-code': 'GitHub did not return an authorization code. Try again.',
+};
+
+onMounted(() => {
+  const code = route.query.error as string | undefined;
+  if (code) error.value = OAUTH_ERRORS[code] ?? `Sign-in failed (${code}).`;
+  if (me.authenticated) router.replace('/');
+});
+
+async function submit() {
+  if (busy.value) return;
+  busy.value = true;
+  error.value = '';
+  try {
+    await api.login(username.value, password.value);
+    await loadMe();
+    router.replace((route.query.redirect as string) || '/');
+  } catch (e) {
+    error.value = (e as Error).message || 'Sign-in failed';
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-canvas px-4 font-sans text-fg">
+    <div class="w-full max-w-sm">
+      <div class="mb-6 flex items-center justify-center gap-2">
+        <span class="text-accent">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="1.75" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 9h16M4 15h16M9 4v16M15 4v16" />
+          </svg>
+        </span>
+        <span class="text-lg font-semibold tracking-tight">loom</span>
+      </div>
+
+      <div class="rounded-lg border border-line bg-surface p-5">
+        <h1 class="mb-1 text-sm font-semibold">Sign in</h1>
+        <p class="mb-4 text-xs text-muted">Authenticate to manage the fleet.</p>
+
+        <p v-if="error" class="mb-3 rounded bg-input px-2.5 py-1.5 text-xs text-block">{{ error }}</p>
+
+        <a
+          v-if="me.methods.github"
+          :href="api.githubLoginUrl"
+          class="btn-secondary mb-3 flex w-full items-center justify-center gap-2 py-2 text-sm"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+          </svg>
+          Continue with GitHub
+        </a>
+
+        <div v-if="me.methods.github" class="my-3 flex items-center gap-2 text-2xs text-faint">
+          <span class="h-px flex-1 bg-line"></span>or<span class="h-px flex-1 bg-line"></span>
+        </div>
+
+        <form class="space-y-2.5" @submit.prevent="submit">
+          <input
+            v-model="username"
+            autocomplete="username"
+            placeholder="Username"
+            class="w-full rounded bg-input px-2.5 py-2 text-sm outline-none focus:ring-1 ring-accent"
+          />
+          <input
+            v-model="password"
+            type="password"
+            autocomplete="current-password"
+            placeholder="Password"
+            class="w-full rounded bg-input px-2.5 py-2 text-sm outline-none focus:ring-1 ring-accent"
+          />
+          <button
+            type="submit"
+            :disabled="busy || !username || !password"
+            class="btn-primary w-full py-2 text-sm"
+          >
+            {{ busy ? 'Signing in…' : 'Sign in' }}
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -3,6 +3,18 @@ import { ref, computed, onMounted } from 'vue';
 import { get, patch } from '../api';
 import type { SettingView } from '../types';
 import ToggleSwitch from '../components/ToggleSwitch.vue';
+import TokensPanel from '../components/TokensPanel.vue';
+import AccountPanel from '../components/AccountPanel.vue';
+
+// In-page tabs: the setting registry (General), API tokens, and the account /
+// access surface (password, approved users, GitHub sign-in config).
+type Tab = 'general' | 'tokens' | 'account';
+const tabs: { id: Tab; label: string }[] = [
+  { id: 'general', label: 'General' },
+  { id: 'tokens', label: 'Tokens' },
+  { id: 'account', label: 'Account' },
+];
+const tab = ref<Tab>('general');
 
 // The server's canonical reply for both GET and PATCH /api/settings.
 interface SettingsEnvelope {
@@ -90,20 +102,43 @@ onMounted(load);
 
 <template>
   <div class="max-w-3xl px-5 py-3">
-    <div class="mb-1 flex min-h-7 items-center gap-2.5">
+    <div class="mb-2 flex min-h-7 items-center gap-2.5">
       <h1 class="text-2xs font-semibold uppercase tracking-wider text-muted">Settings</h1>
     </div>
-    <p class="text-xs text-faint mb-3">
-      Stored in the weaver database and shared by the server and CLI
-      (<code>weaver config</code>).
-    </p>
 
-    <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
-    <p v-if="notice" class="mb-3 text-sm text-accent">{{ notice }}</p>
+    <!-- Tab bar: General (registry), Tokens, Account. -->
+    <div class="mb-4 flex gap-1 border-b border-line">
+      <button
+        v-for="t in tabs"
+        :key="t.id"
+        :data-testid="`settings-tab-${t.id}`"
+        class="-mb-px border-b-2 px-3 py-1.5 text-sm transition-colors"
+        :class="
+          tab === t.id
+            ? 'border-accent text-fg'
+            : 'border-transparent text-muted hover:text-fg'
+        "
+        @click="tab = t.id"
+      >
+        {{ t.label }}
+      </button>
+    </div>
 
-    <!-- One bordered panel per group, hairline-divided rows — the same list
-         anatomy as the fleet/issue boards, instead of free-floating cards. -->
-    <div v-for="g in groups" :key="g.name" class="mb-5">
+    <TokensPanel v-if="tab === 'tokens'" />
+    <AccountPanel v-else-if="tab === 'account'" />
+
+    <div v-else>
+      <p class="text-xs text-faint mb-3">
+        Stored in the weaver database and shared by the server and CLI
+        (<code>weaver config</code>).
+      </p>
+
+      <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
+      <p v-if="notice" class="mb-3 text-sm text-accent">{{ notice }}</p>
+
+      <!-- One bordered panel per group, hairline-divided rows — the same list
+           anatomy as the fleet/issue boards, instead of free-floating cards. -->
+      <div v-for="g in groups" :key="g.name" class="mb-5">
       <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
         {{ g.name }}
       </h2>
@@ -170,8 +205,9 @@ onMounted(load);
           </p>
         </section>
       </div>
-    </div>
+      </div>
 
-    <p v-if="!settings.length && !error" class="text-sm text-muted">Loading…</p>
+      <p v-if="!settings.length && !error" class="text-sm text-muted">Loading…</p>
+    </div>
   </div>
 </template>

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -130,10 +130,17 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
     }
 
     let api_url = format!("http://{}", spec.server_addr);
-    let env = [
+    // Hand the agent the machine-local token so its in-worktree `loom session …`
+    // calls authenticate even when loopback trust is off. Absent file ⇒ omit it
+    // (loopback trust then covers the local case).
+    let local_token = read_local_token();
+    let mut env = vec![
         ("WEAVER_API", api_url.as_str()),
         ("WEAVER_BRANCH", spec.branch_id),
     ];
+    if let Some(token) = local_token.as_deref() {
+        env.push(("LOOM_TOKEN", token));
+    }
     let script = launch_script(
         spec.agent_kind,
         spec.goal_file,
@@ -160,6 +167,15 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
         "agent launched"
     );
     Ok(())
+}
+
+/// The machine-local bearer token (trimmed), if the daemon has minted it. Read
+/// straight off disk so callers needn't thread it through; absent ⇒ `None`.
+pub fn read_local_token() -> Option<String> {
+    std::fs::read_to_string(crate::auth::local_token_path())
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Write (merging into any existing file) `.claude/settings.local.json` so the

--- a/crates/loom/src/auth.rs
+++ b/crates/loom/src/auth.rs
@@ -1,0 +1,833 @@
+//! Authentication for the loom daemon — who may drive the fleet over HTTP.
+//!
+//! This is a loom-only concern: the daemon-less `weaver` CLI talks straight to
+//! sqlite and never authenticates. Three credential shapes all resolve to one
+//! [`Principal`]:
+//!
+//! * **API tokens** (`loom_…`) — the `LOOM_TOKEN` a CI job or remote `loom` CLI
+//!   sends as `Authorization: Bearer`. Stored hashed; shown once at creation.
+//! * **Session cookies** — set after a GitHub or username/password login and
+//!   carried by the browser. Stored hashed, same as tokens.
+//! * **Loopback trust** — a request from `127.0.0.1`/`::1` is taken to be the
+//!   machine owner (the seeded primary user), so the local CLI, the agent, and
+//!   overlooker scripts keep working with zero configuration. Gated on the
+//!   `auth.trust_loopback` setting (on by default).
+//!
+//! The machine also mints a **local token** ([`ensure_local_token`]) it injects
+//! into its own subprocess environments, so same-host automation keeps working
+//! even when loopback trust is turned off (the right posture behind a same-host
+//! reverse proxy, where every forwarded request looks like loopback).
+//!
+//! This module is deliberately free of `axum` — it is the testable core
+//! (crypto, the user/token/session tables, the GitHub OAuth calls). The HTTP
+//! glue (the middleware, cookie headers, the route handlers) lives in
+//! [`crate::web`].
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
+use argon2::Argon2;
+use base64::Engine as _;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use sqlx::Row;
+
+use crate::db::{weaver_home, Db};
+
+/// Prefix on every loom API token, so a leaked secret is recognisable and
+/// greppable. A token looks like `loom_<43 url-safe base64 chars>`.
+const TOKEN_PREFIX: &str = "loom_";
+/// How much of a token's plaintext is kept (non-secret) for the token list —
+/// enough to tell two tokens apart at a glance, far short of guessable.
+const PREFIX_KEEP: usize = 12;
+/// Browser login lifetime, in days. Shared by the stored-session expiry and the
+/// `Max-Age` on the login cookie so the two can't drift.
+pub const SESSION_TTL_DAYS: i64 = 30;
+/// The cookie a browser login is carried in.
+pub const SESSION_COOKIE: &str = "loom_session";
+/// The reserved [`TokenKind::Local`] token name.
+const LOCAL_TOKEN_NAME: &str = "this machine";
+/// SQLite expression for the current instant in our stored ISO format — the one
+/// `weaver-core` writes, so string comparisons against `*_at` columns are sound.
+const SQL_NOW: &str = "strftime('%Y-%m-%dT%H:%M:%fZ','now')";
+
+// ---------------------------------------------------------------------------
+// Principal
+// ---------------------------------------------------------------------------
+
+/// How a request proved its identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthVia {
+    /// Trusted because it came from the loopback interface.
+    Loopback,
+    /// A valid `Authorization: Bearer` API token.
+    Token,
+    /// A valid browser session cookie.
+    Session,
+}
+
+impl AuthVia {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AuthVia::Loopback => "loopback",
+            AuthVia::Token => "token",
+            AuthVia::Session => "session",
+        }
+    }
+}
+
+/// An authenticated caller: which approved user, and how they proved it.
+#[derive(Debug, Clone)]
+pub struct Principal {
+    pub username: String,
+    pub github_login: Option<String>,
+    pub via: AuthVia,
+}
+
+// ---------------------------------------------------------------------------
+// Crypto primitives
+// ---------------------------------------------------------------------------
+
+fn sha256_hex(s: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    hex::encode(h.finalize())
+}
+
+/// `bytes` cryptographically-random bytes as url-safe base64 (no padding).
+fn random_b64(bytes: usize) -> String {
+    let mut buf = vec![0u8; bytes];
+    rand::rng().fill_bytes(&mut buf);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(buf)
+}
+
+/// A short random hex id (token / row identifier).
+fn random_id() -> String {
+    let mut buf = [0u8; 8];
+    rand::rng().fill_bytes(&mut buf);
+    hex::encode(buf)
+}
+
+/// A short random state nonce for the OAuth round-trip (CSRF guard).
+pub fn random_state() -> String {
+    random_b64(18)
+}
+
+/// Mint a fresh secret token: `(plaintext, sha256-hash, display-prefix)`. Only
+/// the hash and prefix are persisted; the plaintext is returned to the caller
+/// once and never stored.
+fn mint_token() -> (String, String, String) {
+    let plain = format!("{TOKEN_PREFIX}{}", random_b64(32));
+    let hash = sha256_hex(&plain);
+    let prefix: String = plain.chars().take(PREFIX_KEEP).collect();
+    (plain, hash, prefix)
+}
+
+/// Hash a password for storage with argon2id (per-password random salt). The
+/// salt is drawn from the same CSPRNG as our tokens, then b64-encoded into the
+/// PHC salt string — sidestepping argon2's `rand_core` version pin.
+pub fn hash_password(password: &str) -> Result<String> {
+    let mut salt_bytes = [0u8; 16];
+    rand::rng().fill_bytes(&mut salt_bytes);
+    let salt = SaltString::encode_b64(&salt_bytes).map_err(|e| anyhow!("encoding salt: {e}"))?;
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| anyhow!("hashing password: {e}"))
+}
+
+/// Constant-time verify a password against a stored argon2 hash. A malformed
+/// stored hash simply fails (never panics).
+fn verify_password(password: &str, stored: &str) -> bool {
+    match PasswordHash::new(stored) {
+        Ok(parsed) => Argon2::default()
+            .verify_password(password.as_bytes(), &parsed)
+            .is_ok(),
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Users (the approved-operator allowlist)
+// ---------------------------------------------------------------------------
+
+/// One approved operator.
+#[derive(Debug, Clone)]
+pub struct User {
+    pub username: String,
+    pub github_login: Option<String>,
+    pub password_hash: Option<String>,
+    pub created_at: String,
+}
+
+impl User {
+    /// Whether this user can log in with a password (has one set).
+    pub fn has_password(&self) -> bool {
+        self.password_hash.is_some()
+    }
+}
+
+fn user_from_row(r: &sqlx::sqlite::SqliteRow) -> User {
+    User {
+        username: r.get("username"),
+        github_login: r.get("github_login"),
+        password_hash: r.get("password_hash"),
+        created_at: r.get("created_at"),
+    }
+}
+
+pub async fn get_user(db: &Db, username: &str) -> Result<Option<User>> {
+    let row = sqlx::query(
+        "SELECT username, github_login, password_hash, created_at FROM users WHERE username = ?",
+    )
+    .bind(username)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.as_ref().map(user_from_row))
+}
+
+/// The approved user whose `github_login` matches (case-insensitively — GitHub
+/// logins are case-insensitive), if any. This is the allowlist check the OAuth
+/// callback runs: an unknown GitHub identity has no row and is rejected.
+pub async fn user_by_github(db: &Db, login: &str) -> Result<Option<User>> {
+    let row = sqlx::query(
+        "SELECT username, github_login, password_hash, created_at FROM users
+         WHERE github_login IS NOT NULL AND lower(github_login) = lower(?)",
+    )
+    .bind(login)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.as_ref().map(user_from_row))
+}
+
+pub async fn list_users(db: &Db) -> Result<Vec<User>> {
+    let rows = sqlx::query(
+        "SELECT username, github_login, password_hash, created_at FROM users ORDER BY created_at, username",
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows.iter().map(user_from_row).collect())
+}
+
+/// The primary (owner) user: the earliest-created row. Loopback requests and the
+/// machine token are attributed to them. `None` only on an unseeded database.
+pub async fn primary_user(db: &Db) -> Result<Option<String>> {
+    let row = sqlx::query("SELECT username FROM users ORDER BY created_at, username LIMIT 1")
+        .fetch_optional(db)
+        .await?;
+    Ok(row.map(|r| r.get::<String, _>("username")))
+}
+
+/// Add an approved user. `github_login` enables GitHub login; `password` (when
+/// given) enables password login. At least one should be set or the user can
+/// never authenticate, but that is the caller's policy to enforce.
+pub async fn add_user(
+    db: &Db,
+    username: &str,
+    github_login: Option<&str>,
+    password: Option<&str>,
+) -> Result<()> {
+    let password_hash = match password {
+        Some(p) => Some(hash_password(p)?),
+        None => None,
+    };
+    sqlx::query("INSERT INTO users (username, github_login, password_hash) VALUES (?, ?, ?)")
+        .bind(username)
+        .bind(github_login)
+        .bind(password_hash)
+        .execute(db)
+        .await
+        .with_context(|| format!("adding user '{username}'"))?;
+    Ok(())
+}
+
+/// Remove an approved user, refusing to delete the last one (which would lock
+/// everyone out). Returns whether a row was removed.
+pub async fn remove_user(db: &Db, username: &str) -> Result<bool> {
+    let count: i64 = sqlx::query("SELECT COUNT(*) AS n FROM users")
+        .fetch_one(db)
+        .await?
+        .get("n");
+    if count <= 1 {
+        return Err(anyhow!("cannot remove the only approved user"));
+    }
+    let res = sqlx::query("DELETE FROM users WHERE username = ?")
+        .bind(username)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Set (or, with `None`, clear) a user's password. Its tokens and sessions are
+/// untouched.
+pub async fn set_password(db: &Db, username: &str, password: Option<&str>) -> Result<()> {
+    let hash = match password {
+        Some(p) => Some(hash_password(p)?),
+        None => None,
+    };
+    let res = sqlx::query("UPDATE users SET password_hash = ? WHERE username = ?")
+        .bind(hash)
+        .bind(username)
+        .execute(db)
+        .await?;
+    if res.rows_affected() == 0 {
+        return Err(anyhow!("no such user '{username}'"));
+    }
+    Ok(())
+}
+
+/// Verify a username/password login, returning the [`Principal`] on success.
+/// A missing user, a user with no password, and a wrong password are all the
+/// same indistinguishable failure (`Ok(None)`).
+pub async fn verify_login(db: &Db, username: &str, password: &str) -> Result<Option<Principal>> {
+    let Some(user) = get_user(db, username).await? else {
+        return Ok(None);
+    };
+    let Some(stored) = user.password_hash.as_deref() else {
+        return Ok(None);
+    };
+    if verify_password(password, stored) {
+        Ok(Some(Principal {
+            username: user.username,
+            github_login: user.github_login,
+            via: AuthVia::Session,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Build the loopback [`Principal`] — the primary user, marked [`AuthVia::Loopback`].
+pub async fn loopback_principal(db: &Db) -> Result<Option<Principal>> {
+    let Some(username) = primary_user(db).await? else {
+        return Ok(None);
+    };
+    Ok(get_user(db, &username).await?.map(|u| Principal {
+        username: u.username,
+        github_login: u.github_login,
+        via: AuthVia::Loopback,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Browser sessions (login cookies)
+// ---------------------------------------------------------------------------
+
+/// Open a browser session for `username`, returning the opaque cookie value.
+pub async fn create_session(db: &Db, username: &str) -> Result<String> {
+    let (plain, hash, _) = mint_token();
+    let sql = format!(
+        "INSERT INTO auth_sessions (token_hash, username, expires_at)
+         VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now','+{SESSION_TTL_DAYS} days'))"
+    );
+    sqlx::query(&sql)
+        .bind(&hash)
+        .bind(username)
+        .execute(db)
+        .await?;
+    Ok(plain)
+}
+
+/// Resolve a session cookie to its [`Principal`], or `None` if unknown, expired,
+/// or its user has since been removed.
+pub async fn lookup_session(db: &Db, cookie: &str) -> Result<Option<Principal>> {
+    let hash = sha256_hex(cookie);
+    let row = sqlx::query(&format!(
+        "SELECT s.username AS username, u.github_login AS github_login
+         FROM auth_sessions s JOIN users u ON u.username = s.username
+         WHERE s.token_hash = ? AND s.expires_at > {SQL_NOW}"
+    ))
+    .bind(&hash)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.map(|r| Principal {
+        username: r.get("username"),
+        github_login: r.get("github_login"),
+        via: AuthVia::Session,
+    }))
+}
+
+/// Drop a session (logout). Best-effort — an unknown cookie is a no-op.
+pub async fn delete_session(db: &Db, cookie: &str) -> Result<()> {
+    let hash = sha256_hex(cookie);
+    sqlx::query("DELETE FROM auth_sessions WHERE token_hash = ?")
+        .bind(&hash)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// API tokens
+// ---------------------------------------------------------------------------
+
+/// 'pat' (a user-managed personal access token) or 'local' (the machine token).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenKind {
+    Pat,
+    Local,
+}
+
+impl TokenKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            TokenKind::Pat => "pat",
+            TokenKind::Local => "local",
+        }
+    }
+}
+
+/// A token's non-secret metadata, for the token list.
+#[derive(Debug, Clone)]
+pub struct TokenInfo {
+    pub id: String,
+    pub name: String,
+    pub prefix: String,
+    pub created_at: String,
+    pub last_used_at: Option<String>,
+    pub expires_at: Option<String>,
+}
+
+fn token_info_from_row(r: &sqlx::sqlite::SqliteRow) -> TokenInfo {
+    TokenInfo {
+        id: r.get("id"),
+        name: r.get("name"),
+        prefix: r.get("prefix"),
+        created_at: r.get("created_at"),
+        last_used_at: r.get("last_used_at"),
+        expires_at: r.get("expires_at"),
+    }
+}
+
+/// Mint a personal access token owned by `username`. Returns the one-time
+/// plaintext plus the stored metadata.
+pub async fn create_token(
+    db: &Db,
+    username: &str,
+    name: &str,
+    expires_in_days: Option<i64>,
+) -> Result<(String, TokenInfo)> {
+    create_token_kind(db, username, name, expires_in_days, TokenKind::Pat).await
+}
+
+async fn create_token_kind(
+    db: &Db,
+    username: &str,
+    name: &str,
+    expires_in_days: Option<i64>,
+    kind: TokenKind,
+) -> Result<(String, TokenInfo)> {
+    let (plain, hash, prefix) = mint_token();
+    let id = random_id();
+    // Expiry is computed in SQL so it shares the exact stored format; a positive
+    // `expires_in_days` sets it, anything else leaves the token non-expiring.
+    let expires_sql = match expires_in_days {
+        Some(d) if d > 0 => format!("strftime('%Y-%m-%dT%H:%M:%fZ','now','+{d} days')"),
+        _ => "NULL".to_string(),
+    };
+    let sql = format!(
+        "INSERT INTO api_tokens (id, username, name, token_hash, prefix, kind, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, {expires_sql})"
+    );
+    sqlx::query(&sql)
+        .bind(&id)
+        .bind(username)
+        .bind(name)
+        .bind(&hash)
+        .bind(&prefix)
+        .bind(kind.as_str())
+        .execute(db)
+        .await
+        .context("creating token")?;
+    let info = get_token(db, &id)
+        .await?
+        .ok_or_else(|| anyhow!("token vanished after insert"))?;
+    Ok((plain, info))
+}
+
+async fn get_token(db: &Db, id: &str) -> Result<Option<TokenInfo>> {
+    let row = sqlx::query(
+        "SELECT id, name, prefix, created_at, last_used_at, expires_at FROM api_tokens WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.as_ref().map(token_info_from_row))
+}
+
+/// Every user-managed token (the machine 'local' token is infrastructure and is
+/// omitted), newest first.
+pub async fn list_tokens(db: &Db) -> Result<Vec<TokenInfo>> {
+    let rows = sqlx::query(
+        "SELECT id, name, prefix, created_at, last_used_at, expires_at FROM api_tokens
+         WHERE kind = 'pat' ORDER BY created_at DESC",
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows.iter().map(token_info_from_row).collect())
+}
+
+/// Revoke a token by id. Refuses the machine 'local' token. Returns whether a
+/// (revocable) row was removed.
+pub async fn revoke_token(db: &Db, id: &str) -> Result<bool> {
+    let res = sqlx::query("DELETE FROM api_tokens WHERE id = ? AND kind = 'pat'")
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Resolve an `Authorization: Bearer` token to its [`Principal`]. Touches
+/// `last_used_at` on a hit (best-effort). `None` for an unknown, expired, or
+/// orphaned token.
+pub async fn lookup_token(db: &Db, token: &str) -> Result<Option<Principal>> {
+    if !token.starts_with(TOKEN_PREFIX) {
+        return Ok(None);
+    }
+    let hash = sha256_hex(token);
+    let row = sqlx::query(&format!(
+        "SELECT t.id AS id, t.username AS username, u.github_login AS github_login
+         FROM api_tokens t JOIN users u ON u.username = t.username
+         WHERE t.token_hash = ? AND (t.expires_at IS NULL OR t.expires_at > {SQL_NOW})"
+    ))
+    .bind(&hash)
+    .fetch_optional(db)
+    .await?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let id: String = row.get("id");
+    let _ = sqlx::query(&format!(
+        "UPDATE api_tokens SET last_used_at = {SQL_NOW} WHERE id = ?"
+    ))
+    .bind(&id)
+    .execute(db)
+    .await;
+    Ok(Some(Principal {
+        username: row.get("username"),
+        github_login: row.get("github_login"),
+        via: AuthVia::Token,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// The machine-local token
+// ---------------------------------------------------------------------------
+
+/// Path to the file holding the machine-local token plaintext (mode 0600).
+pub fn local_token_path() -> PathBuf {
+    weaver_home().join("loom-token")
+}
+
+/// Ensure the machine-local bearer token exists and return its plaintext.
+///
+/// loom injects this into the environments of its own same-host subprocesses
+/// (the agent's tmux, overlooker scripts) and the `loom` CLI reads it, so local
+/// automation authenticates even when `auth.trust_loopback` is off. The
+/// plaintext is persisted (0600) under `$WEAVER_HOME` and reused across
+/// restarts; if the database is reset but the file survives, the same plaintext
+/// is re-registered so existing subprocesses keep working.
+pub async fn ensure_local_token(db: &Db) -> Result<String> {
+    let path = local_token_path();
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        let plain = existing.trim().to_string();
+        if !plain.is_empty() {
+            let hash = sha256_hex(&plain);
+            let known = sqlx::query("SELECT 1 AS ok FROM api_tokens WHERE token_hash = ?")
+                .bind(&hash)
+                .fetch_optional(db)
+                .await?
+                .is_some();
+            if !known {
+                register_local_token(db, &plain).await?;
+            }
+            return Ok(plain);
+        }
+    }
+    let (plain, _, _) = mint_token();
+    write_private(&path, &plain)?;
+    register_local_token(db, &plain).await?;
+    Ok(plain)
+}
+
+/// Register a known plaintext as the machine 'local' token row, owned by the
+/// primary user. Idempotent on the hash.
+async fn register_local_token(db: &Db, plain: &str) -> Result<()> {
+    let owner = primary_user(db)
+        .await?
+        .ok_or_else(|| anyhow!("no users seeded — cannot register the local token"))?;
+    let hash = sha256_hex(plain);
+    let prefix: String = plain.chars().take(PREFIX_KEEP).collect();
+    sqlx::query(
+        "INSERT OR IGNORE INTO api_tokens (id, username, name, token_hash, prefix, kind)
+         VALUES (?, ?, ?, ?, ?, 'local')",
+    )
+    .bind(random_id())
+    .bind(&owner)
+    .bind(LOCAL_TOKEN_NAME)
+    .bind(&hash)
+    .bind(&prefix)
+    .execute(db)
+    .await
+    .context("registering the local token")?;
+    Ok(())
+}
+
+/// Write `contents` to `path` with owner-only (0600) permissions.
+fn write_private(path: &std::path::Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(path, contents).with_context(|| format!("writing {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("chmod 600 {}", path.display()))?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// GitHub OAuth
+// ---------------------------------------------------------------------------
+
+/// Settings keys (also overridable by the env vars in [`github_oauth`]).
+pub const GH_CLIENT_ID_KEY: &str = "auth.github.client_id";
+pub const GH_CLIENT_SECRET_KEY: &str = "auth.github.client_secret";
+
+/// A configured GitHub OAuth app.
+#[derive(Debug, Clone)]
+pub struct GithubOAuth {
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+async fn env_or_setting(db: &Db, env: &str, key: &str) -> String {
+    if let Ok(v) = std::env::var(env) {
+        let v = v.trim().to_string();
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    crate::config::get(db, key).await.unwrap_or_default()
+}
+
+/// The GitHub OAuth app config, or `None` when sign-in-with-GitHub is not set
+/// up. Reads `LOOM_GITHUB_CLIENT_ID`/`_SECRET` first, then the settings table.
+pub async fn github_oauth(db: &Db) -> Option<GithubOAuth> {
+    let client_id = env_or_setting(db, "LOOM_GITHUB_CLIENT_ID", GH_CLIENT_ID_KEY).await;
+    let client_secret = env_or_setting(db, "LOOM_GITHUB_CLIENT_SECRET", GH_CLIENT_SECRET_KEY).await;
+    if client_id.is_empty() || client_secret.is_empty() {
+        return None;
+    }
+    Some(GithubOAuth {
+        client_id,
+        client_secret,
+    })
+}
+
+/// The URL to send the browser to, to begin the OAuth dance. `state` is the
+/// CSRF nonce echoed back to the callback; `redirect_uri` is loom's callback.
+pub fn authorize_url(cfg: &GithubOAuth, state: &str, redirect_uri: &str) -> String {
+    let q = |s: &str| {
+        percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC).to_string()
+    };
+    format!(
+        "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&scope=read:user&state={}",
+        q(&cfg.client_id),
+        q(redirect_uri),
+        q(state),
+    )
+}
+
+/// Exchange an OAuth `code` for a GitHub access token.
+pub async fn exchange_code(cfg: &GithubOAuth, code: &str, redirect_uri: &str) -> Result<String> {
+    #[derive(serde::Deserialize)]
+    struct TokenResp {
+        access_token: Option<String>,
+        error_description: Option<String>,
+    }
+    let resp: TokenResp = reqwest::Client::new()
+        .post("https://github.com/login/oauth/access_token")
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::USER_AGENT, "loom")
+        .json(&serde_json::json!({
+            "client_id": cfg.client_id,
+            "client_secret": cfg.client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }))
+        .send()
+        .await
+        .context("requesting GitHub access token")?
+        .json()
+        .await
+        .context("decoding GitHub token response")?;
+    resp.access_token.ok_or_else(|| {
+        anyhow!(
+            "GitHub did not return an access token: {}",
+            resp.error_description.unwrap_or_default()
+        )
+    })
+}
+
+/// Fetch the authenticated user's GitHub login for `access_token`.
+pub async fn fetch_github_login(access_token: &str) -> Result<String> {
+    #[derive(serde::Deserialize)]
+    struct GhUser {
+        login: String,
+    }
+    let user: GhUser = reqwest::Client::new()
+        .get("https://api.github.com/user")
+        .header(reqwest::header::USER_AGENT, "loom")
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .context("fetching GitHub user")?
+        .error_for_status()
+        .context("GitHub user request failed")?
+        .json()
+        .await
+        .context("decoding GitHub user")?;
+    Ok(user.login)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    #[test]
+    fn minted_tokens_are_prefixed_unique_and_hash_consistently() {
+        let (a, ah, ap) = mint_token();
+        let (b, _, _) = mint_token();
+        assert!(a.starts_with("loom_"));
+        assert_ne!(a, b, "two mints must differ");
+        assert_eq!(sha256_hex(&a), ah, "stored hash must match the plaintext");
+        assert!(a.starts_with(&ap), "prefix is a leading slice of the token");
+        assert_eq!(ap.len(), PREFIX_KEEP);
+    }
+
+    #[test]
+    fn password_hash_roundtrips_and_rejects_wrong_password() {
+        let hash = hash_password("hunter2").unwrap();
+        assert!(verify_password("hunter2", &hash));
+        assert!(!verify_password("hunter3", &hash));
+        // A garbage stored hash fails closed rather than panicking.
+        assert!(!verify_password("hunter2", "not-a-hash"));
+    }
+
+    #[tokio::test]
+    async fn seeded_owner_is_the_primary_user() {
+        let db = db::connect_in_memory().await.unwrap();
+        assert_eq!(primary_user(&db).await.unwrap().as_deref(), Some("rjpower"));
+        let u = user_by_github(&db, "RJPower").await.unwrap();
+        assert_eq!(u.map(|u| u.username), Some("rjpower".to_string()));
+    }
+
+    #[tokio::test]
+    async fn token_lifecycle_create_lookup_revoke() {
+        let db = db::connect_in_memory().await.unwrap();
+        let (plain, info) = create_token(&db, "rjpower", "ci", None).await.unwrap();
+
+        let p = lookup_token(&db, &plain)
+            .await
+            .unwrap()
+            .expect("valid token");
+        assert_eq!(p.username, "rjpower");
+        assert_eq!(p.via, AuthVia::Token);
+
+        assert_eq!(list_tokens(&db).await.unwrap().len(), 1);
+        assert!(revoke_token(&db, &info.id).await.unwrap());
+        assert!(lookup_token(&db, &plain).await.unwrap().is_none());
+        assert!(list_tokens(&db).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn expired_token_does_not_resolve() {
+        let db = db::connect_in_memory().await.unwrap();
+        let (plain, info) = create_token(&db, "rjpower", "old", Some(30)).await.unwrap();
+        // Fresh token resolves; backdate its expiry and it no longer does.
+        assert!(lookup_token(&db, &plain).await.unwrap().is_some());
+        sqlx::query("UPDATE api_tokens SET expires_at = '2000-01-01T00:00:00.000Z' WHERE id = ?")
+            .bind(&info.id)
+            .execute(&db)
+            .await
+            .unwrap();
+        assert!(lookup_token(&db, &plain).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn local_token_is_hidden_and_unrevocable() {
+        let db = db::connect_in_memory().await.unwrap();
+        let (plain, info) =
+            create_token_kind(&db, "rjpower", LOCAL_TOKEN_NAME, None, TokenKind::Local)
+                .await
+                .unwrap();
+        // Authenticates, but never appears in the user-facing list…
+        assert!(lookup_token(&db, &plain).await.unwrap().is_some());
+        assert!(list_tokens(&db).await.unwrap().is_empty());
+        // …and the revoke route can't remove it.
+        assert!(!revoke_token(&db, &info.id).await.unwrap());
+        assert!(lookup_token(&db, &plain).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn sessions_resolve_then_clear_on_logout() {
+        let db = db::connect_in_memory().await.unwrap();
+        let cookie = create_session(&db, "rjpower").await.unwrap();
+        assert_eq!(
+            lookup_session(&db, &cookie)
+                .await
+                .unwrap()
+                .map(|p| p.username),
+            Some("rjpower".to_string())
+        );
+        delete_session(&db, &cookie).await.unwrap();
+        assert!(lookup_session(&db, &cookie).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn password_login_and_user_management() {
+        let db = db::connect_in_memory().await.unwrap();
+        // The seeded owner has no password yet.
+        assert!(verify_login(&db, "rjpower", "x").await.unwrap().is_none());
+        set_password(&db, "rjpower", Some("s3cret")).await.unwrap();
+        assert!(verify_login(&db, "rjpower", "s3cret")
+            .await
+            .unwrap()
+            .is_some());
+        assert!(verify_login(&db, "rjpower", "wrong")
+            .await
+            .unwrap()
+            .is_none());
+
+        add_user(&db, "alice", Some("alice-gh"), None)
+            .await
+            .unwrap();
+        assert_eq!(list_users(&db).await.unwrap().len(), 2);
+        assert!(remove_user(&db, "alice").await.unwrap());
+        // The last remaining user can't be removed.
+        assert!(remove_user(&db, "rjpower").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn local_token_is_minted_once_and_reused() {
+        let db = db::connect_in_memory().await.unwrap();
+        // No file is read in-memory; mint goes through the create path twice and
+        // each ensures a working bearer for the same owner.
+        let first = register_then_lookup(&db).await;
+        assert_eq!(first.username, "rjpower");
+    }
+
+    async fn register_then_lookup(db: &Db) -> Principal {
+        let (plain, _, _) = mint_token();
+        register_local_token(db, &plain).await.unwrap();
+        // Re-registering the same plaintext is a no-op (INSERT OR IGNORE).
+        register_local_token(db, &plain).await.unwrap();
+        lookup_token(db, &plain).await.unwrap().unwrap()
+    }
+}

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -71,6 +71,21 @@ enum Cmd {
         #[command(subcommand)]
         cmd: OverlookerCmd,
     },
+    /// Manage API tokens for automation (the `LOOM_TOKEN` a CI job presents).
+    ///
+    /// Mint a token to drive loom from GitHub Actions or any remote client:
+    ///
+    ///     loom token create github-actions     # prints the secret once — copy it now
+    ///     loom token ls                         # name, prefix, last used
+    ///     loom token rm <id>                    # revoke
+    ///
+    /// Store the printed secret as a CI secret and pass it as `LOOM_TOKEN` (with
+    /// `WEAVER_API` pointing at your server) — every `loom` command then
+    /// authenticates with it.
+    Token {
+        #[command(subcommand)]
+        cmd: TokenCmd,
+    },
     /// Deprecated alias for `loom session launch`.
     #[command(hide = true)]
     Launch(LaunchOpts),
@@ -239,6 +254,25 @@ enum OverlookerCmd {
     },
 }
 
+#[derive(Subcommand)]
+enum TokenCmd {
+    /// Mint a new API token. Prints the secret once — copy it now.
+    Create {
+        /// A label to recognise the token by (e.g. `github-actions`).
+        name: String,
+        /// Optional lifetime in days; omit for a non-expiring token.
+        #[arg(long)]
+        expires_days: Option<i64>,
+    },
+    /// List the API tokens (name, prefix, created, last used).
+    Ls,
+    /// Revoke a token by id.
+    Rm {
+        /// The token id (from `loom token ls`).
+        id: String,
+    },
+}
+
 /// Options for `loom overlooker add` — the flags build the trigger / scope /
 /// program / capability set the REST `CreateOverlookerReq` takes.
 #[derive(Args)]
@@ -356,6 +390,7 @@ async fn run() -> Result<()> {
         Cmd::Restart => cmd_restart().await,
         Cmd::Session { cmd } => run_session(cmd).await,
         Cmd::Overlooker { cmd } => run_overlooker(cmd).await,
+        Cmd::Token { cmd } => run_token(cmd).await,
         Cmd::Launch(opts) => {
             eprintln!("note: `loom launch` is deprecated — use `loom session launch`");
             cmd_launch(opts.into()).await
@@ -414,6 +449,61 @@ async fn run_overlooker(cmd: OverlookerCmd) -> Result<()> {
         OverlookerCmd::Runs { name, limit } => cmd_overlooker_runs(name, limit, false).await,
         OverlookerCmd::Logs { name, limit } => cmd_overlooker_runs(name, limit, true).await,
     }
+}
+
+async fn run_token(cmd: TokenCmd) -> Result<()> {
+    match cmd {
+        TokenCmd::Create { name, expires_days } => cmd_token_create(name, expires_days).await,
+        TokenCmd::Ls => cmd_token_ls().await,
+        TokenCmd::Rm { id } => cmd_token_rm(id).await,
+    }
+}
+
+async fn cmd_token_create(name: String, expires_days: Option<i64>) -> Result<()> {
+    let created = client::default()
+        .create_token(&weaver_api::CreateTokenReq {
+            name,
+            expires_in_days: expires_days,
+        })
+        .await?;
+    // The secret is shown once; lead with it and make the one-shot nature plain.
+    println!("{}", created.token);
+    eprintln!(
+        "\nThis is the only time the token is shown. Store it now, e.g. as a CI \
+         secret, and pass it as LOOM_TOKEN.\nid {}  ·  {}{}",
+        created.info.id,
+        created.info.prefix,
+        match created.info.expires_at {
+            Some(at) => format!("  ·  expires {at}"),
+            None => "  ·  never expires".to_string(),
+        }
+    );
+    Ok(())
+}
+
+async fn cmd_token_ls() -> Result<()> {
+    let tokens = client::default().list_tokens().await?;
+    if tokens.is_empty() {
+        println!("no tokens — create one with `loom token create <name>`");
+        return Ok(());
+    }
+    println!("{:<18}  {:<20}  {:<16}  LAST USED", "ID", "NAME", "PREFIX");
+    for t in tokens {
+        println!(
+            "{:<18}  {:<20}  {:<16}  {}",
+            t.id,
+            truncate(&t.name, 20),
+            t.prefix,
+            t.last_used_at.as_deref().unwrap_or("never"),
+        );
+    }
+    Ok(())
+}
+
+async fn cmd_token_rm(id: String) -> Result<()> {
+    client::default().revoke_token(&id).await?;
+    println!("revoked token {id}");
+    Ok(())
 }
 
 fn init_tracing() {

--- a/crates/loom/src/client.rs
+++ b/crates/loom/src/client.rs
@@ -11,6 +11,25 @@ pub use weaver_api::Client;
 /// A client pointed at the running daemon — the base URL resolved from
 /// `$WEAVER_API`, the recorded server address, then the default
 /// (see [`crate::endpoint::base_url`]).
+///
+/// The bearer token is resolved from `$LOOM_TOKEN`, falling back to the
+/// machine-local token file ([`crate::auth::local_token_path`]) so a same-host
+/// CLI works even when loopback trust is off and the user set no env var. A
+/// remote CLI (talking to a server on another host) has no local file, so it
+/// relies on `$LOOM_TOKEN` being set — as it must, since loopback trust can't
+/// apply across the network.
 pub fn default() -> Client {
-    Client::new(crate::endpoint::base_url())
+    Client::new(crate::endpoint::base_url()).with_token(resolve_token())
+}
+
+/// The bearer token a local CLI should present: `$LOOM_TOKEN`, else the
+/// persisted machine-local token, else none.
+fn resolve_token() -> Option<String> {
+    if let Ok(t) = std::env::var("LOOM_TOKEN") {
+        let t = t.trim().to_string();
+        if !t.is_empty() {
+            return Some(t);
+        }
+    }
+    crate::agent::read_local_token()
 }

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -63,6 +63,47 @@ CREATE TABLE IF NOT EXISTS branch_github (
     merged_at        TEXT,
     fetched_at       TEXT NOT NULL
 );
+
+-- Authentication (loom-only; the daemon-less `weaver` CLI never serves HTTP, so
+-- it has no notion of users). An *approved* operator: a row here is the
+-- allowlist. `github_login` matches the GitHub OAuth identity; `password_hash`
+-- (argon2) backs username/password login. Either may be NULL — a GitHub-only
+-- user has no password until they set one, and vice versa.
+CREATE TABLE IF NOT EXISTS users (
+    username      TEXT PRIMARY KEY,
+    github_login  TEXT UNIQUE,
+    password_hash TEXT,
+    created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- API tokens (personal access tokens) for automation — the `LOOM_TOKEN` a CI
+-- job or the `loom` CLI presents as `Authorization: Bearer`. Only the SHA-256
+-- `token_hash` is stored; the plaintext is shown once at creation. `prefix` is
+-- the leading, non-secret slice kept for display ("loom_AbCd…"). `kind` is
+-- 'pat' for a user token or 'local' for the machine token loom mints for its own
+-- same-host subprocesses (hidden from the token list, not revocable from the UI).
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id           TEXT PRIMARY KEY,
+    username     TEXT NOT NULL REFERENCES users(username) ON DELETE CASCADE,
+    name         TEXT NOT NULL,
+    token_hash   TEXT NOT NULL UNIQUE,
+    prefix       TEXT NOT NULL,
+    kind         TEXT NOT NULL DEFAULT 'pat',
+    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    last_used_at TEXT,
+    expires_at   TEXT
+);
+
+-- Browser login sessions: the opaque cookie a successful GitHub/password login
+-- sets. Stored hashed like a token; named `auth_sessions` to stay clear of the
+-- agent `sessions` table above. A row is dropped on logout or once `expires_at`
+-- passes.
+CREATE TABLE IF NOT EXISTS auth_sessions (
+    token_hash TEXT PRIMARY KEY,
+    username   TEXT NOT NULL REFERENCES users(username) ON DELETE CASCADE,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    expires_at TEXT NOT NULL
+);
 "#;
 
 /// Open the shared database and apply loom's additional tables on top of the
@@ -116,6 +157,28 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
     // ordinary fleet session. Sessions predating the column stay NULL (they are
     // all ordinary fleet sessions, as they were before warm sessions existed).
     add_column_if_missing(pool, "sessions", "managed_by", "TEXT").await?;
+    seed_owner(pool).await?;
+    Ok(())
+}
+
+/// Seed the approved-user allowlist with the deploy owner so a fresh database is
+/// usable immediately: GitHub login works for exactly this one identity until
+/// more users are added. The login defaults to `rjpower` and can be overridden
+/// at first run with `LOOM_OWNER_GITHUB`. `INSERT OR IGNORE` makes this a no-op
+/// once the row (or any same-username row) exists, so it never clobbers later
+/// edits — including a password the owner has set.
+async fn seed_owner(pool: &Db) -> Result<()> {
+    let owner = std::env::var("LOOM_OWNER_GITHUB")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "rjpower".to_string());
+    sqlx::query("INSERT OR IGNORE INTO users (username, github_login) VALUES (?, ?)")
+        .bind(&owner)
+        .bind(&owner)
+        .execute(pool)
+        .await
+        .with_context(|| format!("seeding owner user '{owner}'"))?;
     Ok(())
 }
 

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -6,6 +6,7 @@
 //! purely additive.
 
 pub mod agent;
+pub mod auth;
 pub mod builtins;
 pub mod client;
 pub mod db;

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -601,6 +601,11 @@ async fn run_script(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
+    // The script reaches the daemon over the REST API; hand it the machine-local
+    // token so it authenticates even when loopback trust is off.
+    if let Some(token) = crate::agent::read_local_token() {
+        command.env("LOOM_TOKEN", token);
+    }
     for key in crate::agent::STRIPPED_ENV {
         command.env_remove(key);
     }

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -246,6 +246,13 @@ pub async fn reconcile_managed_sessions(state: &AppState) {
 }
 
 pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
+    // Mint (or reuse) the machine-local token so loom's own same-host
+    // subprocesses authenticate even when loopback trust is off. Best-effort:
+    // a failure here must not stop the server coming up.
+    match crate::auth::ensure_local_token(&state.db).await {
+        Ok(_) => tracing::debug!("machine-local token ready"),
+        Err(e) => tracing::warn!("could not prepare the machine-local token: {e}"),
+    }
     tokio::spawn(monitor::run(state.clone()));
     // The GitHub poller is always spawned; it self-gates on the `github.poll`
     // setting and on `gh` being available, so it idles cheaply when GitHub
@@ -256,9 +263,14 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
     // idles cheaply until the operator opts in.
     tokio::spawn(overlooker::run(state.clone()));
     tracing::debug!("background tasks spawned (monitor, github poll, overlooker)");
-    axum::serve(listener, web::router(state))
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // `into_make_service_with_connect_info` surfaces the peer `SocketAddr` to the
+    // auth middleware, which uses it to recognise (and optionally trust) loopback.
+    axum::serve(
+        listener,
+        web::router(state).into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
     Ok(())
 }
 

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -65,19 +65,20 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::hash::{Hash, Hasher};
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Component, PathBuf};
 
 use axum::{
     body::Bytes,
-    extract::{DefaultBodyLimit, Path, Query, State},
-    http::{header, Request, StatusCode},
+    extract::{ConnectInfo, DefaultBodyLimit, Path, Query, Request, State},
+    http::{header, HeaderMap, StatusCode},
     middleware::Next,
     response::{
         sse::{self, KeepAlive, Sse},
         IntoResponse, Response,
     },
-    routing::{get, post},
-    Json, Router,
+    routing::{delete, get, post},
+    Extension, Json, Router,
 };
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
@@ -88,15 +89,18 @@ use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::services::{ServeDir, ServeFile};
 
+use crate::auth::{self, Principal};
 use crate::db::Db;
 use crate::events::{Event, EventBus};
 use crate::session::{self as session_mod, NewSession, Session};
 use crate::{agent, config, db, events, git, github, overlooker as ov_engine, repo, tmux};
 use weaver_api::{
-    AgentOneshotReq, ArtifactMeta, ArtifactRefs, ArtifactView, ArtifactWriteBody, BranchView,
-    CreateIssueReq, CreateOverlookerReq, CreateRepoIssueReq, CreateReq, IssueRefStatus, IssueView,
-    OverlookerRunView, OverlookerView, PatchIssueReq, PatchOverlookerReq, PatchSessionReq,
-    ProgramView, RunOverlookerReq, ScratchUpload, SendReq, SessionView, TagReq,
+    AddUserReq, AgentOneshotReq, ArtifactMeta, ArtifactRefs, ArtifactView, ArtifactWriteBody,
+    AuthMethods, BranchView, CreateIssueReq, CreateOverlookerReq, CreateRepoIssueReq, CreateReq,
+    CreateTokenReq, CreatedTokenView, GithubConfigView, IssueRefStatus, IssueView, LoginReq,
+    MeView, OverlookerRunView, OverlookerView, PatchIssueReq, PatchOverlookerReq, PatchSessionReq,
+    ProgramView, RunOverlookerReq, ScratchUpload, SendReq, SessionView, SetGithubConfigReq,
+    SetPasswordReq, TagReq, TokenView, UserView,
 };
 use weaver_core::artifact::{self, Artifact};
 use weaver_core::branch as branch_mod;
@@ -351,8 +355,20 @@ fn static_dir() -> PathBuf {
 }
 
 pub fn router(state: AppState) -> Router {
-    let api = Router::new()
+    // Public surface: the liveness probe and the login flow itself. No
+    // middleware — these must work for an unauthenticated caller, since they are
+    // how one *becomes* authenticated.
+    let public = Router::new()
         .route("/health", get(|| async { "ok" }))
+        .route("/auth/me", get(auth_me))
+        .route("/auth/login", post(auth_login))
+        .route("/auth/logout", post(auth_logout))
+        .route("/auth/github/login", get(github_login))
+        .route("/auth/github/callback", get(github_callback));
+
+    // Everything else requires an authenticated principal — a bearer token, a
+    // session cookie, or a trusted-loopback request — gated by `require_auth`.
+    let protected = Router::new()
         // Sessions
         .route("/sessions", get(list_sessions).post(create_session))
         .route(
@@ -431,8 +447,28 @@ pub fn router(state: AppState) -> Router {
         // The one-shot headless agent — the judgement primitive overlooker
         // programs (and any script) call through the daemon.
         .route("/agent/oneshot", post(agent_oneshot))
+        // Authentication management: API tokens, the caller's password, the
+        // approved-user allowlist, and the GitHub OAuth app config.
+        .route("/auth/tokens", get(list_tokens).post(create_token))
+        .route("/auth/tokens/{id}", delete(revoke_token))
+        .route("/auth/password", post(set_own_password))
+        .route("/auth/users", get(list_users).post(add_user))
+        .route("/auth/users/{username}", delete(remove_user))
+        .route(
+            "/auth/github/config",
+            get(get_github_config).put(put_github_config),
+        )
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_auth,
+        ))
         // Scratch uploads can carry images / logs; lift the default 2 MB cap.
-        .layer(DefaultBodyLimit::max(64 * 1024 * 1024))
+        .layer(DefaultBodyLimit::max(64 * 1024 * 1024));
+
+    let api = public
+        .merge(protected)
+        // ETag/304 short-circuit for cacheable GETs — applied across the whole
+        // API surface (public + protected) before the state is sealed in.
         .layer(axum::middleware::from_fn(api_etag_middleware))
         .with_state(state);
 
@@ -2506,6 +2542,449 @@ async fn patch_settings(
     }
     config::apply(&st.db, &changes).await?;
     settings_envelope(&st.db).await
+}
+
+// ===========================================================================
+// Authentication
+//
+// Three credentials resolve to one `auth::Principal`: an `Authorization: Bearer`
+// API token, a login session cookie, or a trusted-loopback request. The
+// `require_auth` middleware enforces this on every route except the public login
+// surface (`/auth/me`, `/auth/login`, `/auth/logout`, `/auth/github/*`) and
+// `/health`. The crypto and storage live in `crate::auth`; this is the HTTP glue.
+// ===========================================================================
+
+/// The login cookie's `Max-Age` in seconds, derived from the stored-session TTL
+/// so the cookie and the server-side expiry can't drift apart.
+const SESSION_MAX_AGE: i64 = auth::SESSION_TTL_DAYS * 24 * 60 * 60;
+/// The short-lived cookie carrying the OAuth CSRF state across the round-trip.
+const OAUTH_STATE_COOKIE: &str = "loom_oauth_state";
+/// The GitHub OAuth callback path — the redirect URI registered on the app and
+/// reported to the settings UI.
+const GITHUB_CALLBACK_PATH: &str = "/api/auth/github/callback";
+
+fn unauthorized(message: &str) -> AppError {
+    AppError::new(StatusCode::UNAUTHORIZED, message)
+}
+
+/// Pull the token out of an `Authorization: Bearer <token>` header.
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    let raw = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let rest = raw
+        .strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))?;
+    let token = rest.trim();
+    (!token.is_empty()).then(|| token.to_string())
+}
+
+/// Read one cookie value by name out of the `Cookie` request header.
+fn cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    let raw = headers.get(header::COOKIE)?.to_str().ok()?;
+    raw.split(';').find_map(|part| {
+        let (k, v) = part.trim().split_once('=')?;
+        (k == name).then(|| v.to_string())
+    })
+}
+
+/// Resolve the caller to an authenticated [`Principal`], or `None`. Order: a
+/// bearer token, a session cookie, then loopback trust.
+async fn resolve_principal(st: &AppState, headers: &HeaderMap, peer: IpAddr) -> Option<Principal> {
+    if let Some(token) = bearer_token(headers) {
+        if let Ok(Some(p)) = auth::lookup_token(&st.db, &token).await {
+            return Some(p);
+        }
+    }
+    if let Some(cookie) = cookie_value(headers, auth::SESSION_COOKIE) {
+        if let Ok(Some(p)) = auth::lookup_session(&st.db, &cookie).await {
+            return Some(p);
+        }
+    }
+    if peer.is_loopback()
+        && config::get_bool(
+            &st.db,
+            "auth.trust_loopback",
+            config::DEFAULT_TRUST_LOOPBACK,
+        )
+        .await
+    {
+        if let Ok(Some(p)) = auth::loopback_principal(&st.db).await {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Middleware: reject any request that doesn't resolve to a [`Principal`],
+/// otherwise stash it in the request extensions for the handler.
+async fn require_auth(
+    State(st): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let headers = req.headers().clone();
+    match resolve_principal(&st, &headers, peer.ip()).await {
+        Some(principal) => {
+            req.extensions_mut().insert(principal);
+            next.run(req).await
+        }
+        None => unauthorized("authentication required").into_response(),
+    }
+}
+
+// -- Cookie + redirect helpers ----------------------------------------------
+
+/// Build a `Set-Cookie` value for the login session. `max_age` of 0 clears it.
+fn session_cookie(value: &str, max_age: i64, secure: bool) -> String {
+    let mut c = format!(
+        "{}={value}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age}",
+        auth::SESSION_COOKIE
+    );
+    if secure {
+        c.push_str("; Secure");
+    }
+    c
+}
+
+/// Build the `Set-Cookie` value for the short-lived OAuth state cookie.
+fn state_cookie(value: &str, max_age: i64) -> String {
+    format!("{OAUTH_STATE_COOKIE}={value}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age}")
+}
+
+/// A 303 redirect to `location`, appending each given `Set-Cookie` header.
+fn redirect_with_cookies(location: &str, cookies: &[String]) -> Response {
+    let mut resp = Response::builder()
+        .status(StatusCode::SEE_OTHER)
+        .header(header::LOCATION, location)
+        .body(axum::body::Body::empty())
+        .expect("static redirect response is well-formed");
+    let h = resp.headers_mut();
+    for c in cookies {
+        if let Ok(v) = header::HeaderValue::from_str(c) {
+            h.append(header::SET_COOKIE, v);
+        }
+    }
+    resp
+}
+
+/// Redirect back to the SPA login screen with an error code it can render.
+fn login_error_redirect(code: &str) -> Response {
+    redirect_with_cookies(&format!("/login?error={code}"), &[])
+}
+
+async fn cookie_secure(st: &AppState) -> bool {
+    config::get_bool(&st.db, "auth.cookie_secure", config::DEFAULT_COOKIE_SECURE).await
+}
+
+/// The externally-visible base URL, for the OAuth callback. Prefers the
+/// `auth.base_url` setting; otherwise derives `{proto}://{host}` from the request
+/// (honouring `X-Forwarded-Proto` from a TLS-terminating proxy).
+async fn external_base(st: &AppState, headers: &HeaderMap) -> Option<String> {
+    let configured = config::get(&st.db, "auth.base_url")
+        .await
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    if !configured.is_empty() {
+        return Some(configured);
+    }
+    let host = headers.get(header::HOST)?.to_str().ok()?;
+    let proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("http");
+    Some(format!("{proto}://{host}"))
+}
+
+// -- Identity ----------------------------------------------------------------
+
+async fn auth_methods(st: &AppState) -> AuthMethods {
+    AuthMethods {
+        password: true,
+        github: auth::github_oauth(&st.db).await.is_some(),
+    }
+}
+
+/// `GET /api/auth/me` — who the caller is + which sign-in methods to offer.
+/// Public: an unauthenticated caller gets `authenticated: false`, not a 401.
+async fn auth_me(
+    State(st): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Json<MeView> {
+    let principal = resolve_principal(&st, &headers, peer.ip()).await;
+    let methods = auth_methods(&st).await;
+    Json(match principal {
+        Some(p) => MeView {
+            authenticated: true,
+            username: Some(p.username),
+            github_login: p.github_login,
+            via: Some(p.via.as_str().to_string()),
+            methods,
+        },
+        None => MeView {
+            authenticated: false,
+            username: None,
+            github_login: None,
+            via: None,
+            methods,
+        },
+    })
+}
+
+/// `POST /api/auth/login` — username/password. Sets the session cookie.
+async fn auth_login(State(st): State<AppState>, Json(body): Json<LoginReq>) -> ApiResult<Response> {
+    let principal = auth::verify_login(&st.db, body.username.trim(), &body.password)
+        .await?
+        .ok_or_else(|| unauthorized("invalid username or password"))?;
+    let cookie = auth::create_session(&st.db, &principal.username).await?;
+    let set = session_cookie(&cookie, SESSION_MAX_AGE, cookie_secure(&st).await);
+    Ok((
+        [(header::SET_COOKIE, set)],
+        Json(json!({ "username": principal.username })),
+    )
+        .into_response())
+}
+
+/// `POST /api/auth/logout` — drop the session and clear the cookie.
+async fn auth_logout(State(st): State<AppState>, headers: HeaderMap) -> ApiResult<Response> {
+    if let Some(cookie) = cookie_value(&headers, auth::SESSION_COOKIE) {
+        auth::delete_session(&st.db, &cookie).await.ok();
+    }
+    let clear = session_cookie("", 0, cookie_secure(&st).await);
+    Ok(([(header::SET_COOKIE, clear)], Json(json!({ "ok": true }))).into_response())
+}
+
+// -- GitHub OAuth ------------------------------------------------------------
+
+/// `GET /api/auth/github/login` — begin the OAuth dance.
+async fn github_login(State(st): State<AppState>, headers: HeaderMap) -> ApiResult<Response> {
+    let cfg = auth::github_oauth(&st.db)
+        .await
+        .ok_or_else(|| AppError::bad_request("GitHub sign-in is not configured"))?;
+    let base = external_base(&st, &headers).await.ok_or_else(|| {
+        AppError::bad_request("cannot determine the callback URL (no Host header)")
+    })?;
+    let redirect_uri = format!("{base}{GITHUB_CALLBACK_PATH}");
+    let state = auth::random_state();
+    let url = auth::authorize_url(&cfg, &state, &redirect_uri);
+    Ok(redirect_with_cookies(&url, &[state_cookie(&state, 600)]))
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubCallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+}
+
+/// `GET /api/auth/github/callback` — finish the dance: verify state, exchange the
+/// code, check the GitHub login against the allowlist, open a session.
+async fn github_callback(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Query(q): Query<GithubCallbackQuery>,
+) -> ApiResult<Response> {
+    let cfg = auth::github_oauth(&st.db)
+        .await
+        .ok_or_else(|| AppError::bad_request("GitHub sign-in is not configured"))?;
+    // CSRF: the returned state must match the cookie we set at /login.
+    let expected = cookie_value(&headers, OAUTH_STATE_COOKIE);
+    if expected.is_none() || q.state.is_none() || expected != q.state {
+        return Ok(login_error_redirect("state-mismatch"));
+    }
+    let Some(code) = q.code.filter(|c| !c.is_empty()) else {
+        return Ok(login_error_redirect("missing-code"));
+    };
+    let base = external_base(&st, &headers)
+        .await
+        .ok_or_else(|| AppError::bad_request("cannot determine the callback URL"))?;
+    let redirect_uri = format!("{base}{GITHUB_CALLBACK_PATH}");
+    let token = auth::exchange_code(&cfg, &code, &redirect_uri).await?;
+    let login = auth::fetch_github_login(&token).await?;
+    let Some(user) = auth::user_by_github(&st.db, &login).await? else {
+        // Authenticated with GitHub, but not on the allowlist.
+        return Ok(login_error_redirect("not-approved"));
+    };
+    let cookie = auth::create_session(&st.db, &user.username).await?;
+    Ok(redirect_with_cookies(
+        "/",
+        &[
+            session_cookie(&cookie, SESSION_MAX_AGE, cookie_secure(&st).await),
+            state_cookie("", 0),
+        ],
+    ))
+}
+
+// -- API tokens --------------------------------------------------------------
+
+fn token_view(info: auth::TokenInfo) -> TokenView {
+    TokenView {
+        id: info.id,
+        name: info.name,
+        prefix: info.prefix,
+        created_at: info.created_at,
+        last_used_at: info.last_used_at,
+        expires_at: info.expires_at,
+    }
+}
+
+/// `GET /api/auth/tokens` — the user-managed API tokens.
+async fn list_tokens(State(st): State<AppState>) -> ApiResult<Json<Vec<TokenView>>> {
+    let tokens = auth::list_tokens(&st.db).await?;
+    Ok(Json(tokens.into_iter().map(token_view).collect()))
+}
+
+/// `POST /api/auth/tokens` — mint a token, returning the plaintext once.
+async fn create_token(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Json(body): Json<CreateTokenReq>,
+) -> ApiResult<Json<CreatedTokenView>> {
+    let name = body.name.trim();
+    if name.is_empty() {
+        return Err(AppError::bad_request("a token name is required"));
+    }
+    let (token, info) =
+        auth::create_token(&st.db, &principal.username, name, body.expires_in_days).await?;
+    Ok(Json(CreatedTokenView {
+        token,
+        info: token_view(info),
+    }))
+}
+
+/// `DELETE /api/auth/tokens/{id}` — revoke a token.
+async fn revoke_token(State(st): State<AppState>, Path(id): Path<String>) -> ApiResult<StatusCode> {
+    if auth::revoke_token(&st.db, &id).await? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AppError::not_found("token"))
+    }
+}
+
+// -- Account + users ---------------------------------------------------------
+
+/// `POST /api/auth/password` — set/change the caller's own password.
+async fn set_own_password(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Json(body): Json<SetPasswordReq>,
+) -> ApiResult<StatusCode> {
+    if body.new_password.len() < 8 {
+        return Err(AppError::bad_request(
+            "password must be at least 8 characters",
+        ));
+    }
+    auth::set_password(&st.db, &principal.username, Some(&body.new_password)).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn user_view(u: auth::User) -> UserView {
+    let has_password = u.has_password();
+    UserView {
+        username: u.username,
+        github_login: u.github_login,
+        has_password,
+        created_at: u.created_at,
+    }
+}
+
+/// `GET /api/auth/users` — the approved-operator allowlist.
+async fn list_users(State(st): State<AppState>) -> ApiResult<Json<Vec<UserView>>> {
+    let users = auth::list_users(&st.db).await?;
+    Ok(Json(users.into_iter().map(user_view).collect()))
+}
+
+/// `POST /api/auth/users` — approve a new operator.
+async fn add_user(
+    State(st): State<AppState>,
+    Json(body): Json<AddUserReq>,
+) -> ApiResult<Json<UserView>> {
+    let username = body.username.trim();
+    if username.is_empty() {
+        return Err(AppError::bad_request("a username is required"));
+    }
+    let github = body
+        .github_login
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let password = body.password.as_deref().filter(|s| !s.is_empty());
+    if github.is_none() && password.is_none() {
+        return Err(AppError::bad_request(
+            "set a GitHub login or a password so the user can sign in",
+        ));
+    }
+    if let Some(p) = password {
+        if p.len() < 8 {
+            return Err(AppError::bad_request(
+                "password must be at least 8 characters",
+            ));
+        }
+    }
+    auth::add_user(&st.db, username, github, password)
+        .await
+        .map_err(|e| AppError::bad_request(format!("could not add user: {e}")))?;
+    let user = auth::get_user(&st.db, username)
+        .await?
+        .ok_or_else(|| AppError::not_found("user"))?;
+    Ok(Json(user_view(user)))
+}
+
+/// `DELETE /api/auth/users/{username}` — remove an approved operator.
+async fn remove_user(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Path(username): Path<String>,
+) -> ApiResult<StatusCode> {
+    if username == principal.username {
+        return Err(AppError::bad_request("you cannot remove yourself"));
+    }
+    match auth::remove_user(&st.db, &username).await {
+        Ok(true) => Ok(StatusCode::NO_CONTENT),
+        Ok(false) => Err(AppError::not_found("user")),
+        Err(e) => Err(AppError::bad_request(e.to_string())),
+    }
+}
+
+// -- GitHub OAuth app config -------------------------------------------------
+
+async fn github_config_view(st: &AppState) -> ApiResult<GithubConfigView> {
+    let client_id = config::get(&st.db, auth::GH_CLIENT_ID_KEY)
+        .await
+        .unwrap_or_default();
+    Ok(GithubConfigView {
+        configured: auth::github_oauth(&st.db).await.is_some(),
+        client_id,
+        callback_path: GITHUB_CALLBACK_PATH.to_string(),
+    })
+}
+
+/// `GET /api/auth/github/config` — the GitHub sign-in setup (secret withheld).
+async fn get_github_config(State(st): State<AppState>) -> ApiResult<Json<GithubConfigView>> {
+    Ok(Json(github_config_view(&st).await?))
+}
+
+/// `PUT /api/auth/github/config` — set the OAuth app id (and, optionally, secret).
+async fn put_github_config(
+    State(st): State<AppState>,
+    Json(body): Json<SetGithubConfigReq>,
+) -> ApiResult<Json<GithubConfigView>> {
+    let mut changes: Vec<config::Change> = vec![(
+        auth::GH_CLIENT_ID_KEY.to_string(),
+        Some(body.client_id.trim().to_string()),
+    )];
+    // The secret is write-only: a value sets it, an empty string clears it, and
+    // omitting the field leaves the stored secret untouched.
+    if let Some(secret) = body.client_secret {
+        let secret = secret.trim().to_string();
+        changes.push((
+            auth::GH_CLIENT_SECRET_KEY.to_string(),
+            (!secret.is_empty()).then_some(secret),
+        ));
+    }
+    config::apply(&st.db, &changes).await?;
+    Ok(Json(github_config_view(&st).await?))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/loom/tests/integration/auth.rs
+++ b/crates/loom/tests/integration/auth.rs
@@ -1,0 +1,184 @@
+//! Authentication wiring against a live server: loopback trust, bearer tokens,
+//! the machine-local token, and password-login cookies.
+//!
+//! The harness connects from `127.0.0.1`, so loopback trust (on by default)
+//! makes every other suite's bare requests work unchanged. Here we do the
+//! trusted setup first, then flip `auth.trust_loopback` off and prove the three
+//! credential paths gate access as designed.
+
+use std::path::Path;
+
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use serial_test::serial;
+
+use super::fixtures::TestServer;
+
+fn url(ts: &TestServer, path: &str) -> String {
+    format!("http://{}{}", ts.addr, path)
+}
+
+#[tokio::test]
+#[serial]
+async fn loopback_trust_then_token_local_and_cookie_gate_access() {
+    let ts = TestServer::start().await;
+    let http = reqwest::Client::new();
+
+    // 1. Default: a loopback request is trusted as the seeded owner.
+    let r = http.get(url(&ts, "/api/sessions")).send().await.unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+    let me: Value = http
+        .get(url(&ts, "/api/auth/me"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(me["authenticated"], true);
+    assert_eq!(me["username"], "rjpower");
+    assert_eq!(me["via"], "loopback");
+    assert_eq!(me["methods"]["password"], true);
+    // No OAuth app configured in the test, so GitHub sign-in is off.
+    assert_eq!(me["methods"]["github"], false);
+
+    // 2. Trusted setup before locking down: mint a token and set a password.
+    let created: Value = http
+        .post(url(&ts, "/api/auth/tokens"))
+        .json(&json!({ "name": "ci" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let token = created["token"].as_str().unwrap().to_string();
+    assert!(token.starts_with("loom_"), "token is prefixed: {token}");
+    let token_id = created["id"].as_str().unwrap().to_string();
+
+    let r = http
+        .post(url(&ts, "/api/auth/password"))
+        .json(&json!({ "new_password": "correct horse" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::NO_CONTENT);
+
+    // 3. Lock it down: stop trusting loopback.
+    let r = http
+        .patch(url(&ts, "/api/settings"))
+        .json(&json!({ "auth.trust_loopback": false }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+
+    // 4a. A bare request is now rejected.
+    let r = http.get(url(&ts, "/api/sessions")).send().await.unwrap();
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+
+    // 4b. The bearer token works.
+    let r = http
+        .get(url(&ts, "/api/sessions"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+
+    // 4c. The machine-local token (what loom injects into its subprocesses) works
+    //     too — that is what keeps the agent and overlookers running with trust off.
+    let home = std::env::var("WEAVER_HOME").unwrap();
+    let local = std::fs::read_to_string(Path::new(&home).join("loom-token")).unwrap();
+    let r = http
+        .get(url(&ts, "/api/sessions"))
+        .bearer_auth(local.trim())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+
+    // 4d. A password login yields a working session cookie.
+    let login = http
+        .post(url(&ts, "/api/auth/login"))
+        .json(&json!({ "username": "rjpower", "password": "correct horse" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(login.status(), StatusCode::OK);
+    let set_cookie = login
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(set_cookie.contains("loom_session="));
+    assert!(set_cookie.contains("HttpOnly"));
+    let cookie_pair = set_cookie.split(';').next().unwrap().to_string();
+    let r = http
+        .get(url(&ts, "/api/sessions"))
+        .header("cookie", &cookie_pair)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+
+    // 4e. A wrong password is rejected.
+    let r = http
+        .post(url(&ts, "/api/auth/login"))
+        .json(&json!({ "username": "rjpower", "password": "nope" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+
+    // 5. Revoking the token invalidates it immediately.
+    let r = http
+        .delete(url(&ts, &format!("/api/auth/tokens/{token_id}")))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::NO_CONTENT);
+    let r = http
+        .get(url(&ts, "/api/sessions"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+#[serial]
+async fn health_is_public_but_protected_routes_are_not() {
+    let ts = TestServer::start().await;
+    let http = reqwest::Client::new();
+
+    // Lock down loopback so the gate is in force.
+    http.patch(url(&ts, "/api/settings"))
+        .json(&json!({ "auth.trust_loopback": false }))
+        .send()
+        .await
+        .unwrap();
+
+    // Health stays public (liveness probes must not need a token).
+    let r = http.get(url(&ts, "/api/health")).send().await.unwrap();
+    assert_eq!(r.status(), StatusCode::OK);
+
+    // /api/auth/me stays public, and now reports an unauthenticated caller.
+    let me: Value = http
+        .get(url(&ts, "/api/auth/me"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(me["authenticated"], false);
+
+    // A protected route is gated.
+    let r = http.get(url(&ts, "/api/branches")).send().await.unwrap();
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+}

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -9,6 +9,7 @@
 mod fixtures;
 
 mod archive;
+mod auth;
 mod branches;
 mod files;
 mod overlookers;

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -11,14 +11,17 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::dto::{
-    CreateOverlookerReq, CreateReq, OverlookerView, PatchOverlookerReq, PatchSessionReq,
-    RunOverlookerReq, SendReq, SessionView, TagReq,
+    CreateOverlookerReq, CreateReq, CreateTokenReq, CreatedTokenView, OverlookerView,
+    PatchOverlookerReq, PatchSessionReq, RunOverlookerReq, SendReq, SessionView, TagReq, TokenView,
 };
 
 /// A client for one loom server, identified by its base URL.
 pub struct Client {
     base: String,
     http: reqwest::Client,
+    /// Optional bearer token sent on every request (the `LOOM_TOKEN` for a
+    /// remote or non-loopback-trusted server). `None` relies on loopback trust.
+    token: Option<String>,
 }
 
 impl Client {
@@ -28,7 +31,16 @@ impl Client {
         Self {
             base: base.into(),
             http: reqwest::Client::new(),
+            token: None,
         }
+    }
+
+    /// Attach a bearer token (sent as `Authorization: Bearer …`). A `None` or
+    /// empty value leaves the client unauthenticated. loom's `client::default`
+    /// wires this from `$LOOM_TOKEN` / the machine token.
+    pub fn with_token(mut self, token: Option<String>) -> Self {
+        self.token = token.filter(|t| !t.trim().is_empty());
+        self
     }
 
     /// Base URL of the server (also the web UI origin).
@@ -41,6 +53,9 @@ impl Client {
     async fn send(&self, method: Method, path: &str, body: Option<Value>) -> Result<Value> {
         let url = format!("{}{}", self.base, path);
         let mut req = self.http.request(method, &url);
+        if let Some(token) = &self.token {
+            req = req.bearer_auth(token);
+        }
         if let Some(body) = body {
             req = req.json(&body);
         }
@@ -280,5 +295,24 @@ impl Client {
         let body = serde_json::to_value(req)?;
         self.post(&format!("/api/overlookers/{key}/run"), body)
             .await
+    }
+
+    // -- API tokens -------------------------------------------------------
+
+    /// List the user-managed API tokens (`GET /api/auth/tokens`).
+    pub async fn list_tokens(&self) -> Result<Vec<TokenView>> {
+        self.get_typed("/api/auth/tokens").await
+    }
+
+    /// Mint a new API token, returning the one-time plaintext
+    /// (`POST /api/auth/tokens`).
+    pub async fn create_token(&self, req: &CreateTokenReq) -> Result<CreatedTokenView> {
+        self.send_typed(Method::POST, "/api/auth/tokens", Some(req))
+            .await
+    }
+
+    /// Revoke an API token by id (`DELETE /api/auth/tokens/{id}`).
+    pub async fn revoke_token(&self, id: &str) -> Result<Value> {
+        self.delete(&format!("/api/auth/tokens/{id}")).await
     }
 }

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -604,3 +604,117 @@ pub struct RunOverlookerReq {
     #[serde(default)]
     pub dry_run: bool,
 }
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+/// Which sign-in methods the server currently offers — what the login screen
+/// renders. `password` is always available (any user can be given one);
+/// `github` is true only once an OAuth app is configured.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthMethods {
+    pub password: bool,
+    pub github: bool,
+}
+
+/// `GET /api/auth/me` — who the caller is and what the login screen needs. The
+/// SPA hits this on load: `authenticated: false` means show the login view.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeView {
+    pub authenticated: bool,
+    /// The approved username, when authenticated.
+    pub username: Option<String>,
+    /// The caller's GitHub login, when known.
+    pub github_login: Option<String>,
+    /// How they authenticated: `loopback` | `token` | `session` | null.
+    pub via: Option<String>,
+    /// The sign-in methods on offer (for the login screen).
+    pub methods: AuthMethods,
+}
+
+/// One API token's non-secret metadata (`GET /api/auth/tokens`). The secret
+/// itself is only ever returned once, in [`CreatedTokenView`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenView {
+    pub id: String,
+    pub name: String,
+    /// The non-secret leading slice, e.g. `loom_AbCd…`, to tell tokens apart.
+    pub prefix: String,
+    pub created_at: String,
+    pub last_used_at: Option<String>,
+    pub expires_at: Option<String>,
+}
+
+/// `POST /api/auth/tokens` reply — the one and only time the plaintext token is
+/// shown. Store it now; the server keeps only a hash.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatedTokenView {
+    /// The full secret — present once, never retrievable again.
+    pub token: String,
+    #[serde(flatten)]
+    pub info: TokenView,
+}
+
+/// Body for `POST /api/auth/tokens`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CreateTokenReq {
+    pub name: String,
+    /// Optional lifetime in days; omitted / non-positive means it never expires.
+    #[serde(default)]
+    pub expires_in_days: Option<i64>,
+}
+
+/// Body for `POST /api/auth/login` (username/password).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LoginReq {
+    pub username: String,
+    pub password: String,
+}
+
+/// Body for `POST /api/auth/password` — set/change the caller's own password.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SetPasswordReq {
+    pub new_password: String,
+}
+
+/// One approved operator (`GET /api/auth/users`). The password hash is never
+/// exposed — only whether one is set.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserView {
+    pub username: String,
+    pub github_login: Option<String>,
+    pub has_password: bool,
+    pub created_at: String,
+}
+
+/// Body for `POST /api/auth/users` — approve a new operator.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AddUserReq {
+    pub username: String,
+    #[serde(default)]
+    pub github_login: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
+}
+
+/// `GET /api/auth/github/config` — the GitHub sign-in setup, secret withheld.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GithubConfigView {
+    /// Whether both a client id and secret are present (sign-in is live).
+    pub configured: bool,
+    /// The OAuth app's client id (public). Empty when unset.
+    pub client_id: String,
+    /// The callback path to register on the GitHub OAuth app
+    /// (`/api/auth/github/callback`).
+    pub callback_path: String,
+}
+
+/// Body for `PUT /api/auth/github/config`. The secret is write-only — send it to
+/// set it, omit it to leave the stored one untouched.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SetGithubConfigReq {
+    pub client_id: String,
+    #[serde(default)]
+    pub client_secret: Option<String>,
+}

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -26,6 +26,16 @@ pub const DEFAULT_GITHUB_ARCHIVE_ON_MERGE: bool = true;
 /// The palette the browser terminal (xterm.js) renders with. `dark` keeps the
 /// classic black background; `light` swaps in a light, readable palette.
 pub const DEFAULT_TERMINAL_THEME: &str = "dark";
+/// Whether requests from the loopback interface are trusted as the machine owner
+/// without a token or login. On by default: it keeps the local CLI, the agent,
+/// and overlooker scripts working with no configuration. Turn it off behind a
+/// same-host reverse proxy, where forwarded requests appear to come from
+/// loopback (the proxy and local automation then authenticate with tokens).
+pub const DEFAULT_TRUST_LOOPBACK: bool = true;
+/// Whether the login cookie carries the `Secure` attribute (HTTPS-only). Off by
+/// default so plain-HTTP and direct-IP access work; turn it on when loom is
+/// reached over HTTPS (e.g. behind a TLS-terminating proxy).
+pub const DEFAULT_COOKIE_SECURE: bool = false;
 
 // ---------------------------------------------------------------------------
 // Setting registry
@@ -129,6 +139,46 @@ pub const REGISTRY: &[SettingSpec] = &[
         kind: SettingKind::Bool,
         default: "true",
         group: "GitHub",
+        options: &[],
+    },
+    SettingSpec {
+        key: "auth.trust_loopback",
+        label: "Trust loopback requests",
+        description: "When enabled, requests from 127.0.0.1/::1 are trusted as \
+            the machine owner with no token or login — keeping the local CLI, \
+            the agent, and overlooker scripts working with zero configuration. \
+            Turn this OFF behind a same-host reverse proxy, where forwarded \
+            requests appear to come from loopback; local automation then uses \
+            the machine token loom injects.",
+        kind: SettingKind::Bool,
+        default: "true",
+        group: "Authentication",
+        options: &[],
+    },
+    SettingSpec {
+        key: "auth.cookie_secure",
+        label: "Secure login cookie",
+        description: "When enabled, the login session cookie is marked `Secure` \
+            so the browser only sends it over HTTPS. Enable this when loom is \
+            served over HTTPS (typically behind a TLS-terminating proxy); leave \
+            it off for plain-HTTP or direct-IP access, where a Secure cookie \
+            would never be sent.",
+        kind: SettingKind::Bool,
+        default: "false",
+        group: "Authentication",
+        options: &[],
+    },
+    SettingSpec {
+        key: "auth.base_url",
+        label: "External base URL",
+        description: "The public URL loom is reached at (e.g. \
+            `https://loom.example.com`), used to build the GitHub OAuth callback. \
+            Leave blank to derive it from each request's Host header (honouring \
+            `X-Forwarded-Proto`); set it when that derivation is wrong behind a \
+            proxy.",
+        kind: SettingKind::String,
+        default: "",
+        group: "Authentication",
         options: &[],
     },
     SettingSpec {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,8 @@ needing the daemon to be reachable.
 | `crates/weaver-core/` | lib: `branches`, `issues`, `events`, `db`, `migrations` (ordered SQL + `schema_migrations` indicator), `git`, `config`, `artifacts` (versioned documents), `repo_config` (`.weaver/config.toml`), agent helpers. Pure logic; used by both binaries. |
 | `crates/smartdoc/` | the markdown-convention layer: parse references (`#N`, `artifact:<name>`), project live status into the render. Dependency-free of weaver. See [artifacts.md](artifacts.md). |
 | `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `readme`, `set-status` [read or set level + message], `tag` [`set`/`rm`/`ls` a branch tag], `issue …`, `where`, `log`, `hook`, `config`) |
-| `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** |
+| `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** (incl. the auth middleware + login/token/user handlers) |
+| `crates/loom/src/auth.rs` | authentication core: token/password crypto, the `users`/`api_tokens`/`auth_sessions` tables, the machine-local token, and the GitHub OAuth calls. `axum`-free so it unit-tests directly |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer |
 | `crates/loom/src/overlooker.rs` | the overlooker engine: cron timer + event dispatcher + the round executor (the script subprocess executor every program runs on) |
@@ -143,7 +144,10 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
   shared by `weaver` and `loom`. WAL mode handles concurrency.
   - Core tables: `branches`, `issues`, `events`, `settings`.
   - Loom tables (`crates/loom/src/db.rs`): `sessions`, `recent_repos`,
-    `branch_github` (per-branch PR snapshot).
+    `branch_github` (per-branch PR snapshot), and the auth tables `users`
+    (the approved-operator allowlist, seeded with the owner), `api_tokens`
+    (hashed bearer tokens), and `auth_sessions` (hashed login cookies). See
+    [Authentication](#authentication).
   - **Schema migrations** (`weaver-core/src/migrations.rs`): ordered SQL files
     under `crates/weaver-core/migrations/` (`NNNN_name.sql`, embedded with
     `include_str!`), applied at startup and recorded in a `schema_migrations`
@@ -192,6 +196,13 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET POST /api/repos/issues?repo_root=…` | repo-wide board (`scope=repo\|backlog`) / create a backlog item |
 | `GET /api/repos/recent` / `GET /api/repos/branches?cwd=…` | recent repos / branches in a repo |
 | `GET PATCH /api/settings` | settings registry |
+| `GET /api/auth/me` | caller identity + sign-in methods (public; never 401s) |
+| `POST /api/auth/login` / `POST /api/auth/logout` | username/password login / drop the session (public) |
+| `GET /api/auth/github/{login,callback}` | the GitHub OAuth dance (public) |
+| `GET POST /api/auth/tokens` / `DELETE /api/auth/tokens/{id}` | list / mint / revoke API tokens |
+| `POST /api/auth/password` | set the caller's own password |
+| `GET POST /api/auth/users` / `DELETE /api/auth/users/{username}` | the approved-operator allowlist |
+| `GET PUT /api/auth/github/config` | the GitHub OAuth app config (secret write-only) |
 | `GET POST /api/overlookers` / `GET PATCH DELETE /api/overlookers/{id}` | overlooker CRUD (see [Overlookers](#overlookers)) |
 | `GET /api/overlookers/programs` | the builtin program registry: titles, suggested defaults, read-only script sources |
 | `POST /api/overlookers/{id}/run` / `GET /api/overlookers/{id}/runs` | fire a round now (`{dry_run}` stubs mutations) / the round-history audit |
@@ -376,6 +387,69 @@ archive, behind both the poller and the refresh endpoint), and `poll` (the
 loop). The merge-archive decision is split into `apply_snapshot` so it is
 testable without invoking `gh`.
 
+## Authentication
+
+Authentication is a **loom-only** concern — the daemon-less `weaver` CLI talks
+straight to sqlite and never authenticates. It lets loom be exposed off the
+loopback interface (so the dashboard and the API are reachable without an SSH
+tunnel) while gating who may drive the fleet. The core (crypto, the tables, the
+GitHub OAuth calls) lives in `crate::auth`, deliberately `axum`-free; the HTTP
+glue (the middleware, cookie handling, route handlers) lives in `crate::web`.
+
+Every `/api` route except the public login surface (`/api/health`,
+`/api/auth/me`, `/api/auth/login`, `/api/auth/logout`, `/api/auth/github/*`) and
+the static SPA passes through the `require_auth` middleware, which resolves the
+request to a `Principal` three ways, in order:
+
+- **API token** — an `Authorization: Bearer loom_…` header. This is the
+  `LOOM_TOKEN` a CI job or a remote `loom` CLI presents. Tokens are random
+  secrets stored only as a SHA-256 hash (`api_tokens.token_hash`); the plaintext
+  is shown once at creation. Managed under Settings → Tokens or `loom token`.
+- **Session cookie** — the opaque `loom_session` cookie set by a successful
+  GitHub or username/password login, stored hashed in `auth_sessions`.
+- **Loopback trust** — a request from `127.0.0.1`/`::1` is taken to be the
+  machine owner (the seeded primary user), gated on the `auth.trust_loopback`
+  setting (on by default). This keeps the local CLI, the agent's in-worktree
+  `loom` calls, and overlooker scripts working with zero configuration. To get
+  the peer address, the server runs `into_make_service_with_connect_info`; the
+  decision uses the real socket peer, **never** a forwarded header.
+
+A request that resolves to none of these gets `401`; the SPA's router guard
+turns that into the login screen.
+
+**The allowlist.** `users` rows are the approved operators. A fresh database is
+seeded with one owner — `github_login = rjpower` by default, overridable at
+first run with `LOOM_OWNER_GITHUB`. GitHub login only succeeds for a login that
+matches a `users` row; an unknown identity is authenticated by GitHub but
+rejected by loom. A user may have a `github_login`, a `password_hash` (argon2),
+or both. All approved users are equal — there is no role hierarchy, matching the
+single-operator scale.
+
+**GitHub OAuth** is configured per-deploy: register an OAuth app and set its id
+and secret via Settings → Account or the `LOOM_GITHUB_CLIENT_ID` /
+`LOOM_GITHUB_CLIENT_SECRET` env vars. The callback is
+`<base>/api/auth/github/callback`, where `<base>` is the `auth.base_url` setting
+or, unset, `{X-Forwarded-Proto|http}://{Host}`. The login route sets a short
+CSRF `state` cookie the callback verifies. Until an app is configured the GitHub
+button is hidden and `GET /api/auth/me` reports `methods.github = false`.
+
+**The machine-local token.** On startup loom mints (and persists, 0600, at
+`$WEAVER_HOME/loom-token`) a `kind = 'local'` `api_tokens` row owned by the
+primary user, and injects it as `LOOM_TOKEN` into the environments of its own
+same-host subprocesses (the agent's tmux, overlooker scripts) — and the `loom`
+CLI reads it. This makes `auth.trust_loopback = false` a fully working mode:
+behind a **same-host reverse proxy** (where forwarded requests look like
+loopback and so trust must be off) local automation still authenticates via this
+token, while remote callers must present their own. The local token is hidden
+from the token list and is not revocable from the UI.
+
+**Cookies** are `HttpOnly; SameSite=Lax; Path=/`; the `Secure` attribute is
+added when `auth.cookie_secure` is on (set it when loom is reached over HTTPS).
+loom terminates no TLS itself — run it behind a TLS-terminating proxy for remote
+use. The `auth.*` settings live in `weaver-core::config::registry()` under the
+**Authentication** group; the GitHub client id/secret are stored outside the
+registry so the secret never rides `GET /api/settings`.
+
 ## Overlookers
 
 An **overlooker** is a periodic / triggered watch program over the fleet: it
@@ -435,6 +509,9 @@ builtins are stdlib-only and need neither).
 | `WEAVER_DB` | sqlite path | `$WEAVER_HOME/weaver.db` |
 | `WEAVER_API` | loom URL (both sides — server binds, CLI talks) | `http://127.0.0.1:7878` |
 | `WEAVER_BRANCH` | override the branch resolver (set by `loom session launch` in the worktree) | — |
+| `LOOM_TOKEN` | bearer token the `loom` CLI / automation sends; falls back to the machine-local token file on the same host | — |
+| `LOOM_OWNER_GITHUB` | GitHub login seeded as the owner on a fresh database | `rjpower` |
+| `LOOM_GITHUB_CLIENT_ID` / `LOOM_GITHUB_CLIENT_SECRET` | GitHub OAuth app credentials (override the settings-stored values) | — |
 | `WEAVER_TMUX_SOCKET` | pin tmux to a dedicated server (`tmux -L <name>`) so ops can't touch real sessions; set by the test harnesses | unset → default socket |
 | `WEAVER_OVERLOOKER_AGENT_CMD` | the one-shot headless agent command behind `POST /api/agent/oneshot` (judgement calls) | `claude -p` |
 | `RUST_LOG` / `EnvFilter` | tracing filter | `loom=info,weaver_core=info,tower_http=warn` |

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '../fixtures/weaver';
+
+// The e2e server binds loopback, so the dashboard loads authenticated as the
+// owner via loopback trust (no login step). These cover the Settings → Tokens
+// management UI end to end against the real API.
+test.describe('settings · tokens', () => {
+  test('creates, lists, and revokes an API token', async ({ page, weaver }) => {
+    await page.goto(`${weaver.baseUrl}/settings`);
+
+    // Switch to the Tokens tab.
+    await page.getByTestId('settings-tab-tokens').click();
+    await expect(page.getByTestId('token-row')).toHaveCount(0);
+
+    // Create a token — the one-time secret banner appears with a `loom_` value.
+    await page.getByTestId('token-name').fill('github-actions');
+    await page.getByTestId('token-create').click();
+
+    const banner = page.getByTestId('new-token');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('loom_');
+
+    // It now shows in the list.
+    const row = page.getByTestId('token-row');
+    await expect(row).toHaveCount(1);
+    await expect(row).toContainText('github-actions');
+
+    // Revoke it (accept the confirm dialog) and it disappears.
+    page.once('dialog', (d) => d.accept());
+    await page.getByTestId('token-revoke').click();
+    await expect(page.getByTestId('token-row')).toHaveCount(0);
+  });
+
+  test('the Account tab shows the loopback identity', async ({ page, weaver }) => {
+    await page.goto(`${weaver.baseUrl}/settings`);
+    await page.getByTestId('settings-tab-account').click();
+    await expect(page.getByText('Signed in')).toBeVisible();
+    // The seeded owner, authenticated via loopback trust.
+    await expect(page.getByText('via loopback')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
+  });
+});

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -113,6 +113,11 @@ class Client:
         url = self.base + "/api" + path
         data = json.dumps(body).encode() if body is not None else None
         headers = {"Content-Type": "application/json"} if data else {}
+        # The engine injects $LOOM_TOKEN (the machine-local token); present it so
+        # the round authenticates even when loopback trust is off.
+        token = (os.environ.get("LOOM_TOKEN") or "").strip()
+        if token:
+            headers["Authorization"] = "Bearer " + token
         req = urllib.request.Request(url, data=data, method=method, headers=headers)
         try:
             with urllib.request.urlopen(req) as resp:


### PR DESCRIPTION
## What

Authentication for `loom` so it can run off loopback — exposed behind a reverse proxy, driven from CI, or hit by a remote CLI — without an SSH tunnel, while gating who can drive the fleet.

Three credentials resolve to one `Principal` through a `require_auth` middleware:

- **`Authorization: Bearer` API token** — `LOOM_TOKEN` for GitHub Actions / a remote CLI. Opaque, SHA-256 at rest, revocable.
- **Session cookie** — from GitHub OAuth or username/password login.
- **Trusted loopback** — on by default (`auth.trust_loopback`), so the local CLI, the agent, and overlookers keep working with zero config.

By default the only approved user is **rjpower** (GitHub); `LOOM_OWNER_GITHUB` overrides the seed. GitHub login only succeeds for an allowlisted login.

## How it fits together

- **`auth.rs`** (axum-free, unit-tested): token + password crypto (SHA-256 tokens, argon2 passwords), the `users` / `api_tokens` / `auth_sessions` tables, the machine-local token, and the GitHub OAuth exchange.
- **`web.rs`**: the middleware, a public vs. protected router split, and the auth REST surface (`/api/auth/{me,login,logout,github/*,tokens,password,users,github/config}`). Served with `ConnectInfo` for the loopback check.
- **Machine-local token** (`$WEAVER_HOME/loom-token`, 0600) injected into the agent/overlooker subprocess envs and read by the loom CLI — so `trust_loopback=false` (the same-host reverse-proxy posture) still works for local automation.
- **Frontend**: a login screen, a router guard, and Settings → **Tokens** / **Account** tabs (manage tokens, set a password, manage approved users, configure the GitHub app).
- **CLI / client**: `loom token create|ls|rm`, and `LOOM_TOKEN` support on the `weaver-api` client and the Python `weaver_loom` layer.

## Design notes

- **Opaque tokens, not JWT** — server-side lookup means instant revocation; no key rotation or claims-expiry dance. (The branch name says "jwt" from the initial framing; opaque won out as cleaner and revocable.)
- **Flat user model** — an allowlist, no roles. Scale-appropriate for a single-owner fleet.
- The GitHub client secret is write-only (a dedicated endpoint), never returned by the config read.

## Tests & docs

- **Unit** (`auth.rs`): token lifecycle, password roundtrip, sessions, user management, local-token invariants.
- **Integration**: loopback trust, then `trust_loopback=false` proving bearer / local-token / cookie paths each gate access, plus revocation and the public-vs-protected split.
- **e2e**: token CRUD through Settings → Tokens, and the Account tab identity.
- **Docs**: ARCHITECTURE *Authentication* section + a README remote-access guide.

Full suite green locally: 59 unit + 32 integration + 45 e2e.

Closes #118.
