### PR TITLE
fix(loom): a finished turn reads as calm "Idle", not stuck "Working" (#247)

### DIFF
--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -169,16 +169,24 @@ export function quietTags(s: Session): Tag[] {
 // a *live* agent resting between turns: a terminal/detached lifecycle (done,
 // error, archived, orphaned) reads through its own badge, not "resting". And
 // only when genuinely calm — any loud signal (the agent's own or an outside
-// mark) supersedes the resting state — and the mark is itself live (not stale:
-// the session hasn't moved on past it). Drives the calm "Idle" presentation in
+// mark) supersedes the resting state. Drives the calm "Idle" presentation in
 // the list and header.
+//
+// Unlike a loud outside mark, the idle mark is deliberately NOT subject to
+// activity-staleness: it is the agent's own lifecycle self-report, retracted
+// event-driven by the `working` hook (monitor `apply_hook` clears IDLE_KEY when
+// a prompt is submitted), not by `last_activity_at` advancing. Comparing it
+// against activity would misfire two ways: (1) the very turn-ending output that
+// triggers the `waiting`/`idle` hook also changes the pane, and the monitor's
+// pane-hash touch bumps `last_activity_at` a millisecond *after* the mark's
+// `set_at` — so the mark would be born stale and a finished turn would never read
+// "Idle"; and (2) sub-agent or shell pane activity under an idle mark is, by
+// design, still "resting" (see monitor `apply_hook`), not a reason to retract it.
 const LIVE_STATUSES = new Set(['launching', 'running']);
 export function idleTag(s: Session): Tag | null {
   if (!LIVE_STATUSES.has(s.status)) return null;
   if (loudTags(s).length > 0) return null;
-  const tag = (s.branch.tags ?? []).find((t) => t.key === IDLE_KEY);
-  if (!tag || tagStale(tag, s.last_activity_at)) return null;
-  return tag;
+  return (s.branch.tags ?? []).find((t) => t.key === IDLE_KEY) ?? null;
 }
 
 // Compact conversation-state line for the detail header (#5): a derived

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -313,7 +313,12 @@ authors its own typed keys. The well-known **`idle`** key is a *quiet* exception
 loom stamps it mechanically when an agent goes quiet (the soothing "resting, no
 one needed" state), carrying the non-loud value `idle` so it never raises a badge
 — the dashboard surfaces it as a calm "Idle" mark, and the status watch may
-replace it with a real loud status. **Absence is the calm/default state** — there
+replace it with a real loud status. Unlike a loud outside mark it is *not* subject
+to activity-staleness (below): it is the agent's own lifecycle mark, cleared
+event-driven by the next `working` hook (a submitted prompt), not retired by
+`last_activity_at` advancing — the turn-ending output that fires the idle hook is
+itself a pane change that bumps `last_activity_at`, so a stale-check would retire
+the mark the instant it lands. **Absence is the calm/default state** — there
 is no stored `ok`; returning to calm *clears* the tag. A tag is **stale** when its
 `set_at` predates the session's `last_activity_at` (the session moved on since it
 was set). The dashboard resolves the loudest non-stale loud tag into one

--- a/e2e/tests/status-hook.spec.ts
+++ b/e2e/tests/status-hook.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures/weaver';
 
 test.describe('status reflects hook and attention events', () => {
-  test('detail view: hooks drive lifecycle and a waiting lull stays calm', async ({
+  test('detail view: hooks drive lifecycle and a waiting lull reads as a calm "Idle"', async ({
     page,
     weaver,
   }) => {
@@ -30,6 +30,12 @@ test.describe('status reflects hook and attention events', () => {
     await expect(
       page.locator('[data-testid="signal-chip"][data-signal-key="attention"]'),
     ).toHaveCount(0);
+    // …and the detail strip resolves to the calm "Idle" — the restful state, not
+    // stuck on "Working". #247 regression guard: the idle mark must outlive the
+    // monitor's pane-hash touch that bumps `last_activity_at` just after the
+    // mark's `set_at`, or `idleTag()` reads the mark as stale and the strip never
+    // leaves "Working".
+    await expect(conv).toContainText('Idle');
   });
 
   test('detail view: weaver status sets level + message via SSE', async ({ page, weaver }) => {


### PR DESCRIPTION
## Problem

The soothing `idle` mark loom stamps when an agent goes quiet (a finished turn / `waiting` lull) was **born stale**, so the calm "Idle" presentation the design intends never showed after a finished turn — the detail strip stayed stuck on `▶ Working` indefinitely.

`monitor::apply_hook` stamps the `idle` mark on the `waiting`/`idle` hook, then the monitor's pane-hash loop touches `last_activity_at` a millisecond later — the turn-ending output that fires the hook is itself a pane change. The frontend `idleTag` selector then read the mark as stale (`last_activity_at > set_at`), so `idleTag()` returned `null` and `conversationState()` fell through to `Working`.

This is the bug #81 discovered and filed as #247 (#81 worked around it in the e2e by asserting "stays calm" instead of "Idle").

## Fix

The `idle` mark is the agent's **own lifecycle self-report**, retracted event-driven by the `working` hook (a submitted prompt clears `IDLE_KEY` in `apply_hook`) — not by activity advancing. Drop the activity-staleness guard from `idleTag`.

- A `working` hook still clears the mark; a loud tag still supersedes it. The only behaviour change is that pane activity no longer retracts a resting agent's mark — which matches the design intent (`apply_hook` deliberately does not distinguish "truly idle" from "waiting on a sub-agent or shell").
- Activity-staleness still governs loud **outside** marks (overlooker triage, etc.) via `effectiveAttention`/`signalChips` — which is what it is for. The quiet idle mark is the agent's own, and is exempt.

## Verification

`e2e/tests/status-hook.spec.ts` now asserts the detail strip flips to the calm `Idle` after a `waiting` hook — the #247 acceptance test — layered on top of #81's "stays calm / no attention" contract.

- **Unfixed selector: fails 3/3** (`Received string: "▶ Working"`, deterministic, not flaky).
- **With the fix: passes 3/3**, and the full `status-hook` suite is green.

CI does not run the Playwright suite; verified locally.

Closes #247.
