### PR TITLE
feat(overlooker): event subscriptions + per-watch execution log

### DIFF
--- a/crates/loom/frontend/src/lib/overlooker.ts
+++ b/crates/loom/frontend/src/lib/overlooker.ts
@@ -19,14 +19,19 @@ export function capabilitiesFrom(ticked: Record<string, boolean>): string[] {
 }
 
 // A one-line, human-readable summary of a trigger — what wakes a round.
-// e.g. "cron 0 * * * *", "every 30m", "on attention=blocked", "on pr_red".
-// An empty/unset trigger reads as "manual" (only fires on Run now).
+// e.g. "cron 0 * * * *", "every 30m", "on pr.merged, pr.opened",
+// "on session.attention=blocked". An empty/unset trigger reads as "manual"
+// (only fires on Run now). A trigger may carry both a schedule and events.
 export function triggerSummary(t: OverlookerTrigger | undefined | null): string {
   if (!t) return 'manual';
-  if (t.cron) return `cron ${t.cron}`;
-  if (t.every) return `every ${t.every}`;
-  if (t.event) return t.level ? `on ${t.event}=${t.level}` : `on ${t.event}`;
-  return 'manual';
+  const parts: string[] = [];
+  if (t.cron) parts.push(`cron ${t.cron}`);
+  if (t.every) parts.push(`every ${t.every}`);
+  // The subscription set: the `on` list plus the legacy single `event`.
+  const events = [...(t.on ?? [])];
+  if (t.event) events.push(t.level ? `${t.event}=${t.level}` : t.event);
+  if (events.length) parts.push(`on ${events.join(', ')}`);
+  return parts.length ? parts.join(' · ') : 'manual';
 }
 
 // A one-line summary of the fleet scope a round surveys.

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -237,13 +237,18 @@ export interface FileContent {
   bytes: number;
 }
 
-/** An overlooker's trigger — the event-match predicate, parsed. A scheduled
- *  trigger carries a `cron` (or `every`) cadence; a reactive one carries an
- *  `event` kind (and optional `level`). An optional `repo` pins it to one
- *  repository. Mirrors weaver-core's `Trigger`. */
+/** An overlooker's trigger — its subscription manifest, parsed. A scheduled
+ *  trigger carries a `cron` (or `every`) cadence; a reactive one subscribes to
+ *  one or more normalized trigger events via `on` (each `"name"` or
+ *  `"name=level"`). `event`/`level` are the legacy single-event shape, still
+ *  honoured. An optional `repo` pins it to one repository. Mirrors weaver-core's
+ *  `Trigger`. */
 export interface OverlookerTrigger {
   cron?: string;
   every?: string;
+  /** The normalized trigger events this watch subscribes to, e.g.
+   *  `["pr.merged", "session.exited=error"]`. */
+  on?: string[];
   event?: string;
   level?: string;
   repo?: string;
@@ -312,16 +317,28 @@ export interface OverlookerAction {
 }
 
 /** One round in an overlooker's history — the audit trail. `actions` is the
- *  array of marks / nudges / would-dos the round recorded. Mirrors
- *  `OverlookerRunView` in web.rs. */
+ *  array of marks / nudges / would-dos the round recorded; `stdout`/`stderr`/
+ *  `exit_code`/`duration_ms` are the captured execution log — what the script
+ *  printed and returned. Mirrors `OverlookerRunView` in web.rs. */
 export interface OverlookerRun {
   id: number;
   trigger_reason: string;
+  /** The normalized event that woke the round (`cron` / `manual` / e.g.
+   *  `pr.merged`). */
+  trigger_event: string;
   started_at: string;
   finished_at: string | null;
   outcome: 'ok' | 'noop' | 'skipped' | 'error' | string;
   summary: string;
   actions: OverlookerAction[];
+  /** A tail of the script's standard output. */
+  stdout: string;
+  /** A tail of the script's standard error. */
+  stderr: string;
+  /** The interpreter's exit status, or null when it never spawned / timed out. */
+  exit_code: number | null;
+  /** Wall-clock the program ran, in milliseconds. */
+  duration_ms: number | null;
 }
 
 /** The reply from `POST /api/overlookers/{id}/run`. */

--- a/crates/loom/frontend/src/views/OverlookerDetail.vue
+++ b/crates/loom/frontend/src/views/OverlookerDetail.vue
@@ -81,6 +81,13 @@ async function loadRuns() {
   }
 }
 
+// A round's wall-clock as a compact label (e.g. "42ms", "1.3s", "12s").
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  return `${s.toFixed(s < 10 ? 1 : 0)}s`;
+}
+
 async function adopt(o: Overlooker) {
   ov.value = o;
 }
@@ -448,47 +455,79 @@ onMounted(() => {
             v-for="r in runs"
             :key="r.id"
             data-testid="overlooker-run-row"
-            class="rounded border border-line bg-surface p-3"
+            class="rounded border border-line bg-surface"
           >
-            <div class="flex items-center gap-2 flex-wrap">
-              <OutcomeBadge :outcome="r.outcome" />
-              <span class="text-sm text-muted">{{ r.summary || 'No summary.' }}</span>
-              <span class="ml-auto text-xs text-faint">{{ timeAgo(r.started_at) }}</span>
-            </div>
-            <div class="mt-1 flex items-center gap-2 text-xs text-faint">
-              <span class="meta-chip">{{ r.trigger_reason }}</span>
-              <button
-                v-if="r.actions && r.actions.length"
-                type="button"
-                data-testid="overlooker-run-actions-toggle"
-                class="text-accent hover:underline"
-                @click="expanded[r.id] = !expanded[r.id]"
-              >
-                {{ expanded[r.id] ? 'Hide' : 'Show' }} {{ r.actions.length }}
-                action{{ r.actions.length === 1 ? '' : 's' }}
-              </button>
-              <span v-else>no actions</span>
-            </div>
-
-            <!-- Expanded action detail: the marks / nudges / would-dos. -->
-            <ul
-              v-if="expanded[r.id] && r.actions && r.actions.length"
-              data-testid="overlooker-run-actions"
-              class="mt-2 space-y-1 border-t border-line pt-2"
+            <!-- The row: click anywhere to expand the run's execution log. -->
+            <button
+              type="button"
+              data-testid="overlooker-run-toggle"
+              class="w-full p-3 text-left"
+              @click="expanded[r.id] = !expanded[r.id]"
             >
-              <li
-                v-for="(a, j) in r.actions"
-                :key="j"
-                class="flex items-start gap-2 text-xs"
-              >
-                <span class="meta-chip shrink-0">
-                  <span v-if="a.would" class="text-faint">would </span>{{ a.action || a.would || 'action' }}
-                  <span v-if="a.level" class="text-faint">={{ a.level }}</span>
+              <div class="flex items-center gap-2 flex-wrap">
+                <OutcomeBadge :outcome="r.outcome" />
+                <span class="text-sm text-muted">{{ r.summary || 'No summary.' }}</span>
+                <span class="ml-auto text-xs text-faint">{{ timeAgo(r.started_at) }}</span>
+              </div>
+              <div class="mt-1 flex items-center gap-2 text-xs text-faint flex-wrap">
+                <span class="meta-chip">{{ r.trigger_reason || r.trigger_event || 'manual' }}</span>
+                <span v-if="r.duration_ms != null" class="meta-chip">{{ formatMs(r.duration_ms) }}</span>
+                <span v-if="r.exit_code != null" class="meta-chip">exit {{ r.exit_code }}</span>
+                <span v-if="r.actions && r.actions.length">
+                  {{ r.actions.length }} action{{ r.actions.length === 1 ? '' : 's' }}
                 </span>
-                <span v-if="a.session" class="font-mono text-faint shrink-0">{{ a.session }}</span>
-                <span class="text-muted min-w-0">{{ a.note || a.text || '' }}</span>
-              </li>
-            </ul>
+                <span class="ml-auto text-accent">{{ expanded[r.id] ? 'Hide' : 'Details' }}</span>
+              </div>
+            </button>
+
+            <!-- Expanded: the actions taken, then the captured stdout/stderr —
+                 the execution log of exactly what the script printed. -->
+            <div
+              v-if="expanded[r.id]"
+              data-testid="overlooker-run-detail"
+              class="border-t border-line p-3 space-y-3"
+            >
+              <ul
+                v-if="r.actions && r.actions.length"
+                data-testid="overlooker-run-actions"
+                class="space-y-1"
+              >
+                <li
+                  v-for="(a, j) in r.actions"
+                  :key="j"
+                  class="flex items-start gap-2 text-xs"
+                >
+                  <span class="meta-chip shrink-0">
+                    <span v-if="a.would" class="text-faint">would </span>{{ a.action || a.would || 'action' }}
+                    <span v-if="a.level" class="text-faint">={{ a.level }}</span>
+                  </span>
+                  <span v-if="a.session" class="font-mono text-faint shrink-0">{{ a.session }}</span>
+                  <span class="text-muted min-w-0">{{ a.note || a.text || '' }}</span>
+                </li>
+              </ul>
+
+              <div v-if="r.stdout">
+                <h3 class="text-2xs font-semibold uppercase tracking-wider text-faint mb-1">stdout</h3>
+                <pre
+                  data-testid="overlooker-run-stdout"
+                  class="max-h-64 overflow-auto rounded bg-input p-2 text-xs font-mono whitespace-pre-wrap"
+                >{{ r.stdout }}</pre>
+              </div>
+              <div v-if="r.stderr">
+                <h3 class="text-2xs font-semibold uppercase tracking-wider text-faint mb-1">stderr</h3>
+                <pre
+                  data-testid="overlooker-run-stderr"
+                  class="max-h-64 overflow-auto rounded bg-input p-2 text-xs font-mono whitespace-pre-wrap text-block"
+                >{{ r.stderr }}</pre>
+              </div>
+
+              <p
+                v-if="!(r.actions && r.actions.length) && !r.stdout && !r.stderr"
+                class="text-xs text-faint"
+              >
+                No actions or output recorded.
+              </p>
+            </div>
           </li>
         </ul>
       </section>

--- a/crates/loom/frontend/src/views/Overlookers.vue
+++ b/crates/loom/frontend/src/views/Overlookers.vue
@@ -165,7 +165,12 @@ async function create() {
           .filter(Boolean);
       }
       if (form.repo.trim()) t.repo = form.repo.trim();
-      trigger = t;
+      // Only override the manifest when the user actually gave a firing
+      // condition. A blank explicit kind (e.g. "Cron" selected, expression left
+      // empty) would otherwise ship a triggerless `{}` and create a dead,
+      // manual-only watch — fall back to `auto` (server reconciles) instead. A
+      // bare repo pin isn't a firing condition; it already rides on `scope`.
+      if (t.cron || t.every || (Array.isArray(t.on) && t.on.length)) trigger = t;
     }
 
     const scope: Record<string, string> = {};

--- a/crates/loom/frontend/src/views/Overlookers.vue
+++ b/crates/loom/frontend/src/views/Overlookers.vue
@@ -87,14 +87,15 @@ async function run(o: Overlooker, dry: boolean) {
 // an optional repo pin. Everything else takes the server's defaults.
 const showForm = ref(false);
 const creating = ref(false);
-type TriggerKind = 'cron' | 'every' | 'event';
+// `auto` honours the script's declared subscription manifest (the recommended
+// default — the script decides what wakes it); the rest are explicit overrides.
+type TriggerKind = 'auto' | 'cron' | 'every' | 'on';
 const form = reactive({
   name: '',
-  triggerKind: 'cron' as TriggerKind,
+  triggerKind: 'auto' as TriggerKind,
   cron: '0 * * * *',
   every: '30m',
-  event: 'attention',
-  level: 'blocked',
+  on: 'pr.opened',
   // A builtin reference from the registry, or the literal 'custom' to free-type
   // a program file path into `customProgram`.
   program: 'builtin:status',
@@ -107,11 +108,10 @@ const form = reactive({
 
 function resetForm() {
   form.name = '';
-  form.triggerKind = 'cron';
+  form.triggerKind = 'auto';
   form.cron = '0 * * * *';
   form.every = '30m';
-  form.event = 'attention';
-  form.level = 'blocked';
+  form.on = 'pr.opened';
   form.program = 'builtin:status';
   form.customProgram = '';
   form.prompt = '';
@@ -120,23 +120,18 @@ function resetForm() {
   form.capabilities = { mark: true, escalate: true, nudge: false, interrupt: false, launch: false };
 }
 
-// Prefill the form from a builtin's suggested defaults (trigger cadence, scope,
-// capability grants) — the registry's starting point, freely editable after.
+// Prefill the form from a builtin's suggested defaults. The script declares its
+// own subscriptions, so default to honouring them (`auto`); the cron/every/on
+// fields are prefilled too, so switching to an explicit override is one click.
 function applyProgramDefaults(programRef: string) {
   const p = programs.value.find((x) => x.program === programRef);
   if (!p) return;
   const t = p.defaults?.trigger ?? {};
-  if (t.cron) {
-    form.triggerKind = 'cron';
-    form.cron = t.cron;
-  } else if (t.every) {
-    form.triggerKind = 'every';
-    form.every = t.every;
-  } else if (t.event) {
-    form.triggerKind = 'event';
-    form.event = t.event;
-    form.level = t.level ?? '';
-  }
+  form.triggerKind = 'auto';
+  if (t.cron) form.cron = t.cron;
+  if (t.every) form.every = t.every;
+  if (Array.isArray(t.on) && t.on.length) form.on = t.on.join(', ');
+  else if (t.event) form.on = t.level ? `${t.event}=${t.level}` : t.event;
   form.scopeAttention = p.defaults?.scope?.attention ?? '';
   const granted = p.defaults?.capabilities ?? [];
   for (const c of GRANTABLE_CAPABILITIES) form.capabilities[c] = granted.includes(c);
@@ -155,14 +150,23 @@ async function create() {
   creating.value = true;
   error.value = '';
   try {
-    const trigger: Record<string, string> = {};
-    if (form.triggerKind === 'cron' && form.cron.trim()) trigger.cron = form.cron.trim();
-    else if (form.triggerKind === 'every' && form.every.trim()) trigger.every = form.every.trim();
-    else if (form.triggerKind === 'event' && form.event.trim()) {
-      trigger.event = form.event.trim();
-      if (form.level.trim()) trigger.level = form.level.trim();
+    // `auto` omits the trigger entirely so the server reconciles it from the
+    // script's manifest; the explicit kinds build the trigger here. (A repo pin
+    // rides on `scope` below either way, so `auto` keeps repo scoping.)
+    let trigger: Record<string, unknown> | undefined;
+    if (form.triggerKind !== 'auto') {
+      const t: Record<string, unknown> = {};
+      if (form.triggerKind === 'cron' && form.cron.trim()) t.cron = form.cron.trim();
+      else if (form.triggerKind === 'every' && form.every.trim()) t.every = form.every.trim();
+      else if (form.triggerKind === 'on' && form.on.trim()) {
+        t.on = form.on
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+      if (form.repo.trim()) t.repo = form.repo.trim();
+      trigger = t;
     }
-    if (form.repo.trim()) trigger.repo = form.repo.trim();
 
     const scope: Record<string, string> = {};
     if (form.scopeAttention.trim()) scope.attention = form.scopeAttention.trim();
@@ -181,12 +185,13 @@ async function create() {
 
     const body: Record<string, unknown> = {
       name: form.name.trim(),
-      trigger,
       scope,
       program: programRef || 'builtin:status',
       params,
       capabilities,
     };
+    // Omit `trigger` for `auto` so the server reconciles from the manifest.
+    if (trigger !== undefined) body.trigger = trigger;
     await post('/overlookers', body);
     resetForm();
     showForm.value = false;
@@ -253,7 +258,7 @@ onMounted(() => {
         <label class="block text-xs text-muted mb-1">Trigger — what wakes a round</label>
         <div class="inline-flex rounded border border-line text-xs overflow-hidden mb-2">
           <button
-            v-for="k in (['cron', 'every', 'event'] as const)"
+            v-for="k in (['auto', 'cron', 'every', 'on'] as const)"
             :key="k"
             type="button"
             :class="[
@@ -262,11 +267,15 @@ onMounted(() => {
             ]"
             @click="form.triggerKind = k"
           >
-            {{ k === 'cron' ? 'Cron' : k === 'every' ? 'Every' : 'On event' }}
+            {{ k === 'auto' ? 'From script' : k === 'cron' ? 'Cron' : k === 'every' ? 'Every' : 'On events' }}
           </button>
         </div>
+        <p v-if="form.triggerKind === 'auto'" class="text-xs text-faint">
+          Wakes on the events the script subscribes to (its manifest) — the
+          recommended default, so the script decides what it reacts to.
+        </p>
         <input
-          v-if="form.triggerKind === 'cron'"
+          v-else-if="form.triggerKind === 'cron'"
           v-model="form.cron"
           placeholder="0 * * * *"
           autocomplete="off"
@@ -281,27 +290,21 @@ onMounted(() => {
           spellcheck="false"
           class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
         />
-        <div v-else class="grid grid-cols-2 gap-3">
-          <div>
-            <label class="block text-xs text-faint mb-1">Event kind</label>
-            <input
-              v-model="form.event"
-              placeholder="attention"
-              autocomplete="off"
-              spellcheck="false"
-              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
-            />
-          </div>
-          <div>
-            <label class="block text-xs text-faint mb-1">Level (optional)</label>
-            <input
-              v-model="form.level"
-              placeholder="blocked"
-              autocomplete="off"
-              spellcheck="false"
-              class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
-            />
-          </div>
+        <div v-else>
+          <input
+            v-model="form.on"
+            placeholder="pr.merged, session.exited=error"
+            autocomplete="off"
+            spellcheck="false"
+            class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
+          />
+          <p class="mt-1 text-xs text-faint">
+            Comma-separated trigger events:
+            <code>session.started/idle/exited/attention/stale</code>,
+            <code>triage.changed</code>,
+            <code>pr.opened/checks_red/checks_green/merged/review_changed</code>.
+            Append <code>=level</code> to filter (e.g. <code>session.attention=blocked</code>).
+          </p>
         </div>
       </div>
 

--- a/crates/loom/overlookers/archive_merged.py
+++ b/crates/loom/overlookers/archive_merged.py
@@ -2,14 +2,19 @@
 
 Read-only: records a would-archive action per merged PR (the
 github.archive_on_merge setting still performs the actual archive).
+
+Subscribes to `pr.merged` — it wakes only when a PR actually merges, on the one
+branch that changed, instead of polling the whole fleet on a timer.
 """
 
 from weaver_loom import Round
 
+#: Wake only on a PR merging — the engine reads this in register mode.
+TRIGGERS = {"on": ["pr.merged"]}
 
-def main():
-    rnd = Round()
-    for session in rnd.sessions():
+
+def main(rnd):
+    for session in rnd.triggered_sessions():
         github = (session.get("branch") or {}).get("github") or {}
         if github.get("pr_state") != "MERGED":
             continue
@@ -24,4 +29,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    Round.main(main, TRIGGERS)

--- a/crates/loom/overlookers/pr_label.py
+++ b/crates/loom/overlookers/pr_label.py
@@ -2,6 +2,9 @@
 
 Read-only: records a would-label action per open PR missing the label
 (params.label, default 'weaver'). Labels are read via the gh CLI.
+
+Subscribes to `pr.opened` — it wakes when a session's PR first appears, on that
+one branch, instead of re-reading every session's labels on a timer.
 """
 
 import json
@@ -10,6 +13,9 @@ import subprocess
 from weaver_loom import Round
 
 DEFAULT_LABEL = "weaver"
+
+#: Wake when a PR opens — the engine reads this in register mode.
+TRIGGERS = {"on": ["pr.opened"]}
 
 
 def pr_labels(repo_root, pr_number):
@@ -30,10 +36,9 @@ def pr_labels(repo_root, pr_number):
     return [label.get("name", "") for label in reply.get("labels") or []]
 
 
-def main():
-    rnd = Round()
+def main(rnd):
     label = rnd.params.get("label") or DEFAULT_LABEL
-    for session in rnd.sessions():
+    for session in rnd.triggered_sessions():
         branch = session.get("branch") or {}
         github = branch.get("github") or {}
         if github.get("pr_state") != "OPEN":
@@ -52,4 +57,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    Round.main(main, TRIGGERS)

--- a/crates/loom/overlookers/status.py
+++ b/crates/loom/overlookers/status.py
@@ -20,6 +20,11 @@ from weaver_loom import Round, WeaverError, parse_judgement
 #: The storable triage values; `ok` is the absence of the tag.
 STORABLE = ("attention", "blocked")
 
+#: A scheduled survey of the whole scoped fleet — the engine reads this in
+#: register mode. (A status sweep is inherently fleet-wide, so it stays on a
+#: cadence rather than a per-session event.)
+TRIGGERS = {"cron": "0 * * * *"}
+
 
 def attention_value(session):
     """The session's own `attention` tag value — `ok` when absent (calm)."""
@@ -50,8 +55,7 @@ def judge(rnd, session):
     return level, f"attention is {attention}"
 
 
-def main():
-    rnd = Round()
+def main(rnd):
     can_mark = rnd.can("mark")
     can_nudge = rnd.can("nudge")
     marked = 0
@@ -106,4 +110,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    Round.main(main, TRIGGERS)

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -63,7 +63,7 @@ pub const BUILTINS: &[BuiltinProgram] = &[
                       sessions are identifiable on GitHub. Read-only: it \
                       reports would-label actions.",
         source: include_str!("../overlookers/pr_label.py"),
-        default_trigger: r#"{"every":"15m"}"#,
+        default_trigger: r#"{"on":["pr.opened"]}"#,
         default_scope: "{}",
         default_params: r#"{"label":"weaver"}"#,
         default_capabilities: &["observe"],
@@ -77,7 +77,7 @@ pub const BUILTINS: &[BuiltinProgram] = &[
                       github.archive_on_merge setting still performs the \
                       archive).",
         source: include_str!("../overlookers/archive_merged.py"),
-        default_trigger: r#"{"every":"5m"}"#,
+        default_trigger: r#"{"on":["pr.merged"]}"#,
         default_scope: "{}",
         default_params: "{}",
         default_capabilities: &["observe"],

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -223,6 +223,32 @@ fn checks_went_red(prev_checks: Option<&str>, next: &GithubStatus) -> bool {
     next.checks.as_deref() == Some("failing") && prev_checks != Some("failing")
 }
 
+/// The mirror of [`checks_went_red`]: the rollup just transitioned **into**
+/// passing. The first sighting of an already-green PR counts as a transition.
+fn checks_went_green(prev_checks: Option<&str>, next: &GithubStatus) -> bool {
+    next.checks.as_deref() == Some("passing") && prev_checks != Some("passing")
+}
+
+/// Whether the PR just became visible as **open**: now `OPEN` and previously
+/// not (unseen, or reopened from `CLOSED`). Lets a watch act once when a
+/// session's PR first appears, rather than re-checking every poll.
+fn pr_just_opened(prev_state: Option<&str>, next: &GithubStatus) -> bool {
+    next.pr_state == "OPEN" && prev_state != Some("OPEN")
+}
+
+/// Whether the PR just **merged**: now `MERGED` and previously not.
+fn pr_just_merged(prev_state: Option<&str>, next: &GithubStatus) -> bool {
+    next.pr_state == "MERGED" && prev_state != Some("MERGED")
+}
+
+/// Whether the review decision changed to a new non-null value (an approval, a
+/// changes-requested, …). A decision dropping back to null (review no longer
+/// required) is not announced — there is nothing to react to.
+fn review_decision_changed(prev: Option<&GithubStatus>, next: &GithubStatus) -> bool {
+    next.review_decision.is_some()
+        && prev.map(|p| &p.review_decision) != Some(&next.review_decision)
+}
+
 /// Whether the `gh` CLI is usable on this machine. Probed once and cached — a
 /// missing `gh` is the common "GitHub integration off" case and shouldn't cost a
 /// process spawn on every poll.
@@ -359,19 +385,46 @@ async fn apply_snapshot(
         .ok();
     }
 
-    // Edge-detect the checks → failing transition and emit a one-shot `pr_red`
-    // event a reactive overlooker can match. Compared against the *prior* stored
-    // value so it fires once per transition, not every poll while it stays red.
-    if checks_went_red(prev.as_ref().and_then(|p| p.checks.as_deref()), snap) {
-        events::record(
-            &state.db,
-            &state.bus,
-            &branch.id,
+    // Edge-detect meaningful PR transitions and emit a one-shot event per
+    // transition (compared against the *prior* stored snapshot, so each fires
+    // once and not every poll while the condition persists). These are the
+    // surfaces watches subscribe to via `pr.*` triggers — so a PR labeller wakes
+    // on `pr.opened`, an archiver on `pr.merged`, a CI watcher on the check
+    // edges — instead of polling the fleet on a timer.
+    let prev_checks = prev.as_ref().and_then(|p| p.checks.as_deref());
+    let prev_state = prev.as_ref().map(|p| p.pr_state.as_str());
+    for (fire, kind, data) in [
+        (
+            pr_just_opened(prev_state, snap),
+            "pr_opened",
+            json!({ "pr": snap.pr_number }),
+        ),
+        (
+            pr_just_merged(prev_state, snap),
+            "pr_merged",
+            json!({ "pr": snap.pr_number }),
+        ),
+        (
+            checks_went_red(prev_checks, snap),
             "pr_red",
             json!({ "pr": snap.pr_number, "checks": "failing" }),
-        )
-        .await
-        .ok();
+        ),
+        (
+            checks_went_green(prev_checks, snap),
+            "pr_green",
+            json!({ "pr": snap.pr_number, "checks": "passing" }),
+        ),
+        (
+            review_decision_changed(prev.as_ref(), snap),
+            "pr_review",
+            json!({ "pr": snap.pr_number, "decision": snap.review_decision }),
+        ),
+    ] {
+        if fire {
+            events::record(&state.db, &state.bus, &branch.id, kind, data)
+                .await
+                .ok();
+        }
     }
 
     if archive_on_merge && snap.pr_state == "MERGED" && !session_mod::is_terminal(&session.status) {
@@ -502,6 +555,57 @@ mod tests {
             checks: checks.map(str::to_string),
             ..snapshot("OPEN")
         }
+    }
+
+    #[test]
+    fn checks_went_green_mirrors_red() {
+        let green = snapshot_with_checks(Some("passing"));
+        // not-passing → passing is the edge (including first-ever sighting).
+        assert!(checks_went_green(None, &green));
+        assert!(checks_went_green(Some("failing"), &green));
+        assert!(checks_went_green(Some("pending"), &green));
+        // Staying green does not re-fire; a non-passing new state never fires.
+        assert!(!checks_went_green(Some("passing"), &green));
+        assert!(!checks_went_green(
+            None,
+            &snapshot_with_checks(Some("failing"))
+        ));
+    }
+
+    #[test]
+    fn pr_open_and_merge_edges_fire_once() {
+        let open = snapshot("OPEN");
+        let merged = snapshot("MERGED");
+        // Opened: unseen → OPEN, or reopened from CLOSED.
+        assert!(pr_just_opened(None, &open));
+        assert!(pr_just_opened(Some("CLOSED"), &open));
+        assert!(!pr_just_opened(Some("OPEN"), &open));
+        // Merged: any prior non-merged state → MERGED, once.
+        assert!(pr_just_merged(Some("OPEN"), &merged));
+        assert!(pr_just_merged(None, &merged));
+        assert!(!pr_just_merged(Some("MERGED"), &merged));
+    }
+
+    #[test]
+    fn review_decision_change_fires_on_new_non_null_decision() {
+        let approved = GithubStatus {
+            review_decision: Some("APPROVED".to_string()),
+            ..snapshot("OPEN")
+        };
+        let changes = GithubStatus {
+            review_decision: Some("CHANGES_REQUESTED".to_string()),
+            ..snapshot("OPEN")
+        };
+        let dropped = GithubStatus {
+            review_decision: None,
+            ..snapshot("OPEN")
+        };
+        // A first decision and a decision that changes both fire.
+        assert!(review_decision_changed(None, &approved));
+        assert!(review_decision_changed(Some(&approved), &changes));
+        // The same decision does not re-fire; dropping back to null is silent.
+        assert!(!review_decision_changed(Some(&approved), &approved));
+        assert!(!review_decision_changed(Some(&approved), &dropped));
     }
 
     #[test]

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -187,7 +187,7 @@ pub fn is_stale(session: &Session, after: i64, now: DateTime<Utc>) -> bool {
 /// * No longer stale (activity resumed) → forget the id, re-arming the edge.
 ///
 /// Branch-scoped rather than system-scoped: the event carries the session's
-/// branch so the dispatcher's `reactive_context` can repo-filter it.
+/// branch so the dispatcher (`event_repo`) can repo-filter it.
 pub async fn detect_stale(
     state: &AppState,
     session: &Session,

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -201,13 +201,63 @@ pub async fn tick_timer(state: &AppState) {
     }
 }
 
+/// The triggering context handed to a round: the normalized event that woke it,
+/// its level, and the one session/branch/repo it concerns (a reactive event
+/// names one branch; a `cron`/`manual` tick names none). It rides in the round
+/// config as `trigger`, so a reactive program can act on just the session that
+/// changed — `rnd.triggered_sessions()` — instead of re-surveying the whole
+/// fleet, which is what keeps a watch like the PR labeller from hitting the
+/// GitHub API once per session every tick.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct TriggerCtx {
+    event: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    level: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repo: Option<String>,
+}
+
+impl TriggerCtx {
+    /// The context for a scheduled (`cron`/`every`) round — no single session.
+    fn scheduled() -> Self {
+        Self {
+            event: "cron".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// The context for an operator "run now" — no single session.
+    pub fn manual() -> Self {
+        Self {
+            event: "manual".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// The context for a reactive round woken by `event` — public so a test can
+    /// drive [`fire`] directly without routing a stream event through
+    /// [`dispatch`].
+    pub fn reactive(event: impl Into<String>) -> Self {
+        Self {
+            event: event.into(),
+            ..Default::default()
+        }
+    }
+}
+
 /// Route one new event to the overlookers it should fire.
 ///
 /// * a `cron` system tick carries `{overlooker}` → fire that one (scheduled);
 /// * a `manual` system tick carries `{overlooker, dry_run, reason}` → fire it
 ///   (operator "run now"), bypassing cooldown;
-/// * any other event is a reactive nudge: for each enabled overlooker with a
-///   matching reactive trigger, fire a (level-triggered) re-survey.
+/// * any other event is **normalized** to a trigger-event name (e.g. a `tag`
+///   write of the `attention` key → `session.attention`, a `pr_merged` →
+///   `pr.merged`): for each enabled overlooker whose subscription set names it,
+///   fire a (level-triggered) re-survey, handing it the triggering session.
 ///
 /// Public so a test (and the engine loop) can route a single event without the
 /// full tick cadence; in production only [`run`] calls it.
@@ -215,7 +265,15 @@ pub async fn dispatch(state: &AppState, in_flight: &InFlight, ev: &events::Event
     match ev.kind.as_str() {
         "cron" => {
             if let Some(o) = resolve_target(state, ev).await {
-                let _ = fire(state, in_flight, &o, "cron", false).await;
+                let _ = fire(
+                    state,
+                    in_flight,
+                    &o,
+                    "cron",
+                    false,
+                    &TriggerCtx::scheduled(),
+                )
+                .await;
             }
         }
         "manual" => {
@@ -230,22 +288,21 @@ pub async fn dispatch(state: &AppState, in_flight: &InFlight, ev: &events::Event
                     .get("reason")
                     .and_then(Value::as_str)
                     .unwrap_or("manual");
-                let _ = fire(state, in_flight, &o, reason, dry_run).await;
+                let _ = fire(state, in_flight, &o, reason, dry_run, &TriggerCtx::manual()).await;
             }
         }
         // The engine's own audit rows (and a `cron`/`manual` already handled)
         // must never re-trigger a reactive round, or it would chase its tail.
         "overlooker" => {}
         ev_kind => {
-            // Reactive: resolve the trigger's match `(kind, level, repo)`. A tag
-            // write is one `"tag"` event carrying `{key, value}` — its key is the
-            // match-kind and value the level, so a `{event:"attention",
-            // level:"blocked"}` trigger fires off the `attention` tag event. Every
-            // other reactive kind (`stale`, `pr_red`, hook-derived) matches on the
-            // event kind with the level from `data.level`. The repo is the
-            // repo_root of the event's branch; system rows (no branch) carry no
-            // repo and match only repo-less triggers.
-            let (match_kind, level, repo) = reactive_context(state, ev, ev_kind).await;
+            // Reactive: normalize the raw stream event into the watch-facing
+            // trigger vocabulary. An event that maps to no trigger event (a
+            // free-form tag, a `created`/`launching` status) wakes nothing.
+            let Some((event, level)) = trigger_event_of(ev, ev_kind) else {
+                return;
+            };
+            let repo = event_repo(state, ev).await;
+            let session = triggering_session(state, ev).await;
             let overlookers = match ov::list_enabled(&state.db).await {
                 Ok(o) => o,
                 Err(e) => {
@@ -255,12 +312,72 @@ pub async fn dispatch(state: &AppState, in_flight: &InFlight, ev: &events::Event
             };
             for o in overlookers {
                 if o.trigger()
-                    .matches_event(&match_kind, level.as_deref(), repo.as_deref())
+                    .matches_event(&event, level.as_deref(), repo.as_deref())
                 {
-                    let _ = fire(state, in_flight, &o, &format!("event:{match_kind}"), false).await;
+                    let ctx = TriggerCtx {
+                        event: event.clone(),
+                        level: level.clone(),
+                        session: session.clone(),
+                        branch: (!events::is_system(&ev.branch_id)).then(|| ev.branch_id.clone()),
+                        repo: repo.clone(),
+                    };
+                    let _ =
+                        fire(state, in_flight, &o, &format!("event:{event}"), false, &ctx).await;
                 }
             }
         }
+    }
+}
+
+/// Normalize a raw stream event into its watch-facing **trigger event** name and
+/// level, or `None` when the raw event isn't a subscription surface. This is the
+/// one place the internal event stream (`status`/`hook`/`tag`/`stale`/`pr_*`) is
+/// mapped to the stable, documented vocabulary scripts subscribe to — adding a
+/// new trigger event is a line here, not a change every script must learn.
+fn trigger_event_of(ev: &events::Event, ev_kind: &str) -> Option<(String, Option<String>)> {
+    let str_field = |key: &str| ev.data.get(key).and_then(Value::as_str);
+    match ev_kind {
+        // A tag write carries `{key, value}`: the agent's `attention` self-report
+        // and a watch's `triage` mark are the two trigger surfaces; a cleared tag
+        // (empty value) presents level `ok`.
+        "tag" => {
+            let level = str_field("value")
+                .filter(|v| !v.is_empty())
+                .map(str::to_string)
+                .or_else(|| Some("ok".to_string()));
+            match str_field("key")? {
+                "attention" => Some(("session.attention".to_string(), level)),
+                "triage" => Some(("triage.changed".to_string(), level)),
+                _ => None,
+            }
+        }
+        // Status transitions are edge-emitted (only on real change): `running`
+        // is the agent starting work; the terminal states are an exit (the level
+        // names which).
+        "status" => match str_field("status")? {
+            "running" => Some(("session.started".to_string(), None)),
+            status @ ("done" | "error" | "archived" | "orphaned") => {
+                Some(("session.exited".to_string(), Some(status.to_string())))
+            }
+            _ => None,
+        },
+        // The `idle` Claude hook is a finished turn — the closest signal to
+        // "round complete". `working`/`waiting`/`session-start` drive status and
+        // attention instead, so they aren't duplicated here.
+        "hook" => match str_field("event")? {
+            "idle" => Some(("session.idle".to_string(), None)),
+            _ => None,
+        },
+        "stale" => Some(("session.stale".to_string(), None)),
+        "pr_red" => Some(("pr.checks_red".to_string(), None)),
+        "pr_green" => Some(("pr.checks_green".to_string(), None)),
+        "pr_opened" => Some(("pr.opened".to_string(), None)),
+        "pr_merged" => Some(("pr.merged".to_string(), None)),
+        "pr_review" => Some((
+            "pr.review_changed".to_string(),
+            str_field("decision").map(str::to_string),
+        )),
+        _ => None,
     }
 }
 
@@ -272,53 +389,35 @@ async fn resolve_target(state: &AppState, ev: &events::Event) -> Option<Overlook
     o.enabled.then_some(o)
 }
 
-/// The `(match_kind, level, repo)` an event presents for reactive matching.
-///
-/// * For a `"tag"` event the match-kind is the tag's `key` and the level its
-///   `value` (an `attention` tag with value `blocked` matches a `{event:
-///   "attention", level:"blocked"}` trigger). A cleared tag (empty value) yields
-///   no level, matching only a level-agnostic `{event:"<key>"}` trigger.
-/// * For every other reactive kind the match-kind is the event kind itself and
-///   the level comes from `data.level`.
-///
-/// `repo` is the originating branch's `repo_root`; system events have no branch
-/// and so no repo.
-async fn reactive_context(
-    state: &AppState,
-    ev: &events::Event,
-    ev_kind: &str,
-) -> (String, Option<String>, Option<String>) {
-    let (match_kind, level) = if ev_kind == "tag" {
-        let key = ev
-            .data
-            .get("key")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string();
-        let level = ev
-            .data
-            .get("value")
-            .and_then(Value::as_str)
-            .filter(|v| !v.is_empty())
-            .map(str::to_string);
-        (key, level)
-    } else {
-        let level = ev
-            .data
-            .get("level")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        (ev_kind.to_string(), level)
-    };
+/// The `repo_root` an event originates from — the originating branch's repo, for
+/// the trigger's optional repo filter. System events have no branch, so no repo.
+async fn event_repo(state: &AppState, ev: &events::Event) -> Option<String> {
     if events::is_system(&ev.branch_id) {
-        return (match_kind, level, None);
+        return None;
     }
-    let repo = branch_mod::get(&state.db, &ev.branch_id)
+    branch_mod::get(&state.db, &ev.branch_id)
         .await
         .ok()
         .flatten()
-        .map(|b| b.repo_root);
-    (match_kind, level, repo)
+        .map(|b| b.repo_root)
+}
+
+/// The session a reactive event concerns: the explicit `data.session` when the
+/// event carries one (e.g. `stale`), else the active session of the event's
+/// branch. `None` for a system event. Handed to the round so it can act on the
+/// one session that changed.
+async fn triggering_session(state: &AppState, ev: &events::Event) -> Option<String> {
+    if let Some(sid) = ev.data.get("session").and_then(Value::as_str) {
+        return Some(sid.to_string());
+    }
+    if events::is_system(&ev.branch_id) {
+        return None;
+    }
+    session_mod::active_for_branch(&state.db, &ev.branch_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|s| s.id)
 }
 
 // ---------------------------------------------------------------------------
@@ -344,6 +443,7 @@ pub async fn fire(
     o: &Overlooker,
     trigger_reason: &str,
     dry_run: bool,
+    ctx: &TriggerCtx,
 ) -> Option<i64> {
     // 1. No-overlap: claim the in-flight slot or drop silently. A dropped round
     //    is intentionally not a run row — it never started.
@@ -373,6 +473,7 @@ pub async fn fire(
                     state,
                     o,
                     trigger_reason,
+                    &ctx.event,
                     &format!("cooldown: {cooldown}s gap not elapsed"),
                 )
                 .await;
@@ -381,7 +482,7 @@ pub async fn fire(
     }
 
     // Open the run row; everything from here closes it via `finish_run`.
-    let run_id = match ov::start_run(&state.db, &o.id, trigger_reason).await {
+    let run_id = match ov::start_run(&state.db, &o.id, trigger_reason, &ctx.event).await {
         Ok(id) => id,
         Err(e) => {
             tracing::warn!(overlooker = %o.id, "overlooker: opening run row failed: {e}");
@@ -396,25 +497,17 @@ pub async fn fire(
         .max(1);
     let result = tokio::time::timeout(
         Duration::from_secs(timeout_secs as u64),
-        run_program(state, o, dry_run),
+        run_program(state, o, dry_run, ctx),
     )
     .await;
 
-    let (outcome, summary, actions) = match result {
-        Ok(Ok(r)) => (r.outcome, r.summary, r.actions),
-        Ok(Err(e)) => (
-            "error".to_string(),
-            format!("round failed: {e}"),
-            Value::Array(vec![]),
-        ),
-        Err(_) => (
-            "error".to_string(),
-            format!("round exceeded {timeout_secs}s budget"),
-            Value::Array(vec![]),
-        ),
+    let round = match result {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => RoundResult::failed(format!("round failed: {e}")),
+        Err(_) => RoundResult::failed(format!("round exceeded {timeout_secs}s budget")),
     };
 
-    let _ = ov::finish_run(&state.db, run_id, &outcome, &summary, &actions).await;
+    let _ = ov::finish_run(&state.db, run_id, &round.record()).await;
     // Stamp the schedule: last_run_at = now; advance next_run_at for a scheduled
     // overlooker (a reactive one keeps None).
     let next = next_fire(o, now).map(iso);
@@ -429,10 +522,26 @@ async fn record_skipped(
     state: &AppState,
     o: &Overlooker,
     trigger_reason: &str,
+    trigger_event: &str,
     summary: &str,
 ) -> Option<i64> {
-    let run_id = ov::start_run(&state.db, &o.id, trigger_reason).await.ok()?;
-    let _ = ov::finish_run(&state.db, run_id, "skipped", summary, &Value::Array(vec![])).await;
+    let run_id = ov::start_run(&state.db, &o.id, trigger_reason, trigger_event)
+        .await
+        .ok()?;
+    let _ = ov::finish_run(
+        &state.db,
+        run_id,
+        &ov::RunRecord {
+            outcome: "skipped",
+            summary,
+            actions: &Value::Array(vec![]),
+            stdout: "",
+            stderr: "",
+            exit_code: None,
+            duration_ms: None,
+        },
+    )
+    .await;
     Some(run_id)
 }
 
@@ -440,41 +549,79 @@ async fn record_skipped(
 // The program substrate — the subprocess script executor
 // ---------------------------------------------------------------------------
 
-/// The result of running a program: an outcome, a one-line human summary, and the
-/// JSON array of actions for the run's audit trail.
+/// The result of running a program: the outcome + one-line summary + actions
+/// for the audit trail, plus the captured execution log (stdout/stderr tails,
+/// the interpreter exit code, and the wall-clock it ran).
 struct RoundResult {
     outcome: String,
     summary: String,
     actions: Value,
+    stdout: String,
+    stderr: String,
+    exit_code: Option<i64>,
+    duration_ms: Option<i64>,
 }
 
-/// Dispatch to the program the overlooker names: a builtin **script**
+impl RoundResult {
+    /// A failed round with no captured output — a guardrail (timeout) or a spawn
+    /// error that produced no streams. The script's own non-zero exit is a
+    /// different path: [`run_script`] returns an `error` result that *does* carry
+    /// the streams, so the execution log shows what it printed.
+    fn failed(summary: String) -> Self {
+        Self {
+            outcome: "error".to_string(),
+            summary,
+            actions: Value::Array(vec![]),
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: None,
+            duration_ms: None,
+        }
+    }
+
+    /// Borrow this result as the [`ov::RunRecord`] `finish_run` stores.
+    fn record(&self) -> ov::RunRecord<'_> {
+        ov::RunRecord {
+            outcome: &self.outcome,
+            summary: &self.summary,
+            actions: &self.actions,
+            stdout: &self.stdout,
+            stderr: &self.stderr,
+            exit_code: self.exit_code,
+            duration_ms: self.duration_ms,
+        }
+    }
+}
+
+/// Resolve the program an overlooker names into its script source: a builtin
 /// embedded from [`crate::builtins`], or a custom program file (an absolute
-/// path, conventionally under `~/.weaver/overlookers/`) — both run on
-/// [`run_script`].
+/// path, conventionally under `~/.weaver/overlookers/`). A bare relative path
+/// or unknown builtin errors.
+fn resolve_source(program: &str) -> anyhow::Result<ScriptSource> {
+    if let Some(source) = crate::builtins::find(program).map(|b| b.source) {
+        return Ok(ScriptSource::Embedded {
+            file_name: program_file_name(program),
+            source,
+        });
+    }
+    let path = std::path::PathBuf::from(program);
+    if path.is_absolute() {
+        return Ok(ScriptSource::File(path));
+    }
+    Err(anyhow::anyhow!(
+        "unknown overlooker program '{program}' — expected 'builtin:<name>' or an absolute path"
+    ))
+}
+
+/// Run the program the overlooker names for one round, handing it the triggering
+/// context so a reactive program can scope to the session that changed.
 async fn run_program(
     state: &AppState,
     o: &Overlooker,
     dry_run: bool,
+    ctx: &TriggerCtx,
 ) -> anyhow::Result<RoundResult> {
-    if let Some(source) = crate::builtins::find(&o.program).map(|b| b.source) {
-        let file_name = program_file_name(&o.program);
-        return run_script(
-            state,
-            o,
-            dry_run,
-            ScriptSource::Embedded { file_name, source },
-        )
-        .await;
-    }
-    let path = std::path::PathBuf::from(&o.program);
-    if path.is_absolute() {
-        return run_script(state, o, dry_run, ScriptSource::File(path)).await;
-    }
-    Err(anyhow::anyhow!(
-        "unknown overlooker program '{}' — expected 'builtin:<name>' or an absolute path",
-        o.program
-    ))
+    run_script(state, o, dry_run, resolve_source(&o.program)?, ctx).await
 }
 
 /// A scratch file name for an embedded builtin: `builtin:pr-label` →
@@ -538,17 +685,111 @@ async fn run_script(
     o: &Overlooker,
     dry_run: bool,
     src: ScriptSource,
+    ctx: &TriggerCtx,
 ) -> anyhow::Result<RoundResult> {
-    // One scratch dir per round: the vendored module always lands here (for
+    let config = json!({
+        "id": o.id,
+        "name": o.name,
+        "program": o.program,
+        "params": o.params(),
+        "scope": serde_json::to_value(o.scope()).unwrap_or(Value::Null),
+        "capabilities": o.capabilities(),
+        "model": o.model,
+        "effort": o.effort,
+        "dry_run": dry_run,
+        "mode": "run",
+        "trigger": serde_json::to_value(ctx).unwrap_or(Value::Null),
+    });
+
+    // A spawn / scratch-setup failure (no interpreter, unreadable file) is a
+    // round error with no streams — propagated up; the script's own non-zero
+    // exit is recorded below *with* its captured output, so the log shows it.
+    let out = spawn_script(state, &src, &config).await?;
+    let stdout = cap_stream(&out.stdout);
+    let stderr = cap_stream(&out.stderr);
+    let duration_ms = Some(out.duration_ms);
+
+    if !out.success {
+        return Ok(RoundResult {
+            outcome: "error".to_string(),
+            summary: format!(
+                "script exited with {}: {}",
+                out.exit_code.unwrap_or(-1),
+                tail(&out.stderr, 400)
+            ),
+            actions: Value::Array(vec![]),
+            stdout,
+            stderr,
+            exit_code: out.exit_code,
+            duration_ms,
+        });
+    }
+
+    let result = match parse_round_result(&out.stdout) {
+        Some(parsed) => RoundResult {
+            outcome: parsed.outcome,
+            summary: parsed.summary,
+            actions: parsed.actions,
+            stdout,
+            stderr,
+            exit_code: out.exit_code,
+            duration_ms,
+        },
+        None => RoundResult {
+            outcome: "error".to_string(),
+            summary: format!(
+                "script printed no result JSON object ({{outcome, summary, actions}}); stdout: {}; stderr: {}",
+                tail(&out.stdout, 200),
+                tail(&out.stderr, 200)
+            ),
+            actions: Value::Array(vec![]),
+            stdout,
+            stderr,
+            exit_code: out.exit_code,
+            duration_ms,
+        },
+    };
+    Ok(result)
+}
+
+/// The captured output of one script spawn: its exit status, stdout/stderr, and
+/// the wall-clock it ran. Shared by the round executor and register-mode
+/// manifest evaluation.
+struct ScriptOutput {
+    success: bool,
+    exit_code: Option<i64>,
+    stdout: String,
+    stderr: String,
+    duration_ms: i64,
+}
+
+/// Spawn a script subprocess and capture its output. An env-stripped process
+/// (the lint-review precedent, like [`crate::agent::run_oneshot`]) that reaches
+/// the fleet only through the loom REST API: `$WEAVER_API` carries the daemon's
+/// own address and `$WEAVER_OVERLOOKER` the JSON `config`; the vendored
+/// `weaver_loom` module rides `PYTHONPATH` so a program imports the API layer
+/// with no install step. The interpreter is `python3`, or `uv run --script` when
+/// the script declares PEP 723 inline metadata and `uv` is installed.
+///
+/// `config.mode` selects what the script does: `run` executes a round (and is
+/// expected to print `{outcome, summary, actions}`); `register` asks it to print
+/// its subscription manifest instead. `kill_on_drop` reaps the subprocess if the
+/// caller's budget cancels the future.
+async fn spawn_script(
+    state: &AppState,
+    src: &ScriptSource,
+    config: &Value,
+) -> anyhow::Result<ScriptOutput> {
+    // One scratch dir per spawn: the vendored module always lands here (for
     // PYTHONPATH), an embedded builtin's source too (so a traceback carries a
-    // real file/line). Removed when the round ends.
+    // real file/line). Removed when the spawn ends.
     let scratch = tempfile::tempdir().map_err(|e| anyhow::anyhow!("creating scratch dir: {e}"))?;
     let module = scratch.path().join("weaver_loom.py");
     tokio::fs::write(&module, crate::builtins::PYTHON_MODULE)
         .await
         .map_err(|e| anyhow::anyhow!("writing {}: {e}", module.display()))?;
 
-    let (script_path, source) = match &src {
+    let (script_path, source) = match src {
         ScriptSource::Embedded { file_name, source } => {
             let path = scratch.path().join(file_name);
             tokio::fs::write(&path, source)
@@ -571,18 +812,11 @@ async fn run_script(
         _ => scratch.path().display().to_string(),
     };
 
-    let config = json!({
-        "id": o.id,
-        "name": o.name,
-        "program": o.program,
-        "params": o.params(),
-        "scope": serde_json::to_value(o.scope()).unwrap_or(Value::Null),
-        "capabilities": o.capabilities(),
-        "model": o.model,
-        "effort": o.effort,
-        "dry_run": dry_run,
-    });
-
+    let mode = config
+        .get("mode")
+        .and_then(Value::as_str)
+        .unwrap_or("run")
+        .to_string();
     let interpreter = if has_pep723(&source) && uv_available().await {
         "uv"
     } else {
@@ -596,6 +830,7 @@ async fn run_script(
         .arg(&script_path)
         .env("WEAVER_API", api_base(&state.addr))
         .env("WEAVER_OVERLOOKER", config.to_string())
+        .env("WEAVER_OVERLOOKER_MODE", &mode)
         .env("PYTHONPATH", pythonpath)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -610,28 +845,45 @@ async fn run_script(
         command.env_remove(key);
     }
 
+    let started = std::time::Instant::now();
     let out = command.output().await.map_err(|e| {
-        anyhow::anyhow!(
-            "spawning {interpreter} for '{}' failed: {e} (is {interpreter} installed?)",
-            o.program
-        )
+        anyhow::anyhow!("spawning {interpreter} failed: {e} (is {interpreter} installed?)")
     })?;
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    if !out.status.success() {
+    Ok(ScriptOutput {
+        success: out.status.success(),
+        exit_code: out.status.code().map(i64::from),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        duration_ms: started.elapsed().as_millis() as i64,
+    })
+}
+
+/// Evaluate a program's **subscription manifest** by running it in register
+/// mode: the script prints its `{cron?, every?, on:[...]}` declaration instead
+/// of running a round, and that becomes the watch's stored trigger. Returns
+/// `None` when the program isn't a manifest-declaring script (a legacy script
+/// that prints a round result), so the caller keeps the existing/default
+/// trigger. Errors only on a spawn failure or a non-zero register exit.
+///
+/// This is the reconcile step: the engine calls it when a watch is created or
+/// its program changes, so the script — not whoever wired it up — owns which
+/// events wake it.
+pub async fn evaluate_manifest(
+    state: &AppState,
+    program: &str,
+    params: &Value,
+) -> anyhow::Result<Option<ov::Trigger>> {
+    let src = resolve_source(program)?;
+    let config = json!({ "mode": "register", "program": program, "params": params });
+    let out = spawn_script(state, &src, &config).await?;
+    if !out.success {
         anyhow::bail!(
-            "script exited with {}: {}",
-            out.status.code().unwrap_or(-1),
-            tail(&stderr, 400)
+            "register mode exited with {}: {}",
+            out.exit_code.unwrap_or(-1),
+            tail(&out.stderr, 400)
         );
     }
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    parse_round_result(&stdout).ok_or_else(|| {
-        anyhow::anyhow!(
-            "script printed no result JSON object ({{outcome, summary, actions}}); stdout: {}; stderr: {}",
-            tail(&stdout, 200),
-            tail(&stderr, 200)
-        )
-    })
+    Ok(parse_manifest(&out.stdout))
 }
 
 /// The REST base URL a script subprocess targets — the daemon's own bound
@@ -646,20 +898,43 @@ fn api_base(addr: &str) -> String {
     format!("http://{dialable}")
 }
 
-/// Parse a script's stdout into a [`RoundResult`]: the whole stdout as one
-/// JSON object, or — so a script may log progress lines first — the **last**
-/// stdout line that is one. The fields are read leniently: a missing/unknown
-/// `outcome` reads as `ok`, a missing `summary` as empty, a missing/non-array
-/// `actions` as none — so a minimal script stays minimal.
-fn parse_round_result(stdout: &str) -> Option<RoundResult> {
-    let trimmed = stdout.trim();
-    parse_result_object(trimmed).or_else(|| trimmed.lines().rev().find_map(parse_result_object))
+/// The largest stored stdout/stderr tail per run — enough to read a traceback
+/// or a chatty progress log without an unbounded script bloating a row.
+const STREAM_CAP: usize = 64_000;
+
+/// Cap a captured stream to its [`STREAM_CAP`] tail for storage.
+fn cap_stream(s: &str) -> String {
+    tail(s, STREAM_CAP)
 }
 
-/// One candidate result line → [`RoundResult`], if it is a JSON object.
-fn parse_result_object(text: &str) -> Option<RoundResult> {
-    let v: Value = serde_json::from_str(text.trim()).ok()?;
-    let obj = v.as_object()?;
+/// The last JSON object on stdout (the whole thing, or — so a script may log
+/// progress lines first — the last line that is one).
+fn parse_last_json_object(stdout: &str) -> Option<Value> {
+    let trimmed = stdout.trim();
+    let as_object = |t: &str| {
+        serde_json::from_str::<Value>(t.trim())
+            .ok()
+            .filter(Value::is_object)
+    };
+    as_object(trimmed).or_else(|| trimmed.lines().rev().find_map(as_object))
+}
+
+/// The three fields a script's result JSON contributes to a [`RoundResult`].
+/// Named (not a bare tuple) so the two same-typed `String` slots — `outcome`
+/// and `summary` — can't be transposed at a call site.
+struct ParsedRound {
+    outcome: String,
+    summary: String,
+    actions: Value,
+}
+
+/// Parse a script's stdout into its [`ParsedRound`]. The fields are read
+/// leniently: a missing/unknown `outcome` reads as `ok`, a missing `summary` as
+/// empty, a missing/non-array `actions` as none — so a minimal script stays
+/// minimal.
+fn parse_round_result(stdout: &str) -> Option<ParsedRound> {
+    let obj = parse_last_json_object(stdout)?;
+    let obj = obj.as_object()?;
     let outcome = obj
         .get("outcome")
         .and_then(Value::as_str)
@@ -674,11 +949,25 @@ fn parse_result_object(text: &str) -> Option<RoundResult> {
         .filter(|a| a.is_array())
         .cloned()
         .unwrap_or_else(|| Value::Array(vec![]));
-    Some(RoundResult {
+    Some(ParsedRound {
         outcome: outcome.to_string(),
         summary: summary.to_string(),
         actions,
     })
+}
+
+/// Parse a script's register-mode stdout into a [`ov::Trigger`] subscription
+/// manifest, or `None` when it isn't one. A round result (an object carrying
+/// `outcome`/`actions`) is *not* a manifest — that is a legacy script that
+/// doesn't declare subscriptions, so the caller keeps the existing trigger. An
+/// explicit (even empty) `{cron?, every?, on?}` object is accepted.
+fn parse_manifest(stdout: &str) -> Option<ov::Trigger> {
+    let value = parse_last_json_object(stdout)?;
+    let obj = value.as_object()?;
+    if obj.contains_key("outcome") || obj.contains_key("actions") {
+        return None;
+    }
+    serde_json::from_value::<ov::Trigger>(value).ok()
 }
 
 /// The last `n` bytes-ish of a process stream (on a char boundary), so an
@@ -724,9 +1013,16 @@ pub async fn fire_now(
     // no-overlap domain (the engine loop guards its own concurrent fires).
     let in_flight = new_in_flight();
     let reason = if reason.is_empty() { "manual" } else { reason };
-    fire(state, &in_flight, &o, reason, dry_run)
-        .await
-        .ok_or_else(|| anyhow::anyhow!("round skipped before it could open a run row"))
+    fire(
+        state,
+        &in_flight,
+        &o,
+        reason,
+        dry_run,
+        &TriggerCtx::manual(),
+    )
+    .await
+    .ok_or_else(|| anyhow::anyhow!("round skipped before it could open a run row"))
 }
 
 // ---------------------------------------------------------------------------
@@ -895,6 +1191,23 @@ mod tests {
     }
 
     #[test]
+    fn parse_manifest_accepts_declarations_not_round_results() {
+        // A subscription manifest parses into a Trigger.
+        let t = parse_manifest(r#"{"on":["pr.merged","pr.opened"]}"#).unwrap();
+        assert_eq!(t.on, vec!["pr.merged", "pr.opened"]);
+        let t = parse_manifest(r#"{"cron":"0 * * * *"}"#).unwrap();
+        assert_eq!(t.cron.as_deref(), Some("0 * * * *"));
+        // An empty manifest is a valid "manual only" declaration.
+        assert!(parse_manifest("{}").is_some());
+        // A round result is NOT a manifest — a legacy script that doesn't
+        // declare subscriptions; the caller keeps the existing trigger.
+        assert!(parse_manifest(r#"{"outcome":"ok","summary":"x","actions":[]}"#).is_none());
+        // A script may log first; the last object wins.
+        let t = parse_manifest("registering...\n{\"every\":\"15m\"}\n").unwrap();
+        assert_eq!(t.every.as_deref(), Some("15m"));
+    }
+
+    #[test]
     fn has_pep723_detects_the_inline_metadata_block() {
         assert!(has_pep723(
             "# /// script\n# dependencies = []\n# ///\nprint()"
@@ -970,9 +1283,16 @@ rnd.finish("name=%s label=%s dry=%s api=%s" % (
         .unwrap();
 
         let (state, o) = script_fixture(&script.display().to_string()).await;
-        let run_id = fire(&state, &new_in_flight(), &o, "manual", true)
-            .await
-            .unwrap();
+        let run_id = fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "manual",
+            true,
+            &TriggerCtx::manual(),
+        )
+        .await
+        .unwrap();
         let run = ov::recent_runs(&state.db, &o.id, 10)
             .await
             .unwrap()
@@ -980,6 +1300,10 @@ rnd.finish("name=%s label=%s dry=%s api=%s" % (
             .find(|r| r.id == run_id)
             .unwrap();
         assert_eq!(run.outcome, "ok", "summary: {}", run.summary);
+        // The execution log captured the script's output and a clean exit.
+        assert_eq!(run.exit_code, Some(0));
+        assert!(run.duration_ms.is_some());
+        assert_eq!(run.trigger_event, "manual");
         assert!(
             run.summary
                 .contains("name=script-test label=weaver dry=true api=http://127.0.0.1:0"),
@@ -1003,9 +1327,16 @@ rnd.finish("name=%s label=%s dry=%s api=%s" % (
         std::fs::write(&script, "raise RuntimeError('kaboom')\n").unwrap();
 
         let (state, o) = script_fixture(&script.display().to_string()).await;
-        let run_id = fire(&state, &new_in_flight(), &o, "manual", false)
-            .await
-            .unwrap();
+        let run_id = fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "manual",
+            false,
+            &TriggerCtx::manual(),
+        )
+        .await
+        .unwrap();
         let run = ov::recent_runs(&state.db, &o.id, 10)
             .await
             .unwrap()
@@ -1018,5 +1349,13 @@ rnd.finish("name=%s label=%s dry=%s api=%s" % (
             "the stderr tail names the failure: {}",
             run.summary
         );
+        // A failed round still records its execution log: the traceback on
+        // stderr and the non-zero exit code.
+        assert!(
+            run.stderr.contains("kaboom"),
+            "stderr captured: {}",
+            run.stderr
+        );
+        assert_eq!(run.exit_code, Some(1));
     }
 }

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -3088,13 +3088,25 @@ async fn create_overlooker(
     validate_program(&program)?;
     let capabilities = req.capabilities.unwrap_or(defaults.capabilities);
     validate_capabilities(&capabilities)?;
+    let params = json_text(req.params, &defaults.params);
+
+    // The script declares what wakes it: evaluate its subscription manifest
+    // (register mode) unless the caller pinned an explicit trigger.
+    let trigger_spec = match req.trigger {
+        Some(t) => t.to_string(),
+        None => {
+            let params_value = serde_json::from_str(&params).unwrap_or_else(|_| json!({}));
+            let fallback = program_default_trigger(&program).unwrap_or(defaults.trigger_spec);
+            reconcile_trigger(&st, &program, &params_value, &fallback).await
+        }
+    };
 
     let new = ov::NewOverlooker {
         name,
-        trigger_spec: json_text(req.trigger, &defaults.trigger_spec),
+        trigger_spec,
         scope: json_text(req.scope, &defaults.scope),
         program,
-        params: json_text(req.params, &defaults.params),
+        params,
         capabilities,
         model: req.model.unwrap_or(defaults.model),
         effort: req.effort.unwrap_or(defaults.effort),
@@ -3102,6 +3114,27 @@ async fn create_overlooker(
     };
     let o = ov::create(&st.db, &new).await?;
     Ok(Json(overlooker_view(&st.db, &o).await?))
+}
+
+/// The program's default trigger (a builtin's suggested manifest), used as the
+/// fallback when register-mode manifest evaluation declares none or fails.
+fn program_default_trigger(program: &str) -> Option<String> {
+    crate::builtins::find(program).map(|b| b.default_trigger.to_string())
+}
+
+/// Resolve a program's stored trigger from its register-mode manifest, falling
+/// back to `fallback` when the script declares no manifest or evaluation fails
+/// (a missing interpreter, a syntax error) — best-effort, never an error that
+/// blocks creating the watch.
+async fn reconcile_trigger(st: &AppState, program: &str, params: &Value, fallback: &str) -> String {
+    match ov_engine::evaluate_manifest(st, program, params).await {
+        Ok(Some(t)) => serde_json::to_string(&t).unwrap_or_else(|_| fallback.to_string()),
+        Ok(None) => fallback.to_string(),
+        Err(e) => {
+            tracing::debug!(program, error = %e, "manifest evaluation failed; using default trigger");
+            fallback.to_string()
+        }
+    }
 }
 
 async fn get_overlooker(
@@ -3128,8 +3161,23 @@ async fn patch_overlooker(
     if let Some(enabled) = req.enabled {
         ov::set_enabled(&st.db, &o.id, enabled).await?;
     }
+    // An explicit trigger wins; otherwise, when the program changes, re-evaluate
+    // the new script's manifest (with the effective params) so subscriptions
+    // follow the script — the same reconcile create does.
+    let trigger_spec = match &req.trigger {
+        Some(t) => Some(t.to_string()),
+        None => match &req.program {
+            Some(program) => {
+                let params = req.params.clone().unwrap_or_else(|| o.params());
+                let fallback =
+                    program_default_trigger(program).unwrap_or_else(|| o.trigger_spec.clone());
+                Some(reconcile_trigger(&st, program, &params, &fallback).await)
+            }
+            None => None,
+        },
+    };
     let patch = ov::OverlookerUpdate {
-        trigger_spec: req.trigger.map(|v| v.to_string()),
+        trigger_spec,
         scope: req.scope.map(|v| v.to_string()),
         program: req.program,
         params: req.params.map(|v| v.to_string()),

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -77,6 +77,16 @@ fn survey_program() -> String {
     .to_string()
 }
 
+/// A reactive fixture that declares a `pr.merged` subscription and surveys only
+/// the triggering session (via `triggered_sessions`).
+fn survey_triggered_program() -> String {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/integration/programs/survey_triggered.py"
+    )
+    .to_string()
+}
+
 /// The session ids a run's recorded `survey` actions name.
 fn surveyed_ids(run: &ov::OverlookerRun) -> Vec<String> {
     serde_json::from_str::<serde_json::Value>(&run.actions)
@@ -535,7 +545,15 @@ async fn cooldown_and_overlap_refire_are_refused() {
         let set = overlooker::new_in_flight();
         set.lock().await.insert(o.id.clone());
         let before = ov::recent_runs(&state.db, &o.id, 100).await.unwrap().len();
-        let dropped = overlooker::fire(&state, &set, &o, "event:attention", false).await;
+        let dropped = overlooker::fire(
+            &state,
+            &set,
+            &o,
+            "event:attention",
+            false,
+            &overlooker::TriggerCtx::reactive("session.attention"),
+        )
+        .await;
         assert!(dropped.is_none(), "an in-flight re-fire is dropped");
         let after = ov::recent_runs(&state.db, &o.id, 100).await.unwrap().len();
         assert_eq!(before, after, "a dropped re-fire opens no run row");
@@ -751,7 +769,8 @@ async fn rest_lists_builtin_programs_and_validates_program_refs() {
             .contains("archive-merged"),
         "the embedded source is served"
     );
-    assert!(archive["defaults"]["trigger"]["every"].is_string());
+    // archive-merged subscribes to the PR-merged event, not a polling timer.
+    assert_eq!(archive["defaults"]["trigger"]["on"][0], "pr.merged");
     assert_eq!(archive["defaults"]["capabilities"][0], "observe");
     let status = arr
         .iter()
@@ -1287,4 +1306,88 @@ async fn ensure_warm_session_reuses_the_same_session() {
     if let Some(s) = session_mod::get(&state.db, &first).await.unwrap() {
         backend::kill_session(&s.term_session).await.ok();
     }
+}
+
+/// The end-to-end subscription path: a watch created over REST has its trigger
+/// reconciled from the script's register-mode manifest; a `pr_merged` event
+/// normalizes to `pr.merged`, wakes the subscribed watch, and the round —
+/// handed the triggering session — surveys only that branch (not the whole
+/// fleet). The run row records the captured execution log (stdout, exit code,
+/// trigger event), which is the watch execution log the UI renders.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pr_merged_event_scopes_round_to_one_session_and_logs_output() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
+    let ts = TestServer::start().await;
+    let state = engine_state(&ts).await;
+    let (merged_id, merged_branch, _repo) = make_session(&ts, "merged work").await;
+    // A second live session in the same repo: it must NOT be surveyed, proving
+    // the round scoped to the triggering branch instead of the whole fleet.
+    let (_other_id, _other_branch, _repo) = make_session(&ts, "other work").await;
+
+    // Create the watch over REST: the script declares `on: [pr.merged]`, and the
+    // register-mode reconcile stores it (the script — not the caller — picks the
+    // event), with no explicit trigger in the request.
+    let created = ts
+        .client
+        .post(
+            "/api/overlookers",
+            json!({
+                "name": "merge-watch",
+                "program": survey_triggered_program(),
+                "capabilities": ["observe"],
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        created["trigger"]["on"][0], "pr.merged",
+        "the stored trigger came from the script's manifest: {created:?}"
+    );
+    ts.client
+        .patch("/api/overlookers/merge-watch", json!({ "enabled": true }))
+        .await
+        .unwrap();
+    let o = ov::get_by_name(&state.db, "merge-watch")
+        .await
+        .unwrap()
+        .unwrap();
+
+    // A merged-PR edge on the merged branch normalizes to `pr.merged`.
+    let ev = events::Event {
+        id: 0,
+        branch_id: merged_branch.clone(),
+        kind: "pr_merged".to_string(),
+        data: json!({ "pr": 41 }),
+        created_at: db::now_iso(),
+    };
+    let in_flight = overlooker::new_in_flight();
+    overlooker::dispatch(&state, &in_flight, &ev).await;
+
+    let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
+    assert_eq!(runs.len(), 1, "the pr.merged event fired exactly one round");
+    let run = &runs[0];
+    assert_eq!(run.outcome, "ok", "summary: {}", run.summary);
+    assert_eq!(run.trigger_event, "pr.merged", "the run records the event");
+    assert_eq!(
+        surveyed_ids(run),
+        vec![merged_id.clone()],
+        "the round surveyed only the triggering session, not the fleet"
+    );
+    // The execution log captured the script's output and a clean exit.
+    assert!(
+        run.stdout.contains("surveyed 1"),
+        "stdout captured: {}",
+        run.stdout
+    );
+    assert_eq!(run.exit_code, Some(0));
+    assert!(run.duration_ms.is_some());
+
+    ts.client
+        .delete(&format!("/api/sessions/{merged_id}"))
+        .await
+        .unwrap();
 }

--- a/crates/loom/tests/integration/programs/survey_triggered.py
+++ b/crates/loom/tests/integration/programs/survey_triggered.py
@@ -1,0 +1,22 @@
+"""Test fixture program: a reactive watch that surveys only the session the
+triggering event named (via `triggered_sessions`), recording one `survey`
+action per session. Declares a `pr.merged` subscription so a test can drive it
+through the engine's register-mode reconcile and event dispatch.
+
+Owned by the engine-mechanics integration tests (`tests/integration/
+overlookers.rs`); it mutates nothing.
+"""
+
+from weaver_loom import Round
+
+TRIGGERS = {"on": ["pr.merged"]}
+
+
+def main(rnd):
+    for session in rnd.triggered_sessions():
+        rnd.did("survey", session=session["id"])
+    rnd.finish(f"surveyed {rnd.surveyed}")
+
+
+if __name__ == "__main__":
+    Round.main(main, TRIGGERS)

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -324,17 +324,30 @@ impl OverlookerView {
 }
 
 /// One round in an overlooker's history (the audit trail), with `actions`
-/// parsed back into JSON for a UI to render.
+/// parsed back into JSON for a UI to render. The `stdout`/`stderr`/`exit_code`/
+/// `duration_ms` fields are the captured execution log — what the script printed
+/// and returned — surfaced so a run page shows exactly what happened.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OverlookerRunView {
     pub id: i64,
     pub trigger_reason: String,
+    /// The normalized event that woke the round (`cron` / `manual` / e.g.
+    /// `pr.merged`).
+    pub trigger_event: String,
     pub started_at: String,
     pub finished_at: Option<String>,
     pub outcome: String,
     pub summary: String,
     /// The JSON array of marks / nudges / would-dos the round recorded.
     pub actions: Value,
+    /// A tail of the script's standard output.
+    pub stdout: String,
+    /// A tail of the script's standard error.
+    pub stderr: String,
+    /// The interpreter's exit status, or `null` when it never spawned / timed out.
+    pub exit_code: Option<i64>,
+    /// Wall-clock the program ran, in milliseconds.
+    pub duration_ms: Option<i64>,
 }
 
 impl From<OverlookerRun> for OverlookerRunView {
@@ -342,11 +355,16 @@ impl From<OverlookerRun> for OverlookerRunView {
         Self {
             id: r.id,
             trigger_reason: r.trigger_reason,
+            trigger_event: r.trigger_event,
             started_at: r.started_at,
             finished_at: r.finished_at,
             outcome: r.outcome,
             summary: r.summary,
             actions: serde_json::from_str(&r.actions).unwrap_or(Value::Null),
+            stdout: r.stdout,
+            stderr: r.stderr,
+            exit_code: r.exit_code,
+            duration_ms: r.duration_ms,
         }
     }
 }

--- a/crates/weaver-core/migrations/0009_overlooker_run_output.sql
+++ b/crates/weaver-core/migrations/0009_overlooker_run_output.sql
@@ -1,0 +1,14 @@
+-- The watch execution log: capture each round's script output so a user can
+-- click a watch and see exactly what every run printed, returned, and how long
+-- it took — not just its one-line summary.
+--
+-- `trigger_event` is the normalized event that woke the round (`cron` /
+-- `manual` / e.g. `pr.merged`), distinct from the free-form `trigger_reason`.
+-- `stdout`/`stderr` are tails of the script's captured streams; `exit_code` is
+-- the interpreter's exit status (NULL when it never spawned or timed out);
+-- `duration_ms` is the wall-clock the program ran.
+ALTER TABLE overlooker_runs ADD COLUMN trigger_event TEXT NOT NULL DEFAULT '';
+ALTER TABLE overlooker_runs ADD COLUMN stdout        TEXT NOT NULL DEFAULT '';
+ALTER TABLE overlooker_runs ADD COLUMN stderr        TEXT NOT NULL DEFAULT '';
+ALTER TABLE overlooker_runs ADD COLUMN exit_code     INTEGER;
+ALTER TABLE overlooker_runs ADD COLUMN duration_ms   INTEGER;

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -57,6 +57,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "drop_plan_task",
         include_str!("../migrations/0008_drop_plan_task.sql"),
     ),
+    (
+        9,
+        "overlooker_run_output",
+        include_str!("../migrations/0009_overlooker_run_output.sql"),
+    ),
 ];
 
 /// Apply every pending migration, bringing the database up to the latest schema.

--- a/crates/weaver-core/src/overlooker.rs
+++ b/crates/weaver-core/src/overlooker.rs
@@ -43,23 +43,53 @@ pub struct Overlooker {
     pub updated_at: String,
 }
 
-/// The parsed trigger: an event-match predicate. A scheduled trigger carries a
-/// `cron` (or `every`) cadence; a reactive one carries an `event` kind (and an
-/// optional `level`). An optional `repo` pins the overlooker to one repository.
-/// Stored as the JSON the plan documents, e.g. `{"cron":"0 * * * *"}` or
-/// `{"event":"attention","level":"blocked","repo":"/path"}`.
+/// The parsed trigger — a watch's **subscription manifest**: what wakes a round.
+/// A scheduled watch carries a `cron` (or `every`) cadence; a reactive one
+/// subscribes to one or more normalized trigger events via `on` (e.g.
+/// `["pr.merged", "session.exited=error"]`). An optional `repo` pins the watch
+/// to one repository. The manifest is what the watch *script declares* (it is
+/// emitted from the script's register mode and stored here), so the script —
+/// not whoever wired it up — decides which events it cares about.
+///
+/// Stored as JSON, e.g. `{"cron":"0 * * * *"}` or
+/// `{"on":["pr.merged","pr.opened"]}`. The legacy single-event shape
+/// (`{"event":"attention","level":"blocked"}`) is still parsed and folded into
+/// the subscription set, so watches predating the manifest keep working.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct Trigger {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cron: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub every: Option<String>,
+    /// The normalized trigger events this watch subscribes to. Each entry is an
+    /// event name (`"pr.merged"`) or a `name=level` filter
+    /// (`"session.attention=blocked"`). Empty means "no reactive subscription".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub on: Vec<String>,
+    /// Legacy single-event subscription, kept for back-compat — folded into the
+    /// effective set by [`Trigger::subscriptions`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub event: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub level: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo: Option<String>,
+}
+
+/// Map a legacy raw event kind to its normalized trigger-event name, so a watch
+/// that predates the manifest (and named the raw stream kind) still matches the
+/// normalized names the dispatcher now emits. An unknown name passes through.
+fn normalize_event_name(name: &str) -> &str {
+    match name {
+        "attention" => "session.attention",
+        "triage" => "triage.changed",
+        "stale" => "session.stale",
+        "pr_red" => "pr.checks_red",
+        "pr_green" => "pr.checks_green",
+        "pr_merged" => "pr.merged",
+        "pr_opened" => "pr.opened",
+        other => other,
+    }
 }
 
 impl Trigger {
@@ -69,22 +99,44 @@ impl Trigger {
         self.cron.is_some() || self.every.is_some()
     }
 
-    /// Whether this trigger matches a stream event of `kind` whose payload
-    /// `level` and originating `repo` are as given. Scheduled triggers never
-    /// match a stream event directly — they fire off their own `cron` tick.
-    pub fn matches_event(&self, kind: &str, level: Option<&str>, repo: Option<&str>) -> bool {
-        let Some(want_kind) = self.event.as_deref() else {
-            return false;
-        };
-        if want_kind != kind {
+    /// The effective event subscriptions as `(event_name, optional_level)`
+    /// pairs: the `on` list (each entry an event name or `name=level`) plus the
+    /// legacy single `event`/`level`. Names are normalized so a legacy raw kind
+    /// matches the dispatcher's normalized vocabulary.
+    pub fn subscriptions(&self) -> Vec<(String, Option<String>)> {
+        let mut subs: Vec<(String, Option<String>)> = self
+            .on
+            .iter()
+            .map(|entry| match entry.split_once('=') {
+                Some((name, level)) => (
+                    normalize_event_name(name.trim()).to_string(),
+                    Some(level.trim().to_string()),
+                ),
+                None => (normalize_event_name(entry.trim()).to_string(), None),
+            })
+            .filter(|(name, _)| !name.is_empty())
+            .collect();
+        if let Some(event) = self.event.as_deref().filter(|e| !e.is_empty()) {
+            subs.push((
+                normalize_event_name(event).to_string(),
+                self.level.clone().filter(|l| !l.is_empty()),
+            ));
+        }
+        subs
+    }
+
+    /// Whether this trigger matches a normalized trigger `event` whose payload
+    /// `level` and originating `repo` are as given. Matches when any
+    /// subscription names this event and either declares no level or one equal
+    /// to the event's. Scheduled triggers never match a stream event directly —
+    /// they fire off their own `cron` tick.
+    pub fn matches_event(&self, event: &str, level: Option<&str>, repo: Option<&str>) -> bool {
+        if !self.repo_matches(repo) {
             return false;
         }
-        if let Some(want_level) = self.level.as_deref() {
-            if level != Some(want_level) {
-                return false;
-            }
-        }
-        self.repo_matches(repo)
+        self.subscriptions().iter().any(|(name, want_level)| {
+            name == event && want_level.as_deref().is_none_or(|wl| level == Some(wl))
+        })
     }
 
     /// Whether the trigger's optional `repo` filter admits an event from `repo`.
@@ -422,51 +474,78 @@ pub async fn delete(db: &Db, id: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 /// One execution of an overlooker — a "round". `actions` is the JSON list of
-/// marks / nudges / etc. it took.
+/// marks / nudges / etc. it took; `stdout`/`stderr`/`exit_code`/`duration_ms`
+/// are the script's captured output (the execution log), and `trigger_event`
+/// the normalized event that woke it (`cron` / `manual` / e.g. `pr.merged`).
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct OverlookerRun {
     pub id: i64,
     pub overlooker_id: String,
     pub trigger_reason: String,
+    pub trigger_event: String,
     pub started_at: String,
     pub finished_at: Option<String>,
     pub outcome: String,
     pub summary: String,
     pub actions: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: Option<i64>,
+    pub duration_ms: Option<i64>,
     pub created_at: String,
 }
 
-/// Open a run row at the start of a round; returns its id. The executor closes
-/// it with [`finish_run`].
-pub async fn start_run(db: &Db, overlooker_id: &str, trigger_reason: &str) -> Result<i64> {
+/// The closing record of a round: its outcome plus the captured execution log.
+/// Grouped into a struct so [`finish_run`] doesn't grow an unreadable argument
+/// list as the audit trail records more about each run.
+#[derive(Debug, Clone)]
+pub struct RunRecord<'a> {
+    pub outcome: &'a str,
+    pub summary: &'a str,
+    pub actions: &'a Value,
+    pub stdout: &'a str,
+    pub stderr: &'a str,
+    pub exit_code: Option<i64>,
+    pub duration_ms: Option<i64>,
+}
+
+/// Open a run row at the start of a round; returns its id. `trigger_event` is
+/// the normalized event that woke it. The executor closes it with
+/// [`finish_run`].
+pub async fn start_run(
+    db: &Db,
+    overlooker_id: &str,
+    trigger_reason: &str,
+    trigger_event: &str,
+) -> Result<i64> {
     let row = sqlx::query(
-        "INSERT INTO overlooker_runs (overlooker_id, trigger_reason, started_at)
-         VALUES (?, ?, ?) RETURNING id",
+        "INSERT INTO overlooker_runs (overlooker_id, trigger_reason, trigger_event, started_at)
+         VALUES (?, ?, ?, ?) RETURNING id",
     )
     .bind(overlooker_id)
     .bind(trigger_reason)
+    .bind(trigger_event)
     .bind(now_iso())
     .fetch_one(db)
     .await?;
     Ok(sqlx::Row::get(&row, "id"))
 }
 
-/// Close a run row with its outcome, a one-line summary, and the actions taken.
-pub async fn finish_run(
-    db: &Db,
-    run_id: i64,
-    outcome: &str,
-    summary: &str,
-    actions: &Value,
-) -> Result<()> {
+/// Close a run row with its outcome, summary, actions, and captured output.
+pub async fn finish_run(db: &Db, run_id: i64, rec: &RunRecord<'_>) -> Result<()> {
     sqlx::query(
-        "UPDATE overlooker_runs SET finished_at = ?, outcome = ?, summary = ?, actions = ?
+        "UPDATE overlooker_runs SET finished_at = ?, outcome = ?, summary = ?, actions = ?,
+           stdout = ?, stderr = ?, exit_code = ?, duration_ms = ?
          WHERE id = ?",
     )
     .bind(now_iso())
-    .bind(outcome)
-    .bind(summary)
-    .bind(actions.to_string())
+    .bind(rec.outcome)
+    .bind(rec.summary)
+    .bind(rec.actions.to_string())
+    .bind(rec.stdout)
+    .bind(rec.stderr)
+    .bind(rec.exit_code)
+    .bind(rec.duration_ms)
     .bind(run_id)
     .execute(db)
     .await?;
@@ -528,10 +607,12 @@ mod tests {
         .unwrap();
         let t = o.trigger();
         assert!(!t.is_scheduled());
-        assert!(t.matches_event("attention", Some("blocked"), Some("/r")));
-        assert!(!t.matches_event("attention", Some("ok"), Some("/r")));
+        // The legacy `{event,level}` shape folds into the normalized
+        // subscription `session.attention=blocked`.
+        assert!(t.matches_event("session.attention", Some("blocked"), Some("/r")));
+        assert!(!t.matches_event("session.attention", Some("ok"), Some("/r")));
         // The repo filter excludes other repos' events.
-        assert!(!t.matches_event("attention", Some("blocked"), Some("/other")));
+        assert!(!t.matches_event("session.attention", Some("blocked"), Some("/other")));
 
         let s = o.scope();
         assert!(s.admits("blocked", "/r"));
@@ -551,13 +632,20 @@ mod tests {
         )
         .await
         .unwrap();
-        let run = start_run(&db, &o.id, "manual").await.unwrap();
+        let run = start_run(&db, &o.id, "manual", "manual").await.unwrap();
+        let actions = serde_json::json!([{ "session": "abc", "mark": "attention" }]);
         finish_run(
             &db,
             run,
-            "ok",
-            "marked 1 session",
-            &serde_json::json!([{ "session": "abc", "mark": "attention" }]),
+            &RunRecord {
+                outcome: "ok",
+                summary: "marked 1 session",
+                actions: &actions,
+                stdout: "surveyed 3\n",
+                stderr: "",
+                exit_code: Some(0),
+                duration_ms: Some(42),
+            },
         )
         .await
         .unwrap();
@@ -565,6 +653,9 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].outcome, "ok");
         assert_eq!(runs[0].trigger_reason, "manual");
+        assert_eq!(runs[0].trigger_event, "manual");
+        assert_eq!(runs[0].stdout, "surveyed 3\n");
+        assert_eq!(runs[0].exit_code, Some(0));
         assert!(runs[0].finished_at.is_some());
     }
 

--- a/crates/weaver-core/src/overlooker.rs
+++ b/crates/weaver-core/src/overlooker.rs
@@ -99,30 +99,35 @@ impl Trigger {
         self.cron.is_some() || self.every.is_some()
     }
 
-    /// The effective event subscriptions as `(event_name, optional_level)`
+    /// The effective event subscriptions as borrowed `(event_name, opt_level)`
     /// pairs: the `on` list (each entry an event name or `name=level`) plus the
-    /// legacy single `event`/`level`. Names are normalized so a legacy raw kind
-    /// matches the dispatcher's normalized vocabulary.
+    /// legacy single `event`/`level`, with names normalized to the dispatcher's
+    /// vocabulary. Borrowed, not collected, so matching an event needs no
+    /// allocation.
+    fn subscription_pairs(&self) -> impl Iterator<Item = (&str, Option<&str>)> {
+        let on = self.on.iter().filter_map(|entry| {
+            let (name, level) = match entry.split_once('=') {
+                Some((name, level)) => (name.trim(), Some(level.trim())),
+                None => (entry.trim(), None),
+            };
+            let name = normalize_event_name(name);
+            (!name.is_empty()).then_some((name, level))
+        });
+        let legacy = self.event.as_deref().filter(|e| !e.is_empty()).map(|e| {
+            (
+                normalize_event_name(e),
+                self.level.as_deref().filter(|l| !l.is_empty()),
+            )
+        });
+        on.chain(legacy)
+    }
+
+    /// The effective subscriptions as owned `(event_name, optional_level)` pairs
+    /// — the [`subscription_pairs`](Self::subscription_pairs) view, collected.
     pub fn subscriptions(&self) -> Vec<(String, Option<String>)> {
-        let mut subs: Vec<(String, Option<String>)> = self
-            .on
-            .iter()
-            .map(|entry| match entry.split_once('=') {
-                Some((name, level)) => (
-                    normalize_event_name(name.trim()).to_string(),
-                    Some(level.trim().to_string()),
-                ),
-                None => (normalize_event_name(entry.trim()).to_string(), None),
-            })
-            .filter(|(name, _)| !name.is_empty())
-            .collect();
-        if let Some(event) = self.event.as_deref().filter(|e| !e.is_empty()) {
-            subs.push((
-                normalize_event_name(event).to_string(),
-                self.level.clone().filter(|l| !l.is_empty()),
-            ));
-        }
-        subs
+        self.subscription_pairs()
+            .map(|(name, level)| (name.to_string(), level.map(str::to_string)))
+            .collect()
     }
 
     /// Whether this trigger matches a normalized trigger `event` whose payload
@@ -134,8 +139,8 @@ impl Trigger {
         if !self.repo_matches(repo) {
             return false;
         }
-        self.subscriptions().iter().any(|(name, want_level)| {
-            name == event && want_level.as_deref().is_none_or(|wl| level == Some(wl))
+        self.subscription_pairs().any(|(name, want_level)| {
+            name == event && want_level.is_none_or(|wl| level == Some(wl))
         })
     }
 
@@ -618,6 +623,38 @@ mod tests {
         assert!(s.admits("blocked", "/r"));
         assert!(!s.admits("ok", "/r")); // !ok excludes ok
         assert!(!s.admits("blocked", "/other")); // repo filter
+    }
+
+    #[test]
+    fn on_list_subscriptions_match_per_event_and_level() {
+        // A manifest `on` list with a bare event and a `name=level` filter, plus
+        // a legacy `event`. `matches_event` and the collected `subscriptions()`
+        // must agree on every entry — they share one parse path.
+        let t: Trigger = serde_json::from_str(
+            r#"{"on":["pr.merged","session.exited=error"],"event":"attention"}"#,
+        )
+        .unwrap();
+
+        // Bare `on` entry: matches regardless of payload level.
+        assert!(t.matches_event("pr.merged", None, None));
+        assert!(t.matches_event("pr.merged", Some("whatever"), None));
+        // `name=level` entry: matches only the named level.
+        assert!(t.matches_event("session.exited", Some("error"), None));
+        assert!(!t.matches_event("session.exited", Some("ok"), None));
+        assert!(!t.matches_event("session.exited", None, None));
+        // Legacy `event` folds in, normalized.
+        assert!(t.matches_event("session.attention", Some("blocked"), None));
+        // An unsubscribed event never matches.
+        assert!(!t.matches_event("pr.opened", None, None));
+
+        assert_eq!(
+            t.subscriptions(),
+            vec![
+                ("pr.merged".to_string(), None),
+                ("session.exited".to_string(), Some("error".to_string())),
+                ("session.attention".to_string(), None),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/docs/plans/overlooker.md
+++ b/docs/plans/overlooker.md
@@ -119,35 +119,57 @@ weaver already has a single event spine — the append-only `events` table that
 `weaver hook` writes and the monitor consumes on a watermark. The overlooker
 engine joins it as **another consumer**, and the trigger model collapses to:
 
-> A **trigger** is an event-match predicate. The engine consumes new events and,
-> for each, fires every overlooker whose trigger matches. **Cron is not a
-> separate mechanism — it is an event source.**
+> A **trigger** is a **subscription manifest** — a set of named events (plus an
+> optional schedule) the *script declares*. The engine consumes new events and,
+> for each, fires every overlooker subscribed to it. **Cron is not a separate
+> mechanism — it is an event source.**
+
+The manifest (stored in `trigger_spec`) carries `cron`/`every` (a schedule) and
+`on: [...]` (the normalized trigger events to subscribe to, each `name` or
+`name=level`), plus an optional `repo` filter. The script owns it: a watch runs
+in **register mode** (`WEAVER_OVERLOOKER_MODE=register`) and prints its
+manifest, which the engine reconciles onto the row whenever the watch is created
+or its program changes. So the script — not whoever wired it up — decides which
+events wake it (`Round.main(main, TRIGGERS)` in `weaver_loom`).
 
 Concretely the engine has two halves:
 
 - **The timer (a producer).** It keeps each scheduled overlooker's next-fire time
   (parsed with the [`croner`](https://github.com/Hexagon/croner-rust) crate) and,
   at fire time, writes a `cron` event into the stream — nothing more. A cron tick
-  is now a first-class, logged, SSE-broadcast event (`{kind: "cron", overlooker}`)
+  is a first-class, logged, SSE-broadcast event (`{kind: "cron", overlooker}`)
   you can see in the history, exactly like a hook.
 - **The dispatcher (a consumer).** It reads `events::since(watermark)` like the
-  monitor (its own independent watermark), and for each new event fires the
-  overlookers whose trigger matches: a scheduled overlooker matches its own `cron`
-  tick; a reactive one matches `attention=blocked`, a staleness signal, a PR
-  going red. `loom overlooker run` injects a `manual` trigger event. One dispatch
-  path, whatever woke it. A trigger may also carry a **`repo`** filter; when set,
-  the dispatcher only fires for events whose branch lives in that repo (and a
-  `cron` round scopes its survey to that repo), so an overlooker can be pinned to
-  a single project.
+  monitor (its own independent watermark). For each new raw event it **normalizes**
+  it into the watch-facing trigger vocabulary (`trigger_event_of`): a `tag` write
+  of the `attention` key → `session.attention`, a `status` transition →
+  `session.started`/`session.exited`, a `pr_merged` → `pr.merged`, and so on —
+  one place maps the internal stream to the stable names scripts subscribe to.
+  It then fires every overlooker whose manifest names that event. `loom
+  overlooker run` injects a `manual` event. One dispatch path, whatever woke it.
+  A trigger may also carry a **`repo`** filter; when set, the dispatcher only
+  fires for events whose branch lives in that repo, so an overlooker can be
+  pinned to a single project.
+
+The normalized vocabulary: **schedule** (`cron`); **session lifecycle**
+(`session.started`, `session.idle` — a finished turn —, `session.exited`,
+`session.attention`, `session.stale`); **triage** (`triage.changed`); and **PR**
+edges (`pr.opened`, `pr.checks_red`, `pr.checks_green`, `pr.merged`,
+`pr.review_changed`). The PR edges are emitted once per real transition by the
+GitHub poller's snapshot diff, so a watch wakes on the change, not on a poll.
 
 This is why **level-triggered** (the K8s lesson) matters and is now structural:
-the matched event is only a *nudge to look*. The round always observes the
-*current* scoped fleet and reconciles — it never "handles" the specific event.
-So firing twice is idempotent, a restart that misses events self-heals on the
-next tick, and a session legitimately waiting isn't hammered by an edge-triggered
-nag. The one accommodation the events table needs: a **system scope** for
-fleet-global rows (a reserved branch id, or a nullable `branch_id`) so a `cron`
-tick — which belongs to no branch — lives in the same stream.
+the matched event is only a *nudge to look*. The round reconciles the *current*
+scoped fleet — it never "handles" the specific event, so firing twice is
+idempotent and a restart that misses events self-heals on the next tick. But the
+round is also handed the **triggering session** (the branch the event named) as
+its `trigger` context, so a reactive program can survey just that one session
+(`rnd.triggered_sessions()`) instead of the whole fleet — the difference between
+one GitHub call and one per session every tick. A `cron`/`manual` tick names no
+session, so `triggered_sessions()` falls back to the full survey. The one
+accommodation the events table needs: a **system scope** for fleet-global rows
+(a reserved branch id) so a `cron` tick — which belongs to no branch — lives in
+the same stream.
 
 ### The mark: a separate tag
 
@@ -245,24 +267,31 @@ Two authoring languages sit on that one substrate:
   audit trail, and capability gate as a custom one.
 
 ```python
-import weaver
+from weaver_loom import Round
 
-@weaver.on_cron("0 * * * *")               # the trigger — a cron event source
-def hourly_status(ov):
-    for s in ov.sessions(attention="!ok"): # the scope, queried over the fleet
-        if s.idle_minutes() > 30 and s.pr_checks() == "failing":
-            s.mark("attention", "idle 30m with red CI")        # a pure rule
-        else:
-            verdict = ov.run_agent(           # …or a fresh agent for judgement
-                f"Is this session stuck? Screen:\n{s.preview(200)}")
-            s.mark(verdict.level, verdict.note)
-            if verdict.level != "ok" and ov.can("nudge"):
-                s.nudge(verdict.suggestion)
+TRIGGERS = {"cron": "0 * * * *"}           # the manifest — what wakes a round
+
+def hourly_status(rnd):
+    for s in rnd.triggered_sessions():     # the triggering session, else the fleet
+        gh = (s.get("branch") or {}).get("github") or {}
+        if gh.get("checks") == "failing":
+            rnd.client.mark(s["id"], "attention", "red CI", by=rnd.name)  # a rule
+        elif rnd.params.get("prompt"):
+            out = rnd.client.agent(          # …or a fresh agent for judgement
+                f"Is this session stuck? Screen:\n{rnd.client.preview(s['id'], 200)}")
+            # parse_judgement(out) → (level, note); mark accordingly
+    rnd.finish(f"surveyed {rnd.surveyed}")
+
+if __name__ == "__main__":
+    Round.main(hourly_status, TRIGGERS)
 ```
 
-`@weaver.on_cron(...)` / `@weaver.on_event(...)` declare the trigger the engine
-registers; the body is the round. The binding enforces capabilities — a program
-without `nudge` can't call `s.nudge` — and the per-round budget kills a runaway.
+The module-level `TRIGGERS` is the subscription manifest; `Round.main` handles
+both engine modes — in **register mode** it prints `TRIGGERS` (the engine stores
+it), and in run mode it constructs the `Round` and calls the function. The
+binding enforces capabilities — a program without `nudge` can't call
+`client.nudge` — and the per-round budget kills a runaway. A reactive watch
+subscribes to events instead of a clock, e.g. `TRIGGERS = {"on": ["pr.merged"]}`.
 
 ## Authoring & iteration (agent-friendly)
 
@@ -367,9 +396,12 @@ through the same `weaver-api` the out-of-process programs use.
   `params` (JSON for a stock program / the prompt), `capabilities` (JSON set),
   `model`, `effort`, `cooldown_secs`, `last_run_at`, `next_run_at`,
   `warm_session_id` (nullable), `created_at`, `updated_at`.
-- `overlooker_runs` — `id`, `overlooker_id`, `trigger_reason`, `started_at`,
-  `finished_at`, `outcome` (`ok|noop|skipped|error`), `summary`, `actions`
-  (JSON), `created_at`. The audit trail + the panel's history.
+- `overlooker_runs` — `id`, `overlooker_id`, `trigger_reason`, `trigger_event`
+  (the normalized event that woke it), `started_at`, `finished_at`, `outcome`
+  (`ok|noop|skipped|error`), `summary`, `actions` (JSON), plus the captured
+  **execution log** — `stdout`, `stderr`, `exit_code`, `duration_ms` — so the
+  panel shows exactly what each run printed and returned, and `created_at`. The
+  audit trail + the panel's history.
 - **`tags` table** — one row per `(branch_id, key)` (`value/note/set_by/set_at`)
   with a registry of well-known keys (`attention`, `triage`); a `tag` event kind
   carries `{key, value, note, by}`. The overlooker's mark is the `triage` key.
@@ -409,7 +441,8 @@ the "separate panel & system" the problem asks for, API-first
 - **List** — each overlooker: trigger (next fire / last run), enabled toggle,
   last outcome, a **Run now** (and **Dry-run**) button.
 - **Detail** — the program (the file, or the declarative config editor), the
-  **round history** (`overlooker_runs` with summaries and the marks made), and,
+  **round history** (`overlooker_runs`: click a run to see its marks plus the
+  captured stdout/stderr, exit code, and duration — the execution log), and,
   for an overlooker that keeps a warm session, its **live terminal** via the
   existing `AgentTerminal` component.
 - **On the fleet** — every session's resolved attention signal carries the

--- a/e2e/tests/overlookers.spec.ts
+++ b/e2e/tests/overlookers.spec.ts
@@ -94,6 +94,23 @@ test.describe('overlooker panel', () => {
     await expect(runRows.first()).toContainText(/run \(dry\)/i);
   });
 
+  test('expands a run to show its captured execution log', async ({ page, weaver }) => {
+    const o = await weaver.seedOverlooker({ name: 'logged', scope: { attention: '!ok' } });
+    await page.goto(`${weaver.baseUrl}/overlookers/${o.id}`);
+
+    // A dry-run produces a round; with no sessions in scope the script prints a
+    // noop result line — which the run row captures as its stdout.
+    await page.getByTestId('overlooker-dryrun').click();
+    const runRows = page.getByTestId('overlooker-run-row');
+    await expect(runRows.first()).toBeVisible();
+
+    // Click the row to expand its execution log; the captured stdout is shown.
+    await runRows.first().getByTestId('overlooker-run-toggle').click();
+    const stdout = page.getByTestId('overlooker-run-stdout').first();
+    await expect(stdout).toBeVisible();
+    await expect(stdout).toContainText(/noop|surveyed 0/i);
+  });
+
   test('edits the prompt and capabilities from the detail page', async ({ page, weaver }) => {
     const o = await weaver.seedOverlooker({ name: 'editable', params: { prompt: 'original' } });
 

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -305,8 +305,12 @@ class Round:
         that changed instead of re-surveying the whole fleet — the difference
         between one GitHub call and one per session. When it names none (a
         ``cron``/``manual`` tick) it falls back to the full :meth:`sessions`
-        survey. Sets :attr:`surveyed`.
+        survey. Empty in register mode, like :meth:`sessions` — a script asked
+        only what wakes it must not touch the fleet. Sets :attr:`surveyed`.
         """
+        if self.mode == "register":
+            self.surveyed = 0
+            return []
         sid = (self.trigger or {}).get("session")
         bid = (self.trigger or {}).get("branch")
         if not sid and not bid:

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -16,16 +16,30 @@ Two pieces:
   capabilities, the scope-filtered fleet survey, and the
   ``{outcome, summary, actions}`` result the engine reads from stdout.
 
-A minimal program::
+A program declares **what wakes it** with a ``TRIGGERS`` manifest and ends with
+``Round.main(main, TRIGGERS)`` — the engine reads the manifest in *register
+mode* and then only calls the round for those events, handing it the session
+that changed via :meth:`Round.triggered_sessions`::
 
     from weaver_loom import Round
 
-    rnd = Round()
-    for session in rnd.sessions():
-        github = (session.get("branch") or {}).get("github") or {}
-        if github.get("pr_state") == "MERGED":
-            rnd.would("archive", session=session["id"], note="PR merged")
-    rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} findings")
+    TRIGGERS = {"on": ["pr.merged"]}
+
+    def main(rnd):
+        for session in rnd.triggered_sessions():
+            github = (session.get("branch") or {}).get("github") or {}
+            if github.get("pr_state") == "MERGED":
+                rnd.would("archive", session=session["id"], note="PR merged")
+        rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} findings")
+
+    if __name__ == "__main__":
+        Round.main(main, TRIGGERS)
+
+The manifest keys are ``cron`` / ``every`` (a schedule) and ``on`` (a list of
+normalized trigger events — ``session.started``, ``session.idle``,
+``session.exited``, ``session.attention``, ``session.stale``, ``triage.changed``,
+``pr.opened``, ``pr.checks_red``, ``pr.checks_green``, ``pr.merged``,
+``pr.review_changed`` — each optionally ``name=level``).
 
 The loom engine vendors this module onto ``PYTHONPATH`` for every script it
 runs, so a program needs no install step; for standalone iteration, install it
@@ -224,11 +238,37 @@ class Round:
         #: these to :meth:`Client.agent` so judgement honours the config.
         self.model = config.get("model", "")
         self.effort = config.get("effort", "")
-        self.dry_run = bool(config.get("dry_run"))
-        self.client = client or Client(capabilities=config.get("capabilities") or [])
+        #: ``run`` (execute a round) or ``register`` (declare the manifest). The
+        #: engine sets it via the config and ``$WEAVER_OVERLOOKER_MODE``; in
+        #: register mode the round is neutered (no mutations, empty survey) so a
+        #: script that doesn't use :meth:`main` can't act when merely asked what
+        #: wakes it.
+        self.mode = config.get("mode") or os.environ.get("WEAVER_OVERLOOKER_MODE") or "run"
+        #: The triggering context the engine passed: ``{event, level, session,
+        #: branch, repo}`` for a reactive round; ``{event: "cron"|"manual"}``
+        #: otherwise. Drives :meth:`triggered_sessions`.
+        self.trigger = config.get("trigger") or {}
+        self.dry_run = bool(config.get("dry_run")) or self.mode == "register"
+        caps = [] if self.mode == "register" else (config.get("capabilities") or [])
+        self.client = client or Client(capabilities=caps)
         self.actions = []
-        #: How many live sessions the last :meth:`sessions` survey admitted.
+        #: How many live sessions the last survey admitted.
         self.surveyed = 0
+
+    @staticmethod
+    def main(fn, triggers=None):
+        """Entry point that handles both engine modes — a script ends with
+        ``Round.main(main, TRIGGERS)``.
+
+        In ``register`` mode (the engine asking what events wake this watch) it
+        prints the subscription manifest and returns *without running*, so
+        declaring triggers has no side effects. Otherwise it constructs a
+        :class:`Round` and calls ``fn(round)``.
+        """
+        if os.environ.get("WEAVER_OVERLOOKER_MODE", "run") == "register":
+            print(json.dumps(triggers or {}))
+            return
+        fn(Round())
 
     def can(self, cap):
         """Whether this round holds ``cap`` (``observe`` is always held)."""
@@ -239,11 +279,43 @@ class Round:
 
         Terminal sessions are skipped; the overlooker's scope applies its
         ``attention`` filter (``!ok`` or an exact level; an absent tag is the
-        calm ``ok``) and its ``repo`` pin. Sets :attr:`surveyed`.
+        calm ``ok``) and its ``repo`` pin. Sets :attr:`surveyed`. Empty in
+        register mode (the round must not touch the fleet just to be asked what
+        wakes it).
         """
+        if self.mode == "register":
+            self.surveyed = 0
+            return []
         admitted = []
         for session in self.client.sessions():
             if session.get("status") in TERMINAL_STATUSES:
+                continue
+            if not self._admits(session):
+                continue
+            admitted.append(session)
+        self.surveyed = len(admitted)
+        return admitted
+
+    def triggered_sessions(self):
+        """The session(s) the triggering event concerns — the survey a reactive
+        round should act on.
+
+        When the trigger names a single session/branch (a reactive event), this
+        returns just that one (scope-filtered), so the round acts on the branch
+        that changed instead of re-surveying the whole fleet — the difference
+        between one GitHub call and one per session. When it names none (a
+        ``cron``/``manual`` tick) it falls back to the full :meth:`sessions`
+        survey. Sets :attr:`surveyed`.
+        """
+        sid = (self.trigger or {}).get("session")
+        bid = (self.trigger or {}).get("branch")
+        if not sid and not bid:
+            return self.sessions()
+        admitted = []
+        for session in self.client.sessions():
+            if sid and session.get("id") != sid:
+                continue
+            if bid and (session.get("branch") or {}).get("id") != bid:
                 continue
             if not self._admits(session):
                 continue

--- a/python/weaver-loom/tests/test_status_program.py
+++ b/python/weaver-loom/tests/test_status_program.py
@@ -76,14 +76,9 @@ def make_round(client, **config):
 
 
 def run_main(client, capsys, **config):
-    """Drive main() with a stubbed round; return the parsed result line."""
+    """Drive main(rnd) with a stubbed round; return the parsed result line."""
     rnd = make_round(client, capabilities=client.capabilities, **config)
-    orig = status.Round
-    status.Round = lambda: rnd
-    try:
-        status.main()
-    finally:
-        status.Round = orig
+    status.main(rnd)
     return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
 
 

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -191,6 +191,28 @@ def test_register_mode_neuters_the_round(monkeypatch):
         rnd.client.mark("live", "blocked")
 
 
+def test_register_mode_triggered_sessions_is_empty(monkeypatch):
+    # triggered_sessions() honours the same register-mode guard as sessions():
+    # even when the trigger names a concrete session, a legacy script that calls
+    # it while merely being asked what wakes it must not touch the fleet. The
+    # round is given a client that explodes on any survey to prove it isn't hit.
+    monkeypatch.setenv("WEAVER_OVERLOOKER_MODE", "register")
+
+    class Exploding:
+        def can(self, _cap):
+            return False
+
+        def sessions(self):
+            raise AssertionError("register mode must not survey the fleet")
+
+    rnd = Round(
+        config={"trigger": {"event": "pr.opened", "session": "s1"}},
+        client=Exploding(),
+    )
+    assert rnd.triggered_sessions() == []
+    assert rnd.surveyed == 0
+
+
 # -- capability gating ---------------------------------------------------------
 
 

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -120,6 +120,77 @@ def test_scope_repo_pin_excludes_other_repos():
     assert [s["id"] for s in rnd.sessions()] == ["here"]
 
 
+# -- triggered_sessions: scope to the session the event named ------------------
+
+
+def branch_session(id, branch_id, **kw):
+    s = session(id, **kw)
+    s["branch"]["id"] = branch_id
+    return s
+
+
+def trigger_round(trigger, sessions, scope=None):
+    client = StubClient(capabilities=[], replies={"/sessions": sessions})
+    return Round(
+        config={"name": "t", "scope": scope or {}, "trigger": trigger}, client=client
+    )
+
+
+def test_triggered_sessions_scopes_to_the_named_branch():
+    fleet = [branch_session("a", "b1"), branch_session("b", "b2")]
+    rnd = trigger_round({"event": "pr.merged", "branch": "b1"}, fleet)
+    assert [s["id"] for s in rnd.triggered_sessions()] == ["a"]
+    assert rnd.surveyed == 1
+
+
+def test_triggered_sessions_scopes_to_the_named_session():
+    fleet = [branch_session("a", "b1"), branch_session("b", "b1")]
+    rnd = trigger_round({"event": "session.idle", "session": "b"}, fleet)
+    assert [s["id"] for s in rnd.triggered_sessions()] == ["b"]
+
+
+def test_triggered_sessions_falls_back_to_full_survey_without_a_target():
+    # A cron/manual tick names no session, so the round surveys the whole fleet.
+    fleet = [session("a"), session("b"), session("done", status="done")]
+    rnd = trigger_round({"event": "cron"}, fleet)
+    assert [s["id"] for s in rnd.triggered_sessions()] == ["a", "b"]
+
+
+# -- Round.main: register declares, run executes -------------------------------
+
+
+def test_main_register_mode_prints_manifest_without_running(monkeypatch, capsys):
+    monkeypatch.setenv("WEAVER_OVERLOOKER_MODE", "register")
+    ran = []
+    Round.main(lambda rnd: ran.append(rnd), {"on": ["pr.merged"]})
+    assert ran == [], "register mode declares triggers, it never runs a round"
+    assert json.loads(capsys.readouterr().out) == {"on": ["pr.merged"]}
+
+
+def test_main_run_mode_invokes_the_round(monkeypatch):
+    monkeypatch.delenv("WEAVER_OVERLOOKER_MODE", raising=False)
+    monkeypatch.setenv("WEAVER_OVERLOOKER", "{}")
+    ran = []
+    Round.main(lambda rnd: ran.append(rnd))
+    assert len(ran) == 1 and isinstance(ran[0], Round)
+
+
+def test_register_mode_neuters_the_round(monkeypatch):
+    # A legacy script that constructs a Round directly in register mode must not
+    # be able to act: the survey is empty, the round is dry, and the engine-built
+    # client is granted no write capabilities even when the config names some.
+    monkeypatch.setenv("WEAVER_OVERLOOKER_MODE", "register")
+    monkeypatch.setenv(
+        "WEAVER_OVERLOOKER", json.dumps({"name": "t", "capabilities": ["mark"]})
+    )
+    rnd = Round()
+    assert rnd.sessions() == []
+    assert rnd.dry_run is True
+    assert not rnd.client.can("mark"), "register mode drops the granted capabilities"
+    with pytest.raises(CapabilityDenied):
+        rnd.client.mark("live", "blocked")
+
+
 # -- capability gating ---------------------------------------------------------
 
 


### PR DESCRIPTION
## Why

Overlookers ("watches") ran on every engine *round*, and a round fired on any event from any session. So a watch like `pr-label` re-surveyed the whole fleet — and hit the GitHub API — whenever anything happened anywhere. Triggers were a single opaque DB column, decoupled from the script the operator actually wrote, and the builtins leaned on time-polling (`every 5m` / `15m`) to paper over it.

Fixes #137.

## What changed

Watch scripts now **declare the events they care about**, and the engine runs them **only for those events, scoped to the session that fired**.

- **Subscription manifest.** A script exports `TRIGGERS = {cron?, every?, on:[events]}` and calls `Round.main(main, TRIGGERS)`. On create / program-change the engine runs the script in *register mode* (`WEAVER_OVERLOOKER_MODE=register`) and reconciles the declared manifest onto the row — the manifest is the source of truth. Legacy single-event triggers still parse, and a legacy script that declares nothing keeps its existing trigger.
- **Normalized trigger vocabulary.** `cron`, `session.{started,idle,exited,attention,stale}`, `triage.changed`, `pr.{opened,checks_red,checks_green,merged,review_changed}`, `manual`. Raw internal event kinds map onto these names in the dispatcher; the underlying event stream is unchanged.
- **Trigger context.** A reactive round receives the firing session via `rnd.triggered_sessions()` instead of re-surveying the fleet — so `pr-label` labels the one PR that just opened rather than scanning every session. This is the actual GitHub-call reduction.
- **GitHub edges.** `apply_snapshot` now emits `pr.opened` / `pr.merged` / `pr.checks_*` / `pr.review_changed` transition events, so PR watches react to changes instead of polling.
- **Execution log.** `overlooker_runs` captures `trigger_event`, `stdout`, `stderr`, `exit_code` and `duration_ms` per run (migration `0009`). The watch detail page lists every run, each expandable to its captured output and exit code.
- **Builtins migrated to subscriptions.** `pr-label` → `pr.opened`, `archive-merged` → `pr.merged`, `status` stays on cron.

The design recommendation (with control-flow mermaid diagrams) is in the `watch-triggers-design` weaver artifact.

## Testing

- `weaver-core` 50, `loom` lib 61, `loom` integration (overlookers) 13, `weaver-loom` pytest 28 — all green.
- e2e `overlookers.spec.ts` green, including a new test that expands a run row and asserts the captured stdout.
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Visual validation of the run-log UI in both light and dark themes.

Closes #137, #140, #141, #142, #143, #144, #145.
