### PR TITLE
fix: reap container zombies via tini PID 1 + process-group kill on reap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN set -eux; \
     echo "deb [signed-by=/etc/apt/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt cloud-sdk main" \
       > /etc/apt/sources.list.d/google-cloud-sdk.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends nodejs git ca-certificates gh google-cloud-cli; \
+    apt-get install -y --no-install-recommends nodejs git ca-certificates gh google-cloud-cli tini; \
     npm i -g @anthropic-ai/claude-code; \
     rm -rf /var/lib/apt/lists/*
 
@@ -106,6 +106,13 @@ ENV WEAVER_STATIC_DIR=/app/static/dist
 
 USER app
 EXPOSE 7878
+# tini as PID 1. loom is a tokio app that reaps only the children it spawns, but
+# as the container's init it also inherits every orphan its agents leave behind:
+# they shell out to `gh`, `sleep`, MCP servers, etc. and routinely detach, so
+# those processes reparent to PID 1 when their immediate parent exits. With no
+# init to `wait()` on them they pile up as zombies for the container's whole
+# lifetime. tini reaps them and forwards signals through to loom.
+ENTRYPOINT ["/usr/bin/tini", "--"]
 # `server run` is the foreground daemon (REST API + Vue UI + monitor loop); bind
 # off loopback so the Caddy container can reach it over the `web` network.
 CMD ["loom", "server", "run", "--addr", "0.0.0.0:7878"]

--- a/crates/tapestry/Cargo.toml
+++ b/crates/tapestry/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 vt100 = "0.16"
 
 [dev-dependencies]
+libc = "0.2"
 tempfile = "3"
 # The lifecycle tests set the process-global WEAVER_HOME, so they must not run
 # concurrently within the test binary.

--- a/crates/tapestry/src/bin/tapestry.rs
+++ b/crates/tapestry/src/bin/tapestry.rs
@@ -30,6 +30,37 @@ usage:
     std::process::exit(2);
 }
 
+/// Reap exited children on every `SIGCHLD`. In a supervisor process the only
+/// children are the agent and whatever it reparents to us — we are the session's
+/// subreaper (see the `supervise` arm) — so `waitpid(-1)` over all of them is
+/// correct: it keeps orphaned, detached helpers (a backgrounded `gh`, `sleep`,
+/// an MCP server) from lingering as zombies. The agent's own exit is still
+/// detected inside `supervise`; if a reap here wins that race the wait there
+/// just returns early and the exit is reported all the same.
+#[cfg(target_os = "linux")]
+fn reap_orphans() {
+    use tokio::signal::unix::{signal, SignalKind};
+    tokio::spawn(async {
+        let Ok(mut sigchld) = signal(SignalKind::child()) else {
+            tracing::warn!("cannot watch SIGCHLD; orphaned children may linger as zombies");
+            return;
+        };
+        loop {
+            sigchld.recv().await;
+            // Drain every child that has exited. `WNOHANG` so we never block the
+            // task; 0 (none ready) or -1 (no children) both mean "done — wait
+            // for the next SIGCHLD".
+            loop {
+                let mut status = 0;
+                let pid = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+                if pid <= 0 {
+                    break;
+                }
+            }
+        }
+    });
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -47,6 +78,18 @@ async fn main() -> Result<()> {
             let spec_json = args.get(1).context("supervise needs a JSON spec")?;
             let spec: LaunchSpec =
                 serde_json::from_str(spec_json).context("parsing supervise spec")?;
+            // This process supervises exactly one session, so make it the
+            // session's subreaper: anything the agent orphans (it backgrounds
+            // gh, sleep, MCP servers, … which then detach) reparents here
+            // instead of escaping up to loom / PID 1, and `reap_orphans` waits
+            // on it. Per-session cleanup that holds whether or not loom runs
+            // under a container init — the standalone-binary case has no init,
+            // and a containerised loom that *is* PID 1 never sees these orphans.
+            #[cfg(target_os = "linux")]
+            {
+                unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) };
+                reap_orphans();
+            }
             tapestry::supervise(spec.into()).await?;
         }
         "spawn" => {

--- a/crates/tapestry/src/supervisor.rs
+++ b/crates/tapestry/src/supervisor.rs
@@ -297,6 +297,17 @@ pub async fn run(cfg: SupervisorConfig) -> Result<()> {
                         subscribers.remove(&id);
                     }
                     Cmd::Kill => {
+                        // Reap the *whole* agent, not just its top shell.
+                        // portable_pty `setsid`s the child into its own session, so
+                        // the child pid is also the process-group id: SIGKILL the
+                        // negative pid to take down the shell and everything it
+                        // spawned in one shot. `killer.kill()` alone hits only the
+                        // leader, leaving group members that ignore the PTY's
+                        // SIGHUP (detached helpers, daemons) running and orphaned to
+                        // PID 1; SIGKILL can't be caught, so the teardown is total.
+                        if let Some(pid) = child_pid {
+                            unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+                        }
                         let _ = killer.kill();
                         break;
                     }

--- a/crates/tapestry/src/supervisor.rs
+++ b/crates/tapestry/src/supervisor.rs
@@ -305,8 +305,18 @@ pub async fn run(cfg: SupervisorConfig) -> Result<()> {
                         // leader, leaving group members that ignore the PTY's
                         // SIGHUP (detached helpers, daemons) running and orphaned to
                         // PID 1; SIGKILL can't be caught, so the teardown is total.
-                        if let Some(pid) = child_pid {
-                            unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+                        // Guard `pid != 0`: a real spawned child never has pid 0,
+                        // but `kill(-0, …)` would target the supervisor's *own*
+                        // process group, so rule the footgun out explicitly. ESRCH
+                        // (group already gone) is success; anything else is worth a
+                        // line.
+                        if let Some(pid) = child_pid.filter(|&p| p != 0) {
+                            if unsafe { libc::kill(-(pid as i32), libc::SIGKILL) } != 0 {
+                                let err = std::io::Error::last_os_error();
+                                if err.raw_os_error() != Some(libc::ESRCH) {
+                                    tracing::warn!(pid, error = %err, "process-group kill failed");
+                                }
+                            }
                         }
                         let _ = killer.kill();
                         break;

--- a/crates/tapestry/tests/detached.rs
+++ b/crates/tapestry/tests/detached.rs
@@ -81,6 +81,103 @@ async fn detached_supervisor_outlives_its_launcher() {
     let _ = Client::connect(&name).await.unwrap().kill().await;
 }
 
+/// The supervisor is its session's subreaper: a process the agent detaches and
+/// orphans must reparent to the supervisor (not escape to PID 1) and then get
+/// reaped when it dies, instead of lingering as a zombie. Without this a
+/// long-lived agent that shells out to detached helpers (`gh`, `sleep`, MCP
+/// servers) accretes zombies for the life of the session.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+#[serial]
+async fn detached_supervisor_reaps_orphaned_descendants() {
+    let home = TempDir::new().unwrap();
+    std::env::set_var("WEAVER_HOME", home.path());
+    let bin = env!("CARGO_BIN_EXE_tapestry");
+    let name = format!("tap-reap-{}", std::process::id());
+
+    // The subshell backgrounds `sleep` then exits immediately, orphaning it; with
+    // the supervisor as subreaper the orphan reparents to the supervisor. The
+    // foreground `sleep` keeps the session (and supervisor) alive meanwhile.
+    let pidfile = std::env::temp_dir().join(format!("tap-reap-{}.pid", std::process::id()));
+    let _ = std::fs::remove_file(&pidfile);
+    let script = format!(
+        "(sleep 300 & echo $! > {}); exec sleep 300",
+        pidfile.display()
+    );
+    spawn_via_binary(bin, &name, &script).await;
+
+    // Read the orphan's pid.
+    let mut orphan = String::new();
+    for _ in 0..200 {
+        if let Ok(s) = std::fs::read_to_string(&pidfile) {
+            if !s.trim().is_empty() {
+                orphan = s.trim().to_string();
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(!orphan.is_empty(), "orphan pid never recorded");
+
+    // It reparents to the supervisor (a `tapestry` process), not to init —
+    // proof the subreaper attribute took effect.
+    let mut reparented = false;
+    for _ in 0..200 {
+        if let Some(ppid) = proc_field(&orphan, 1) {
+            if ppid != "1" && proc_comm(&ppid).as_deref() == Some("tapestry") {
+                reparented = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(
+        reparented,
+        "orphan {orphan} did not reparent to the supervisor"
+    );
+
+    // Kill it; the supervisor must reap it — /proc/<pid> disappears rather than
+    // sticking around as a zombie (state 'Z').
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &orphan])
+        .status();
+    let mut reaped = false;
+    for _ in 0..200 {
+        if proc_field(&orphan, 0).is_none() {
+            reaped = true; // /proc entry gone → reaped
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let _ = std::fs::remove_file(&pidfile);
+    let _ = Client::connect(&name).await.unwrap().kill().await;
+    assert!(
+        reaped,
+        "orphan {orphan} was not reaped — lingered as a zombie"
+    );
+}
+
+/// Field `n` (0-based) of `/proc/<pid>/stat` *after* the parenthesised comm —
+/// so field 0 is state, field 1 is ppid. `None` if the process is gone. Reading
+/// after the last `)` sidesteps spaces/parens inside comm.
+#[cfg(target_os = "linux")]
+fn proc_field(pid: &str, n: usize) -> Option<String> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let rest = stat.rsplit_once(')')?.1;
+    rest.split_whitespace().nth(n).map(str::to_string)
+}
+
+/// `/proc/<pid>/comm` (the executable name), or `None` if the process is gone.
+#[cfg(target_os = "linux")]
+fn proc_comm(pid: &str) -> Option<String> {
+    Some(
+        std::fs::read_to_string(format!("/proc/{pid}/comm"))
+            .ok()?
+            .trim()
+            .to_string(),
+    )
+}
+
 /// Drive the `tapestry spawn` subcommand of the built binary, which setsid-
 /// detaches a supervisor and returns immediately. Using the CLI (rather than the
 /// library `spawn_detached`, which re-execs `current_exe`) makes the supervisor

--- a/crates/tapestry/tests/detached.rs
+++ b/crates/tapestry/tests/detached.rs
@@ -138,9 +138,9 @@ async fn detached_supervisor_reaps_orphaned_descendants() {
 
     // Kill it; the supervisor must reap it — /proc/<pid> disappears rather than
     // sticking around as a zombie (state 'Z').
-    let _ = std::process::Command::new("kill")
-        .args(["-9", &orphan])
-        .status();
+    if let Ok(pid) = orphan.parse::<i32>() {
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+    }
     let mut reaped = false;
     for _ in 0..200 {
         if proc_field(&orphan, 0).is_none() {

--- a/crates/tapestry/tests/lifecycle.rs
+++ b/crates/tapestry/tests/lifecycle.rs
@@ -104,18 +104,18 @@ async fn kill_reaps_the_whole_process_group() {
     let h = Harness::start("pgroup", &script).await;
 
     // Wait for the grandchild to record its pid.
-    let mut pid = String::new();
+    let mut pid = 0i32;
     for _ in 0..200 {
         if let Ok(s) = std::fs::read_to_string(&pidfile) {
-            if !s.trim().is_empty() {
-                pid = s.trim().to_string();
+            if let Ok(p) = s.trim().parse::<i32>() {
+                pid = p;
                 break;
             }
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
-    assert!(!pid.is_empty(), "grandchild never recorded its pid");
-    assert!(alive(&pid), "grandchild should be running before the reap");
+    assert!(pid > 0, "grandchild never recorded its pid");
+    assert!(alive(pid), "grandchild should be running before the reap");
 
     Client::connect(&h.name)
         .await
@@ -126,7 +126,7 @@ async fn kill_reaps_the_whole_process_group() {
 
     let mut gone = false;
     for _ in 0..200 {
-        if !alive(&pid) {
+        if !alive(pid) {
             gone = true;
             break;
         }
@@ -139,15 +139,14 @@ async fn kill_reaps_the_whole_process_group() {
     );
 }
 
-/// `kill -0` probes a pid without delivering a signal: exit 0 ⇒ it is live (or a
-/// not-yet-reaped zombie), non-zero ⇒ gone.
-fn alive(pid: &str) -> bool {
-    std::process::Command::new("kill")
-        .args(["-0", pid])
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+/// Whether `pid` still exists. `kill(pid, 0)` delivers no signal — it only
+/// probes: `Ok` ⇒ alive (or a not-yet-reaped zombie), `EPERM` ⇒ alive but not
+/// ours to signal, `ESRCH` ⇒ gone.
+fn alive(pid: i32) -> bool {
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 #[tokio::test]

--- a/crates/tapestry/tests/lifecycle.rs
+++ b/crates/tapestry/tests/lifecycle.rs
@@ -88,6 +88,70 @@ async fn capture_sees_child_output() {
 
 #[tokio::test]
 #[serial]
+async fn kill_reaps_the_whole_process_group() {
+    // A reap must take down everything the agent spawned, not just its top
+    // shell. portable_pty puts the child in its own session, so the supervisor
+    // SIGKILLs the entire process group. Spawn a backgrounded grandchild that
+    // *ignores* SIGHUP (as detached agent helpers do), so only the group-wide
+    // SIGKILL — not the PTY hangup the supervisor's exit delivers — can stop it,
+    // then confirm it is gone after the kill.
+    let pidfile = std::env::temp_dir().join(format!("tap-pg-{}.pid", std::process::id()));
+    let _ = std::fs::remove_file(&pidfile);
+    let script = format!(
+        "nohup sleep 300 >/dev/null 2>&1 & echo $! > {}; exec sleep 300",
+        pidfile.display()
+    );
+    let h = Harness::start("pgroup", &script).await;
+
+    // Wait for the grandchild to record its pid.
+    let mut pid = String::new();
+    for _ in 0..200 {
+        if let Ok(s) = std::fs::read_to_string(&pidfile) {
+            if !s.trim().is_empty() {
+                pid = s.trim().to_string();
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(!pid.is_empty(), "grandchild never recorded its pid");
+    assert!(alive(&pid), "grandchild should be running before the reap");
+
+    Client::connect(&h.name)
+        .await
+        .unwrap()
+        .kill()
+        .await
+        .unwrap();
+
+    let mut gone = false;
+    for _ in 0..200 {
+        if !alive(&pid) {
+            gone = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let _ = std::fs::remove_file(&pidfile);
+    assert!(
+        gone,
+        "grandchild {pid} survived the reap — orphaned, not killed"
+    );
+}
+
+/// `kill -0` probes a pid without delivering a signal: exit 0 ⇒ it is live (or a
+/// not-yet-reaped zombie), non-zero ⇒ gone.
+fn alive(pid: &str) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", pid])
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[tokio::test]
+#[serial]
 async fn send_reaches_the_shell() {
     // A bare shell; type a command and confirm its output appears on screen.
     let h = Harness::start("send", "exec sh").await;


### PR DESCRIPTION
## Problem

Login showed `=> There are 83 zombie processes.` Every zombie was a `[gh]` or `[sleep]` `<defunct>` parented to the loom server, and `/proc/<loom>/status` showed `NSpid: <host> 1` — **loom runs as PID 1 inside its Docker container.**

This is the classic init problem: loom is a tokio app and reaps only the children *it* spawns, but as PID 1 it also inherits every orphan its agents leave behind (agents background `gh`, `sleep`, MCP servers, … which then detach, so when their immediate parent exits they reparent to PID 1). With no init to `wait()` on them they pile up as zombies for the container's lifetime.

But this needs to hold **whether or not loom is PID 1**. Run loom directly as a host daemon and it isn't PID 1 — today those orphans escape to the host init, which reaps them by luck, not design, and gives no per-session control. So the fix has two layers, the second being the real per-session mechanism.

## Fix

**1. Per-session subreaper (`crates/tapestry/src/bin/tapestry.rs`) — the deployment-independent fix.** Each session's tapestry supervisor is a dedicated process, so it now marks itself `PR_SET_CHILD_SUBREAPER` and runs a `SIGCHLD`-driven `waitpid(-1)` reaper. Every descendant the agent orphans reparents to *the supervisor* (never escaping up to loom / PID 1), and the supervisor waits on it. Cleanup is genuinely per-session and works the same whether loom runs standalone or as a container's PID 1 (which then never sees these orphans at all). It lives in the `supervise` binary, not the library `run()` — tests drive `run()` in-process, where a process-wide reaper would eat the test's own subprocesses.

**2. tini as PID 1 (`Dockerfile`) — a container backstop.** Install `tini` + `ENTRYPOINT ["/usr/bin/tini", "--"]` so anything that somehow still reaches PID 1 (e.g. a process spawned before the supervisor set the flag, or after a supervisor dies) is reaped, and signals are forwarded to loom.

**3. Process-group kill on reap (`crates/tapestry/src/supervisor.rs`).** `Cmd::Kill` previously SIGKILLed only the top shell. portable_pty `setsid`s the agent into its own session (child pid == process-group id), so we SIGKILL the whole group — uncatchable, total teardown — instead of relying on a catchable PTY SIGHUP that detached helpers can ignore.

> Remaining gap: a descendant that `setsid`s into its *own* session and is still alive at reap escapes the process-group kill. The subreaper reaps it once it dies; killing such a live detached daemon at reap would need a per-session cgroup (heavier, out of scope). The reported symptom — short-lived `gh`/`sleep` corpses — is fully covered.

## Tests

- `detached_supervisor_reaps_orphaned_descendants` (drives the real binary): an orphaned grandchild must reparent to the supervisor *and* then be reaped, not linger as a zombie. Verified it fails both without the subreaper flag (reparents to init) and without the reaper (lingers as `Z`).
- `kill_reaps_the_whole_process_group`: a SIGHUP-ignoring grandchild is gone after a reap; fails without the group-kill.
- Full `tapestry` suite + workspace clippy green.

## Rollout

The existing 83 zombies clear when the container is recreated with the new image (`docker compose up -d --build`) — they can only be reaped by their parent. Going forward each supervisor reaps its own session's orphans, and tini backstops PID 1.