### PR TITLE
Containerize loom for a reverse-proxy deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,9 @@ RUN set -eux; \
 # in-container name/home stay generic — only the numeric ids affect ownership.
 ARG HOST_UID=1000
 ARG HOST_GID=1000
-RUN groupadd -g "${HOST_GID}" app 2>/dev/null || true; \
+# Create the group only if that gid is free; a real groupadd failure (bad gid)
+# still aborts the build instead of being masked by `|| true`.
+RUN if ! getent group "${HOST_GID}" >/dev/null; then groupadd -g "${HOST_GID}" app; fi; \
     useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -d /home/app -s /bin/bash app
 
 # Let agents `git push` over HTTPS with the injected GH_TOKEN — no mounted SSH
@@ -39,7 +41,10 @@ RUN groupadd -g "${HOST_GID}" app 2>/dev/null || true; \
 RUN <<'EOF'
 cat > /usr/local/bin/git-credential-ghtoken <<'SH'
 #!/bin/sh
-[ "$1" = get ] && printf 'username=x-access-token\npassword=%s\n' "$GH_TOKEN"
+# git invokes the helper for get/store/erase; only `get` returns a credential,
+# and store/erase must exit 0 or git warns about a failing helper.
+[ "$1" = get ] || exit 0
+printf 'username=x-access-token\npassword=%s\n' "$GH_TOKEN"
 SH
 chmod +x /usr/local/bin/git-credential-ghtoken
 git config --system credential.https://github.com.helper ghtoken
@@ -62,5 +67,6 @@ ENV WEAVER_STATIC_DIR=/app/static/dist
 
 USER app
 EXPOSE 7878
-# Bind off loopback so the Caddy container can reach it over the `web` network.
-CMD ["loom", "serve", "--addr", "0.0.0.0:7878"]
+# `server run` is the foreground daemon (REST API + Vue UI + monitor loop); bind
+# off loopback so the Caddy container can reach it over the `web` network.
+CMD ["loom", "server", "run", "--addr", "0.0.0.0:7878"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+# loom — the weaver orchestrator — packaged for a reverse-proxy deploy.
+#
+# loom is not a stateless web app: it creates git worktrees and launches coding
+# agents (claude, git, gh) as subprocesses *inside this container*. The runtime
+# stage therefore stays on the Rust image and carries node + gh + the Claude
+# Code CLI, so an in-container agent can build/test weaver itself. Slim this
+# down once you know exactly which repos loom will drive.
+
+# ---- build: loom + tapestry + weaver, plus the embedded Vue bundle ----
+FROM rust:1-bookworm AS build
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+# loom's build.rs runs `npm install` + rspack, emitting crates/loom/static/dist.
+RUN cargo build --release -p loom -p tapestry -p weaver
+
+# ---- runtime: loom + the toolchain its agents shell out to ----
+FROM rust:1-bookworm
+RUN set -eux; \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -; \
+    install -m 0755 -d /etc/apt/keyrings; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    chmod a+r /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends nodejs git ca-certificates gh; \
+    npm i -g @anthropic-ai/claude-code; \
+    rm -rf /var/lib/apt/lists/*
+
+# Run as the host user that owns the bind-mounted code, so the worktrees and
+# edits loom's agents create are owned by you on the host, not root. The uid/gid
+# come from build args (set HOST_UID/HOST_GID in secrets/weaver.env); the
+# in-container name/home stay generic — only the numeric ids affect ownership.
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+RUN groupadd -g "${HOST_GID}" app 2>/dev/null || true; \
+    useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -d /home/app -s /bin/bash app
+
+# Let agents `git push` over HTTPS with the injected GH_TOKEN — no mounted SSH
+# key. (Repos with git@github.com SSH remotes need ~/.ssh mounted; see compose.)
+RUN <<'EOF'
+cat > /usr/local/bin/git-credential-ghtoken <<'SH'
+#!/bin/sh
+[ "$1" = get ] && printf 'username=x-access-token\npassword=%s\n' "$GH_TOKEN"
+SH
+chmod +x /usr/local/bin/git-credential-ghtoken
+git config --system credential.https://github.com.helper ghtoken
+EOF
+
+# loom resolves the tapestry PTY supervisor as a sibling of its own binary
+# (current_exe dir + /tapestry), so the two must land in the same directory.
+COPY --from=build /src/target/release/loom     /usr/local/bin/loom
+COPY --from=build /src/target/release/tapestry /usr/local/bin/tapestry
+# `weaver` is the agent-facing CLI — kept on PATH for `docker exec weaver
+# weaver config set …` (settings live in the shared sqlite db).
+COPY --from=build /src/target/release/weaver   /usr/local/bin/weaver
+COPY --from=build /src/crates/loom/static/dist /app/static/dist
+
+# static_dir() defaults to a build-time CARGO_MANIFEST_DIR path that doesn't
+# exist here, so point it at the copied bundle explicitly. WEAVER_HOME is left to
+# default to $HOME/.weaver — the persisted /home/app volume — holding the
+# sqlite db, server.json, and the 0600 machine-local token.
+ENV WEAVER_STATIC_DIR=/app/static/dist
+
+USER app
+EXPOSE 7878
+# Bind off loopback so the Caddy container can reach it over the `web` network.
+CMD ["loom", "serve", "--addr", "0.0.0.0:7878"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
 # loom — the weaver orchestrator — packaged for a reverse-proxy deploy.
-#
-# loom is not a stateless web app: it creates git worktrees and launches coding
-# agents (claude, git, gh) as subprocesses *inside this container*. The runtime
-# stage therefore stays on the Rust image and carries node + gh + the Claude
-# Code CLI, so an in-container agent can build/test weaver itself. Slim this
-# down once you know exactly which repos loom will drive.
 
 # ---- build: loom + tapestry + weaver, plus the embedded Vue bundle ----
 FROM rust:1-bookworm AS build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+# loom front-end for a halcyon-style deploy: Caddy terminates TLS and routes
+# weaver.<domain> -> this container over the shared external `web` network.
+#
+# loom drives the repos you already have on the host: HOST_CODE is bind-mounted
+# at the same path, so the worktrees it creates appear on the host unchanged, and
+# it runs as HOST_UID:HOST_GID so those files aren't root-owned. All three knobs
+# (plus credentials) come from secrets/weaver.env — nothing host-specific is
+# baked into this file or the image.
+#
+# Deliberately NO `ports:` — loom stays internal to `web`, reachable only through
+# the front-door proxy, never published to the host or the internet.
+name: weaver
+
+services:
+  weaver:
+    container_name: weaver        # Caddy routes by this name: reverse_proxy weaver:7878
+    build:
+      context: .
+      args:
+        HOST_UID: ${HOST_UID:-1000}
+        HOST_GID: ${HOST_GID:-1000}
+    restart: unless-stopped
+    env_file: .env                # halcyon symlinks secrets/weaver.env -> ./.env
+    volumes:
+      # Persistent HOME for the container user: the weaver sqlite db, the 0600
+      # loom-token, and ~/.claude.json live here and survive a recreate.
+      - weaver_home:/home/app
+      # The repos + the worktrees loom creates, shared with the host at the SAME
+      # path. HOST_CODE is your repo dir (e.g. /home/you/code); set it in the env.
+      - ${HOST_CODE:?set HOST_CODE (host repo dir) in secrets/weaver.env}:${HOST_CODE}
+      # Repos with git@github.com SSH remotes need your key — uncomment & set the
+      # host path (target is the container user's home):
+      # - /home/you/.ssh:/home/app/.ssh:ro
+    networks:
+      - web
+
+networks:
+  web:
+    external: true
+
+volumes:
+  weaver_home:


### PR DESCRIPTION
## What

Adds a `Dockerfile` and `docker-compose.yml` so `loom` can be served behind a
TLS-terminating reverse proxy (e.g. Caddy routing `weaver.<domain>` → the
container) rather than only over loopback. This pairs with the auth work from
#53 — the proxy fronts the public side while loom gates who can drive the fleet.

## How it's shaped

loom isn't a stateless web app: it creates git worktrees and launches coding
agents (`claude`, `git`, `gh`) as subprocesses. So:

- **Build** is multi-stage — compiles `loom`, `tapestry`, and `weaver` plus the
  embedded Vue bundle (`build.rs` runs npm + rspack). The **runtime** stage stays
  on the Rust image and carries node, `gh`, and the Claude Code CLI so an
  in-container agent can build/test the repo it's working on.
- `tapestry` lands beside `loom` (loom resolves the PTY supervisor as a sibling
  of its own binary); `WEAVER_STATIC_DIR` points at the copied bundle since the
  default `CARGO_MANIFEST_DIR` path only exists at build time.
- loom binds `0.0.0.0:7878`; compose publishes **no ports**, so it's reachable
  only through the proxy on the shared external `web` network.

## Drives the host's own repos

Rather than cloning into an opaque volume, the container operates on the repos
you already have:

- `HOST_CODE` is bind-mounted **at the same path** in and out, so worktrees loom
  creates show up unchanged on the host.
- Runs as `HOST_UID:HOST_GID` so those files are owned by you, not root.
- Credentials (Anthropic key, GH token, commit identity) are injected as env
  vars; `git push` over HTTPS works via a `GH_TOKEN` credential helper.

Nothing host-specific is baked into the image or compose file — `HOST_UID`,
`HOST_GID`, and `HOST_CODE` come from the deployer's env (with `HOST_CODE`
defaulting to `$HOME/code`). State (sqlite db, machine-local token,
`~/.claude.json`) persists in a named home volume.

## Notes

- `HOST_UID`/`HOST_GID` are build args, so changing them needs an image rebuild
  (and recreating the home volume, which keeps its first-init ownership).
- Repos with `git@github.com:` SSH remotes need a key — there's a commented
  `~/.ssh` mount line ready to uncomment.
- No Rust/frontend changes, so the fmt+clippy gate is unaffected.
