### PR TITLE
feat(overlooker): on by default + UI-created watchers go live

### DIFF
--- a/crates/loom/frontend/src/views/Overlookers.vue
+++ b/crates/loom/frontend/src/views/Overlookers.vue
@@ -194,6 +194,10 @@ async function create() {
       program: programRef || 'builtin:status',
       params,
       capabilities,
+      // Created overlookers go live immediately — the master switch is on by
+      // default, so a freshly-added watcher should fire on its trigger without
+      // a separate manual enable. The per-row toggle still disables it later.
+      enabled: true,
     };
     // Omit `trigger` for `auto` so the server reconciles from the manifest.
     if (trigger !== undefined) body.trigger = trigger;

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -259,8 +259,8 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
     // integration is off or unavailable.
     tokio::spawn(github::poll(state.clone()));
     // The Overlooker engine (timer + dispatcher). Always spawned; it self-gates
-    // on the `overlooker.enabled` master switch, so a default loom runs it but it
-    // idles cheaply until the operator opts in.
+    // on the `overlooker.enabled` master switch, which is on by default, so a
+    // default loom runs it. Turning the switch off idles it cheaply.
     tokio::spawn(overlooker::run(state.clone()));
     tracing::debug!("background tasks spawned (monitor, github poll, overlooker)");
     // `into_make_service_with_connect_info` surfaces the peer `SocketAddr` to the

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -3111,6 +3111,7 @@ async fn create_overlooker(
         model: req.model.unwrap_or(defaults.model),
         effort: req.effort.unwrap_or(defaults.effort),
         cooldown_secs: req.cooldown_secs.unwrap_or(defaults.cooldown_secs),
+        enabled: req.enabled.unwrap_or(defaults.enabled),
     };
     let o = ov::create(&st.db, &new).await?;
     Ok(Json(overlooker_view(&st.db, &o).await?))

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -21,6 +21,7 @@ use loom::{db, server};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
+use weaver_core::config as core_config;
 
 /// Run `program args` in `dir`, asserting it succeeds.
 pub fn sh(dir: &Path, program: &str, args: &[&str]) {
@@ -126,6 +127,15 @@ impl TestServer {
             bus: EventBus::new(),
             addr: addr.to_string(),
         };
+        // The overlooker master switch ships on by default, but these tests
+        // drive the engine directly and must not race the background loop that
+        // `server::serve` spawns. Pin it off so the daemon's own engine idles.
+        core_config::apply(
+            &state.db,
+            &[("overlooker.enabled".to_string(), Some("false".to_string()))],
+        )
+        .await
+        .unwrap();
         tokio::spawn(server::serve(state, listener));
 
         std::env::set_var("WEAVER_API", format!("http://{addr}"));

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -8,9 +8,10 @@
 //! and its mutations land with attribution. Don't re-test program logic here.
 //!
 //! These cases drive the engine **directly** on the test server's isolated db
-//! rather than through the spawned background loop: the `overlooker.enabled`
-//! master switch is left at its default (off), so the daemon's own engine idles
-//! and never races these deterministic calls. Each test builds its own
+//! rather than through the spawned background loop: the test harness pins the
+//! `overlooker.enabled` master switch off (it ships on by default), so the
+//! daemon's own engine idles and never races these deterministic calls. Each
+//! test builds its own
 //! `AppState` over the same isolated db (the harness exports `WEAVER_HOME`) and
 //! calls the public engine seams — `dispatch`, `fire_now`, `new_in_flight` /
 //! `fire` — so a round runs without waiting on the timer.

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -591,6 +591,12 @@ pub struct CreateOverlookerReq {
     pub effort: Option<String>,
     #[serde(default)]
     pub cooldown_secs: Option<i64>,
+    /// Whether the overlooker fires as soon as it is created. Omitted by API
+    /// clients that want the model default (disabled); the loom UI sends `true`
+    /// so a watcher picked from the builtin registry is live without a separate
+    /// manual enable.
+    #[serde(default)]
+    pub enabled: Option<bool>,
 }
 
 /// Body for `PATCH /api/overlookers/{id}`: every mutable field optional.

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -197,10 +197,10 @@ pub const REGISTRY: &[SettingSpec] = &[
         label: "Enable overlookers",
         description: "Master switch for the Overlooker engine — the periodic / \
             triggered watch programs that survey the fleet and stamp triage \
-            marks. Off by default: nothing fires until you opt in, even if \
-            individual overlookers are enabled.",
+            marks. On by default: turn it off to stop every overlooker cold, \
+            regardless of the individual per-overlooker toggles.",
         kind: SettingKind::Bool,
-        default: "false",
+        default: "true",
         group: "Overlooker",
         options: &[],
     },
@@ -255,8 +255,8 @@ pub const REGISTRY: &[SettingSpec] = &[
     },
 ];
 
-/// Whether the Overlooker engine master switch is on. Off by default.
-pub const DEFAULT_OVERLOOKER_ENABLED: bool = false;
+/// Whether the Overlooker engine master switch is on. On by default.
+pub const DEFAULT_OVERLOOKER_ENABLED: bool = true;
 
 /// Whether the server re-adopts engine-managed (warm) overlooker sessions on
 /// startup. On by default and independent of [`DEFAULT_AUTO_ADOPT`]: a warm

--- a/crates/weaver-core/src/overlooker.rs
+++ b/crates/weaver-core/src/overlooker.rs
@@ -262,6 +262,10 @@ pub struct NewOverlooker {
     pub model: String,
     pub effort: String,
     pub cooldown_secs: i64,
+    /// Whether the overlooker is live the moment it is created. Defaults to
+    /// `false` so a bare `NewOverlooker` (CLI / seeds / tests) starts disabled;
+    /// the loom create UI opts in to `true`.
+    pub enabled: bool,
 }
 
 impl Default for NewOverlooker {
@@ -280,6 +284,7 @@ impl Default for NewOverlooker {
             model: String::new(),
             effort: String::new(),
             cooldown_secs: 0,
+            enabled: false,
         }
     }
 }
@@ -292,10 +297,11 @@ pub async fn create(db: &Db, new: &NewOverlooker) -> Result<Overlooker> {
         "INSERT INTO overlookers
            (id, name, enabled, trigger_spec, scope, program, params, capabilities,
             model, effort, cooldown_secs, created_at, updated_at)
-         VALUES (?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&new.name)
+    .bind(new.enabled)
     .bind(&new.trigger_spec)
     .bind(&new.scope)
     .bind(&new.program)

--- a/docs/plans/overlooker.md
+++ b/docs/plans/overlooker.md
@@ -429,7 +429,7 @@ through the same `weaver-api` the out-of-process programs use.
   `tags` list.
 
 **Settings (`config::registry()`):** `overlooker.enabled` (Bool, default
-`false`), `overlooker.default_timeout_secs`, `overlooker.default_cooldown_secs`,
+`true`), `overlooker.default_timeout_secs`, `overlooker.default_cooldown_secs`,
 under an **Overlooker** group.
 
 ## The panel (loom UI)


### PR DESCRIPTION
## What

Reverse the Overlooker engine's default: the `overlooker.enabled` master switch now ships **on**, so a fresh loom surveys the fleet and stamps triage marks without an explicit opt-in. The engine is still self-gated on the switch — turning it off stops every overlooker cold, exactly as before.

Newly-created overlookers (the dashboard **Use** / create-form flow) now go **live the moment they're created** — no separate manual enable click.

## How

- `config.rs` — `overlooker.enabled` default `false → true`; const `DEFAULT_OVERLOOKER_ENABLED = true`; setting description/docs updated.
- `enabled` threaded through creation: `CreateOverlookerReq` (new optional field) → `NewOverlooker.enabled` → `create()` binds it instead of a hardcoded `0`.
  - **Model default stays `false`**, so the API, seeds, tests, and `loom overlooker add` (which deliberately registers disabled and guides `loom overlooker enable`) are unchanged.
  - The loom create form sends `enabled: true`.
- Integration harness pins the switch **off** so the now-always-running background loop can't race the suites that drive the engine directly.

## Scope decision

Per the request, only the **dashboard** create path opts into enabled-by-default. The CLI keeps its explicit register→arm flow.

## Tests

`weaver-core` overlooker (6), `weaver-api` (7), and `loom` integration overlooker (13) suites pass; fmt + clippy clean via the pre-commit gate. The Playwright e2e suite was not run locally (needs a live loom + browsers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)