### PR TITLE
loom: fix proxied terminal WebSocket + pre-seed Claude first-run gates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# The image build does its own clean `cargo build --release` and `npm install`
+# inside the build stage, so none of these host artifacts belong in the build
+# context — shipping them just bloats the daemon upload (host target/ alone is
+# >1GB) and can shadow a clean build.
+target/
+.git/
+**/node_modules/
+crates/loom/static/dist/
+.env

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::backend;
 use weaver_core::agent::hooks_json;
@@ -127,6 +127,14 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
 
     if spec.agent_kind == "claude" {
         install_hooks(spec.work_dir, &weaver_bin).await.ok();
+        // A fresh container HOME hasn't cleared Claude Code's first-run gates
+        // (theme picker, workspace trust, API-key + bypass-mode prompts), so an
+        // unattended `claude` would stall — or quit — before reading the goal.
+        // Pre-seed that state so it runs. Pass the resolved args so the
+        // bypass-mode gate is only seeded when we actually launch in that mode.
+        seed_claude_launch_gates(spec.work_dir, spec.claude_args)
+            .await
+            .ok();
     }
 
     let api_url = format!("http://{}", spec.server_addr);
@@ -192,6 +200,127 @@ pub async fn install_hooks(work_dir: &Path, weaver_bin: &str) -> Result<()> {
     root["hooks"] = hooks["hooks"].clone();
     tokio::fs::write(&path, serde_json::to_string_pretty(&root)?).await?;
     tracing::debug!(path = %path.display(), "claude hooks installed");
+    Ok(())
+}
+
+/// Pre-clear Claude Code's first-run interactive gates in the agent user's
+/// global `~/.claude.json` so a detached, unattended `claude` runs its task
+/// instead of stalling — or *quitting* — at a prompt no human can answer.
+///
+/// On a fresh, persisted container HOME these gates fire in sequence and each
+/// wedges the session (it sits at "launching" with no `weaver status`, worktree
+/// idle). Each gate is just state Claude records after a human answers once; we
+/// write the same state ahead of time. Everything here is additive and
+/// idempotent — only missing/false gates are set, existing config is preserved —
+/// so it is safe to re-run before every launch. Gates handled:
+///
+/// * `hasCompletedOnboarding` + `theme` — the first-run theme picker.
+/// * `projects.<repo-root>.hasTrustDialogAccepted` — the workspace-trust dialog.
+///   Claude resolves a git worktree back to its **main repo root** and records
+///   trust there, so trusting the root once covers every worktree under it.
+/// * `customApiKeyResponses.approved` — the "use this `ANTHROPIC_API_KEY`?"
+///   prompt, keyed by the key's last 20 chars; seeded only when that env var is
+///   set (i.e. the agent authenticates by API key).
+/// * `bypassPermissionsModeAccepted` — the one-time "you're in Bypass
+///   Permissions mode" confirmation, **which defaults to *exit***. Seeded only
+///   when this launch actually runs with a bypass flag, since the dialog only
+///   appears then.
+pub async fn seed_claude_launch_gates(work_dir: &Path, claude_args: &str) -> Result<()> {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        tracing::debug!("HOME unset; skipping claude launch-gate seed");
+        return Ok(());
+    };
+    let path = home.join(".claude.json");
+    let mut root: Value = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|_| json!({})),
+        Err(_) => json!({}),
+    };
+    if !root.is_object() {
+        root = json!({});
+    }
+    let obj = root.as_object_mut().expect("root is an object");
+    let mut changed = false;
+
+    // 1. Onboarding / theme picker.
+    if obj.get("hasCompletedOnboarding").and_then(Value::as_bool) != Some(true) {
+        obj.insert("hasCompletedOnboarding".into(), json!(true));
+        changed = true;
+    }
+    if !obj.contains_key("theme") {
+        obj.insert("theme".into(), json!("dark"));
+        changed = true;
+    }
+
+    // 2. Bypass-permissions acceptance — only when we launch in that mode.
+    let bypass = claude_args.contains("--dangerously-skip-permissions")
+        || claude_args.contains("bypassPermissions");
+    if bypass && obj.get("bypassPermissionsModeAccepted").and_then(Value::as_bool) != Some(true) {
+        obj.insert("bypassPermissionsModeAccepted".into(), json!(true));
+        changed = true;
+    }
+
+    // 3. Ambient ANTHROPIC_API_KEY approval (keyed by the key's last 20 chars).
+    if let Some(key) = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| k.len() >= 20) {
+        let tail = key[key.len() - 20..].to_string();
+        let entry = obj
+            .entry("customApiKeyResponses")
+            .or_insert_with(|| json!({"approved": [], "rejected": []}));
+        if !entry.is_object() {
+            *entry = json!({"approved": [], "rejected": []});
+        }
+        let entry = entry.as_object_mut().unwrap();
+        if !entry.get("approved").map(Value::is_array).unwrap_or(false) {
+            entry.insert("approved".into(), json!([]));
+        }
+        let approved = entry.get_mut("approved").unwrap().as_array_mut().unwrap();
+        if !approved.iter().any(|v| v.as_str() == Some(tail.as_str())) {
+            approved.push(json!(tail));
+            changed = true;
+        }
+        if !entry.contains_key("rejected") {
+            entry.insert("rejected".into(), json!([]));
+        }
+    }
+
+    // 4. Workspace trust, recorded at the worktree's main repo root.
+    match weaver_core::git::repo_root(work_dir).await {
+        Ok(repo_root) => {
+            let key = repo_root.to_string_lossy().to_string();
+            let projects = obj.entry("projects").or_insert_with(|| json!({}));
+            if !projects.is_object() {
+                *projects = json!({});
+            }
+            let proj = projects
+                .as_object_mut()
+                .unwrap()
+                .entry(key)
+                .or_insert_with(|| json!({}));
+            if !proj.is_object() {
+                *proj = json!({});
+            }
+            let proj = proj.as_object_mut().unwrap();
+            if proj.get("hasTrustDialogAccepted").and_then(Value::as_bool) != Some(true) {
+                proj.insert("hasTrustDialogAccepted".into(), json!(true));
+                changed = true;
+            }
+        }
+        Err(e) => tracing::debug!(work_dir = %work_dir.display(), error = %e,
+            "could not resolve repo root for trust seed"),
+    }
+
+    if !changed {
+        return Ok(());
+    }
+    tokio::fs::write(&path, serde_json::to_string_pretty(&root)?)
+        .await
+        .with_context(|| format!("seeding {}", path.display()))?;
+    // claude writes this file 0600; preserve that posture.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await;
+    }
+    tracing::info!(path = %path.display(), bypass, "seeded claude launch gates");
     Ok(())
 }
 

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -126,15 +126,21 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
         .unwrap_or_else(|| "weaver".to_string());
 
     if spec.agent_kind == "claude" {
-        install_hooks(spec.work_dir, &weaver_bin).await.ok();
+        // Both steps are best-effort — a failure shouldn't abort the launch — but
+        // log it, since a silent failure here resurfaces only as a stalled agent.
+        if let Err(e) = install_hooks(spec.work_dir, &weaver_bin).await {
+            tracing::warn!(work_dir = %spec.work_dir.display(), error = %e,
+                "install_hooks failed; launching agent without weaver hooks");
+        }
         // A fresh container HOME hasn't cleared Claude Code's first-run gates
         // (theme picker, workspace trust, API-key + bypass-mode prompts), so an
         // unattended `claude` would stall — or quit — before reading the goal.
         // Pre-seed that state so it runs. Pass the resolved args so the
         // bypass-mode gate is only seeded when we actually launch in that mode.
-        seed_claude_launch_gates(spec.work_dir, spec.claude_args)
-            .await
-            .ok();
+        if let Err(e) = seed_claude_launch_gates(spec.work_dir, spec.claude_args).await {
+            tracing::warn!(work_dir = %spec.work_dir.display(), error = %e,
+                "seeding claude launch gates failed; agent may stall on first-run prompts");
+        }
     }
 
     let api_url = format!("http://{}", spec.server_addr);
@@ -231,12 +237,87 @@ pub async fn seed_claude_launch_gates(work_dir: &Path, claude_args: &str) -> Res
         return Ok(());
     };
     let path = home.join(".claude.json");
+    // Read any existing config, distinguishing "absent" (fine — start fresh) from
+    // "present but unparseable" (bail). On a parse error we must NOT fall back to
+    // `{}` and write: that would clobber a real config that's momentarily
+    // truncated or mid-write (e.g. a concurrent `claude` writing the file).
     let mut root: Value = match tokio::fs::read_to_string(&path).await {
-        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|_| json!({})),
-        Err(_) => json!({}),
+        Ok(s) if s.trim().is_empty() => json!({}),
+        Ok(s) => match serde_json::from_str(&s) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e,
+                    "~/.claude.json present but unparseable; skipping launch-gate \
+                     seed rather than overwriting it");
+                return Ok(());
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => json!({}),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", path.display())),
     };
+
+    let bypass = claude_args.contains("--dangerously-skip-permissions")
+        || claude_args.contains("bypassPermissions");
+    // Approve the ambient ANTHROPIC_API_KEY by its last 20 chars (how claude keys
+    // these), when one is set and long enough to slice.
+    let api_key_tail = std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|k| k.len() >= 20)
+        .map(|k| k[k.len() - 20..].to_string());
+    // Workspace trust is recorded at the worktree's *main* repo root, which Claude
+    // resolves a git worktree to, so trusting the root covers every worktree.
+    let repo_root = match weaver_core::git::repo_root(work_dir).await {
+        Ok(r) => Some(r.to_string_lossy().into_owned()),
+        Err(e) => {
+            tracing::debug!(work_dir = %work_dir.display(), error = %e,
+                "could not resolve repo root for trust seed");
+            None
+        }
+    };
+
+    let seed = GateSeed {
+        bypass,
+        api_key_tail: api_key_tail.as_deref(),
+        repo_root: repo_root.as_deref(),
+    };
+    if !apply_launch_gates(&mut root, &seed) {
+        return Ok(());
+    }
+
+    tokio::fs::write(&path, serde_json::to_string_pretty(&root)?)
+        .await
+        .with_context(|| format!("seeding {}", path.display()))?;
+    // claude writes this file 0600; preserve that posture.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await;
+    }
+    tracing::info!(path = %path.display(), bypass, "seeded claude launch gates");
+    Ok(())
+}
+
+/// The environment-derived inputs for [`apply_launch_gates`], gathered by
+/// [`seed_claude_launch_gates`] so the merge itself is a pure function.
+struct GateSeed<'a> {
+    /// Seed `bypassPermissionsModeAccepted` — only when launching with a bypass
+    /// flag, since the dialog appears only then.
+    bypass: bool,
+    /// The ambient `ANTHROPIC_API_KEY`'s last 20 chars to mark approved, if set.
+    api_key_tail: Option<&'a str>,
+    /// The worktree's main repo root, to record workspace trust against.
+    repo_root: Option<&'a str>,
+}
+
+/// Merge the first-run gate state into a parsed `.claude.json` value. Pure,
+/// additive, and idempotent: only missing or `false` keys are written and every
+/// existing value is preserved, so re-running is a no-op and a user's real config
+/// is never clobbered. Returns whether anything changed. Split out from
+/// [`seed_claude_launch_gates`] (which does the env/fs/git I/O) so these merge
+/// paths are unit-testable without touching HOME or a git repo.
+fn apply_launch_gates(root: &mut Value, seed: &GateSeed) -> bool {
     if !root.is_object() {
-        root = json!({});
+        *root = json!({});
     }
     let obj = root.as_object_mut().expect("root is an object");
     let mut changed = false;
@@ -252,16 +333,18 @@ pub async fn seed_claude_launch_gates(work_dir: &Path, claude_args: &str) -> Res
     }
 
     // 2. Bypass-permissions acceptance — only when we launch in that mode.
-    let bypass = claude_args.contains("--dangerously-skip-permissions")
-        || claude_args.contains("bypassPermissions");
-    if bypass && obj.get("bypassPermissionsModeAccepted").and_then(Value::as_bool) != Some(true) {
+    if seed.bypass
+        && obj
+            .get("bypassPermissionsModeAccepted")
+            .and_then(Value::as_bool)
+            != Some(true)
+    {
         obj.insert("bypassPermissionsModeAccepted".into(), json!(true));
         changed = true;
     }
 
     // 3. Ambient ANTHROPIC_API_KEY approval (keyed by the key's last 20 chars).
-    if let Some(key) = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| k.len() >= 20) {
-        let tail = key[key.len() - 20..].to_string();
+    if let Some(tail) = seed.api_key_tail {
         let entry = obj
             .entry("customApiKeyResponses")
             .or_insert_with(|| json!({"approved": [], "rejected": []}));
@@ -273,7 +356,7 @@ pub async fn seed_claude_launch_gates(work_dir: &Path, claude_args: &str) -> Res
             entry.insert("approved".into(), json!([]));
         }
         let approved = entry.get_mut("approved").unwrap().as_array_mut().unwrap();
-        if !approved.iter().any(|v| v.as_str() == Some(tail.as_str())) {
+        if !approved.iter().any(|v| v.as_str() == Some(tail)) {
             approved.push(json!(tail));
             changed = true;
         }
@@ -283,45 +366,27 @@ pub async fn seed_claude_launch_gates(work_dir: &Path, claude_args: &str) -> Res
     }
 
     // 4. Workspace trust, recorded at the worktree's main repo root.
-    match weaver_core::git::repo_root(work_dir).await {
-        Ok(repo_root) => {
-            let key = repo_root.to_string_lossy().to_string();
-            let projects = obj.entry("projects").or_insert_with(|| json!({}));
-            if !projects.is_object() {
-                *projects = json!({});
-            }
-            let proj = projects
-                .as_object_mut()
-                .unwrap()
-                .entry(key)
-                .or_insert_with(|| json!({}));
-            if !proj.is_object() {
-                *proj = json!({});
-            }
-            let proj = proj.as_object_mut().unwrap();
-            if proj.get("hasTrustDialogAccepted").and_then(Value::as_bool) != Some(true) {
-                proj.insert("hasTrustDialogAccepted".into(), json!(true));
-                changed = true;
-            }
+    if let Some(repo_root) = seed.repo_root {
+        let projects = obj.entry("projects").or_insert_with(|| json!({}));
+        if !projects.is_object() {
+            *projects = json!({});
         }
-        Err(e) => tracing::debug!(work_dir = %work_dir.display(), error = %e,
-            "could not resolve repo root for trust seed"),
+        let proj = projects
+            .as_object_mut()
+            .unwrap()
+            .entry(repo_root.to_string())
+            .or_insert_with(|| json!({}));
+        if !proj.is_object() {
+            *proj = json!({});
+        }
+        let proj = proj.as_object_mut().unwrap();
+        if proj.get("hasTrustDialogAccepted").and_then(Value::as_bool) != Some(true) {
+            proj.insert("hasTrustDialogAccepted".into(), json!(true));
+            changed = true;
+        }
     }
 
-    if !changed {
-        return Ok(());
-    }
-    tokio::fs::write(&path, serde_json::to_string_pretty(&root)?)
-        .await
-        .with_context(|| format!("seeding {}", path.display()))?;
-    // claude writes this file 0600; preserve that posture.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await;
-    }
-    tracing::info!(path = %path.display(), bypass, "seeded claude launch gates");
-    Ok(())
+    changed
 }
 
 // ---------------------------------------------------------------------------
@@ -458,5 +523,107 @@ mod tests {
             "",
         );
         assert_eq!(script, "claude --continue; exec \"${SHELL:-/bin/sh}\"");
+    }
+
+    fn seed<'a>(
+        bypass: bool,
+        api_key_tail: Option<&'a str>,
+        repo_root: Option<&'a str>,
+    ) -> GateSeed<'a> {
+        GateSeed {
+            bypass,
+            api_key_tail,
+            repo_root,
+        }
+    }
+
+    #[test]
+    fn seeds_all_gates_into_an_empty_config() {
+        let mut root = json!({});
+        assert!(apply_launch_gates(
+            &mut root,
+            &seed(true, Some("KEYTAIL0123456789abc"), Some("/repo"))
+        ));
+        assert_eq!(root["hasCompletedOnboarding"], json!(true));
+        assert_eq!(root["theme"], json!("dark"));
+        assert_eq!(root["bypassPermissionsModeAccepted"], json!(true));
+        assert_eq!(
+            root["customApiKeyResponses"]["approved"],
+            json!(["KEYTAIL0123456789abc"])
+        );
+        assert_eq!(
+            root["projects"]["/repo"]["hasTrustDialogAccepted"],
+            json!(true)
+        );
+    }
+
+    #[test]
+    fn is_idempotent_and_returns_false_on_a_second_pass() {
+        let mut root = json!({});
+        let s = seed(true, Some("KEYTAIL0123456789abc"), Some("/repo"));
+        assert!(apply_launch_gates(&mut root, &s));
+        let after_first = root.clone();
+        // A second pass changes nothing and reports no change.
+        assert!(!apply_launch_gates(&mut root, &s));
+        assert_eq!(root, after_first);
+        // The approved key is not duplicated.
+        assert_eq!(
+            root["customApiKeyResponses"]["approved"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn preserves_existing_user_config() {
+        // A real config the user already has: a chosen theme, an unrelated
+        // approved key, and an unrelated trusted project with extra fields.
+        let mut root = json!({
+            "theme": "light",
+            "hasCompletedOnboarding": true,
+            "customApiKeyResponses": { "approved": ["existing-key"], "rejected": ["nope"] },
+            "projects": { "/other": { "hasTrustDialogAccepted": true, "keep": 1 } },
+        });
+        assert!(apply_launch_gates(
+            &mut root,
+            &seed(false, Some("KEYTAIL0123456789abc"), Some("/repo"))
+        ));
+        // Existing values untouched...
+        assert_eq!(root["theme"], json!("light"));
+        assert_eq!(root["projects"]["/other"]["keep"], json!(1));
+        assert_eq!(root["customApiKeyResponses"]["rejected"], json!(["nope"]));
+        // ...new approved key appended alongside the existing one...
+        assert_eq!(
+            root["customApiKeyResponses"]["approved"],
+            json!(["existing-key", "KEYTAIL0123456789abc"])
+        );
+        // ...new project trusted, and (bypass=false) no bypass key written.
+        assert_eq!(
+            root["projects"]["/repo"]["hasTrustDialogAccepted"],
+            json!(true)
+        );
+        assert!(root.get("bypassPermissionsModeAccepted").is_none());
+    }
+
+    #[test]
+    fn omits_optional_gates_when_inputs_absent() {
+        let mut root = json!({});
+        assert!(apply_launch_gates(&mut root, &seed(false, None, None)));
+        // Onboarding/theme always seed; the env-dependent gates do not.
+        assert_eq!(root["hasCompletedOnboarding"], json!(true));
+        assert!(root.get("bypassPermissionsModeAccepted").is_none());
+        assert!(root.get("customApiKeyResponses").is_none());
+        assert!(root.get("projects").is_none());
+    }
+
+    #[test]
+    fn replaces_a_non_object_root() {
+        // A corrupt/unexpected shape is reset rather than panicking.
+        let mut root = json!("not an object");
+        assert!(apply_launch_gates(&mut root, &seed(false, None, None)));
+        assert!(root.is_object());
+        assert_eq!(root["hasCompletedOnboarding"], json!(true));
     }
 }

--- a/crates/loom/src/terminal.rs
+++ b/crates/loom/src/terminal.rs
@@ -21,6 +21,7 @@
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, State};
+use axum::http::header::{HOST, ORIGIN};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use futures_util::{SinkExt, StreamExt};
@@ -47,6 +48,19 @@ pub async fn terminal_ws(
     // CSWSH defence: CORS does NOT apply to WebSockets, so a localhost bind is
     // not protection — validate the Origin before upgrading. See `origin_ok`.
     if !origin_ok(&headers, &st.addr) {
+        // This rejection used to be silent — invisible behind a reverse proxy,
+        // where it surfaces only as the browser's endless "reconnecting". Log it
+        // with the Origin/Host so a proxy misconfig is one `docker logs` away.
+        let origin = header_str(&headers, ORIGIN);
+        let host = header_str(&headers, HOST);
+        tracing::warn!(
+            session = %key,
+            origin = %origin,
+            host = %host,
+            bound = %st.addr,
+            "terminal websocket rejected: Origin is neither loopback on the bound \
+             port nor the request Host"
+        );
         return (StatusCode::FORBIDDEN, "cross-origin websocket rejected").into_response();
     }
     let session = match require_session(&st.db, &key).await {
@@ -62,11 +76,14 @@ pub async fn terminal_ws(
             .into_response();
     }
     let target = session.term_session.clone();
+    tracing::info!(session = %key, target = %target, "terminal websocket attached");
     ws.max_message_size(MAX_FRAME)
         .max_frame_size(MAX_FRAME)
         .on_upgrade(move |socket| async move {
-            if let Err(e) = bridge(socket, target).await {
-                tracing::debug!(error = %e, "terminal bridge ended with error");
+            if let Err(e) = bridge(socket, target.clone()).await {
+                tracing::debug!(target = %target, error = %e, "terminal bridge ended with error");
+            } else {
+                tracing::debug!(target = %target, "terminal bridge detached cleanly");
             }
         })
 }
@@ -144,19 +161,85 @@ async fn bridge(socket: WebSocket, target: String) -> anyhow::Result<()> {
 /// weaken the browser-CSWSH defence (it only waives same-host non-browser
 /// processes, acceptable under the single-user-localhost assumption).
 ///
-/// A *present* Origin must be a loopback host on our actual bound port. We
-/// deliberately do NOT compare against the request `Host` header: Host is
-/// client-supplied and a DNS-rebinding attacker can make `Origin == Host` even
-/// on the default `127.0.0.1` bind. Pinning to the loopback set + the real bound
-/// port closes that vector.
+/// A *present* Origin is accepted when either:
+///
+/// 1. it is a loopback host on our actual bound port — direct localhost access
+///    (`loom open`, an SSH tunnel), the original single-user posture; or
+/// 2. its host+port equals the request's own `Host` header — i.e. the browser
+///    is talking to the same public origin the front-door proxy serves us under
+///    (`weaver.example.com`). Behind Caddy the loopback rule can never match
+///    (the browser's Origin is the public HTTPS host), so without this the
+///    in-browser terminal is wedged on an endless "reconnecting".
+///
+/// Trusting `Host` reopens the DNS-rebinding vector the loopback pin closed: a
+/// rebinding attacker can force `Origin == Host`. We accept that here because
+/// this build is deployed behind a reverse proxy that publishes no host port —
+/// loom is reachable only through the front door, never directly — so the proxy
+/// is the sole arbiter of `Host`. Do NOT rely on this check alone when loom is
+/// bound to a publicly reachable port.
 fn origin_ok(headers: &HeaderMap, bound_addr: &str) -> bool {
-    match headers.get(axum::http::header::ORIGIN) {
-        None => true,
+    let origin = match headers.get(ORIGIN) {
+        // Non-browser clients (the CLI, tests, tokio-tungstenite) omit Origin.
+        None => return true,
         Some(v) => match v.to_str() {
-            Ok(origin) => origin_is_loopback(origin, bound_addr),
-            Err(_) => false,
+            Ok(o) => o,
+            Err(_) => return false,
         },
+    };
+    if origin_is_loopback(origin, bound_addr) {
+        return true;
     }
+    match headers.get(HOST).and_then(|v| v.to_str().ok()) {
+        Some(host) => origin_matches_host(origin, host),
+        None => false,
+    }
+}
+
+/// Read a header as a `&str`, or `"<none>"` when absent/non-ASCII. For logging.
+fn header_str<'a>(headers: &'a HeaderMap, name: axum::http::HeaderName) -> &'a str {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("<none>")
+}
+
+/// Split an authority (`host`, `host:port`, `[::1]`, or `[::1]:port`) into its
+/// host and optional port. Shared by the loopback and proxied-Host checks so
+/// both parse IPv6 literals identically.
+fn split_authority(authority: &str) -> (&str, Option<&str>) {
+    if let Some(after) = authority.strip_prefix('[') {
+        // IPv6 literal: [::1] or [::1]:port
+        match after.split_once(']') {
+            Some((h, tail)) => (h, tail.strip_prefix(':')),
+            None => (authority, None),
+        }
+    } else if let Some((h, p)) = authority.rsplit_once(':') {
+        (h, Some(p))
+    } else {
+        (authority, None)
+    }
+}
+
+/// True iff `origin` (`http(s)://host[:port]`) names the same host+port as the
+/// request's `Host` header. The browser sends the page's own origin on a WS
+/// handshake, so behind a proxy serving `https://h/` the Origin is `https://h`
+/// and the Host is `h` — they agree once default ports (443/80) are filled in.
+fn origin_matches_host(origin: &str, host: &str) -> bool {
+    let (scheme, rest) = if let Some(r) = origin.strip_prefix("https://") {
+        ("https", r)
+    } else if let Some(r) = origin.strip_prefix("http://") {
+        ("http", r)
+    } else {
+        return false;
+    };
+    let origin_authority = rest.split('/').next().unwrap_or(rest);
+    let (o_host, o_port) = split_authority(origin_authority);
+    let (h_host, h_port) = split_authority(host);
+    if o_host.is_empty() || o_host != h_host {
+        return false;
+    }
+    let default = if scheme == "https" { "443" } else { "80" };
+    o_port.unwrap_or(default) == h_port.unwrap_or(default)
 }
 
 /// True iff `origin` is `http(s)://<loopback>[:<port>]` whose port equals the
@@ -174,17 +257,7 @@ fn origin_is_loopback(origin: &str, bound_addr: &str) -> bool {
     };
     // Origin carries no path, but be defensive about a trailing slash.
     let authority = rest.split('/').next().unwrap_or(rest);
-    let (host, port) = if let Some(after) = authority.strip_prefix('[') {
-        // IPv6 literal: [::1] or [::1]:port
-        match after.split_once(']') {
-            Some((h, tail)) => (h, tail.strip_prefix(':')),
-            None => return false,
-        }
-    } else if let Some((h, p)) = authority.rsplit_once(':') {
-        (h, Some(p))
-    } else {
-        (authority, None)
-    };
+    let (host, port) = split_authority(authority);
     let port = port.unwrap_or(if scheme == "https" { "443" } else { "80" });
     if port != want_port {
         return false;
@@ -194,7 +267,7 @@ fn origin_is_loopback(origin: &str, bound_addr: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::origin_is_loopback;
+    use super::{origin_is_loopback, origin_matches_host};
 
     #[test]
     fn accepts_loopback_origins_on_the_bound_port() {
@@ -243,5 +316,40 @@ mod tests {
         ));
         assert!(!origin_is_loopback("null", "127.0.0.1:7878"));
         assert!(!origin_is_loopback("", "127.0.0.1:7878"));
+    }
+
+    #[test]
+    fn accepts_origin_matching_proxied_host() {
+        // Behind Caddy: browser at https://weaver.rjp.io, proxy forwards
+        // Host: weaver.rjp.io. Default https port (443) fills in on both sides.
+        assert!(origin_matches_host(
+            "https://weaver.rjp.io",
+            "weaver.rjp.io"
+        ));
+        assert!(origin_matches_host("https://loom.rjp.io", "loom.rjp.io"));
+        // Explicit matching ports also agree.
+        assert!(origin_matches_host(
+            "https://h.example:8443",
+            "h.example:8443"
+        ));
+        // Plain http with the default port elided on the Origin side.
+        assert!(origin_matches_host("http://box.local", "box.local:80"));
+    }
+
+    #[test]
+    fn rejects_origin_not_matching_host() {
+        // A different host (the cross-site attacker case) never matches.
+        assert!(!origin_matches_host(
+            "https://attacker.example",
+            "weaver.rjp.io"
+        ));
+        // Same host, mismatched explicit port.
+        assert!(!origin_matches_host(
+            "https://weaver.rjp.io:1234",
+            "weaver.rjp.io"
+        ));
+        // Non-http scheme and garbage.
+        assert!(!origin_matches_host("ftp://weaver.rjp.io", "weaver.rjp.io"));
+        assert!(!origin_matches_host("null", "weaver.rjp.io"));
     }
 }

--- a/crates/loom/src/terminal.rs
+++ b/crates/loom/src/terminal.rs
@@ -47,7 +47,11 @@ pub async fn terminal_ws(
 ) -> Response {
     // CSWSH defence: CORS does NOT apply to WebSockets, so a localhost bind is
     // not protection — validate the Origin before upgrading. See `origin_ok`.
-    if !origin_ok(&headers, &st.addr) {
+    // `auth.base_url` (when set) is the operator-declared canonical origin and is
+    // trusted directly; absent that, only loopback or a *proxied* same-Host
+    // Origin is accepted.
+    let base_url = crate::config::get(&st.db, "auth.base_url").await;
+    if !origin_ok(&headers, &st.addr, base_url.as_deref()) {
         // This rejection used to be silent — invisible behind a reverse proxy,
         // where it surfaces only as the browser's endless "reconnecting". Log it
         // with the Origin/Host so a proxy misconfig is one `docker logs` away.
@@ -58,8 +62,9 @@ pub async fn terminal_ws(
             origin = %origin,
             host = %host,
             bound = %st.addr,
-            "terminal websocket rejected: Origin is neither loopback on the bound \
-             port nor the request Host"
+            base_url = base_url.as_deref().unwrap_or("<unset>"),
+            "terminal websocket rejected: Origin is not loopback, the configured \
+             auth.base_url, nor a proxied (X-Forwarded-*) request's own Host"
         );
         return (StatusCode::FORBIDDEN, "cross-origin websocket rejected").into_response();
     }
@@ -161,23 +166,29 @@ async fn bridge(socket: WebSocket, target: String) -> anyhow::Result<()> {
 /// weaken the browser-CSWSH defence (it only waives same-host non-browser
 /// processes, acceptable under the single-user-localhost assumption).
 ///
-/// A *present* Origin is accepted when either:
+/// A *present* Origin is accepted when any of:
 ///
 /// 1. it is a loopback host on our actual bound port — direct localhost access
 ///    (`loom open`, an SSH tunnel), the original single-user posture; or
-/// 2. its host+port equals the request's own `Host` header — i.e. the browser
-///    is talking to the same public origin the front-door proxy serves us under
-///    (`weaver.example.com`). Behind Caddy the loopback rule can never match
-///    (the browser's Origin is the public HTTPS host), so without this the
-///    in-browser terminal is wedged on an endless "reconnecting".
+/// 2. it matches the operator-configured `auth.base_url` (the canonical public
+///    origin) — trusted however the request arrived, so it also works behind a
+///    proxy that strips `X-Forwarded-*`; or
+/// 3. it equals the request's own `Host` *and* the request carries an
+///    `X-Forwarded-*` header — i.e. the browser is talking to the same public
+///    origin the front-door proxy serves us under (`weaver.example.com`), and
+///    the request demonstrably transited that proxy. Behind Caddy the loopback
+///    rule never matches (the Origin is the public HTTPS host), so without 2/3
+///    the in-browser terminal wedges on an endless "reconnecting". Rule 3 keeps
+///    multi-vhost deploys zero-config (no need to enumerate every hostname).
 ///
-/// Trusting `Host` reopens the DNS-rebinding vector the loopback pin closed: a
-/// rebinding attacker can force `Origin == Host`. We accept that here because
-/// this build is deployed behind a reverse proxy that publishes no host port —
-/// loom is reachable only through the front door, never directly — so the proxy
-/// is the sole arbiter of `Host`. Do NOT rely on this check alone when loom is
-/// bound to a publicly reachable port.
-fn origin_ok(headers: &HeaderMap, bound_addr: &str) -> bool {
+/// Why rule 3 is safe where a bare `Origin == Host` would not be: trusting the
+/// raw `Host` reopens the DNS-rebinding vector the loopback pin closed (a
+/// rebinding page can force `Origin == Host` against a directly bound daemon).
+/// Gating on `X-Forwarded-*` closes it: a reverse proxy adds those headers, and
+/// a browser's WebSocket handshake — the attack vector — cannot set request
+/// headers, so a rebinding page reaching a directly bound daemon has none and is
+/// rejected. (Non-browser clients omit Origin entirely and are handled above.)
+fn origin_ok(headers: &HeaderMap, bound_addr: &str, base_url: Option<&str>) -> bool {
     let origin = match headers.get(ORIGIN) {
         // Non-browser clients (the CLI, tests, tokio-tungstenite) omit Origin.
         None => return true,
@@ -189,14 +200,50 @@ fn origin_ok(headers: &HeaderMap, bound_addr: &str) -> bool {
     if origin_is_loopback(origin, bound_addr) {
         return true;
     }
-    match headers.get(HOST).and_then(|v| v.to_str().ok()) {
-        Some(host) => origin_matches_host(origin, host),
-        None => false,
+    // (a) The operator-declared canonical origin (`auth.base_url`) is trusted
+    // however the request reached us — covers a proxy that strips X-Forwarded-*.
+    if let Some(authority) = base_url.and_then(url_authority) {
+        if origin_matches_host(origin, authority) {
+            return true;
+        }
     }
+    // (b) Otherwise trust an Origin equal to the request's own Host ONLY when the
+    // request demonstrably transited the reverse proxy (it carries X-Forwarded-*).
+    // This keeps multi-vhost proxied deploys zero-config while closing the
+    // DNS-rebinding / CSWSH vector the loopback pin guarded: a browser-driven
+    // handshake (the attack vector) cannot set X-Forwarded-* — the WebSocket API
+    // forbids custom request headers — so a rebinding page reaching a directly
+    // bound daemon yields Origin == Host but no forwarded header, and is rejected.
+    if via_trusted_proxy(headers) {
+        if let Some(host) = headers.get(HOST).and_then(|v| v.to_str().ok()) {
+            return origin_matches_host(origin, host);
+        }
+    }
+    false
+}
+
+/// The host[:port] authority of a `http(s)://` URL (e.g. `auth.base_url`), or
+/// `None` if it isn't an http(s) URL. Trailing path/slash is dropped.
+fn url_authority(url: &str) -> Option<&str> {
+    let rest = url
+        .trim()
+        .strip_prefix("https://")
+        .or_else(|| url.trim().strip_prefix("http://"))?;
+    Some(rest.split('/').next().unwrap_or(rest))
+}
+
+/// True iff the request carries a header a reverse proxy adds (`X-Forwarded-*`).
+/// Caddy/nginx set these; a browser's WebSocket handshake cannot, so their
+/// presence is evidence the request reached us *through* the proxy rather than
+/// from a page that rebound a hostname to a directly bound daemon.
+fn via_trusted_proxy(headers: &HeaderMap) -> bool {
+    headers.contains_key("x-forwarded-for")
+        || headers.contains_key("x-forwarded-proto")
+        || headers.contains_key("x-forwarded-host")
 }
 
 /// Read a header as a `&str`, or `"<none>"` when absent/non-ASCII. For logging.
-fn header_str<'a>(headers: &'a HeaderMap, name: axum::http::HeaderName) -> &'a str {
+fn header_str(headers: &HeaderMap, name: axum::http::HeaderName) -> &str {
     headers
         .get(name)
         .and_then(|v| v.to_str().ok())
@@ -235,7 +282,9 @@ fn origin_matches_host(origin: &str, host: &str) -> bool {
     let origin_authority = rest.split('/').next().unwrap_or(rest);
     let (o_host, o_port) = split_authority(origin_authority);
     let (h_host, h_port) = split_authority(host);
-    if o_host.is_empty() || o_host != h_host {
+    // DNS hostnames are case-insensitive, so compare them that way — else a
+    // browser Origin and proxy Host differing only in ASCII case falsely reject.
+    if o_host.is_empty() || !o_host.eq_ignore_ascii_case(h_host) {
         return false;
     }
     let default = if scheme == "https" { "443" } else { "80" };
@@ -267,7 +316,21 @@ fn origin_is_loopback(origin: &str, bound_addr: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{origin_is_loopback, origin_matches_host};
+    use super::{
+        origin_is_loopback, origin_matches_host, origin_ok, url_authority, via_trusted_proxy,
+    };
+    use axum::http::{HeaderMap, HeaderName, HeaderValue};
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        h
+    }
 
     #[test]
     fn accepts_loopback_origins_on_the_bound_port() {
@@ -351,5 +414,120 @@ mod tests {
         // Non-http scheme and garbage.
         assert!(!origin_matches_host("ftp://weaver.rjp.io", "weaver.rjp.io"));
         assert!(!origin_matches_host("null", "weaver.rjp.io"));
+    }
+
+    #[test]
+    fn host_match_is_case_insensitive() {
+        // DNS is case-insensitive; an Origin/Host casing difference must not reject.
+        assert!(origin_matches_host(
+            "https://Weaver.RJP.io",
+            "weaver.rjp.io"
+        ));
+        assert!(origin_matches_host(
+            "https://weaver.rjp.io",
+            "WEAVER.RJP.IO"
+        ));
+    }
+
+    #[test]
+    fn url_authority_extracts_host_port() {
+        assert_eq!(url_authority("https://loom.rjp.io"), Some("loom.rjp.io"));
+        assert_eq!(url_authority("https://loom.rjp.io/"), Some("loom.rjp.io"));
+        assert_eq!(
+            url_authority("http://h.example:8443/x"),
+            Some("h.example:8443")
+        );
+        assert_eq!(url_authority("ws://loom.rjp.io"), None); // not http(s)
+        assert_eq!(url_authority(""), None);
+    }
+
+    #[test]
+    fn via_trusted_proxy_detects_forwarded_headers() {
+        assert!(via_trusted_proxy(&headers(&[(
+            "x-forwarded-proto",
+            "https"
+        )])));
+        assert!(via_trusted_proxy(&headers(&[(
+            "x-forwarded-for",
+            "1.2.3.4"
+        )])));
+        assert!(via_trusted_proxy(&headers(&[("x-forwarded-host", "h")])));
+        assert!(!via_trusted_proxy(&headers(&[("host", "h")])));
+    }
+
+    #[test]
+    fn proxied_same_host_origin_requires_forwarded_header() {
+        // Behind Caddy: Origin == Host AND X-Forwarded-* present → accepted, even
+        // for a vhost that isn't the configured base_url.
+        assert!(origin_ok(
+            &headers(&[
+                ("origin", "https://weaver.rjp.io"),
+                ("host", "weaver.rjp.io"),
+                ("x-forwarded-proto", "https"),
+            ]),
+            "0.0.0.0:7878",
+            None,
+        ));
+        // DNS-rebinding / CSWSH: a page rebinds a hostname to a directly bound
+        // daemon, so Origin == Host — but a browser handshake can't add a
+        // forwarded header, so it's rejected. This is the hole the gate closes.
+        assert!(!origin_ok(
+            &headers(&[
+                ("origin", "http://evil.example:7878"),
+                ("host", "evil.example:7878"),
+            ]),
+            "0.0.0.0:7878",
+            None,
+        ));
+    }
+
+    #[test]
+    fn base_url_origin_trusted_without_forwarded_header() {
+        let base = Some("https://loom.rjp.io");
+        // The configured canonical origin is trusted however it arrived.
+        assert!(origin_ok(
+            &headers(&[("origin", "https://loom.rjp.io"), ("host", "loom.rjp.io")]),
+            "0.0.0.0:7878",
+            base,
+        ));
+        // A different vhost is NOT the base_url, so without proxy evidence it's
+        // rejected...
+        assert!(!origin_ok(
+            &headers(&[
+                ("origin", "https://weaver.rjp.io"),
+                ("host", "weaver.rjp.io"),
+            ]),
+            "0.0.0.0:7878",
+            base,
+        ));
+        // ...but Caddy supplies that evidence, so the real path still works.
+        assert!(origin_ok(
+            &headers(&[
+                ("origin", "https://weaver.rjp.io"),
+                ("host", "weaver.rjp.io"),
+                ("x-forwarded-for", "1.2.3.4"),
+            ]),
+            "0.0.0.0:7878",
+            base,
+        ));
+    }
+
+    #[test]
+    fn loopback_and_missing_origin_always_ok() {
+        // Loopback on the bound port: no proxy headers or base_url needed.
+        assert!(origin_ok(
+            &headers(&[
+                ("origin", "http://localhost:7878"),
+                ("host", "localhost:7878"),
+            ]),
+            "127.0.0.1:7878",
+            None,
+        ));
+        // A non-browser client (CLI, tests) omits Origin entirely.
+        assert!(origin_ok(
+            &headers(&[("host", "loom.rjp.io")]),
+            "0.0.0.0:7878",
+            None,
+        ));
     }
 }


### PR DESCRIPTION
Fixes two issues that surface when loom runs **behind a reverse proxy in Docker** (Caddy → `weaver:7878`), where the dashboard is served on a public HTTPS host rather than `localhost`.

## 1. Terminal stuck on "reconnecting"

`terminal_ws`'s CSWSH guard only accepted **loopback** `Origin`s on the bound port. Behind Caddy the browser's `Origin` is the public host (`https://weaver.example.com`, port 443), so every WebSocket upgrade was rejected with `403` and xterm.js looped forever on *reconnecting*. The auth layer already had reverse-proxy knobs (`auth.base_url`, `auth.cookie_secure`, "turn trust_loopback off behind a proxy") — the terminal origin check just hadn't been updated to match.

- Accept an `Origin` whose host+port equals the request `Host` (the public origin the proxy serves us under), in addition to loopback. Genuine cross-site `Origin`s are still rejected.
- The reject path was **silent** — add a `WARN` log (Origin / Host / bound addr) on rejection, plus attach/detach logs.

Verified against a live proxied container: proxied `Origin == Host` → `101 Switching Protocols`; cross-site `Origin` → `403`. New unit tests cover both.

## 2. Detached agent stalls at Claude Code's first-run prompts

On a fresh container HOME an unattended `claude` never reaches the goal — it parks on its interactive first-run gates (theme picker → workspace-trust → `ANTHROPIC_API_KEY` approval → bypass-mode), so the session sits at `launching` with no `weaver status` and the worktree looks idle even though it was created.

`seed_claude_launch_gates()` pre-writes that state into `~/.claude.json` before each `claude` launch (additive + idempotent):

- `hasCompletedOnboarding` + `theme`
- workspace trust at the worktree's **main repo root** — Claude resolves a git worktree to its primary checkout, so trusting the root covers every worktree under it
- `customApiKeyResponses.approved` for an ambient `ANTHROPIC_API_KEY` (only when set)
- `bypassPermissionsModeAccepted` (only when launching with a bypass flag)

> ⚠️ Note: the "Bypass Permissions mode" warning shown by `--dangerously-skip-permissions` is rendered **every launch** and can't be pre-seeded (it defaults to *exit*). If you set that in `agent.claude_args`, the operator still accepts it once per session via the (now-working) terminal.

## 3. `.dockerignore`

The image build does its own clean `cargo build --release` + `npm install`, so keep host `target/` (>1 GB), `.git`, `node_modules`, the prebuilt static bundle, and the `.env` symlink out of the build context.

## Test plan

- `cargo test -p loom` (terminal origin tests pass)
- Built the image, recreated the container behind Caddy, launched a session: terminal connects in the browser; the agent clears onboarding/trust/api-key gates unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)