### PR TITLE
loom(deploy): give the container its own uv volume instead of the host bind-mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 # uv — for the Python repos loom's agents work in. Only the binary lives in the
-# image; the actual interpreters are the HOST's uv-managed Pythons, shared in at
-# the same path via a bind mount (see docker-compose.yml + HOST_UV), so the
-# repos' `.venv` symlinks (which point at ~/.local/share/uv/python) resolve
-# unchanged in-container. Pinned to a recent uv; it reads venvs from older uv fine.
+# image; its downloaded interpreters and wheel cache live in a named volume (see
+# UV_PYTHON_INSTALL_DIR / UV_CACHE_DIR below + docker-compose.yml), so the
+# container manages its own Pythons — self-contained and persisted across
+# recreates, isolated from the host's uv. Pinned to a recent uv.
 COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /usr/local/bin/
 
 # Run as the host user that owns the bind-mounted code, so the worktrees and
@@ -42,6 +42,15 @@ ARG HOST_GID=1000
 # still aborts the build instead of being masked by `|| true`.
 RUN if ! getent group "${HOST_GID}" >/dev/null; then groupadd -g "${HOST_GID}" app; fi; \
     useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -d /home/app -s /bin/bash app
+
+# Where uv keeps its managed interpreters and wheel cache. Kept off /home/app so
+# the (large) Python builds don't bloat the home volume and can be reset on their
+# own; compose mounts a named volume here. Created owned by the host uid/gid so
+# the fresh volume initialises app-writable (Docker seeds a new volume from the
+# image dir's contents + ownership).
+RUN mkdir -p /opt/uv/python /opt/uv/cache && chown -R "${HOST_UID}:${HOST_GID}" /opt/uv
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    UV_CACHE_DIR=/opt/uv/cache
 
 # Let agents `git push` over HTTPS with the injected GH_TOKEN — no mounted SSH
 # key. The bind-mounted host repos usually have `git@github.com:` SSH remotes, so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,6 @@ services:
         HOST_GID: ${HOST_GID:-1000}
     restart: unless-stopped
     env_file: .env                # halcyon symlinks secrets/weaver.env -> ./.env
-    environment:
-      # Point in-container uv at the shared host interpreter set (the bind mount
-      # below), the same path baked into every repo's `.venv`, so `uv run`/`uv
-      # sync` reuse the host Pythons instead of trying to download their own.
-      UV_PYTHON_INSTALL_DIR: ${HOST_UV:-/root/.local/share/uv/python}
     volumes:
       # Persistent HOME for the container user: the weaver sqlite db, the 0600
       # loom-token, and ~/.claude.json live here and survive a recreate.
@@ -33,10 +28,14 @@ services:
       # The repos + the worktrees loom creates, shared with the host at the SAME
       # path. HOST_CODE is your repo dir (e.g. /home/you/code); set it in the env.
       - ${HOST_CODE:?set HOST_CODE (host repo dir) in secrets/weaver.env}:${HOST_CODE}
-      # The host's uv-managed Python interpreters, shared at the SAME path so the
-      # `.venv` symlinks in the bind-mounted repos resolve in-container. HOST_UV
-      # is your host uv python dir (default ~/.local/share/uv/python).
-      - ${HOST_UV:?set HOST_UV (host uv python dir) in secrets/weaver.env}:${HOST_UV}
+      # uv's managed interpreters + wheel cache (UV_PYTHON_INSTALL_DIR /
+      # UV_CACHE_DIR in the Dockerfile point here). A named volume keeps them
+      # self-contained and persistent across recreates: the container downloads
+      # its own Pythons, isolated from the host's uv. The bind-mounted repos'
+      # `.venv`s are rebuilt in-container on first `uv run`/`uv sync` (their host
+      # interpreter symlinks don't resolve here, and that's fine — separate from
+      # the host's). Reset with `docker volume rm weaver_uv`.
+      - uv:/opt/uv
       # GitHub SSH remotes (git@github.com:) work without a key — the image
       # rewrites them to HTTPS over the GH_TOKEN helper. Mount your key only for
       # non-GitHub SSH remotes — uncomment & set the host path (target is the
@@ -51,3 +50,4 @@ networks:
 
 volumes:
   weaver_home:
+  uv:


### PR DESCRIPTION
Reworks the uv setup from #66. Instead of bind-mounting the host's `~/.local/share/uv/python` into the container, the container now keeps its **own** uv interpreters + cache in a named volume — self-contained and isolated from the host.

### Before (#66)
`docker-compose.yml` bind-mounted `${HOST_UV}:${HOST_UV}` and set `UV_PYTHON_INSTALL_DIR` to it, so in-container uv reused the host's interpreters (and the repos' `.venv` symlinks resolved to host paths). That couples the container to the host's uv tree.

### After (this PR)
- **Dockerfile**: set `UV_PYTHON_INSTALL_DIR` / `UV_CACHE_DIR` to `/opt/uv/{python,cache}` and create that dir owned by the app uid/gid, so a fresh named volume mounted there initialises app-writable. The `uv` binary still ships in the image.
- **docker-compose.yml**: drop the host bind-mount and the env override; mount a named `uv` volume at `/opt/uv`. The container downloads its own Pythons into the volume; they persist across recreates and are isolated from the host's uv.

### Trade-off (intended)
The bind-mounted repos' existing `.venv`s point their interpreter symlinks at host paths that don't exist in the container, so the first `uv run`/`uv sync` in a repo rebuilds `.venv` against the container's own Python. The container's and host's environments are independent — which is the point.

`HOST_UV` is no longer referenced (removed from the untracked `secrets/weaver.env`). `docker compose config` renders the volume; `docker build --check` reports no warnings. Activates on the next `docker compose build && up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)