### PR TITLE
fix(loom): value-driven loud tags + idle-triggered status watch

### DIFF
--- a/crates/loom/frontend/src/components/SignalChip.vue
+++ b/crates/loom/frontend/src/components/SignalChip.vue
@@ -2,23 +2,29 @@
 import { computed } from 'vue';
 import type { SignalChip } from '../lib/sessionState';
 
-// A loud attention signal as an individually-dismissable chip: severity fill
-// (amber for attention, red for blocked), the agent's plain dot or an
-// overlooker's ⊙ "watched" glyph, and a × that clears the underlying tag. This
-// replaces the old full-tile wash + "Mark OK" control — every signal is now a
-// chip you delete, the agent's `attention` and an overlooker's `triage` each on
-// its own. A stale triage mark (the session has moved on since it was set) fades
-// but stays clearable, so it can never get "stuck" lit. Quiet free-form tags use
-// TagPill; the loud amber/red fill is reserved for these. Tokens auto-swap
-// light/dark. `readonly` drops the × for contexts that show but don't edit.
+// A loud signal as an individually-dismissable chip: severity fill (amber for
+// attention, red for blocked) from the tag's VALUE, a label from the tag's KEY
+// (its type — `attention`, `review`, `stuck`, …), the agent's plain dot or an
+// outside mark's ⊙ "watched" glyph, and a × that clears the underlying tag.
+// Every signal is a chip you delete — the agent's own loud tags and a watch's
+// typed marks each on its own. A stale mark (the session has moved on since it
+// was set) fades but stays clearable, so it can never get "stuck" lit. Quiet
+// free-form tags use TagPill; the loud amber/red fill is reserved for these.
+// Tokens auto-swap light/dark. `readonly` drops the × for contexts that show
+// but don't edit.
 const props = defineProps<{ chip: SignalChip; busy?: boolean; readonly?: boolean }>();
 const emit = defineEmits<{ clear: [key: string] }>();
 
-const label = computed(() => (props.chip.level === 'blocked' ? 'Blocked' : 'Needs attention'));
+// The chip's label is its tag key, humanized — the type of attention it names.
+const label = computed(() =>
+  props.chip.key
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase()),
+);
 const cls = computed(() =>
   props.chip.level === 'blocked' ? 'bg-block text-block-fg' : 'bg-attn text-attn-fg',
 );
-const fromOverlooker = computed(() => props.chip.raisedBy === 'triage');
+const fromOverlooker = computed(() => props.chip.raisedBy === 'overlooker');
 
 const tooltip = computed(() => {
   if (fromOverlooker.value) {

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -2,31 +2,29 @@ import type { Session, Tag } from '../types';
 
 export type Attention = 'ok' | 'attention' | 'blocked';
 
-// The well-known LOUD tag keys, both on the attention | blocked ladder. Every
-// other key is a quiet, free-form pill. Mirrors weaver-core's tag registry.
-export const ATTENTION_KEY = 'attention';
-export const TRIAGE_KEY = 'triage';
-const LOUD_KEYS = new Set<string>([ATTENTION_KEY, TRIAGE_KEY]);
+// Loudness lives in the tag VALUE, not the key. Any tag whose value is on this
+// ladder raises a badge — regardless of key — so agents and watches both add
+// loud tags without a hardcoded key registry. A tag's KEY is its type (the chip
+// label); its VALUE is the severity. Every other value is a quiet, free-form
+// pill. Mirrors weaver-core's `ATTENTION_VALUES`.
+const SEVERITY: Record<string, number> = { attention: 1, blocked: 2 };
 
-// Severity order for the loud ladder. Absence (no tag) is `ok`, the calm floor.
-const SEVERITY: Record<Attention, number> = { ok: 0, attention: 1, blocked: 2 };
-
-// One branch tag by key, or undefined when absent (the calm state).
-function tagOf(s: Session, key: string): Tag | undefined {
-  return s.branch.tags?.find((t) => t.key === key);
+// Severity of a tag value: 0 is quiet (a pill), >0 is loud (a badge).
+function severityOf(value: string | undefined): number {
+  return (value && SEVERITY[value]) || 0;
 }
 
-// Normalize a stored loud value to the ladder; anything unexpected is `ok`.
-function normalize(value: string | undefined): Attention {
-  return value === 'attention' || value === 'blocked' ? value : 'ok';
+// A loud tag's value, narrowed to the ladder (loud tags only — callers guard
+// with severityOf first).
+function levelValue(value: string): Exclude<Attention, 'ok'> {
+  return value === 'blocked' ? 'blocked' : 'attention';
 }
 
-// Agent-declared attention, read off the `attention` tag. Archived sessions are
-// forced quiet (the agent is gone); an absent tag is the calm `ok` floor.
-// Mirrors the backend; keeps stale/archived rows from shouting.
-export function levelOf(s: Session): Attention {
-  if (s.status === 'archived') return 'ok';
-  return normalize(tagOf(s, ATTENTION_KEY)?.value);
+// An agent's own self-report vs an outside mark (a watch/overlooker, or a
+// manual mark). The agent authors the well-known `attention` key; anything else
+// loud is an outside assessment, rendered with the ⊙ "watched" treatment.
+function isAgentTag(tag: Tag): boolean {
+  return tag.key === 'attention' || tag.set_by === 'agent';
 }
 
 // The current-state message (Branch.description). Suppressed for archived
@@ -36,18 +34,8 @@ export function messageOf(s: Session): string {
   return s.branch.description ?? '';
 }
 
-// The overlooker's triage mark, read off the `triage` tag. '' means unmarked
-// (no badge). Distinct from levelOf(): that is the agent's own attention; this
-// is an outside assessment stamped by an overlooker. Archived sessions show
-// nothing.
-export function triageOf(s: Session): '' | Attention {
-  if (s.status === 'archived') return '';
-  const t = tagOf(s, TRIAGE_KEY);
-  return t ? normalize(t.value) : '';
-}
-
 // Whether a tag predates the session's latest activity — the session has "moved
-// on" since the tag was set, so a triage mark may no longer hold. The badge
+// on" since the tag was set, so an outside mark may no longer hold. The badge
 // renders this faded with a stale hint. No tag, or no activity timestamp, is
 // never stale.
 export function tagStale(tag: Tag | undefined, lastActivityAt: string): boolean {
@@ -55,140 +43,116 @@ export function tagStale(tag: Tag | undefined, lastActivityAt: string): boolean 
   return lastActivityAt > tag.set_at;
 }
 
+// The loud tags on a session (value on the ladder), archived shown none.
+function loudTags(s: Session): Tag[] {
+  if (s.status === 'archived') return [];
+  return (s.branch.tags ?? []).filter((t) => severityOf(t.value) > 0);
+}
+
 // Who raised the resolved attention signal: the agent's own self-report, or an
-// overlooker's outside assessment (triage). The pages render the agent's signal
-// as the plain loud badge and an overlooker's with the ⊙ "watched" treatment.
+// outside assessment. The pages render the agent's signal as the plain loud
+// badge and an outside mark with the ⊙ "watched" treatment.
 export interface EffectiveAttention {
   level: Attention;
-  /** Which axis is loudest: 'agent' (its own `attention`) or 'triage' (an
-   *  overlooker). 'none' when calm. */
-  raisedBy: 'none' | 'agent' | 'triage';
+  /** Which axis is loudest: 'agent' (its own loud tag) or 'overlooker' (an
+   *  outside mark). 'none' when calm. */
+  raisedBy: 'none' | 'agent' | 'overlooker';
   /** The `set_by` of the loudest tag (the overlooker name, or 'agent'). */
   by: string;
+  /** The key of the loudest tag — its type, e.g. 'attention', 'review'. */
+  key: string;
   /** One-line reason from the loudest tag. */
   note: string;
-  /** True when a triage mark is the loudest signal but the session has moved on
-   *  since it was set, so it should fade. */
+  /** True when an outside mark is the loudest signal but the session has moved
+   *  on since it was set, so it should fade. */
   stale: boolean;
 }
 
-// The single resolved attention signal the dashboard renders: the louder of the
-// agent's `attention` tag and the *non-stale* `triage` tag. The agent saying
-// calm while an overlooker says attention surfaces as "needs attention (raised
-// by <overlooker>)". A stale triage mark is ignored for the resolved level (the
-// session has moved on) but still flagged when it is the only signal, so an
-// hour-old "looks stuck" fades rather than lies.
-export function effectiveAttention(s: Session): EffectiveAttention {
-  if (s.status === 'archived') {
-    return { level: 'ok', raisedBy: 'none', by: '', note: '', stale: false };
-  }
-
-  const agentTag = tagOf(s, ATTENTION_KEY);
-  const triageTag = tagOf(s, TRIAGE_KEY);
-  const agentLevel = normalize(agentTag?.value);
-  const triageLevel = normalize(triageTag?.value);
-  const triageIsStale = tagStale(triageTag, s.last_activity_at);
-
-  // A stale triage mark doesn't drive the resolved level; only a live one does.
-  const liveTriage = triageTag && !triageIsStale ? triageLevel : 'ok';
-
-  // The louder axis wins; on a tie the agent's own report takes precedence
-  // (its self-report is the primary signal).
-  if (SEVERITY[liveTriage] > SEVERITY[agentLevel]) {
-    return {
-      level: liveTriage,
-      raisedBy: 'triage',
-      by: triageTag!.set_by || 'overlooker',
-      note: triageTag!.note,
-      stale: false,
-    };
-  }
-  if (agentLevel !== 'ok') {
-    return {
-      level: agentLevel,
-      raisedBy: 'agent',
-      by: agentTag?.set_by || 'agent',
-      note: agentTag?.note ?? messageOf(s),
-      stale: false,
-    };
-  }
-  // The agent is calm. Surface a stale triage mark, faded, as the lone signal so
-  // it stays visible (with attribution) without claiming the session is live.
-  if (triageTag) {
-    return {
-      level: triageLevel,
-      raisedBy: 'triage',
-      by: triageTag.set_by || 'overlooker',
-      note: triageTag.note,
-      stale: triageIsStale,
-    };
-  }
-  return { level: 'ok', raisedBy: 'none', by: '', note: '', stale: false };
+// Severity-then-agent ordering: the louder tag wins; on a tie the agent's own
+// self-report leads (its self-report is the primary signal).
+function louder(a: Tag, b: Tag): number {
+  const d = severityOf(b.value) - severityOf(a.value);
+  if (d !== 0) return d;
+  return Number(isAgentTag(b)) - Number(isAgentTag(a));
 }
 
-// One loud tag (`attention` or `triage`) surfaced as an individually-dismissable
-// chip. Unlike effectiveAttention (which resolves the single loudest level for
-// filtering, sorting and counts), this surfaces EACH present loud tag so a human
-// can clear them independently: the agent's own `attention` and an overlooker's
-// `triage` are separate rows, and each gets its own × . Clearing a chip DELETEs
-// that tag — the calm state is its absence, so there is no "Mark OK" verb, just
-// the same chip-delete gesture as any quiet tag.
+// The attribution a loud tag carries: its type (key), severity (level), author
+// (by/raisedBy) and reason (note, with the agent's message as fallback).
+// effectiveAttention and signalChips both build on this so the rules stay in one
+// place; they differ only in how each treats staleness.
+function markOf(s: Session, tag: Tag): Omit<SignalChip, 'stale'> {
+  const agent = isAgentTag(tag);
+  return {
+    key: tag.key,
+    level: levelValue(tag.value),
+    by: tag.set_by || (agent ? 'agent' : 'overlooker'),
+    raisedBy: agent ? 'agent' : 'overlooker',
+    note: tag.note || (tag.key === 'attention' ? messageOf(s) : ''),
+  };
+}
+
+// The single resolved attention signal the dashboard renders: the loudest of a
+// session's loud tags. A *non-stale* mark always beats a stale one (the session
+// has moved on past a stale mark); a stale mark surfaces, faded, only when it is
+// the lone signal — so an hour-old "looks stuck" fades rather than lies.
+export function effectiveAttention(s: Session): EffectiveAttention {
+  const calm: EffectiveAttention = {
+    level: 'ok',
+    raisedBy: 'none',
+    by: '',
+    key: '',
+    note: '',
+    stale: false,
+  };
+  const tags = loudTags(s);
+  if (tags.length === 0) return calm;
+
+  const live = tags.filter((t) => !tagStale(t, s.last_activity_at));
+  const pool = live.length ? live : tags;
+  const stale = live.length === 0;
+  const top = [...pool].sort(louder)[0];
+
+  return { ...markOf(s, top), stale };
+}
+
+// One loud tag surfaced as an individually-dismissable chip. Unlike
+// effectiveAttention (which resolves the single loudest level for filtering,
+// sorting and counts), this surfaces EACH loud tag so a human can clear them
+// independently: the agent's own `attention` and a watch's typed marks are
+// separate rows, each gets its own × . Clearing a chip DELETEs that tag — the
+// calm state is its absence, so there is no "Mark OK" verb, just the same
+// chip-delete gesture as any quiet tag.
 export interface SignalChip {
-  /** The tag key to DELETE when the chip is cleared: 'attention' | 'triage'. */
+  /** The tag key to DELETE when the chip is cleared, and the chip's type label. */
   key: string;
   level: Exclude<Attention, 'ok'>;
-  /** Who set it: 'agent', or the overlooker's name. */
+  /** Who set it: 'agent', or the overlooker's / mark's name. */
   by: string;
-  /** Which axis: 'agent' (its own `attention`) or 'triage' (an overlooker). */
-  raisedBy: 'agent' | 'triage';
+  /** Which axis: 'agent' (its own loud tag) or 'overlooker' (an outside mark). */
+  raisedBy: 'agent' | 'overlooker';
   /** One-line reason from the tag. */
   note: string;
-  /** A triage mark the session has moved on past — shown faded, still clearable. */
+  /** An outside mark the session has moved on past — shown faded, still clearable. */
   stale: boolean;
 }
 
-// The loud signals on a session as dismissable chips, in severity-then-axis
-// order. The agent's `attention` and an overlooker's `triage` each render as
-// their own chip so either can be cleared on its own — which is the whole point:
-// a stale overlooker mark is no longer a thing you "can't resolve", it's just a
-// chip with an × . Archived sessions show none (the agent is gone).
+// The loud signals on a session as dismissable chips, in severity-then-agent
+// order. Each loud tag renders as its own chip so any one can be cleared on its
+// own — which is the whole point: a stale mark is no longer a thing you "can't
+// resolve", it's just a chip with an × . Archived sessions show none.
 export function signalChips(s: Session): SignalChip[] {
-  if (s.status === 'archived') return [];
-  const chips: SignalChip[] = [];
-  const agentTag = tagOf(s, ATTENTION_KEY);
-  const agentLevel = normalize(agentTag?.value);
-  if (agentTag && agentLevel !== 'ok') {
-    chips.push({
-      key: ATTENTION_KEY,
-      level: agentLevel,
-      by: agentTag.set_by || 'agent',
-      raisedBy: 'agent',
-      note: agentTag.note || messageOf(s),
-      stale: false,
-    });
-  }
-  const triageTag = tagOf(s, TRIAGE_KEY);
-  const triageLevel = normalize(triageTag?.value);
-  if (triageTag && triageLevel !== 'ok') {
-    chips.push({
-      key: TRIAGE_KEY,
-      level: triageLevel,
-      by: triageTag.set_by || 'overlooker',
-      raisedBy: 'triage',
-      note: triageTag.note,
-      stale: tagStale(triageTag, s.last_activity_at),
-    });
-  }
-  // Blocked before attention, so the louder chip leads.
-  return chips.sort((a, b) => SEVERITY[b.level] - SEVERITY[a.level]);
+  return loudTags(s)
+    .slice()
+    .sort(louder)
+    .map((t) => ({ ...markOf(s, t), stale: tagStale(t, s.last_activity_at) }));
 }
 
-// The session's quiet tags: every tag whose key is not loud, for the pill row.
+// The session's quiet tags: every tag whose value is not loud, for the pill row.
 // These are free-form, deletable annotations (priority, needs-rebase, …).
 // Archived sessions show none.
 export function quietTags(s: Session): Tag[] {
   if (s.status === 'archived') return [];
-  return (s.branch.tags ?? []).filter((t) => !LOUD_KEYS.has(t.key));
+  return (s.branch.tags ?? []).filter((t) => severityOf(t.value) === 0);
 }
 
 // Compact conversation-state line for the detail header (#5): a derived
@@ -208,8 +172,8 @@ export function conversationState(s: Session): ConvState {
   if (s.status === 'orphaned') return { glyph: '◦', label: 'Orphaned — detached', tone: 'muted' };
   if (s.status === 'error') return { glyph: '◦', label: 'Error', tone: 'muted' };
 
-  // Then the resolved attention signal (agent's own, or a non-stale overlooker
-  // mark — whichever is louder).
+  // Then the resolved attention signal (the loudest live loud tag — the agent's
+  // own, or an outside mark).
   const level = effectiveAttention(s).level;
   if (level === 'blocked') return { glyph: '●', label: 'Blocked', tone: 'block' };
   if (level === 'attention') return { glyph: '●', label: 'Needs attention', tone: 'attn' };

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -1,17 +1,17 @@
-/** One (key, value) annotation on a branch. A status axis collapsed into data:
- *  the well-known *loud* keys are `attention` (authored by the agent) and
- *  `triage` (authored by an overlooker or `manual`), both on the
- *  `attention | blocked` ladder; every other key is a quiet, free-form pill.
- *  Absence is the calm state — there is no stored `ok`. Mirrors weaver-api's
- *  `TagView`. */
+/** One (key, value) annotation on a branch. Loudness lives in the VALUE: a tag
+ *  whose value is on the `attention | blocked` ladder is *loud* (raises a badge)
+ *  regardless of key — the agent's own `attention` self-report and a watch's
+ *  typed marks (`review`, `stuck`, …) alike. The key is the type (the chip
+ *  label); every other value is a quiet, free-form pill. Absence is the calm
+ *  state — there is no stored `ok`. Mirrors weaver-api's `TagView`. */
 export interface Tag {
   key: string;
   value: string;
   /** One-line reason accompanying the tag. */
   note: string;
-  /** Who set it — `agent`, an overlooker name, or `manual`. */
+  /** Who set it — `agent`, a watch/overlooker name, or `manual`. */
   set_by: string;
-  /** When it was last set (ISO). The dashboard fades a triage mark stale once
+  /** When it was last set (ISO). The dashboard fades an outside mark stale once
    *  the session's activity advances past this. */
   set_at: string;
 }
@@ -30,8 +30,8 @@ export interface Branch {
    *  via `weaver status` (e.g. "Wired up routes; tests pass"). Shown even
    *  when the branch is calm. */
   description: string;
-  /** Every tag on the branch: the agent's `attention`, an overlooker's
-   *  `triage`, and any free-form key. Empty when the branch is calm and
+  /** Every tag on the branch: the agent's own loud `attention`, a watch's typed
+   *  marks, and any free-form quiet key. Empty when the branch is calm and
    *  unmarked — absence is the default state, there is no `ok` tag. */
   tags: Tag[];
   repo_root: string;

--- a/crates/loom/overlookers/status.py
+++ b/crates/loom/overlookers/status.py
@@ -1,112 +1,122 @@
-"""status — survey the scoped fleet and stamp a triage mark on each session.
+"""status — when a session goes idle, judge it and stamp the watch's own tags.
 
-The judgement is best-effort-LLM with a deterministic fallback, so the round
-works fully without a real agent:
+On the agent's finished-turn hook (``session.idle``) this watch re-assesses just
+that session: it asks the judge model (the daemon's one-shot agent) for advice on
+a set of attention tags to apply given the recent screen, then reconciles its own
+marks to that set — setting the recommended tags and clearing any it set earlier
+that no longer apply.
 
-* when a prompt is configured (params.prompt), ask the daemon's one-shot
-  agent for a level + note from the session's screen preview (parsed
-  leniently via parse_judgement);
-* otherwise — or when the agent is absent or unparseable — fall back to a
-  rule that mirrors the session's own `attention` tag as the mark.
-
-An `ok` judgement returns the triage axis to calm (clears the tag) rather
-than marking. With the `nudge` capability, a freshly marked session is also
-nudged with the note. Honours dry_run: would-be marks are logged as
-`{would: "mark"}` actions and nothing mutates.
+User attention is expensive, so the default prompt tells the model to flag a
+session ONLY when it genuinely needs the human, and to name the *kind* of
+attention (the tag key — `review`, `question`, `stuck`, …) rather than a generic
+"needs attention". The watch never mirrors the agent's own ``attention``
+self-report; that is the agent's signal, on its own key. With no judge model
+available (no agent, or an empty/garbled reply), the round is a no-op — it leaves
+every mark untouched rather than guess. Honours dry_run: would-be writes are
+logged as actions and nothing mutates.
 """
 
-from weaver_loom import Round, WeaverError, parse_judgement
+from weaver_loom import Round, WeaverError, parse_tag_recommendations
 
-#: The storable triage values; `ok` is the absence of the tag.
-STORABLE = ("attention", "blocked")
+#: Wake on the agent's finished-turn hook — "assess when the agent goes quiet".
+TRIGGERS = {"on": ["session.idle"]}
 
-#: A scheduled survey of the whole scoped fleet — the engine reads this in
-#: register mode. (A status sweep is inherently fleet-wide, so it stays on a
-#: cadence rather than a per-session event.)
-TRIGGERS = {"cron": "0 * * * *"}
+#: Lines of terminal scrollback handed to the judge as context.
+SCREEN_LINES = 200
+
+#: The default judge prompt, overridable via params.prompt. Asks for a JSON array
+#: of {key, value, note} tags, or [] when the human is not needed.
+DEFAULT_PROMPT = (
+    "You are triaging a detached coding-agent session for a human operator who "
+    "reviews many sessions asynchronously. Their attention is expensive: flag a "
+    "session ONLY when it genuinely needs the human now. Read the recent session "
+    "screen below and decide which attention tags apply.\n\n"
+    "Reply with ONLY a JSON array of objects "
+    '{"key": "<short-type>", "value": "attention" | "blocked", "note": "<one '
+    'line>"}. Use an empty array [] when the session does not need the human. '
+    "The key names the KIND of attention; pick the few that fit, e.g.:\n"
+    '  - "review"   — work looks finished / a PR is ready to look at (value "attention")\n'
+    '  - "question" — waiting on a decision only the operator can make (value "attention")\n'
+    '  - "stuck"    — looping or erroring with no progress (value "blocked")\n'
+    '  - "idle"     — went quiet mid-task for no clear reason (value "attention")\n'
+    "Do not invent noise, and do not restate the agent's own self-reported "
+    "status — add only what an outside observer would flag."
+)
 
 
-def attention_value(session):
-    """The session's own `attention` tag value — `ok` when absent (calm)."""
-    for tag in (session.get("branch") or {}).get("tags") or []:
-        if tag.get("key") == "attention":
-            return tag.get("value") or "ok"
-    return "ok"
+def judge_tags(rnd, session):
+    """Ask the judge model for the set of tags to apply to ``session``.
+
+    Returns the parsed list (possibly empty — the "nothing needed" verdict that
+    clears the watch's marks), or ``None`` for "no judgement" (no agent, or an
+    unparseable reply) so the caller leaves the session's marks untouched."""
+    prompt = rnd.params.get("prompt") or DEFAULT_PROMPT
+    try:
+        screen = rnd.client.preview(session["id"], SCREEN_LINES)
+    except WeaverError:
+        screen = ""
+    out = rnd.client.agent(f"{prompt}\n\nSession screen:\n{screen}\n", rnd.model, rnd.effort)
+    if not out:
+        return None
+    return parse_tag_recommendations(out)
 
 
-def judge(rnd, session):
-    """Decide a (level, note) for one session: best-effort LLM judgement when
-    a prompt is configured, else mirror the agent's self-reported attention."""
-    prompt = rnd.params.get("prompt") or ""
-    if prompt:
-        try:
-            screen = rnd.client.preview(session["id"], 200)
-        except WeaverError:
-            screen = ""
-        out = rnd.client.agent(
-            f"{prompt}\n\nSession screen:\n{screen}\n", rnd.model, rnd.effort
-        )
-        judged = parse_judgement(out) if out else None
-        if judged:
-            return judged
-
-    attention = attention_value(session)
-    level = attention if attention in STORABLE else "ok"
-    return level, f"attention is {attention}"
+def watch_tags(rnd, session):
+    """The keys of tags on ``session`` that THIS watch authored — the marks it
+    owns and may reconcile (never the agent's own or another author's)."""
+    return {
+        tag.get("key")
+        for tag in (session.get("branch") or {}).get("tags") or []
+        if tag.get("set_by") == rnd.name and tag.get("key")
+    }
 
 
 def main(rnd):
     can_mark = rnd.can("mark")
-    can_nudge = rnd.can("nudge")
-    marked = 0
-    counts = {}
+    assessed = 0
+    tagged = 0
 
-    for session in rnd.sessions():
-        level, note = judge(rnd, session)
+    # Reactive on session.idle: act on just the session that went quiet. A manual
+    # run (no trigger session) falls back to the whole scoped fleet.
+    for session in rnd.triggered_sessions():
+        desired = judge_tags(rnd, session)
+        if desired is None:
+            continue  # no judgement available — leave this session's marks alone
+        assessed += 1
+        sid = session["id"]
+        stale = watch_tags(rnd, session) - {t["key"] for t in desired}
 
-        # An `ok` judgement returns the triage axis to calm rather than
-        # marking: clear the tag (the server records the cleared-tag event —
-        # the audit rule). The dry-run path mutates nothing.
-        if level not in STORABLE:
-            if can_mark and not rnd.dry_run:
-                rnd.client.mark(session["id"], "ok", by=rnd.name)
-            continue
-
+        # Without `mark`, the round is read-only: report what it would tag.
         if not can_mark:
-            rnd.did("observe", session=session["id"], level=level, note=note)
+            for t in desired:
+                rnd.did("observe", session=sid, **t)
             continue
 
-        marked += 1
-        counts[level] = counts.get(level, 0) + 1
-        if rnd.dry_run:
-            rnd.would("mark", session=session["id"], level=level, note=note)
-            continue
-
-        rnd.client.mark(session["id"], level, note, by=rnd.name)
-        rnd.did("mark", session=session["id"], level=level, note=note)
-
-        # The nudge rung of the intervention ladder: only when capability-
-        # granted. Best-effort; a session with no live terminal just no-ops.
-        if can_nudge:
-            text = f"[overlooker {rnd.name}] {note}"
-            try:
-                rnd.client.nudge(session["id"], text, by=rnd.name)
-                rnd.did("nudge", session=session["id"], text=text)
-            except WeaverError:
-                pass
+        tagged += len(desired)
+        for t in desired:
+            if rnd.dry_run:
+                rnd.would("tag", session=sid, **t)
+            else:
+                rnd.client.set_tag(sid, t["key"], t["value"], t["note"], by=rnd.name)
+                rnd.did("tag", session=sid, **t)
+        # Reconcile: clear the watch's own marks the new judgement dropped.
+        for key in sorted(stale):
+            if rnd.dry_run:
+                rnd.would("clear", session=sid, key=key)
+            else:
+                rnd.client.clear_tag(sid, key, by=rnd.name)
+                rnd.did("clear", session=sid, key=key)
 
     if rnd.surveyed == 0:
         rnd.finish("surveyed 0 sessions in scope", outcome="noop")
         return
 
-    breakdown = ", ".join(f"{n} {level}" for level, n in sorted(counts.items()))
-    dry = " (dry run, no marks applied)" if rnd.dry_run else ""
-    verb = "would mark" if rnd.dry_run else "marked"
-    if breakdown:
-        summary = f"surveyed {rnd.surveyed}, {verb} {marked} ({breakdown}){dry}"
-    else:
-        summary = f"surveyed {rnd.surveyed}, {verb} 0{dry}"
-    rnd.finish(summary, outcome="ok")
+    dry = " (dry run, no writes applied)" if rnd.dry_run else ""
+    verb = "would apply" if rnd.dry_run else "applied"
+    rnd.finish(
+        f"assessed {assessed} of {rnd.surveyed}, {verb} {tagged} tag(s){dry}",
+        outcome="ok" if rnd.actions else "noop",
+    )
 
 
 if __name__ == "__main__":

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -45,15 +45,18 @@ pub const BUILTINS: &[BuiltinProgram] = &[
     BuiltinProgram {
         name: "status",
         title: "Status check",
-        description: "Survey the scoped fleet and stamp a triage mark on each \
-                      session — judgement via the configured prompt (the \
-                      daemon's one-shot agent when available), else mirroring \
-                      the agent's own attention tag.",
+        description: "When a session goes idle (the agent's finished-turn hook), \
+                      ask the judge model (the daemon's one-shot agent) for the \
+                      set of attention tags it warrants and reconcile the watch's \
+                      own marks to that set. Names the kind of attention (review, \
+                      question, stuck, …) rather than a generic mark; with no \
+                      judge model available it no-ops, never mirroring the \
+                      agent's own attention tag.",
         source: include_str!("../overlookers/status.py"),
-        default_trigger: r#"{"cron":"0 * * * *"}"#,
-        default_scope: r#"{"attention":"!ok"}"#,
+        default_trigger: r#"{"on":["session.idle"]}"#,
+        default_scope: "{}",
         default_params: "{}",
-        default_capabilities: &["observe", "mark", "escalate"],
+        default_capabilities: &["observe", "mark"],
     },
     BuiltinProgram {
         name: "pr-label",

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -1168,14 +1168,15 @@ pub async fn archive(
     }
     session_mod::set_status(&st.db, &session.id, "archived").await?;
     // An archived session is finished with: its agent is gone, so it can no
-    // longer "need me". Clear the loud tags (the agent's `attention` and any
-    // overlooker `triage` mark) so the dashboard stops flagging a torn-down
+    // longer "need me". Clear every loud tag — the agent's own `attention` and
+    // any watch's typed marks (loudness is value-driven, so match on the value,
+    // not a fixed key set) — so the dashboard stops flagging a torn-down
     // workstream — absence is the calm state. The history (goal, status, events)
-    // is kept; the `description` message stays too.
-    for key in tags::LOUD_KEYS {
-        if tags::get(&st.db, &branch.id, key).await?.is_some() {
-            tags::clear(&st.db, &branch.id, key).await?;
-            events::record_tag(&st.db, &st.bus, &branch.id, key, "", "", "manual")
+    // is kept; the `description` message stays too, as do any quiet pills.
+    for tag in tags::list(&st.db, &branch.id).await? {
+        if tags::is_loud_value(&tag.value) {
+            tags::clear(&st.db, &branch.id, &tag.key).await?;
+            events::record_tag(&st.db, &st.bus, &branch.id, &tag.key, "", "", "manual")
                 .await
                 .ok();
         }

--- a/crates/loom/tests/integration/archive.rs
+++ b/crates/loom/tests/integration/archive.rs
@@ -51,6 +51,15 @@ async fn archive_keeps_branch_and_history() {
         )
         .await
         .unwrap();
+    // A watch's typed loud mark (a non-well-known key on the ladder): archiving
+    // must clear it too — loudness is value-driven, not a fixed key set.
+    client
+        .put(
+            &format!("/api/sessions/{arch_id}/tags/review"),
+            json!({ "value": "attention", "by": "status-check" }),
+        )
+        .await
+        .unwrap();
     client
         .patch(
             &format!("/api/sessions/{arch_id}"),
@@ -84,6 +93,10 @@ async fn archive_keeps_branch_and_history() {
     assert!(
         branch_tag(&view, "attention").is_none(),
         "archive should clear the attention tag"
+    );
+    assert!(
+        branch_tag(&view, "review").is_none(),
+        "archive should clear a watch's typed loud mark too"
     );
     assert_eq!(
         view["branch"]["description"], "Waiting for input",

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -314,16 +314,33 @@ async fn stale_session_emits_one_event_and_wakes_a_reactive_overlooker() {
         .unwrap();
 }
 
-/// The status program's wiring proof: a round over a non-ok session lands an
-/// attributed triage mark on the live server and records the action on the
-/// run row. The program's decision logic (judge fallback, dry-run, capability
-/// branches, summaries) is covered server-free in
-/// `python/weaver-loom/tests/test_status_program.py`; dry-run flag
-/// propagation through the executor is covered by the lib test
+/// Write a one-shot fake judge agent that ignores its stdin (the composed
+/// prompt) and prints `out`, point `WEAVER_OVERLOOKER_AGENT_CMD` at it, and
+/// return its path. Robust where `cat` is not: the round feeds a real terminal
+/// screen into the prompt, and a shell screen can carry brackets that would
+/// corrupt an echo-then-parse. Reused paths overwrite, so a test can re-stub
+/// between fires. Restore `WEAVER_OVERLOOKER_AGENT_CMD=true` after.
+fn fake_judge_agent(name: &str, out: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = std::env::temp_dir().join(name);
+    let script = format!("#!/bin/sh\ncat >/dev/null 2>&1\ncat <<'WEAVER_EOF'\n{out}\nWEAVER_EOF\n");
+    std::fs::write(&path, script).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::env::set_var("WEAVER_OVERLOOKER_AGENT_CMD", path.to_str().unwrap());
+    path
+}
+
+/// The status program's wiring proof: an idle-triggered round asks the judge for
+/// a set of tags and reconciles its own marks — a recommended tag lands as its
+/// own typed key (never the agent's `attention` axis — no mirror), and a
+/// follow-up "nothing needed" verdict clears it. The program's decision logic
+/// (parse, no-judgement vs calm, capability branches, summaries) is covered
+/// server-free in `python/weaver-loom/tests/test_status_program.py`; dry-run
+/// flag propagation through the executor is covered by the lib test
 /// `run_script_round_trips_the_contract`.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn builtin_status_round_lands_an_attributed_mark() {
+async fn builtin_status_round_applies_typed_tags_and_reconciles() {
     if !python3_available() {
         eprintln!("skipping: python3 not on PATH");
         return;
@@ -332,21 +349,18 @@ async fn builtin_status_round_lands_an_attributed_mark() {
     let state = engine_state(&ts).await;
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "status me").await;
 
-    // The session reports `attention` about itself → it's in a `!ok` scope.
-    ts.client
-        .put(
-            &format!("/api/sessions/{session_id}/tags/attention"),
-            json!({ "value": "attention", "by": "agent" }),
-        )
-        .await
-        .unwrap();
+    // The judge model is stubbed: a fixed tag set the round should apply.
+    let _agent = fake_judge_agent(
+        "weaver-fake-judge-status",
+        r#"[{"key":"review","value":"attention","note":"looks done"}]"#,
+    );
 
     let o = enabled_overlooker(
         &state,
         ov::NewOverlooker {
             name: "status-check".to_string(),
-            trigger_spec: json!({ "cron": "0 * * * *" }).to_string(),
-            scope: json!({ "attention": "!ok" }).to_string(),
+            trigger_spec: json!({ "on": ["session.idle"] }).to_string(),
+            scope: json!({}).to_string(),
             program: "builtin:status".to_string(),
             capabilities: vec!["observe".to_string(), "mark".to_string()],
             ..Default::default()
@@ -359,34 +373,56 @@ async fn builtin_status_round_lands_an_attributed_mark() {
         .await
         .unwrap();
 
-    // The mark landed on the session's branch.
+    // The judged tag landed on its own typed key, attributed to the watch.
     let view = ts
         .client
         .get(&format!("/api/sessions/{session_id}"))
         .await
         .unwrap();
     assert_eq!(
-        branch_tag_value(&view, "triage"),
+        branch_tag_value(&view, "review"),
         "attention",
-        "the round marks the in-scope session"
+        "the round applies the judge's typed tag"
     );
     assert_eq!(
-        branch_tag(&view, "triage").unwrap()["set_by"],
+        branch_tag(&view, "review").unwrap()["set_by"],
         "status-check"
     );
+    assert!(
+        branch_tag(&view, "attention").is_none(),
+        "the watch never mirrors onto the agent's own `attention` axis"
+    );
 
-    // The run row records the mark action.
+    // The run row records a `tag` action (not the old generic `mark`).
     let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
     let run = runs.iter().find(|r| r.id == run_id).unwrap();
     assert_eq!(run.outcome, "ok");
     let actions: serde_json::Value = serde_json::from_str(&run.actions).unwrap();
     let arr = actions.as_array().unwrap();
     assert!(
-        arr.iter()
-            .any(|a| a["action"] == "mark" && a["session"] == session_id.as_str()),
-        "the run records a mark action: {actions}"
+        arr.iter().any(|a| a["action"] == "tag"
+            && a["session"] == session_id.as_str()
+            && a["key"] == "review"),
+        "the run records a tag action: {actions}"
     );
 
+    // Reconcile: a follow-up "nothing needed" verdict clears the watch's own mark.
+    let _calm = fake_judge_agent("weaver-fake-judge-status", "[]");
+    overlooker::fire_now(&state, &o.name, false, "manual")
+        .await
+        .unwrap();
+    let view = ts
+        .client
+        .get(&format!("/api/sessions/{session_id}"))
+        .await
+        .unwrap();
+    assert!(
+        branch_tag(&view, "review").is_none(),
+        "the empty verdict clears the watch's own mark"
+    );
+
+    // Restore the fixture's no-op agent for the tests that follow.
+    std::env::set_var("WEAVER_OVERLOOKER_AGENT_CMD", "true");
     ts.client
         .delete(&format!("/api/sessions/{session_id}"))
         .await
@@ -579,7 +615,8 @@ async fn rest_overlooker_lifecycle_and_validation() {
         return;
     }
     let ts = TestServer::start().await;
-    // A non-ok session so the dry-run round has something in scope to "would-mark".
+    // A session in scope plus a stubbed judge that recommends a tag, so the
+    // dry-run round has something to "would-tag".
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "rest me").await;
     ts.client
         .put(
@@ -588,6 +625,10 @@ async fn rest_overlooker_lifecycle_and_validation() {
         )
         .await
         .unwrap();
+    let _agent = fake_judge_agent(
+        "weaver-fake-judge-lifecycle",
+        r#"[{"key":"review","value":"attention","note":"looks done"}]"#,
+    );
 
     // Create: structured trigger/scope/params JSON in, an OverlookerView out.
     let created = ts
@@ -683,7 +724,7 @@ async fn rest_overlooker_lifecycle_and_validation() {
         .await
         .unwrap();
     assert!(
-        branch_tag(&view, "triage").is_none(),
+        branch_tag(&view, "review").is_none(),
         "a dry run applies no mark"
     );
 
@@ -778,9 +819,11 @@ async fn rest_lists_builtin_programs_and_validates_program_refs() {
         .find(|p| p["program"] == "builtin:status")
         .unwrap();
     assert!(
-        status["source"].as_str().unwrap().contains("triage"),
+        status["source"].as_str().unwrap().contains("session.idle"),
         "the status program is a script like every other builtin"
     );
+    // The status builtin wakes on the agent's finished-turn hook, not a timer.
+    assert_eq!(status["defaults"]["trigger"]["on"][0], "session.idle");
 
     // An unknown builtin is rejected at create time; a known script accepted.
     let bad = ts
@@ -910,25 +953,23 @@ async fn builtin_scripts_report_merged_and_unlabelled_prs() {
     }
 }
 
-/// The LLM judgement path end to end: with a prompt configured and the
-/// one-shot agent stubbed (`WEAVER_OVERLOOKER_AGENT_CMD=cat` echoes the
-/// prompt back), the status script calls the daemon's `POST /api/agent/oneshot`
-/// and parses the level + note out of the reply — the mark carries the
-/// agent's judgement, not the attention mirror. Also drives the endpoint
-/// directly: a stubbed agent echoes, and an empty prompt is rejected.
+/// The LLM judgement path end to end: the status script calls the daemon's
+/// `POST /api/agent/oneshot` for its verdict and applies the parsed tag set.
+/// First drives the endpoint directly (a stubbed `cat` echoes the prompt; an
+/// empty prompt 400s), then runs a round whose stubbed judge recommends a
+/// `blocked` mark on an otherwise-calm session — the tag lands attributed,
+/// proving the verdict (not a mirror) drove it.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn status_judgement_uses_the_oneshot_agent_when_prompted() {
+async fn status_judgement_uses_the_oneshot_agent() {
     if !python3_available() {
         eprintln!("skipping: python3 not on PATH");
         return;
     }
     let ts = TestServer::start().await;
-    // `cat` echoes the composed prompt (prompt + screen) straight back, so the
-    // judgement parser sees the prompt's own first line.
-    std::env::set_var("WEAVER_OVERLOOKER_AGENT_CMD", "cat");
 
-    // The endpoint itself: output echoes the prompt; an empty prompt 400s.
+    // The endpoint itself: `cat` echoes the prompt; an empty prompt 400s.
+    std::env::set_var("WEAVER_OVERLOOKER_AGENT_CMD", "cat");
     let reply = ts
         .client
         .post("/api/agent/oneshot", json!({ "prompt": "ping" }))
@@ -943,17 +984,21 @@ async fn status_judgement_uses_the_oneshot_agent_when_prompted() {
         "an empty prompt is rejected"
     );
 
-    // A calm session (no attention tag): the fallback rule would clear, so a
-    // `blocked` mark proves the agent judgement was used.
+    // A calm session (no attention tag): a `blocked` verdict proves the judge
+    // drove the mark — there is no fallback that would have invented one.
     let state = engine_state(&ts).await;
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "judge me").await;
+    let _agent = fake_judge_agent(
+        "weaver-fake-judge-oneshot",
+        r#"[{"key":"stuck","value":"blocked","note":"the judge says so"}]"#,
+    );
     let o = enabled_overlooker(
         &state,
         ov::NewOverlooker {
             name: "judge-watch".to_string(),
-            trigger_spec: json!({ "cron": "0 * * * *" }).to_string(),
+            trigger_spec: json!({ "on": ["session.idle"] }).to_string(),
             program: "builtin:status".to_string(),
-            params: json!({ "prompt": "blocked - the judge says so" }).to_string(),
+            params: json!({ "prompt": "is it stuck?" }).to_string(),
             capabilities: vec!["observe".to_string(), "mark".to_string()],
             ..Default::default()
         },
@@ -969,16 +1014,13 @@ async fn status_judgement_uses_the_oneshot_agent_when_prompted() {
         .await
         .unwrap();
     assert_eq!(
-        branch_tag_value(&view, "triage"),
+        branch_tag_value(&view, "stuck"),
         "blocked",
-        "the agent judgement (not the calm attention mirror) lands as the mark"
+        "the judge's verdict lands as a typed mark"
     );
-    // (Judgement parsing detail — level/note extraction — is pytest-covered in
+    // (Parsing detail — the JSON tag-set extraction — is pytest-covered in
     // weaver_loom; here only the through-the-stack outcome matters.)
-    assert_eq!(
-        branch_tag(&view, "triage").unwrap()["set_by"],
-        "judge-watch"
-    );
+    assert_eq!(branch_tag(&view, "stuck").unwrap()["set_by"], "judge-watch");
 
     // Restore the fixture's no-op agent for the tests that follow.
     std::env::set_var("WEAVER_OVERLOOKER_AGENT_CMD", "true");

--- a/crates/weaver-core/src/tags.rs
+++ b/crates/weaver-core/src/tags.rs
@@ -79,6 +79,15 @@ pub fn is_valid_value(key: &str, value: &str) -> bool {
     }
 }
 
+/// Whether `value` raises a badge — i.e. it sits on the [`ATTENTION_VALUES`]
+/// ladder. **Loudness is carried by the value**, so *any* key holding such a
+/// value is loud (the agent's own `attention`, a watch's typed `review`/`stuck`,
+/// …); the dashboard renders each as a chip labelled by its key. Distinct from
+/// [`is_loud`], which gates the well-known *keys* to the ladder in validation.
+pub fn is_loud_value(value: &str) -> bool {
+    ATTENTION_VALUES.contains(&value)
+}
+
 // ---------------------------------------------------------------------------
 // CRUD
 // ---------------------------------------------------------------------------
@@ -169,6 +178,15 @@ mod tests {
         // A free-form key accepts any non-empty value.
         assert!(is_valid_value("priority", "high"));
         assert!(!is_valid_value("priority", ""));
+
+        // Loudness is value-driven: any key holding a ladder value is loud (a
+        // watch's typed `review`/`stuck`), while a quiet value never is.
+        assert!(is_loud_value("attention"));
+        assert!(is_loud_value("blocked"));
+        assert!(!is_loud_value("high"));
+        assert!(!is_loud_value("ok"));
+        // A free-form key may legitimately carry a loud value (the watch's marks).
+        assert!(is_valid_value("review", "attention"));
     }
 
     #[tokio::test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -301,14 +301,21 @@ branch.
 **Tags** are single-valued `(key, value)` annotations on a branch, each with a
 `note`, `set_by`, and `set_at`, stored in the shared `tags` table (one row per
 `(branch_id, key)`, registry in [`weaver_core::tags`](../crates/weaver-core/WEAVER.md)).
-The well-known keys are **`attention`** (the agent's own self-report) and
-**`triage`** (an overlooker's assessment); both are *loud* (they raise a badge)
-and hold `attention` | `blocked`. Any other key is a free-form, quiet pill.
-**Absence is the calm/default state** — there is no stored `ok`; returning to
-calm *clears* the tag. A tag is **stale** when its `set_at` predates the
-session's `last_activity_at` (the session moved on since it was set). The
-dashboard resolves the louder of the agent's `attention` tag and the non-stale
-`triage` tag into one attention signal, with attribution.
+**Loudness lives in the value, not the key:** a tag whose value is on the
+`attention` | `blocked` ladder is *loud* (raises a badge) regardless of key, so
+agents and watches both add loud tags without a privileged key registry. A tag's
+**key is its type** (the chip label — `attention`, `review`, `stuck`, …) and its
+**value is the severity**; every other value is a free-form, quiet pill. The
+agent authors the well-known **`attention`** key for its own self-report; a watch
+authors its own typed keys. **Absence is the calm/default state** — there is no
+stored `ok`; returning to calm *clears* the tag. A tag is **stale** when its
+`set_at` predates the session's `last_activity_at` (the session moved on since it
+was set). The dashboard resolves the loudest non-stale loud tag into one
+attention signal, with attribution (the agent's own, or an outside mark). The
+agent's own `attention` self-report stays the *server-side* signal — what
+`weaver status`, `resolve_attention`, and `weaver issue wait` read — so a watch's
+outside marks surface on the dashboard without spuriously waking sub-agent
+tracking.
 
 **Lifecycle** is driven by Claude Code hooks. `loom session launch` merges a `hooks`
 block into the worktree's `.claude/settings.local.json` (see
@@ -344,11 +351,13 @@ SSE. A bare `weaver status <level>` changes only the level and keeps the last
 message. Last write wins, so an explicit declaration overrides the hook-inferred
 default. The general `weaver tag set|rm|ls` group writes any key the same way;
 the `PUT`/`DELETE /api/sessions/{id}/tags/{key}` routes do it over HTTP for the
-UI and the [overlooker](plans/overlooker.md) (whose `mark` writes the `triage`
-tag).
+UI and the [overlooker](plans/overlooker.md). The builtin status watch, when a
+session goes idle (the agent's finished-turn hook), asks the judge model for the
+set of tags the session warrants and reconciles its own typed marks to that set
+— never mirroring the agent's own `attention`.
 
-Archiving a session clears its `attention` (and `triage`) tags (and drops any
-snapshotted `pending_prompt`): the agent is gone, so a torn-down workstream
+Archiving a session clears its loud tags (and drops any snapshotted
+`pending_prompt`): the agent is gone, so a torn-down workstream
 can't still "need me", and the dashboard stops flagging it. The UI also treats
 any `archived` session as calm regardless of a stale tag left on the branch.
 

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -77,7 +77,7 @@ test.describe('session list view', () => {
     const card = page.locator(`[data-session-id="${s.id}"]`);
     const chip = card.locator('[data-testid="signal-chip"][data-signal-key="triage"]');
     await expect(chip).toHaveAttribute('data-level', 'blocked');
-    await expect(chip).toHaveAttribute('data-raised-by', 'triage');
+    await expect(chip).toHaveAttribute('data-raised-by', 'overlooker');
     // It counts toward "needs attention" even though the agent is calm.
     await expect(page.getByTestId('filter-attention')).toContainText('1');
 

--- a/e2e/tests/overlookers.spec.ts
+++ b/e2e/tests/overlookers.spec.ts
@@ -169,7 +169,7 @@ test.describe('overlooker panel', () => {
     const status = rows.filter({ hasText: 'builtin:status' });
     await status.getByTestId('program-source-toggle').click();
     await expect(status.getByTestId('program-source')).toContainText(
-      'stamp a triage mark',
+      'assess when the agent goes quiet',
     );
 
     // "Use" opens the create form prefilled with the program and a name.

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -65,6 +65,12 @@ TERMINAL_STATUSES = {"done", "error", "archived"}
 #: axis to calm (the caller then clears the tag rather than marking).
 JUDGED_LEVELS = ("ok", "attention", "blocked")
 
+#: The storable loud values, calm → urgent. ``ok``/empty is never stored (it
+#: clears the tag). A tag whose value is one of these is *loud* — it raises a
+#: badge — regardless of key; the key is the type. Mirrors weaver-core's
+#: ``ATTENTION_VALUES``.
+LOUD_VALUES = ("attention", "blocked")
+
 
 def parse_judgement(text):
     """Parse an agent judgement into ``(level, note)``, or ``None``.
@@ -82,6 +88,55 @@ def parse_judgement(text):
                 note = line[min(cuts) + 1 :].strip() if cuts else ""
                 return level, note or line.strip()
     return None
+
+
+def _slug(text):
+    """A short tag key: lowercased, runs of non-alphanumerics → single hyphens,
+    trimmed. ``"Needs Review!"`` → ``"needs-review"``; ``""`` → ``""``."""
+    cleaned = "".join(c if c.isalnum() else "-" for c in (text or "").strip().lower())
+    return "-".join(p for p in cleaned.split("-") if p)
+
+
+def _json_array(text):
+    """The first ``[`` … last ``]`` slice of ``text``, or ``None`` — a forgiving
+    grab so the array survives surrounding prose or a code fence."""
+    text = text or ""
+    start, end = text.find("["), text.rfind("]")
+    return text[start : end + 1] if 0 <= start < end else None
+
+
+def parse_tag_recommendations(text):
+    """Parse a judge model's reply into a list of ``{key, value, note}`` tags, or
+    ``None`` when the reply carries no recognizable recommendation.
+
+    The reply is expected to be a JSON array of objects (the model may wrap it in
+    prose or a code fence — the first ``[`` … last ``]`` is extracted). Each
+    entry needs a non-empty key and a ``value`` on the loud ladder
+    (:data:`LOUD_VALUES`); malformed entries are dropped and keys are slugged and
+    de-duplicated. An empty array parses to ``[]`` — the explicit "nothing
+    needed" verdict, so the caller clears its marks. ``None`` (no array / invalid
+    JSON) means "no judgement", distinct from a calm verdict: the caller then
+    leaves marks untouched rather than guess."""
+    blob = _json_array(text)
+    if blob is None:
+        return None
+    try:
+        items = json.loads(blob)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(items, list):
+        return None
+    out, seen = [], set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        key = _slug(item.get("key"))
+        value = str(item.get("value") or "").strip().lower()
+        if not key or value not in LOUD_VALUES or key in seen:
+            continue
+        seen.add(key)
+        out.append({"key": key, "value": value, "note": str(item.get("note") or "").strip()})
+    return out
 
 
 class WeaverError(RuntimeError):

--- a/python/weaver-loom/tests/test_status_program.py
+++ b/python/weaver-loom/tests/test_status_program.py
@@ -1,13 +1,14 @@
 """The builtin status program's decision logic, with no server required.
 
-Loads `crates/loom/overlookers/status.py` straight from the repo and drives
-it with stubbed clients: the judge's prompt/fallback split, the ok-clears
-rule, the capability branches, and the summary format all live here. The
-Rust integration suite keeps only the wiring proof — that the script runs
-under the engine against a live loom and its marks/audit rows land.
+Loads `crates/loom/overlookers/status.py` straight from the repo and drives it
+with stubbed clients: the judge's parse + no-judgement split, the reconcile
+(set recommended tags, clear the watch's own dropped ones), the capability
+branches, dry-run, and the summary all live here. The Rust integration suite
+keeps only the wiring proof — that the script runs under the engine against a
+live loom and its writes/audit rows land.
 
-pr-label and archive-merged carry no logic beyond a one-line predicate over
-the PR snapshot, so their coverage stays in the Rust end-to-end test
+pr-label and archive-merged carry no logic beyond a one-line predicate over the
+PR snapshot, so their coverage stays in the Rust end-to-end test
 (`builtin_scripts_report_merged_and_unlabelled_prs`) — a pytest double of a
 one-liner would be duplication, not coverage.
 """
@@ -30,17 +31,17 @@ def load_program(name):
 
 status = load_program("status")
 
+TAGS = '[{"key": "review", "value": "attention", "note": "looks done"}]'
+
 
 class StubClient:
     """The slice of Client the status program touches, scripted per test."""
 
-    def __init__(self, capabilities=None, sessions=None, agent_reply=None,
-                 screen="the pane", nudge_fails=False):
+    def __init__(self, capabilities=None, sessions=None, agent_reply=None, screen="the pane"):
         self.capabilities = capabilities or []
         self._sessions = sessions or []
         self.agent_reply = agent_reply
         self.screen = screen
-        self.nudge_fails = nudge_fails
         self.calls = []
 
     def can(self, cap):
@@ -50,25 +51,29 @@ class StubClient:
         return self._sessions
 
     def preview(self, key, lines=0):
-        self.calls.append(("preview", key))
+        self.calls.append(("preview", key, lines))
         return self.screen
 
     def agent(self, prompt, model="", effort=""):
         self.calls.append(("agent", prompt, model, effort))
         return self.agent_reply
 
-    def mark(self, key, level, note="", by=None):
-        self.calls.append(("mark", key, level, note, by))
+    def set_tag(self, key, tag_key, value, note="", by=None):
+        self.calls.append(("set_tag", key, tag_key, value, note, by))
 
-    def nudge(self, key, text, submit=True, by=None):
-        if self.nudge_fails:
-            raise WeaverError("no live terminal")
-        self.calls.append(("nudge", key, text, by))
+    def clear_tag(self, key, tag_key, by=None):
+        self.calls.append(("clear_tag", key, tag_key, by))
 
 
-def session(id, attention=None):
-    tags = [{"key": "attention", "value": attention}] if attention else []
-    return {"id": id, "status": "running", "branch": {"tags": tags, "repo_root": "/r"}}
+def session(id, attention=None, watch=None, status="running"):
+    """A session dict: an optional `attention` self-report (set_by agent) and any
+    number of watch-authored marks (set_by 'watch', this round's name)."""
+    tags = []
+    if attention:
+        tags.append({"key": "attention", "value": attention, "set_by": "agent"})
+    for key, value in (watch or {}).items():
+        tags.append({"key": key, "value": value, "set_by": "watch"})
+    return {"id": id, "status": status, "branch": {"tags": tags, "repo_root": "/r"}}
 
 
 def make_round(client, **config):
@@ -82,31 +87,54 @@ def run_main(client, capsys, **config):
     return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
 
 
-# -- judge: fallback rule vs prompt path ---------------------------------------
+def sets(client):
+    return [c for c in client.calls if c[0] == "set_tag"]
 
 
-def test_judge_mirrors_attention_without_a_prompt():
-    rnd = make_round(StubClient())
-    assert status.judge(rnd, session("s", "blocked")) == ("blocked", "attention is blocked")
-    assert status.judge(rnd, session("s")) == ("ok", "attention is ok")
+def clears(client):
+    return [c for c in client.calls if c[0] == "clear_tag"]
 
 
-def test_judge_prompt_path_asks_the_agent_with_screen_and_model():
-    client = StubClient(agent_reply="blocked: stuck on a test")
-    rnd = make_round(client, params={"prompt": "stuck?"}, model="haiku", effort="low")
-    assert status.judge(rnd, session("s")) == ("blocked", "stuck on a test")
+# -- judge: parse the agent's tag set, no-judgement vs calm verdict ------------
+
+
+def test_judge_parses_the_agents_tag_set():
+    client = StubClient(agent_reply=TAGS)
+    rnd = make_round(client)
+    assert status.judge_tags(rnd, session("s")) == [
+        {"key": "review", "value": "attention", "note": "looks done"}
+    ]
+
+
+def test_judge_is_none_without_an_agent():
+    # No agent (empty reply) → None ("no judgement"), distinct from a calm []
+    # verdict: the caller leaves the session's marks untouched.
+    for reply in (None, ""):
+        rnd = make_round(StubClient(agent_reply=reply))
+        assert status.judge_tags(rnd, session("s")) is None
+
+
+def test_judge_empty_array_is_the_calm_verdict():
+    rnd = make_round(StubClient(agent_reply="nothing needed: []"))
+    assert status.judge_tags(rnd, session("s")) == []
+
+
+def test_judge_uses_the_default_prompt_with_screen_and_model():
+    client = StubClient(agent_reply=TAGS)
+    rnd = make_round(client, model="haiku", effort="low")
+    status.judge_tags(rnd, session("s"))
+    assert ("preview", "s", status.SCREEN_LINES) in client.calls
     kind, prompt, model, effort = client.calls[-1]
     assert (kind, model, effort) == ("agent", "haiku", "low")
-    assert prompt.startswith("stuck?") and "the pane" in prompt
+    assert prompt.startswith(status.DEFAULT_PROMPT) and "the pane" in prompt
 
 
-def test_judge_falls_back_when_agent_is_absent_or_unparseable():
-    for reply in (None, "no verdict here"):
-        rnd = make_round(StubClient(agent_reply=reply), params={"prompt": "stuck?"})
-        assert status.judge(rnd, session("s", "attention")) == (
-            "attention",
-            "attention is attention",
-        )
+def test_judge_honours_a_configured_prompt():
+    client = StubClient(agent_reply=TAGS)
+    rnd = make_round(client, params={"prompt": "MY PROMPT"})
+    status.judge_tags(rnd, session("s"))
+    _, prompt, *_ = client.calls[-1]
+    assert prompt.startswith("MY PROMPT")
 
 
 def test_judge_survives_a_dead_pane():
@@ -114,66 +142,99 @@ def test_judge_survives_a_dead_pane():
         def preview(self, key, lines=0):
             raise WeaverError("409 no live terminal")
 
-    rnd = make_round(NoPane(agent_reply="ok - all quiet"), params={"prompt": "stuck?"})
-    assert status.judge(rnd, session("s")) == ("ok", "all quiet")
+    client = NoPane(agent_reply=TAGS)
+    rnd = make_round(client, params={"prompt": "judge"})
+    assert status.judge_tags(rnd, session("s")) == [
+        {"key": "review", "value": "attention", "note": "looks done"}
+    ]
+    # The agent was still consulted, with an empty screen.
+    assert any(c[0] == "agent" for c in client.calls)
 
 
-# -- main: marking, clearing, capabilities, dry-run, summary --------------------
+# -- main: apply + reconcile, capabilities, dry-run, summary -------------------
 
 
-def test_marks_loud_sessions_and_clears_calm_ones(capsys):
+def test_applies_tags_and_reconciles_its_own_dropped_marks(capsys):
+    # The watch previously marked `stuck`; the new judgement recommends `review`,
+    # so `review` is set and the watch's own `stuck` is cleared.
     client = StubClient(
         capabilities=["mark"],
-        sessions=[session("loud", "blocked"), session("calm")],
+        agent_reply=TAGS,
+        sessions=[session("s", watch={"stuck": "blocked"})],
     )
     result = run_main(client, capsys)
-    assert ("mark", "loud", "blocked", "attention is blocked", "watch") in client.calls
-    assert ("mark", "calm", "ok", "", "watch") in client.calls  # ok ⇒ clear
+    assert ("set_tag", "s", "review", "attention", "looks done", "watch") in client.calls
+    assert ("clear_tag", "s", "stuck", "watch") in client.calls
     assert result["outcome"] == "ok"
-    assert result["summary"] == "surveyed 2, marked 1 (1 blocked)"
-    assert result["actions"] == [
-        {"action": "mark", "session": "loud", "level": "blocked",
-         "note": "attention is blocked"}
-    ]
+    assert result["summary"] == "assessed 1 of 1, applied 1 tag(s)"
+
+
+def test_empty_verdict_clears_the_watchs_own_marks(capsys):
+    client = StubClient(
+        capabilities=["mark"],
+        agent_reply="[]",
+        sessions=[session("s", watch={"review": "attention"})],
+    )
+    result = run_main(client, capsys)
+    assert sets(client) == []
+    assert ("clear_tag", "s", "review", "watch") in client.calls
+    assert result["summary"] == "assessed 1 of 1, applied 0 tag(s)"
+
+
+def test_no_judgement_leaves_every_mark_untouched(capsys):
+    # Agent absent → None: the round must not clear the watch's existing marks.
+    client = StubClient(
+        capabilities=["mark"],
+        agent_reply=None,
+        sessions=[session("s", watch={"review": "attention"})],
+    )
+    result = run_main(client, capsys)
+    assert sets(client) == [] and clears(client) == []
+    assert result == {
+        "outcome": "noop",
+        "summary": "assessed 0 of 1, applied 0 tag(s)",
+        "actions": [],
+    }
+
+
+def test_never_touches_the_agents_own_self_report(capsys):
+    # The agent self-reports `attention`; the judge says nothing is needed. Only
+    # watch-authored marks are reconciled, so the agent's tag is never cleared.
+    client = StubClient(
+        capabilities=["mark"],
+        agent_reply="[]",
+        sessions=[session("s", attention="attention")],
+    )
+    run_main(client, capsys)
+    assert not any(c[0] == "clear_tag" and c[2] == "attention" for c in client.calls)
+    assert clears(client) == []
 
 
 def test_without_mark_capability_only_observes(capsys):
-    client = StubClient(sessions=[session("loud", "attention")])
+    client = StubClient(agent_reply=TAGS, sessions=[session("s")])
     result = run_main(client, capsys)
-    assert client.calls == []  # no mutation attempted
+    assert sets(client) == [] and clears(client) == []
     assert result["actions"] == [
-        {"action": "observe", "session": "loud", "level": "attention",
-         "note": "attention is attention"}
+        {"action": "observe", "session": "s", "key": "review",
+         "value": "attention", "note": "looks done"}
     ]
 
 
-def test_dry_run_mutates_nothing_and_says_so(capsys):
-    client = StubClient(capabilities=["mark"],
-                        sessions=[session("loud", "blocked"), session("calm")])
+def test_dry_run_records_would_and_mutates_nothing(capsys):
+    client = StubClient(
+        capabilities=["mark"],
+        agent_reply=TAGS,
+        sessions=[session("s", watch={"stuck": "blocked"})],
+    )
     result = run_main(client, capsys, dry_run=True)
-    assert client.calls == []
-    assert result["actions"] == [
-        {"would": "mark", "session": "loud", "level": "blocked",
-         "note": "attention is blocked"}
-    ]
-    assert result["summary"] == "surveyed 2, would mark 1 (1 blocked) (dry run, no marks applied)"
+    assert sets(client) == [] and clears(client) == []
+    assert {"would": "tag", "session": "s", "key": "review",
+            "value": "attention", "note": "looks done"} in result["actions"]
+    assert {"would": "clear", "session": "s", "key": "stuck"} in result["actions"]
+    assert result["summary"] == "assessed 1 of 1, would apply 1 tag(s) (dry run, no writes applied)"
 
 
-def test_nudge_follows_a_mark_and_a_dead_pane_no_ops(capsys):
-    client = StubClient(capabilities=["mark", "nudge"],
-                        sessions=[session("loud", "blocked")])
-    result = run_main(client, capsys)
-    assert ("nudge", "loud", "[overlooker watch] attention is blocked", "watch") in client.calls
-    assert {"action": "nudge", "session": "loud",
-            "text": "[overlooker watch] attention is blocked"} in result["actions"]
-
-    dead = StubClient(capabilities=["mark", "nudge"],
-                      sessions=[session("loud", "blocked")], nudge_fails=True)
-    result = run_main(dead, capsys)
-    assert not any(a.get("action") == "nudge" for a in result["actions"])
-
-
-def test_empty_scope_is_a_noop(capsys):
+def test_empty_survey_is_a_noop(capsys):
     result = run_main(StubClient(capabilities=["mark"]), capsys)
     assert result == {"outcome": "noop", "summary": "surveyed 0 sessions in scope",
                       "actions": []}

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -17,6 +17,7 @@ from weaver_loom import (
     Client,
     Round,
     parse_judgement,
+    parse_tag_recommendations,
 )
 
 
@@ -72,6 +73,48 @@ def test_parse_judgement_scans_lines_and_degrades_to_none():
     assert parse_judgement("looks fine to me, carry on") is None
     assert parse_judgement("") is None
     assert parse_judgement(None) is None
+
+
+# -- parse_tag_recommendations -----------------------------------------------
+
+
+def test_parse_tag_recommendations_validates_and_slugs():
+    out = parse_tag_recommendations(
+        '[{"key": "Needs Review!", "value": "Attention", "note": "PR is up"},'
+        ' {"key": "stuck", "value": "blocked", "note": ""}]'
+    )
+    assert out == [
+        {"key": "needs-review", "value": "attention", "note": "PR is up"},
+        {"key": "stuck", "value": "blocked", "note": ""},
+    ]
+
+
+def test_parse_tag_recommendations_drops_malformed_and_dedupes():
+    out = parse_tag_recommendations(
+        '[{"key": "review", "value": "ok"},'        # value off the loud ladder
+        ' {"key": "", "value": "attention"},'        # no key
+        ' "not-an-object",'                           # not a dict
+        ' {"key": "review", "value": "attention"},'   # first review wins
+        ' {"key": "review", "value": "blocked"}]'     # dupe key dropped
+    )
+    assert out == [{"key": "review", "value": "attention", "note": ""}]
+
+
+def test_parse_tag_recommendations_extracts_an_array_from_prose():
+    out = parse_tag_recommendations(
+        'Sure — here you go:\n```json\n[{"key": "review", "value": "attention"}]\n```\n'
+    )
+    assert out == [{"key": "review", "value": "attention", "note": ""}]
+
+
+def test_parse_tag_recommendations_none_vs_empty():
+    # An explicit empty array is the calm verdict ([]); no array / invalid JSON
+    # is "no judgement" (None) — the caller treats the two differently.
+    assert parse_tag_recommendations("nothing to flag: []") == []
+    assert parse_tag_recommendations("looks fine, carry on") is None
+    assert parse_tag_recommendations("[not json]") is None
+    assert parse_tag_recommendations("") is None
+    assert parse_tag_recommendations(None) is None
 
 
 # -- the survey's scope filter -------------------------------------------------


### PR DESCRIPTION
## The bug (issue #170)

Multiple "needs attention" tags on a session looked like duplicate rows, but the DB cannot hold them: `tags` is `PRIMARY KEY (branch_id, key)` and every write upserts (verified against the live db). The "duplicate" was **two distinct tags the UI labelled identically** — the agent's own `attention` self-report and the status watch's `triage` mark **mirroring** it. With no prompt configured, the builtin `status` watch just copied the agent's attention into a parallel `triage` axis, and both rendered as "Needs attention".

## The change

Per the steer on #170, this drops the hardcoded two-key special case and makes tags general.

**Loudness moves from the tag key to the tag value.** Any tag whose value is on the `attention | blocked` ladder raises a badge — regardless of key. A tag's **key is its type** (the chip label) and its **value is the severity**. Agents and watches both add typed tags; the dashboard differentiates them with `●` (agent's own) vs `⊙` (an outside mark) attribution. No backend storage change was needed — typed tags like `review=attention` were already valid.

**The status watch is rebuilt** (`crates/loom/overlookers/status.py`):
- Triggers on `session.idle` (the agent's finished-turn hook) — "assess when the agent goes quiet" — instead of an hourly cron over already-flagged sessions.
- Asks the judge model (the daemon's one-shot agent, with recent screen context) for a **set** of typed tags the session warrants — `review`, `question`, `stuck`, `idle`, … — and reconciles only its **own** marks to that set.
- **Never mirrors** the agent's `attention`. No judge model available → a no-op, not a mirror.

The agent's `attention` stays the **server-side** signal (`weaver status`, `resolve_attention`, `weaver issue wait`), so a watch's outside marks surface on the dashboard without spuriously waking sub-agent tracking.

### Before / after

The old "double needs attention" (agent flags `attention` **and** the watch marks it) now renders as two distinct chips — `● ATTENTION` + `⊙ REVIEW` — instead of two identical badges. A watch flagging a silent session shows differentiated `⊙ STUCK` / `⊙ QUESTION` marks. Validated by screenshot in light + dark themes.

## Scope

- Frontend value-driven display: `effectiveAttention`/`signalChips` fold over loud-valued tags; `SignalChip` labels by key. (#173)
- Watch redesign + `parse_tag_recommendations` in `weaver_loom` (pytest-covered). (#174)
- `archive` clears **all** loud-valued tags, not just the two well-known keys.
- Rust integration + pytest + e2e tests and ARCHITECTURE/`types.ts` docs updated. (#175)

## Tests

`cargo test --workspace`, `uv run pytest`, and the affected Playwright specs all pass locally. Plan artifact: `weaver artifact show plan`.

## Deferred follow-ups

- A calmer "review-ready" severity rung distinct from "attention" (today the type lives in the key, severity stays the 2-rung ladder).
- Feed the judge real transcript/exchanges instead of the terminal screen preview.