### PR TITLE
fix(loom): route the bare `…/ide/` so the editor proxies code-server, not loom

### DIFF
--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -409,10 +409,15 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{id}/github", post(refresh_github_session))
         .route("/sessions/{id}/raw", get(raw_session))
         // Embedded VS Code (code-server), reverse-proxied per session. `ide-info`
-        // is the UI's availability probe; the `ide`/`ide/*` routes serve the
-        // editor itself (the static segments win over the `{*rest}` catch-all).
+        // is the UI's availability probe; the `ide`/`ide/`/`ide/*` routes serve
+        // the editor itself (the static segments win over the `{*rest}`
+        // catch-all). The bare `…/ide/` (trailing slash, empty rest) needs its
+        // own route: a catch-all does NOT match an empty final segment, so
+        // without it the iframe's exact `…/ide/?folder=…` URL would fall through
+        // to the SPA index.html and render loom inside its own editor pane.
         .route("/sessions/{id}/ide-info", get(crate::ide::info))
         .route("/sessions/{id}/ide", axum::routing::any(crate::ide::proxy))
+        .route("/sessions/{id}/ide/", axum::routing::any(crate::ide::proxy))
         .route(
             "/sessions/{id}/ide/{*rest}",
             axum::routing::any(crate::ide::proxy),

--- a/crates/loom/tests/integration/ide.rs
+++ b/crates/loom/tests/integration/ide.rs
@@ -38,6 +38,7 @@ async fn start_stub_upstream() -> u16 {
     }
 
     let app = Router::new()
+        .route("/", get(|| async { "root-from-upstream" }))
         .route("/marker", get(|| async { "ok-from-upstream" }))
         .route("/ws", get(ws_echo));
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -91,6 +92,22 @@ async fn ide_proxy_strips_prefix_redirects_and_passes_websockets() {
     assert_eq!(
         resp.headers().get(reqwest::header::LOCATION).unwrap(),
         "/api/sessions/stub/ide/?folder=/w"
+    );
+
+    // 2b. The bare `…/ide/` (trailing slash, empty rest) — the exact URL the
+    //     iframe loads — must reach the upstream root, not fall through to loom's
+    //     SPA index.html. A catch-all route (`…/ide/{*rest}`) does NOT match an
+    //     empty final segment, so this needs its own dedicated route.
+    let resp = http
+        .get(format!("{base}/api/sessions/stub/ide/?folder=/w"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.text().await.unwrap(),
+        "root-from-upstream",
+        "the trailing-slash editor root must proxy to code-server, not loom's SPA"
     );
 
     // 3. A WebSocket frame round-trips through the upgrade passthrough.

--- a/docs/embedded-ide.md
+++ b/docs/embedded-ide.md
@@ -84,8 +84,12 @@ Explorer.
 ### 3.2 The reverse proxy (`ide.rs`)
 
 The one genuinely new piece of infra. A single handler bound to
-`ANY /api/sessions/{id}/ide` and `ANY /api/sessions/{id}/ide/{*rest}` in the
-**protected** (authenticated) router. Per request:
+`ANY /api/sessions/{id}/ide`, `ANY /api/sessions/{id}/ide/`, and
+`ANY /api/sessions/{id}/ide/{*rest}` in the **protected** (authenticated)
+router. The trailing-slash form needs its own route because a catch-all
+(`{*rest}`) does **not** match an empty final segment — without it the iframe's
+exact `…/ide/?folder=…` URL falls through to the SPA's `index.html` and renders
+loom inside its own editor pane. Per request:
 
 1. Parse `{id}` and the suffix from the original URI. code-server derives its own
    base path per-request from relative URLs and has **no base-path flag**, so the


### PR DESCRIPTION
## Problem

The embedded-editor pane rendered **loom's own UI** (the Sessions/Issues/Watch/Shell sidebar) instead of VS Code — a duplicate of the dashboard inside the editor frame.

![bug: loom UI inside the editor pane](https://github.com/rjpower/weaver/assets/placeholder)

## Root cause

`IdeFrame.vue` loads the iframe at `…/ide/?folder=…` — a **trailing slash with an empty final segment**. That URL matched neither route registered for the proxy:

- `…/ide` — no trailing slash, doesn't match.
- `…/ide/{*rest}` — matchit catch-alls don't match an *empty* segment, so `…/ide/` doesn't match either.

With no match under the `nest("/api", …)` router, the request fell through to the outer SPA fallback (`ServeDir → index.html`). The iframe loaded loom's `index.html`, the SPA booted inside the frame, and rendered the default dashboard. The bare-`…/ide` → `…/ide/` 308 redirect was broken for the same reason — it redirected to a URL that didn't route.

## Fix

Add a dedicated `…/ide/` route onto the same proxy handler, so the trailing-slash root (and the redirect target) reach code-server. One line; matchit accepts the explicit empty-segment route alongside the catch-all.

## Verification

- **Integration test** (`tests/integration/ide.rs`): new assertion that `GET …/ide/?folder=…` reaches the stub upstream's root, not loom's `index.html`. Fails on `main`, passes with the fix.
- **Playwright + real code-server**: on a host with `code-server` installed, a temp spec opened the editor panel and confirmed the actual VS Code workbench (`.monaco-workbench`, EXPLORER, the worktree folder) renders in the frame. (Temp spec not committed — the committed e2e stays CI-friendly, which has no code-server.)
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and the ide unit/integration suites are clean.

Docs: `docs/embedded-ide.md` §3.2 updated to list all three routes and note why the trailing-slash form needs its own.

Closes the editor-proxy issue tracked as weaver #211.