### PR TITLE
loom: soothing idle tag instead of attention; status watch replaces it

### DIFF
--- a/crates/loom/frontend/src/components/IdleChip.vue
+++ b/crates/loom/frontend/src/components/IdleChip.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Tag } from '../types';
+
+// The soothing `idle` mark as a calm, recessive chip: the agent is resting — a
+// finished turn or a quiet lull, no one needed. Deliberately NEUTRAL (faint text
+// + hairline border, a soft dot), never the reserved amber/red loud fill, so an
+// idle agent reads as calm and the loud attention axis stays the only thing that
+// pops. Informational only — the mark is re-stamped each time the agent goes
+// quiet and the status watch manages it, so there is no × to clear by hand.
+const props = defineProps<{ tag: Tag }>();
+
+const tooltip = computed(
+  () => props.tag.note || 'Idle — the agent is resting; no one is needed.',
+);
+</script>
+
+<template>
+  <span
+    data-testid="idle-chip"
+    :title="tooltip"
+    class="inline-flex items-center gap-1 rounded border border-line px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide text-faint"
+  >
+    <span class="h-1.5 w-1.5 rounded-full bg-current opacity-50"></span>
+    Idle
+  </span>
+</template>

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -9,6 +9,13 @@ export type Attention = 'ok' | 'attention' | 'blocked';
 // pill. Mirrors weaver-core's `ATTENTION_VALUES`.
 const SEVERITY: Record<string, number> = { attention: 1, blocked: 2 };
 
+// The soothing, quiet `idle` mark loom stamps when an agent goes quiet (a
+// finished turn or a `waiting` lull): the calm "resting, no one needed" state.
+// It carries the quiet value `idle`, so it is never loud — an idle agent no
+// longer reads as needing the user. The status watch may replace it with a real
+// loud status. Mirrors weaver-core's `IDLE_KEY`.
+export const IDLE_KEY = 'idle';
+
 // Severity of a tag value: 0 is quiet (a pill), >0 is loud (a badge).
 function severityOf(value: string | undefined): number {
   return (value && SEVERITY[value]) || 0;
@@ -148,11 +155,30 @@ export function signalChips(s: Session): SignalChip[] {
 }
 
 // The session's quiet tags: every tag whose value is not loud, for the pill row.
-// These are free-form, deletable annotations (priority, needs-rebase, …).
-// Archived sessions show none.
+// These are free-form, deletable annotations (priority, needs-rebase, …). The
+// soothing `idle` mark is excluded — it is a lifecycle signal surfaced calmly by
+// idleTag/conversationState, not a free-form pill. Archived sessions show none.
 export function quietTags(s: Session): Tag[] {
   if (s.status === 'archived') return [];
-  return (s.branch.tags ?? []).filter((t) => severityOf(t.value) === 0);
+  return (s.branch.tags ?? []).filter(
+    (t) => severityOf(t.value) === 0 && t.key !== IDLE_KEY,
+  );
+}
+
+// The soothing `idle` mark to surface, or null. Present only when the session is
+// a *live* agent resting between turns: a terminal/detached lifecycle (done,
+// error, archived, orphaned) reads through its own badge, not "resting". And
+// only when genuinely calm — any loud signal (the agent's own or an outside
+// mark) supersedes the resting state — and the mark is itself live (not stale:
+// the session hasn't moved on past it). Drives the calm "Idle" presentation in
+// the list and header.
+const LIVE_STATUSES = new Set(['launching', 'running']);
+export function idleTag(s: Session): Tag | null {
+  if (!LIVE_STATUSES.has(s.status)) return null;
+  if (loudTags(s).length > 0) return null;
+  const tag = (s.branch.tags ?? []).find((t) => t.key === IDLE_KEY);
+  if (!tag || tagStale(tag, s.last_activity_at)) return null;
+  return tag;
 }
 
 // Compact conversation-state line for the detail header (#5): a derived
@@ -178,8 +204,11 @@ export function conversationState(s: Session): ConvState {
   if (level === 'blocked') return { glyph: '●', label: 'Blocked', tone: 'block' };
   if (level === 'attention') return { glyph: '●', label: 'Needs attention', tone: 'attn' };
 
-  // Otherwise infer working vs idle from lifecycle. "Working"/"Idle" stay
-  // neutral so amber/red remains the sole loud signal.
+  // Calm: an explicit `idle` mark means the agent is resting — surface it even
+  // while the lifecycle is still `running` between turns (a finished turn leaves
+  // the session running but quiet). "Working"/"Idle" stay neutral so amber/red
+  // remains the sole loud signal.
+  if (idleTag(s)) return { glyph: '✓', label: 'Idle', tone: 'muted' };
   if (s.status === 'running' || s.status === 'launching') return { glyph: '▶', label: 'Working', tone: 'muted' };
   return { glyph: '✓', label: 'Idle', tone: 'muted' };
 }

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -5,11 +5,12 @@ import { get, post } from '../api';
 import type { Session, RecentRepo, RepoBranch } from '../types';
 import StatusBadge from '../components/StatusBadge.vue';
 import SignalChip from '../components/SignalChip.vue';
+import IdleChip from '../components/IdleChip.vue';
 import TagPill from '../components/TagPill.vue';
 import GithubStatus from '../components/GithubStatus.vue';
 import ScratchPicker from '../components/ScratchPicker.vue';
 import { timeAgo } from '../lib/time';
-import { effectiveAttention, messageOf, quietTags, signalChips } from '../lib/sessionState';
+import { effectiveAttention, idleTag, messageOf, quietTags, signalChips } from '../lib/sessionState';
 import { del } from '../api';
 
 const sessions = ref<Session[]>([]);
@@ -751,6 +752,9 @@ onUnmounted(() => clearInterval(timer));
                  the running state — nearly every live row is running, so the pill
                  would just be repeated noise; only off-nominal states show one. -->
             <StatusBadge v-if="s.status !== 'running'" :status="s.status" class="shrink-0" />
+            <!-- Soothing idle mark: a calm, neutral chip when the agent is
+                 resting (no loud signal). Reassures rather than alarms. -->
+            <IdleChip v-if="idleTag(s)" :tag="idleTag(s)!" />
             <!-- Quiet free-form tags: deletable pills, never the loud fill. -->
             <TagPill
               v-for="t in quietTags(s)"

--- a/crates/loom/overlookers/status.py
+++ b/crates/loom/overlookers/status.py
@@ -23,7 +23,7 @@ every mark untouched (including ``idle``) rather than guess. Honours dry_run:
 would-be writes are logged as actions and nothing mutates.
 """
 
-from weaver_loom import IDLE_KEY, Round, WeaverError, parse_tag_recommendations
+from weaver_loom import IDLE_KEY, IDLE_VALUE, Round, WeaverError, parse_tag_recommendations
 
 #: Wake on the agent's finished-turn hook — "assess when the agent goes quiet".
 TRIGGERS = {"on": ["session.idle"]}
@@ -83,9 +83,11 @@ def watch_tags(rnd, session):
 
 def _has_idle(session):
     """Whether ``session`` carries the soothing ``idle`` mark the idle hook
-    stamps — the calm state a real status should replace."""
+    stamps — the calm state a real status should replace. Matches the canonical
+    ``(idle, idle)`` mark exactly (key AND value), so a stray free-form tag that
+    merely shares the ``idle`` key is never mistaken for it and cleared."""
     return any(
-        tag.get("key") == IDLE_KEY
+        tag.get("key") == IDLE_KEY and tag.get("value") == IDLE_VALUE
         for tag in (session.get("branch") or {}).get("tags") or []
     )
 

--- a/crates/loom/overlookers/status.py
+++ b/crates/loom/overlookers/status.py
@@ -1,10 +1,17 @@
-"""status — when a session goes idle, judge it and stamp the watch's own tags.
+"""status — when a session goes quiet, judge it and replace the calm idle mark.
 
-On the agent's finished-turn hook (``session.idle``) this watch re-assesses just
-that session: it asks the judge model (the daemon's one-shot agent) for advice on
-a set of attention tags to apply given the recent screen, then reconciles its own
-marks to that set — setting the recommended tags and clearing any it set earlier
-that no longer apply.
+When the agent goes quiet, loom stamps a soothing, *quiet* ``idle`` mark — the
+calm "resting, no one needed" state (so an idle agent never reads as needing the
+user). On the agent's finished-turn hook (``session.idle``) this watch
+re-assesses just that session: it asks the judge model (the daemon's one-shot
+agent) for advice on a set of attention tags to apply given the recent screen,
+then reconciles its own marks to that set — setting the recommended tags and
+clearing any it set earlier that no longer apply.
+
+When the judge finds the session genuinely needs a human, that session is
+actively waiting, not resting: the watch *replaces* the calm ``idle`` mark with
+the real loud status it names. A "nothing needed" verdict leaves the soothing
+``idle`` mark in place.
 
 User attention is expensive, so the default prompt tells the model to flag a
 session ONLY when it genuinely needs the human, and to name the *kind* of
@@ -12,11 +19,11 @@ attention (the tag key — `review`, `question`, `stuck`, …) rather than a gen
 "needs attention". The watch never mirrors the agent's own ``attention``
 self-report; that is the agent's signal, on its own key. With no judge model
 available (no agent, or an empty/garbled reply), the round is a no-op — it leaves
-every mark untouched rather than guess. Honours dry_run: would-be writes are
-logged as actions and nothing mutates.
+every mark untouched (including ``idle``) rather than guess. Honours dry_run:
+would-be writes are logged as actions and nothing mutates.
 """
 
-from weaver_loom import Round, WeaverError, parse_tag_recommendations
+from weaver_loom import IDLE_KEY, Round, WeaverError, parse_tag_recommendations
 
 #: Wake on the agent's finished-turn hook — "assess when the agent goes quiet".
 TRIGGERS = {"on": ["session.idle"]}
@@ -28,17 +35,20 @@ SCREEN_LINES = 200
 #: of {key, value, note} tags, or [] when the human is not needed.
 DEFAULT_PROMPT = (
     "You are triaging a detached coding-agent session for a human operator who "
-    "reviews many sessions asynchronously. Their attention is expensive: flag a "
-    "session ONLY when it genuinely needs the human now. Read the recent session "
+    "reviews many sessions asynchronously. A quiet agent is already shown as a "
+    "calm 'idle' state that needs no one, so do NOT flag a session merely for "
+    "being idle or having finished a turn. Their attention is expensive: flag a "
+    "session ONLY when it genuinely needs the human now — naming that need "
+    "replaces the calm idle mark with a real status. Read the recent session "
     "screen below and decide which attention tags apply.\n\n"
     "Reply with ONLY a JSON array of objects "
     '{"key": "<short-type>", "value": "attention" | "blocked", "note": "<one '
-    'line>"}. Use an empty array [] when the session does not need the human. '
-    "The key names the KIND of attention; pick the few that fit, e.g.:\n"
+    'line>"}. Use an empty array [] when the session does not need the human (it '
+    "stays calmly idle). The key names the KIND of attention; pick the few that "
+    "fit, e.g.:\n"
     '  - "review"   — work looks finished / a PR is ready to look at (value "attention")\n'
     '  - "question" — waiting on a decision only the operator can make (value "attention")\n'
     '  - "stuck"    — looping or erroring with no progress (value "blocked")\n'
-    '  - "idle"     — went quiet mid-task for no clear reason (value "attention")\n'
     "Do not invent noise, and do not restate the agent's own self-reported "
     "status — add only what an outside observer would flag."
 )
@@ -71,6 +81,15 @@ def watch_tags(rnd, session):
     }
 
 
+def _has_idle(session):
+    """Whether ``session`` carries the soothing ``idle`` mark the idle hook
+    stamps — the calm state a real status should replace."""
+    return any(
+        tag.get("key") == IDLE_KEY
+        for tag in (session.get("branch") or {}).get("tags") or []
+    )
+
+
 def main(rnd):
     can_mark = rnd.can("mark")
     assessed = 0
@@ -85,6 +104,12 @@ def main(rnd):
         assessed += 1
         sid = session["id"]
         stale = watch_tags(rnd, session) - {t["key"] for t in desired}
+        # When the judge names a real need, the session is actively waiting, not
+        # resting — replace the soothing `idle` mark with that status. A calm
+        # verdict (no desired tags) leaves `idle` in place. The mark is the
+        # agent's own, set mechanically by the idle hook, so the watch is
+        # explicitly allowed to clear it here (it is not one of its own marks).
+        replace_idle = bool(desired) and _has_idle(session)
 
         # Without `mark`, the round is read-only: report what it would tag.
         if not can_mark:
@@ -99,8 +124,9 @@ def main(rnd):
             else:
                 rnd.client.set_tag(sid, t["key"], t["value"], t["note"], by=rnd.name)
                 rnd.did("tag", session=sid, **t)
-        # Reconcile: clear the watch's own marks the new judgement dropped.
-        for key in sorted(stale):
+        # Reconcile: clear the watch's own marks the new judgement dropped, plus
+        # the calm `idle` mark when a real status replaces it.
+        for key in sorted(stale) + ([IDLE_KEY] if replace_idle else []):
             if rnd.dry_run:
                 rnd.would("clear", session=sid, key=key)
             else:

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -49,9 +49,10 @@ pub const BUILTINS: &[BuiltinProgram] = &[
                       ask the judge model (the daemon's one-shot agent) for the \
                       set of attention tags it warrants and reconcile the watch's \
                       own marks to that set. Names the kind of attention (review, \
-                      question, stuck, …) rather than a generic mark; with no \
-                      judge model available it no-ops, never mirroring the \
-                      agent's own attention tag.",
+                      question, stuck, …) rather than a generic mark, and when it \
+                      finds a genuine need it replaces the soothing `idle` mark \
+                      with that real status. With no judge model available it \
+                      no-ops, never mirroring the agent's own attention tag.",
         source: include_str!("../overlookers/status.py"),
         default_trigger: r#"{"on":["session.idle"]}"#,
         default_scope: "{}",

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -238,9 +238,12 @@ fn parse_iso(ts: &str) -> Option<DateTime<Utc>> {
 /// Returns the new event watermark (it records its own bus events). `None` when
 /// there is no active session for the branch.
 ///
-/// Mapping rationale: hooks drive only liveness and a soothing idle signal. Any
-/// hook means the agent process is alive → `running` (this also promotes a
-/// freshly-`launching` session). Beyond that:
+/// Mapping rationale: the work hooks drive only liveness and a soothing idle
+/// signal. A `working` / `waiting` / `idle` hook means the agent process is
+/// alive → `running` (this also promotes a freshly-`launching` session).
+/// `session-start` is returned early below — it is recorded for the primer
+/// injection (in the `weaver hook` CLI) but the launch path owns the initial
+/// status, so it carries no liveness or tag signal here. Beyond liveness:
 ///
 /// * `working` (a prompt was submitted — the user is engaged) clears the calm
 ///   `idle` mark *and* the agent's `attention` tag back to calm: an engaged
@@ -260,7 +263,8 @@ async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64
     // The tag mutations the hook implies: `(key, value)` where an empty value
     // clears the tag (absence is the calm/default state). `working` returns the
     // agent to calm (clearing both axes it might carry); the quiet signals stamp
-    // the soothing `idle` mark. `session-start` and the unknown carry none.
+    // the soothing `idle` mark. `session-start` and any unknown kind return early
+    // — they neither prove liveness here nor carry a tag signal.
     let mutations: &[(&str, &str)] = match kind {
         "working" => &[(tags::ATTENTION_KEY, ""), (tags::IDLE_KEY, "")],
         "waiting" | "idle" => &[(tags::IDLE_KEY, tags::IDLE_VALUE)],

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -238,26 +238,32 @@ fn parse_iso(ts: &str) -> Option<DateTime<Utc>> {
 /// Returns the new event watermark (it records its own bus events). `None` when
 /// there is no active session for the branch.
 ///
-/// Mapping rationale: hooks now drive only liveness and the genuine
-/// attention signals. Any hook means the agent process is alive → `running`
-/// (this also promotes a freshly-`launching` session). Beyond that the hook
-/// writes the agent's `attention` tag:
+/// Mapping rationale: hooks drive only liveness and a soothing idle signal. Any
+/// hook means the agent process is alive → `running` (this also promotes a
+/// freshly-`launching` session). Beyond that:
 ///
-/// * `working` (a prompt was submitted — the user is engaged) clears the
-///   attention tag back to calm (`ok`).
-/// * `waiting` (Claude is blocked asking the user) sets the attention tag to
-///   `attention`.
-/// * `idle` (a turn ended) leaves attention untouched — a finished-but-fine
-///   agent must not be mistaken for one that needs the user. If it actually
-///   needs something it will have said so via `weaver status`.
+/// * `working` (a prompt was submitted — the user is engaged) clears the calm
+///   `idle` mark *and* the agent's `attention` tag back to calm: an engaged
+///   agent is neither resting nor waiting on the user.
+/// * `waiting` (a `Notification` lull) and `idle` (a turn ended) stamp the quiet
+///   [`tags::IDLE_KEY`] mark — the soothing "resting, no one needed" state.
+///   Crucially this is **not** loud, so a finished-but-fine agent no longer
+///   reads as needing the user. They leave the agent's own `attention` tag
+///   untouched (a loud self-report still wins the badge), and the status watch
+///   may later replace this idle mark with a real loud status — or clear it —
+///   once it judges the session genuinely needs a human.
+///
+/// We don't try to mechanically tell "truly idle" from "waiting on a sub-agent
+/// or shell": the finished-turn hook is a good-enough idle signal, and the
+/// status watch upgrades it when warranted.
 async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64> {
-    // The attention level the hook implies, or `None` to leave it untouched. An
-    // empty string is the calm state — it clears the tag rather than storing.
-    let attention: Option<&str> = match kind {
-        "working" => Some(""),
-        "waiting" => Some("attention"),
-        "idle" => None,
-        // `session-start` and anything unknown carry no status signal.
+    // The tag mutations the hook implies: `(key, value)` where an empty value
+    // clears the tag (absence is the calm/default state). `working` returns the
+    // agent to calm (clearing both axes it might carry); the quiet signals stamp
+    // the soothing `idle` mark. `session-start` and the unknown carry none.
+    let mutations: &[(&str, &str)] = match kind {
+        "working" => &[(tags::ATTENTION_KEY, ""), (tags::IDLE_KEY, "")],
+        "waiting" | "idle" => &[(tags::IDLE_KEY, tags::IDLE_VALUE)],
         _ => return None,
     };
 
@@ -273,35 +279,6 @@ async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64
     }
     let _ = session_mod::touch(&state.db, &session.id).await;
 
-    // Attention, only when the hook carries a signal and the tag value differs.
-    // Calm (empty) clears the tag (absence is the default state); any other level
-    // upserts it. Emit a `tag` event on a real change so dashboards refresh.
-    let mut attention_changed: Option<&str> = None;
-    if let Some(level) = attention {
-        let current = tags::get(&state.db, branch_id, tags::ATTENTION_KEY)
-            .await
-            .ok()
-            .flatten()
-            .map(|t| t.value)
-            .unwrap_or_default();
-        if current != level {
-            if level.is_empty() {
-                let _ = tags::clear(&state.db, branch_id, tags::ATTENTION_KEY).await;
-            } else {
-                let _ = tags::set(
-                    &state.db,
-                    branch_id,
-                    tags::ATTENTION_KEY,
-                    level,
-                    "",
-                    "agent",
-                )
-                .await;
-            }
-            attention_changed = Some(level);
-        }
-    }
-
     if status_changed {
         let _ = events::record(
             &state.db,
@@ -312,18 +289,29 @@ async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64
         )
         .await;
     }
-    if let Some(level) = attention_changed {
-        let _ = events::record_tag(
-            &state.db,
-            &state.bus,
-            branch_id,
-            tags::ATTENTION_KEY,
-            level,
-            "",
-            "agent",
-        )
-        .await;
+
+    // Apply each tag mutation only when it actually changes the stored value, so
+    // a repeated hook (e.g. another finished turn while already idle) is a no-op
+    // and dashboards refresh only on a real edge. The author is `agent` — these
+    // are the agent's own lifecycle marks.
+    for &(key, value) in mutations {
+        let current = tags::get(&state.db, branch_id, key)
+            .await
+            .ok()
+            .flatten()
+            .map(|t| t.value)
+            .unwrap_or_default();
+        if current == value {
+            continue;
+        }
+        if value.is_empty() {
+            let _ = tags::clear(&state.db, branch_id, key).await;
+        } else {
+            let _ = tags::set(&state.db, branch_id, key, value, "", "agent").await;
+        }
+        let _ = events::record_tag(&state.db, &state.bus, branch_id, key, value, "", "agent").await;
     }
+
     // Advance the watermark past our own freshly-recorded events so the next
     // tick doesn't reprocess them. `None` on a read error just leaves the
     // caller's watermark untouched (the consumed event is already accounted for).

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -1168,13 +1168,14 @@ pub async fn archive(
     }
     session_mod::set_status(&st.db, &session.id, "archived").await?;
     // An archived session is finished with: its agent is gone, so it can no
-    // longer "need me". Clear every loud tag — the agent's own `attention` and
-    // any watch's typed marks (loudness is value-driven, so match on the value,
-    // not a fixed key set) — so the dashboard stops flagging a torn-down
-    // workstream — absence is the calm state. The history (goal, status, events)
-    // is kept; the `description` message stays too, as do any quiet pills.
+    // longer "need me" — nor is it "resting". Clear every loud tag — the agent's
+    // own `attention` and any watch's typed marks (loudness is value-driven, so
+    // match on the value, not a fixed key set) — plus the soothing `idle` mark,
+    // so the dashboard stops flagging or labelling a torn-down workstream —
+    // absence is the calm state. The history (goal, status, events) is kept; the
+    // `description` message stays too, as do any free-form quiet pills.
     for tag in tags::list(&st.db, &branch.id).await? {
-        if tags::is_loud_value(&tag.value) {
+        if tags::is_loud_value(&tag.value) || tag.key == tags::IDLE_KEY {
             tags::clear(&st.db, &branch.id, &tag.key).await?;
             events::record_tag(&st.db, &st.bus, &branch.id, &tag.key, "", "", "manual")
                 .await

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -137,32 +137,35 @@ async fn hook_event_drives_session_status() {
         "monitor should have flipped status to running"
     );
 
-    // A `waiting` hook (Claude blocked asking the user) raises the agent-declared
-    // attention axis to `attention` — the `attention` tag, the dashboard's
-    // "needs me" flag.
+    // A `waiting` hook (a quiet lull) stamps the soothing, *quiet* `idle` mark —
+    // the calm "resting, no one needed" state, never the loud `attention` axis,
+    // so an idle agent doesn't read as needing the user.
     weaver_core::events::record_local(&pool, &branch_id, "hook", json!({ "event": "waiting" }))
         .await
         .unwrap();
-    let mut attention = String::new();
+    let mut idle = String::new();
     for _ in 0..40 {
         tokio::time::sleep(Duration::from_millis(200)).await;
         let ws = client.get(&format!("/api/sessions/{id}")).await.unwrap();
-        attention = ws["branch"]["tags"]
-            .as_array()
-            .and_then(|tags| {
-                tags.iter()
-                    .find(|t| t["key"] == "attention")
-                    .and_then(|t| t["value"].as_str())
-            })
+        let tags = ws["branch"]["tags"].as_array().cloned().unwrap_or_default();
+        idle = tags
+            .iter()
+            .find(|t| t["key"] == "idle")
+            .and_then(|t| t["value"].as_str())
             .unwrap_or("")
             .to_string();
-        if attention == "attention" {
+        // It must NOT raise the loud attention axis.
+        assert!(
+            !tags.iter().any(|t| t["key"] == "attention"),
+            "waiting hook must not raise the loud attention tag"
+        );
+        if idle == "idle" {
             break;
         }
     }
     assert_eq!(
-        attention, "attention",
-        "waiting hook should raise the attention tag"
+        idle, "idle",
+        "waiting hook should stamp the soothing idle mark"
     );
 
     // Verify the hook event row landed too.

--- a/crates/loom/tests/integration/archive.rs
+++ b/crates/loom/tests/integration/archive.rs
@@ -60,6 +60,16 @@ async fn archive_keeps_branch_and_history() {
         )
         .await
         .unwrap();
+    // The soothing `idle` mark is quiet (not on the loud ladder) but is still a
+    // lifecycle signal a torn-down workstream shouldn't carry: archiving clears
+    // it too.
+    client
+        .put(
+            &format!("/api/sessions/{arch_id}/tags/idle"),
+            json!({ "value": "idle", "by": "agent" }),
+        )
+        .await
+        .unwrap();
     client
         .patch(
             &format!("/api/sessions/{arch_id}"),
@@ -97,6 +107,10 @@ async fn archive_keeps_branch_and_history() {
     assert!(
         branch_tag(&view, "review").is_none(),
         "archive should clear a watch's typed loud mark too"
+    );
+    assert!(
+        branch_tag(&view, "idle").is_none(),
+        "archive should clear the soothing idle mark too"
     );
     assert_eq!(
         view["branch"]["description"], "Waiting for input",

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -169,9 +169,17 @@ the work is ready:
   unless the user has told you otherwise. Most teams gate integration on review
   and CI; respect that. Use the project's normal PR workflow (e.g. `gh pr
   create`).
-- Raise `weaver status attention "ready for review"` (the message doubles as
-  your concise summary, and file any follow-ups as issues with `weaver issue
-  add`) so the user knows to look.
+- **Drive the PR to green — opening it is the start of integration, not the
+  end.** Do not walk away the moment it's open. Watch CI to completion
+  (`gh pr checks <N> --watch`) and fetch review feedback — both the top-level
+  reviews (`gh pr view <N> --json reviews,comments`) and inline code comments
+  (`gh api repos/{owner}/{repo}/pulls/<N>/comments`). Local green is not CI
+  green: fix any failing check and address every review comment with follow-up
+  commits on the same branch, then re-watch. Keep `weaver status` honest while
+  you wait (`weaver status ok "waiting on CI"`).
+- Once CI is green and review is addressed, raise `weaver status attention
+  "ready for review"` (the message doubles as your concise summary, and file any
+  follow-ups as issues with `weaver issue add`) so the user knows to look.
 
 When a session is finished with, the user may **archive** it from the dashboard:
 that tears down this terminal session and removes the worktree, but preserves the

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -123,7 +123,7 @@ message. This replaces the old guessed working/waiting/idle indicator, which was
 often wrong (e.g. it read "idle" while you were really waiting on a workflow).
 
 Under the hood, status is stored as **tags** on your branch. A tag is a single
-`(key, value)` annotation with a note, an author, and a timestamp. Two keys are
+`(key, value)` annotation with a note, an author, and a timestamp. Three keys are
 well known:
 
 - `attention` — your self-report, the value being `attention` or `blocked`. This
@@ -134,6 +134,11 @@ well known:
   `attention`/`blocked` ladder but authored by an overlooker (or `manual`), never
   by you. It is independent of your `attention` tag and carries its own reason
   and attribution.
+- `idle` — a soothing, *quiet* mark stamped mechanically when your agent goes
+  quiet (a finished turn or a lull): the calm "resting, no one needed" state. It
+  is **not** loud — an idle agent does not read as needing the user — and you
+  never set it yourself. The status watch may replace it with a real `attention`
+  status once it judges the session genuinely needs a human.
 
 Your prose `description` is separate from the tags and is shown even when you are
 calm. Any other key is a free-form, quiet tag. A tag is stale once your session

--- a/crates/weaver-core/src/tags.rs
+++ b/crates/weaver-core/src/tags.rs
@@ -52,8 +52,20 @@ pub const ATTENTION_KEY: &str = "attention";
 /// anchor.
 pub const TRIAGE_KEY: &str = "triage";
 
+/// A soothing, **quiet** mark stamped mechanically when the agent goes quiet (a
+/// finished turn or a `waiting` lull — see loom's `apply_hook`). It is the calm
+/// "this agent is resting, no one is needed" signal — deliberately *not* on the
+/// loud ladder, so an idle agent no longer reads as needing the user. Its value
+/// is the fixed [`IDLE_VALUE`]; the status watch may replace it with a real loud
+/// status (or clear it) once it judges the session genuinely needs a human.
+pub const IDLE_KEY: &str = "idle";
+
+/// The fixed value the [`IDLE_KEY`] tag carries. Quiet by design (not on
+/// [`ATTENTION_VALUES`]), so it renders soothing rather than loud.
+pub const IDLE_VALUE: &str = "idle";
+
 /// The loud keys: those that raise an attention signal on the dashboard. Any
-/// other key is quiet (a deletable pill).
+/// other key is quiet (a deletable pill) — including the soothing [`IDLE_KEY`].
 pub const LOUD_KEYS: &[&str] = &[ATTENTION_KEY, TRIAGE_KEY];
 
 /// Whether `key` is a loud (badge-raising) key.
@@ -178,6 +190,13 @@ mod tests {
         // A free-form key accepts any non-empty value.
         assert!(is_valid_value("priority", "high"));
         assert!(!is_valid_value("priority", ""));
+
+        // `idle` is a quiet, soothing key — never on the loud ladder, so an idle
+        // agent doesn't read as needing the user. It validates as a free-form
+        // key (any non-empty value), and its fixed value is not loud.
+        assert!(!is_loud(IDLE_KEY));
+        assert!(!is_loud_value(IDLE_VALUE));
+        assert!(is_valid_value(IDLE_KEY, IDLE_VALUE));
 
         // Loudness is value-driven: any key holding a ladder value is loud (a
         // watch's typed `review`/`stuck`), while a quiet value never is.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -334,9 +334,11 @@ block into the worktree's `.claude/settings.local.json` (see
 
 `weaver hook` writes an `events` row keyed on the branch resolved from
 `$WEAVER_BRANCH` (set by the launcher) — no HTTP. Loom's monitor (`apply_hook`)
-consumes new `hook` rows on its next tick. Any hook means the agent process is
-alive, so all three set `status = running` (this also promotes a freshly
-`launching` session). Liveness is all a hook proves, so that is all the
+consumes new `hook` rows on its next tick. A `working` / `waiting` / `idle` hook
+means the agent process is alive, so each sets `status = running` (this also
+promotes a freshly `launching` session); `session-start` is recorded for the
+primer injection but the launch path owns the initial status, so it drives no
+liveness here. Liveness is all a work hook proves, so that is all the
 orchestrator tracks — it does not infer working/waiting/idle from stillness.
 
 The hooks also stamp a soothing, **quiet `idle` tag** — the calm "resting, no one

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -307,8 +307,12 @@ agents and watches both add loud tags without a privileged key registry. A tag's
 **key is its type** (the chip label — `attention`, `review`, `stuck`, …) and its
 **value is the severity**; every other value is a free-form, quiet pill. The
 agent authors the well-known **`attention`** key for its own self-report; a watch
-authors its own typed keys. **Absence is the calm/default state** — there is no
-stored `ok`; returning to calm *clears* the tag. A tag is **stale** when its
+authors its own typed keys. The well-known **`idle`** key is a *quiet* exception:
+loom stamps it mechanically when an agent goes quiet (the soothing "resting, no
+one needed" state), carrying the non-loud value `idle` so it never raises a badge
+— the dashboard surfaces it as a calm "Idle" mark, and the status watch may
+replace it with a real loud status. **Absence is the calm/default state** — there
+is no stored `ok`; returning to calm *clears* the tag. A tag is **stale** when its
 `set_at` predates the session's `last_activity_at` (the session moved on since it
 was set). The dashboard resolves the loudest non-stale loud tag into one
 attention signal, with attribution (the agent's own, or an outside mark). The
@@ -335,13 +339,15 @@ alive, so all three set `status = running` (this also promotes a freshly
 `launching` session). Liveness is all a hook proves, so that is all the
 orchestrator tracks — it does not infer working/waiting/idle from stillness.
 
-The hooks also nudge the **`attention` tag** where they carry a genuine signal:
-`working` clears it (back to calm) and drops any pending prompt (the user is
-engaged); `waiting` raises it to `attention` and snapshots the terminal screen
-into `pending_prompt` (Claude is blocked asking the user — the snapshot conveys what
-it's waiting on, so no separate note is stored); `idle` (a turn ending) leaves
-the tag untouched, so a finished-but-fine agent isn't mistaken for one that
-needs you.
+The hooks also stamp a soothing, **quiet `idle` tag** — the calm "resting, no one
+needed" state, deliberately *not* on the loud ladder, so an idle agent never
+reads as needing the user. `working` (a prompt was submitted — the user is
+engaged) returns the agent to calm, clearing both the `idle` mark and the agent's
+own `attention` tag. `waiting` (a `Notification` lull) and `idle` (a turn ending)
+both stamp the `idle` mark; they leave the agent's `attention` tag untouched, so a
+loud self-report still wins the badge. We don't try to mechanically separate
+"truly idle" from "waiting on a sub-agent or shell" — the finished-turn hook is a
+good-enough idle signal, and the status watch upgrades it when warranted (below).
 
 The **`attention` tag** is otherwise the agent's own call, set via `weaver
 status <level> ["<message>"]`. That writes the tag (and, when a message is
@@ -354,11 +360,14 @@ the `PUT`/`DELETE /api/sessions/{id}/tags/{key}` routes do it over HTTP for the
 UI and the [overlooker](plans/overlooker.md). The builtin status watch, when a
 session goes idle (the agent's finished-turn hook), asks the judge model for the
 set of tags the session warrants and reconciles its own typed marks to that set
-— never mirroring the agent's own `attention`.
+— never mirroring the agent's own `attention`. When the judge names a genuine
+need, that session is actively waiting, not resting, so the watch *replaces* the
+soothing `idle` mark with the real loud status; a "nothing needed" verdict leaves
+`idle` in place.
 
-Archiving a session clears its loud tags (and drops any snapshotted
-`pending_prompt`): the agent is gone, so a torn-down workstream
-can't still "need me", and the dashboard stops flagging it. The UI also treats
+Archiving a session clears its loud tags **and** the soothing `idle` mark: the
+agent is gone, so a torn-down workstream can't still "need me" nor is it
+"resting", and the dashboard stops flagging or labelling it. The UI also treats
 any `archived` session as calm regardless of a stale tag left on the branch.
 
 Orphan detection is independent: if the session's supervisor is no longer alive,

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -89,6 +89,34 @@ test.describe('session list view', () => {
     expect(updated.branch.tags.find((t) => t.key === 'triage')).toBeUndefined();
   });
 
+  test('a resting agent shows a soothing idle mark, not a loud signal', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await weaver.seedSession({ goal: 'Resting', name: 'resting' });
+    // The idle hook stamps the quiet `idle` mark when the agent goes quiet.
+    await weaver.setTag(s, 'idle', 'idle');
+
+    await page.goto(weaver.baseUrl);
+    const card = page.locator(`[data-session-id="${s.id}"]`);
+    // It renders as a calm, neutral idle chip — never a loud signal chip, and not
+    // as a generic quiet pill (it's a lifecycle signal, surfaced soothingly).
+    await expect(card.getByTestId('idle-chip')).toContainText(/idle/i);
+    await expect(card.getByTestId('signal-chip')).toHaveCount(0);
+    await expect(card.getByTestId('tag-pill')).toHaveCount(0);
+    // A resting agent does not count toward "needs attention".
+    await expect(page.getByTestId('filter-attention')).toContainText('0');
+
+    // A loud signal supersedes the calm mark: once the agent raises attention,
+    // the idle chip yields to the loud signal chip.
+    await weaver.setStatus(s, 'attention', 'ready for review');
+    await page.reload();
+    await expect(card.getByTestId('idle-chip')).toHaveCount(0);
+    await expect(
+      card.locator('[data-testid="signal-chip"][data-signal-key="attention"]'),
+    ).toHaveAttribute('data-level', 'attention');
+  });
+
   test('a quiet free-form tag renders as a deletable pill', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Tag me', name: 'tagged' });
     await weaver.setTag(s, 'priority', 'high');

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -71,6 +71,14 @@ JUDGED_LEVELS = ("ok", "attention", "blocked")
 #: ``ATTENTION_VALUES``.
 LOUD_VALUES = ("attention", "blocked")
 
+#: The quiet, soothing mark loom stamps when an agent goes quiet (a finished
+#: turn or a ``waiting`` lull): the calm "resting, no one needed" state. Not on
+#: :data:`LOUD_VALUES`, so it never raises a badge. The status watch replaces it
+#: with a real loud status — or clears it — when the session actually needs a
+#: human. Mirrors weaver-core's ``IDLE_KEY`` / ``IDLE_VALUE``.
+IDLE_KEY = "idle"
+IDLE_VALUE = "idle"
+
 
 def parse_judgement(text):
     """Parse an agent judgement into ``(level, note)``, or ``None``.

--- a/python/weaver-loom/tests/test_status_program.py
+++ b/python/weaver-loom/tests/test_status_program.py
@@ -279,6 +279,22 @@ def test_no_idle_mark_means_nothing_to_replace(capsys):
     assert not any(c[0] == "clear_tag" and c[2] == "idle" for c in client.calls)
 
 
+def test_stray_idle_keyed_tag_is_not_cleared(capsys):
+    # A free-form tag that merely shares the `idle` key but isn't the canonical
+    # (idle, idle) mark must NOT be cleared when a real status is applied.
+    sess = {
+        "id": "s",
+        "status": "running",
+        "branch": {
+            "repo_root": "/r",
+            "tags": [{"key": "idle", "value": "paused", "set_by": "manual"}],
+        },
+    }
+    client = StubClient(capabilities=["mark"], agent_reply=TAGS, sessions=[sess])
+    run_main(client, capsys)
+    assert not any(c[0] == "clear_tag" and c[2] == "idle" for c in client.calls)
+
+
 def test_dry_run_would_clear_the_idle_mark(capsys):
     client = StubClient(
         capabilities=["mark"],

--- a/python/weaver-loom/tests/test_status_program.py
+++ b/python/weaver-loom/tests/test_status_program.py
@@ -65,12 +65,15 @@ class StubClient:
         self.calls.append(("clear_tag", key, tag_key, by))
 
 
-def session(id, attention=None, watch=None, status="running"):
-    """A session dict: an optional `attention` self-report (set_by agent) and any
+def session(id, attention=None, watch=None, status="running", idle=False):
+    """A session dict: an optional `attention` self-report (set_by agent), an
+    optional soothing `idle` mark (set_by agent, the idle hook's stamp), and any
     number of watch-authored marks (set_by 'watch', this round's name)."""
     tags = []
     if attention:
         tags.append({"key": "attention", "value": attention, "set_by": "agent"})
+    if idle:
+        tags.append({"key": "idle", "value": "idle", "set_by": "agent"})
     for key, value in (watch or {}).items():
         tags.append({"key": key, "value": value, "set_by": "watch"})
     return {"id": id, "status": status, "branch": {"tags": tags, "repo_root": "/r"}}
@@ -232,6 +235,59 @@ def test_dry_run_records_would_and_mutates_nothing(capsys):
             "value": "attention", "note": "looks done"} in result["actions"]
     assert {"would": "clear", "session": "s", "key": "stuck"} in result["actions"]
     assert result["summary"] == "assessed 1 of 1, would apply 1 tag(s) (dry run, no writes applied)"
+
+
+# -- idle: a real status replaces the soothing idle mark ----------------------
+
+
+def test_real_status_replaces_the_soothing_idle_mark(capsys):
+    # The session is resting (the idle hook stamped `idle`); the judge finds work
+    # ready to review → the watch sets `review` AND clears `idle`, replacing the
+    # calm mark with the real status. The `idle` mark is the agent's own, yet the
+    # watch is allowed to clear it here.
+    client = StubClient(
+        capabilities=["mark"],
+        agent_reply=TAGS,
+        sessions=[session("s", idle=True)],
+    )
+    run_main(client, capsys)
+    assert ("set_tag", "s", "review", "attention", "looks done", "watch") in client.calls
+    assert ("clear_tag", "s", "idle", "watch") in client.calls
+
+
+def test_calm_verdict_leaves_the_idle_mark(capsys):
+    # Nothing needed → the agent stays calmly idle; the watch must NOT clear the
+    # soothing `idle` mark.
+    client = StubClient(
+        capabilities=["mark"],
+        agent_reply="[]",
+        sessions=[session("s", idle=True)],
+    )
+    run_main(client, capsys)
+    assert not any(c[0] == "clear_tag" and c[2] == "idle" for c in client.calls)
+
+
+def test_no_idle_mark_means_nothing_to_replace(capsys):
+    # A real verdict but no `idle` mark on the session → the round sets the tag
+    # without a spurious idle clear.
+    client = StubClient(
+        capabilities=["mark"],
+        agent_reply=TAGS,
+        sessions=[session("s")],
+    )
+    run_main(client, capsys)
+    assert not any(c[0] == "clear_tag" and c[2] == "idle" for c in client.calls)
+
+
+def test_dry_run_would_clear_the_idle_mark(capsys):
+    client = StubClient(
+        capabilities=["mark"],
+        agent_reply=TAGS,
+        sessions=[session("s", idle=True)],
+    )
+    result = run_main(client, capsys, dry_run=True)
+    assert sets(client) == [] and clears(client) == []
+    assert {"would": "clear", "session": "s", "key": "idle"} in result["actions"]
 
 
 def test_empty_survey_is_a_noop(capsys):


### PR DESCRIPTION
## Problem

Agents flagged loud `attention` whenever they merely went quiet — the Claude `Notification`/`waiting` hook fires on a 60s prompt lull, and that was mapped straight to the loud `attention` tag. An idle agent therefore read as "needs me" on the dashboard, which was noisy for users scanning many sessions.

## Approach

Going quiet now stamps a soothing, **quiet** `idle` tag — the calm "resting, no one needed" state, deliberately *off* the loud `attention | blocked` ladder, so an idle agent no longer raises a badge. Per the issue's guidance, we don't attempt to mechanically separate "truly idle" from "waiting on a sub-agent or shell": the finished-turn hook is a good-enough idle signal, and the **status watch upgrades it when warranted**.

## Changes

- **monitor `apply_hook`**: `working` returns the agent to calm (clears both `attention` and `idle`); `waiting`/`idle` stamp the quiet `idle` mark and leave the agent's own `attention` self-report untouched (a loud self-report still wins the badge).
- **status watch** (`builtin:status`): when the judge names a genuine need, the session is actively waiting — not resting — so it **replaces** the `idle` mark with that real loud status. A "nothing needed" verdict leaves `idle` in place. The default prompt is reframed: do **not** flag a session merely for being idle.
- **archive** clears the `idle` mark too (a torn-down workstream isn't "resting"). `resolve_attention` / `weaver issue wait` are unaffected — `idle` is a separate, quiet key.
- **frontend**: an `idleTag` selector (live + calm + non-stale), a neutral, recessive `IdleChip` (no new hue — soothing means *calm*; amber/red stay the only loud signals), `conversationState` honours the explicit mark, and `idle` is excluded from the quiet-pill row.
- **weaver-core / weaver_loom** register `IDLE_KEY` / `IDLE_VALUE`.
- Rust + pytest + Playwright coverage, plus `ARCHITECTURE.md` / `WEAVER.md` updated.

## Visual

The idle agent shows a faint, neutral **IDLE** chip and counts as **OK**, not "Needs attention"; a loud signal (the agent's own `attention`, or a watch's `triage`) supersedes the idle chip.

## Testing

- `cargo test --workspace` — green
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cd python/weaver-loom && uv run pytest` — 41 passed
- `cd e2e && npx playwright test list.spec.ts overlookers.spec.ts` — green (incl. a new resting-agent test)

Closes the work tracked by weaver issue #185.