### PR TITLE
feat(loom): overlooker lookaside state + dynamic self-wake, and a `resume` watch

### DIFF
--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -280,6 +280,12 @@ export interface Overlooker {
   warm_session_id: string | null;
   last_run_at: string | null;
   next_run_at: string | null;
+  /** A one-shot dynamic re-trigger a round armed for itself (a backoff recheck),
+   *  or null. Distinct from `next_run_at` (the cron cadence). */
+  wake_at: string | null;
+  /** The program's lookaside state — its scratch memory carried across rounds
+   *  (e.g. a backoff watcher's per-session attempt counts). `{}` when none. */
+  state: Record<string, unknown>;
   /** The most recent round's outcome, or null if it has never run. */
   last_outcome: 'ok' | 'noop' | 'skipped' | 'error' | null;
   created_at: string;

--- a/crates/loom/frontend/src/views/OverlookerDetail.vue
+++ b/crates/loom/frontend/src/views/OverlookerDetail.vue
@@ -217,6 +217,7 @@ onMounted(() => {
             <span v-if="ov.last_run_at">last run {{ timeAgo(ov.last_run_at) }}</span>
             <span v-else>never run</span>
             <span v-if="ov.enabled && ov.next_run_at"> · next {{ timeAgo(ov.next_run_at) }}</span>
+            <span v-if="ov.enabled && ov.wake_at"> · recheck {{ timeAgo(ov.wake_at) }}</span>
           </p>
         </div>
         <div class="ml-auto flex items-center gap-2">

--- a/crates/loom/overlookers/resume.py
+++ b/crates/loom/overlookers/resume.py
@@ -1,0 +1,200 @@
+"""resume — when a session stalls on a transient API error, gently re-prompt it
+to continue, backing off exponentially so a sustained outage is never hammered.
+
+Claude Code surfaces a server-side overload as a line like
+``API Error: 529 Overloaded`` and then sits idle: the conversation is intact, so
+a single "continue" resumes it once the overload clears. This watch wakes when a
+session goes quiet (the idle / stale signals), reads the recent screen, and when
+it matches the transient-error pattern nudges the session to resume.
+
+But a nudge that itself 529s must not become a tight retry loop. So each
+consecutive stall doubles the wait before the next nudge — exponential backoff
+(``base_secs`` → ``max_secs``), tracked per session in the watch's **lookaside
+state** and driven by its **dynamic self-wake**: the watch re-triggers itself at
+the soonest due recheck (``rnd.wake_in``) rather than polling. While a session is
+inside its backoff window the watch leaves it alone — quietly waiting, not
+re-prompting. After ``max_attempts`` consecutive failures it escalates (marks the
+session ``attention``) and stops re-prompting until the session recovers, at
+which point it drops the session from tracking and clears the mark.
+
+State shape (opaque to the engine), per session id::
+
+    {"<session-id>": {"attempts": <int>, "next": <epoch-seconds>, "escalated": <bool>}}
+
+Honours dry_run: would-be nudges/marks are logged as actions and nothing
+mutates. Needs ``nudge`` to resume and ``mark`` to escalate; without a capability
+it records the would-be action and moves on.
+"""
+
+import re
+import time
+
+from weaver_loom import Round, WeaverError
+
+#: Wake when a session goes quiet — a finished turn (idle) or no activity
+#: (stale). The watch also re-triggers itself via wake_in for backoff rechecks.
+TRIGGERS = {"on": ["session.idle", "session.stale"]}
+
+#: The transient-error signature, overridable via params.pattern. Matches the
+#: Claude overload line (`API Error: 529 Overloaded`) and the bare word
+#: `Overloaded`; the `5\d\d` form also catches sibling 5xx API errors.
+DEFAULT_PATTERN = r"(?i)(api error:\s*5\d\d|overloaded)"
+
+#: What to type to resume; the conversation is intact, so "continue" is enough.
+DEFAULT_NUDGE = "continue"
+
+#: First backoff, the cap it doubles toward, and how many consecutive failures
+#: to re-prompt through before escalating instead. All overridable via params.
+DEFAULT_BASE_SECS = 30
+DEFAULT_MAX_SECS = 900
+DEFAULT_MAX_ATTEMPTS = 6
+
+#: How the escalation marks a session it has given up re-prompting.
+ESCALATE_VALUE = "attention"
+
+
+def _conf(rnd):
+    """The round's tuned parameters, with defaults filled in."""
+    p = rnd.params or {}
+    return {
+        "pattern": re.compile(p.get("pattern") or DEFAULT_PATTERN),
+        "nudge": p.get("nudge") or DEFAULT_NUDGE,
+        "base": float(p.get("base_secs") or DEFAULT_BASE_SECS),
+        "cap": float(p.get("max_secs") or DEFAULT_MAX_SECS),
+        "max_attempts": int(p.get("max_attempts") or DEFAULT_MAX_ATTEMPTS),
+        "lines": int(p.get("screen_lines") or 0),
+    }
+
+
+def is_stalled(rnd, sid, conf):
+    """Whether ``sid``'s current screen shows the transient-error signature.
+
+    Reads the live viewport (``screen_lines`` of scrollback, 0 = just what's on
+    screen) so a *recovered* session — whose error has scrolled out of view —
+    reads as healthy. A dead pane is treated as not-stalled (nothing to resume)."""
+    try:
+        screen = rnd.client.preview(sid, conf["lines"])
+    except WeaverError:
+        return False
+    return bool(conf["pattern"].search(screen or ""))
+
+
+def backoff(conf, attempts):
+    """The delay before the next nudge after ``attempts`` consecutive failures:
+    ``base * 2**(attempts-1)``, capped at ``max_secs``."""
+    return min(conf["cap"], conf["base"] * (2 ** max(0, attempts - 1)))
+
+
+def escalate(rnd, sid, attempts):
+    """Mark a session the watch has given up re-prompting (capability/dry-run
+    aware). Returns nothing; records the action it took or would take."""
+    note = "stalled on a transient API error after %d resume attempts" % attempts
+    if not rnd.can("mark"):
+        rnd.would("escalate", session=sid, note=note + " (mark capability not granted)")
+        return
+    if rnd.dry_run:
+        rnd.would("mark", session=sid, value=ESCALATE_VALUE, note=note)
+    else:
+        rnd.client.mark(sid, ESCALATE_VALUE, note, by=rnd.name)
+        rnd.did("mark", session=sid, value=ESCALATE_VALUE, note=note)
+
+
+def clear_escalation(rnd, sid):
+    """Clear the watch's escalation mark when a session recovers."""
+    if not rnd.can("mark"):
+        return
+    if rnd.dry_run:
+        rnd.would("clear", session=sid, key="triage")
+    else:
+        rnd.client.mark(sid, "ok", by=rnd.name)  # mark "ok" clears the triage tag
+        rnd.did("clear", session=sid, key="triage")
+
+
+def reprompt(rnd, sid, conf):
+    """Nudge a stalled session to resume (capability/dry-run aware). Returns True
+    when a (real or simulated) nudge was issued, False when the capability is
+    absent."""
+    if not rnd.can("nudge"):
+        rnd.would("nudge", session=sid, text=conf["nudge"], note="nudge capability not granted")
+        return False
+    if rnd.dry_run:
+        rnd.would("nudge", session=sid, text=conf["nudge"])
+    else:
+        rnd.client.nudge(sid, conf["nudge"], by=rnd.name)
+        rnd.did("nudge", session=sid, text=conf["nudge"])
+    return True
+
+
+def main(rnd):
+    conf = _conf(rnd)
+    now = time.time()
+    state = dict(rnd.state or {})
+
+    # The live fleet (scope-filtered). On a reactive idle/stale we examine just
+    # the session that fired plus any we are already tracking; on a cron/manual
+    # tick (which includes our own self-wake) we sweep the whole fleet, so a wake
+    # set for one session also catches others the same outage hit.
+    live = {s["id"]: s for s in rnd.sessions()}
+    trig_sid = (rnd.trigger or {}).get("session")
+    if trig_sid:
+        candidates = ({trig_sid} | set(state)) & set(live)
+    else:
+        candidates = set(live) | (set(state) & set(live))
+
+    nudged = 0
+    for sid in sorted(candidates):
+        st = state.get(sid) or {}
+        attempts = int(st.get("attempts") or 0)
+        next_at = float(st.get("next") or 0.0)
+        escalated = bool(st.get("escalated"))
+
+        if not is_stalled(rnd, sid, conf):
+            # Recovered (or never stalled): drop tracking and clear any mark.
+            if st:
+                if escalated:
+                    clear_escalation(rnd, sid)
+                state.pop(sid, None)
+            continue
+
+        # Still stalled but inside the backoff window → wait quietly, don't nudge.
+        if st and now < next_at:
+            continue
+
+        if attempts >= conf["max_attempts"]:
+            # Sustained outage: escalate once, then stop re-prompting. Keep a slow
+            # recheck so the mark clears once the session finally recovers.
+            if not escalated:
+                escalate(rnd, sid, attempts)
+            state[sid] = {"attempts": attempts, "next": now + conf["cap"], "escalated": True}
+            continue
+
+        # Re-prompt, then back off before the next attempt.
+        if reprompt(rnd, sid, conf):
+            nudged += 1
+        attempts += 1
+        state[sid] = {"attempts": attempts, "next": now + backoff(conf, attempts), "escalated": False}
+
+    # Forget sessions that have gone away entirely.
+    for sid in list(state):
+        if sid not in live:
+            state.pop(sid, None)
+
+    # Re-arm the dynamic wake at the soonest pending recheck, or clear it when
+    # nothing is left to watch. Persist the lookaside state either way.
+    pending = [float(st.get("next") or 0.0) for st in state.values()]
+    rnd.wake_in(max(1, int(min(pending) - now)) if pending else 0)
+    rnd.set_state(state)
+
+    if not candidates:
+        rnd.finish("no sessions to check", outcome="noop")
+        return
+    dry = " (dry run, no writes applied)" if rnd.dry_run else ""
+    verb = "would nudge" if rnd.dry_run else "nudged"
+    rnd.finish(
+        "checked %d, %s %d, tracking %d%s" % (len(candidates), verb, nudged, len(state), dry),
+        outcome="ok" if rnd.actions else "noop",
+    )
+
+
+if __name__ == "__main__":
+    Round.main(main, TRIGGERS)

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -60,6 +60,23 @@ pub const BUILTINS: &[BuiltinProgram] = &[
         default_capabilities: &["observe", "mark"],
     },
     BuiltinProgram {
+        name: "resume",
+        title: "Resume stalled",
+        description: "When a session stalls on a transient API error (e.g. \
+                      `529 Overloaded`) and sits idle, gently re-prompt it to \
+                      continue — backing off exponentially so a sustained outage \
+                      is never hammered. Tracks per-session retries in its \
+                      lookaside state and reschedules itself (dynamic self-wake) \
+                      for each backoff recheck; after `max_attempts` consecutive \
+                      failures it escalates (marks the session) and stops \
+                      re-prompting until it recovers. Needs `nudge` to resume.",
+        source: include_str!("../overlookers/resume.py"),
+        default_trigger: r#"{"on":["session.idle","session.stale"]}"#,
+        default_scope: "{}",
+        default_params: "{}",
+        default_capabilities: &["observe", "nudge", "mark"],
+    },
+    BuiltinProgram {
         name: "pr-label",
         title: "PR labeller",
         description: "Flag sessions whose open pull request lacks the loom \

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -168,13 +168,13 @@ pub async fn tick_timer(state: &AppState) {
     let now = Utc::now();
     for o in overlookers {
         // Dynamic one-shot wake (any overlooker, scheduled or reactive): a round
-        // asked to re-run at `wake_at`. Fire it once, clear the column, and move
-        // on — clearing first makes it strictly one-shot, so a slow round can't
-        // be re-fired by the next tick before it persists a fresh wake.
+        // asked to re-run at `wake_at`. Record the tick first and only clear the
+        // column once it lands — a failed insert then leaves the wake set to retry
+        // next pass, rather than silently losing it. The clear still happens in
+        // this same (awaited) pass, before the round runs, so it stays one-shot.
         if let Some(wake) = o.wake_at.as_deref().and_then(parse_iso) {
             if wake <= now {
-                let _ = ov::set_wake_at(&state.db, &o.id, None).await;
-                if let Err(e) = events::record_system(
+                match events::record_system(
                     &state.db,
                     &state.bus,
                     "cron",
@@ -182,7 +182,17 @@ pub async fn tick_timer(state: &AppState) {
                 )
                 .await
                 {
-                    tracing::warn!(overlooker = %o.id, "overlooker timer: recording wake tick failed: {e}");
+                    Ok(_) => {
+                        if let Err(e) = ov::set_wake_at(&state.db, &o.id, None).await {
+                            // A failed clear leaves the wake set, so next pass
+                            // re-fires it — a benign idempotent re-survey (under
+                            // no-overlap), but surface it rather than swallow it.
+                            tracing::warn!(overlooker = %o.id, "overlooker timer: clearing wake_at failed: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(overlooker = %o.id, "overlooker timer: recording wake tick failed: {e}");
+                    }
                 }
                 continue;
             }

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -167,6 +167,26 @@ pub async fn tick_timer(state: &AppState) {
     };
     let now = Utc::now();
     for o in overlookers {
+        // Dynamic one-shot wake (any overlooker, scheduled or reactive): a round
+        // asked to re-run at `wake_at`. Fire it once, clear the column, and move
+        // on — clearing first makes it strictly one-shot, so a slow round can't
+        // be re-fired by the next tick before it persists a fresh wake.
+        if let Some(wake) = o.wake_at.as_deref().and_then(parse_iso) {
+            if wake <= now {
+                let _ = ov::set_wake_at(&state.db, &o.id, None).await;
+                if let Err(e) = events::record_system(
+                    &state.db,
+                    &state.bus,
+                    "cron",
+                    json!({ "overlooker": o.id, "wake": true }),
+                )
+                .await
+                {
+                    tracing::warn!(overlooker = %o.id, "overlooker timer: recording wake tick failed: {e}");
+                }
+                continue;
+            }
+        }
         let trigger = o.trigger();
         if !trigger.is_scheduled() {
             continue;
@@ -265,11 +285,26 @@ pub async fn dispatch(state: &AppState, in_flight: &InFlight, ev: &events::Event
     match ev.kind.as_str() {
         "cron" => {
             if let Some(o) = resolve_target(state, ev).await {
+                // A wake tick (a watch's own self-scheduled recheck) carries
+                // `wake:true` and fires under reason "wake", which bypasses
+                // cooldown — the delay the round chose IS its self-imposed gap, so
+                // a global cooldown must not swallow the recheck and strand the
+                // backoff. A plain scheduled tick stays "cron" and is gated.
+                let reason = if ev
+                    .data
+                    .get("wake")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    "wake"
+                } else {
+                    "cron"
+                };
                 let _ = fire(
                     state,
                     in_flight,
                     &o,
-                    "cron",
+                    reason,
                     false,
                     &TriggerCtx::scheduled(),
                 )
@@ -432,7 +467,8 @@ async fn triggering_session(state: &AppState, ev: &events::Event) -> Option<Stri
 /// 1. **no-overlap** — a re-fire while a round of the same overlooker is in
 ///    flight is dropped (no run row); the in-flight set is the gate.
 /// 2. **cooldown** — a fire inside `max(cooldown_secs, default_cooldown_secs)`
-///    of the last run is recorded `skipped`. A `manual`/`run-now` bypasses it.
+///    of the last run is recorded `skipped`. A `manual`/`run-now`, and a watch's
+///    own self-scheduled `wake`, bypass it (the wake's delay is the gap).
 /// 3. **timeout** — the program is wrapped in a wall-clock budget; an overrun
 ///    is recorded `error`.
 /// 4. **no-recursion** — the survey ([`run_program`]) excludes overlooker warm
@@ -460,13 +496,17 @@ pub async fn fire(
     };
 
     let manual = trigger_reason == "manual" || trigger_reason.starts_with("run");
+    // A self-scheduled wake bypasses cooldown too: its backoff delay is the
+    // watch's own chosen gap, so a global cooldown must not strand the recheck.
+    let bypass_cooldown = manual || trigger_reason == "wake";
     let now = Utc::now();
 
-    // 2. Cooldown: a non-manual re-fire inside the gap is recorded `skipped`.
+    // 2. Cooldown: a re-fire inside the gap is recorded `skipped` (a manual run
+    //    or a self-scheduled wake bypasses it).
     let cooldown = o
         .cooldown_secs
         .max(get_int(&state.db, "overlooker.default_cooldown_secs", 0).await);
-    if !manual && cooldown > 0 {
+    if !bypass_cooldown && cooldown > 0 {
         if let Some(last) = o.last_run_at.as_deref().and_then(parse_iso) {
             if (now - last).num_seconds() < cooldown {
                 return record_skipped(
@@ -513,6 +553,24 @@ pub async fn fire(
     let next = next_fire(o, now).map(iso);
     let _ = ov::set_schedule(&state.db, &o.id, Some(&iso(now)), next.as_deref()).await;
 
+    // Persist the program's lookaside-state write and its dynamic-wake request.
+    // These are how a round carries memory forward and self-schedules its next
+    // look (e.g. an exponential-backoff recheck) — independent of the cron
+    // cadence above.
+    if let Some(new_state) = &round.state {
+        let _ = ov::set_state(&state.db, &o.id, new_state).await;
+    }
+    match round.wake {
+        Wake::Leave => {}
+        Wake::Clear => {
+            let _ = ov::set_wake_at(&state.db, &o.id, None).await;
+        }
+        Wake::In(secs) => {
+            let wake_at = iso(now + chrono::Duration::seconds(secs.max(1)));
+            let _ = ov::set_wake_at(&state.db, &o.id, Some(&wake_at)).await;
+        }
+    }
+
     Some(run_id)
 }
 
@@ -549,9 +607,26 @@ async fn record_skipped(
 // The program substrate — the subprocess script executor
 // ---------------------------------------------------------------------------
 
+/// What a round's result asks the engine to do with the overlooker's one-shot
+/// dynamic wake (`wake_at`). The program controls it via the `wake_in` field of
+/// its result JSON.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Wake {
+    /// No `wake_in` in the result — leave `wake_at` as it was. Used by every
+    /// program that never self-schedules, and by the error/timeout paths so a
+    /// transient script failure never drops a pending backoff recheck.
+    Leave,
+    /// `wake_in: 0` (or negative) — the program is done; clear any pending wake.
+    Clear,
+    /// `wake_in: N` (> 0) — re-fire this overlooker in `N` seconds.
+    In(i64),
+}
+
 /// The result of running a program: the outcome + one-line summary + actions
 /// for the audit trail, plus the captured execution log (stdout/stderr tails,
-/// the interpreter exit code, and the wall-clock it ran).
+/// the interpreter exit code, and the wall-clock it ran), and the program's
+/// lookaside-state write + dynamic-wake request (both engine bookkeeping, not
+/// part of the audit record).
 struct RoundResult {
     outcome: String,
     summary: String,
@@ -560,6 +635,11 @@ struct RoundResult {
     stderr: String,
     exit_code: Option<i64>,
     duration_ms: Option<i64>,
+    /// The new lookaside state to persist (`None` = the program returned none,
+    /// leave the stored state untouched).
+    state: Option<Value>,
+    /// What to do with the dynamic wake timer.
+    wake: Wake,
 }
 
 impl RoundResult {
@@ -576,6 +656,8 @@ impl RoundResult {
             stderr: String::new(),
             exit_code: None,
             duration_ms: None,
+            state: None,
+            wake: Wake::Leave,
         }
     }
 
@@ -699,6 +781,7 @@ async fn run_script(
         "dry_run": dry_run,
         "mode": "run",
         "trigger": serde_json::to_value(ctx).unwrap_or(Value::Null),
+        "state": o.state(),
     });
 
     // A spawn / scratch-setup failure (no interpreter, unreadable file) is a
@@ -710,6 +793,8 @@ async fn run_script(
     let duration_ms = Some(out.duration_ms);
 
     if !out.success {
+        // A script crash leaves state and the dynamic wake untouched: a transient
+        // failure must not drop a pending backoff recheck.
         return Ok(RoundResult {
             outcome: "error".to_string(),
             summary: format!(
@@ -722,6 +807,8 @@ async fn run_script(
             stderr,
             exit_code: out.exit_code,
             duration_ms,
+            state: None,
+            wake: Wake::Leave,
         });
     }
 
@@ -734,6 +821,8 @@ async fn run_script(
             stderr,
             exit_code: out.exit_code,
             duration_ms,
+            state: parsed.state,
+            wake: parsed.wake,
         },
         None => RoundResult {
             outcome: "error".to_string(),
@@ -747,6 +836,8 @@ async fn run_script(
             stderr,
             exit_code: out.exit_code,
             duration_ms,
+            state: None,
+            wake: Wake::Leave,
         },
     };
     Ok(result)
@@ -919,19 +1010,25 @@ fn parse_last_json_object(stdout: &str) -> Option<Value> {
     as_object(trimmed).or_else(|| trimmed.lines().rev().find_map(as_object))
 }
 
-/// The three fields a script's result JSON contributes to a [`RoundResult`].
-/// Named (not a bare tuple) so the two same-typed `String` slots — `outcome`
-/// and `summary` — can't be transposed at a call site.
+/// The fields a script's result JSON contributes to a [`RoundResult`]. Named
+/// (not a bare tuple) so the two same-typed `String` slots — `outcome` and
+/// `summary` — can't be transposed at a call site.
 struct ParsedRound {
     outcome: String,
     summary: String,
     actions: Value,
+    /// The lookaside state to persist, if the script returned a `state` object
+    /// (`None` = absent, leave the stored state alone).
+    state: Option<Value>,
+    /// The dynamic-wake request from the script's optional `wake_in`.
+    wake: Wake,
 }
 
 /// Parse a script's stdout into its [`ParsedRound`]. The fields are read
 /// leniently: a missing/unknown `outcome` reads as `ok`, a missing `summary` as
 /// empty, a missing/non-array `actions` as none — so a minimal script stays
-/// minimal.
+/// minimal. The optional `state` (an object) and `wake_in` (seconds) drive the
+/// engine's lookaside-state and dynamic-wake bookkeeping.
 fn parse_round_result(stdout: &str) -> Option<ParsedRound> {
     let obj = parse_last_json_object(stdout)?;
     let obj = obj.as_object()?;
@@ -949,10 +1046,20 @@ fn parse_round_result(stdout: &str) -> Option<ParsedRound> {
         .filter(|a| a.is_array())
         .cloned()
         .unwrap_or_else(|| Value::Array(vec![]));
+    // Only an object is accepted as state; anything else is ignored (leave).
+    let state = obj.get("state").filter(|s| s.is_object()).cloned();
+    // `wake_in` absent → leave; <= 0 → clear; > 0 → re-fire in that many seconds.
+    let wake = match obj.get("wake_in").and_then(Value::as_i64) {
+        None => Wake::Leave,
+        Some(secs) if secs > 0 => Wake::In(secs),
+        Some(_) => Wake::Clear,
+    };
     Some(ParsedRound {
         outcome: outcome.to_string(),
         summary: summary.to_string(),
         actions,
+        state,
+        wake,
     })
 }
 
@@ -1191,6 +1298,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_round_result_reads_state_and_wake() {
+        // No state / no wake_in → leave both alone.
+        let r = parse_round_result(r#"{"outcome":"ok"}"#).unwrap();
+        assert!(r.state.is_none());
+        assert_eq!(r.wake, Wake::Leave);
+
+        // A state object is captured; wake_in > 0 schedules a re-fire.
+        let r = parse_round_result(r#"{"outcome":"ok","state":{"s":{"attempts":2}},"wake_in":30}"#)
+            .unwrap();
+        assert_eq!(r.state.unwrap(), serde_json::json!({"s":{"attempts":2}}));
+        assert_eq!(r.wake, Wake::In(30));
+
+        // wake_in 0 (or negative) clears the pending wake — "I'm done".
+        let r = parse_round_result(r#"{"outcome":"noop","wake_in":0}"#).unwrap();
+        assert_eq!(r.wake, Wake::Clear);
+        let r = parse_round_result(r#"{"outcome":"noop","wake_in":-5}"#).unwrap();
+        assert_eq!(r.wake, Wake::Clear);
+
+        // A non-object state is ignored rather than persisted as junk.
+        let r = parse_round_result(r#"{"outcome":"ok","state":"nope"}"#).unwrap();
+        assert!(r.state.is_none());
+    }
+
+    #[test]
     fn parse_manifest_accepts_declarations_not_round_results() {
         // A subscription manifest parses into a Trigger.
         let t = parse_manifest(r#"{"on":["pr.merged","pr.opened"]}"#).unwrap();
@@ -1313,6 +1444,203 @@ rnd.finish("name=%s label=%s dry=%s api=%s" % (
         );
         let actions: Value = serde_json::from_str(&run.actions).unwrap();
         assert_eq!(actions[0]["would"], "label");
+    }
+
+    /// A round that returns `state` and `wake_in` has both persisted on the
+    /// overlooker row: the lookaside state carries to the next round, and the
+    /// dynamic wake is armed for a self-scheduled recheck.
+    #[tokio::test]
+    async fn fire_persists_state_and_wake() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not on PATH");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("stateful.py");
+        std::fs::write(
+            &script,
+            r#"
+from weaver_loom import Round
+rnd = Round()
+# Echo the prior state's counter, incremented, and schedule a recheck.
+n = (rnd.state.get("n") or 0) + 1
+rnd.set_state({"n": n})
+rnd.wake_in(30)
+rnd.finish("counted to %d" % n)
+"#,
+        )
+        .unwrap();
+
+        let (state, o) = script_fixture(&script.display().to_string()).await;
+        // First round: no prior state → n = 1, wake armed.
+        fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "manual",
+            false,
+            &TriggerCtx::manual(),
+        )
+        .await
+        .unwrap();
+        let after = ov::get(&state.db, &o.id).await.unwrap().unwrap();
+        assert_eq!(after.state(), serde_json::json!({"n": 1}));
+        assert!(after.wake_at.is_some(), "a wake_in armed wake_at");
+
+        // Second round reads the persisted state back: n = 2.
+        fire(
+            &state,
+            &new_in_flight(),
+            &after,
+            "manual",
+            false,
+            &TriggerCtx::manual(),
+        )
+        .await
+        .unwrap();
+        let after = ov::get(&state.db, &o.id).await.unwrap().unwrap();
+        assert_eq!(after.state(), serde_json::json!({"n": 2}));
+    }
+
+    /// A self-scheduled `wake` fire bypasses cooldown, where a plain `cron` fire
+    /// inside the window is skipped — so a global cooldown can never strand a
+    /// backoff recheck the watch armed for itself.
+    #[tokio::test]
+    async fn wake_bypasses_cooldown_but_cron_is_gated() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not on PATH");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("noop.py");
+        std::fs::write(
+            &script,
+            "from weaver_loom import Round\nRound().finish('ok')\n",
+        )
+        .unwrap();
+        let (state, _) = script_fixture(&script.display().to_string()).await;
+        // A long cooldown so a back-to-back re-fire would normally be skipped.
+        let o = ov::create(
+            &state.db,
+            &ov::NewOverlooker {
+                name: "gated".to_string(),
+                program: script.display().to_string(),
+                cooldown_secs: 3600,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        // Seed last_run_at via a manual run (manual bypasses cooldown). A fresh
+        // in-flight set per fire — each is its own no-overlap domain, sidestepping
+        // the async drop of the guard between sequential calls.
+        fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "manual",
+            false,
+            &TriggerCtx::manual(),
+        )
+        .await
+        .unwrap();
+        let o = ov::get(&state.db, &o.id).await.unwrap().unwrap();
+
+        // A plain cron re-fire inside the window is skipped…
+        let cron_id = fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "cron",
+            false,
+            &TriggerCtx::scheduled(),
+        )
+        .await
+        .unwrap();
+        // …but a self-scheduled wake runs anyway.
+        let wake_id = fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "wake",
+            false,
+            &TriggerCtx::scheduled(),
+        )
+        .await
+        .unwrap();
+
+        let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
+        let outcome = |id| runs.iter().find(|r| r.id == id).unwrap().outcome.as_str();
+        assert_eq!(outcome(cron_id), "skipped", "cron is gated by cooldown");
+        assert_ne!(outcome(wake_id), "skipped", "wake bypasses cooldown");
+    }
+
+    /// A due `wake_at` makes the timer emit one `cron` tick for that overlooker
+    /// and clear the column — the dynamic self-trigger, working for a reactive
+    /// overlooker the scheduled timer would otherwise never visit.
+    #[tokio::test]
+    async fn timer_fires_a_due_wake_once_and_clears_it() {
+        let state = AppState {
+            db: crate::db::connect_in_memory().await.unwrap(),
+            bus: events::EventBus::new(),
+            addr: "127.0.0.1:0".to_string(),
+            ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
+        };
+        // A reactive overlooker (no cron) — the scheduled half of the timer skips
+        // it; only the wake half should fire it.
+        let o = ov::create(
+            &state.db,
+            &ov::NewOverlooker {
+                name: "waker".to_string(),
+                trigger_spec: r#"{"on":["session.idle"]}"#.to_string(),
+                enabled: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        ov::set_wake_at(&state.db, &o.id, Some("2000-01-01T00:00:00.000Z"))
+            .await
+            .unwrap();
+
+        tick_timer(&state).await;
+
+        // Exactly one cron tick naming this overlooker, and the wake is cleared.
+        let crons: Vec<_> = events::since(&state.db, 0)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|e| {
+                e.kind == "cron"
+                    && e.data.get("overlooker").and_then(Value::as_str) == Some(o.id.as_str())
+            })
+            .collect();
+        assert_eq!(crons.len(), 1, "one wake tick emitted");
+        assert_eq!(
+            crons[0].data.get("wake").and_then(Value::as_bool),
+            Some(true),
+            "the wake tick is marked so it bypasses cooldown"
+        );
+        assert!(
+            ov::get(&state.db, &o.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .wake_at
+                .is_none(),
+            "wake_at cleared so it is strictly one-shot"
+        );
+
+        // A second pass with no wake set emits no further tick.
+        tick_timer(&state).await;
+        let crons = events::since(&state.db, 0)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|e| e.kind == "cron")
+            .count();
+        assert_eq!(crons, 1, "no re-fire once the wake is consumed");
     }
 
     /// A failing script errors the round with the stderr tail in the summary,

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -430,6 +430,94 @@ async fn builtin_status_round_applies_typed_tags_and_reconciles() {
         .unwrap();
 }
 
+/// The `resume` builtin's wiring proof: a session whose live screen shows the
+/// transient-error signature (`API Error: 529 Overloaded`) is detected, nudged
+/// to resume, and the round persists its backoff bookkeeping — the lookaside
+/// `state` tracks the session (one attempt) and a dynamic `wake_at` is armed for
+/// the recheck. The backoff math / escalation / capability branches are covered
+/// server-free in `python/weaver-loom/tests/test_resume_program.py`; this proves
+/// the screen-scrape → nudge → state+wake plumbing against a live server.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn resume_nudges_a_stalled_session_and_arms_backoff() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
+    use crate::fixtures::{connect_terminal, drain_until, send_input};
+    use std::time::Duration;
+
+    let ts = TestServer::start().await;
+    let state = engine_state(&ts).await;
+    let (session_id, _branch_id, _repo_root) = make_session(&ts, "resume me").await;
+
+    // Make the session's live screen show the overload error: echo it into the
+    // shell and wait for it to render before we survey.
+    let mut term = connect_terminal(&ts.addr, &session_id).await;
+    send_input(&mut term, "echo API Error: 529 Overloaded\r").await;
+    let screen = drain_until(&mut term, "529 Overloaded", Duration::from_secs(5)).await;
+    assert!(
+        screen.contains("529 Overloaded"),
+        "the overload line rendered on the session screen: {screen:?}"
+    );
+
+    let o = enabled_overlooker(
+        &state,
+        ov::NewOverlooker {
+            name: "resume-watch".to_string(),
+            trigger_spec: json!({ "on": ["session.idle", "session.stale"] }).to_string(),
+            scope: json!({}).to_string(),
+            program: "builtin:resume".to_string(),
+            capabilities: vec![
+                "observe".to_string(),
+                "nudge".to_string(),
+                "mark".to_string(),
+            ],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // A manual round surveys the fleet, detects the stall, and nudges.
+    let run_id = overlooker::fire_now(&state, &o.name, false, "manual")
+        .await
+        .unwrap();
+
+    // The run recorded a real `nudge` of the stalled session.
+    let runs = ov::recent_runs(&state.db, &o.id, 10).await.unwrap();
+    let run = runs.iter().find(|r| r.id == run_id).unwrap();
+    assert_eq!(run.outcome, "ok", "summary: {}", run.summary);
+    let actions: serde_json::Value = serde_json::from_str(&run.actions).unwrap();
+    assert!(
+        actions
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|a| a["action"] == "nudge" && a["session"] == session_id.as_str()),
+        "the round nudges the stalled session: {actions}"
+    );
+
+    // The overlooker now tracks the session (one attempt) and has armed a wake
+    // for the backoff recheck — the lookaside-state + dynamic-wake primitives.
+    let after = ov::get(&state.db, &o.id).await.unwrap().unwrap();
+    let tracked = &after.state()[session_id.as_str()];
+    assert_eq!(
+        tracked["attempts"],
+        1,
+        "first attempt tracked: {}",
+        after.state()
+    );
+    assert!(
+        after.wake_at.is_some(),
+        "a backoff recheck wake is armed: {after:?}"
+    );
+
+    ts.client
+        .delete(&format!("/api/sessions/{session_id}"))
+        .await
+        .unwrap();
+}
+
 /// T6: the timer half emits a `cron` system tick for a due scheduled overlooker
 /// (visible in the event log) and advances its `next_run_at`; that tick then
 /// drives a round through the dispatcher — the producer→consumer chain unattended.
@@ -794,11 +882,27 @@ async fn rest_lists_builtin_programs_and_validates_program_refs() {
     let names: Vec<&str> = arr.iter().map(|p| p["program"].as_str().unwrap()).collect();
     for expected in [
         "builtin:status",
+        "builtin:resume",
         "builtin:pr-label",
         "builtin:archive-merged",
     ] {
         assert!(names.contains(&expected), "{expected} missing: {names:?}");
     }
+
+    // The resume builtin wakes on the quiet signals and opts into `nudge`.
+    let resume = arr
+        .iter()
+        .find(|p| p["program"] == "builtin:resume")
+        .unwrap();
+    assert_eq!(resume["defaults"]["trigger"]["on"][0], "session.idle");
+    assert!(
+        resume["defaults"]["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c == "nudge"),
+        "resume requests the nudge capability to re-prompt"
+    );
 
     // Every builtin is a script: it ships its source and suggested defaults.
     let archive = arr

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -288,6 +288,14 @@ pub struct OverlookerView {
     pub warm_session_id: Option<String>,
     pub last_run_at: Option<String>,
     pub next_run_at: Option<String>,
+    /// The one-shot dynamic re-trigger time a round armed (`wake_in`), or `null`.
+    /// Distinct from `next_run_at` (the cron cadence): a self-scheduled backoff
+    /// recheck a watch set for itself.
+    pub wake_at: Option<String>,
+    /// The program's lookaside state, parsed — its scratch memory carried across
+    /// rounds (e.g. a backoff watcher's per-session attempt counts). `{}` when
+    /// the program keeps none.
+    pub state: Value,
     /// The most recent round's outcome (`ok|noop|skipped|error`), or `null` if
     /// it has never run — the at-a-glance health a list view shows.
     pub last_outcome: Option<String>,
@@ -316,6 +324,8 @@ impl OverlookerView {
             warm_session_id: o.warm_session_id.clone(),
             last_run_at: o.last_run_at.clone(),
             next_run_at: o.next_run_at.clone(),
+            wake_at: o.wake_at.clone(),
+            state: o.state(),
             last_outcome,
             created_at: o.created_at.clone(),
             updated_at: o.updated_at.clone(),

--- a/crates/weaver-core/migrations/0010_overlooker_state.sql
+++ b/crates/weaver-core/migrations/0010_overlooker_state.sql
@@ -1,0 +1,15 @@
+-- Lookaside state + dynamic self-wake for overlookers.
+--
+-- `state` is a free-form JSON blob a watch program reads at the top of a round
+-- and writes back at the end (the engine carries it across rounds). It is the
+-- program's own scratch memory — e.g. a backoff watcher tracks, per session, how
+-- many consecutive failures it has seen and when to retry next. Opaque to the
+-- engine; the program owns its shape.
+--
+-- `wake_at` is a one-shot dynamic re-trigger: a round may ask the engine to fire
+-- it again at a chosen time (`{wake_in: <secs>}` in its result), independent of
+-- any cron cadence. The timer fires the tick once and clears the column, so a
+-- watch can self-schedule its next look (an exponential-backoff recheck) instead
+-- of polling on a fixed interval.
+ALTER TABLE overlookers ADD COLUMN state   TEXT NOT NULL DEFAULT '{}';
+ALTER TABLE overlookers ADD COLUMN wake_at TEXT;

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -62,6 +62,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "overlooker_run_output",
         include_str!("../migrations/0009_overlooker_run_output.sql"),
     ),
+    (
+        10,
+        "overlooker_state",
+        include_str!("../migrations/0010_overlooker_state.sql"),
+    ),
 ];
 
 /// Apply every pending migration, bringing the database up to the latest schema.

--- a/crates/weaver-core/src/overlooker.rs
+++ b/crates/weaver-core/src/overlooker.rs
@@ -39,6 +39,16 @@ pub struct Overlooker {
     pub last_run_at: Option<String>,
     pub next_run_at: Option<String>,
     pub warm_session_id: Option<String>,
+    /// The program's lookaside state — a free-form JSON blob it reads at the top
+    /// of a round and writes back at the end, carried across rounds by the
+    /// engine. Opaque to the engine; the program owns its shape (e.g. a backoff
+    /// watcher keeps per-session attempt counts and retry times here).
+    pub state: String,
+    /// A one-shot dynamic re-trigger time. When a round returns `wake_in`, the
+    /// engine stamps `now + wake_in` here; the timer fires that overlooker once
+    /// when due and clears it. Lets a watch self-schedule its next look (a
+    /// backoff recheck) independent of any cron cadence.
+    pub wake_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -203,6 +213,15 @@ impl Overlooker {
     /// The raw `params` JSON (a stock program reads its `prompt` etc. here).
     pub fn params(&self) -> Value {
         serde_json::from_str(&self.params).unwrap_or(Value::Null)
+    }
+
+    /// The program's lookaside state, parsed. An unparseable/empty blob yields an
+    /// empty object so a program can always treat `rnd.state` as a dict.
+    pub fn state(&self) -> Value {
+        serde_json::from_str(&self.state)
+            .ok()
+            .filter(Value::is_object)
+            .unwrap_or_else(|| Value::Object(Default::default()))
     }
 
     /// Whether this overlooker runs in **warm mode** — the engine keeps one
@@ -458,6 +477,31 @@ pub async fn set_schedule(
     Ok(())
 }
 
+/// Persist a round's lookaside `state` (the JSON blob it returned). Replaces the
+/// prior state wholesale — the program reads it back as `rnd.state` next round.
+pub async fn set_state(db: &Db, id: &str, state: &Value) -> Result<()> {
+    sqlx::query("UPDATE overlookers SET state = ?, updated_at = ? WHERE id = ?")
+        .bind(state.to_string())
+        .bind(now_iso())
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Set (or clear, with `None`) the one-shot dynamic wake time. The timer fires
+/// the overlooker once when `wake_at` is due and clears it; a round re-arms it by
+/// returning a fresh `wake_in`.
+pub async fn set_wake_at(db: &Db, id: &str, wake_at: Option<&str>) -> Result<()> {
+    sqlx::query("UPDATE overlookers SET wake_at = ?, updated_at = ? WHERE id = ?")
+        .bind(wake_at)
+        .bind(now_iso())
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
 pub async fn set_warm_session(db: &Db, id: &str, session_id: Option<&str>) -> Result<()> {
     sqlx::query("UPDATE overlookers SET warm_session_id = ?, updated_at = ? WHERE id = ?")
         .bind(session_id)
@@ -703,6 +747,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn state_and_wake_round_trip() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let o = create(
+            &db,
+            &NewOverlooker {
+                name: "stateful".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        // Fresh overlookers default to an empty state and no pending wake.
+        assert_eq!(o.state(), serde_json::json!({}));
+        assert!(o.wake_at.is_none());
+
+        let blob = serde_json::json!({"sess-a": {"attempts": 2, "next": 1234.5}});
+        set_state(&db, &o.id, &blob).await.unwrap();
+        set_wake_at(&db, &o.id, Some("2026-06-08T11:00:00.000Z"))
+            .await
+            .unwrap();
+        let after = get(&db, &o.id).await.unwrap().unwrap();
+        assert_eq!(after.state(), blob);
+        assert_eq!(after.wake_at.as_deref(), Some("2026-06-08T11:00:00.000Z"));
+
+        // Clearing the wake leaves the state untouched.
+        set_wake_at(&db, &o.id, None).await.unwrap();
+        let after = get(&db, &o.id).await.unwrap().unwrap();
+        assert!(after.wake_at.is_none());
+        assert_eq!(after.state(), blob);
+    }
+
+    #[tokio::test]
     async fn update_overwrites_only_the_set_fields() {
         let db = crate::db::connect_in_memory().await.unwrap();
         let o = create(
@@ -750,6 +826,8 @@ mod tests {
             last_run_at: None,
             next_run_at: None,
             warm_session_id: None,
+            state: "{}".into(),
+            wake_at: None,
             created_at: String::new(),
             updated_at: String::new(),
         };

--- a/docs/plans/overlooker.md
+++ b/docs/plans/overlooker.md
@@ -252,6 +252,21 @@ warm/fresh/rules distinctions become *library calls inside the program*:
   first use, reused after), for accumulating judgement across rounds — "still
   stuck since last hour?" The binding handles create-or-reuse; the program just
   calls it.
+- `rnd.state` / `rnd.set_state(d)` — the watch's **lookaside state**: a JSON blob
+  it reads at the top of a round and writes back at the end, carried across
+  rounds by the engine (no warm session, no file). Scratch memory for a stateful
+  rule — "how many times has this session 529'd in a row, and when do I retry?"
+- `rnd.wake_in(secs)` — a **dynamic self-trigger**: ask the engine to re-run this
+  watch once in `secs`, independent of any cron cadence (`wake_in(0)` cancels a
+  pending one). Lets a round schedule its own next look — an exponential-backoff
+  recheck rather than a fixed poll — and stop waking once its work is done.
+
+Together those last two are what let a watch **back off**: the `resume` stock
+program (below) nudges a session stalled on a transient API error (`529
+Overloaded`) to continue, tracks consecutive failures per session in `state`, and
+`wake_in`s the next attempt on a doubling delay — quietly waiting instead of
+hammering a server that is already overloaded, and escalating to a human mark only
+after it has retried and given up.
 
 Two authoring languages sit on that one substrate:
 
@@ -395,7 +410,9 @@ through the same `weaver-api` the out-of-process programs use.
   `program` (`builtin:status` or a file path under `~/.weaver/overlookers/`),
   `params` (JSON for a stock program / the prompt), `capabilities` (JSON set),
   `model`, `effort`, `cooldown_secs`, `last_run_at`, `next_run_at`,
-  `warm_session_id` (nullable), `created_at`, `updated_at`.
+  `warm_session_id` (nullable), `state` (the program's lookaside JSON, carried
+  across rounds), `wake_at` (a one-shot dynamic re-trigger a round armed for
+  itself, nullable), `created_at`, `updated_at`.
 - `overlooker_runs` — `id`, `overlooker_id`, `trigger_reason`, `trigger_event`
   (the normalized event that woke it), `started_at`, `finished_at`, `outcome`
   (`ok|noop|skipped|error`), `summary`, `actions` (JSON), plus the captured
@@ -628,7 +645,9 @@ The `deps` graph collapses into five phases, each independently shippable:
   one repository; the open call is whether finer scoping (a branch glob, a label)
   earns its keep, or whether repo + the existing `scope` fleet query is enough.
 - **Stock-program coverage.** How many declarative `builtin:` programs earn their
-  keep (status, idle-nudge, PR-watch) before the rest is "write a Python one"?
+  keep before the rest is "write a Python one"? So far: `status` (triage marks),
+  `resume` (back off and re-prompt a session stalled on a transient API error),
+  `pr-label`, `archive-merged`.
 - **Escalation channel.** `escalate` raising the overlooker's own `attention` is
   free; a real push (the deferred `PushNotification` capability) is a richer
   follow-up once the panel exists.

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -435,7 +435,13 @@ class Round:
         """Persist ``state`` (a JSON-able dict) as this overlooker's lookaside
         state, replacing the prior one. It is handed back as :attr:`state` on the
         next round — the program's across-round memory (the engine carries it; no
-        session or file needed)."""
+        session or file needed).
+
+        Must be a dict: the engine only persists an object, so a non-dict would be
+        silently dropped (leaving the prior state in place). Reject it here so the
+        mistake surfaces at the program boundary instead."""
+        if not isinstance(state, dict):
+            raise TypeError(f"set_state expects a dict, got {type(state).__name__}")
         self._next_state = state
 
     def wake_in(self, seconds):

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -284,10 +284,16 @@ class Round:
     """One overlooker round, as the engine runs it.
 
     Reads the round config from ``$WEAVER_OVERLOOKER`` (``{id, name, program,
-    params, scope, capabilities, model, effort, dry_run}``), builds a
+    params, scope, capabilities, model, effort, dry_run, state}``), builds a
     :class:`Client` granted that round's capabilities, accumulates the action
     log, and prints the result the engine parses. A mutating program must
     check :attr:`dry_run` (record a :meth:`would` action instead of acting).
+
+    Two optional primitives let a watch persist memory and pace itself across
+    rounds: :attr:`state` (read) + :meth:`set_state` (write) is its lookaside
+    scratch memory, and :meth:`wake_in` schedules a dynamic self-trigger — the
+    pair a backoff watcher uses to track per-session retries and recheck them on
+    an exponential schedule instead of polling.
     """
 
     def __init__(self, config=None, client=None):
@@ -317,6 +323,17 @@ class Round:
         self.actions = []
         #: How many live sessions the last survey admitted.
         self.surveyed = 0
+        #: The overlooker's **lookaside state** — its scratch memory from the
+        #: previous round, carried across rounds by the engine. A plain dict the
+        #: program reads at the top of a round; write the next round's state with
+        #: :meth:`set_state`. ``{}`` when the program keeps none.
+        self.state = config.get("state") or {}
+        #: The next-state write (``None`` until :meth:`set_state`) and the
+        #: dynamic-wake request (``None`` until :meth:`wake_in`); both surface in
+        #: :meth:`finish` only when set, so a program that uses neither is
+        #: unchanged.
+        self._next_state = None
+        self._wake_in = None
 
     @staticmethod
     def main(fn, triggers=None):
@@ -414,15 +431,33 @@ class Round:
         """Record an action the round actually performed."""
         self.actions.append({"action": action, **fields})
 
+    def set_state(self, state):
+        """Persist ``state`` (a JSON-able dict) as this overlooker's lookaside
+        state, replacing the prior one. It is handed back as :attr:`state` on the
+        next round — the program's across-round memory (the engine carries it; no
+        session or file needed)."""
+        self._next_state = state
+
+    def wake_in(self, seconds):
+        """Ask the engine to re-run this overlooker once in ``seconds`` — a
+        dynamic self-trigger, independent of any cron cadence. Use it to schedule
+        the next look in a backoff loop (``rnd.wake_in(60)``). ``seconds <= 0``
+        clears any pending wake (``rnd.wake_in(0)`` — "nothing left to recheck").
+        Re-arm it every round you still have pending work; the wake is one-shot."""
+        self._wake_in = int(seconds)
+
     def finish(self, summary, outcome=None):
         """Print the round result the engine reads from stdout. ``outcome``
-        defaults to ``ok`` when any action was recorded, else ``noop``."""
-        print(
-            json.dumps(
-                {
-                    "outcome": outcome or ("ok" if self.actions else "noop"),
-                    "summary": summary,
-                    "actions": self.actions,
-                }
-            )
-        )
+        defaults to ``ok`` when any action was recorded, else ``noop``. A
+        :meth:`set_state` write and a :meth:`wake_in` request ride along when
+        set, so the engine persists them after the round."""
+        result = {
+            "outcome": outcome or ("ok" if self.actions else "noop"),
+            "summary": summary,
+            "actions": self.actions,
+        }
+        if self._next_state is not None:
+            result["state"] = self._next_state
+        if self._wake_in is not None:
+            result["wake_in"] = self._wake_in
+        print(json.dumps(result))

--- a/python/weaver-loom/tests/test_resume_program.py
+++ b/python/weaver-loom/tests/test_resume_program.py
@@ -1,0 +1,280 @@
+"""The builtin resume program's decision logic, with no server required.
+
+Loads `crates/loom/overlookers/resume.py` straight from the repo and drives it
+with a stubbed client and a frozen clock: the detection (screen pattern), the
+exponential backoff cadence carried in the lookaside state, the dynamic-wake
+scheduling, escalation after `max_attempts`, recovery, reactive-vs-sweep
+candidate selection, the capability branches, and dry-run all live here. The
+Rust integration suite keeps only the wiring proof — that the script runs under
+the engine, detects a live screen, nudges, and persists state + wake.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+from weaver_loom import Round
+
+OVERLOOKERS = Path(__file__).resolve().parents[3] / "crates" / "loom" / "overlookers"
+
+
+def load_program(name):
+    spec = importlib.util.spec_from_file_location(name, OVERLOOKERS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+resume = load_program("resume")
+
+OVERLOAD = "  thinking...\n● API Error: 529 Overloaded. try again in a moment.\n> "
+CALM = "user@host:~/work$ tests passed\n> "
+
+
+class StubClient:
+    """The slice of Client the resume program touches, scripted per test."""
+
+    def __init__(self, capabilities=None, sessions=None, screens=None):
+        self.capabilities = capabilities or []
+        self._sessions = sessions or []
+        self.screens = screens or {}
+        self.calls = []
+
+    def can(self, cap):
+        return cap == "observe" or cap in self.capabilities
+
+    def sessions(self):
+        return self._sessions
+
+    def preview(self, key, lines=0):
+        self.calls.append(("preview", key, lines))
+        return self.screens.get(key, "")
+
+    def nudge(self, key, text, submit=True, by=None):
+        self.calls.append(("nudge", key, text, by))
+
+    def mark(self, key, level, note="", by=None):
+        self.calls.append(("mark", key, level, note, by))
+
+
+def sess(id, status="running"):
+    return {"id": id, "status": status, "branch": {"tags": [], "repo_root": "/r"}}
+
+
+def make_round(client, **config):
+    return Round(config={"name": "resume", "capabilities": client.capabilities, **config}, client=client)
+
+
+def run_main(client, capsys, monkeypatch, now, **config):
+    """Drive main(rnd) with a frozen clock; return the parsed result line."""
+    monkeypatch.setattr(resume.time, "time", lambda: now)
+    rnd = make_round(client, **config)
+    resume.main(rnd)
+    return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+
+
+def nudges(client):
+    return [c for c in client.calls if c[0] == "nudge"]
+
+
+def marks(client):
+    return [c for c in client.calls if c[0] == "mark"]
+
+
+# -- backoff math -------------------------------------------------------------
+
+
+def test_backoff_doubles_and_caps():
+    conf = {"base": 30.0, "cap": 900.0}
+    assert resume.backoff(conf, 1) == 30
+    assert resume.backoff(conf, 2) == 60
+    assert resume.backoff(conf, 3) == 120
+    assert resume.backoff(conf, 4) == 240
+    # 30 * 2**5 = 960, clamped to the 900s cap.
+    assert resume.backoff(conf, 6) == 900
+    assert resume.backoff(conf, 99) == 900
+
+
+# -- detection + first nudge --------------------------------------------------
+
+
+def test_first_detection_nudges_and_arms_backoff(capsys, monkeypatch):
+    client = StubClient(
+        capabilities=["nudge", "mark"],
+        sessions=[sess("s")],
+        screens={"s": OVERLOAD},
+    )
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={})
+    assert nudges(client) == [("nudge", "s", "continue", "resume")]
+    # First failure → one attempt, next recheck a base backoff (30s) out.
+    assert result["state"]["s"]["attempts"] == 1
+    assert result["state"]["s"]["next"] == 1030
+    assert result["state"]["s"]["escalated"] is False
+    # The dynamic wake is armed at the soonest pending recheck.
+    assert result["wake_in"] == 30
+    assert result["outcome"] == "ok"
+
+
+def test_calm_session_is_never_nudged(capsys, monkeypatch):
+    client = StubClient(capabilities=["nudge"], sessions=[sess("s")], screens={"s": CALM})
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={})
+    assert nudges(client) == []
+    assert result["state"] == {}
+    # Nothing pending → the wake is cleared.
+    assert result["wake_in"] == 0
+    assert result["outcome"] == "noop"
+
+
+def test_pattern_and_nudge_text_are_configurable(capsys, monkeypatch):
+    client = StubClient(
+        capabilities=["nudge"],
+        sessions=[sess("s")],
+        screens={"s": "...KABOOM..."},
+    )
+    result = run_main(
+        client, capsys, monkeypatch, now=0, trigger={},
+        params={"pattern": "KABOOM", "nudge": "carry on"},
+    )
+    assert nudges(client) == [("nudge", "s", "carry on", "resume")]
+    assert "s" in result["state"]
+
+
+# -- backoff cadence across rounds --------------------------------------------
+
+
+def test_inside_backoff_window_waits_without_nudging(capsys, monkeypatch):
+    # Still stalled, but the recheck time hasn't arrived → wait, don't re-prompt.
+    prior = {"s": {"attempts": 1, "next": 1030, "escalated": False}}
+    client = StubClient(capabilities=["nudge"], sessions=[sess("s")], screens={"s": OVERLOAD})
+    result = run_main(client, capsys, monkeypatch, now=1010, trigger={}, state=prior)
+    assert nudges(client) == []
+    assert result["state"]["s"]["attempts"] == 1, "attempt count unchanged while waiting"
+    # The wake re-arms at the remaining backoff (1030 - 1010).
+    assert result["wake_in"] == 20
+
+
+def test_consecutive_stall_after_window_backs_off_further(capsys, monkeypatch):
+    # The recheck arrived and it is STILL stalled → re-prompt and double the wait.
+    prior = {"s": {"attempts": 1, "next": 1030, "escalated": False}}
+    client = StubClient(capabilities=["nudge"], sessions=[sess("s")], screens={"s": OVERLOAD})
+    result = run_main(client, capsys, monkeypatch, now=1030, trigger={}, state=prior)
+    assert len(nudges(client)) == 1
+    assert result["state"]["s"]["attempts"] == 2
+    # Second failure → 60s backoff (30 * 2**1).
+    assert result["state"]["s"]["next"] == 1090
+    assert result["wake_in"] == 60
+
+
+def test_recovery_clears_tracking(capsys, monkeypatch):
+    prior = {"s": {"attempts": 2, "next": 1090, "escalated": False}}
+    client = StubClient(capabilities=["nudge"], sessions=[sess("s")], screens={"s": CALM})
+    result = run_main(client, capsys, monkeypatch, now=1100, trigger={}, state=prior)
+    assert nudges(client) == []
+    assert "s" not in result["state"], "a recovered session is dropped from tracking"
+    assert result["wake_in"] == 0, "nothing left to recheck → wake cleared"
+
+
+# -- escalation after max_attempts --------------------------------------------
+
+
+def test_max_attempts_escalates_and_stops_nudging(capsys, monkeypatch):
+    prior = {"s": {"attempts": 6, "next": 1000, "escalated": False}}
+    client = StubClient(capabilities=["nudge", "mark"], sessions=[sess("s")], screens={"s": OVERLOAD})
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={}, state=prior)
+    # No further nudge; instead a single escalation mark.
+    assert nudges(client) == []
+    assert len(marks(client)) == 1
+    assert marks(client)[0][1:3] == ("s", "attention")
+    assert result["state"]["s"]["escalated"] is True
+    # It keeps a slow recheck (the cap) so the mark can clear on recovery.
+    assert result["wake_in"] == 900
+
+
+def test_escalated_session_is_not_marked_again(capsys, monkeypatch):
+    prior = {"s": {"attempts": 6, "next": 1900, "escalated": True}}
+    client = StubClient(capabilities=["nudge", "mark"], sessions=[sess("s")], screens={"s": OVERLOAD})
+    run_main(client, capsys, monkeypatch, now=1900, trigger={}, state=prior)
+    assert marks(client) == [], "an already-escalated session is not re-marked"
+    assert nudges(client) == []
+
+
+def test_escalated_recovery_clears_the_mark(capsys, monkeypatch):
+    prior = {"s": {"attempts": 6, "next": 1900, "escalated": True}}
+    client = StubClient(capabilities=["nudge", "mark"], sessions=[sess("s")], screens={"s": CALM})
+    result = run_main(client, capsys, monkeypatch, now=2000, trigger={}, state=prior)
+    assert marks(client) == [("mark", "s", "ok", "", "resume")], "recovery clears the triage mark"
+    assert "s" not in result["state"]
+
+
+# -- candidate selection: reactive vs sweep -----------------------------------
+
+
+def test_reactive_trigger_scopes_to_the_triggering_session(capsys, monkeypatch):
+    client = StubClient(
+        capabilities=["nudge"],
+        sessions=[sess("a"), sess("b")],
+        screens={"a": OVERLOAD, "b": OVERLOAD},
+    )
+    result = run_main(client, capsys, monkeypatch, now=0, trigger={"session": "a"})
+    # Only the triggering session is examined and nudged; "b" is untouched.
+    assert [n[1] for n in nudges(client)] == ["a"]
+    assert not any(c[0] == "preview" and c[1] == "b" for c in client.calls)
+    assert "b" not in result["state"]
+
+
+def test_sweep_checks_the_whole_fleet(capsys, monkeypatch):
+    # A cron/manual tick (no triggering session) sweeps every session, catching
+    # several the same outage hit.
+    client = StubClient(
+        capabilities=["nudge"],
+        sessions=[sess("a"), sess("b")],
+        screens={"a": OVERLOAD, "b": OVERLOAD},
+    )
+    result = run_main(client, capsys, monkeypatch, now=0, trigger={})
+    assert sorted(n[1] for n in nudges(client)) == ["a", "b"]
+    assert set(result["state"]) == {"a", "b"}
+
+
+def test_a_tracked_session_that_vanished_is_forgotten(capsys, monkeypatch):
+    # "ghost" is tracked but no longer in the live fleet → dropped silently.
+    prior = {"ghost": {"attempts": 2, "next": 500, "escalated": False}}
+    client = StubClient(capabilities=["nudge"], sessions=[sess("s")], screens={"s": CALM})
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={}, state=prior)
+    assert "ghost" not in result["state"]
+    assert result["state"] == {}
+
+
+# -- dry-run + capability gating ----------------------------------------------
+
+
+def test_dry_run_records_would_and_mutates_nothing(capsys, monkeypatch):
+    client = StubClient(
+        capabilities=["nudge", "mark"],
+        sessions=[sess("s")],
+        screens={"s": OVERLOAD},
+    )
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={}, dry_run=True)
+    assert nudges(client) == [] and marks(client) == []
+    assert {"would": "nudge", "session": "s", "text": "continue"} in result["actions"]
+    # The backoff still advances and the wake is still armed in a dry run.
+    assert result["state"]["s"]["attempts"] == 1
+    assert result["wake_in"] == 30
+    assert "dry run" in result["summary"]
+
+
+def test_without_nudge_capability_only_observes(capsys, monkeypatch):
+    client = StubClient(capabilities=[], sessions=[sess("s")], screens={"s": OVERLOAD})
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={})
+    assert nudges(client) == []
+    assert any(
+        a.get("would") == "nudge" and "not granted" in (a.get("note") or "")
+        for a in result["actions"]
+    )
+
+
+def test_max_attempts_without_mark_capability_records_would(capsys, monkeypatch):
+    prior = {"s": {"attempts": 6, "next": 1000, "escalated": False}}
+    client = StubClient(capabilities=["nudge"], sessions=[sess("s")], screens={"s": OVERLOAD})
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={}, state=prior)
+    assert marks(client) == []
+    assert any(a.get("would") == "escalate" for a in result["actions"])

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -403,3 +403,12 @@ def test_wake_in_zero_is_emitted_to_clear_a_pending_wake(capsys):
 
 def test_state_defaults_to_empty_dict_without_config(capsys):
     assert make_round().state == {}
+
+
+def test_set_state_rejects_non_dict():
+    # The engine only persists an object; a non-dict would be silently dropped,
+    # so the boundary rejects it loudly instead.
+    rnd = make_round()
+    for bad in ([1, 2], "nope", None, 7):
+        with pytest.raises(TypeError):
+            rnd.set_state(bad)

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -369,3 +369,37 @@ def test_finish_defaults_to_noop_without_actions(capsys):
     result = json.loads(capsys.readouterr().out.strip())
     assert result["outcome"] == "noop"
     assert result["actions"] == []
+
+
+def test_state_is_read_from_config_and_omitted_from_finish_by_default(capsys):
+    # The lookaside state arrives as a plain dict the program reads…
+    rnd = make_round(state={"n": 3})
+    assert rnd.state == {"n": 3}
+    # …and a program that doesn't write it back / self-schedule leaves both keys
+    # out of the result, so existing programs are unchanged.
+    rnd.finish("done")
+    result = json.loads(capsys.readouterr().out.strip())
+    assert "state" not in result and "wake_in" not in result
+
+
+def test_set_state_and_wake_in_ride_along_in_finish(capsys):
+    rnd = make_round(state={"n": 3})
+    rnd.set_state({"n": 4})
+    rnd.wake_in(60)
+    rnd.finish("rescheduled")
+    result = json.loads(capsys.readouterr().out.strip())
+    assert result["state"] == {"n": 4}
+    assert result["wake_in"] == 60
+
+
+def test_wake_in_zero_is_emitted_to_clear_a_pending_wake(capsys):
+    # wake_in(0) is distinct from never calling it: it explicitly clears.
+    rnd = make_round()
+    rnd.wake_in(0)
+    rnd.finish("nothing left to watch")
+    result = json.loads(capsys.readouterr().out.strip())
+    assert result["wake_in"] == 0
+
+
+def test_state_defaults_to_empty_dict_without_config(capsys):
+    assert make_round().state == {}


### PR DESCRIPTION
## Why

An idle session can stall on a transient server error and just sit there:

> ● API Error: 529 Overloaded. This is a server-side issue, usually temporary — try again in a moment.

The conversation is intact, so a single "continue" resumes it once the overload clears. But a watcher that re-prompts and immediately 529s again must not become a tight retry loop — it should **back off**. That needs two things a watch couldn't do before: remember state across rounds, and re-trigger itself on a schedule it chooses.

## What

Two **general primitives** added to the overlooker substrate (the engine stays mechanism; policy lives in the program):

- **Lookaside state** — a per-overlooker JSON blob (`overlookers.state`) a program reads as `rnd.state` and writes back with `rnd.set_state(...)`. The engine carries it across rounds; it's opaque to the engine, so the program owns its shape.
- **Dynamic self-wake** — a round returns `wake_in: <secs>` (via `rnd.wake_in`) and the engine arms a one-shot `wake_at`. The timer fires it once — **including for reactive watches**, which the scheduled timer otherwise never visits — then clears it. A wake **bypasses cooldown**, since its delay *is* the watch's own self-imposed gap (so a global cooldown can't strand a backoff).

Then a new **`builtin:resume`** that uses them: on the quiet signals (`session.idle` / `session.stale`) it reads the recent screen, and when it matches the transient-error pattern (`529 Overloaded`, configurable) it nudges the session to `continue`. Each consecutive stall doubles the wait before the next nudge (exponential backoff, `base_secs`→`max_secs`), tracked per session in `state` and driven by `wake_in` — so it quietly waits instead of hammering. After `max_attempts` it escalates (a `triage` mark) and stops re-prompting until the session recovers, then drops it from tracking. Honours `dry_run` and is capability-gated (`nudge` to resume, `mark` to escalate).

## Tests

- **Program logic** (server-free pytest, `test_resume_program.py`): detection, the backoff cadence across rounds, escalation + recovery, reactive-vs-sweep candidate selection, dry-run, capability branches.
- **Engine plumbing** (Rust unit): `state`/`wake_in` parse + persist through a round, the timer firing a due wake once and clearing it, a wake bypassing cooldown where a plain cron is gated.
- **Wiring** (Rust integration): a live session whose screen shows `529 Overloaded` is detected, nudged, and the round persists backoff state + arms `wake_at`.
- `weaver_loom` `Round` tests for `set_state`/`wake_in`/`finish`.

All green: loom (98 lib + integration), weaver-core, weaver-api, 62 python; `cargo fmt`/`clippy --all-targets -D warnings` clean.

Closes #235.