### PR TITLE
refactor(cli): normalize loom & weaver command surfaces

### DIFF
--- a/.agents/skills/pull-request.md
+++ b/.agents/skills/pull-request.md
@@ -133,11 +133,11 @@ up after a few idle hours). Each pass check **both**:
    bots comment after CI passes.
 
 Answer every comment: fix the clear ones (commit as a **new** commit, reply
-in-thread prefixed 🤖, resolve). Genuinely unclear → `weaver set-status attention
+in-thread prefixed 🤖, resolve). Genuinely unclear → `weaver status attention
 "<question>"`, keep monitoring while you wait.
 
 Status tracks the loop: `ok` while CI runs or you await review; `weaver
-set-status attention "ready for review"` only once green and every comment is
+status attention "ready for review"` only once green and every comment is
 handled. Close the tracking issue when the PR is open and the work is genuinely
 done — not before.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,13 +40,13 @@ core.hooksPath .githooks`. Build/test internals and the Playwright setup live in
 
 ## Don't disturb the user's live loom
 
-A real `loom serve` is **machine-global**: one shared `~/.weaver/weaver.db` and a
+A real `loom server run` is **machine-global**: one shared `~/.weaver/weaver.db` and a
 set of detached `tapestry` terminal supervisors (under `~/.weaver/sock`),
 normally running the user's agents — including the one running *you*. The
-supervisors are detached, so they outlive `loom serve` and a broad kill is what
+supervisors are detached, so they outlive `loom server run` and a broad kill is what
 wipes them. So unless the user explicitly asks:
 
-- **Don't** start your own `loom serve` / `loom launch` against the default
+- **Don't** start your own `loom server run` or `loom session launch` against the default
   `~/.weaver`, kill the user's terminal supervisors, or run broad process cleanup
   (`pkill -f tapestry`, `pkill -f weaver`). Each wipes the user's agents at a
   stroke.
@@ -57,7 +57,7 @@ To exercise loom behaviour, extend the test suites — they isolate via a temp
 loom by hand, isolate it the same way:
 
 ```sh
-WEAVER_HOME=$(mktemp -d) loom serve --addr 127.0.0.1:0
+WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0
 ```
 
 ## Landing changes
@@ -77,7 +77,7 @@ when you're ready to land. The rules it enforces:
   more than the local gate (Playwright `e2e/`, CodeQL, a clean-checkout SPA
   build). After pushing, block on `gh pr checks <n> --watch --fail-fast`, answer
   comments in-thread, and fix failures until green. Only **then** raise `weaver
-  set-status attention "ready for review"`; while CI runs you are `ok`, not done.
+  status attention "ready for review"`; while CI runs you are `ok`, not done.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ written for it to run; do them yourself if you'd rather.
 Then start the orchestrator and open the dashboard:
 
 ```sh
-loom serve     # REST + SSE server, terminal launcher, background monitor
+loom server run     # REST + SSE server, terminal launcher, background monitor
 loom open      # open the web UI (http://127.0.0.1:7878)
 ```
 
 `weaver` needs no running daemon — it talks straight to the sqlite db — so the
-agent inside a worktree works the moment it's on your PATH. `loom serve` is only
+agent inside a worktree works the moment it's on your PATH. `loom server run` is only
 for the dashboard, terminal sessions, and summaries. See [Usage](#usage) for the
 full command surface, and [AGENTS.md](AGENTS.md) for the build/test loop and how
 to work on weaver itself.
@@ -70,7 +70,7 @@ to work on weaver itself.
 ```
 weaver CLI ──sqlite──┐
                      ├─ ~/.weaver/weaver.db   (shared, WAL mode)
-loom serve  ─────────┘
+loom server run ────┘
   │
   ├─ axum REST + SSE (127.0.0.1:7878)
   ├─ terminal supervisors + git worktree wrappers
@@ -88,7 +88,7 @@ key decoupling — the agent CLI never speaks HTTP.
 
 ```sh
 # Orchestrator (optional)
-loom serve                            # run the daemon (REST + UI + terminals + monitor)
+loom server run                            # run the daemon (REST + UI + terminals + monitor)
 loom session launch "Add a /health endpoint"               # new worktree + terminal + agent, seeded with the task
 loom session launch "Refactor the parser" --name parser-refactor   # override the branch slug
 loom session launch "Big refactor" --model opus --effort high      # pick model tier + reasoning effort
@@ -98,18 +98,18 @@ loom session send <session> "try the curl again"   # type a message + Enter (tri
 loom session break <session>          # send Escape — interrupt the current turn
 loom session preview <session>        # print the recent terminal screen
 loom ps                               # list active sessions
-loom show <branch>                    # session detail
+loom session show <branch>                    # session detail
 loom attach <branch>                  # attach your terminal to the session (or use the browser terminal)
-loom archive <branch>                 # tear down terminal + worktree, keep branch + history
-loom adopt <branch>                   # recreate the terminal for an orphaned session
-loom rm <branch>                      # remove worktree + terminal + db row
+loom session archive <branch>                 # tear down terminal + worktree, keep branch + history
+loom session adopt <branch>                   # recreate the terminal for an orphaned session
+loom session rm <branch>                      # remove worktree + terminal + db row
 loom open                             # open the web UI
 
 # Agent-facing (run from inside the worktree, no daemon required)
 weaver goal "ship the feature"
 weaver goal                           # print the current goal
 weaver summary                        # goal + outstanding tasks + next-step hints
-weaver set-status attention "ready for review"   # level (ok|attention|blocked) + current-state message
+weaver status attention "ready for review"   # level (ok|attention|blocked) + current-state message
 weaver issue add "Backfill old rows" --body "ETA after the schema change"
 weaver issue add "Audit the logger" --repo   # unclaimed repo backlog item
 weaver issue ls                       # this branch's work + the repo backlog
@@ -118,7 +118,7 @@ weaver issue ls --repo                # the whole repo, grouped by branch
 weaver issue close 7
 weaver issue show 7                   # an issue + the live status of the branch working it
 weaver issue wait 7                   # block until a sub-session finishes or needs you
-weaver set-status                     # read: goal + status + open-issue count
+weaver status                     # read: goal + status + open-issue count
 weaver where                          # debug: print resolved repo / branch / branch-id
 weaver log --limit 50                 # recent events for the current branch
 ```
@@ -144,12 +144,12 @@ Three flags seed the task from existing work instead of a fresh description:
 `loom session launch --issue 123` takes the branch's title / goal / description
 from a GitHub issue (via the `gh` CLI), `--claim 7` takes them from an existing
 weaver issue and moves it out of the repo backlog, and `--branch <name>` resumes
-an existing branch. `loom issues` prints the repo's board across branches.
+an existing branch. `loom issue ls` prints the repo's board across branches.
 
 Every launch opens a **tracking issue** claimed by the new branch — the task as
 a weaver issue — and the launch prints its number. That number is the handle
 for following the session: `weaver issue show <n>` reports the issue plus the
-live `set-status` of the branch working it, and `weaver issue wait <n>` blocks
+live `status` of the branch working it, and `weaver issue wait <n>` blocks
 until the issue closes or that branch raises its attention. The launched agent
 is told to keep its status current and close the issue when the work is done.
 When an agent already inside a weaver session runs `loom session launch`, the
@@ -182,9 +182,9 @@ prompt itself is read straight from the terminal, one tab away.
 The **attention** axis is the agent's own signal of whether it needs you:
 `ok` (going fine, or blocked on something external like a CI run or PR review),
 `attention` (a question, a decision, "ready for review"), or `blocked` (stuck,
-needs help). Agents set it with `weaver set-status <level> "<message>"`, which
+needs help). Agents set it with `weaver status <level> "<message>"`, which
 records both the level and a one-line current-state message; a bare
-`weaver set-status <level>` changes the level and keeps the last message. The
+`weaver status <level>` changes the level and keeps the last message. The
 dashboard shows both and lets you filter for sessions that need a human. It
 replaces the old guessed working/waiting/idle indicator, which was often wrong —
 e.g. it read "idle" while the agent was actually waiting on a background
@@ -201,7 +201,7 @@ An orphaned session can be adopted — its terminal recreated and its
 agent resumed (`claude --continue`):
 
 ```sh
-loom adopt <branch>                   # or the "Adopt" button in the web UI
+loom session adopt <branch>                   # or the "Adopt" button in the web UI
 ```
 
 Set `server.auto_adopt` to have loom adopt every recoverable session
@@ -254,16 +254,16 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the shape of `SessionView`.
 
 ## Server address
 
-`loom serve` binds `127.0.0.1:7878` by default. Set `WEAVER_API` (e.g.
+`loom server run` binds `127.0.0.1:7878` by default. Set `WEAVER_API` (e.g.
 `WEAVER_API=http://127.0.0.1:9000`) to point loom *and* the `loom` CLI at a
-different address. `loom serve --addr <host:port>` overrides `WEAVER_API`.
+different address. `loom server run --addr <host:port>` overrides `WEAVER_API`.
 The running daemon records the address it bound in `~/.weaver/server.json`,
 so the `loom` CLI finds it with no configuration in the common case.
 
 ## Authentication
 
 loom can be exposed off `127.0.0.1` so the dashboard and the API are reachable
-without an SSH tunnel — `loom serve --addr 0.0.0.0:7878`, ideally behind a
+without an SSH tunnel — `loom server run --addr 0.0.0.0:7878`, ideally behind a
 TLS-terminating reverse proxy. Access is then gated three ways:
 
 - **Local use needs nothing.** Requests from the loopback interface are trusted
@@ -279,7 +279,7 @@ TLS-terminating reverse proxy. Access is then gated three ways:
   CLI presents as a bearer. Mint one under **Settings → Tokens** or:
 
   ```sh
-  loom token create github-actions     # prints the secret once — store it now
+  loom token add github-actions     # prints the secret once — store it now
   ```
 
   Then, from anywhere (e.g. a GitHub Actions step that kicks off a session in
@@ -315,10 +315,10 @@ label, help text, type, and default.
 Edit them in the **Settings** pane of the web UI, or from the CLI:
 
 ```sh
-weaver config list
+weaver config ls
 weaver config get agent.default
 weaver config set agent.claude_args "--model claude-opus-4-7"
-weaver config unset agent.claude_args
+weaver config rm agent.claude_args
 ```
 
 Notable settings:

--- a/crates/loom/frontend/src/components/SessionOverview.vue
+++ b/crates/loom/frontend/src/components/SessionOverview.vue
@@ -10,7 +10,7 @@ import MarkdownView from './MarkdownView.vue';
 // projected markdown), the pinned `plan` artifact, claimed work + repo backlog,
 // and the de-noised activity feed. The PR snapshot lives as a small link in the
 // session header rather than as a section here.
-// Everything here is authored by the AGENT (the goal, `weaver set-status`,
+// Everything here is authored by the AGENT (the goal, `weaver status`,
 // `weaver issue`, `weaver artifact write plan`); the page's writes (acknowledge
 // attention, rename, lifecycle) all live in the header, and the live working
 // surface (terminal + scratch) is the Terminal tab.

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -186,7 +186,7 @@ const quiet = computed(() => quietTags(props.ws));
       {{ messageOf(ws) }}
     </p>
     <p v-else class="mt-1 text-sm text-faint">
-      No status yet — agent hasn't run <code>weaver set-status</code>.
+      No status yet — agent hasn't run <code>weaver status</code>.
     </p>
 
     <!-- Quiet tags — free-form, deletable pills (priority, needs-rebase, …),

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -27,7 +27,7 @@ export interface Branch {
   title: string;
   goal: string;
   /** The agent's current-state message, set together with the `attention` tag
-   *  via `weaver set-status` (e.g. "Wired up routes; tests pass"). Shown even
+   *  via `weaver status` (e.g. "Wired up routes; tests pass"). Shown even
    *  when the branch is calm. */
   description: string;
   /** Every tag on the branch: the agent's `attention`, an overlooker's

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -761,7 +761,7 @@ onUnmounted(() => clearInterval(timer));
             />
           </div>
 
-          <!-- Current-state headline (agent's set-status message), else the goal.
+          <!-- Current-state headline (agent's status message), else the goal.
                On an attention row the goal steps up from faint to muted so the
                metadata doesn't recede next to the loud chip. -->
           <p

--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -8,7 +8,7 @@
 //!
 //! Every session is a [`tapestry`] supervisor: a per-session detached PTY process
 //! that streams raw PTY bytes, so an attached xterm owns its own scrollback,
-//! selection, and search. Its lifetime is independent of `loom serve`, so a loom
+//! selection, and search. Its lifetime is independent of `loom server run`, so a loom
 //! restart leaves running terminals untouched — the recovery property that keeps
 //! agents alive across restarts.
 

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1,10 +1,10 @@
 //! loom — the orchestration CLI.
 //!
 //! Most subcommands talk to the running loom daemon over HTTP (session
-//! lifecycle, archive, adopt). `serve` runs the daemon itself;
-//! `start`/`stop`/`restart`/`status` manage its background lifecycle. To
-//! interact with an agent, `attach` to its terminal (the browser terminal is the
-//! other interaction surface).
+//! lifecycle, archive, adopt). `loom server run` runs the daemon itself in the
+//! foreground; `loom server start`/`stop`/`restart`/`status` manage its
+//! background lifecycle. To interact with an agent, `loom session attach` to its
+//! terminal (the browser terminal is the other interaction surface).
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, CommandFactory, Parser, Subcommand};
@@ -25,31 +25,33 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
-    /// Run the loom server (REST API + Vue UI + monitor loop).
-    Serve {
-        #[arg(long)]
-        addr: Option<String>,
-    },
-    /// Show the running daemon's status.
-    Status,
-    /// Start the loom daemon in the background.
-    Start,
-    /// Stop the loom daemon.
-    Stop,
-    /// Stop and re-start the loom daemon.
-    Restart,
-
-    /// Manage sessions: launch, poll, wait, send, break, preview.
+    /// Manage the loom server daemon: run, start, stop, restart, status.
     ///
-    /// A uniform surface for driving a child session — start one, watch it, and
-    /// interact with its agent pane:
+    /// `loom server run` runs the server in the foreground (REST API + Vue UI +
+    /// monitor loop), blocking until interrupted — the form to run under a
+    /// process supervisor (systemd, Docker) or while developing. `loom server
+    /// start` runs that same process in the background and waits for it to come
+    /// up.
+    Server {
+        #[command(subcommand)]
+        cmd: ServerCmd,
+    },
+
+    /// Manage sessions: launch, ls, attach, poll, wait, send, break, preview.
+    ///
+    /// The uniform surface for a child session — start one, list the fleet,
+    /// watch one, and interact with its agent pane:
     ///
     ///     loom session launch "Add a /health endpoint and a test for it"
+    ///     loom session ls                      # the active fleet
     ///     loom session poll weaver/health      # one-shot status
     ///     loom session wait weaver/health      # block until done / needs you
     ///     loom session send weaver/health "try the curl again"
     ///     loom session break weaver/health     # interrupt the current turn
     ///     loom session preview weaver/health   # peek at the terminal screen
+    ///
+    /// The three you reach for constantly have top-level shortcuts: `loom
+    /// launch`, `loom ps`, `loom attach`.
     Session {
         #[command(subcommand)]
         cmd: SessionCmd,
@@ -75,7 +77,7 @@ enum Cmd {
     ///
     /// Mint a token to drive loom from GitHub Actions or any remote client:
     ///
-    ///     loom token create github-actions     # prints the secret once — copy it now
+    ///     loom token add github-actions        # prints the secret once — copy it now
     ///     loom token ls                         # name, prefix, last used
     ///     loom token rm <id>                    # revoke
     ///
@@ -86,13 +88,52 @@ enum Cmd {
         #[command(subcommand)]
         cmd: TokenCmd,
     },
-    /// Deprecated alias for `loom session launch`.
-    #[command(hide = true)]
-    Launch(LaunchOpts),
-    /// List active sessions.
-    Ps,
     /// Show the repo's issue board (every issue across branches + backlog).
-    Issues {
+    Issue {
+        #[command(subcommand)]
+        cmd: IssueCmd,
+    },
+
+    /// Launch a new session — shortcut for `loom session launch`.
+    Launch(LaunchOpts),
+    /// List active sessions — shortcut for `loom session ls`.
+    Ps,
+    /// Attach your terminal to a session — shortcut for `loom session attach`.
+    Attach { branch: String },
+
+    /// Open the loom web UI in a browser.
+    Open,
+    /// Generate shell completions.
+    Completions { shell: clap_complete::Shell },
+}
+
+/// Subcommands under `loom server` — the daemon lifecycle.
+#[derive(Subcommand)]
+enum ServerCmd {
+    /// Run the server in the foreground (REST API + Vue UI + monitor loop).
+    ///
+    /// Blocks until interrupted — the form to run under a process supervisor
+    /// (systemd, Docker) or while developing/testing. `loom server start` runs
+    /// this same process in the background.
+    Run {
+        #[arg(long)]
+        addr: Option<String>,
+    },
+    /// Start the server in the background (daemonize) and wait for it to be healthy.
+    Start,
+    /// Stop the background server.
+    Stop,
+    /// Stop and re-start the background server.
+    Restart,
+    /// Show the running server's status.
+    Status,
+}
+
+/// Subcommands under `loom issue` — the read-only issue board.
+#[derive(Subcommand)]
+enum IssueCmd {
+    /// Show the repo's issue board (every issue across branches + backlog).
+    Ls {
         /// Include closed issues.
         #[arg(long)]
         all: bool,
@@ -100,24 +141,6 @@ enum Cmd {
         #[arg(long)]
         backlog: bool,
     },
-    /// Show one session's details.
-    Show { branch: String },
-    /// Attach your terminal to a session.
-    Attach { branch: String },
-    /// Archive a session: tear down terminal + worktree, keep branch + history.
-    Archive { branch: String },
-    /// Recreate the terminal session for an orphaned session.
-    Adopt { branch: String },
-    /// Remove a session (worktree + terminal + DB row).
-    Rm {
-        branch: String,
-        #[arg(long)]
-        keep_branch: bool,
-    },
-    /// Open the loom web UI in a browser.
-    Open,
-    /// Generate shell completions.
-    Completions { shell: clap_complete::Shell },
 }
 
 /// Subcommands under `loom session` — the uniform way to drive a child session.
@@ -177,13 +200,28 @@ enum SessionCmd {
         session: String,
     },
     /// Print a session's recent terminal screen.
-    #[command(alias = "sp")]
     Preview {
         /// Session key: id, branch id, branch name, or `repo:branch`.
         session: String,
         /// Extra scrollback lines above the visible screen (0 = visible only).
         #[arg(long, default_value = "0")]
         lines: usize,
+    },
+    /// List active sessions (also `loom ps`).
+    Ls,
+    /// Show one session's details.
+    Show { branch: String },
+    /// Attach your terminal to a session (also `loom attach`).
+    Attach { branch: String },
+    /// Archive a session: tear down terminal + worktree, keep branch + history.
+    Archive { branch: String },
+    /// Recreate the terminal session for an orphaned session.
+    Adopt { branch: String },
+    /// Remove a session (worktree + terminal + DB row).
+    Rm {
+        branch: String,
+        #[arg(long)]
+        keep_branch: bool,
     },
 }
 
@@ -257,7 +295,7 @@ enum OverlookerCmd {
 #[derive(Subcommand)]
 enum TokenCmd {
     /// Mint a new API token. Prints the secret once — copy it now.
-    Create {
+    Add {
         /// A label to recognise the token by (e.g. `github-actions`).
         name: String,
         /// Optional lifetime in days; omit for a non-expiring token.
@@ -321,7 +359,7 @@ struct AddOpts {
 }
 
 /// Shared `launch` options, used by both `loom session launch` and the
-/// deprecated top-level `loom launch` alias.
+/// top-level `loom launch` shortcut.
 #[derive(Args)]
 struct LaunchOpts {
     /// What the agent should do. Sets the branch goal and is fed to the agent as
@@ -379,38 +417,42 @@ async fn main() {
 async fn run() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
-        Cmd::Serve { addr } => {
-            init_tracing();
-            let addr = loom::endpoint::bind_addr(addr.as_deref());
-            loom::server::run(&addr).await
-        }
-        Cmd::Status => cmd_status().await,
-        Cmd::Start => cmd_start().await,
-        Cmd::Stop => cmd_stop().await,
-        Cmd::Restart => cmd_restart().await,
+        Cmd::Server { cmd } => run_server(cmd).await,
         Cmd::Session { cmd } => run_session(cmd).await,
+        Cmd::Issue { cmd } => run_issue(cmd).await,
         Cmd::Overlooker { cmd } => run_overlooker(cmd).await,
         Cmd::Token { cmd } => run_token(cmd).await,
-        Cmd::Launch(opts) => {
-            eprintln!("note: `loom launch` is deprecated — use `loom session launch`");
-            cmd_launch(opts.into()).await
-        }
+        Cmd::Launch(opts) => cmd_launch(opts.into()).await,
         Cmd::Ps => cmd_ps().await,
-        Cmd::Issues { all, backlog } => cmd_issues(all, backlog).await,
-        Cmd::Show { branch } => cmd_show(branch).await,
         Cmd::Attach { branch } => cmd_attach(branch).await,
-        Cmd::Archive { branch } => cmd_archive(branch).await,
-        Cmd::Adopt { branch } => cmd_adopt(branch).await,
-        Cmd::Rm {
-            branch,
-            keep_branch,
-        } => cmd_rm(branch, keep_branch).await,
         Cmd::Open => cmd_open().await,
         Cmd::Completions { shell } => {
             let mut cmd = Cli::command();
             clap_complete::generate(shell, &mut cmd, "loom", &mut std::io::stdout());
             Ok(())
         }
+    }
+}
+
+/// Dispatch the `loom server <verb>` daemon-lifecycle subcommands.
+async fn run_server(cmd: ServerCmd) -> Result<()> {
+    match cmd {
+        ServerCmd::Run { addr } => {
+            init_tracing();
+            let addr = loom::endpoint::bind_addr(addr.as_deref());
+            loom::server::run(&addr).await
+        }
+        ServerCmd::Start => cmd_start().await,
+        ServerCmd::Stop => cmd_stop().await,
+        ServerCmd::Restart => cmd_restart().await,
+        ServerCmd::Status => cmd_status().await,
+    }
+}
+
+/// Dispatch the `loom issue <verb>` subcommands (the read-only board).
+async fn run_issue(cmd: IssueCmd) -> Result<()> {
+    match cmd {
+        IssueCmd::Ls { all, backlog } => cmd_issues(all, backlog).await,
     }
 }
 
@@ -432,6 +474,15 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
         } => cmd_session_send(session, message.join(" "), !no_enter).await,
         SessionCmd::Break { session } => cmd_session_break(session).await,
         SessionCmd::Preview { session, lines } => cmd_session_preview(session, lines).await,
+        SessionCmd::Ls => cmd_ps().await,
+        SessionCmd::Show { branch } => cmd_show(branch).await,
+        SessionCmd::Attach { branch } => cmd_attach(branch).await,
+        SessionCmd::Archive { branch } => cmd_archive(branch).await,
+        SessionCmd::Adopt { branch } => cmd_adopt(branch).await,
+        SessionCmd::Rm {
+            branch,
+            keep_branch,
+        } => cmd_rm(branch, keep_branch).await,
     }
 }
 
@@ -453,7 +504,7 @@ async fn run_overlooker(cmd: OverlookerCmd) -> Result<()> {
 
 async fn run_token(cmd: TokenCmd) -> Result<()> {
     match cmd {
-        TokenCmd::Create { name, expires_days } => cmd_token_create(name, expires_days).await,
+        TokenCmd::Add { name, expires_days } => cmd_token_create(name, expires_days).await,
         TokenCmd::Ls => cmd_token_ls().await,
         TokenCmd::Rm { id } => cmd_token_rm(id).await,
     }
@@ -484,7 +535,7 @@ async fn cmd_token_create(name: String, expires_days: Option<i64>) -> Result<()>
 async fn cmd_token_ls() -> Result<()> {
     let tokens = client::default().list_tokens().await?;
     if tokens.is_empty() {
-        println!("no tokens — create one with `loom token create <name>`");
+        println!("no tokens — create one with `loom token add <name>`");
         return Ok(());
     }
     println!("{:<18}  {:<20}  {:<16}  LAST USED", "ID", "NAME", "PREFIX");
@@ -663,14 +714,14 @@ async fn spawn_server() -> Result<()> {
 
     let mut command = std::process::Command::new(&exe);
     command
-        .args(["serve"])
+        .args(["server", "run"])
         .arg("--addr")
         .arg(&addr)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::from(log))
         .stderr(std::process::Stdio::from(log_err))
         .process_group(0);
-    let child = command.spawn().context("spawning `loom serve`")?;
+    let child = command.spawn().context("spawning `loom server run`")?;
     drop(child);
 
     let base = format!("http://{addr}");
@@ -952,7 +1003,7 @@ fn wake_reason(ws: &Value, key: &str, lifecycle_only: bool) -> Option<String> {
     }
     if status == "orphaned" {
         return Some(format!(
-            "session {key} is orphaned — its terminal was lost (try `loom adopt {key}`)"
+            "session {key} is orphaned — its terminal was lost (try `loom session adopt {key}`)"
         ));
     }
     if !lifecycle_only && branch_attention(ws) != "ok" {

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -1,6 +1,6 @@
 //! Background task: detects when a session's terminal has ended and consumes the
 //! event rows the `weaver` CLI writes — `hook` events (Claude lifecycle) and
-//! `tag` events (`weaver set-status` writing the `attention` tag) — reflecting
+//! `tag` events (`weaver status` writing the `attention` tag) — reflecting
 //! them onto the session and the dashboard.
 //!
 //! The browser terminal (xterm.js over a PTY) is the live-screen surface; this
@@ -42,7 +42,7 @@ pub async fn run(state: AppState) {
                 for ev in new_events {
                     last_event = last_event.max(ev.id);
                     match ev.kind.as_str() {
-                        // A `tag` write — `weaver set-status` (the agent's
+                        // A `tag` write — `weaver status` (the agent's
                         // `attention`), an overlooker's `triage`, or any free-form
                         // key — or an `artifact_written` from `weaver artifact
                         // write`: recorded daemon-less by the CLI, so it never
@@ -138,7 +138,7 @@ pub async fn run(state: AppState) {
 
             // Hash the pane to detect activity and bump `last_activity_at`.
             // Inferred working→idle demotion is gone: liveness is all we can
-            // know, and the agent reports the rest via `weaver set-status`.
+            // know, and the agent reports the rest via `weaver status`.
             let screen = backend::capture(&session.term_session, 0)
                 .await
                 .unwrap_or_default();
@@ -249,7 +249,7 @@ fn parse_iso(ts: &str) -> Option<DateTime<Utc>> {
 ///   `attention`.
 /// * `idle` (a turn ended) leaves attention untouched — a finished-but-fine
 ///   agent must not be mistaken for one that needs the user. If it actually
-///   needs something it will have said so via `weaver set-status`.
+///   needs something it will have said so via `weaver status`.
 async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64> {
     // The attention level the hook implies, or `None` to leave it untouched. An
     // empty string is the calm state — it clears the tag rather than storing.

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -34,7 +34,7 @@ pub fn read_state() -> Option<ServerState> {
 /// Remove the state file on shutdown, but only if it still describes *this*
 /// process.
 ///
-/// A restart overlaps two servers on the same port: `loom stop` drops the old
+/// A restart overlaps two servers on the same port: `loom server stop` drops the old
 /// listener (freeing the port) the instant it signals shutdown, but the old
 /// process keeps running until its in-flight connections drain — and the
 /// dashboard's SSE/terminal streams can hold those open for a long time. In
@@ -42,7 +42,7 @@ pub fn read_state() -> Option<ServerState> {
 /// `loom.json`. If the departing server then deleted the file unconditionally
 /// it would wipe the *successor's* state, leaving a live server with no state
 /// file — exactly the "loom is running but loom.json is missing" failure on the
-/// next `loom restart`. So we only remove the file when the pid on disk is
+/// next `loom server restart`. So we only remove the file when the pid on disk is
 /// still ours; otherwise a newer server owns it and we leave it be.
 fn remove_state_if_ours(path: &std::path::Path, my_pid: u32) {
     let owner = std::fs::read_to_string(path)

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -47,7 +47,7 @@ pub struct Session {
 /// guessed at the agent's state from hooks and screen stillness and were
 /// frequently wrong (e.g. an agent waiting on a background workflow looked
 /// "idle"). Liveness is all the orchestrator can know for sure; the agent
-/// reports the rest via `weaver set-status`.
+/// reports the rest via `weaver status`.
 pub const STATUSES: &[&str] = &[
     "created",
     "launching",

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -41,7 +41,7 @@
 //!     "name": "feature-x",            // short label (weaver/<slug> with prefix stripped)
 //!     "title": "...",
 //!     "goal": "...",
-//!     "description": "...",         // current-state message (weaver set-status)
+//!     "description": "...",         // current-state message (weaver status)
 //!     "tags": [                     // every (key, value) annotation on the branch
 //!       { "key": "attention", "value": "blocked", "note": "...",
 //!         "set_by": "agent", "set_at": "..." }
@@ -868,7 +868,7 @@ async fn create_session(
 fn tracking_note(issue_id: i64) -> String {
     format!(
         "This session is tracked as weaver issue #{issue_id}. Keep your status \
-         current with `weaver set-status <level> \"<message>\"` as you work, and \
+         current with `weaver status <level> \"<message>\"` as you work, and \
          run `weaver issue close {issue_id}` once the task is complete (e.g. the \
          PR is open) so whoever launched you knows you are done."
     )
@@ -3326,7 +3326,7 @@ mod tests {
         assert!(note.contains("weaver issue #42"));
         // It tells the agent exactly how to signal "done".
         assert!(note.contains("weaver issue close 42"));
-        assert!(note.contains("weaver set-status"));
+        assert!(note.contains("weaver status"));
     }
 
     #[test]

--- a/crates/tapestry/src/lib.rs
+++ b/crates/tapestry/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! Each session is one tiny **detached supervisor process** that owns the
 //! agent's PTY, runs a vt100 screen emulator, and serves a unix control socket.
-//! Because the supervisor's lifetime is independent of `loom serve`, restarting
+//! Because the supervisor's lifetime is independent of `loom server run`, restarting
 //! loom leaves a live agent untouched (the recovery property loom relies on),
 //! while the interactive surface streams *raw PTY bytes*, so an attached xterm
 //! owns its own scrollback, selection, and search rather than a server-rendered

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -57,7 +57,7 @@ pub struct BranchView {
     pub name: String,
     pub title: String,
     pub goal: String,
-    /// The agent's current-state message, set via `weaver set-status`, shown even
+    /// The agent's current-state message, set via `weaver status`, shown even
     /// when the branch is calm. The attention *level* is the `attention` tag.
     pub description: String,
     /// Every tag on the branch (the agent's `attention`, an overlooker's

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -17,7 +17,7 @@ It is on your `PATH`. From anywhere in the worktree you can run:
 - `weaver readme` — print this guide (the full weaver workflow). Re-read it when
   you need the rules back — e.g. after a compaction, when only the concise
   catch-up was replayed.
-- `weaver set-status <level> "<message>"` — tell the dashboard how you are
+- `weaver status <level> "<message>"` — tell the dashboard how you are
   doing. `level` is one of `ok`, `attention`, or `blocked`; the message is a
   short current-state note ("Wired up routes; tests pass"). This is your single
   channel for reporting status — both the level and the message in one call —
@@ -47,7 +47,7 @@ It is on your `PATH`. From anywhere in the worktree you can run:
   the reconciler.** File the issues with `weaver issue add`, reference them in
   the doc, and keep the two aligned as work moves. See the smartdoc skill
   (`.agents/skills/smartdoc.md`).
-- `weaver set-status` — with no argument, show the goal, status, and open-issue
+- `weaver status` — with no argument, show the goal, status, and open-issue
   count.
 
 These talk directly to the weaver database — no daemon required.
@@ -59,7 +59,7 @@ that represents the task you were launched for. `weaver issue ls --mine` shows
 it. It is how the agent (or human) that launched you watches your progress
 without reading this terminal:
 
-- Keep your status honest with `weaver set-status` as you work — that is the
+- Keep your status honest with `weaver status` as you work — that is the
   live signal whoever launched you polls.
 - When the task is genuinely complete (the PR is open, the work is done), run
   `weaver issue close <id>` on the tracking issue. Closing it is the
@@ -76,7 +76,7 @@ own branch and worktree — and track it the same way someone tracks you:
   issue is your handle on the sub-tree. The new branch forks from a
   freshly-fetched `origin/<default branch>` unless you pass `--base <branch>`.
 - `weaver issue show <id>` — poll the sub-tree: its tracking issue's
-  open/closed state plus the sub-agent's live `set-status` (attention +
+  open/closed state plus the sub-agent's live `weaver status` (attention +
   current-state message).
 - `weaver issue wait <id>` — block until the sub-tree finishes (its tracking
   issue closes) or needs you (the sub-agent raises its attention to
@@ -105,20 +105,20 @@ history, and you can hand it off or revisit it later.
 ## Signalling your status
 
 The user scans the dashboard for sessions that need them. Keep your status
-honest with `weaver set-status <level> "<message>"`. The level is the
+honest with `weaver status <level> "<message>"`. The level is the
 "does this need me?" signal; the message says what's going on:
 
 - `ok` — progressing normally, **or** blocked on something external that is not
   the user (a CI run, a PR review, a long workflow). No action needed.
-  Example: `weaver set-status ok "waiting on PR review feedback"`.
+  Example: `weaver status ok "waiting on PR review feedback"`.
 - `attention` — you want the user to look: a question, a decision to confirm, or
-  "done — ready for review". Example: `weaver set-status attention "ready for review"`.
+  "done — ready for review". Example: `weaver status attention "ready for review"`.
 - `blocked` — you are stuck or hit an error and need help to proceed.
-  Example: `weaver set-status blocked "build broken, can't reproduce locally"`.
+  Example: `weaver status blocked "build broken, can't reproduce locally"`.
 
 Set it as your situation changes — especially raise it to `attention` before you
 finish a turn expecting the user, and drop back to `ok` once you are moving
-again. A bare `weaver set-status ok` lowers the level and keeps your last
+again. A bare `weaver status ok` lowers the level and keeps your last
 message. This replaces the old guessed working/waiting/idle indicator, which was
 often wrong (e.g. it read "idle" while you were really waiting on a workflow).
 
@@ -127,8 +127,8 @@ Under the hood, status is stored as **tags** on your branch. A tag is a single
 well known:
 
 - `attention` — your self-report, the value being `attention` or `blocked`. This
-  is what `weaver set-status` writes; `ok` is the absence of the tag, so
-  `set-status ok` clears it. Absence is the calm state — a calm branch carries no
+  is what `weaver status` writes; `ok` is the absence of the tag, so
+  `weaver status ok` clears it. Absence is the calm state — a calm branch carries no
   attention tag, only its `description` message.
 - `triage` — an overlooker's outside assessment of your branch, the same
   `attention`/`blocked` ladder but authored by an overlooker (or `manual`), never
@@ -141,13 +141,13 @@ has moved on since it was set (its timestamp predates your last activity).
 
 ## How to work here
 
-- Prefer to make a well-reasoned decision, record it with `weaver set-status`,
+- Prefer to make a well-reasoned decision, record it with `weaver status`,
   and keep going. Default to recording and continuing rather than stopping.
 - You may still ask the user for feedback in plain prose when a choice genuinely
   matters. But **never block on an interactive TUI prompt** — multiple-choice
   menus, plan-approval dialogs, and the like cannot be answered from the
   dashboard. State the question as plain text and
-  set `weaver set-status attention "<the question>"`, then continue with your
+  set `weaver status attention "<the question>"`, then continue with your
   best assumption.
 
 ## Finishing work
@@ -164,7 +164,7 @@ the work is ready:
   unless the user has told you otherwise. Most teams gate integration on review
   and CI; respect that. Use the project's normal PR workflow (e.g. `gh pr
   create`).
-- Raise `weaver set-status attention "ready for review"` (the message doubles as
+- Raise `weaver status attention "ready for review"` (the message doubles as
   your concise summary, and file any follow-ups as issues with `weaver issue
   add`) so the user knows to look.
 

--- a/crates/weaver-core/src/agent.rs
+++ b/crates/weaver-core/src/agent.rs
@@ -83,7 +83,7 @@ mod tests {
         assert!(v["hookSpecificOutput"]["additionalContext"]
             .as_str()
             .unwrap()
-            .contains("weaver set-status"));
+            .contains("weaver status"));
     }
 
     #[test]

--- a/crates/weaver-core/src/branch.rs
+++ b/crates/weaver-core/src/branch.rs
@@ -16,7 +16,7 @@ pub struct Branch {
     pub base_branch: String,
     pub goal: String,
     pub title: String,
-    /// The agent's current-state message, set via `weaver set-status`. Free-form
+    /// The agent's current-state message, set via `weaver status`. Free-form
     /// ("Wired up routes; tests pass"), shown even when the branch is calm. The
     /// attention *level* is a separate [`crate::tags`] tag.
     pub description: String,

--- a/crates/weaver-core/src/tags.rs
+++ b/crates/weaver-core/src/tags.rs
@@ -43,7 +43,7 @@ pub struct Tag {
 // ---------------------------------------------------------------------------
 
 /// The agent's self-reported attention level — "does this need me?". Authored by
-/// the agent via `weaver set-status`. Loud (raises a badge).
+/// the agent via `weaver status`. Loud (raises a badge).
 pub const ATTENTION_KEY: &str = "attention";
 
 /// An overlooker's (or `manual`) outside assessment of a branch — a second axis

--- a/crates/weaver-py/tests/test_live_roundtrip.py
+++ b/crates/weaver-py/tests/test_live_roundtrip.py
@@ -86,7 +86,7 @@ def isolated_loom():
         env["WEAVER_API"] = f"http://{addr}"
 
         proc = subprocess.Popen(
-            [binary, "serve", "--addr", addr],
+            [binary, "server", "run", "--addr", addr],
             env=env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -98,7 +98,7 @@ def isolated_loom():
             up = False
             while time.time() < deadline:
                 if proc.poll() is not None:
-                    raise RuntimeError("loom serve exited during startup")
+                    raise RuntimeError("loom server run exited during startup")
                 try:
                     with socket.create_connection(("127.0.0.1", port), timeout=0.5):
                         up = True
@@ -106,7 +106,7 @@ def isolated_loom():
                 except OSError:
                     time.sleep(0.1)
             if not up:
-                raise RuntimeError("loom serve never came up")
+                raise RuntimeError("loom server run never came up")
             # Give the HTTP stack a beat past the TCP accept.
             time.sleep(0.3)
             yield base

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -1395,7 +1395,7 @@ async fn cmd_config(cmd: ConfigCmd) -> Result<()> {
         }
         ConfigCmd::Rm { key } => {
             config::apply(&db, &[(key.clone(), None)]).await?;
-            println!("unset {key}");
+            println!("removed {key}");
         }
     }
     Ok(())

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -47,7 +47,7 @@ enum Cmd {
     /// for review", a question) and `blocked` when stuck and needing help; `ok`
     /// covers both progressing normally and being blocked on something external
     /// (a CI run, a PR review) that is not the user.
-    SetStatus {
+    Status {
         /// Attention level: `ok`, `attention`, or `blocked`. Omit to read.
         level: Option<String>,
         /// Current-state message, e.g. "Wired up routes; tests pass".
@@ -57,10 +57,10 @@ enum Cmd {
     ///
     /// A tag is a single-valued `(key, value)` annotation on a branch with a
     /// one-line note and an author. The well-known loud keys are `attention`
-    /// (the agent's own signal, normally written by `set-status`) and `triage`
+    /// (the agent's own signal, normally written by `weaver status`) and `triage`
     /// (an overlooker's outside assessment); both accept `attention` or
     /// `blocked`. Any other key is free-form and quiet. Daemon-less, like
-    /// `set-status`.
+    /// `weaver status`.
     Tag {
         #[command(subcommand)]
         cmd: TagCmd,
@@ -105,6 +105,7 @@ enum Cmd {
     },
     /// Record an agent hook event. Writes an `events` row; loom's monitor
     /// consumes it on its next tick.
+    #[command(hide = true)]
     Hook {
         /// Hook event name (e.g. `working`, `waiting`, `idle`, `session-start`).
         #[arg(long)]
@@ -174,12 +175,22 @@ enum IssueCmd {
     Reopen { id: i64 },
     /// Delete an issue.
     Rm { id: i64 },
-    /// Label an issue: set (insert or replace) a free-form `(key, value)` tag.
+    /// Label an issue with free-form `(key, value)` tags: set, rm, or ls.
     ///
     /// Issue tags are quiet annotations (priority, area, kind, …) rendered as
     /// pills in the loom Issues pane — there is no loud `attention`/`triage`
-    /// ladder. The value must be non-empty; clear a label with `issue untag`.
+    /// ladder.
     Tag {
+        #[command(subcommand)]
+        cmd: IssueTagCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum IssueTagCmd {
+    /// Set (insert or replace) a tag on an issue. The value must be non-empty;
+    /// clear a label with `weaver issue tag rm`.
+    Set {
         id: i64,
         /// The tag key, e.g. `priority` or `area`.
         key: String,
@@ -193,7 +204,9 @@ enum IssueCmd {
         by: String,
     },
     /// Clear an issue label — delete the `(key)` tag.
-    Untag { id: i64, key: String },
+    Rm { id: i64, key: String },
+    /// List an issue's tags.
+    Ls { id: i64 },
 }
 
 #[derive(Subcommand)]
@@ -250,10 +263,14 @@ enum ArtifactCmd {
 
 #[derive(Subcommand)]
 enum ConfigCmd {
+    /// Print one setting's value.
     Get { key: String },
+    /// Set a setting.
     Set { key: String, value: String },
-    Unset { key: String },
-    List,
+    /// Clear a setting, restoring its default.
+    Rm { key: String },
+    /// List every setting and its value.
+    Ls,
 }
 
 #[derive(Subcommand)]
@@ -306,7 +323,7 @@ async fn run() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
         Cmd::Goal { cmd } => cmd_goal(cmd).await,
-        Cmd::SetStatus { level, message } => cmd_set_status(level, message.join(" ")).await,
+        Cmd::Status { level, message } => cmd_status(level, message.join(" ")).await,
         Cmd::Tag { cmd } => cmd_tag(cmd).await,
         Cmd::Summary => cmd_summary().await,
         Cmd::Readme => cmd_readme().await,
@@ -385,7 +402,7 @@ const SUMMARY_TASK_CAP: usize = 10;
 /// status, the outstanding tasks, and a hint or two for what to do next.
 ///
 /// This is the catch-up an agent reads when it picks up a branch. Everything is
-/// pulled straight from the database — no LLM, no daemon. It overlaps `set-status`
+/// pulled straight from the database — no LLM, no daemon. It overlaps `weaver status`
 /// (read), but where that shows an open-issue *count*, summary lists the actual
 /// tasks and points at the next action.
 async fn cmd_summary() -> Result<()> {
@@ -419,7 +436,7 @@ async fn render_summary(db: &db::Db, b: &branch::Branch) -> Result<String> {
     } else {
         format!("{attention} — {}", b.description)
     };
-    let _ = writeln!(out, "Status:  {status}  (weaver set-status)");
+    let _ = writeln!(out, "Status:  {status}  (weaver status)");
 
     // Artifacts visible from this branch (its own + repo-shared) — the documents
     // the agent has written to weaver (designs, reports, the `plan`).
@@ -480,7 +497,7 @@ async fn render_summary(db: &db::Db, b: &branch::Branch) -> Result<String> {
     // The current status (where work was left off) is already on the `Status:`
     // line above, sourced from the status-description trail.
     out.push('\n');
-    let _ = writeln!(out, "Next steps:  (weaver log · weaver set-status)");
+    let _ = writeln!(out, "Next steps:  (weaver log · weaver status)");
     let _ = writeln!(out, "  - {}", next_action_hint(&open, &delegated));
     Ok(out)
 }
@@ -563,11 +580,11 @@ async fn cmd_log(limit: i64) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_set_status(level: Option<String>, message: String) -> Result<()> {
+async fn cmd_status(level: Option<String>, message: String) -> Result<()> {
     let db = open_db().await?;
     let b = branch::resolve(&db).await?;
     if let Some(level) = level {
-        return cmd_set_status_write(&db, &b, &level, &message).await;
+        return cmd_status_write(&db, &b, &level, &message).await;
     }
     let open = issue::open_count_for_branch(&db, &b.repo_root, &b.branch)
         .await
@@ -595,7 +612,7 @@ async fn cmd_set_status(level: Option<String>, message: String) -> Result<()> {
 
 /// The attention value that means "calm" — the default when a branch has no
 /// `attention` tag. Never stored (absence is calm); it is both the resolved
-/// value the status reads fall back to and the `set-status` input that clears
+/// value the status reads fall back to and the `weaver status` input that clears
 /// the tag.
 const CALM: &str = "ok";
 
@@ -616,9 +633,9 @@ async fn resolve_attention(db: &db::Db, branch_id: &str) -> Result<String> {
 /// state), `attention`/`blocked` set it. Writes the description directly
 /// (daemon-less) and records a `tag` event so a running loom can push the change
 /// to the dashboard on its next tick. An empty message leaves the previous
-/// message in place — `set-status ok` just lowers the level without wiping what
+/// message in place — `weaver status ok` just lowers the level without wiping what
 /// the agent last said.
-async fn cmd_set_status_write(
+async fn cmd_status_write(
     db: &db::Db,
     b: &branch::Branch,
     level: &str,
@@ -864,14 +881,22 @@ async fn cmd_issue(cmd: IssueCmd) -> Result<()> {
             issue::delete(&db, id).await?;
             println!("removed #{id}");
         }
-        IssueCmd::Tag {
+        IssueCmd::Tag { cmd } => cmd_issue_tag(&db, &b.repo_root, cmd).await?,
+    }
+    Ok(())
+}
+
+/// Set, clear, or list a free-form tag on an issue (`weaver issue tag …`).
+async fn cmd_issue_tag(db: &db::Db, repo_root: &str, cmd: IssueTagCmd) -> Result<()> {
+    match cmd {
+        IssueTagCmd::Set {
             id,
             key,
             value,
             note,
             by,
         } => {
-            ensure_issue_in_repo(&db, id, &b.repo_root).await?;
+            ensure_issue_in_repo(db, id, repo_root).await?;
             let key = key.trim();
             let value = value.trim();
             let note = note.trim();
@@ -881,20 +906,36 @@ async fn cmd_issue(cmd: IssueCmd) -> Result<()> {
             }
             if value.is_empty() {
                 bail!(
-                    "a tag value cannot be empty — use `weaver issue untag {id} {key}` to clear it"
+                    "a tag value cannot be empty — use `weaver issue tag rm {id} {key}` to clear it"
                 );
             }
-            issue::set_tag(&db, id, key, value, note, by).await?;
+            issue::set_tag(db, id, key, value, note, by).await?;
             if note.is_empty() {
                 println!("tag: #{id} → {key} = {value} (by {by})");
             } else {
                 println!("tag: #{id} → {key} = {value} (by {by}) — {note}");
             }
         }
-        IssueCmd::Untag { id, key } => {
-            ensure_issue_in_repo(&db, id, &b.repo_root).await?;
-            issue::clear_tag(&db, id, key.trim()).await?;
+        IssueTagCmd::Rm { id, key } => {
+            ensure_issue_in_repo(db, id, repo_root).await?;
+            issue::clear_tag(db, id, key.trim()).await?;
             println!("tag: #{id} → cleared {}", key.trim());
+        }
+        IssueTagCmd::Ls { id } => {
+            ensure_issue_in_repo(db, id, repo_root).await?;
+            let tags = issue::list_tags(db, id).await?;
+            if tags.is_empty() {
+                println!("(no tags)");
+                return Ok(());
+            }
+            for t in &tags {
+                let note = if t.note.is_empty() {
+                    String::new()
+                } else {
+                    format!("  — {}", t.note)
+                };
+                println!("{} = {}{note}", t.key, t.value);
+            }
         }
     }
     Ok(())
@@ -1276,7 +1317,7 @@ fn read_hook_source() -> Option<String> {
 fn compact_replay(b: &branch::Branch, summary: &str) -> String {
     let summary = summary.trim_end();
     format!(
-        "Context was just compacted — you are still in a **weaver session** on branch `{branch}` (a detached agent workstream in a git worktree; the user reviews asynchronously via the loom dashboard, not this terminal). Re-orientation:\n\n{summary}\n\nReminders: keep your status honest with `weaver set-status <ok|attention|blocked> \"<message>\"`; never block on an interactive TUI prompt — state the question as plain text and raise `weaver set-status attention`; finish by opening a PR (`gh pr create`) rather than merging, and `weaver issue close <id>` your tracking issue when the work is done. Run `weaver readme` for the full weaver workflow guide.\n",
+        "Context was just compacted — you are still in a **weaver session** on branch `{branch}` (a detached agent workstream in a git worktree; the user reviews asynchronously via the loom dashboard, not this terminal). Re-orientation:\n\n{summary}\n\nReminders: keep your status honest with `weaver status <ok|attention|blocked> \"<message>\"`; never block on an interactive TUI prompt — state the question as plain text and raise `weaver status attention`; finish by opening a PR (`gh pr create`) rather than merging, and `weaver issue close <id>` your tracking issue when the work is done. Run `weaver readme` for the full weaver workflow guide.\n",
         branch = b.branch,
     )
 }
@@ -1328,7 +1369,7 @@ async fn cmd_hook(event: String) -> Result<()> {
 async fn cmd_config(cmd: ConfigCmd) -> Result<()> {
     let db = open_db().await?;
     match cmd {
-        ConfigCmd::List => {
+        ConfigCmd::Ls => {
             let settings = config::describe(&db).await?;
             for s in &settings {
                 let suffix = if s.is_default { "  (default)" } else { "" };
@@ -1339,7 +1380,7 @@ async fn cmd_config(cmd: ConfigCmd) -> Result<()> {
             let settings = config::describe(&db).await?;
             match settings.iter().find(|s| s.spec.key == key) {
                 Some(s) => println!("{}", s.value),
-                None => bail!("no setting '{key}' — see `weaver config list`"),
+                None => bail!("no setting '{key}' — see `weaver config ls`"),
             }
         }
         ConfigCmd::Set { key, value } => {
@@ -1352,7 +1393,7 @@ async fn cmd_config(cmd: ConfigCmd) -> Result<()> {
             config::apply(&db, &[(key.clone(), Some(value))]).await?;
             println!("set {key}");
         }
-        ConfigCmd::Unset { key } => {
+        ConfigCmd::Rm { key } => {
             config::apply(&db, &[(key.clone(), None)]).await?;
             println!("unset {key}");
         }

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -125,24 +125,24 @@ fn issue_lifecycle() {
     assert!(!out.contains("fix the thing"));
 }
 
-/// `issue tag` sets a free-form label, `issue show` surfaces it, and `issue
-/// untag` clears it.
+/// `issue tag set` sets a free-form label, `issue show` surfaces it, and
+/// `issue tag rm` clears it.
 #[test]
 fn issue_tag_set_show_clear() {
     let env = setup();
     run(&env, &["issue", "add", "label", "me"]);
 
-    run(&env, &["issue", "tag", "1", "priority", "high"]);
+    run(&env, &["issue", "tag", "set", "1", "priority", "high"]);
     let out = run(&env, &["issue", "show", "1"]);
     assert!(out.contains("priority=high"), "show output: {out}");
 
     // A second set overwrites the value in place (single-valued per key).
-    run(&env, &["issue", "tag", "1", "priority", "low"]);
+    run(&env, &["issue", "tag", "set", "1", "priority", "low"]);
     let out = run(&env, &["issue", "show", "1"]);
     assert!(out.contains("priority=low"), "show output: {out}");
     assert!(!out.contains("priority=high"));
 
-    run(&env, &["issue", "untag", "1", "priority"]);
+    run(&env, &["issue", "tag", "rm", "1", "priority"]);
     let out = run(&env, &["issue", "show", "1"]);
     assert!(!out.contains("priority="), "tag should be cleared: {out}");
 }
@@ -170,7 +170,7 @@ fn issue_ls_separates_branch_work_from_repo_backlog() {
     );
 
     // The badge counts only this branch's claimed work, not the backlog.
-    let out = run(&env, &["set-status"]);
+    let out = run(&env, &["status"]);
     assert!(out.contains("open issues: 1"), "status: {out}");
 }
 
@@ -181,7 +181,7 @@ fn issue_show_includes_the_working_branch_status() {
     let env = setup();
     run(&env, &["issue", "add", "the", "sub-task"]);
     // The current branch claims it; give the branch a live status.
-    run(&env, &["set-status", "blocked", "build", "is", "broken"]);
+    run(&env, &["status", "blocked", "build", "is", "broken"]);
     let out = run(&env, &["issue", "show", "1"]);
     assert!(
         out.contains("working:"),
@@ -317,7 +317,7 @@ fn summary_orients_an_agent_on_the_branch() {
     run(&env, &["goal", "set", "ship", "the", "feature"]);
     run(&env, &["issue", "add", "wire", "up", "routes"]);
     run(&env, &["issue", "add", "add", "tests"]);
-    run(&env, &["set-status", "ok", "routes", "wired"]);
+    run(&env, &["status", "ok", "routes", "wired"]);
 
     let out = run(&env, &["summary"]);
     assert!(out.contains("ship the feature"), "summary: {out}");
@@ -332,7 +332,7 @@ fn summary_orients_an_agent_on_the_branch() {
     // Every section advertises the command that drills into it.
     for hint in [
         "(weaver goal)",
-        "(weaver set-status)",
+        "(weaver status)",
         "(weaver issue ls)",
         "weaver artifact",
         "weaver log",
@@ -492,7 +492,7 @@ fn readme_prints_the_full_weaver_guide() {
         "readme should print the WEAVER.md guide: {out}"
     );
     assert!(
-        out.contains("weaver set-status"),
+        out.contains("weaver status"),
         "readme should describe the weaver CLI: {out}"
     );
 }
@@ -527,7 +527,7 @@ fn session_start_hook_after_compaction_replays_the_concise_summary() {
     let env = setup();
     run(&env, &["goal", "set", "ship", "the", "feature"]);
     run(&env, &["issue", "add", "wire", "up", "routes"]);
-    run(&env, &["set-status", "ok", "routes", "wired"]);
+    run(&env, &["status", "ok", "routes", "wired"]);
 
     let payload = r#"{"hook_event_name":"SessionStart","source":"compact"}"#;
     let out = run_with_stdin(&env, &["hook", "--event", "session-start"], payload);
@@ -577,7 +577,7 @@ fn set_status_with_no_id_reports_current_branch() {
     let env = setup();
     run(&env, &["goal", "set", "do", "the", "thing"]);
     run(&env, &["issue", "add", "step", "one"]);
-    let out = run(&env, &["set-status"]);
+    let out = run(&env, &["status"]);
     assert!(out.contains("branch:      feature-test"), "status: {out}");
     assert!(out.contains("goal:        do the thing"), "status: {out}");
     assert!(out.contains("open issues: 1"), "status: {out}");
@@ -591,29 +591,22 @@ fn set_status_sets_level_and_message() {
     // Declare a level with a message, then read it back.
     let out = run(
         &env,
-        &[
-            "set-status",
-            "attention",
-            "Waiting",
-            "for",
-            "PR",
-            "feedback",
-        ],
+        &["status", "attention", "Waiting", "for", "PR", "feedback"],
     );
     assert!(
         out.contains("attention — Waiting for PR feedback"),
         "set output: {out}"
     );
 
-    let out = run(&env, &["set-status"]);
+    let out = run(&env, &["status"]);
     assert!(
         out.contains("status:      attention — Waiting for PR feedback"),
         "status read: {out}"
     );
 
     // A new message replaces the old one.
-    run(&env, &["set-status", "ok", "back", "to", "work"]);
-    let out = run(&env, &["set-status"]);
+    run(&env, &["status", "ok", "back", "to", "work"]);
+    let out = run(&env, &["status"]);
     assert!(
         out.contains("status:      ok — back to work"),
         "status read: {out}"
@@ -621,8 +614,8 @@ fn set_status_sets_level_and_message() {
 
     // A bare level change keeps the last message (the message is the persistent
     // current-state note; only the level is volatile).
-    run(&env, &["set-status", "blocked"]);
-    let out = run(&env, &["set-status"]);
+    run(&env, &["status", "blocked"]);
+    let out = run(&env, &["status"]);
     assert!(
         out.contains("status:      blocked — back to work"),
         "message should persist across a bare level change: {out}"
@@ -644,7 +637,7 @@ fn set_status_sets_level_and_message() {
 fn triage_tag_marks_a_session_without_touching_attention() {
     let env = setup();
     // The agent declares its own attention about itself.
-    run(&env, &["set-status", "blocked", "build", "broke"]);
+    run(&env, &["status", "blocked", "build", "broke"]);
 
     // No triage tag until an overlooker looks.
     let out = run(&env, &["tag", "ls", "--session", "feature-test"]);
@@ -684,7 +677,7 @@ fn triage_tag_marks_a_session_without_touching_attention() {
         out.contains("attention = blocked"),
         "agent attention must survive a triage write: {out}"
     );
-    let out = run(&env, &["set-status"]);
+    let out = run(&env, &["status"]);
     assert!(
         out.contains("status:      blocked — build broke"),
         "the resolved status reads the agent's attention tag: {out}"
@@ -708,7 +701,7 @@ fn triage_tag_marks_a_session_without_touching_attention() {
 }
 
 /// A loud key (`attention`/`triage`) rejects a value off the attention ladder
-/// with a non-zero exit, like `set-status`.
+/// with a non-zero exit, like `status`.
 #[test]
 fn tag_set_rejects_invalid_loud_value() {
     let env = setup();
@@ -773,27 +766,27 @@ fn tag_set_ls_rm_roundtrip() {
     assert!(out.contains("(no tags)"), "tag rm cleared it: {out}");
 }
 
-/// `set-status ok` clears the agent's `attention` tag (returns to calm) while
+/// `status ok` clears the agent's `attention` tag (returns to calm) while
 /// leaving the branch `description` in place.
 #[test]
 fn set_status_ok_clears_attention_tag_but_keeps_description() {
     let env = setup();
     // Raise attention with a message.
-    run(&env, &["set-status", "attention", "ready", "for", "review"]);
+    run(&env, &["status", "attention", "ready", "for", "review"]);
     let out = run(&env, &["tag", "ls"]);
     assert!(
         out.contains("attention = attention"),
-        "set-status should write the attention tag: {out}"
+        "status should write the attention tag: {out}"
     );
 
     // Return to calm — the attention tag is cleared, the description survives.
-    run(&env, &["set-status", "ok"]);
+    run(&env, &["status", "ok"]);
     let out = run(&env, &["tag", "ls"]);
     assert!(
         !out.contains("attention ="),
-        "set-status ok should clear the attention tag: {out}"
+        "status ok should clear the attention tag: {out}"
     );
-    let out = run(&env, &["set-status"]);
+    let out = run(&env, &["status"]);
     assert!(
         out.contains("status:      ok — ready for review"),
         "ok must keep the last description beside the calm level: {out}"
@@ -804,7 +797,7 @@ fn set_status_ok_clears_attention_tag_but_keeps_description() {
 fn set_status_rejects_unknown_level() {
     let env = setup();
     let out = Command::new(weaver_bin())
-        .args(["set-status", "bogus"])
+        .args(["status", "bogus"])
         .current_dir(&env.repo_path)
         .env("WEAVER_HOME", &env.home_path)
         .env("WEAVER_API", "http://127.0.0.1:1")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ weaver ships **two binaries** over a **shared sqlite database**:
 ```
 weaver CLI ──sqlite──┐
                      ├─ ~/.weaver/weaver.db   (shared, WAL)
-loom serve  ─────────┘    │
+loom server run ────┘    │
   │                       │
   ├─ axum REST + SSE      │
   ├─ terminal + git wrap. │
@@ -45,7 +45,7 @@ needing the daemon to be reachable.
 |---|---|
 | `crates/weaver-core/` | lib: `branches`, `issues`, `events`, `db`, `migrations` (ordered SQL + `schema_migrations` indicator), `git`, `config`, `artifacts` (versioned documents), `repo_config` (`.weaver/config.toml`), agent helpers. Pure logic; used by both binaries. |
 | `crates/smartdoc/` | the markdown-convention layer: parse references (`#N`, `artifact:<name>`), project live status into the render. Dependency-free of weaver. See [artifacts.md](artifacts.md). |
-| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `readme`, `set-status` [read or set level + message], `tag` [`set`/`rm`/`ls` a branch tag], `issue …`, `where`, `log`, `hook`, `config`) |
+| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `readme`, `status` [read or set level + message], `tag` [`set`/`rm`/`ls` a branch tag], `issue …`, `where`, `log`, `hook`, `config`) |
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** (incl. the auth middleware + login/token/user handlers) |
 | `crates/loom/src/auth.rs` | authentication core: token/password crypto, the `users`/`api_tokens`/`auth_sessions` tables, the machine-local token, and the GitHub OAuth calls. `axum`-free so it unit-tests directly |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
@@ -60,11 +60,11 @@ needing the daemon to be reachable.
 | `crates/loom/src/terminal.rs` | WebSocket ⇄ live-terminal bridge: xterm.js ⇄ the tapestry session socket |
 | `crates/loom/src/github.rs` | `gh` CLI shell-out: issue seeding, PR opening, and the PR-status poll loop (snapshots each branch's PR; archives on merge) |
 | `crates/loom/src/client.rs` | HTTP client used by the `loom` CLI to talk to its own daemon |
-| `crates/loom/src/bin/loom.rs` | the orchestrator CLI (`serve`, `launch`, `ps`, `attach`, …) |
+| `crates/loom/src/bin/loom.rs` | the orchestrator CLI (`server`, `session`, `ps`, `attach`, …) |
 | `crates/loom/frontend/` | Vue 3 SPA, rspack, Tailwind. `api.ts` + views in `views/`; the visual rules live in [loom-ui.md](loom-ui.md) |
 | `crates/loom/static/dist/` | Build output (placeholder; real build overwrites) |
 | `crates/loom/tests/` | integration tests: `integration/` (server suites) + `hook_monitor.rs`; need `git` (they spawn `tapestry` supervisors, built by the same `cargo test`) |
-| `e2e/` | Playwright; talks to a real `loom serve`. Separate `package.json` |
+| `e2e/` | Playwright; talks to a real `loom server run`. Separate `package.json` |
 | `crates/loom/build.rs` | Builds the SPA into `static/dist` (npm + rspack); writes a placeholder when Node is unavailable |
 
 ## Build internals
@@ -111,7 +111,7 @@ commit --no-verify`.
 ### End-to-end (Playwright)
 
 The `e2e/` suite drives the real UI against a real server. It boots **one**
-`loom serve` per Playwright *worker* (not per test) on a random port, each with
+`loom server run` per Playwright *worker* (not per test) on a random port, each with
 its own `WEAVER_HOME` / sqlite db (which also scopes the `tapestry` terminal
 sockets) and a throwaway git repo (see `e2e/fixtures/weaver.ts`),
 using the deterministic `shell` agent. The per-test `weaver` fixture wipes every
@@ -244,7 +244,7 @@ Status is two orthogonal axes. The session's `status` is the **lifecycle**
 `orphaned` / `done` / `error`. The branch's **`attention` tag** (value
 `attention` | `blocked`, absent ⇒ calm) plus its `description` (a one-line
 current-state message) are the **agent-declared** "does this need me?" signal,
-both set via `weaver set-status`. The dashboard resolves and filters on the
+both set via `weaver status`. The dashboard resolves and filters on the
 attention signal.
 
 There is **no** `/api/hook` endpoint — see [Status & tags](#status--tags).
@@ -289,8 +289,8 @@ uniformly. Each requires a live terminal (else 409). The CLI's `loom session
   change and a fresh `EventBus` notification.
 - **No tracking-branch state in the server:** loom can be killed and restarted
   at any time. Terminal supervisors and worktrees survive (the supervisor is a
-  detached process, independent of `loom serve`); "orphaned" is a first-class
-  status, recovered via `loom adopt` (or the Adopt button in the UI).
+  detached process, independent of `loom server run`); "orphaned" is a first-class
+  status, recovered via `loom session adopt` (or the Adopt button in the UI).
 
 ## Status & tags
 
@@ -337,10 +337,10 @@ the tag untouched, so a finished-but-fine agent isn't mistaken for one that
 needs you.
 
 The **`attention` tag** is otherwise the agent's own call, set via `weaver
-set-status <level> ["<message>"]`. That writes the tag (and, when a message is
+status <level> ["<message>"]`. That writes the tag (and, when a message is
 given, the `description`) directly (daemon-less) — `ok` clears the tag, the two
 loud levels upsert it — and records a `tag` event the monitor re-broadcasts over
-SSE. A bare `weaver set-status <level>` changes only the level and keeps the last
+SSE. A bare `weaver status <level>` changes only the level and keeps the last
 message. Last write wins, so an explicit declaration overrides the hook-inferred
 default. The general `weaver tag set|rm|ls` group writes any key the same way;
 the `PUT`/`DELETE /api/sessions/{id}/tags/{key}` routes do it over HTTP for the

--- a/docs/plans/overlooker.md
+++ b/docs/plans/overlooker.md
@@ -37,7 +37,7 @@ parent first and hand it the children. The common reality is the opposite:
 So the missing primitive is a **retroactive, scheduled, fleet-wide watcher**: a
 thing that wakes on a trigger — a clock tick, or a session event — surveys
 whatever sessions exist *right now*, applies judgement, and acts: marks a
-session as fine, tags one that looks stuck, nudges a third, escalates to you. 
+session as fine, tags one that looks stuck, nudges a third, escalates a fourth to you.
 It is not tied to any one workstream. It is infrastructure that watches
 the workstreams.
 
@@ -442,7 +442,7 @@ early. The equivalent **custom** form is the Python program shown
 
 The agent-authored path: you ask a session "make me an overlooker that watches
 for sessions stuck retrying a test"; it runs `loom overlooker new test-watch`,
-explores with `loom session preview`, writes the rule, `loom overlooker run test-watch --dry-run` 
+explores with `loom session preview`, writes the rule, `loom overlooker run test-watch --dry-run`
 until the would-do output looks right, then registers it with `nudge` enabled.
 
 ## Tasks

--- a/docs/plans/overlooker.md
+++ b/docs/plans/overlooker.md
@@ -37,8 +37,8 @@ parent first and hand it the children. The common reality is the opposite:
 So the missing primitive is a **retroactive, scheduled, fleet-wide watcher**: a
 thing that wakes on a trigger — a clock tick, or a session event — surveys
 whatever sessions exist *right now*, applies judgement, and acts: marks a
-session as fine, tags one that looks stuck, nudges a third, escalates a fourth
-to you. It is not tied to any one workstream. It is infrastructure that watches
+session as fine, tags one that looks stuck, nudges a third, escalates to you. 
+It is not tied to any one workstream. It is infrastructure that watches
 the workstreams.
 
 ## What the field does (and what to steal)
@@ -209,7 +209,7 @@ shared crate:
 logic" true for everything outside the daemon **without** a second tmux owner,
 and it removes the `web.rs` ↔ `types.ts` drift on the Rust side as a bonus. The
 `weaver` agent CLI stays DB-direct for the daemon-less writes it already does
-(`set-status`, which writes the `attention` tag, and the general `weaver tag`
+(`status`, which writes the `attention` tag, and the general `weaver tag`
 group), exactly as the `attention` tag works.
 
 ## Execution: one program, one API
@@ -379,7 +379,7 @@ through the same `weaver-api` the out-of-process programs use.
 **CLI — `weaver` (DB-direct, the agent/program side):**
 
 - `weaver tag set triage <level> --note "<note>" --session <s>` — write the
-  mark, daemon-less, like `set-status`. The binding and any agent both call it;
+  mark, daemon-less, like `status`. The binding and any agent both call it;
   `weaver tag rm triage --session <s>` returns it to calm.
 
 **CLI — `loom overlooker` (the operator + authoring side):**
@@ -387,7 +387,7 @@ through the same `weaver-api` the out-of-process programs use.
 - `loom overlooker new <name>` — scaffold a program file.
 - `loom overlooker add|rm|enable|disable <name>` — register / manage.
 - `loom overlooker run <name> [--dry-run]` — fire now / simulate.
-- `loom overlooker ls | runs <name> | logs <name>`; `loom attach` a warm one.
+- `loom overlooker ls`, `loom overlooker runs <name>`, `loom overlooker logs <name>`; `loom attach` a warm one.
 
 **API — `loom` (`web.rs`, DTOs now in `weaver-api`):**
 
@@ -442,9 +442,8 @@ early. The equivalent **custom** form is the Python program shown
 
 The agent-authored path: you ask a session "make me an overlooker that watches
 for sessions stuck retrying a test"; it runs `loom overlooker new test-watch`,
-explores with `loom session preview`, writes the rule, `loom overlooker run
-test-watch --dry-run` until the would-do output looks right, then registers it
-with `nudge` enabled.
+explores with `loom session preview`, writes the rule, `loom overlooker run test-watch --dry-run` 
+until the would-do output looks right, then registers it with `nudge` enabled.
 
 ## Tasks
 

--- a/docs/structured-projects.md
+++ b/docs/structured-projects.md
@@ -88,7 +88,7 @@ agent implement it." Three reference points, then the lessons.
 | Tool | Artifacts | Tasks live in | Sync model | Where it hurts |
 |---|---|---|---|---|
 | **Kiro** (AWS) | `requirements.md` (user stories + EARS criteria), `design.md` (arch + sequence diagrams), `tasks.md` | `tasks.md`, traceable to requirement numbers; dependency "waves" run sequentially, concurrent within a wave | Linear phase gates; no persistent re-anchoring after tasks are cut | **Verbose for small problems** — a one-line bugfix expands into 4 user stories and 16 acceptance criteria |
-| **GitHub Spec Kit** | `specs/<branch>/` folder of 8+ files (`spec`, `plan`, `research`, `data-model`, `contracts/`, `tasks`…), a project "constitution", `[NEEDS CLARIFICATION]` markers | `tasks.md`, `[P]`-marked for parallel-safe, grouped by user story | `/specify`→`/plan`→`/tasks`→`/implement`; no defined re-sync after tasks generated | **Review overload** — verbose, repetitive with the code, agent ignores or over-follows |
+| **GitHub Spec Kit** | `specs/<branch>/` folder of 8+ files (`spec`, `plan`, `research`, `data-model`, `contracts/`, `tasks`…), a project "constitution", `[NEEDS CLARIFICATION]` markers | `tasks.md`, `[P]`-marked for parallel-safe, grouped by user story | `/specify` → `/plan` → `/tasks` → `/implement`; no defined re-sync after tasks generated | **Review overload** — verbose, repetitive with the code, agent ignores or over-follows |
 | **Tessl** | one `*.spec.md` per code file; `@generate`/`@test` tags; generated code stamped `DO NOT EDIT` | implicit in the spec | **Bidirectional** — `tessl build` regenerates code from spec | Model-Driven-Development risk: **inflexibility *and* non-determinism** |
 
 Sources: Martin Fowler's [three-tool comparison](https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html),
@@ -241,7 +241,7 @@ This is the missing front-end for the fan-out that
 [repo-scoped issues](repo-scoped-issues.md) was explicitly designed to enable —
 "create N issues up front, then launch one session per issue." Today a human
 hand-writes those N issues; the plan *generates* them from the design, keeps
-them linked, and gives the board something to group by. `loom session launch --claim N`
+them linked, and gives the board something to group by. `loom session launch --claim <n>`
 already turns an issue into a session and stamps `claimed_branch`; nothing in
 that path changes. The plan just sits one level above it as the index and the
 source of the breakdown.
@@ -273,7 +273,7 @@ The diff, by task ID:
 That last-two-rows nuance is the durable-HITL lesson made concrete: **in-flight
 work is preserved across a design change and surfaced for a human decision,
 never silently rewritten or dropped.** It is also pure weaver idiom — explicit,
-daemon-less, last-write-wins, agent-driven, exactly like `set-status`. No file
+daemon-less, last-write-wins, agent-driven, exactly like `status`. No file
 watcher, no continuous bidirectional codegen (that's the Tessl trap). The user
 edits the file, hits **Reconcile** in the dashboard (or the agent runs
 `weaver plan sync` after a design conversation), reviews the proposed delta, and
@@ -289,7 +289,7 @@ just a normal session whose deliverable is the plan file.** You
 (rendered, with diagrams) and iterates — asynchronously, the way they already
 review everything. Because the agent never blocks on a TUI prompt (per
 [WEAVER.md](../crates/weaver-core/WEAVER.md)), the loop is: agent drafts → sets
-`attention "plan ready for review"` → user edits the file or comments → agent
+`status attention "plan ready for review"` → user edits the file or comments → agent
 reconciles → repeat. When the plan is blessed, `weaver plan sync` materializes
 the issues and the human launches the fan-out, one session per high-value task.
 The plan file then keeps living as the project's design doc and its status map.

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -28,7 +28,7 @@ export interface Branch {
   name: string;
   title: string;
   goal: string;
-  /** Current-state message, set with the `attention` tag via `weaver set-status`. */
+  /** Current-state message, set with the `attention` tag via `weaver status`. */
   description: string;
   /** Every tag on the branch (the agent's `attention`, an overlooker's
    *  `triage`, any free-form key). Empty when calm — absence is the default. */
@@ -133,7 +133,7 @@ export interface WeaverFixture {
   listSessions(): Promise<Session[]>;
   /** Flip a session's status by writing a hook event row via `weaver hook`. */
   hook(session: Session, event: 'working' | 'waiting' | 'idle'): Promise<void>;
-  /** Declare the agent's status (level + message) via `weaver set-status`. It
+  /** Declare the agent's status (level + message) via `weaver status`. It
    *  writes the branch's `attention` tag (clearing it on `ok`) and the
    *  current-state message, recording a `tag` event the monitor re-broadcasts. */
   setStatus(
@@ -283,7 +283,7 @@ interface WorkerFixtures {
 
 export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
   // One loom server per worker, reused across all of that worker's tests. Booting
-  // a server (build a throwaway repo, spawn `loom serve`) is the expensive part;
+  // a server (build a throwaway repo, spawn `loom server run`) is the expensive part;
   // the per-test `weaver` fixture below just wipes sessions between tests so each
   // starts from a clean slate. Workers are fully isolated (own WEAVER_HOME/db and
   // port — the home also scopes the tapestry terminal sockets), so they run in
@@ -312,7 +312,7 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
       };
 
       // Bind to a random free port (0) and parse the actual port from stdout.
-      const server: ChildProcess = spawn(LOOM_BINARY, ['serve', '--addr', '127.0.0.1:0'], {
+      const server: ChildProcess = spawn(LOOM_BINARY, ['server', 'run', '--addr', '127.0.0.1:0'], {
         env: childEnv,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
@@ -491,10 +491,10 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
       },
 
       async setStatus(session, level, message) {
-        // `weaver set-status <level> [message]` writes the branch's `attention`
+        // `weaver status <level> [message]` writes the branch's `attention`
         // tag (clearing it on `ok`) and the current-state message, recording a
         // `tag` event the monitor re-broadcasts.
-        const args = ['set-status', level, ...(message ? [message] : [])];
+        const args = ['status', level, ...(message ? [message] : [])];
         execFileSync(WEAVER_BINARY, args, {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
           stdio: 'pipe',

--- a/e2e/tests/status-hook.spec.ts
+++ b/e2e/tests/status-hook.spec.ts
@@ -22,7 +22,7 @@ test.describe('status reflects hook and attention events', () => {
     ).toHaveAttribute('data-level', 'attention');
   });
 
-  test('detail view: weaver set-status sets level + message via SSE', async ({ page, weaver }) => {
+  test('detail view: weaver status sets level + message via SSE', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Declare my status', name: 'status-detail' });
 
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);


### PR DESCRIPTION
Restructures both CLIs around one consistent scheme — **`<binary> <singular-noun> <verb>`, with `ls`/`rm` as the canonical list/remove verbs across both binaries**. Clean break: no back-compat aliases (per request). Implements the proposal artifact `cli-normalization`.

### loom
- **daemon lifecycle grouped** → `loom server <run|start|stop|restart|status>`. `run` is the foreground form (under a supervisor / for dev); `start` daemonizes it. Answers the "is `serve` duplicative with `start`?" question: they're foreground vs background, now spelled and documented as such.
- **session management moves under `loom session`** — `ps`→`session ls`, plus `show`/`archive`/`adopt`/`rm`. The three daily-drivers (`launch`, `ps`, `attach`) stay as top-level shortcuts.
- `loom issues` → `loom issue ls` (singular noun, matches weaver)
- `loom token create` → `loom token add`
- dropped the undocumented `preview`→`sp` alias

Top-level help drops from 17 flat verbs to 7 nouns + 2 utilities + 3 shortcuts.

### weaver
- `set-status` → **`weaver status`** (bare `status` reads, `status <level> <msg>` sets — the `set-` prefix lied on reads)
- `config list`/`unset` → `config ls`/`rm`
- `issue tag <id> …`/`issue untag` → `issue tag <set|rm|ls>` (symmetric with branch `tag`)
- internal `hook` command hidden from help

### Sweep
Updated the injected `WEAVER.md` primer, the tracking-issue note, README, AGENTS, docs, doc-comments, Rust/e2e/python tests and harnesses. The three immutable sqlx migration `.sql` files keep their original comments (editing them changes their checksums and breaks migration validation on existing DBs).

### Checks
`cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test --workspace --locked` all green locally (loom integration + weaver + weaver-core + py harness). No e2e CI job; the e2e fixture was still updated to the new spellings.