### PR TITLE
feat(loom): launch a session from an issue on the Issues pane

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -61,12 +61,19 @@ export const del = (path: string) => request(path, { method: 'DELETE' });
 
 // --- Issues ----------------------------------------------------------------
 
-import type { Issue, ArtifactMeta, ArtifactView, ArtifactWriteBody } from './types';
+import type { Issue, Session, ArtifactMeta, ArtifactView, ArtifactWriteBody } from './types';
 
 /** Every issue across every repo — the Issues pane's cross-repo board. Pass
  *  `all` to include closed issues. */
 export const listIssues = (all = false) =>
   get(`/issues${all ? '?all=true' : ''}`) as Promise<Issue[]>;
+
+/** Launch a new loom session that picks up (claims) an existing weaver issue:
+ *  the issue's repo is the new session's cwd, and the backend seeds the branch's
+ *  title/goal from the issue and stamps it as the tracking (claimed) issue.
+ *  Returns the created session view, whose `id` deep-links to its detail page. */
+export const launchSessionForIssue = (repoRoot: string, issueId: number) =>
+  post('/sessions', { cwd: repoRoot, claim_issue: issueId }) as Promise<Session>;
 
 /** Create an unclaimed repo-level backlog issue. Tags aren't part of the create
  *  body — apply them as follow-up `setIssueTag` upserts on the returned id. */

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, computed, nextTick, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 import {
   get,
   listIssues,
@@ -8,10 +9,13 @@ import {
   deleteIssue,
   setIssueTag,
   clearIssueTag,
+  launchSessionForIssue,
 } from '../api';
 import type { Issue, Session, Tag } from '../types';
 import TagPill from '../components/TagPill.vue';
 import { timeAgo } from '../lib/time';
+
+const router = useRouter();
 
 // The Issues pane — the cross-repo weaver issue board, sibling to the session
 // list and the overlooker panel. API-first: every row is an `IssueView` from
@@ -246,6 +250,23 @@ async function withBusy<T>(id: number, fn: () => Promise<T>): Promise<T | undefi
 
 async function setStatus(i: Issue, status: 'open' | 'closed') {
   await withBusy(i.id, async () => replaceIssue((await patchIssue(i.id, { status })) as Issue));
+}
+
+// Launch a fresh loom session that picks up an unclaimed backlog issue: the
+// server forks a branch in the issue's repo, claims the issue as its tracker,
+// and seeds the goal from it. On success we follow straight to the new
+// session's detail page (so the row's claim-state is re-read on the next visit).
+const launching = ref<number | null>(null);
+async function launch(i: Issue) {
+  launching.value = i.id;
+  error.value = '';
+  try {
+    const session = await launchSessionForIssue(i.repo_root, i.id);
+    router.push(`/s/${session.id}`);
+  } catch (e) {
+    error.value = (e as Error).message;
+    launching.value = null;
+  }
 }
 
 async function remove(i: Issue) {
@@ -519,6 +540,18 @@ async function removeTag(i: Issue, key: string) {
           <div
             class="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
           >
+            <!-- Launch a session to work this issue — the lead, accent-tinted
+                 action. Offered only for an unclaimed open item; a claimed issue
+                 already has its working session (linked in row 2). -->
+            <button
+              v-if="i.status === 'open' && !i.claimed_branch"
+              type="button"
+              class="rounded px-1.5 py-0.5 text-2xs font-medium text-accent hover:bg-subtle"
+              data-testid="issue-launch"
+              :disabled="busy[i.id] || launching === i.id"
+              :title="`Launch a session to work issue #${i.id}`"
+              @click="launch(i)"
+            >{{ launching === i.id ? 'Launching…' : 'Launch' }}</button>
             <button
               v-if="i.status === 'open'"
               type="button"

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -114,6 +114,9 @@ export interface WeaverFixture {
   /** Create an issue claimed by a seeded session's branch (so it shares the
    *  session's canonical repo_root and resolves back to it in the Issues pane). */
   seedIssue(session: Session, title: string, body?: string): Promise<Issue>;
+  /** Create an *unclaimed* backlog issue in a repo via `POST /api/repos/issues`
+   *  — the kind the Issues pane offers a Launch button for. */
+  seedBacklogIssue(repoRoot: string, title: string, body?: string): Promise<Issue>;
   /** Write an artifact via `weaver artifact write` — creates it on first call,
    *  appends an immutable revision after. Content is piped on stdin; `--repo`
    *  publishes it repo-shared instead of scoping it to the branch. */
@@ -443,6 +446,13 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
         return (await fetchJson(`${baseUrl}/api/branches/${session.branch.id}/issues`, {
           method: 'POST',
           body: JSON.stringify({ title, body: body ?? '' }),
+        })) as Issue;
+      },
+
+      async seedBacklogIssue(repoRoot, title, body) {
+        return (await fetchJson(`${baseUrl}/api/repos/issues`, {
+          method: 'POST',
+          body: JSON.stringify({ repo_root: repoRoot, title, body: body ?? '' }),
         })) as Issue;
       },
 

--- a/e2e/tests/issues.spec.ts
+++ b/e2e/tests/issues.spec.ts
@@ -141,6 +141,37 @@ test.describe('issues pane', () => {
     await expect(row.getByTestId('tag-pill')).toContainText('priority: high');
   });
 
+  test('launches a session from an unclaimed backlog issue', async ({ page, weaver }) => {
+    // Seed a session to put one repo on the board, then file an *unclaimed*
+    // backlog item in that same repo — the Launch button picks it up.
+    const session = await weaver.seedSession({ goal: 'g', name: 'feature' });
+    const backlog = await weaver.seedBacklogIssue(session.branch.repo_root, 'pick me up');
+
+    await page.goto(`${weaver.baseUrl}/issues`);
+
+    // The session's own tracking issue is already claimed, so it offers no
+    // Launch button — only the unclaimed backlog item does.
+    const claimed = (await weaver.listIssues()).find((i) => i.claimed_branch);
+    await expect(
+      page.locator(`[data-issue-id="${claimed!.id}"]`).getByTestId('issue-launch'),
+    ).toHaveCount(0);
+
+    const row = page.locator(`[data-issue-id="${backlog.id}"]`);
+    await expect(row.getByTestId('issue-launch')).toBeVisible();
+    await row.getByTestId('issue-launch').click();
+
+    // Lands on the freshly-launched session's detail page…
+    await page.waitForURL(/\/s\/[^/]+$/);
+
+    // …and the backlog issue is now claimed by a branch (its new tracker).
+    await expect
+      .poll(async () => {
+        const persisted = await weaver.listIssues();
+        return persisted.find((i) => i.id === backlog.id)?.claimed_branch;
+      })
+      .not.toBeNull();
+  });
+
   test('rejects an empty title and does not create', async ({ page, weaver }) => {
     await weaver.seedSession({ goal: 'g', name: 'feature' });
 


### PR DESCRIPTION
## What

Adds a **Launch** button to each unclaimed, open issue row on the Issues pane. Clicking it forks a new loom session to work that issue and takes you straight to the new session's detail page.

## How

- **API-first, no new backend.** It reuses the existing `POST /api/sessions` `claim_issue` path (already used by `loom session launch --claim <id>`): the server forks a branch in the issue's repo, claims the issue as the session's tracking issue, and seeds the branch title/goal from it.
- **Thin REST client.** New `launchSessionForIssue(repoRoot, issueId)` wrapper in `api.ts`; the view calls it and `router.push`es to `/s/<id>` on success, surfacing any error in the existing banner.
- **Quiet by default.** The button is the accent-tinted lead in the row's hover-revealed action group. It's offered only for an **unclaimed, open** issue — a claimed issue already has its working session linked in row 2, so it shows none.

## Testing

- New e2e test (`issues.spec.ts`): seeds an unclaimed backlog issue, clicks Launch, asserts it lands on the new session detail page and that the issue becomes claimed; also asserts a claimed issue offers no Launch button. Adds a `seedBacklogIssue` fixture helper.
- Full `issues.spec.ts` suite green (10/10); `cargo fmt`/`clippy` clean; agent lint review clean.
- Visually verified in light and dark themes.