### PR TITLE
fix(loom): restore mermaid labels, stop error "bombs" leaking into the page

### DIFF
--- a/crates/loom/frontend/src/markdown.ts
+++ b/crates/loom/frontend/src/markdown.ts
@@ -376,6 +376,14 @@ export async function renderMermaid(root: HTMLElement, dark: boolean): Promise<v
     theme: 'base',
     themeVariables: mermaidThemeVariables(dark),
     fontFamily: 'inherit',
+    // Throw on a bad diagram instead of drawing mermaid's "bomb" error graphic.
+    // The default renders that graphic into a temp node mermaid appends to
+    // `document.body` and only removes on success — so a failed parse leaks the
+    // bomb into the page body, where it survives route changes and shows up at
+    // the bottom of every view. Suppressing it makes `render` reject cleanly
+    // (mermaid removes its temp node), and the catch below shows our own inline
+    // error note instead.
+    suppressErrorRendering: true,
   });
 
   for (const block of blocks) {
@@ -387,10 +395,18 @@ export async function renderMermaid(root: HTMLElement, dark: boolean): Promise<v
       wrap.className = 'mermaid-diagram';
       // Mermaid already sanitises under `securityLevel: 'strict'`, but the SVG
       // is derived from DOM text, so pass it through DOMPurify before innerHTML
-      // for defence-in-depth (and to keep the flow provably XSS-safe). The svg +
-      // html profiles keep mermaid's structure, incl. `<foreignObject>` labels.
+      // for defence-in-depth (and to keep the flow provably XSS-safe).
+      //
+      // Mermaid draws node/cluster labels as HTML inside `<foreignObject>`. That
+      // only survives sanitising if DOMPurify is told `foreignobject` is an HTML
+      // integration point (otherwise its XHTML children are dropped as stray SVG
+      // and every label renders blank). These options mirror mermaid's own
+      // internal sanitise call, so we keep its structure verbatim while still
+      // stripping scripts/handlers.
       wrap.innerHTML = DOMPurify.sanitize(svg, {
-        USE_PROFILES: { svg: true, svgFilters: true, html: true },
+        ADD_TAGS: ['foreignobject'],
+        ADD_ATTR: ['dominant-baseline'],
+        HTML_INTEGRATION_POINTS: { foreignobject: true },
       });
       block.replaceWith(wrap);
     } catch (e) {

--- a/e2e/tests/markdown.spec.ts
+++ b/e2e/tests/markdown.spec.ts
@@ -77,6 +77,10 @@ test.describe('rich markdown preview', () => {
     const mermaidSvg = body.locator('.mermaid-diagram svg');
     await expect(mermaidSvg).toBeVisible({ timeout: 30_000 });
     await expect(mermaidSvg.locator('g').first()).toBeVisible({ timeout: 30_000 });
+    // Node labels must survive rendering. Mermaid draws them as HTML inside
+    // `<foreignObject>`; our DOMPurify pass has to keep that intact (it once
+    // stripped it, leaving every box blank), so assert the label text is there.
+    await expect(mermaidSvg.locator('.nodeLabel').first()).toHaveText('A');
 
     // Source flips to the Monaco editor showing the raw markdown…
     await page.getByRole('button', { name: 'Source', exact: true }).click();
@@ -86,6 +90,32 @@ test.describe('rich markdown preview', () => {
     // …and Preview flips back to the rendered view.
     await page.getByRole('button', { name: 'Preview', exact: true }).click();
     await expect(page.locator('.markdown-body h1')).toContainText('Design Doc');
+  });
+
+  test('a broken mermaid diagram errors inline, never leaking into the page body', async ({
+    page,
+    weaver,
+  }) => {
+    const session = await weaver.seedSession({ goal: 'write docs', name: 'md-bad-mermaid' });
+    // A diagram mermaid can't parse. By default mermaid draws its "bomb" error
+    // graphic into a temp node it appends to `document.body` and only removes on
+    // success — so a failed render used to leak the bomb into the page body,
+    // where it survived route changes and stacked up at the bottom of every view.
+    const doc = ['# Doc', '', '```mermaid', 'graph TD; A --> ((( broken', '```', ''].join('\n');
+    writeFileSync(join(session.work_dir, 'BAD.md'), doc);
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}/files`);
+    await page.getByText('BAD.md', { exact: true }).first().click();
+
+    // The failure surfaces as our own inline note inside the preview…
+    await expect(page.locator('.markdown-body .mermaid-error')).toBeVisible({ timeout: 30_000 });
+
+    // …and nothing leaks into the document body outside the app.
+    const leaked = await page.evaluate(() =>
+      document.querySelectorAll('body > svg[aria-roledescription="error"], body > .mermaid, body .error-icon')
+        .length,
+    );
+    expect(leaked).toBe(0);
   });
 
   test('non-markdown files have no Preview toggle', async ({ page, weaver }) => {


### PR DESCRIPTION
## What

Markdown-preview mermaid diagrams rendered as **empty boxes** (no label text), and a diagram that failed to parse stacked **"Syntax error in text" bomb graphics** at the bottom of every view — for any session, surviving route changes.

Before / after (dark mode, the diagram from the report):

| before | after |
| --- | --- |
| blank boxes + arrows | labelled `Event → Round → Log`, clusters titled |

## Why

Both bugs live in `renderMermaid` (`crates/loom/frontend/src/markdown.ts`):

1. **Blank labels.** Mermaid draws node/cluster labels as HTML inside `<foreignObject>`. The post-render `DOMPurify.sanitize(svg, { USE_PROFILES: { svg, svgFilters, html } })` pass (added in #41 for defence-in-depth) drops the foreignObject's XHTML children as stray SVG, so every label sanitised away to nothing. Mermaid's *own* internal sanitise keeps them by declaring `foreignobject` an HTML integration point — we now mirror that config (`ADD_TAGS: ['foreignobject']`, `ADD_ATTR: ['dominant-baseline']`, `HTML_INTEGRATION_POINTS: { foreignobject: true }`). Verified it still strips `<script>`/`onerror`.

2. **Leaked error bombs.** On a parse/draw failure, mermaid (default `suppressErrorRendering: false`) draws its error graphic into the temp node it appends to `document.body`, then throws *before* removing it — leaking the bomb into the body where it persists across navigation (each re-render on the theme/source/refs watchers leaks another, hence the stack). Setting `suppressErrorRendering: true` makes `render` reject cleanly; the existing `catch` already shows our inline `.mermaid-error` note.

## Tests

`e2e/tests/markdown.spec.ts`:
- the existing diagram test now asserts label text actually renders (`.nodeLabel` = `A`);
- a new test feeds a broken diagram and asserts it errors inline with **nothing leaking into `document.body`**.

Both fail against the pre-fix code (blank label; 6 leaked bomb nodes) and pass with the fix. Verified visually in light and dark mode.