### PR TITLE
feat(loom): tighten the conversation view for skimming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,12 @@ when you're ready to land. The rules it enforces:
   build). After pushing, block on `gh pr checks <n> --watch --fail-fast`, answer
   comments in-thread, and fix failures until green. Only **then** raise `weaver
   status attention "ready for review"`; while CI runs you are `ok`, not done.
+- **Wait for the bot reviewers — they're slower than CI.** GitHub's Copilot/Codex
+  reviewers post inline comments minutes after the PR opens (not instantly, and
+  after the checks pass). Don't call a PR done the moment it's pushed: block for
+  their review, or check back after ~30 min — `gh pr view <n> --json reviews,comments`
+  plus `gh api repos/{owner}/{repo}/pulls/<n>/comments` for the inline threads —
+  then address or reply to each before handing off.
 
 ## Conventions
 

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -21,6 +21,11 @@ const errorMsg = ref('');
 
 async function load() {
   state.value = 'loading';
+  // Fold keys are per-render row indices (`ctx-0`, `tg-1-0`) and the highlight
+  // tracks this session's turns — so reset both when the session changes, or the
+  // next session would inherit the previous one's open folds and active anchor.
+  open.value = new Set();
+  activeAnchor.value = '';
   try {
     const data = (await get(`/sessions/${props.id}/conversation`)) as IrisLog;
     log.value = data;
@@ -204,7 +209,13 @@ function toggle(k: string) {
   s.has(k) ? s.delete(k) : s.add(k);
   open.value = s;
 }
-const allOpen = computed(() => model.value.foldKeys.length > 0 && open.value.size >= model.value.foldKeys.length);
+// True only when *every current* fold is open — checking membership rather than
+// a size comparison, so stale keys left in `open` (from a prior render model)
+// can't mislabel the toggle as "Collapse all".
+const allOpen = computed(() => {
+  const keys = model.value.foldKeys;
+  return keys.length > 0 && keys.every((k) => open.value.has(k));
+});
 function toggleAll() {
   open.value = allOpen.value ? new Set() : new Set(model.value.foldKeys);
 }
@@ -359,12 +370,19 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
         <template v-for="row in visibleRows" :key="row.key">
           <!-- Injected context (primers, system/permissions) — folded away. -->
           <div v-if="row.type === 'context'" class="overflow-hidden rounded border border-line bg-subtle/30">
-            <button type="button" class="fold-head text-muted" @click="toggle('ctx-' + row.key)">
+            <button
+              type="button"
+              class="fold-head text-muted"
+              :aria-expanded="isOpen('ctx-' + row.key)"
+              :aria-controls="'ctx-' + row.key + '-panel'"
+              @click="toggle('ctx-' + row.key)"
+            >
               <span class="chev" :class="{ open: isOpen('ctx-' + row.key) }">▸</span>
               <span>📎 Context</span>
             </button>
             <pre
               v-if="isOpen('ctx-' + row.key)"
+              :id="'ctx-' + row.key + '-panel'"
               class="conv-pre border-t border-line text-muted"
               >{{ row.text }}</pre>
           </div>
@@ -395,12 +413,19 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
 
           <!-- Thinking — folded. -->
           <div v-else-if="row.type === 'thinking'" class="overflow-hidden rounded border border-line bg-subtle/30">
-            <button type="button" class="fold-head text-muted" @click="toggle('think-' + row.key)">
+            <button
+              type="button"
+              class="fold-head text-muted"
+              :aria-expanded="isOpen('think-' + row.key)"
+              :aria-controls="'think-' + row.key + '-panel'"
+              @click="toggle('think-' + row.key)"
+            >
               <span class="chev" :class="{ open: isOpen('think-' + row.key) }">▸</span>
               <span>💭 Thinking</span>
             </button>
             <pre
               v-if="isOpen('think-' + row.key)"
+              :id="'think-' + row.key + '-panel'"
               class="conv-pre border-t border-line text-muted"
               >{{ row.text }}</pre>
           </div>
@@ -413,7 +438,13 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
               class="overflow-hidden rounded border border-line bg-subtle/30"
               data-testid="tool-fold"
             >
-              <button type="button" class="fold-head" @click="toggle(`tg-${row.key}-${gi}`)">
+              <button
+                type="button"
+                class="fold-head"
+                :aria-expanded="isOpen(`tg-${row.key}-${gi}`)"
+                :aria-controls="`tg-${row.key}-${gi}-panel`"
+                @click="toggle(`tg-${row.key}-${gi}`)"
+              >
                 <span class="chev" :class="{ open: isOpen(`tg-${row.key}-${gi}`) }">▸</span>
                 <span class="shrink-0">🔧</span>
                 <span class="shrink-0 font-mono text-fg">{{ g.name }}</span>
@@ -421,7 +452,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
                 <span v-else class="min-w-0 truncate font-mono text-faint">{{ preview(g.items[0]) }}</span>
                 <span v-if="groupHasError(g)" class="ml-auto shrink-0 text-2xs font-medium text-block">error</span>
               </button>
-              <div v-if="isOpen(`tg-${row.key}-${gi}`)" class="border-t border-line">
+              <div v-if="isOpen(`tg-${row.key}-${gi}`)" :id="`tg-${row.key}-${gi}-panel`" class="border-t border-line">
                 <div
                   v-for="(it, ii) in g.items"
                   :key="ii"

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -1,14 +1,17 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, reactive, computed, onMounted, watch, nextTick } from 'vue';
 import { get } from '../api';
-import type { IrisLog, IrisMessage } from '../types';
+import type { IrisLog, IrisBlock } from '../types';
 import MarkdownView from './MarkdownView.vue';
 
 // The Conversation tab: the agent's chat with the model, rendered for review.
 // Reads the normalized iris log from `GET /sessions/{id}/conversation` (live
 // transcript when present, else the capture archived on teardown) and renders it
-// natively — user/assistant turns, collapsible thinking, tool calls + results —
-// so an archived session (whose terminal is gone) is still reviewable here.
+// as a *skimmable* log — prose stays in full view, while the agent's machinery
+// (tool calls + outputs, thinking, injected context) folds away behind compact
+// one-liners. Runs of the same tool call are run-length collapsed (`10× TaskCreate`)
+// so a burst of bookkeeping never buries the conversation, and a right-hand
+// prompt index lets a reviewer jump straight to any user turn.
 const props = defineProps<{ id: string }>();
 
 type LoadState = 'loading' | 'ready' | 'empty' | 'error';
@@ -33,12 +36,210 @@ async function load() {
       state.value = 'error';
     }
   }
+  await nextTick();
+  updateActive();
 }
 
 onMounted(load);
 watch(() => props.id, load);
 
-// One banner line: source agent · model · message count · time span.
+// ── The render model ────────────────────────────────────────────────────────
+// We flatten the message/block stream into a flat list of `Row`s the template
+// renders directly. Two transforms happen here: tool_use blocks are paired with
+// the tool_result that follows them, and consecutive tool items sharing a name
+// are run-length grouped. A `TocItem` is emitted for every user turn, anchoring
+// the jump list on the right.
+
+interface ToolItem {
+  name: string;
+  input: unknown;
+  result?: { output: string; is_error: boolean };
+}
+/** A run-length group of consecutive same-name tool items (`items.length >= 1`). */
+interface ToolGroup {
+  name: string;
+  items: ToolItem[];
+}
+type Row =
+  | { type: 'context'; key: number; text: string }
+  | { type: 'user'; key: number; anchor: string; n: number; time?: string; blocks: IrisBlock[] }
+  | { type: 'text'; key: number; text: string }
+  | { type: 'thinking'; key: number; text: string }
+  | { type: 'tools'; key: number; groups: ToolGroup[] }
+  | { type: 'image'; key: number };
+interface TocItem {
+  anchor: string;
+  n: number;
+  title: string;
+}
+interface Model {
+  rows: Row[];
+  toc: TocItem[];
+  foldKeys: string[];
+  counts: { tools: number; thinking: number; context: number };
+}
+
+/** Run-length encode a flat tool stream: fold a run of same-name items into one group. */
+function rle(items: ToolItem[]): ToolGroup[] {
+  const groups: ToolGroup[] = [];
+  for (const it of items) {
+    const last = groups[groups.length - 1];
+    if (last && last.name === it.name) last.items.push(it);
+    else groups.push({ name: it.name, items: [it] });
+  }
+  return groups;
+}
+
+/** The first non-blank line of a string, trimmed (`''` if there is none). */
+function firstLine(s: string): string {
+  return s.split('\n').map((l) => l.trim()).find(Boolean) ?? '';
+}
+
+/** A user prompt's jump-list label: the first non-empty line, lightly de-marked. */
+function userTitle(blocks: IrisBlock[]): string {
+  const t = blocks.find((b) => b.kind === 'text') as { text: string } | undefined;
+  const first = firstLine(t?.text ?? '') || '(no text)';
+  return first.replace(/^[#>\-*`\s]+/, '').trim() || first;
+}
+
+const model = computed<Model>(() => {
+  const rows: Row[] = [];
+  const toc: TocItem[] = [];
+  const foldKeys: string[] = [];
+  const counts = { tools: 0, thinking: 0, context: 0 };
+  let key = 0;
+  let turn = 0;
+  let toolBuf: ToolItem[] = [];
+
+  const flushTools = () => {
+    if (!toolBuf.length) return;
+    const k = key++;
+    const groups = rle(toolBuf);
+    rows.push({ type: 'tools', key: k, groups });
+    groups.forEach((_, gi) => foldKeys.push(`tg-${k}-${gi}`));
+    toolBuf = [];
+  };
+
+  for (const msg of log.value?.messages ?? []) {
+    if (msg.role === 'context') {
+      flushTools();
+      const text = msg.blocks
+        .filter((b): b is { kind: 'text' | 'thinking'; text: string } => b.kind === 'text' || b.kind === 'thinking')
+        .map((b) => b.text)
+        .join('\n\n')
+        .trim();
+      if (text) {
+        const k = key++;
+        rows.push({ type: 'context', key: k, text });
+        foldKeys.push(`ctx-${k}`);
+        counts.context++;
+      }
+      continue;
+    }
+    if (msg.role === 'user') {
+      flushTools();
+      turn++;
+      const anchor = `conv-turn-${turn}`;
+      rows.push({ type: 'user', key: key++, anchor, n: turn, time: msg.timestamp, blocks: msg.blocks });
+      toc.push({ anchor, n: turn, title: userTitle(msg.blocks) });
+      continue;
+    }
+    // assistant
+    for (const b of msg.blocks) {
+      switch (b.kind) {
+        case 'text':
+          flushTools();
+          if (b.text.trim()) rows.push({ type: 'text', key: key++, text: b.text });
+          break;
+        case 'thinking': {
+          flushTools();
+          if (b.text.trim()) {
+            const k = key++;
+            rows.push({ type: 'thinking', key: k, text: b.text });
+            foldKeys.push(`think-${k}`);
+            counts.thinking++;
+          }
+          break;
+        }
+        case 'tool_use':
+          toolBuf.push({ name: b.name, input: b.input });
+          counts.tools++;
+          break;
+        case 'tool_result': {
+          const last = toolBuf[toolBuf.length - 1];
+          if (last && !last.result) last.result = { output: b.output, is_error: b.is_error };
+          else toolBuf.push({ name: '↳ result', input: undefined, result: { output: b.output, is_error: b.is_error } });
+          break;
+        }
+        case 'image':
+          flushTools();
+          rows.push({ type: 'image', key: key++ });
+          break;
+      }
+    }
+  }
+  flushTools();
+  return { rows, toc, foldKeys, counts };
+});
+
+// ── Visibility filters + fold state ─────────────────────────────────────────
+// The machinery is hidden by default in the sense that it renders collapsed;
+// these category toggles let a reviewer remove a class of noise entirely.
+const show = reactive({ tools: true, thinking: true, context: true });
+const visibleRows = computed(() =>
+  model.value.rows.filter((r) => {
+    if (r.type === 'tools') return show.tools;
+    if (r.type === 'thinking') return show.thinking;
+    if (r.type === 'context') return show.context;
+    return true;
+  }),
+);
+
+// Which folds are open. Default: empty (everything collapsed) — that's the
+// whole point: tool calls/outputs and bookkeeping stay tucked until asked for.
+const open = ref<Set<string>>(new Set());
+const isOpen = (k: string) => open.value.has(k);
+function toggle(k: string) {
+  const s = new Set(open.value);
+  s.has(k) ? s.delete(k) : s.add(k);
+  open.value = s;
+}
+const allOpen = computed(() => model.value.foldKeys.length > 0 && open.value.size >= model.value.foldKeys.length);
+function toggleAll() {
+  open.value = allOpen.value ? new Set() : new Set(model.value.foldKeys);
+}
+
+// ── Prompt jump-list (scroll-spy) ───────────────────────────────────────────
+const convScroll = ref<HTMLElement | null>(null);
+const activeAnchor = ref('');
+
+// The "current" prompt is the last user turn scrolled to (or past) the top of
+// the viewport — so the index highlight tracks the turn you're reading.
+function updateActive() {
+  const root = convScroll.value;
+  if (!root) return;
+  const rootTop = root.getBoundingClientRect().top;
+  const anchors = root.querySelectorAll<HTMLElement>('[data-anchor]');
+  let current = anchors[0]?.dataset.anchor ?? '';
+  for (const el of anchors) {
+    if (el.getBoundingClientRect().top - rootTop <= 72) current = el.dataset.anchor ?? current;
+    else break;
+  }
+  if (current) activeAnchor.value = current;
+}
+
+// Re-seed the highlight whenever the rendered turns change (load, id switch, a
+// filter toggle that shifts the layout).
+watch(visibleRows, () => nextTick(updateActive));
+
+function goTo(anchor: string) {
+  activeAnchor.value = anchor;
+  convScroll.value
+    ?.querySelector(`[data-anchor="${CSS.escape(anchor)}"]`)
+    ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+// ── Banner + small formatters ───────────────────────────────────────────────
 const banner = computed(() => {
   const l = log.value;
   if (!l) return '';
@@ -56,14 +257,8 @@ function shortTime(ts?: string): string {
   return ts.length >= 19 && ts[10] === 'T' ? ts.slice(11, 19) : ts;
 }
 
-// An assistant heading opens each contiguous assistant run; a tool call/result
-// emitted as its own message must not start a fresh heading.
-function startsAssistantRun(messages: IrisMessage[], i: number): boolean {
-  return i === 0 || messages[i - 1].role !== 'assistant';
-}
-
-// A shell command (Bash `command`, Codex `cmd`) renders as a shell block; any
-// other tool input as pretty JSON or its raw string.
+// A shell command (Bash `command`, Codex `cmd`) renders as the command itself;
+// any other tool input as pretty JSON or its raw string.
 function toolCommand(input: unknown): string | null {
   if (input && typeof input === 'object') {
     const o = input as Record<string, unknown>;
@@ -72,25 +267,74 @@ function toolCommand(input: unknown): string | null {
   }
   return null;
 }
-function toolBody(input: unknown): string {
-  if (typeof input === 'string') return input;
+function inputText(it: ToolItem): string {
+  if (it.input === undefined) return '';
+  if (typeof it.input === 'string') return it.input;
+  const cmd = toolCommand(it.input);
+  if (cmd !== null) return cmd;
   try {
-    return JSON.stringify(input, null, 2);
+    return JSON.stringify(it.input, null, 2);
   } catch {
-    return String(input);
+    return String(it.input);
   }
 }
+/** A one-line hint shown beside a single tool's collapsed header. */
+function preview(it: ToolItem): string {
+  return firstLine(inputText(it));
+}
+const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error);
 </script>
 
 <template>
   <div class="flex h-full flex-col">
-    <!-- Banner + refresh: a live session's conversation grows, so allow a manual
-         reload without re-opening the tab. -->
-    <div class="mb-2 flex items-center justify-between gap-2">
-      <p class="truncate text-xs text-muted">{{ banner }}</p>
+    <!-- Toolbar: banner · category filters · expand-all · refresh. A live
+         session's conversation grows, so a manual reload stays available. -->
+    <div class="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
+      <p class="min-w-0 flex-1 truncate text-xs text-muted">{{ banner }}</p>
+
+      <div v-if="state === 'ready'" class="flex items-center gap-1" data-testid="conversation-filters">
+        <button
+          type="button"
+          class="chip"
+          :data-active="show.tools"
+          aria-label="Toggle tool calls"
+          @click="show.tools = !show.tools"
+        >
+          Tools<span v-if="model.counts.tools" class="chip-n">{{ model.counts.tools }}</span>
+        </button>
+        <button
+          type="button"
+          class="chip"
+          :data-active="show.thinking"
+          aria-label="Toggle thinking"
+          @click="show.thinking = !show.thinking"
+        >
+          Thinking<span v-if="model.counts.thinking" class="chip-n">{{ model.counts.thinking }}</span>
+        </button>
+        <button
+          v-if="model.counts.context"
+          type="button"
+          class="chip"
+          :data-active="show.context"
+          aria-label="Toggle context"
+          @click="show.context = !show.context"
+        >
+          Context<span class="chip-n">{{ model.counts.context }}</span>
+        </button>
+        <span class="mx-0.5 h-3.5 w-px bg-line"></span>
+        <button
+          type="button"
+          class="chip"
+          :disabled="!model.foldKeys.length"
+          @click="toggleAll"
+        >
+          {{ allOpen ? 'Collapse all' : 'Expand all' }}
+        </button>
+      </div>
+
       <button
         type="button"
-        class="btn-secondary shrink-0 text-xs"
+        class="btn-secondary shrink-0 px-2 py-0.5 text-xs"
         :disabled="state === 'loading'"
         @click="load"
       >
@@ -104,63 +348,284 @@ function toolBody(input: unknown): string {
       No conversation recorded for this session yet.
     </p>
 
-    <div v-else class="min-h-0 flex-1 space-y-4 overflow-auto pb-2">
-      <template v-for="(msg, i) in log!.messages" :key="i">
-        <!-- Injected context (primers, system/permissions) — tucked away. -->
-        <details v-if="msg.role === 'context'" class="rounded border border-line bg-subtle/40 px-3 py-2">
-          <summary class="cursor-pointer text-xs text-muted">📎 Context</summary>
-          <div class="mt-2 space-y-2">
-            <template v-for="(b, j) in msg.blocks" :key="j">
-              <pre
-                v-if="b.kind === 'text' || b.kind === 'thinking'"
-                class="whitespace-pre-wrap break-words font-mono text-xs text-muted"
-                >{{ b.text }}</pre>
-            </template>
+    <div v-else class="flex min-h-0 flex-1 gap-4">
+      <!-- The conversation stream. -->
+      <div
+        ref="convScroll"
+        data-testid="conversation"
+        class="conv-scroll min-h-0 flex-1 space-y-3 overflow-auto pb-8 pr-1"
+        @scroll.passive="updateActive"
+      >
+        <template v-for="row in visibleRows" :key="row.key">
+          <!-- Injected context (primers, system/permissions) — folded away. -->
+          <div v-if="row.type === 'context'" class="overflow-hidden rounded border border-line bg-subtle/30">
+            <button type="button" class="fold-head text-muted" @click="toggle('ctx-' + row.key)">
+              <span class="chev" :class="{ open: isOpen('ctx-' + row.key) }">▸</span>
+              <span>📎 Context</span>
+            </button>
+            <pre
+              v-if="isOpen('ctx-' + row.key)"
+              class="conv-pre border-t border-line text-muted"
+              >{{ row.text }}</pre>
           </div>
-        </details>
 
-        <!-- User turn. -->
-        <section v-else-if="msg.role === 'user'" class="rounded border-l-2 border-accent bg-subtle/40 px-3 py-2">
-          <header class="mb-1 text-xs font-medium text-accent">
-            🧑 User<span v-if="msg.timestamp" class="ml-2 font-normal text-muted">{{ shortTime(msg.timestamp) }}</span>
-          </header>
-          <template v-for="(b, j) in msg.blocks" :key="j">
-            <MarkdownView v-if="b.kind === 'text'" :id="props.id" path="" :source="b.text" />
-            <p v-else-if="b.kind === 'image'" class="text-xs italic text-muted">[image]</p>
-          </template>
-        </section>
+          <!-- User turn — the anchor for the jump list; always shown in full. -->
+          <section
+            v-else-if="row.type === 'user'"
+            :id="row.anchor"
+            :data-anchor="row.anchor"
+            class="conv-anchor rounded-md border-l-2 border-accent bg-subtle/40 px-3 py-2"
+          >
+            <header class="mb-1 flex items-center gap-2 text-xs font-medium text-accent">
+              <span class="turn-badge">{{ row.n }}</span>
+              <span>🧑 User</span>
+              <span v-if="row.time" class="font-normal text-muted">{{ shortTime(row.time) }}</span>
+            </header>
+            <template v-for="(b, j) in row.blocks" :key="j">
+              <MarkdownView v-if="b.kind === 'text'" :id="props.id" path="" :source="b.text" />
+              <p v-else-if="b.kind === 'image'" class="text-xs italic text-muted">[image]</p>
+            </template>
+          </section>
 
-        <!-- Assistant turn (one heading per run). -->
-        <section v-else>
-          <header v-if="startsAssistantRun(log!.messages, i)" class="mb-1 text-xs font-medium text-fg">
-            🤖 Assistant<span v-if="msg.timestamp" class="ml-2 font-normal text-muted">{{ shortTime(msg.timestamp) }}</span>
-          </header>
-          <template v-for="(b, j) in msg.blocks" :key="j">
-            <MarkdownView v-if="b.kind === 'text'" :id="props.id" path="" :source="b.text" class="mb-2" />
+          <!-- Assistant prose. No role heading — the boxed/accented user turns
+               are the dividers, so the agent's replies just flow as plain text. -->
+          <div v-else-if="row.type === 'text'" class="px-3">
+            <MarkdownView :id="props.id" path="" :source="row.text" />
+          </div>
 
-            <details v-else-if="b.kind === 'thinking'" class="mb-2 rounded border border-line bg-subtle/40 px-3 py-1.5">
-              <summary class="cursor-pointer text-xs text-muted">💭 Thinking</summary>
-              <pre class="mt-2 whitespace-pre-wrap break-words font-mono text-xs text-muted">{{ b.text }}</pre>
-            </details>
+          <!-- Thinking — folded. -->
+          <div v-else-if="row.type === 'thinking'" class="overflow-hidden rounded border border-line bg-subtle/30">
+            <button type="button" class="fold-head text-muted" @click="toggle('think-' + row.key)">
+              <span class="chev" :class="{ open: isOpen('think-' + row.key) }">▸</span>
+              <span>💭 Thinking</span>
+            </button>
+            <pre
+              v-if="isOpen('think-' + row.key)"
+              class="conv-pre border-t border-line text-muted"
+              >{{ row.text }}</pre>
+          </div>
 
-            <div v-else-if="b.kind === 'tool_use'" class="mb-2 overflow-hidden rounded border border-line">
-              <div class="border-b border-line bg-subtle/60 px-3 py-1 text-xs font-medium text-fg">
-                🔧 {{ b.name }}
+          <!-- Tool activity — each run-length group a compact, collapsed strip. -->
+          <div v-else-if="row.type === 'tools'" class="space-y-1">
+            <div
+              v-for="(g, gi) in row.groups"
+              :key="gi"
+              class="overflow-hidden rounded border border-line bg-subtle/30"
+              data-testid="tool-fold"
+            >
+              <button type="button" class="fold-head" @click="toggle(`tg-${row.key}-${gi}`)">
+                <span class="chev" :class="{ open: isOpen(`tg-${row.key}-${gi}`) }">▸</span>
+                <span class="shrink-0">🔧</span>
+                <span class="shrink-0 font-mono text-fg">{{ g.name }}</span>
+                <span v-if="g.items.length > 1" class="rle-badge" data-testid="rle-count">{{ g.items.length }}×</span>
+                <span v-else class="min-w-0 truncate font-mono text-faint">{{ preview(g.items[0]) }}</span>
+                <span v-if="groupHasError(g)" class="ml-auto shrink-0 text-2xs font-medium text-block">error</span>
+              </button>
+              <div v-if="isOpen(`tg-${row.key}-${gi}`)" class="border-t border-line">
+                <div
+                  v-for="(it, ii) in g.items"
+                  :key="ii"
+                  :class="ii > 0 ? 'border-t border-line/60' : ''"
+                >
+                  <div v-if="g.items.length > 1" class="px-3 pt-1.5 font-mono text-2xs text-faint">
+                    #{{ ii + 1 }} · {{ it.name }}
+                  </div>
+                  <pre v-if="inputText(it)" class="conv-pre text-fg">{{ inputText(it) }}</pre>
+                  <pre
+                    v-if="it.result && it.result.output.trim()"
+                    class="conv-pre conv-result"
+                    :class="it.result.is_error ? 'text-block' : 'text-muted'"
+                    >{{ it.result.output }}</pre>
+                </div>
               </div>
-              <pre class="overflow-x-auto px-3 py-2 font-mono text-xs text-fg">{{ toolCommand(b.input) ?? toolBody(b.input) }}</pre>
             </div>
+          </div>
 
-            <details v-else-if="b.kind === 'tool_result'" class="mb-2 rounded border border-line bg-subtle/30 px-3 py-1.5">
-              <summary class="cursor-pointer text-xs" :class="b.is_error ? 'text-block' : 'text-muted'">
-                ↳ result{{ b.is_error ? ' (error)' : '' }}
-              </summary>
-              <pre class="mt-2 overflow-x-auto whitespace-pre-wrap break-words font-mono text-xs text-muted">{{ b.output }}</pre>
-            </details>
+          <p v-else-if="row.type === 'image'" class="text-xs italic text-muted">[image]</p>
+        </template>
+      </div>
 
-            <p v-else-if="b.kind === 'image'" class="mb-2 text-xs italic text-muted">[image]</p>
-          </template>
-        </section>
-      </template>
+      <!-- Prompt jump-list: one entry per user turn, with scroll-spy highlight. -->
+      <nav
+        v-if="model.toc.length"
+        class="hidden w-56 shrink-0 overflow-auto border-l border-line pl-3 lg:block"
+        data-testid="conversation-toc"
+        aria-label="Prompts"
+      >
+        <p class="mb-2 px-1 text-2xs font-medium uppercase tracking-wider text-faint">
+          Prompts · {{ model.toc.length }}
+        </p>
+        <ul class="space-y-0.5">
+          <li v-for="t in model.toc" :key="t.anchor">
+            <button
+              type="button"
+              class="toc-item"
+              :data-active="activeAnchor === t.anchor"
+              data-testid="conversation-toc-item"
+              @click="goTo(t.anchor)"
+            >
+              <span class="toc-num">{{ t.n }}</span>
+              <span class="truncate">{{ t.title }}</span>
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </template>
+
+<style scoped>
+/* Anchored user turns sit a touch below the top edge when jumped to. */
+.conv-anchor {
+  scroll-margin-top: 0.5rem;
+}
+
+/* The shared MarkdownView wraps prose in a padded, centred surface card — right
+   for a standalone document, too heavy for a chat line. Inside the conversation
+   we flatten it to tight, left-aligned prose directly on the canvas so the agent's
+   replies read as conversation, not as a stack of cards. */
+.conv-scroll :deep(div:has(> .markdown-body)) {
+  background: transparent;
+  overflow: visible;
+}
+.conv-scroll :deep(.markdown-body) {
+  max-width: none;
+  margin: 0;
+  padding: 0.125rem 0;
+}
+
+/* The clickable header of any fold (context, thinking, a tool group). */
+.fold-head {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3125rem 0.625rem;
+  text-align: left;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  cursor: pointer;
+}
+.fold-head:hover {
+  background: color-mix(in srgb, var(--subtle) 60%, transparent);
+}
+
+/* The disclosure caret — rotates from ▸ to ▾ when its fold opens. */
+.chev {
+  display: inline-block;
+  flex: none;
+  color: var(--faint);
+  transition: transform 0.12s ease;
+}
+.chev.open {
+  transform: rotate(90deg);
+}
+
+/* Run-length count badge (`10×`) for a folded run of identical tool calls. */
+.rle-badge {
+  flex: none;
+  border-radius: 0.25rem;
+  background: var(--input);
+  color: var(--muted);
+  box-shadow: inset 0 0 0 1px var(--line);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  line-height: 1rem;
+  padding: 0 0.375rem;
+}
+
+/* Turn number on a user prompt's header. */
+.turn-badge {
+  display: inline-flex;
+  min-width: 1.25rem;
+  justify-content: center;
+  border-radius: 0.25rem;
+  background: var(--input);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  line-height: 1rem;
+  padding: 0 0.25rem;
+}
+
+/* Preformatted bodies inside folds — tool input, results, context, thinking. */
+.conv-pre {
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.1rem;
+  padding: 0.5rem 0.625rem;
+}
+.conv-result {
+  max-height: 22rem;
+  overflow: auto;
+  background: color-mix(in srgb, var(--subtle) 35%, transparent);
+}
+
+/* Filter / expand-all chips in the toolbar. */
+.chip {
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  line-height: 1rem;
+  font-weight: 500;
+  color: var(--faint);
+  cursor: pointer;
+  transition: color 0.12s ease, background-color 0.12s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3125rem;
+}
+.chip:hover:not(:disabled) {
+  color: var(--muted);
+  background: color-mix(in srgb, var(--subtle) 50%, transparent);
+}
+.chip[data-active='true'] {
+  color: var(--fg);
+  background: var(--subtle);
+}
+.chip:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.chip-n {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  color: var(--faint);
+}
+
+/* Jump-list entries. */
+.toc-item {
+  display: flex;
+  width: 100%;
+  align-items: baseline;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  border-left: 2px solid transparent;
+  padding: 0.1875rem 0.5rem;
+  text-align: left;
+  font-size: 0.75rem;
+  line-height: 1.1rem;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.12s ease, background-color 0.12s ease;
+}
+.toc-item:hover {
+  background: color-mix(in srgb, var(--subtle) 55%, transparent);
+  color: var(--fg);
+}
+.toc-item[data-active='true'] {
+  background: var(--subtle);
+  border-left-color: var(--accent);
+  color: var(--fg);
+}
+.toc-num {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  color: var(--faint);
+}
+</style>

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -464,9 +464,11 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
       async seedConversation(session, log) {
         // The conversation endpoint prefers a live agent transcript, but a
         // seeded `shell` session has none — so it falls back to the captured
-        // `chat.json` under the configured log dir. Point that at a temp folder
-        // and drop the log there, slugging the branch the same way the server does.
-        const logRoot = mkdtempSync(join(tmpdir(), 'weaver-conv-'));
+        // `chat.json` under the configured log dir. Point that at a folder under
+        // this worker's WEAVER_HOME (reaped in worker teardown, so no stray
+        // /tmp/weaver-conv-* dirs leak across runs) and drop the log there,
+        // slugging the branch the same way the server does.
+        const logRoot = mkdtempSync(join(childEnv.WEAVER_HOME!, 'conv-'));
         await fetchJson(`${baseUrl}/api/settings`, {
           method: 'PATCH',
           body: JSON.stringify({ 'session.log_dir': logRoot }),

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -117,6 +117,11 @@ export interface WeaverFixture {
   /** Create an *unclaimed* backlog issue in a repo via `POST /api/repos/issues`
    *  — the kind the Issues pane offers a Launch button for. */
   seedBacklogIssue(repoRoot: string, title: string, body?: string): Promise<Issue>;
+  /** Plant a normalized iris conversation log for a session so the Conversation
+   *  tab has something to render. Points `session.log_dir` at a temp folder and
+   *  writes the log where the endpoint's capture fallback reads it
+   *  (`<log_dir>/<branch-slug>/chat.json`). `log` is an iris `Log` shape. */
+  seedConversation(session: Session, log: unknown): Promise<void>;
   /** Write an artifact via `weaver artifact write` — creates it on first call,
    *  appends an immutable revision after. Content is piped on stdin; `--repo`
    *  publishes it repo-shared instead of scoping it to the branch. */
@@ -454,6 +459,21 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
           method: 'POST',
           body: JSON.stringify({ repo_root: repoRoot, title, body: body ?? '' }),
         })) as Issue;
+      },
+
+      async seedConversation(session, log) {
+        // The conversation endpoint prefers a live agent transcript, but a
+        // seeded `shell` session has none — so it falls back to the captured
+        // `chat.json` under the configured log dir. Point that at a temp folder
+        // and drop the log there, slugging the branch the same way the server does.
+        const logRoot = mkdtempSync(join(tmpdir(), 'weaver-conv-'));
+        await fetchJson(`${baseUrl}/api/settings`, {
+          method: 'PATCH',
+          body: JSON.stringify({ 'session.log_dir': logRoot }),
+        });
+        const slug = session.branch.branch.replace(/[^A-Za-z0-9._-]/g, '-');
+        mkdirSync(join(logRoot, slug), { recursive: true });
+        writeFileSync(join(logRoot, slug, 'chat.json'), JSON.stringify(log));
       },
 
       async writeArtifact(session, name, content, opts) {

--- a/e2e/tests/conversation.spec.ts
+++ b/e2e/tests/conversation.spec.ts
@@ -1,0 +1,111 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures/weaver';
+import type { WeaverFixture } from '../fixtures/weaver';
+
+// The Conversation tab renders a session's normalized iris log as a *skimmable*
+// review surface: prose stays in view, the agent's machinery (tool calls +
+// outputs, thinking, context) folds away collapsed, runs of the same tool call
+// are run-length collapsed, and a right-hand prompt index jumps between turns.
+
+/** A small iris log: three user turns, a thinking block, a folded context
+ *  block, a single Bash call, and a burst of ten identical TaskCreate calls. */
+function demoLog() {
+  const tasks: unknown[] = [];
+  for (let i = 0; i < 10; i++) {
+    tasks.push({ kind: 'tool_use', name: 'TaskCreate', input: { title: `subtask ${i + 1}` } });
+    tasks.push({ kind: 'tool_result', output: `Created #${100 + i}`, is_error: false });
+  }
+  return {
+    source: 'claude',
+    model: 'claude-opus-4-8',
+    messages: [
+      { role: 'context', blocks: [{ kind: 'text', text: 'Session primer — follow AGENTS.md.' }] },
+      { role: 'user', timestamp: '2026-06-21T10:00:00.000Z', blocks: [{ kind: 'text', text: 'Add a dark-mode toggle.' }] },
+      {
+        role: 'assistant',
+        timestamp: '2026-06-21T10:00:01.000Z',
+        blocks: [
+          { kind: 'thinking', text: 'Let me find the theme store first.' },
+          { kind: 'text', text: 'Looking at the settings view.' },
+          { kind: 'tool_use', name: 'Bash', input: { command: 'rg -n theme src/' } },
+          { kind: 'tool_result', output: 'src/theme.ts:12', is_error: false },
+          { kind: 'text', text: 'Filing tasks for the work.' },
+          ...tasks,
+        ],
+      },
+      { role: 'user', timestamp: '2026-06-21T10:05:00.000Z', blocks: [{ kind: 'text', text: 'Make it persist.' }] },
+      { role: 'assistant', timestamp: '2026-06-21T10:05:01.000Z', blocks: [{ kind: 'text', text: 'It persists via the store.' }] },
+      { role: 'user', timestamp: '2026-06-21T10:09:00.000Z', blocks: [{ kind: 'text', text: 'Ship it.' }] },
+      { role: 'assistant', timestamp: '2026-06-21T10:09:01.000Z', blocks: [{ kind: 'text', text: 'Opening the PR.' }] },
+    ],
+  };
+}
+
+async function openConversation(page: Page, weaver: WeaverFixture) {
+  const s = await weaver.seedSession({ goal: 'demo', name: 'conv' });
+  await weaver.seedConversation(s, demoLog());
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(`${weaver.baseUrl}/s/${s.id}`);
+  await page.locator('[data-tab="conversation"]').click();
+  await expect(page.getByTestId('conversation')).toBeVisible();
+  return s;
+}
+
+test.describe('conversation view', () => {
+  test('folds tool activity and run-length collapses repeated calls', async ({ page, weaver }) => {
+    await openConversation(page, weaver);
+    const conv = page.getByTestId('conversation');
+
+    // The ten TaskCreate calls collapse to a single fold with a 10× count, not
+    // ten separate rows. Bash and TaskCreate are the only two tool folds.
+    await expect(page.getByTestId('tool-fold')).toHaveCount(2);
+    await expect(page.getByTestId('rle-count')).toHaveText('10×');
+
+    // Folds are collapsed by default — the collapsed header shows a one-line
+    // command preview, but the tool's *output* stays hidden until expanded.
+    await expect(conv.getByText('rg -n theme src/', { exact: false })).toBeVisible();
+    await expect(conv.getByText('src/theme.ts:12')).toHaveCount(0);
+    await page.getByTestId('tool-fold').filter({ hasText: 'Bash' }).getByRole('button').first().click();
+    await expect(conv.getByText('src/theme.ts:12')).toBeVisible();
+  });
+
+  test('category filters strip tool / thinking noise on demand', async ({ page, weaver }) => {
+    await openConversation(page, weaver);
+
+    // Hiding tools removes every tool fold, leaving just the prose.
+    await page.getByRole('button', { name: 'Toggle tool calls' }).click();
+    await expect(page.getByTestId('tool-fold')).toHaveCount(0);
+    // The agent's prose still reads.
+    await expect(page.getByText('It persists via the store.')).toBeVisible();
+
+    // Toggling it back restores them.
+    await page.getByRole('button', { name: 'Toggle tool calls' }).click();
+    await expect(page.getByTestId('tool-fold')).toHaveCount(2);
+  });
+
+  test('expand-all opens every fold, collapse-all closes them', async ({ page, weaver }) => {
+    await openConversation(page, weaver);
+    const conv = page.getByTestId('conversation');
+
+    await page.getByRole('button', { name: 'Expand all' }).click();
+    await expect(conv.getByText('src/theme.ts:12')).toBeVisible();
+    await expect(conv.getByText('Let me find the theme store first.')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Collapse all' }).click();
+    await expect(conv.getByText('src/theme.ts:12')).toHaveCount(0);
+  });
+
+  test('the prompt index lists every user turn and highlights on jump', async ({ page, weaver }) => {
+    await openConversation(page, weaver);
+
+    const items = page.getByTestId('conversation-toc-item');
+    await expect(items).toHaveCount(3);
+    await expect(items.first()).toContainText('Add a dark-mode toggle.');
+
+    // The first prompt is active on load; clicking the third makes it active.
+    await expect(items.first()).toHaveAttribute('data-active', 'true');
+    await items.nth(2).click();
+    await expect(items.nth(2)).toHaveAttribute('data-active', 'true');
+    await expect(items.first()).toHaveAttribute('data-active', 'false');
+  });
+});

--- a/e2e/tests/ide.spec.ts
+++ b/e2e/tests/ide.spec.ts
@@ -2,9 +2,9 @@ import { test, expect } from '../fixtures/weaver';
 
 // The embedded editor (code-server) lives in a panel pulled in from the right,
 // beside the terminal. The proxy/lifecycle is covered by the Rust integration
-// test; this drives the UX. CI has no code-server installed, so opening the
-// panel must degrade gracefully to a clear "not installed" message — never a
-// broken frame.
+// test; this drives the UX. Opening the panel must always settle into a valid
+// mount — the live editor when code-server is on the host, else a graceful
+// "not installed" note — never a broken/blank frame.
 test.describe('embedded editor panel', () => {
   test('pulls in from the right, then collapses', async ({ page, weaver }) => {
     const session = await weaver.seedSession({ goal: 'edit some code', name: 'ide-panel' });
@@ -17,9 +17,12 @@ test.describe('embedded editor panel', () => {
 
     // The panel mounts with its header…
     await expect(page.getByText('Editor', { exact: true })).toBeVisible();
-    // …and, with no code-server on the host, the graceful not-installed note
-    // (CI has none — see docs/embedded-ide.md).
-    await expect(page.getByText("code-server isn't installed")).toBeVisible();
+    // …and its body settles into a valid state: the live editor iframe when
+    // code-server is installed, else the graceful not-installed note (e.g. CI;
+    // see docs/embedded-ide.md). Either is correct — neither is a broken frame.
+    const liveEditor = page.locator('iframe[title="VS Code"]');
+    const notInstalled = page.getByText("code-server isn't installed");
+    await expect(liveEditor.or(notInstalled)).toBeVisible();
 
     // Closing collapses back to the handle.
     await page.getByLabel('Close editor').click();

--- a/e2e/tests/overlookers.spec.ts
+++ b/e2e/tests/overlookers.spec.ts
@@ -154,9 +154,14 @@ test.describe('overlooker panel', () => {
 
     // The registry section lists the stock programs that ship with loom.
     const rows = page.getByTestId('program-row');
-    await expect(rows).toHaveCount(3);
+    await expect(rows).toHaveCount(4);
     const section = page.getByTestId('builtin-programs');
-    for (const name of ['builtin:status', 'builtin:pr-label', 'builtin:archive-merged']) {
+    for (const name of [
+      'builtin:status',
+      'builtin:resume',
+      'builtin:pr-label',
+      'builtin:archive-merged',
+    ]) {
       await expect(section).toContainText(name);
     }
 

--- a/e2e/tests/status-hook.spec.ts
+++ b/e2e/tests/status-hook.spec.ts
@@ -1,25 +1,35 @@
 import { test, expect } from '../fixtures/weaver';
 
 test.describe('status reflects hook and attention events', () => {
-  test('detail view: hooks drive lifecycle + attention via SSE', async ({ page, weaver }) => {
+  test('detail view: hooks drive lifecycle and a waiting lull stays calm', async ({
+    page,
+    weaver,
+  }) => {
     const s = await weaver.seedSession({ goal: 'Watch my status', name: 'hook-detail' });
 
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);
-    // While calm, the agent's state shows on the quiet conversation-state strip.
+    // The agent's derived state shows on the quiet conversation-state strip.
     const conv = page.getByTestId('conversation-state');
     await expect(conv).toBeVisible();
 
-    // Any hook means the agent process is alive → lifecycle `running`, the
-    // silent default: the header shows no lifecycle badge for it.
+    // A `working` hook means a prompt was submitted — the agent process is alive
+    // → lifecycle `running` (the silent default: no lifecycle badge), and an
+    // engaged agent reads as "Working".
     await weaver.hook(s, 'working');
     await expect(page.getByTestId('status-badge')).toHaveCount(0);
+    await expect(conv).toContainText('Working');
 
-    // A `waiting` hook (Claude blocked on the user) raises the attention signal,
-    // which surfaces as a chip.
+    // A `waiting` hook (a Notification lull) is no longer loud: it stamps the
+    // soothing idle mark rather than raising attention (see monitor.rs::apply_hook).
+    // The mark lands on the branch…
     await weaver.hook(s, 'waiting');
+    await expect
+      .poll(async () => (await weaver.getSession(s.id)).branch.tags.some((t) => t.key === 'idle'))
+      .toBe(true);
+    // …but the session stays calm — the loud attention axis is never raised.
     await expect(
       page.locator('[data-testid="signal-chip"][data-signal-key="attention"]'),
-    ).toHaveAttribute('data-level', 'attention');
+    ).toHaveCount(0);
   });
 
   test('detail view: weaver status sets level + message via SSE', async ({ page, weaver }) => {


### PR DESCRIPTION
The Conversation tab rendered every tool call, output, thinking block, and injected primer inline, so a real session's chat was mostly machinery and hard to scan. This reworks it into a skimmable log.

## What changed
- Tool calls + outputs, thinking, and context fold away collapsed by default. A tool shows a one-line header with a command preview and an error flag; its output opens on click.
- Consecutive calls to the same tool are run-length collapsed into a single `N× ToolName` fold, so a burst of TaskCreate bookkeeping no longer buries the conversation.
- Category filters (Tools / Thinking / Context) and Expand/Collapse-all sit in the toolbar for tuning how much machinery shows.
- A right-hand prompt index lists every user turn and jumps to it, with a scroll-spy highlight tracking the turn in view.
- Assistant prose is flattened from a padded surface card to inline text so replies read as conversation; user turns are numbered and boxed as the dividers between them.

It is pure presentation over the existing iris log served by `GET /sessions/{id}/conversation` — no API or backend change. A `seedConversation` e2e fixture helper plants a transcript so `e2e/tests/conversation.spec.ts` can cover the folding, run-length grouping, filters, and prompt index.

Fixes #246