### PR TITLE
feat(loom): per-session worktree debug shells in a terminal tab strip

### DIFF
--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -90,7 +90,7 @@ const quiet = computed(() => quietTags(props.ws));
 </script>
 
 <template>
-  <header class="mb-2 rounded-r border-l-2 border-transparent pl-3 pr-1 py-1.5">
+  <header class="mb-1.5 rounded-r border-l-2 border-transparent py-1 pl-3 pr-1">
     <!-- Row 1 — nav, title (inline rename), attention + lifecycle controls -->
     <div class="flex items-center gap-3">
       <router-link to="/" class="shrink-0 text-sm text-muted hover:text-fg">← all</router-link>
@@ -180,18 +180,18 @@ const quiet = computed(() => quietTags(props.ws));
          foreground — it's the point of the page, not chrome. -->
     <p
       v-if="messageOf(ws)"
-      class="mt-1 line-clamp-2 text-sm leading-snug text-fg"
+      class="mt-0.5 line-clamp-2 text-sm leading-snug text-fg"
       data-testid="status-message"
     >
       {{ messageOf(ws) }}
     </p>
-    <p v-else class="mt-1 text-sm text-faint">
+    <p v-else class="mt-0.5 text-sm text-faint">
       No status yet — agent hasn't run <code>weaver status</code>.
     </p>
 
     <!-- Quiet tags — free-form, deletable pills (priority, needs-rebase, …),
          never the reserved loud fill. Each × clears that tag. -->
-    <div v-if="quiet.length" class="mt-1.5 flex flex-wrap items-center gap-1.5">
+    <div v-if="quiet.length" class="mt-1 flex flex-wrap items-center gap-1.5">
       <TagPill
         v-for="t in quiet"
         :key="t.key"
@@ -204,7 +204,7 @@ const quiet = computed(() => quietTags(props.ws));
     <!-- Row 3 — one quiet meta line: repo/branch · agent, then the calm
          conversation-state + freshness pushed to the right. (When attention is
          raised the state lives loudly up on row 1 instead.) -->
-    <div class="mt-2 flex items-center gap-2 text-xs">
+    <div class="mt-1 flex items-center gap-2 text-xs">
       <span class="min-w-0 truncate font-mono text-muted">
         {{ repoName(ws.branch.repo_root) }}/{{ ws.branch.name }}
       </span>
@@ -230,7 +230,7 @@ const quiet = computed(() => quietTags(props.ws));
 
     <!-- Write feedback (rename / clear tag / archive). Inline so it travels
          with the header on every surface. -->
-    <p v-if="error" class="mt-1.5 text-xs text-block">{{ error }}</p>
-    <p v-else-if="notice" class="mt-1.5 text-xs text-accent">{{ notice }}</p>
+    <p v-if="error" class="mt-1 text-xs text-block">{{ error }}</p>
+    <p v-else-if="notice" class="mt-1 text-xs text-accent">{{ notice }}</p>
   </header>
 </template>

--- a/crates/loom/frontend/src/components/SessionTerminals.vue
+++ b/crates/loom/frontend/src/components/SessionTerminals.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import AgentTerminal from './AgentTerminal.vue';
+import { get, del } from '../api';
+
+// The session's terminal area: an inner tab strip over the always-mounted agent
+// terminal plus zero or more worktree **debug shells**.
+//
+// The agent terminal is the live agent — it never unmounts (tearing down its
+// socket/xterm/WebGL is the worst thing on a terminal-first page), so it sits
+// under v-show like the parent's top-level tabs. Each debug shell is a plain
+// login shell in the session's worktree for testing/debugging beside the agent
+// (run the tests, inspect the diff). A shell is spawned on the backend the first
+// time its tab is attached and torn down with the session on archive; closing a
+// tab kills it now. Shells survive a reload (their supervisors are detached), so
+// we rediscover the open ones on mount.
+const props = defineProps<{ id: string }>();
+
+// 'agent' selects the live agent terminal; a number selects that debug shell by
+// its backend index.
+const active = ref<'agent' | number>('agent');
+// Open shell tabs, by backend index. Indices are monotonic per page so a closed
+// tab's index is never reused while open; the supervisor is `loom-shell-<id>-<idx>`.
+const shells = ref<number[]>([]);
+let nextIdx = 0;
+
+async function loadShells() {
+  try {
+    const idxs = (await get(`/sessions/${props.id}/shells`)) as number[];
+    shells.value = [...idxs].sort((a, b) => a - b);
+    nextIdx = shells.value.length ? Math.max(...shells.value) + 1 : 0;
+  } catch {
+    /* best-effort: a probe failure just opens with no rediscovered shells */
+  }
+}
+
+function addShell() {
+  const idx = nextIdx++;
+  shells.value.push(idx);
+  active.value = idx;
+}
+
+async function closeShell(idx: number) {
+  shells.value = shells.value.filter((n) => n !== idx);
+  if (active.value === idx) active.value = 'agent';
+  // Kill the backend supervisor so a worktree shell never lingers after its tab
+  // is gone (archive also sweeps these; closing is the explicit "I'm done").
+  try {
+    await del(`/sessions/${props.id}/shell/${idx}`);
+  } catch {
+    /* already gone */
+  }
+}
+
+onMounted(loadShells);
+</script>
+
+<template>
+  <div class="flex h-full flex-col">
+    <!-- Inner tab strip: Agent + the worktree debug shells + a new-shell button.
+         Quiet and compact — it lives inside the work area, beneath the main
+         tabs, so it stays visually subordinate to them. -->
+    <div class="mb-2 flex items-center gap-1 text-xs">
+      <button
+        type="button"
+        data-term-tab="agent"
+        class="rounded px-2 py-1"
+        :class="active === 'agent' ? 'bg-subtle font-medium text-fg' : 'text-muted hover:text-fg'"
+        @click="active = 'agent'"
+      >
+        Agent
+      </button>
+      <div
+        v-for="(idx, i) in shells"
+        :key="idx"
+        class="flex items-center rounded"
+        :class="active === idx ? 'bg-subtle text-fg' : 'text-muted hover:text-fg'"
+      >
+        <button type="button" class="py-1 pl-2 pr-1 font-medium" @click="active = idx">
+          Shell {{ i + 1 }}
+        </button>
+        <button
+          type="button"
+          class="px-1 py-1 text-faint hover:text-block"
+          title="Close this shell"
+          aria-label="Close shell"
+          @click="closeShell(idx)"
+        >
+          ✕
+        </button>
+      </div>
+      <button
+        type="button"
+        data-term-tab="add-shell"
+        class="rounded px-2 py-1 text-muted hover:bg-subtle hover:text-fg"
+        title="Open a shell in the worktree"
+        @click="addShell"
+      >
+        + Shell
+      </button>
+    </div>
+
+    <div class="min-h-0 flex-1">
+      <!-- Agent terminal: always mounted (v-show), never v-if — its host stays in
+           the DOM so AgentTerminal's zero-size guard skips the bogus resize while
+           hidden and its ResizeObserver re-fits on return. -->
+      <section v-show="active === 'agent'" class="h-full">
+        <AgentTerminal :id="props.id" />
+      </section>
+      <!-- Debug shells: mounted when opened and kept mounted (v-show) so switching
+           tabs never drops the PTY; unmounted only when the tab is closed. -->
+      <section v-for="idx in shells" v-show="active === idx" :key="idx" class="h-full">
+        <AgentTerminal :ws-path="`/api/sessions/${props.id}/shell/${idx}/terminal`" class="h-full" />
+      </section>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { get, ideInfo } from '../api';
 import type { Session, WeaverEvent, Issue } from '../types';
-import AgentTerminal from '../components/AgentTerminal.vue';
+import SessionTerminals from '../components/SessionTerminals.vue';
 import IdeFrame from '../components/IdeFrame.vue';
 import ScratchPanel from '../components/ScratchPanel.vue';
 import SessionPageHeader from '../components/SessionPageHeader.vue';
@@ -188,12 +188,13 @@ onUnmounted(() => {
       <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
 
       <div class="min-h-0 flex-1">
-        <!-- Terminal (default) — the working zone: the live agent fills the
-             space. v-show, NEVER v-if: keeping the host in the DOM means
-             AgentTerminal's zero-size guard skips the bogus resize while hidden,
-             and its ResizeObserver re-fits on return. -->
+        <!-- Terminal (default) — the working zone: the live agent, plus on-demand
+             worktree debug shells in an inner tab strip. v-show, NEVER v-if:
+             keeping the agent terminal's host in the DOM means its zero-size
+             guard skips the bogus resize while hidden and its ResizeObserver
+             re-fits on return. -->
         <section v-show="tab === 'terminal'" class="h-full">
-          <AgentTerminal :id="props.id" />
+          <SessionTerminals :id="props.id" />
         </section>
 
         <!-- Overview — read-only context (goal, issues, activity). Scrolls

--- a/crates/loom/src/shell.rs
+++ b/crates/loom/src/shell.rs
@@ -1,25 +1,36 @@
-//! The operator **scratch shell** — a single, always-available login shell
-//! inside the container, reachable from the web UI (the "Shell" nav item) over
-//! the same WebSocket terminal bridge agent sessions use.
+//! Operator and per-session **scratch shells** — plain login shells reachable
+//! from the web UI over the same WebSocket terminal bridge agent sessions use.
 //!
-//! Unlike an agent session it is not tied to any branch or worktree: it is one
-//! persistent [`tapestry`] supervisor (named [`SHELL_SESSION`]) running a plain
-//! login shell in the container user's `$HOME`. Its purpose is one-time operator
-//! setup that would otherwise need `docker exec -it weaver …` — most concretely
-//! `gcloud auth login`, whose credentials land in the `CLOUDSDK_CONFIG` volume
-//! and so survive recreates (see the Dockerfile / docker-compose.yml).
+//! Two flavours share the launch machinery here:
 //!
-//! Because tapestry supervisors are detached and outlive `loom server run`, the
-//! shell — and any login half-finished in it — persists across a loom restart,
-//! exactly like an agent terminal. It is spawned lazily on first attach
-//! ([`ensure`]) and can be reset with [`restart`].
+//! * The **operator scratch shell** ([`SHELL_SESSION`]): a single persistent
+//!   shell, not tied to any branch or worktree, running in the container user's
+//!   `$HOME`. Its purpose is one-time operator setup that would otherwise need
+//!   `docker exec -it weaver …` — most concretely `gcloud auth login`, whose
+//!   credentials land in the `CLOUDSDK_CONFIG` volume and so survive recreates
+//!   (see the Dockerfile / docker-compose.yml). Spawned lazily by [`ensure`],
+//!   reset with [`restart`].
+//!
+//! * Per-session **debug shells** ([`ensure_debug`]): one or more login shells
+//!   *in a session's worktree*, carrying its `WEAVER_BRANCH`, for poking at the
+//!   agent's checkout (run the tests, inspect the diff) beside the live agent.
+//!   They are spawned lazily on first attach and swept with the session on
+//!   archive/remove ([`kill_debug_all`]) so a worktree shell never outlives the
+//!   worktree it sits in. The UI rediscovers open ones after a reload via
+//!   [`list_debug`] (the supervisors are detached, like the agent terminal).
+//!
+//! Because tapestry supervisors are detached and outlive `loom server run`, a
+//! shell — and any login or long-running command in it — persists across a loom
+//! restart, exactly like an agent terminal.
 
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use weaver_core::branch::Branch;
 
 use crate::agent::{self, LaunchMode};
 use crate::backend;
+use crate::session::Session;
 use crate::{agent_env, AppState};
 
 /// The fixed supervisor name for the operator scratch shell. Distinct from any
@@ -36,24 +47,23 @@ fn shell_cwd() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("/"))
 }
 
-/// Ensure the scratch-shell supervisor is up, spawning it if not. Idempotent: a
-/// live shell is left untouched (so reconnecting/refreshing the UI reattaches to
-/// the same session rather than starting a new one).
-///
-/// The launch script exports the same operator surface an agent session gets —
-/// `WEAVER_API` + `LOOM_TOKEN` so the in-container `weaver`/`loom` CLIs work, and
-/// the operator-managed [`agent_env`] vars — then `exec`s the login shell. It is
-/// deliberately *not* given a `WEAVER_BRANCH`: there's no branch behind it.
-pub async fn ensure(st: &AppState) -> Result<()> {
-    if backend::has_session(SHELL_SESSION).await {
-        return Ok(());
-    }
-
+/// Build the launch script for a scratch/debug login shell: export the operator
+/// surface an agent session gets — `WEAVER_API` + `LOOM_TOKEN` so the in-place
+/// `weaver`/`loom` CLIs work, the operator-managed [`agent_env`] vars, and (for a
+/// per-session debug shell) the session's `WEAVER_BRANCH` — then `exec` the login
+/// shell. `agent_kind = "shell"` means no inner agent command; the empty
+/// args/`Adopt` mode are irrelevant for a bare shell.
+async fn shell_script(st: &AppState, branch_id: Option<&str>) -> String {
     let api_url = format!("http://{}", st.addr);
     let local_token = agent::read_local_token();
     let extra = agent_env::pairs(&st.db).await.unwrap_or_default();
 
     let mut env: Vec<(&str, &str)> = vec![("WEAVER_API", api_url.as_str())];
+    // A debug shell is rooted in a branch's worktree, so it gets that branch; the
+    // operator scratch shell has none and is deliberately left without one.
+    if let Some(branch) = branch_id {
+        env.push(("WEAVER_BRANCH", branch));
+    }
     if let Some(token) = local_token.as_deref() {
         env.push(("LOOM_TOKEN", token));
     }
@@ -63,10 +73,17 @@ pub async fn ensure(st: &AppState) -> Result<()> {
 
     let loom_exe = std::env::current_exe().ok();
     let weaver_dir = loom_exe.as_deref().and_then(Path::parent);
-    // `agent_kind = "shell"` ⇒ no inner command, just the env exports followed by
-    // `exec "${SHELL:-/bin/sh}"`. Adopt/empty args are irrelevant for a shell.
-    let script = agent::launch_script("shell", None, &env, weaver_dir, LaunchMode::Adopt, "");
+    agent::launch_script("shell", None, &env, weaver_dir, LaunchMode::Adopt, "")
+}
 
+/// Ensure the scratch-shell supervisor is up, spawning it if not. Idempotent: a
+/// live shell is left untouched (so reconnecting/refreshing the UI reattaches to
+/// the same session rather than starting a new one).
+pub async fn ensure(st: &AppState) -> Result<()> {
+    if backend::has_session(SHELL_SESSION).await {
+        return Ok(());
+    }
+    let script = shell_script(st, None).await;
     let cwd = shell_cwd();
     tracing::info!(session = SHELL_SESSION, cwd = %cwd.display(), "spawning operator scratch shell");
     backend::new_session(SHELL_SESSION, &cwd, &script).await
@@ -86,4 +103,76 @@ pub async fn restart(st: &AppState) -> Result<()> {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
     ensure(st).await
+}
+
+// ---------------------------------------------------------------------------
+// Per-session worktree debug shells
+// ---------------------------------------------------------------------------
+
+/// Supervisor-name prefix for a session's worktree debug shells; each shell is
+/// `…-<idx>`. The session id is a random slug, so this collides with neither the
+/// agent terminal (`weaver-<id>`) nor the operator shell ([`SHELL_SESSION`]).
+fn debug_prefix(session_id: &str) -> String {
+    format!("loom-shell-{session_id}-")
+}
+
+/// The supervisor name for session `session_id`'s debug shell number `idx`.
+pub fn debug_session(session_id: &str, idx: u32) -> String {
+    format!("{}{idx}", debug_prefix(session_id))
+}
+
+/// Ensure session `session`'s worktree debug shell `idx` is up, spawning it if
+/// not. Idempotent: a live shell is reattached (a refresh reconnects to the same
+/// one). The shell lands in the session's worktree and carries `branch`'s
+/// `WEAVER_BRANCH`, so its in-worktree `weaver`/`loom` resolve to this branch.
+/// Returns the supervisor name to bridge to.
+pub async fn ensure_debug(
+    st: &AppState,
+    session: &Session,
+    branch: &Branch,
+    idx: u32,
+) -> Result<String> {
+    let name = debug_session(&session.id, idx);
+    if backend::has_session(&name).await {
+        return Ok(name);
+    }
+    let script = shell_script(st, Some(&branch.id)).await;
+    let cwd = PathBuf::from(&session.work_dir);
+    tracing::info!(session = %name, cwd = %cwd.display(), "spawning session debug shell");
+    backend::new_session(&name, &cwd, &script).await?;
+    Ok(name)
+}
+
+/// The live debug-shell indices for a session, parsed from the running
+/// supervisor names and sorted ascending — so the UI can re-open the tabs after
+/// a reload (the supervisors are detached and outlive the page). Never spawns.
+pub async fn list_debug(session_id: &str) -> Vec<u32> {
+    let prefix = debug_prefix(session_id);
+    let mut idxs: Vec<u32> = backend::list_sessions()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|n| n.strip_prefix(&prefix).and_then(|s| s.parse().ok()))
+        .collect();
+    idxs.sort_unstable();
+    idxs
+}
+
+/// Kill one of a session's debug shells (the UI's tab-close). Best-effort: a
+/// missing supervisor is already gone.
+pub async fn kill_debug(session_id: &str, idx: u32) {
+    backend::kill_session(&debug_session(session_id, idx))
+        .await
+        .ok();
+}
+
+/// Tear down every debug shell for a session — called from archive/remove
+/// teardown so a worktree shell never outlives the worktree it sits in.
+pub async fn kill_debug_all(session_id: &str) {
+    let prefix = debug_prefix(session_id);
+    for name in backend::list_sessions().await.unwrap_or_default() {
+        if name.starts_with(&prefix) {
+            backend::kill_session(&name).await.ok();
+        }
+    }
 }

--- a/crates/loom/src/terminal.rs
+++ b/crates/loom/src/terminal.rs
@@ -82,15 +82,7 @@ pub async fn terminal_ws(
     }
     let target = session.term_session.clone();
     tracing::info!(session = %key, target = %target, "terminal websocket attached");
-    ws.max_message_size(MAX_FRAME)
-        .max_frame_size(MAX_FRAME)
-        .on_upgrade(move |socket| async move {
-            if let Err(e) = bridge(socket, target.clone()).await {
-                tracing::debug!(target = %target, error = %e, "terminal bridge ended with error");
-            } else {
-                tracing::debug!(target = %target, "terminal bridge detached cleanly");
-            }
-        })
+    upgrade_to_bridge(ws, target)
 }
 
 /// `GET /api/shell/terminal` — upgrade to a WebSocket bridged to the operator
@@ -122,13 +114,63 @@ pub async fn shell_ws(
     }
     let target = crate::shell::SHELL_SESSION.to_string();
     tracing::info!(target = %target, "shell websocket attached");
+    upgrade_to_bridge(ws, target)
+}
+
+/// `GET /api/sessions/{id}/shell/{idx}/terminal` — upgrade to a WebSocket bridged
+/// to one of the session's worktree **debug shells** (see [`crate::shell`]). Same
+/// Origin check and byte pump as [`terminal_ws`], but the target is a plain login
+/// shell *in the session's worktree*, spawned lazily here on first attach — not
+/// the agent itself. Multiple indices give multiple concurrent shells.
+pub async fn session_shell_ws(
+    ws: WebSocketUpgrade,
+    State(st): State<AppState>,
+    Path((key, idx)): Path<(String, u32)>,
+    headers: HeaderMap,
+) -> Response {
+    let base_url = crate::config::get(&st.db, "auth.base_url").await;
+    if !origin_ok(&headers, &st.addr, base_url.as_deref()) {
+        let origin = header_str(&headers, ORIGIN);
+        let host = header_str(&headers, HOST);
+        tracing::warn!(
+            session = %key,
+            origin = %origin,
+            host = %host,
+            bound = %st.addr,
+            "session shell websocket rejected: Origin is not loopback, the \
+             configured auth.base_url, nor a proxied (X-Forwarded-*) request's \
+             own Host"
+        );
+        return (StatusCode::FORBIDDEN, "cross-origin websocket rejected").into_response();
+    }
+    let (session, branch) = match require_session(&st.db, &key).await {
+        Ok(pair) => pair,
+        Err(_) => return (StatusCode::NOT_FOUND, "no such session").into_response(),
+    };
+    let target = match crate::shell::ensure_debug(&st, &session, &branch, idx).await {
+        Ok(name) => name,
+        Err(e) => {
+            tracing::error!(session = %key, idx, error = %e, "failed to bring up session debug shell");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "could not start shell").into_response();
+        }
+    };
+    tracing::info!(session = %key, target = %target, "session debug shell attached");
+    upgrade_to_bridge(ws, target)
+}
+
+/// The shared tail of every terminal/shell handler: bound the inbound frame size
+/// (keystrokes and resizes are tiny — see [`MAX_FRAME`]), then upgrade and
+/// byte-pump the socket against `target`'s supervisor until either side closes.
+/// `target` already names the supervisor in the logs, so the bridge's own lines
+/// don't requalify it as "terminal"/"shell".
+fn upgrade_to_bridge(ws: WebSocketUpgrade, target: String) -> Response {
     ws.max_message_size(MAX_FRAME)
         .max_frame_size(MAX_FRAME)
         .on_upgrade(move |socket| async move {
             if let Err(e) = bridge(socket, target.clone()).await {
-                tracing::debug!(target = %target, error = %e, "shell bridge ended with error");
+                tracing::debug!(target = %target, error = %e, "terminal bridge ended with error");
             } else {
-                tracing::debug!(target = %target, "shell bridge detached cleanly");
+                tracing::debug!(target = %target, "terminal bridge detached cleanly");
             }
         })
 }

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -437,6 +437,18 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{id}/conversation", get(conversation_session))
         .route("/sessions/{id}/events", get(events_sse))
         .route("/sessions/{id}/terminal", get(crate::terminal::terminal_ws))
+        // Per-session worktree debug shells: `shells` lists the live ones (so the
+        // UI re-opens the tabs after a reload), `shell/{idx}/terminal` is the
+        // lazily-spawned WebSocket bridge, and DELETE closes one (the tab's ×).
+        .route("/sessions/{id}/shells", get(list_session_shells))
+        .route(
+            "/sessions/{id}/shell/{idx}",
+            axum::routing::delete(delete_session_shell),
+        )
+        .route(
+            "/sessions/{id}/shell/{idx}/terminal",
+            get(crate::terminal::session_shell_ws),
+        )
         // Drive a session's terminal pane: type a message, interrupt, peek at it.
         .route("/sessions/{id}/send", post(send_session))
         .route("/sessions/{id}/interrupt", post(interrupt_session))
@@ -1149,6 +1161,7 @@ async fn delete_session(
     let mut warnings: Vec<String> = Vec::new();
 
     backend::kill_session(&session.term_session).await.ok();
+    crate::shell::kill_debug_all(&session.id).await;
     st.ide.kill(&session.id);
     let repo_root = PathBuf::from(&branch.repo_root);
     let work_dir = PathBuf::from(&session.work_dir);
@@ -1205,6 +1218,7 @@ pub async fn archive(
     warnings.extend(log_warnings);
 
     backend::kill_session(&session.term_session).await.ok();
+    crate::shell::kill_debug_all(&session.id).await;
     st.ide.kill(&session.id);
     let repo_root = PathBuf::from(&branch.repo_root);
     let work_dir = PathBuf::from(&session.work_dir);
@@ -1254,6 +1268,28 @@ async fn archive_session(
     Ok(Json(
         json!({ "archived": true, "branch": branch.branch, "warnings": warnings }),
     ))
+}
+
+/// `GET /api/sessions/{id}/shells` — the live worktree debug-shell indices for a
+/// session, so the UI re-opens the shell tabs after a reload (the shells are
+/// detached supervisors that outlive the page). Never spawns.
+async fn list_session_shells(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<Vec<u32>>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    Ok(Json(crate::shell::list_debug(&session.id).await))
+}
+
+/// `DELETE /api/sessions/{id}/shell/{idx}` — close one worktree debug shell (the
+/// tab's ×), killing its supervisor. Idempotent: a missing shell is a no-op.
+async fn delete_session_shell(
+    State(st): State<AppState>,
+    Path((key, idx)): Path<(String, u32)>,
+) -> ApiResult<Json<Value>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    crate::shell::kill_debug(&session.id, idx).await;
+    Ok(Json(json!({ "closed": true })))
 }
 
 /// Refresh a session's GitHub PR snapshot on demand (the dashboard's "refresh"

--- a/crates/loom/tests/integration/shell.rs
+++ b/crates/loom/tests/integration/shell.rs
@@ -10,7 +10,7 @@ use serial_test::serial;
 use tokio_tungstenite::tungstenite::Message;
 
 use loom::backend;
-use loom::shell::SHELL_SESSION;
+use loom::shell::{self, SHELL_SESSION};
 
 use crate::fixtures::{drain_until, send_input, TermWs, TestServer};
 
@@ -19,6 +19,15 @@ async fn connect_shell(addr: &std::net::SocketAddr) -> TermWs {
     let (ws, _resp) = tokio_tungstenite::connect_async(url)
         .await
         .expect("shell websocket should connect");
+    ws
+}
+
+/// Connect to a session's worktree debug shell `idx`.
+async fn connect_session_shell(addr: &std::net::SocketAddr, id: &str, idx: u32) -> TermWs {
+    let url = format!("ws://{addr}/api/sessions/{id}/shell/{idx}/terminal");
+    let (ws, _resp) = tokio_tungstenite::connect_async(url)
+        .await
+        .expect("session shell websocket should connect");
     ws
 }
 
@@ -95,4 +104,98 @@ async fn shell_spawns_lazily_runs_and_restarts() {
 
     // Best-effort cleanup so the detached supervisor doesn't linger.
     backend::kill_session(SHELL_SESSION).await.ok();
+}
+
+/// A session's worktree debug shells: each spawns lazily in the session's
+/// worktree (carrying its `WEAVER_BRANCH`), `/shells` lists the live ones for
+/// reload-rediscovery, and archiving the session sweeps every one.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_debug_shells_run_in_worktree_and_are_swept_on_archive() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let session = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "debug shell test", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = session["id"].as_str().unwrap().to_string();
+    let work_dir = session["work_dir"].as_str().unwrap().to_string();
+
+    // No debug shell exists until the first attach.
+    assert!(
+        shell::list_debug(&id).await.is_empty(),
+        "no debug shells before anyone connects"
+    );
+
+    // Attaching to index 0 spawns a shell rooted in the worktree, with the
+    // session's branch exported — distinct from the operator scratch shell.
+    let mut sh0 = connect_session_shell(&ts.addr, &id, 0).await;
+    await_shell_ready(&mut sh0, "RDY0").await;
+    // `WT$((0))` is `WT0` in the OUTPUT but `WT$((0))` in the echoed keystrokes,
+    // so draining for `WT0=` matches the command's result, not the typed line.
+    send_input(&mut sh0, "echo WT$((0))=$PWD BR=${WEAVER_BRANCH:-none}\n").await;
+    let probe = drain_until(&mut sh0, "WT0=", Duration::from_secs(8)).await;
+    assert!(
+        probe.contains(&format!("WT0={work_dir}")),
+        "shell should land in the session's worktree; got:\n{probe}"
+    );
+    assert!(
+        !probe.contains("BR=none"),
+        "shell should export the session's WEAVER_BRANCH; got:\n{probe}"
+    );
+
+    // The live shell is rediscoverable both via the helper and the HTTP route.
+    assert_eq!(shell::list_debug(&id).await, vec![0]);
+    let listed = client
+        .get(&format!("/api/sessions/{id}/shells"))
+        .await
+        .unwrap();
+    assert_eq!(listed, json!([0]), "the route lists the live shell index");
+
+    // A second index is an independent shell — multiple tabs.
+    let mut sh1 = connect_session_shell(&ts.addr, &id, 1).await;
+    await_shell_ready(&mut sh1, "RDY1").await;
+    assert_eq!(shell::list_debug(&id).await, vec![0, 1], "both shells live");
+
+    // Closing one tab (DELETE) kills just that supervisor.
+    client
+        .delete(&format!("/api/sessions/{id}/shell/0"))
+        .await
+        .unwrap();
+    let mut gone = false;
+    for _ in 0..20 {
+        if !backend::has_session(&shell::debug_session(&id, 0)).await {
+            gone = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(gone, "closing a tab must kill that debug shell");
+    assert_eq!(
+        shell::list_debug(&id).await,
+        vec![1],
+        "the other shell lives"
+    );
+
+    // Archiving the session sweeps every remaining debug shell — a worktree
+    // shell must never outlive the worktree it sits in.
+    sh0.send(Message::Close(None)).await.ok();
+    sh1.send(Message::Close(None)).await.ok();
+    client
+        .post(&format!("/api/sessions/{id}/archive"), json!({}))
+        .await
+        .unwrap();
+    let mut swept = false;
+    for _ in 0..20 {
+        if shell::list_debug(&id).await.is_empty() {
+            swept = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(swept, "archive must sweep every debug shell");
 }


### PR DESCRIPTION
## What

Adds **per-session worktree debug shells** — on-demand login shells *in a
session's worktree*, for poking at the agent's checkout (run the tests,
inspect the diff) beside the live agent. They're reached from a new inner
tab strip on the Terminal pane:

`[Agent] [Shell 1 ×] [Shell 2 ×] … [+ Shell]`

The agent terminal stays always-mounted (tearing down its socket/xterm is
the worst thing on a terminal-first page). Each debug shell is a detached
`tapestry` supervisor (`loom-shell-<id>-<idx>`) rooted in the worktree and
carrying the session's `WEAVER_BRANCH`, so the in-worktree `weaver`/`loom`
CLIs resolve to that branch.

Also **tightens the session summary header**: trims the outer padding and
inter-row margins so the bar gives more of the pane back to the terminal.

## Lifecycle / cleanup

- **Lazy:** a shell spawns on the backend the first time its tab attaches.
- **Swept on archive/remove:** `kill_debug_all` runs in both teardown paths
  before the worktree is removed — a worktree shell never outlives the
  worktree it sits in.
- **Survives reload / loom restart:** the supervisors are detached, so the
  UI rediscovers open shells via `GET /sessions/{id}/shells`.
- **Close kills:** a tab's × `DELETE`s just that supervisor.

## Routes

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/sessions/{id}/shells` | live debug-shell indices (reload rediscovery) |
| `GET` | `/api/sessions/{id}/shell/{idx}/terminal` | lazily-spawned WS bridge |
| `DELETE` | `/api/sessions/{id}/shell/{idx}` | close one shell |

The three terminal/shell WS handlers now share an `upgrade_to_bridge` helper.

## Testing

- New integration test `session_debug_shells_run_in_worktree_and_are_swept_on_archive`:
  lazy spawn in the worktree (asserts `$PWD` + `WEAVER_BRANCH`), `/shells`
  listing, multiple concurrent shells, tab-close kills one, archive sweeps
  the rest. Full loom suite green (39 integration + 98 lib), clippy clean.
- Visually validated the header + tab strip in both light and dark themes.
