### PR TITLE
fix(docker): push to GitHub SSH-remote repos via the token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,10 @@ RUN if ! getent group "${HOST_GID}" >/dev/null; then groupadd -g "${HOST_GID}" a
     useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -d /home/app -s /bin/bash app
 
 # Let agents `git push` over HTTPS with the injected GH_TOKEN — no mounted SSH
-# key. (Repos with git@github.com SSH remotes need ~/.ssh mounted; see compose.)
+# key. The bind-mounted host repos usually have `git@github.com:` SSH remotes, so
+# also rewrite GitHub SSH URLs to HTTPS: with no key in the container an SSH push
+# fails with "Permission denied (publickey)", but rewritten it rides the token
+# helper below. (Non-GitHub SSH remotes still need ~/.ssh mounted; see compose.)
 RUN <<'EOF'
 cat > /usr/local/bin/git-credential-ghtoken <<'SH'
 #!/bin/sh
@@ -48,6 +51,8 @@ printf 'username=x-access-token\npassword=%s\n' "$GH_TOKEN"
 SH
 chmod +x /usr/local/bin/git-credential-ghtoken
 git config --system credential.https://github.com.helper ghtoken
+git config --system url.https://github.com/.insteadOf git@github.com:
+git config --system url.https://github.com/.insteadOf ssh://git@github.com/
 EOF
 
 # loom resolves the tapestry PTY supervisor as a sibling of its own binary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,10 @@ services:
       # The repos + the worktrees loom creates, shared with the host at the SAME
       # path. HOST_CODE is your repo dir (e.g. /home/you/code); set it in the env.
       - ${HOST_CODE:?set HOST_CODE (host repo dir) in secrets/weaver.env}:${HOST_CODE}
-      # Repos with git@github.com SSH remotes need your key — uncomment & set the
-      # host path (target is the container user's home):
+      # GitHub SSH remotes (git@github.com:) work without a key — the image
+      # rewrites them to HTTPS over the GH_TOKEN helper. Mount your key only for
+      # non-GitHub SSH remotes — uncomment & set the host path (target is the
+      # container user's home):
       # - /home/you/.ssh:/home/app/.ssh:ro
     networks:
       - web


### PR DESCRIPTION
## Problem

The containerized loom deploy installs a `git-credential-ghtoken` helper so agents can `git push` over HTTPS with the injected `GH_TOKEN`, and deliberately mounts **no** SSH key. But the host repos it bind-mounts almost always have `git@github.com:` **SSH** `origin` remotes, and a worktree push uses that remote — so the push fails:

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

This bites the common case (agent finishes work → `git push` → open PR) on any repo cloned over SSH, which is most of them.

## Fix

Add two `url.insteadOf` rewrites to the image's **system** git config, right next to the existing credential helper:

```dockerfile
git config --system url.https://github.com/.insteadOf git@github.com:
git config --system url.https://github.com/.insteadOf ssh://git@github.com/
```

GitHub SSH URLs are transparently rewritten to HTTPS, which the `GH_TOKEN` helper already authenticates — no key mount, no host-specific config, container-only (host git is untouched). Non-GitHub SSH remotes still need `~/.ssh` mounted; the compose comment is updated to say so.

## Verification

In a running container built from this image (host repos bind-mounted), against a `git@github.com:` remote:

- **Before:** `git ls-remote origin` → `Permission denied (publickey)`.
- **After:** `git ls-remote origin HEAD` → `f8c39c8…  HEAD` (resolved over HTTPS via the token).

Dockerfile + compose-comment only; no Rust/SPA changes.