### PR TITLE
loom(deploy): provide uv + share host Pythons into the container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ python/weaver-loom/dist/
 __pycache__/
 python/weaver-loom/.venv/
 python/weaver-loom/uv.lock
+
+# Local-only container env: a halcyon-style deploy symlinks secrets/weaver.env
+# to ./.env (holds GH_TOKEN etc.). Never commit it — it's host-specific secrets.
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,13 @@ RUN set -eux; \
     npm i -g @anthropic-ai/claude-code; \
     rm -rf /var/lib/apt/lists/*
 
+# uv — for the Python repos loom's agents work in. Only the binary lives in the
+# image; the actual interpreters are the HOST's uv-managed Pythons, shared in at
+# the same path via a bind mount (see docker-compose.yml + HOST_UV), so the
+# repos' `.venv` symlinks (which point at ~/.local/share/uv/python) resolve
+# unchanged in-container. Pinned to a recent uv; it reads venvs from older uv fine.
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /usr/local/bin/
+
 # Run as the host user that owns the bind-mounted code, so the worktrees and
 # edits loom's agents create are owned by you on the host, not root. The uid/gid
 # come from build args (set HOST_UID/HOST_GID in secrets/weaver.env); the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,11 @@ services:
         HOST_GID: ${HOST_GID:-1000}
     restart: unless-stopped
     env_file: .env                # halcyon symlinks secrets/weaver.env -> ./.env
+    environment:
+      # Point in-container uv at the shared host interpreter set (the bind mount
+      # below), the same path baked into every repo's `.venv`, so `uv run`/`uv
+      # sync` reuse the host Pythons instead of trying to download their own.
+      UV_PYTHON_INSTALL_DIR: ${HOST_UV:-/root/.local/share/uv/python}
     volumes:
       # Persistent HOME for the container user: the weaver sqlite db, the 0600
       # loom-token, and ~/.claude.json live here and survive a recreate.
@@ -28,6 +33,10 @@ services:
       # The repos + the worktrees loom creates, shared with the host at the SAME
       # path. HOST_CODE is your repo dir (e.g. /home/you/code); set it in the env.
       - ${HOST_CODE:?set HOST_CODE (host repo dir) in secrets/weaver.env}:${HOST_CODE}
+      # The host's uv-managed Python interpreters, shared at the SAME path so the
+      # `.venv` symlinks in the bind-mounted repos resolve in-container. HOST_UV
+      # is your host uv python dir (default ~/.local/share/uv/python).
+      - ${HOST_UV:?set HOST_UV (host uv python dir) in secrets/weaver.env}:${HOST_UV}
       # GitHub SSH remotes (git@github.com:) work without a key — the image
       # rewrites them to HTTPS over the GH_TOKEN helper. Mount your key only for
       # non-GitHub SSH remotes — uncomment & set the host path (target is the


### PR DESCRIPTION
Follow-up to #64 (which merged while this was in flight, so it lands as its own PR).

The Python repos loom's agents work in use uv-managed venvs whose `.venv` interpreter symlinks point at the host's `~/.local/share/uv/python`. A fresh container had neither `uv` nor those interpreters, so `.venv` / `uv run` resolved to a missing Python and agents fell back to bare `python3`.

- **Dockerfile**: `COPY` the `uv`/`uvx` binaries from the official image — binary only, no baked interpreters.
- **docker-compose.yml**: bind-mount the host's uv Python dir at the **same path** (`HOST_UV`, mirroring the existing `HOST_CODE` pattern) so the repos' `.venv` symlinks resolve unchanged in-container, and set `UV_PYTHON_INSTALL_DIR` so in-container `uv` reuses them instead of downloading its own.
- **.gitignore**: ignore the local-only `.env` symlink (a halcyon deploy points it at `secrets/weaver.env`, which holds `GH_TOKEN`) so it can't be committed by accident.

`HOST_UV` goes in `secrets/weaver.env` (untracked). `docker compose config` renders the mount + env correctly. Takes effect on the next `docker compose build && up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)