### PR TITLE
feat(loom): capture the agent conversation log on archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ weaver issue wait 7                   # block until a sub-session finishes or ne
 weaver status                     # read: goal + status + open-issue count
 weaver where                          # debug: print resolved repo / branch / branch-id
 weaver log --limit 50                 # recent events for the current branch
+weaver chatlog                        # render this worktree's agent conversation as markdown
 ```
 
 `loom session` is the uniform surface for driving a child session. `loom
@@ -220,6 +221,14 @@ surfaces the result on the dashboard: a link straight to the PR, its state
 requested / review required), and a rolled-up CI verdict (checks passing /
 failing / pending). The session's Overview tab has a **Refresh** button to
 re-poll on demand.
+
+Whenever a session is archived — by the Archive button or automatically on merge
+— loom first captures the agent's conversation log: it finds the agent's
+transcript (Claude Code or Codex), normalizes it, and writes a machine-readable
+`chat.json` plus a readable `chat.md` under `session.log_dir`
+(default `~/.iris/logs/sessions/<branch>/`), so the conversation is reviewable
+after the worktree is gone. `weaver chatlog` renders the same log for a live
+session on demand.
 
 Once a branch's PR merges, loom archives the session automatically — tearing
 down its terminal and worktree while keeping the branch and its weaver history, the
@@ -332,6 +341,10 @@ Notable settings:
   check status (on by default; a no-op without `gh` or a GitHub remote).
 - `github.archive_on_merge` — archive a session automatically once its PR
   merges (on by default).
+- `session.log_dir` — where a session's agent conversation log is captured on
+  archive (a normalized `chat.json` + a rendered `chat.md` under
+  `<dir>/<branch>/`). Blank ⇒ `~/.iris/logs/sessions`; point it at a persistent
+  path when the home dir isn't a mounted volume.
 - `terminal.theme` — colour palette for the in-browser terminal: `dark` (the
   classic black background, default) or `light`.
 - `auth.trust_loopback` — trust loopback requests as the machine owner (on by

--- a/README.md
+++ b/README.md
@@ -222,13 +222,16 @@ requested / review required), and a rolled-up CI verdict (checks passing /
 failing / pending). The session's Overview tab has a **Refresh** button to
 re-poll on demand.
 
+Every session detail has a **Conversation** tab that renders the agent's chat
+with the model — user turns, replies, thinking, and tool calls — live and
+(via the archive capture below) still there to review after the terminal is gone.
+
 Whenever a session is archived — by the Archive button or automatically on merge
-— loom first captures the agent's conversation log: it finds the agent's
-transcript (Claude Code or Codex), normalizes it, and writes a machine-readable
-`chat.json` plus a readable `chat.md` under `session.log_dir`
-(default `~/.iris/logs/sessions/<branch>/`), so the conversation is reviewable
-after the worktree is gone. `weaver chatlog` renders the same log for a live
-session on demand.
+— loom first captures that conversation to disk: it finds the agent's transcript
+(Claude Code or Codex), normalizes it, and writes a machine-readable `chat.json`
+plus a readable `chat.md` under `session.log_dir`
+(default `~/.iris/logs/sessions/<branch>/`). `weaver chatlog` renders the same
+log for a live session on the command line.
 
 Once a branch's PR merges, loom archives the session automatically — tearing
 down its terminal and worktree while keeping the branch and its weaver history, the

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue';
+import { get } from '../api';
+import type { IrisLog, IrisMessage } from '../types';
+import MarkdownView from './MarkdownView.vue';
+
+// The Conversation tab: the agent's chat with the model, rendered for review.
+// Reads the normalized iris log from `GET /sessions/{id}/conversation` (live
+// transcript when present, else the capture archived on teardown) and renders it
+// natively — user/assistant turns, collapsible thinking, tool calls + results —
+// so an archived session (whose terminal is gone) is still reviewable here.
+const props = defineProps<{ id: string }>();
+
+type LoadState = 'loading' | 'ready' | 'empty' | 'error';
+const log = ref<IrisLog | null>(null);
+const state = ref<LoadState>('loading');
+const errorMsg = ref('');
+
+async function load() {
+  state.value = 'loading';
+  try {
+    const data = (await get(`/sessions/${props.id}/conversation`)) as IrisLog;
+    log.value = data;
+    state.value = data && data.messages.length ? 'ready' : 'empty';
+  } catch (e) {
+    // A 404 means nothing's been recorded (a shell session, or not yet) — that's
+    // an empty state, not an error worth shouting about.
+    const msg = (e as Error).message ?? '';
+    if (/not found|conversation/i.test(msg)) {
+      state.value = 'empty';
+    } else {
+      errorMsg.value = msg;
+      state.value = 'error';
+    }
+  }
+}
+
+onMounted(load);
+watch(() => props.id, load);
+
+// One banner line: source agent · model · message count · time span.
+const banner = computed(() => {
+  const l = log.value;
+  if (!l) return '';
+  const parts: string[] = [];
+  if (l.source) parts.push(l.source);
+  parts.push(`${l.messages.length} messages`);
+  if (l.model) parts.push(l.model);
+  const times = l.messages.map((m) => m.timestamp).filter(Boolean) as string[];
+  if (times.length) parts.push(`${shortTime(times[0])} – ${shortTime(times[times.length - 1])}`);
+  return parts.join(' · ');
+});
+
+function shortTime(ts?: string): string {
+  if (!ts) return '';
+  return ts.length >= 19 && ts[10] === 'T' ? ts.slice(11, 19) : ts;
+}
+
+// An assistant heading opens each contiguous assistant run; a tool call/result
+// emitted as its own message must not start a fresh heading.
+function startsAssistantRun(messages: IrisMessage[], i: number): boolean {
+  return i === 0 || messages[i - 1].role !== 'assistant';
+}
+
+// A shell command (Bash `command`, Codex `cmd`) renders as a shell block; any
+// other tool input as pretty JSON or its raw string.
+function toolCommand(input: unknown): string | null {
+  if (input && typeof input === 'object') {
+    const o = input as Record<string, unknown>;
+    const c = o.command ?? o.cmd;
+    if (typeof c === 'string') return c;
+  }
+  return null;
+}
+function toolBody(input: unknown): string {
+  if (typeof input === 'string') return input;
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+}
+</script>
+
+<template>
+  <div class="flex h-full flex-col">
+    <!-- Banner + refresh: a live session's conversation grows, so allow a manual
+         reload without re-opening the tab. -->
+    <div class="mb-2 flex items-center justify-between gap-2">
+      <p class="truncate text-xs text-muted">{{ banner }}</p>
+      <button
+        type="button"
+        class="btn-secondary shrink-0 text-xs"
+        :disabled="state === 'loading'"
+        @click="load"
+      >
+        Refresh
+      </button>
+    </div>
+
+    <p v-if="state === 'loading'" class="text-sm text-muted">Loading conversation…</p>
+    <p v-else-if="state === 'error'" class="text-sm text-block">{{ errorMsg }}</p>
+    <p v-else-if="state === 'empty'" class="text-sm text-muted">
+      No conversation recorded for this session yet.
+    </p>
+
+    <div v-else class="min-h-0 flex-1 space-y-4 overflow-auto pb-2">
+      <template v-for="(msg, i) in log!.messages" :key="i">
+        <!-- Injected context (primers, system/permissions) — tucked away. -->
+        <details v-if="msg.role === 'context'" class="rounded border border-line bg-subtle/40 px-3 py-2">
+          <summary class="cursor-pointer text-xs text-muted">📎 Context</summary>
+          <div class="mt-2 space-y-2">
+            <template v-for="(b, j) in msg.blocks" :key="j">
+              <pre
+                v-if="b.kind === 'text' || b.kind === 'thinking'"
+                class="whitespace-pre-wrap break-words font-mono text-xs text-muted"
+                >{{ b.text }}</pre>
+            </template>
+          </div>
+        </details>
+
+        <!-- User turn. -->
+        <section v-else-if="msg.role === 'user'" class="rounded border-l-2 border-accent bg-subtle/40 px-3 py-2">
+          <header class="mb-1 text-xs font-medium text-accent">
+            🧑 User<span v-if="msg.timestamp" class="ml-2 font-normal text-muted">{{ shortTime(msg.timestamp) }}</span>
+          </header>
+          <template v-for="(b, j) in msg.blocks" :key="j">
+            <MarkdownView v-if="b.kind === 'text'" :id="props.id" path="" :source="b.text" />
+            <p v-else-if="b.kind === 'image'" class="text-xs italic text-muted">[image]</p>
+          </template>
+        </section>
+
+        <!-- Assistant turn (one heading per run). -->
+        <section v-else>
+          <header v-if="startsAssistantRun(log!.messages, i)" class="mb-1 text-xs font-medium text-fg">
+            🤖 Assistant<span v-if="msg.timestamp" class="ml-2 font-normal text-muted">{{ shortTime(msg.timestamp) }}</span>
+          </header>
+          <template v-for="(b, j) in msg.blocks" :key="j">
+            <MarkdownView v-if="b.kind === 'text'" :id="props.id" path="" :source="b.text" class="mb-2" />
+
+            <details v-else-if="b.kind === 'thinking'" class="mb-2 rounded border border-line bg-subtle/40 px-3 py-1.5">
+              <summary class="cursor-pointer text-xs text-muted">💭 Thinking</summary>
+              <pre class="mt-2 whitespace-pre-wrap break-words font-mono text-xs text-muted">{{ b.text }}</pre>
+            </details>
+
+            <div v-else-if="b.kind === 'tool_use'" class="mb-2 overflow-hidden rounded border border-line">
+              <div class="border-b border-line bg-subtle/60 px-3 py-1 text-xs font-medium text-fg">
+                🔧 {{ b.name }}
+              </div>
+              <pre class="overflow-x-auto px-3 py-2 font-mono text-xs text-fg">{{ toolCommand(b.input) ?? toolBody(b.input) }}</pre>
+            </div>
+
+            <details v-else-if="b.kind === 'tool_result'" class="mb-2 rounded border border-line bg-subtle/30 px-3 py-1.5">
+              <summary class="cursor-pointer text-xs" :class="b.is_error ? 'text-block' : 'text-muted'">
+                ↳ result{{ b.is_error ? ' (error)' : '' }}
+              </summary>
+              <pre class="mt-2 overflow-x-auto whitespace-pre-wrap break-words font-mono text-xs text-muted">{{ b.output }}</pre>
+            </details>
+
+            <p v-else-if="b.kind === 'image'" class="mb-2 text-xs italic text-muted">[image]</p>
+          </template>
+        </section>
+      </template>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionTabs.vue
+++ b/crates/loom/frontend/src/components/SessionTabs.vue
@@ -10,7 +10,7 @@
 // Overview tab as a quiet pill rather than owning a tab of its own. Artifacts is
 // the agent's out-of-repo documents (designs, reports, the plan). The worktree
 // files live in the embedded editor (the side panel), not a tab.
-type Tab = 'terminal' | 'overview' | 'artifacts';
+type Tab = 'terminal' | 'overview' | 'conversation' | 'artifacts';
 
 // The Artifacts tab is a real navigation; the rest are local.
 type LocalTab = Exclude<Tab, 'artifacts'>;
@@ -21,6 +21,9 @@ defineEmits<{ select: [LocalTab] }>();
 const LOCAL_TABS: { key: LocalTab; label: string }[] = [
   { key: 'terminal', label: 'Terminal' },
   { key: 'overview', label: 'Overview' },
+  // The agent's chat with the model — live, and (via the archive capture) still
+  // here to review after the terminal is gone.
+  { key: 'conversation', label: 'Conversation' },
 ];
 </script>
 

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -430,3 +430,32 @@ export interface GithubConfig {
   client_id: string;
   callback_path: string;
 }
+
+// --- Conversation log (iris format) ----------------------------------------
+// The normalized agent conversation served by `GET /sessions/{id}/conversation`.
+// Mirrors `weaver_core::transcript::iris`: a list of role-tagged messages, each
+// an ordered list of content blocks. The Conversation tab renders this.
+
+/** A content block, discriminated by `kind` (serde `tag = "kind"`). */
+export type IrisBlock =
+  | { kind: 'text'; text: string }
+  | { kind: 'thinking'; text: string }
+  | { kind: 'tool_use'; name: string; input: unknown }
+  | { kind: 'tool_result'; output: string; is_error: boolean }
+  | { kind: 'image' };
+
+/** One message: who said it, when, and its content blocks. */
+export interface IrisMessage {
+  role: 'user' | 'assistant' | 'context';
+  timestamp?: string;
+  blocks: IrisBlock[];
+}
+
+/** A whole normalized conversation. Mirrors `iris::Log`. */
+export interface IrisLog {
+  source: string;
+  session_id?: string;
+  model?: string;
+  cwd?: string;
+  messages: IrisMessage[];
+}

--- a/crates/loom/frontend/src/views/Artifacts.vue
+++ b/crates/loom/frontend/src/views/Artifacts.vue
@@ -23,7 +23,7 @@ const router = useRouter();
 
 // Selecting a work-area tab returns to the session page, carrying which tab so
 // Overview lands on Overview (Terminal is the default).
-function selectTab(t: 'terminal' | 'overview') {
+function selectTab(t: 'terminal' | 'overview' | 'conversation') {
   router.push(t === 'terminal' ? `/s/${props.id}` : `/s/${props.id}?tab=${t}`);
 }
 

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -9,6 +9,7 @@ import ScratchPanel from '../components/ScratchPanel.vue';
 import SessionPageHeader from '../components/SessionPageHeader.vue';
 import SessionTabs from '../components/SessionTabs.vue';
 import SessionOverview from '../components/SessionOverview.vue';
+import SessionConversation from '../components/SessionConversation.vue';
 
 const props = defineProps<{ id: string }>();
 const route = useRoute();
@@ -25,7 +26,10 @@ const error = ref('');
 // `?tab=overview` query deep-links the Overview tab (e.g. the list's open-issue
 // link). Files are no longer a tab — they live in the embedded editor panel.
 const initialTab = route.query.tab;
-const tab = ref<'terminal' | 'overview'>(initialTab === 'overview' ? 'overview' : 'terminal');
+type WorkTab = 'terminal' | 'overview' | 'conversation';
+const tab = ref<WorkTab>(
+  initialTab === 'overview' || initialTab === 'conversation' ? initialTab : 'terminal',
+);
 
 const issueCount = computed(() => issues.value.length + backlog.value.length);
 
@@ -202,6 +206,13 @@ onUnmounted(() => {
             :issues="issues"
             :backlog="backlog"
           />
+        </div>
+
+        <!-- Conversation — the agent's chat with the model (live, or the
+             archived capture). Mounted only when selected; it fetches on its
+             own and re-fetches via its Refresh button. -->
+        <div v-if="tab === 'conversation'" class="h-full">
+          <SessionConversation :id="props.id" />
         </div>
       </div>
     </div>

--- a/crates/loom/src/chatlog.rs
+++ b/crates/loom/src/chatlog.rs
@@ -1,0 +1,196 @@
+//! Capturing a session's agent conversation when it is archived.
+//!
+//! Archiving tears down a session's worktree, but its agent's conversation
+//! transcript lives outside the worktree (`~/.claude/projects/…`,
+//! `~/.codex/sessions/…`) and survives. At archive time we locate that
+//! transcript, normalize it to the [iris format](weaver_core::transcript::iris),
+//! and write two files under `<log_dir>/<branch>/`:
+//!
+//! * `chat.json` — the normalized iris log (machine-readable, re-renderable).
+//! * `chat.md` — a readable markdown render for review.
+//!
+//! `log_dir` is the `session.log_dir` setting, defaulting to
+//! `~/.iris/logs/sessions`. Everything here is best-effort: a capture failure
+//! returns a warning and never blocks the archive.
+
+use std::path::{Path, PathBuf};
+
+use weaver_core::branch::Branch;
+use weaver_core::transcript;
+
+use crate::db::Db;
+use crate::session::Session;
+
+/// Resolve the directory conversation logs are captured under: the
+/// `session.log_dir` setting, or `~/.iris/logs/sessions` when unset. `None` only
+/// when the default is needed but `$HOME` is unset.
+pub async fn log_dir(db: &Db) -> Option<PathBuf> {
+    let configured = weaver_core::config::get(db, "session.log_dir")
+        .await
+        .filter(|s| !s.trim().is_empty());
+    match configured {
+        Some(dir) => Some(PathBuf::from(dir.trim())),
+        None => std::env::var_os("HOME")
+            .map(|h| PathBuf::from(h).join(".iris").join("logs").join("sessions")),
+    }
+}
+
+/// A filesystem-safe single-component name for a branch: `weaver/fix-thing` →
+/// `weaver-fix-thing`. Mirrors the session-socket sanitizer — alphanumerics and
+/// `-`/`_`/`.` survive, everything else becomes `-`.
+fn branch_slug(branch: &Branch) -> String {
+    let s: String = branch
+        .branch
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if s.is_empty() {
+        branch.id.clone()
+    } else {
+        s
+    }
+}
+
+/// Capture `session`'s conversation log to `<log_dir>/<branch>/`. Returns any
+/// warnings (no transcript found, write failure) — never an error, so a capture
+/// problem can't abort the archive. Returns the written markdown path on success
+/// for logging.
+pub async fn capture(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+) -> (Option<PathBuf>, Vec<String>) {
+    let mut warnings = Vec::new();
+    let work_dir = PathBuf::from(&session.work_dir);
+
+    // Claude's transcript is a cheap path lookup, so always try it. Codex needs a
+    // `~/.codex` directory walk, so only fall back to it for an agent that could
+    // be Codex — never for a plain `shell`/`none` session, which has no
+    // conversation and would pay for the scan for nothing.
+    let mut source = transcript::Source::Claude;
+    let mut files = transcript::claude_transcripts_for(&work_dir);
+    let conversational = !matches!(session.agent_kind.as_str(), "shell" | "none");
+    if files.is_empty() && conversational {
+        files = transcript::codex_transcripts_for(&work_dir);
+        source = transcript::Source::Codex;
+    }
+    if files.is_empty() {
+        // Missing transcript for a real agent is worth a warning; for a shell
+        // session it's expected, so stay quiet.
+        if conversational {
+            warnings.push(format!(
+                "no agent transcript found for {}",
+                work_dir.display()
+            ));
+        }
+        return (None, warnings);
+    }
+    let Some(log) = transcript::parse_files(&files) else {
+        warnings.push(format!(
+            "found {} transcript file(s) but none parsed",
+            files.len()
+        ));
+        return (None, warnings);
+    };
+
+    let Some(dir) = log_dir(db).await else {
+        warnings.push("cannot resolve session log dir (HOME unset)".to_string());
+        return (None, warnings);
+    };
+    let dest = dir.join(branch_slug(branch));
+    match write_log(&dest, &log).await {
+        Ok(md_path) => {
+            tracing::info!(
+                branch = %branch.branch, source = ?source,
+                messages = log.messages.len(), path = %md_path.display(),
+                "captured conversation log"
+            );
+            (Some(md_path), warnings)
+        }
+        Err(e) => {
+            warnings.push(format!("writing session log to {}: {e}", dest.display()));
+            (None, warnings)
+        }
+    }
+}
+
+/// Write the iris JSON and rendered markdown into `dest`, returning the markdown
+/// path.
+async fn write_log(dest: &Path, log: &transcript::Log) -> std::io::Result<PathBuf> {
+    tokio::fs::create_dir_all(dest).await?;
+    tokio::fs::write(dest.join("chat.json"), log.to_json()).await?;
+    let md_path = dest.join("chat.md");
+    tokio::fs::write(&md_path, log.render_markdown()).await?;
+    Ok(md_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn branch(name: &str) -> Branch {
+        Branch {
+            id: "abc12345".to_string(),
+            repo_root: "/repo".to_string(),
+            branch: name.to_string(),
+            base_branch: "main".to_string(),
+            goal: String::new(),
+            title: String::new(),
+            description: String::new(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn branch_slug_is_a_safe_single_component() {
+        assert_eq!(branch_slug(&branch("weaver/fix-thing")), "weaver-fix-thing");
+        assert_eq!(branch_slug(&branch("feature/a_b.c")), "feature-a_b.c");
+    }
+
+    #[tokio::test]
+    async fn log_dir_honors_the_setting_and_defaults_under_iris() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        // Unset → default under $HOME/.iris.
+        let def = log_dir(&db).await.unwrap();
+        assert!(def.ends_with("logs/sessions"), "default: {}", def.display());
+        assert!(def.to_string_lossy().contains(".iris"));
+
+        // Set → used verbatim.
+        weaver_core::config::apply(&db, &[("session.log_dir".into(), Some("/tmp/logs".into()))])
+            .await
+            .unwrap();
+        assert_eq!(log_dir(&db).await.unwrap(), PathBuf::from("/tmp/logs"));
+    }
+
+    #[tokio::test]
+    async fn write_log_produces_both_files() {
+        let tmp = std::env::temp_dir().join(format!("chatlog-test-{}", std::process::id()));
+        let log = transcript::Log {
+            source: "claude".into(),
+            session_id: Some("s1".into()),
+            model: None,
+            cwd: None,
+            messages: vec![transcript::Message::new(
+                transcript::Role::User,
+                None,
+                vec![transcript::Block::text("hi")],
+            )],
+        };
+        let md = write_log(&tmp, &log).await.unwrap();
+        assert!(md.ends_with("chat.md"));
+        let md_body = tokio::fs::read_to_string(&md).await.unwrap();
+        assert!(md_body.contains("# Conversation log"));
+        let json = tokio::fs::read_to_string(tmp.join("chat.json"))
+            .await
+            .unwrap();
+        assert!(json.contains("\"source\": \"claude\""));
+        tokio::fs::remove_dir_all(&tmp).await.ok();
+    }
+}

--- a/crates/loom/src/chatlog.rs
+++ b/crates/loom/src/chatlog.rs
@@ -1,17 +1,22 @@
-//! Capturing a session's agent conversation when it is archived.
+//! Capturing and serving a session's agent conversation.
 //!
 //! Archiving tears down a session's worktree, but its agent's conversation
 //! transcript lives outside the worktree (`~/.claude/projects/…`,
-//! `~/.codex/sessions/…`) and survives. At archive time we locate that
-//! transcript, normalize it to the [iris format](weaver_core::transcript::iris),
-//! and write two files under `<log_dir>/<branch>/`:
+//! `~/.codex/sessions/…`) and survives. At archive time [`capture`] locates that
+//! transcript, normalizes it to the [iris format](weaver_core::transcript::iris),
+//! and writes two files under `<log_dir>/<branch>/`:
 //!
 //! * `chat.json` — the normalized iris log (machine-readable, re-renderable).
 //! * `chat.md` — a readable markdown render for review.
 //!
+//! [`conversation`] loads the same iris log for the dashboard's Conversation
+//! view, working for both a live session (parse the transcript fresh) and an
+//! archived one (the live transcript usually still exists; the captured
+//! `chat.json` is the durable fallback if it's been cleaned up).
+//!
 //! `log_dir` is the `session.log_dir` setting, defaulting to
-//! `~/.iris/logs/sessions`. Everything here is best-effort: a capture failure
-//! returns a warning and never blocks the archive.
+//! `~/.iris/logs/sessions`. Capture is best-effort: a failure returns a warning
+//! and never blocks the archive.
 
 use std::path::{Path, PathBuf};
 
@@ -57,6 +62,49 @@ fn branch_slug(branch: &Branch) -> String {
     }
 }
 
+/// Locate a session's live agent transcript files (oldest first). Claude's are a
+/// cheap path lookup, so always try them; Codex needs a `~/.codex` directory
+/// walk, so only fall back to it for an agent that could be Codex — never for a
+/// plain `shell`/`none` session, which has no conversation and would pay for the
+/// scan for nothing. Empty when none are found.
+fn locate(session: &Session) -> Vec<PathBuf> {
+    let work_dir = PathBuf::from(&session.work_dir);
+    let files = transcript::claude_transcripts_for(&work_dir);
+    if !files.is_empty() {
+        return files;
+    }
+    if matches!(session.agent_kind.as_str(), "shell" | "none") {
+        return Vec::new();
+    }
+    transcript::codex_transcripts_for(&work_dir)
+}
+
+/// The captured iris-JSON path for a session's branch (`<log_dir>/<branch>/
+/// chat.json`), whether or not it exists yet. `None` only when the log dir can't
+/// be resolved.
+pub async fn captured_json_path(db: &Db, branch: &Branch) -> Option<PathBuf> {
+    Some(
+        log_dir(db)
+            .await?
+            .join(branch_slug(branch))
+            .join("chat.json"),
+    )
+}
+
+/// The session's conversation as an iris [`Log`](transcript::Log), for the
+/// dashboard viewer. Prefers the live transcript (always fresh); falls back to
+/// the captured `chat.json` for an archived session whose transcript files have
+/// since been cleaned up. `None` when neither is available.
+pub async fn conversation(db: &Db, session: &Session, branch: &Branch) -> Option<transcript::Log> {
+    let files = locate(session);
+    if let Some(log) = transcript::parse_files(&files) {
+        return Some(log);
+    }
+    let path = captured_json_path(db, branch).await?;
+    let raw = tokio::fs::read_to_string(&path).await.ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
 /// Capture `session`'s conversation log to `<log_dir>/<branch>/`. Returns any
 /// warnings (no transcript found, write failure) — never an error, so a capture
 /// problem can't abort the archive. Returns the written markdown path on success
@@ -67,26 +115,14 @@ pub async fn capture(
     branch: &Branch,
 ) -> (Option<PathBuf>, Vec<String>) {
     let mut warnings = Vec::new();
-    let work_dir = PathBuf::from(&session.work_dir);
-
-    // Claude's transcript is a cheap path lookup, so always try it. Codex needs a
-    // `~/.codex` directory walk, so only fall back to it for an agent that could
-    // be Codex — never for a plain `shell`/`none` session, which has no
-    // conversation and would pay for the scan for nothing.
-    let mut source = transcript::Source::Claude;
-    let mut files = transcript::claude_transcripts_for(&work_dir);
-    let conversational = !matches!(session.agent_kind.as_str(), "shell" | "none");
-    if files.is_empty() && conversational {
-        files = transcript::codex_transcripts_for(&work_dir);
-        source = transcript::Source::Codex;
-    }
+    let files = locate(session);
     if files.is_empty() {
         // Missing transcript for a real agent is worth a warning; for a shell
         // session it's expected, so stay quiet.
-        if conversational {
+        if !matches!(session.agent_kind.as_str(), "shell" | "none") {
             warnings.push(format!(
                 "no agent transcript found for {}",
-                work_dir.display()
+                session.work_dir
             ));
         }
         return (None, warnings);
@@ -107,7 +143,7 @@ pub async fn capture(
     match write_log(&dest, &log).await {
         Ok(md_path) => {
             tracing::info!(
-                branch = %branch.branch, source = ?source,
+                branch = %branch.branch, source = %log.source,
                 messages = log.messages.len(), path = %md_path.display(),
                 "captured conversation log"
             );

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -10,6 +10,7 @@ pub mod agent_env;
 pub mod auth;
 pub mod backend;
 pub mod builtins;
+pub mod chatlog;
 pub mod client;
 pub mod db;
 pub mod endpoint;

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -434,6 +434,7 @@ pub fn router(state: AppState) -> Router {
                 .delete(delete_scratch),
         )
         .route("/sessions/{id}/log", get(log_session))
+        .route("/sessions/{id}/conversation", get(conversation_session))
         .route("/sessions/{id}/events", get(events_sse))
         .route("/sessions/{id}/terminal", get(crate::terminal::terminal_ws))
         // Drive a session's terminal pane: type a message, interrupt, peek at it.
@@ -1889,6 +1890,20 @@ async fn log_session(
 ) -> ApiResult<Json<Vec<Event>>> {
     let branch = require_branch(&st.db, &key).await?;
     Ok(Json(events::history(&st.db, &branch.id, 200).await?))
+}
+
+/// The session's agent conversation as a normalized iris log — the live
+/// transcript when present, else the capture archived alongside it. 404 when the
+/// session has no conversation (e.g. a `shell` session, or none recorded yet).
+async fn conversation_session(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<weaver_core::transcript::Log>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    match crate::chatlog::conversation(&st.db, &session, &branch).await {
+        Some(log) => Ok(Json(log)),
+        None => Err(AppError::not_found("conversation")),
+    }
 }
 
 async fn events_sse(

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -1197,6 +1197,12 @@ pub async fn archive(
 ) -> Result<Vec<String>, AppError> {
     let mut warnings: Vec<String> = Vec::new();
 
+    // Capture the agent's conversation log before teardown. The transcript lives
+    // outside the worktree so it would survive removal, but capturing first keeps
+    // it whole regardless. Best-effort: failures are warnings, never fatal.
+    let (_, log_warnings) = crate::chatlog::capture(&st.db, session, branch).await;
+    warnings.extend(log_warnings);
+
     backend::kill_session(&session.term_session).await.ok();
     st.ide.kill(&session.id);
     let repo_root = PathBuf::from(&branch.repo_root);

--- a/crates/loom/tests/integration/archive.rs
+++ b/crates/loom/tests/integration/archive.rs
@@ -11,6 +11,106 @@ use loom::backend;
 
 use crate::fixtures::{branch_tag, TestServer};
 
+/// Restores `$HOME` on drop, so a test that points it at a temp dir (to exercise
+/// transcript capture, which reads `~/.claude`) can't leak that into siblings.
+struct HomeGuard(Option<std::ffi::OsString>);
+impl HomeGuard {
+    fn set(path: &Path) -> Self {
+        let prev = std::env::var_os("HOME");
+        std::env::set_var("HOME", path);
+        HomeGuard(prev)
+    }
+}
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        match &self.0 {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}
+
+/// Archiving captures the agent's conversation log: it locates the Claude Code
+/// transcript for the worktree (under `~/.claude/projects/<munged-cwd>/`),
+/// normalizes it, and writes a rendered `chat.md` and an iris `chat.json` under
+/// the configured session log dir — all before the worktree is torn down.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn archive_captures_the_conversation_log() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    // Point HOME (transcript source) and the log dir (capture sink) at temp dirs.
+    let home = tempfile::tempdir().unwrap();
+    let _home_guard = HomeGuard::set(home.path());
+    let logs = tempfile::tempdir().unwrap();
+
+    let sess = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "log me", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = sess["id"].as_str().unwrap().to_string();
+    let work_dir = sess["work_dir"].as_str().unwrap().to_string();
+
+    // Set the capture sink via the settings API.
+    client
+        .patch(
+            "/api/settings",
+            json!({ "session.log_dir": logs.path().to_string_lossy() }),
+        )
+        .await
+        .unwrap();
+
+    // Plant a Claude transcript where the agent would have written it: keyed off
+    // the worktree path the same way Claude Code munges it.
+    let proj = home.path().join(".claude").join("projects").join(
+        weaver_core::transcript::claude_project_dir_name(Path::new(&work_dir)),
+    );
+    std::fs::create_dir_all(&proj).unwrap();
+    let transcript = [
+        json!({"type": "user", "sessionId": "abc", "timestamp": "2026-06-17T10:00:00.000Z",
+               "message": {"role": "user", "content": "implement the thing"}}),
+        json!({"type": "assistant", "sessionId": "abc", "timestamp": "2026-06-17T10:00:01.000Z",
+               "message": {"role": "assistant", "model": "claude-opus-4-8",
+                           "content": [{"type": "text", "text": "Done — shipped it."}]}}),
+    ]
+    .iter()
+    .map(ToString::to_string)
+    .collect::<Vec<_>>()
+    .join("\n");
+    std::fs::write(proj.join("session.jsonl"), transcript).unwrap();
+
+    let res = client
+        .post(&format!("/api/sessions/{id}/archive"), json!({}))
+        .await
+        .unwrap();
+    assert_eq!(res["archived"], true);
+    let branch = res["branch"].as_str().unwrap();
+    let slug = branch.replace('/', "-");
+
+    // Both the rendered markdown and the normalized iris JSON are written.
+    let md = std::fs::read_to_string(logs.path().join(&slug).join("chat.md"))
+        .expect("chat.md should be captured on archive");
+    assert!(md.contains("# Conversation log"), "rendered markdown: {md}");
+    assert!(
+        md.contains("implement the thing"),
+        "user turn captured: {md}"
+    );
+    assert!(
+        md.contains("Done — shipped it."),
+        "assistant turn captured: {md}"
+    );
+
+    let raw_json = std::fs::read_to_string(logs.path().join(&slug).join("chat.json"))
+        .expect("chat.json should be captured on archive");
+    let iris: serde_json::Value = serde_json::from_str(&raw_json).unwrap();
+    assert_eq!(iris["source"], "claude");
+    assert_eq!(iris["messages"].as_array().unwrap().len(), 2);
+}
+
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn archive_keeps_branch_and_history() {

--- a/crates/loom/tests/integration/archive.rs
+++ b/crates/loom/tests/integration/archive.rs
@@ -9,26 +9,7 @@ use serial_test::serial;
 
 use loom::backend;
 
-use crate::fixtures::{branch_tag, TestServer};
-
-/// Restores `$HOME` on drop, so a test that points it at a temp dir (to exercise
-/// transcript capture, which reads `~/.claude`) can't leak that into siblings.
-struct HomeGuard(Option<std::ffi::OsString>);
-impl HomeGuard {
-    fn set(path: &Path) -> Self {
-        let prev = std::env::var_os("HOME");
-        std::env::set_var("HOME", path);
-        HomeGuard(prev)
-    }
-}
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        match &self.0 {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
-        }
-    }
-}
+use crate::fixtures::{branch_tag, plant_claude_transcript, HomeGuard, TestServer};
 
 /// Archiving captures the agent's conversation log: it locates the Claude Code
 /// transcript for the worktree (under `~/.claude/projects/<munged-cwd>/`),
@@ -64,24 +45,13 @@ async fn archive_captures_the_conversation_log() {
         .await
         .unwrap();
 
-    // Plant a Claude transcript where the agent would have written it: keyed off
-    // the worktree path the same way Claude Code munges it.
-    let proj = home.path().join(".claude").join("projects").join(
-        weaver_core::transcript::claude_project_dir_name(Path::new(&work_dir)),
+    // Plant a Claude transcript where the agent would have written it.
+    plant_claude_transcript(
+        home.path(),
+        &work_dir,
+        "implement the thing",
+        "Done — shipped it.",
     );
-    std::fs::create_dir_all(&proj).unwrap();
-    let transcript = [
-        json!({"type": "user", "sessionId": "abc", "timestamp": "2026-06-17T10:00:00.000Z",
-               "message": {"role": "user", "content": "implement the thing"}}),
-        json!({"type": "assistant", "sessionId": "abc", "timestamp": "2026-06-17T10:00:01.000Z",
-               "message": {"role": "assistant", "model": "claude-opus-4-8",
-                           "content": [{"type": "text", "text": "Done — shipped it."}]}}),
-    ]
-    .iter()
-    .map(ToString::to_string)
-    .collect::<Vec<_>>()
-    .join("\n");
-    std::fs::write(proj.join("session.jsonl"), transcript).unwrap();
 
     let res = client
         .post(&format!("/api/sessions/{id}/archive"), json!({}))

--- a/crates/loom/tests/integration/conversation.rs
+++ b/crates/loom/tests/integration/conversation.rs
@@ -1,0 +1,54 @@
+//! `GET /api/sessions/{id}/conversation` — the normalized iris log behind the
+//! dashboard's Conversation tab.
+
+use serde_json::json;
+use serial_test::serial;
+
+use crate::fixtures::{plant_claude_transcript, HomeGuard, TestServer};
+
+/// With a transcript present, the endpoint returns the parsed iris log: source,
+/// model, and the user/assistant turns the viewer renders.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn conversation_endpoint_returns_the_iris_log() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let home = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(home.path());
+
+    let sess = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "chat me", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = sess["id"].as_str().unwrap().to_string();
+    let work_dir = sess["work_dir"].as_str().unwrap().to_string();
+
+    // Before any transcript exists, the endpoint 404s (no conversation yet).
+    assert!(
+        client
+            .get(&format!("/api/sessions/{id}/conversation"))
+            .await
+            .is_err(),
+        "no transcript yet → 404"
+    );
+
+    plant_claude_transcript(home.path(), &work_dir, "do the work", "Working on it.");
+
+    let log = client
+        .get(&format!("/api/sessions/{id}/conversation"))
+        .await
+        .unwrap();
+    assert_eq!(log["source"], "claude");
+    assert_eq!(log["model"], "claude-opus-4-8");
+    let messages = log["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0]["role"], "user");
+    assert_eq!(messages[0]["blocks"][0]["kind"], "text");
+    assert_eq!(messages[0]["blocks"][0]["text"], "do the work");
+    assert_eq!(messages[1]["role"], "assistant");
+    assert_eq!(messages[1]["blocks"][0]["text"], "Working on it.");
+}

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -180,6 +180,50 @@ impl TestServer {
     }
 }
 
+/// Restores `$HOME` on drop, so a test that points it at a temp dir (to exercise
+/// transcript capture / the conversation view, which read `~/.claude`) can't leak
+/// that into siblings. The suite is `#[serial]`, so the swap is safe.
+pub struct HomeGuard(Option<std::ffi::OsString>);
+impl HomeGuard {
+    pub fn set(path: &Path) -> Self {
+        let prev = std::env::var_os("HOME");
+        std::env::set_var("HOME", path);
+        HomeGuard(prev)
+    }
+}
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        match &self.0 {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}
+
+/// Plant a minimal two-turn Claude transcript where the agent would have written
+/// it for `work_dir` (`$HOME/.claude/projects/<munged-cwd>/session.jsonl`), so a
+/// test can exercise capture / the conversation view without a real agent run.
+pub fn plant_claude_transcript(home: &Path, work_dir: &str, user: &str, assistant: &str) {
+    let proj = home.join(".claude").join("projects").join(
+        weaver_core::transcript::claude_project_dir_name(Path::new(work_dir)),
+    );
+    std::fs::create_dir_all(&proj).unwrap();
+    let transcript = [
+        serde_json::json!({"type": "user", "sessionId": "abc",
+            "timestamp": "2026-06-17T10:00:00.000Z",
+            "message": {"role": "user", "content": user}}),
+        serde_json::json!({"type": "assistant", "sessionId": "abc",
+            "timestamp": "2026-06-17T10:00:01.000Z",
+            "message": {"role": "assistant", "model": "claude-opus-4-8",
+                        "content": [{"type": "text", "text": assistant}]}}),
+    ]
+    .iter()
+    .map(ToString::to_string)
+    .collect::<Vec<_>>()
+    .join("\n");
+    std::fs::write(proj.join("session.jsonl"), transcript).unwrap();
+}
+
 /// One tag off a `SessionView` (or `BranchView`) JSON `branch.tags` array by
 /// key, or `None` when the branch carries no tag for that key. The status axes
 /// — the agent's `attention` and an overlooker's `triage` — are tags, so this is

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod fixtures;
 mod archive;
 mod auth;
 mod branches;
+mod conversation;
 mod env;
 mod ide;
 mod overlookers;

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -289,6 +289,19 @@ pub const REGISTRY: &[SettingSpec] = &[
         group: "Editor",
         options: &[],
     },
+    SettingSpec {
+        key: "session.log_dir",
+        label: "Session log directory",
+        description: "Where the agent's conversation log is captured when a \
+            session is archived: a normalized `chat.json` and a rendered \
+            `chat.md` are written under `<dir>/<branch>/`. Empty uses \
+            `~/.iris/logs/sessions`. Point it at a persistent path when running \
+            in a container where the default home isn't a mounted volume.",
+        kind: SettingKind::String,
+        default: "",
+        group: "Sessions",
+        options: &[],
+    },
 ];
 
 /// Whether the Overlooker engine master switch is on. On by default.

--- a/crates/weaver-core/src/lib.rs
+++ b/crates/weaver-core/src/lib.rs
@@ -14,5 +14,6 @@ pub mod issue;
 pub mod migrations;
 pub mod overlooker;
 pub mod tags;
+pub mod transcript;
 
 pub use db::Db;

--- a/crates/weaver-core/src/transcript/claude.rs
+++ b/crates/weaver-core/src/transcript/claude.rs
@@ -1,0 +1,223 @@
+//! Claude Code raw transcript → [`iris`](super::iris) format.
+//!
+//! Claude Code writes one JSON object per line. The conversation lives in
+//! `user` / `assistant` records, each with a `message.content` that is either a
+//! plain string or an array of typed blocks (`text`, `thinking`, `tool_use`,
+//! `tool_result`). Tool results come back on a *following* `user` record whose
+//! content is only `tool_result` blocks — we fold those into an assistant-role
+//! message so they render under the tool call that produced them. Bookkeeping
+//! records (mode, permission-mode, snapshots) are dropped.
+
+use serde_json::Value;
+
+use super::iris::{Block, Log, Message, Role};
+
+/// Convert a Claude Code transcript (concatenated JSONL is fine) into an iris
+/// [`Log`]. Malformed lines and non-message records are skipped.
+pub fn to_iris(jsonl: &str) -> Log {
+    let records: Vec<Value> = jsonl
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+        .collect();
+
+    let session_id = records
+        .iter()
+        .find_map(|r| r.get("sessionId").and_then(Value::as_str))
+        .map(str::to_string);
+    let model = records
+        .iter()
+        .find_map(|r| {
+            r.get("message")
+                .and_then(|m| m.get("model"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_string);
+    let cwd = records
+        .iter()
+        .find_map(|r| r.get("cwd").and_then(Value::as_str))
+        .map(str::to_string);
+
+    let mut messages = Vec::new();
+    for rec in &records {
+        if let Some(msg) = convert_record(rec) {
+            messages.push(msg);
+        }
+    }
+
+    Log {
+        source: "claude".to_string(),
+        session_id,
+        model,
+        cwd,
+        messages,
+    }
+}
+
+fn convert_record(rec: &Value) -> Option<Message> {
+    let kind = rec.get("type").and_then(Value::as_str)?;
+    if kind != "user" && kind != "assistant" {
+        return None;
+    }
+    let timestamp = rec
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let is_meta = rec.get("isMeta").and_then(Value::as_bool) == Some(true);
+    let content = rec.get("message").and_then(|m| m.get("content"));
+
+    // Plain-string content: a real human prompt or a bare assistant reply.
+    if let Some(text) = content.and_then(Value::as_str) {
+        if text.trim().is_empty() {
+            return None;
+        }
+        let role = role_for(kind, is_meta);
+        return Some(Message::new(role, timestamp, vec![Block::text(text)]));
+    }
+
+    let blocks = content.and_then(Value::as_array)?;
+    let converted = convert_blocks(blocks);
+    if converted.is_empty() {
+        return None;
+    }
+
+    // A `user` record carrying only tool_result blocks is the result-bearer for
+    // the preceding assistant tool calls — attribute it to the assistant so it
+    // groups under that turn. One that also carries text is a real prompt.
+    let only_results = kind == "user"
+        && converted
+            .iter()
+            .all(|b| matches!(b, Block::ToolResult { .. } | Block::Image));
+    let role = if only_results {
+        Role::Assistant
+    } else {
+        role_for(kind, is_meta)
+    };
+    Some(Message::new(role, timestamp, converted))
+}
+
+fn role_for(kind: &str, is_meta: bool) -> Role {
+    if is_meta {
+        Role::Context
+    } else if kind == "assistant" {
+        Role::Assistant
+    } else {
+        Role::User
+    }
+}
+
+fn convert_blocks(blocks: &[Value]) -> Vec<Block> {
+    let mut out = Vec::new();
+    for block in blocks {
+        match block.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(t) = block.get("text").and_then(Value::as_str) {
+                    out.push(Block::text(t));
+                }
+            }
+            Some("thinking") => {
+                if let Some(t) = block.get("thinking").and_then(Value::as_str) {
+                    out.push(Block::thinking(t));
+                }
+            }
+            Some("tool_use") => {
+                let name = block
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("tool")
+                    .to_string();
+                let input = block.get("input").cloned().unwrap_or(Value::Null);
+                out.push(Block::ToolUse { name, input });
+            }
+            Some("tool_result") => {
+                let output = content_to_text(block.get("content"));
+                let is_error = block.get("is_error").and_then(Value::as_bool) == Some(true);
+                out.push(Block::tool_result(output, is_error));
+            }
+            Some("image") => out.push(Block::Image),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Flatten a content value to plain text: a bare string passes through; an array
+/// of `{type:text,text}` blocks is concatenated.
+fn content_to_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .filter_map(|b| b.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn line(v: Value) -> String {
+        v.to_string()
+    }
+
+    #[test]
+    fn converts_a_turn_with_thinking_tool_call_and_result() {
+        let jsonl = [
+            line(json!({"type": "mode", "sessionId": "s1"})),
+            line(json!({
+                "type": "user", "sessionId": "s1", "cwd": "/w",
+                "timestamp": "2026-06-17T10:00:00.000Z",
+                "message": {"role": "user", "content": "Fix the bug"}
+            })),
+            line(json!({
+                "type": "assistant", "sessionId": "s1",
+                "timestamp": "2026-06-17T10:00:01.000Z",
+                "message": {"role": "assistant", "model": "claude-opus-4-8", "content": [
+                    {"type": "thinking", "thinking": "Let me look."},
+                    {"type": "text", "text": "On it."},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}
+                ]}
+            })),
+            line(json!({
+                "type": "user", "sessionId": "s1",
+                "timestamp": "2026-06-17T10:00:02.000Z",
+                "message": {"role": "user", "content": [
+                    {"type": "tool_result", "content": "total 0", "is_error": false}
+                ]}
+            })),
+        ]
+        .join("\n");
+
+        let log = to_iris(&jsonl);
+        assert_eq!(log.source, "claude");
+        assert_eq!(log.session_id.as_deref(), Some("s1"));
+        assert_eq!(log.model.as_deref(), Some("claude-opus-4-8"));
+        assert_eq!(log.cwd.as_deref(), Some("/w"));
+        // mode record dropped → 3 messages (user, assistant, tool-result).
+        assert_eq!(log.messages.len(), 3);
+        assert!(matches!(log.messages[0].role, Role::User));
+        assert!(matches!(log.messages[1].role, Role::Assistant));
+        // The tool-result-only user record is folded onto the assistant.
+        assert!(matches!(log.messages[2].role, Role::Assistant));
+        assert!(matches!(
+            log.messages[2].blocks[0],
+            Block::ToolResult { .. }
+        ));
+    }
+
+    #[test]
+    fn marks_meta_records_as_context() {
+        let jsonl = line(json!({
+            "type": "user", "isMeta": true,
+            "message": {"role": "user", "content": "injected primer"}
+        }));
+        let log = to_iris(&jsonl);
+        assert_eq!(log.messages.len(), 1);
+        assert!(matches!(log.messages[0].role, Role::Context));
+    }
+}

--- a/crates/weaver-core/src/transcript/codex.rs
+++ b/crates/weaver-core/src/transcript/codex.rs
@@ -1,0 +1,385 @@
+//! Codex raw rollout transcript → [`iris`](super::iris) format.
+//!
+//! Codex writes a `rollout-*.jsonl` per session, one JSON object per line, each
+//! `{ timestamp, type, payload }`. Two streams are interleaved: `response_item`
+//! (the model's Responses-API items — messages, reasoning, function/tool calls
+//! and their outputs) and `event_msg` (UI-level events). We take the backbone
+//! from `response_item` and the *clean* user turns from `event_msg/user_message`
+//! — the `response_item` user messages are wrapped in injected context
+//! (AGENTS.md, environment, permissions), so using the event stream for prompts
+//! keeps the log clean. Everything else (`token_count`, `task_*`, duplicate
+//! `agent_message`, …) is dropped.
+//!
+//! Codex reasoning is usually `encrypted_content` with no plaintext summary, so
+//! thinking only appears when a summary is present.
+
+use serde_json::Value;
+
+use super::iris::{Block, Log, Message, Role};
+
+/// Convert a Codex rollout transcript (concatenated JSONL is fine) into an iris
+/// [`Log`]. Malformed lines and non-conversational records are skipped.
+pub fn to_iris(jsonl: &str) -> Log {
+    let records: Vec<Value> = jsonl
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+        .collect();
+
+    let mut session_id = None;
+    let mut model = None;
+    let mut cwd = None;
+    let mut messages = Vec::new();
+
+    for rec in &records {
+        let payload = rec.get("payload");
+        let top_type = rec.get("type").and_then(Value::as_str).unwrap_or("");
+        let ts = rec
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+
+        match top_type {
+            "session_meta" => {
+                if let Some(p) = payload {
+                    session_id = session_id
+                        .or_else(|| p.get("id").and_then(Value::as_str).map(str::to_string));
+                    cwd = cwd.or_else(|| p.get("cwd").and_then(Value::as_str).map(str::to_string));
+                }
+            }
+            "turn_context" => {
+                if let Some(p) = payload {
+                    model = model
+                        .or_else(|| p.get("model").and_then(Value::as_str).map(str::to_string));
+                    cwd = cwd.or_else(|| p.get("cwd").and_then(Value::as_str).map(str::to_string));
+                }
+            }
+            "event_msg" => {
+                if let Some(msg) = convert_event_msg(payload, ts) {
+                    messages.push(msg);
+                }
+            }
+            "response_item" => {
+                if let Some(msg) = convert_response_item(payload, ts) {
+                    messages.push(msg);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Log {
+        source: "codex".to_string(),
+        session_id,
+        model,
+        cwd,
+        messages,
+    }
+}
+
+/// Only `user_message` is taken from the event stream — the clean text the human
+/// actually typed. Everything else there duplicates `response_item` or is noise.
+fn convert_event_msg(payload: Option<&Value>, ts: Option<String>) -> Option<Message> {
+    let p = payload?;
+    if p.get("type").and_then(Value::as_str)? != "user_message" {
+        return None;
+    }
+    let text = p.get("message").and_then(Value::as_str)?.trim();
+    if text.is_empty() {
+        return None;
+    }
+    Some(Message::new(Role::User, ts, vec![Block::text(text)]))
+}
+
+fn convert_response_item(payload: Option<&Value>, ts: Option<String>) -> Option<Message> {
+    let p = payload?;
+    match p.get("type").and_then(Value::as_str)? {
+        "message" => convert_message(p, ts),
+        "reasoning" => convert_reasoning(p, ts),
+        "function_call" => {
+            let name = p.get("name").and_then(Value::as_str).unwrap_or("tool");
+            // `arguments` is a JSON string; surface it as structured input when it
+            // parses, else keep the raw string.
+            let input = p
+                .get("arguments")
+                .and_then(Value::as_str)
+                .map(parse_json_or_string)
+                .unwrap_or(Value::Null);
+            Some(Message::new(
+                Role::Assistant,
+                ts,
+                vec![Block::ToolUse {
+                    name: name.to_string(),
+                    input,
+                }],
+            ))
+        }
+        "custom_tool_call" => {
+            let name = p.get("name").and_then(Value::as_str).unwrap_or("tool");
+            // `input` here is a raw string (e.g. an apply_patch body).
+            let input = p.get("input").cloned().unwrap_or(Value::Null);
+            Some(Message::new(
+                Role::Assistant,
+                ts,
+                vec![Block::ToolUse {
+                    name: name.to_string(),
+                    input,
+                }],
+            ))
+        }
+        "function_call_output" | "custom_tool_call_output" => {
+            let (output, is_error) = tool_output(p.get("output"));
+            if output.trim().is_empty() {
+                return None;
+            }
+            Some(Message::new(
+                Role::Assistant,
+                ts,
+                vec![Block::tool_result(output, is_error)],
+            ))
+        }
+        "web_search_call" => {
+            let input = p
+                .get("action")
+                .or_else(|| p.get("query"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            Some(Message::new(
+                Role::Assistant,
+                ts,
+                vec![Block::ToolUse {
+                    name: "web_search".to_string(),
+                    input,
+                }],
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// A `response_item` message. `developer` is system/permissions material →
+/// [`Role::Context`]; `assistant` text is a reply; `user` is dropped (the clean
+/// prompt comes from `event_msg/user_message`).
+fn convert_message(p: &Value, ts: Option<String>) -> Option<Message> {
+    let role = p.get("role").and_then(Value::as_str)?;
+    let text = text_from_content(p.get("content"));
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    match role {
+        "assistant" => Some(Message::new(Role::Assistant, ts, vec![Block::text(text)])),
+        "developer" => Some(Message::new(Role::Context, ts, vec![Block::text(text)])),
+        _ => None,
+    }
+}
+
+/// Reasoning, only when a plaintext summary/content is present (it is usually
+/// just `encrypted_content`).
+fn convert_reasoning(p: &Value, ts: Option<String>) -> Option<Message> {
+    let mut text = text_from_content(p.get("summary"));
+    if text.trim().is_empty() {
+        text = text_from_content(p.get("content"));
+    }
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    Some(Message::new(
+        Role::Assistant,
+        ts,
+        vec![Block::thinking(text)],
+    ))
+}
+
+/// Pull display text out of a Responses-API content value: a bare string, or an
+/// array of `{text}` / `{type, text}` blocks (`input_text`, `output_text`,
+/// `summary_text`).
+fn text_from_content(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .filter_map(|b| match b {
+                Value::String(s) => Some(s.clone()),
+                Value::Object(_) => b.get("text").and_then(Value::as_str).map(str::to_string),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+/// A tool output, with Codex's two output envelopes unwrapped to just the text
+/// (and whether the command failed): the JSON `{"output": "...", "metadata": {
+/// "exit_code": N }}` form (apply_patch, MCP) and the `exec_command` text form
+/// (a `Chunk ID:` / `Process exited with code N` / `Output:` preamble). Anything
+/// else passes through unchanged with no error flag.
+fn tool_output(output: Option<&Value>) -> (String, bool) {
+    let Some(v) = output else {
+        return (String::new(), false);
+    };
+    let raw = match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
+    if let Ok(Value::Object(obj)) = serde_json::from_str::<Value>(&raw) {
+        if let Some(inner) = obj.get("output").and_then(Value::as_str) {
+            let failed = obj
+                .get("metadata")
+                .and_then(|m| m.get("exit_code"))
+                .and_then(Value::as_i64)
+                .map(|c| c != 0)
+                .unwrap_or(false);
+            return (inner.to_string(), failed);
+        }
+    }
+    if let Some(unwrapped) = strip_exec_envelope(&raw) {
+        return unwrapped;
+    }
+    (raw, false)
+}
+
+/// Strip the `exec_command` text preamble, returning just the command's output
+/// and whether it exited non-zero. The preamble is bookkeeping lines
+/// (`Chunk ID:`, `Wall time:`, `Process exited with code N`, `Original token
+/// count:`) terminated by an `Output:` line; the real output follows. `None`
+/// when the text isn't in that shape, so non-exec outputs are left untouched.
+fn strip_exec_envelope(raw: &str) -> Option<(String, bool)> {
+    if !raw.starts_with("Chunk ID:") && !raw.contains("\nProcess exited with code ") {
+        return None;
+    }
+    let (preamble, body) = raw.split_once("\nOutput:\n").or_else(|| {
+        // An empty-output command ends at a bare trailing `Output:`.
+        raw.split_once("\nOutput:").map(|(p, _)| (p, ""))
+    })?;
+    let failed = preamble
+        .lines()
+        .find_map(|l| l.strip_prefix("Process exited with code "))
+        .and_then(|c| c.trim().parse::<i64>().ok())
+        .map(|c| c != 0)
+        .unwrap_or(false);
+    Some((body.to_string(), failed))
+}
+
+/// Parse a JSON string into a [`Value`], or wrap it as a string when it isn't
+/// valid JSON.
+fn parse_json_or_string(s: &str) -> Value {
+    serde_json::from_str(s).unwrap_or_else(|_| Value::String(s.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn line(v: Value) -> String {
+        v.to_string()
+    }
+
+    #[test]
+    fn converts_meta_user_assistant_tools_and_drops_noise() {
+        let jsonl = [
+            line(json!({"timestamp": "t0", "type": "session_meta",
+                "payload": {"id": "sess-1", "cwd": "/home/me/proj"}})),
+            line(json!({"timestamp": "t0", "type": "turn_context",
+                "payload": {"model": "gpt-5.5", "cwd": "/home/me/proj"}})),
+            // Clean user prompt from the event stream.
+            line(json!({"timestamp": "t1", "type": "event_msg",
+                "payload": {"type": "user_message", "message": "review this"}})),
+            // Noise that must be dropped.
+            line(json!({"timestamp": "t1", "type": "event_msg",
+                "payload": {"type": "token_count", "info": {}}})),
+            line(json!({"timestamp": "t1", "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "dup"}})),
+            // The response_item user message (wrapped context) must be dropped.
+            line(json!({"timestamp": "t1", "type": "response_item",
+                "payload": {"type": "message", "role": "user",
+                    "content": [{"type": "input_text", "text": "# AGENTS.md ..."}]}})),
+            // Developer message → context.
+            line(json!({"timestamp": "t1", "type": "response_item",
+                "payload": {"type": "message", "role": "developer",
+                    "content": [{"type": "input_text", "text": "permissions ..."}]}})),
+            // Assistant reply.
+            line(json!({"timestamp": "t2", "type": "response_item",
+                "payload": {"type": "message", "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Looking now."}]}})),
+            // A function call + its output (with the JSON envelope + nonzero exit).
+            line(json!({"timestamp": "t3", "type": "response_item",
+                "payload": {"type": "function_call", "name": "exec_command",
+                    "arguments": "{\"cmd\":\"ls\"}", "call_id": "c1"}})),
+            line(json!({"timestamp": "t4", "type": "response_item",
+                "payload": {"type": "function_call_output", "call_id": "c1",
+                    "output": "{\"output\":\"boom\",\"metadata\":{\"exit_code\":1}}"}})),
+            // A custom tool call (raw-string input).
+            line(json!({"timestamp": "t5", "type": "response_item",
+                "payload": {"type": "custom_tool_call", "name": "apply_patch",
+                    "input": "*** Begin Patch", "call_id": "c2"}})),
+        ]
+        .join("\n");
+
+        let log = to_iris(&jsonl);
+        assert_eq!(log.source, "codex");
+        assert_eq!(log.session_id.as_deref(), Some("sess-1"));
+        assert_eq!(log.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(log.cwd.as_deref(), Some("/home/me/proj"));
+
+        let roles: Vec<Role> = log.messages.iter().map(|m| m.role).collect();
+        // user, developer→context, assistant, tool-call, tool-output, custom-call.
+        // The agent_message dup and the response_item user message are gone.
+        assert_eq!(roles.len(), 6, "messages: {:#?}", log.messages);
+        assert!(matches!(roles[0], Role::User));
+        assert!(matches!(roles[1], Role::Context));
+        assert!(matches!(roles[2], Role::Assistant));
+
+        // The user prompt is the clean event-stream text, not the AGENTS wrapper.
+        match &log.messages[0].blocks[0] {
+            Block::Text { text } => assert_eq!(text, "review this"),
+            b => panic!("expected user text, got {b:?}"),
+        }
+        // exec_command arguments parsed into structured input.
+        match &log.messages[3].blocks[0] {
+            Block::ToolUse { name, input } => {
+                assert_eq!(name, "exec_command");
+                assert_eq!(input.get("cmd").and_then(Value::as_str), Some("ls"));
+            }
+            b => panic!("expected tool_use, got {b:?}"),
+        }
+        // Output envelope unwrapped + flagged as an error (exit_code 1).
+        match &log.messages[4].blocks[0] {
+            Block::ToolResult { output, is_error } => {
+                assert_eq!(output, "boom");
+                assert!(is_error);
+            }
+            b => panic!("expected tool_result, got {b:?}"),
+        }
+        // Raw-string custom tool input preserved.
+        match &log.messages[5].blocks[0] {
+            Block::ToolUse { name, input } => {
+                assert_eq!(name, "apply_patch");
+                assert_eq!(input.as_str(), Some("*** Begin Patch"));
+            }
+            b => panic!("expected tool_use, got {b:?}"),
+        }
+    }
+
+    #[test]
+    fn strips_the_exec_command_envelope_and_reads_the_exit_code() {
+        let raw = "Chunk ID: abc\nWall time: 0.1 seconds\nProcess exited with code 2\n\
+                   Original token count: 9\nOutput:\nbad command\nsecond line\n";
+        let (body, failed) = strip_exec_envelope(raw).expect("recognized envelope");
+        assert_eq!(body, "bad command\nsecond line\n");
+        assert!(failed, "nonzero exit → error");
+
+        // A clean exit, output passed through tool_output end-to-end.
+        let ok = serde_json::json!("Chunk ID: x\nProcess exited with code 0\nOutput:\nhello\n");
+        let (body, failed) = tool_output(Some(&ok));
+        assert_eq!(body, "hello\n");
+        assert!(!failed);
+
+        // Plain output that isn't an envelope is left untouched.
+        assert_eq!(strip_exec_envelope("just some text"), None);
+    }
+}

--- a/crates/weaver-core/src/transcript/iris.rs
+++ b/crates/weaver-core/src/transcript/iris.rs
@@ -1,0 +1,380 @@
+//! The **iris log format**: one normalized, agent-agnostic representation of a
+//! coding-agent conversation, plus its markdown renderer.
+//!
+//! Every agent (Claude Code, Codex, …) records its conversation in its own raw
+//! shape. The per-agent converters ([`super::claude`], [`super::codex`]) flatten
+//! those into this single [`Log`] — a list of [`Message`]s, each a role and an
+//! ordered list of [`Block`]s. Everything downstream (the markdown renderer
+//! here, anything that wants to read a captured log) speaks only iris, so it
+//! never has to know which agent produced it.
+//!
+//! [`Log`] is `serde`-serializable, so a captured conversation persists as iris
+//! JSON and re-renders later without re-parsing the agent's raw transcript.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A whole conversation, normalized. `source` names the agent it came from
+/// (`"claude"`, `"codex"`); the rest is optional context the renderer banners.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Log {
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    pub messages: Vec<Message>,
+}
+
+/// Who a [`Message`] is from. `Context` is injected, non-conversational material
+/// (a session primer, system/permissions instructions) — kept for completeness
+/// but rendered out of the way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    User,
+    Assistant,
+    Context,
+}
+
+/// One message: who said it, when, and its ordered content blocks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: Role,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    pub blocks: Vec<Block>,
+}
+
+impl Message {
+    pub fn new(role: Role, timestamp: Option<String>, blocks: Vec<Block>) -> Self {
+        Self {
+            role,
+            timestamp,
+            blocks,
+        }
+    }
+}
+
+/// A unit of message content. Tool input is kept as raw JSON so the renderer
+/// owns all formatting decisions (a shell command fenced as `sh`, a patch as
+/// text, anything else as pretty JSON).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Block {
+    Text { text: String },
+    Thinking { text: String },
+    ToolUse { name: String, input: Value },
+    ToolResult { output: String, is_error: bool },
+    Image,
+}
+
+impl Block {
+    pub fn text(s: impl Into<String>) -> Self {
+        Block::Text { text: s.into() }
+    }
+    pub fn thinking(s: impl Into<String>) -> Self {
+        Block::Thinking { text: s.into() }
+    }
+    pub fn tool_result(output: impl Into<String>, is_error: bool) -> Self {
+        Block::ToolResult {
+            output: output.into(),
+            is_error,
+        }
+    }
+}
+
+impl Log {
+    /// Serialize to pretty iris JSON — the persisted capture format.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Render this conversation as a markdown-like log (see module-level docs of
+    /// [`super`]). Delegates to [`render_markdown`].
+    pub fn render_markdown(&self) -> String {
+        render_markdown(self)
+    }
+}
+
+/// A tool result longer than this many characters is truncated in the rendered
+/// log, with a marker noting how much was dropped — one noisy command (a big
+/// `cat`, a test run) shouldn't drown the conversation.
+const MAX_RESULT_CHARS: usize = 3000;
+
+/// Render an iris [`Log`] as a markdown-like conversation: a metadata banner,
+/// then each turn under a role heading — user prompts, assistant replies,
+/// collapsible thinking, and each tool call with its (truncated) result.
+/// Consecutive assistant messages share one heading so an agent that emits each
+/// reply, reasoning, and tool call as a separate record still reads as one turn.
+pub fn render_markdown(log: &Log) -> String {
+    let mut out = String::new();
+    out.push_str("# Conversation log\n\n");
+    out.push_str(&banner(log));
+    out.push_str("\n---\n");
+
+    let mut prev_role: Option<Role> = None;
+    for msg in &log.messages {
+        let time = msg.timestamp.as_deref().map(short_time).unwrap_or_default();
+        match msg.role {
+            Role::Context => render_context(&mut out, msg),
+            Role::User => {
+                push_heading(&mut out, "🧑 User", &time);
+                render_blocks(&mut out, &msg.blocks);
+            }
+            Role::Assistant => {
+                // One heading per contiguous assistant run.
+                if prev_role != Some(Role::Assistant) {
+                    push_heading(&mut out, "🤖 Assistant", &time);
+                }
+                render_blocks(&mut out, &msg.blocks);
+            }
+        }
+        prev_role = Some(msg.role);
+    }
+    out
+}
+
+/// The one-line metadata banner under the title: source agent, message count,
+/// model, and the time span covered.
+fn banner(log: &Log) -> String {
+    let mut parts = Vec::new();
+    if !log.source.is_empty() {
+        parts.push(log.source.clone());
+    }
+    parts.push(format!("{} messages", log.messages.len()));
+    if let Some(m) = &log.model {
+        parts.push(m.clone());
+    }
+    let times: Vec<&str> = log
+        .messages
+        .iter()
+        .filter_map(|m| m.timestamp.as_deref())
+        .collect();
+    if let (Some(first), Some(last)) = (times.first(), times.last()) {
+        parts.push(format!("{first} – {last}"));
+    }
+    format!("_{}_\n", parts.join(" · "))
+}
+
+fn push_heading(out: &mut String, label: &str, time: &str) {
+    if time.is_empty() {
+        out.push_str(&format!("\n## {label}\n\n"));
+    } else {
+        out.push_str(&format!("\n## {label} · {time}\n\n"));
+    }
+}
+
+/// Injected context (a primer, system instructions) — collapsed out of the way
+/// so it's available but doesn't dominate the log.
+fn render_context(out: &mut String, msg: &Message) {
+    let text: String = msg
+        .blocks
+        .iter()
+        .filter_map(|b| match b {
+            Block::Text { text } | Block::Thinking { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let text = text.trim();
+    if text.is_empty() {
+        return;
+    }
+    out.push_str("\n<details><summary>📎 Context</summary>\n\n");
+    out.push_str(truncate(text, MAX_RESULT_CHARS).trim_end());
+    out.push_str("\n\n</details>\n\n");
+}
+
+fn render_blocks(out: &mut String, blocks: &[Block]) {
+    for block in blocks {
+        match block {
+            Block::Text { text } => {
+                let t = text.trim();
+                if !t.is_empty() {
+                    out.push_str(t);
+                    out.push_str("\n\n");
+                }
+            }
+            Block::Thinking { text } => {
+                let t = text.trim();
+                if !t.is_empty() {
+                    out.push_str("<details><summary>💭 Thinking</summary>\n\n");
+                    out.push_str(t);
+                    out.push_str("\n\n</details>\n\n");
+                }
+            }
+            Block::ToolUse { name, input } => render_tool_use(out, name, input),
+            Block::ToolResult { output, is_error } => render_tool_result(out, output, *is_error),
+            Block::Image => out.push_str("_[image]_\n\n"),
+        }
+    }
+}
+
+/// `🔧 **Tool**` with its input fenced: a shell command as `sh`, a bare string
+/// (e.g. a patch) as a plain fence, anything structured as pretty JSON.
+fn render_tool_use(out: &mut String, name: &str, input: &Value) {
+    out.push_str(&format!("🔧 **{name}**\n\n"));
+    let command = input
+        .get("command")
+        .or_else(|| input.get("cmd"))
+        .and_then(Value::as_str);
+    if let Some(cmd) = command {
+        fence(out, "sh", cmd);
+    } else if let Some(s) = input.as_str() {
+        if !s.trim().is_empty() {
+            fence(out, "", s);
+        }
+    } else if let Some(obj) = input.as_object() {
+        if !obj.is_empty() {
+            let pretty = serde_json::to_string_pretty(obj).unwrap_or_default();
+            fence(out, "json", &pretty);
+        }
+    }
+}
+
+/// A tool's output, collapsed and truncated; errors flagged in the summary.
+fn render_tool_result(out: &mut String, output: &str, is_error: bool) {
+    let text = output.trim();
+    if text.is_empty() {
+        return;
+    }
+    let label = if is_error {
+        "↳ result (error)"
+    } else {
+        "↳ result"
+    };
+    out.push_str(&format!("<details><summary>{label}</summary>\n\n```\n"));
+    out.push_str(truncate(text, MAX_RESULT_CHARS).trim_end());
+    out.push_str("\n```\n\n</details>\n\n");
+}
+
+/// Append a fenced code block, truncated to [`MAX_RESULT_CHARS`].
+fn fence(out: &mut String, lang: &str, body: &str) {
+    out.push_str("```");
+    out.push_str(lang);
+    out.push('\n');
+    out.push_str(truncate(body, MAX_RESULT_CHARS).trim_end());
+    out.push_str("\n```\n\n");
+}
+
+/// The `HH:MM:SS` of an ISO-8601 timestamp (`2026-06-17T18:30:00.000Z`), or the
+/// whole string when it isn't in that shape.
+fn short_time(ts: &str) -> String {
+    let bytes = ts.as_bytes();
+    if bytes.len() >= 19 && bytes[10] == b'T' {
+        ts[11..19].to_string()
+    } else {
+        ts.to_string()
+    }
+}
+
+/// Truncate to `max` characters on a char boundary, appending a marker that says
+/// how many characters were dropped.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let kept: String = s.chars().take(max).collect();
+    let dropped = s.chars().count() - max;
+    format!("{kept}\n… (truncated, {dropped} more characters)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn log_with(messages: Vec<Message>) -> Log {
+        Log {
+            source: "claude".into(),
+            session_id: Some("s1".into()),
+            model: Some("claude-opus-4-8".into()),
+            cwd: None,
+            messages,
+        }
+    }
+
+    #[test]
+    fn groups_consecutive_assistant_messages_under_one_heading() {
+        let log = log_with(vec![
+            Message::new(
+                Role::User,
+                Some("2026-06-17T10:00:00.000Z".into()),
+                vec![Block::text("Fix it")],
+            ),
+            Message::new(
+                Role::Assistant,
+                Some("2026-06-17T10:00:01.000Z".into()),
+                vec![
+                    Block::thinking("hmm"),
+                    Block::text("On it."),
+                    Block::ToolUse {
+                        name: "Bash".into(),
+                        input: json!({"command": "ls -la"}),
+                    },
+                ],
+            ),
+            // The tool result arrives as its own assistant-role message; it must
+            // NOT start a second "Assistant" heading.
+            Message::new(
+                Role::Assistant,
+                Some("2026-06-17T10:00:02.000Z".into()),
+                vec![Block::tool_result("total 0", false)],
+            ),
+        ]);
+        let md = render_markdown(&log);
+        assert!(md.contains("# Conversation log"));
+        assert!(md.contains("claude · 3 messages · claude-opus-4-8"));
+        assert_eq!(
+            md.matches("## 🤖 Assistant").count(),
+            1,
+            "one heading: {md}"
+        );
+        assert!(md.contains("## 🧑 User · 10:00:00"));
+        assert!(md.contains("<details><summary>💭 Thinking</summary>"));
+        assert!(md.contains("🔧 **Bash**"));
+        assert!(md.contains("```sh\nls -la\n```"));
+        assert!(md.contains("<details><summary>↳ result</summary>"));
+        assert!(md.contains("total 0"));
+    }
+
+    #[test]
+    fn renders_string_input_and_error_result_and_context() {
+        let log = log_with(vec![
+            Message::new(Role::Context, None, vec![Block::text("primer")]),
+            Message::new(
+                Role::Assistant,
+                None,
+                vec![
+                    Block::ToolUse {
+                        name: "apply_patch".into(),
+                        input: json!("*** Begin Patch"),
+                    },
+                    Block::tool_result("boom", true),
+                ],
+            ),
+        ]);
+        let md = render_markdown(&log);
+        assert!(md.contains("<details><summary>📎 Context</summary>"));
+        assert!(md.contains("🔧 **apply_patch**"));
+        assert!(md.contains("*** Begin Patch"));
+        assert!(md.contains("↳ result (error)"));
+    }
+
+    #[test]
+    fn iris_log_round_trips_through_json() {
+        let log = log_with(vec![Message::new(
+            Role::User,
+            None,
+            vec![Block::text("hi")],
+        )]);
+        let json = log.to_json();
+        let back: Log = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.messages.len(), 1);
+        assert_eq!(back.source, "claude");
+        assert!(matches!(back.messages[0].role, Role::User));
+    }
+}

--- a/crates/weaver-core/src/transcript/mod.rs
+++ b/crates/weaver-core/src/transcript/mod.rs
@@ -1,0 +1,276 @@
+//! Reading a coding agent's conversation transcript and rendering it for review.
+//!
+//! Two parts, deliberately separated:
+//!
+//! 1. **raw → iris** — per-agent converters ([`claude::to_iris`],
+//!    [`codex::to_iris`]) flatten an agent's own transcript shape into the one
+//!    normalized [`iris`] format. [`parse`] sniffs which agent produced a log and
+//!    dispatches.
+//! 2. **iris → markdown** — [`iris::render_markdown`] turns that normalized log
+//!    into a readable, markdown-like conversation, agent-agnostic.
+//!
+//! Plus the filesystem glue to *find* a worktree's transcript: Claude Code keys
+//! its `~/.claude/projects/<munged-cwd>/` dir off the working directory, so a
+//! worktree maps to its transcripts deterministically ([`claude_transcripts_for`])
+//! even after it's archived; Codex stores `~/.codex/sessions/.../rollout-*.jsonl`
+//! and records the cwd inside, so we match on that ([`codex_transcripts_for`]).
+//! This module is pure model + filesystem reads — no process spawning. loom calls
+//! it at archive time to capture the log; the `weaver chatlog` CLI renders on
+//! demand.
+
+pub mod claude;
+pub mod codex;
+pub mod iris;
+
+use std::path::{Path, PathBuf};
+
+pub use iris::{Block, Log, Message, Role};
+
+/// Which agent produced a raw transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    Claude,
+    Codex,
+}
+
+/// Sniff which agent produced a raw JSONL transcript. Codex records are tagged
+/// `{type: session_meta|response_item|event_msg|turn_context, payload}`; Claude
+/// records are `{type: user|assistant, message}`. Returns `None` when neither
+/// shape is recognised in the first handful of lines.
+pub fn detect(jsonl: &str) -> Option<Source> {
+    for line in jsonl
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .take(40)
+    {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let t = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if v.get("payload").is_some()
+            && matches!(
+                t,
+                "session_meta" | "response_item" | "event_msg" | "turn_context"
+            )
+        {
+            return Some(Source::Codex);
+        }
+        if matches!(t, "user" | "assistant") && v.get("message").is_some() {
+            return Some(Source::Claude);
+        }
+    }
+    None
+}
+
+/// Parse a raw transcript into the iris format, auto-detecting the agent. Returns
+/// `None` when the format isn't recognised.
+pub fn parse(jsonl: &str) -> Option<Log> {
+    match detect(jsonl)? {
+        Source::Claude => Some(claude::to_iris(jsonl)),
+        Source::Codex => Some(codex::to_iris(jsonl)),
+    }
+}
+
+/// Read a set of transcript files (in order), concatenate, and parse to iris.
+/// Unreadable files are skipped. Returns `None` when nothing parses.
+pub fn parse_files(paths: &[PathBuf]) -> Option<Log> {
+    let mut jsonl = String::new();
+    for p in paths {
+        if let Ok(s) = std::fs::read_to_string(p) {
+            jsonl.push_str(&s);
+            if !s.ends_with('\n') {
+                jsonl.push('\n');
+            }
+        }
+    }
+    if jsonl.trim().is_empty() {
+        return None;
+    }
+    parse(&jsonl)
+}
+
+/// Read and render a worktree's transcript to markdown — locating it across both
+/// agents ([`locate`]). `None` when no transcript is found or it can't be parsed.
+pub fn render_worktree(work_dir: &Path) -> Option<String> {
+    let (_, files) = locate(work_dir)?;
+    parse_files(&files).map(|log| log.render_markdown())
+}
+
+/// Find a worktree's transcript files, trying Claude first (its layout is an
+/// exact path lookup) then Codex (a bounded scan). Returns the source and the
+/// files oldest-first, or `None` when neither agent has a transcript for it.
+pub fn locate(work_dir: &Path) -> Option<(Source, Vec<PathBuf>)> {
+    let claude = claude_transcripts_for(work_dir);
+    if !claude.is_empty() {
+        return Some((Source::Claude, claude));
+    }
+    let codex = codex_transcripts_for(work_dir);
+    if !codex.is_empty() {
+        return Some((Source::Codex, codex));
+    }
+    None
+}
+
+// --- Claude Code transcript location -----------------------------------------
+
+/// `~/.claude/projects` for the current user, honouring `$HOME`.
+pub fn claude_projects_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".claude").join("projects"))
+}
+
+/// Claude Code's project-directory name for a working directory: every `/` and
+/// `.` becomes `-`. e.g. `/home/a/code/x/.worktrees/y` →
+/// `-home-a-code-x--worktrees-y`. Mirrors Claude Code's own munging.
+pub fn claude_project_dir_name(work_dir: &Path) -> String {
+    work_dir
+        .to_string_lossy()
+        .chars()
+        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .collect()
+}
+
+/// Every Claude transcript (`*.jsonl`) for a working directory, oldest first by
+/// mtime. A worktree accumulates one file per Claude session, so a resumed
+/// (`--continue`) session leaves several; ordering them reconstructs the whole
+/// conversation. Empty when the project dir is absent.
+pub fn claude_transcripts_for(work_dir: &Path) -> Vec<PathBuf> {
+    let Some(projects) = claude_projects_dir() else {
+        return Vec::new();
+    };
+    jsonl_files_sorted(&projects.join(claude_project_dir_name(work_dir)))
+}
+
+// --- Codex rollout transcript location ---------------------------------------
+
+/// `~/.codex/sessions` for the current user, honouring `$HOME`.
+pub fn codex_sessions_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".codex").join("sessions"))
+}
+
+/// Every Codex rollout transcript whose recorded cwd is `work_dir`, oldest first
+/// by mtime. Codex doesn't key its session files by path, so this walks the
+/// `~/.codex/sessions/YYYY/MM/DD/` tree and matches each file's `session_meta`
+/// cwd. Best-effort and bounded to the `.jsonl` rollouts; empty when none match.
+pub fn codex_transcripts_for(work_dir: &Path) -> Vec<PathBuf> {
+    let Some(root) = codex_sessions_dir() else {
+        return Vec::new();
+    };
+    let want = work_dir.to_string_lossy();
+    let mut matched: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    for path in walk_jsonl(&root) {
+        if rollout_cwd(&path).as_deref() == Some(want.as_ref()) {
+            let mtime = mtime_of(&path);
+            matched.push((mtime, path));
+        }
+    }
+    matched.sort_by_key(|(mtime, _)| *mtime);
+    matched.into_iter().map(|(_, p)| p).collect()
+}
+
+/// The cwd a Codex rollout was recorded in, read from its `session_meta` line
+/// (the first line). `None` when the file is unreadable or has no cwd.
+fn rollout_cwd(path: &Path) -> Option<String> {
+    use std::io::{BufRead, BufReader};
+    let file = std::fs::File::open(path).ok()?;
+    // The cwd lives in session_meta, which is the first record; scan a few lines
+    // in case anything precedes it.
+    for line in BufReader::new(file).lines().take(5).map_while(Result::ok) {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if let Some(cwd) = v
+            .get("payload")
+            .and_then(|p| p.get("cwd"))
+            .and_then(|c| c.as_str())
+        {
+            return Some(cwd.to_string());
+        }
+    }
+    None
+}
+
+// --- shared filesystem helpers -----------------------------------------------
+
+fn mtime_of(path: &Path) -> std::time::SystemTime {
+    path.metadata()
+        .and_then(|m| m.modified())
+        .unwrap_or(std::time::UNIX_EPOCH)
+}
+
+/// `*.jsonl` files directly in `dir`, oldest first by mtime. Empty when absent.
+fn jsonl_files_sorted(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut files: Vec<(std::time::SystemTime, PathBuf)> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "jsonl"))
+        .map(|p| (mtime_of(&p), p))
+        .collect();
+    files.sort_by_key(|(mtime, _)| *mtime);
+    files.into_iter().map(|(_, p)| p).collect()
+}
+
+/// All `*.jsonl` files anywhere under `root` (a shallow recursive walk).
+fn walk_jsonl(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|x| x == "jsonl") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn detects_claude_vs_codex() {
+        let claude =
+            json!({"type": "user", "message": {"role": "user", "content": "hi"}}).to_string();
+        let codex = json!({"type": "session_meta", "payload": {"id": "x"}}).to_string();
+        assert_eq!(detect(&claude), Some(Source::Claude));
+        assert_eq!(detect(&codex), Some(Source::Codex));
+        assert_eq!(detect("not json\n{}"), None);
+    }
+
+    #[test]
+    fn parse_dispatches_by_detected_source() {
+        let claude =
+            json!({"type": "user", "message": {"role": "user", "content": "hi"}}).to_string();
+        let log = parse(&claude).unwrap();
+        assert_eq!(log.source, "claude");
+
+        let codex = [
+            json!({"type": "session_meta", "payload": {"id": "x", "cwd": "/w"}}).to_string(),
+            json!({"type": "event_msg", "payload": {"type": "user_message", "message": "hey"}})
+                .to_string(),
+        ]
+        .join("\n");
+        let log = parse(&codex).unwrap();
+        assert_eq!(log.source, "codex");
+        assert_eq!(log.messages.len(), 1);
+    }
+
+    #[test]
+    fn munges_cwd_into_claude_project_dir_name() {
+        assert_eq!(
+            claude_project_dir_name(Path::new("/home/a/code/x/.worktrees/y")),
+            "-home-a-code-x--worktrees-y"
+        );
+    }
+}

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -103,6 +103,17 @@ enum Cmd {
         #[arg(long, default_value = "20")]
         limit: i64,
     },
+    /// Render the agent's conversation transcript as a markdown log. With no
+    /// `--file`, locates the current worktree's transcript (Claude Code or
+    /// Codex); `--json` prints the normalized iris format instead of markdown.
+    Chatlog {
+        /// Render this raw transcript file instead of locating one.
+        #[arg(long)]
+        file: Option<String>,
+        /// Print the normalized iris JSON rather than rendered markdown.
+        #[arg(long)]
+        json: bool,
+    },
     /// Record an agent hook event. Writes an `events` row; loom's monitor
     /// consumes it on its next tick.
     #[command(hide = true)]
@@ -331,6 +342,7 @@ async fn run() -> Result<()> {
         Cmd::Artifact { cmd } => cmd_artifact(cmd).await,
         Cmd::Where => cmd_where().await,
         Cmd::Log { limit } => cmd_log(limit).await,
+        Cmd::Chatlog { file, json } => cmd_chatlog(file, json),
         Cmd::Hook { event } => cmd_hook(event).await,
         Cmd::Config { cmd } => cmd_config(cmd).await,
         Cmd::Completions { shell } => {
@@ -533,6 +545,51 @@ fn next_action_hint(open: &[issue::Issue], delegated: &[issue::Issue]) -> String
         "no open tasks — wrap up and open a PR (`gh pr create`), or `weaver issue add` to track more"
             .to_string()
     }
+}
+
+/// Ascend from `start` to the enclosing git worktree root (the directory holding
+/// a `.git` entry — a dir in a normal clone, a file in a linked worktree).
+/// Falls back to `start` when none is found, so a non-repo path still resolves.
+fn worktree_root(start: &std::path::Path) -> std::path::PathBuf {
+    let mut dir = start;
+    loop {
+        if dir.join(".git").exists() {
+            return dir.to_path_buf();
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return start.to_path_buf(),
+        }
+    }
+}
+
+/// Render the current worktree's (or a named file's) agent transcript. No DB
+/// access — pure filesystem, so it works whether or not loom is up.
+fn cmd_chatlog(file: Option<String>, as_json: bool) -> Result<()> {
+    use weaver_core::transcript;
+    let log = match file {
+        Some(path) => {
+            let raw = std::fs::read_to_string(&path).map_err(|e| anyhow!("reading {path}: {e}"))?;
+            transcript::parse(&raw)
+                .ok_or_else(|| anyhow!("{path}: unrecognized transcript format"))?
+        }
+        None => {
+            // Agents key their transcript off the worktree root (where the agent
+            // was launched), so resolve that rather than the possibly-deeper cwd.
+            let cwd = std::env::current_dir()?;
+            let root = worktree_root(&cwd);
+            let (_, files) = transcript::locate(&root)
+                .ok_or_else(|| anyhow!("no agent transcript found for {}", root.display()))?;
+            transcript::parse_files(&files)
+                .ok_or_else(|| anyhow!("transcript found but could not be parsed"))?
+        }
+    };
+    if as_json {
+        println!("{}", log.to_json());
+    } else {
+        print!("{}", log.render_markdown());
+    }
+    Ok(())
 }
 
 async fn cmd_where() -> Result<()> {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,9 +43,9 @@ needing the daemon to be reachable.
 
 | Path | What's in it |
 |---|---|
-| `crates/weaver-core/` | lib: `branches`, `issues`, `events`, `db`, `migrations` (ordered SQL + `schema_migrations` indicator), `git`, `config`, `artifacts` (versioned documents), `repo_config` (`.weaver/config.toml`), agent helpers. Pure logic; used by both binaries. |
+| `crates/weaver-core/` | lib: `branches`, `issues`, `events`, `db`, `migrations` (ordered SQL + `schema_migrations` indicator), `git`, `config`, `artifacts` (versioned documents), `repo_config` (`.weaver/config.toml`), `transcript` (agent conversation logs: raw → iris format → markdown), agent helpers. Pure logic; used by both binaries. |
 | `crates/smartdoc/` | the markdown-convention layer: parse references (`#N`, `artifact:<name>`), project live status into the render. Dependency-free of weaver. See [artifacts.md](artifacts.md). |
-| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `readme`, `status` [read or set level + message], `tag` [`set`/`rm`/`ls` a branch tag], `issue …`, `where`, `log`, `hook`, `config`) |
+| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`goal`, `summary`, `readme`, `status` [read or set level + message], `tag` [`set`/`rm`/`ls` a branch tag], `issue …`, `where`, `log`, `chatlog` [render the agent's conversation transcript], `hook`, `config`) |
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** (incl. the auth middleware + login/token/user handlers) |
 | `crates/loom/src/auth.rs` | authentication core: token/password crypto, the `users`/`api_tokens`/`auth_sessions` tables, the machine-local token, and the GitHub OAuth calls. `axum`-free so it unit-tests directly |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
@@ -55,6 +55,7 @@ needing the daemon to be reachable.
 | `python/weaver-loom/` | the pure-Python layer over the loom REST API (`weaver_loom`: client + overlooker round context); stdlib-only, uv-buildable, vendored onto every script's `PYTHONPATH` by the engine; server-free contract tests in `tests/` (`uv run pytest`, CI's `python-binding` job) |
 | `crates/loom/src/agent.rs` | launching agents into per-session terminals + installing `.claude/settings.local.json` hooks + the one-shot headless agent behind `POST /api/agent/oneshot` |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
+| `crates/loom/src/chatlog.rs` | conversation-log capture at archive: locate the worktree's agent transcript, write the iris `chat.json` + rendered `chat.md` under `session.log_dir` |
 | `crates/loom/src/backend.rs` | the terminal-management seam: every programmatic terminal op (create/has/capture/send/kill/list) drives the session's `tapestry` supervisor |
 | `crates/tapestry/` | the terminal backend: a per-session detached PTY supervisor (PTY + vt100 screen emulator + unix control socket) that outlives loom and streams raw PTY bytes, so an attached xterm owns its own scrollback/search |
 | `crates/loom/src/terminal.rs` | WebSocket ⇄ live-terminal bridge: xterm.js ⇄ the tapestry session socket |
@@ -371,6 +372,19 @@ Archiving a session clears its loud tags **and** the soothing `idle` mark: the
 agent is gone, so a torn-down workstream can't still "need me" nor is it
 "resting", and the dashboard stops flagging or labelling it. The UI also treats
 any `archived` session as calm regardless of a stale tag left on the branch.
+
+Archiving also **captures the agent's conversation log** (`crate::chatlog`,
+inside the shared `web::archive`, so both the Archive button and the
+merge-archive poller get it). The agent's transcript lives outside the worktree —
+Claude Code under `~/.claude/projects/<munged-cwd>/`, Codex under
+`~/.codex/sessions/` — so it survives the worktree removal; capture locates it,
+normalizes it through `weaver_core::transcript` (raw → **iris format** → a
+rendered markdown log), and writes `chat.json` (iris) + `chat.md` under
+`<session.log_dir>/<branch>/` (`session.log_dir` defaults to
+`~/.iris/logs/sessions`). It is best-effort: a missing or unreadable transcript
+is a logged warning, never a failed archive. The same conversion/render pipeline
+backs `weaver chatlog`, which renders the current worktree's (or a named file's)
+transcript on demand.
 
 Orphan detection is independent: if the session's supervisor is no longer alive,
 the session becomes `orphaned` and is eligible for `loom adopt`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,7 @@ needing the daemon to be reachable.
 | `python/weaver-loom/` | the pure-Python layer over the loom REST API (`weaver_loom`: client + overlooker round context); stdlib-only, uv-buildable, vendored onto every script's `PYTHONPATH` by the engine; server-free contract tests in `tests/` (`uv run pytest`, CI's `python-binding` job) |
 | `crates/loom/src/agent.rs` | launching agents into per-session terminals + installing `.claude/settings.local.json` hooks + the one-shot headless agent behind `POST /api/agent/oneshot` |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
-| `crates/loom/src/chatlog.rs` | conversation-log capture at archive: locate the worktree's agent transcript, write the iris `chat.json` + rendered `chat.md` under `session.log_dir` |
+| `crates/loom/src/chatlog.rs` | conversation log: capture at archive (write the iris `chat.json` + rendered `chat.md` under `session.log_dir`) and serve it for the Conversation tab (`conversation()` — live transcript, else the capture) |
 | `crates/loom/src/backend.rs` | the terminal-management seam: every programmatic terminal op (create/has/capture/send/kill/list) drives the session's `tapestry` supervisor |
 | `crates/tapestry/` | the terminal backend: a per-session detached PTY supervisor (PTY + vt100 screen emulator + unix control socket) that outlives loom and streams raw PTY bytes, so an attached xterm owns its own scrollback/search |
 | `crates/loom/src/terminal.rs` | WebSocket ⇄ live-terminal bridge: xterm.js ⇄ the tapestry session socket |
@@ -187,6 +187,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/sessions/{id}/artifacts` | list the branch's [artifacts](artifacts.md) plus repo-shared ones |
 | `GET PUT /api/sessions/{id}/artifacts/{name}` | read content + projected refs (`rev=N` for a revision) / write a user edit as a new revision |
 | `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
+| `GET /api/sessions/{id}/conversation` | the agent conversation as a normalized iris log (live transcript, else the archive capture); 404 when there is none — backs the Conversation tab |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ the session's tapestry PTY (the interaction surface) |
 | `POST /api/sessions/{id}/send` | type `{text}` into the agent's terminal; `submit` (default true) follows it with Enter to trigger a round |
 | `POST /api/sessions/{id}/interrupt` | send a break (Escape) to the terminal — stop the current turn |
@@ -385,6 +386,13 @@ rendered markdown log), and writes `chat.json` (iris) + `chat.md` under
 is a logged warning, never a failed archive. The same conversion/render pipeline
 backs `weaver chatlog`, which renders the current worktree's (or a named file's)
 transcript on demand.
+
+The dashboard surfaces this as a **Conversation tab** on the session detail,
+backed by `GET /api/sessions/{id}/conversation` (`chatlog::conversation` →
+the live transcript when present, else the archived `chat.json`). The Vue viewer
+renders the iris log natively — user/assistant turns, collapsible thinking, and
+each tool call with its result — so a session stays reviewable in the UI after
+its terminal is gone.
 
 Orphan detection is independent: if the session's supervisor is no longer alive,
 the session becomes `orphaned` and is eligible for `loom adopt`.


### PR DESCRIPTION
## What

Capture a session's agent conversation when it's archived, so it stays
reviewable after the worktree is gone — and render it in a friendly,
markdown-like format. Closes weaver #218.

When a session is archived (the **Archive** button *or* auto-archive-on-merge),
loom locates the agent's transcript, normalizes it, and writes the log under
`session.log_dir` (default `~/.iris/logs/sessions/<branch>/`). The transcript
lives **outside** the worktree — Claude Code under `~/.claude/projects/`, Codex
under `~/.codex/sessions/` — so it survives teardown.

## How — two parts, as designed

A reusable `weaver_core::transcript` module, split exactly along the two
requested seams:

1. **raw → iris format.** Per-agent converters (`claude`, `codex`) flatten each
   agent's own transcript shape into one normalized, agent-agnostic
   `Log`/`Message`/`Block` model (the **iris format**). `parse()` sniffs the
   source and dispatches. Heuristics keep each clean:
   - *claude*: folds tool-result-only turns onto the assistant; marks injected
     `isMeta` turns as context.
   - *codex*: takes clean prompts from `event_msg/user_message` (the raw
     `response_item` user messages are wrapped in AGENTS/permissions context);
     drops `developer`/duplicate/bookkeeping records; parses tool arguments; and
     strips the `exec_command` output envelope, reading its exit code for the
     error flag.
2. **iris → markdown.** One renderer turns the normalized log into a readable
   conversation: role headings (grouped per turn), collapsible thinking, fenced
   tool calls, and truncated results — agent-agnostic.

The iris `Log` is `serde`-serializable, so capture writes both `chat.json` (the
normalized log) and `chat.md` (the render). `weaver chatlog` renders a live
worktree's transcript (or `--file <path>`, `--json`) on demand via the same
pipeline.

Capture is **best-effort**: a missing/unreadable transcript is a logged warning,
never a failed archive. Plain `shell`/`none` sessions are skipped (no
conversation, and it avoids a needless `~/.codex` scan).

## Config

New `session.log_dir` setting (blank ⇒ `~/.iris/logs/sessions`). Point it at a
persistent path when the home dir isn't a mounted volume.

## Tests

- weaver-core: claude/codex converters, the markdown renderer, format detection,
  exec-envelope stripping, iris JSON round-trip.
- loom: `chatlog` unit tests (log-dir resolution, slug, file writing) + an
  end-to-end integration test that archives a session and asserts `chat.md` /
  `chat.json` are captured.
- Validated the renderer against real Claude **and** Codex transcripts on disk.
- Full `cargo fmt` + `clippy -D warnings` + `cargo test --workspace` green; the
  pre-commit agent lint review passed.

## Docs

README (usage, archive behaviour, settings) and `docs/ARCHITECTURE.md` (module
layout, conversation-log capture) updated.