### PR TITLE
loom: close a session's claimed weaver issues when its PR merges

### DIFF
--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -8,8 +8,8 @@
 //! * **PR status polling** ([`poll`], [`refresh`], [`fetch_pr`]) — the
 //!   background loop that snapshots each active session's pull request (link,
 //!   review decision, check rollup) into the `branch_github` table, and
-//!   archives a session once its PR merges. The snapshot rides along on
-//!   `BranchView`; the dashboard renders it.
+//!   archives a session — closing the weaver issues it was working — once its PR
+//!   merges. The snapshot rides along on `BranchView`; the dashboard renders it.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -342,9 +342,9 @@ pub async fn upsert_status(db: &Db, branch_id: &str, s: &GithubStatus) -> Result
 
 /// Fetch a branch's PR, store the snapshot, announce a meaningful change on the
 /// activity feed, and — when `archive_on_merge` is set and the PR has merged —
-/// archive the still-live session. Returns the fresh snapshot, or `None` when
-/// the branch has no PR. The single code path behind both the poller and the
-/// on-demand refresh endpoint.
+/// archive the still-live session and close the weaver issues it was working.
+/// Returns the fresh snapshot, or `None` when the branch has no PR. The single
+/// code path behind both the poller and the on-demand refresh endpoint.
 pub async fn refresh(
     state: &AppState,
     session: &Session,
@@ -360,9 +360,10 @@ pub async fn refresh(
 }
 
 /// Persist a freshly-fetched snapshot, announce a meaningful change on the
-/// activity feed, and archive a still-live session whose PR has merged (when
-/// `archive_on_merge` is set). Split from [`refresh`] so the storage and
-/// merge-archive behaviour is testable without invoking `gh`.
+/// activity feed, and — when `archive_on_merge` is set — archive a still-live
+/// session whose PR has merged and close the weaver issues that session claimed.
+/// Split from [`refresh`] so the storage and merge-archive behaviour is testable
+/// without invoking `gh`.
 async fn apply_snapshot(
     state: &AppState,
     session: &Session,
@@ -431,11 +432,14 @@ async fn apply_snapshot(
         // The merge is already on the record as a `github` event (above) and the
         // archive records a `status` event, so no extra log line is needed.
         match crate::web::archive(state, session, branch).await {
-            Ok(_) => tracing::info!(
-                branch = %branch.branch,
-                pr = snap.pr_number,
-                "archived session after PR merge"
-            ),
+            Ok(_) => {
+                tracing::info!(
+                    branch = %branch.branch,
+                    pr = snap.pr_number,
+                    "archived session after PR merge"
+                );
+                close_claimed_issues(state, branch, snap.pr_number).await;
+            }
             Err(e) => tracing::warn!(
                 branch = %branch.branch,
                 error = %e.message(),
@@ -444,6 +448,41 @@ async fn apply_snapshot(
         }
     }
     Ok(())
+}
+
+/// Close every open weaver issue the merged branch was working and log each
+/// closure to its activity feed. The session is being torn down because its PR
+/// shipped, so the tracking issues it claimed close out with it — emitting the
+/// same `issue_closed` event `weaver issue close` records, so the dashboard
+/// reacts identically whether a person or the merge closed them. Best-effort:
+/// the archive has already happened, so a hiccup here only loses the auto-close,
+/// it must not surface as an error.
+async fn close_claimed_issues(state: &AppState, branch: &Branch, pr: i64) {
+    let closed = match weaver_core::issue::close_for_branch(
+        &state.db,
+        &branch.repo_root,
+        &branch.branch,
+    )
+    .await
+    {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!(branch = %branch.branch, error = %e, "closing claimed issues on PR merge failed");
+            return;
+        }
+    };
+    for id in closed {
+        events::record(
+            &state.db,
+            &state.bus,
+            &branch.id,
+            "issue_closed",
+            json!({ "id": id, "reason": "pr_merged", "pr": pr }),
+        )
+        .await
+        .ok();
+        tracing::info!(branch = %branch.branch, issue = id, pr, "closed claimed issue after PR merge");
+    }
 }
 
 /// Background loop: snapshot every active session's PR on a fixed cadence. A
@@ -770,6 +809,41 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.pr_state, "MERGED");
+    }
+
+    #[tokio::test]
+    async fn merged_pr_closes_the_branchs_claimed_issues() {
+        let f = fixture().await;
+        let issue = weaver_core::issue::add(
+            &f.state.db,
+            &weaver_core::issue::NewIssue {
+                repo_root: f.branch.repo_root.clone(),
+                claimed_branch: Some(f.branch.branch.clone()),
+                title: "ship the feature".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        apply_snapshot(&f.state, &f.session, &f.branch, &snapshot("MERGED"), true)
+            .await
+            .unwrap();
+
+        // The tracking issue closes out with the merged session…
+        let closed = weaver_core::issue::get(&f.state.db, issue.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(closed.status, "closed");
+        // …and the closure lands on the activity feed as an `issue_closed` event,
+        // just as `weaver issue close` would have recorded it.
+        let logged = events::history(&f.state.db, &f.branch.id, 50)
+            .await
+            .unwrap()
+            .into_iter()
+            .any(|e| e.kind == "issue_closed" && e.data["id"] == issue.id);
+        assert!(logged, "an issue_closed event was recorded for the merge");
     }
 
     #[tokio::test]

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -133,9 +133,10 @@ pub const REGISTRY: &[SettingSpec] = &[
         key: "github.archive_on_merge",
         label: "Archive on PR merge",
         description: "When enabled, loom archives a session automatically once \
-            its pull request is merged — tearing down the terminal session and \
-            removing the worktree, while keeping the branch and its history. \
-            Requires GitHub polling.",
+            its pull request is merged — tearing down the terminal session, \
+            removing the worktree, and closing the weaver issues that session \
+            was working, while keeping the branch and its history. Requires \
+            GitHub polling.",
         kind: SettingKind::Bool,
         default: "true",
         group: "GitHub",

--- a/crates/weaver-core/src/issue.rs
+++ b/crates/weaver-core/src/issue.rs
@@ -220,6 +220,27 @@ pub async fn unclaim_branch(db: &Db, repo_root: &str, branch: &str) -> Result<u6
     Ok(res.rows_affected())
 }
 
+/// Close every open issue claimed by `branch` in `repo_root`, returning the ids
+/// that were closed. Used when a session is torn down on PR merge: the work the
+/// branch claimed shipped, so its tracking issues close out with it. Contrast
+/// [`unclaim_branch`], which releases the claim but leaves the issue open for
+/// another branch to pick up.
+pub async fn close_for_branch(db: &Db, repo_root: &str, branch: &str) -> Result<Vec<i64>> {
+    let now = now_iso();
+    let rows: Vec<(i64,)> = sqlx::query_as(
+        "UPDATE issues SET status = 'closed', closed_at = ?, updated_at = ?
+         WHERE repo_root = ? AND claimed_branch = ? AND status = 'open'
+         RETURNING id",
+    )
+    .bind(&now)
+    .bind(&now)
+    .bind(repo_root)
+    .bind(branch)
+    .fetch_all(db)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
 pub async fn close(db: &Db, id: i64) -> Result<()> {
     let now = now_iso();
     sqlx::query("UPDATE issues SET status = 'closed', closed_at = ?, updated_at = ? WHERE id = ?")
@@ -421,6 +442,41 @@ mod tests {
         );
         assert_eq!(list_backlog(&db, "/r", false).await.unwrap().len(), 2);
         assert_eq!(list_for_repo(&db, "/r", false).await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn close_for_branch_closes_only_that_branchs_open_issues() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let a = add(&db, &claimed("/r", "feature", "task one"))
+            .await
+            .unwrap();
+        let b = add(&db, &claimed("/r", "feature", "task two"))
+            .await
+            .unwrap();
+        // Already closed on `feature` — must not reappear in the closed set.
+        let done = add(&db, &claimed("/r", "feature", "done")).await.unwrap();
+        close(&db, done.id).await.unwrap();
+        // A different branch's claim is untouched.
+        let other = add(&db, &claimed("/r", "other", "theirs")).await.unwrap();
+
+        let mut closed = close_for_branch(&db, "/r", "feature").await.unwrap();
+        closed.sort_unstable();
+        assert_eq!(closed, vec![a.id, b.id]);
+        assert_eq!(
+            open_count_for_branch(&db, "/r", "feature").await.unwrap(),
+            0
+        );
+        assert_eq!(
+            get(&db, other.id).await.unwrap().unwrap().status,
+            "open",
+            "another branch's claim is left alone"
+        );
+
+        // Idempotent: a second call finds nothing open to close.
+        assert!(close_for_branch(&db, "/r", "feature")
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

When `github.archive_on_merge` is on, the PR watcher already tears down a session once its pull request merges — killing the terminal and removing the worktree. It left the weaver issues that session was working **open**, so a merged-and-shipped task lingered on the dashboard as unfinished.

This closes those tracking issues alongside the archive. The session that worked the PR is exactly the branch that claimed the issues, so when its PR ships, the work is done.

## How

- `issue::close_for_branch(repo_root, branch)` — closes every *open* issue claimed by a branch and returns the closed ids. Contrast `unclaim_branch`, which only releases the claim.
- `github::apply_snapshot` calls it after a **successful** archive (new `close_claimed_issues` helper), emitting the same `issue_closed` event `weaver issue close` records — so the dashboard reacts identically whether a person or the merge closed them.

Best-effort: the archive has already happened, so a hiccup closing issues is logged and swallowed, never surfaced as an error. Manual archive (the dashboard's archive button) is unchanged — it still leaves issues alone, since only a merge means the work shipped.

Config description for **Archive on PR merge** updated to mention the issue closure.

## Tests

- `issue::close_for_branch_closes_only_that_branchs_open_issues` — closes only the target branch's open issues, leaves another branch's claim and already-closed issues alone, idempotent.
- `github::merged_pr_closes_the_branchs_claimed_issues` — a MERGED snapshot closes the branch's claimed issue and records an `issue_closed` event.

fmt + clippy clean.
