### PR TITLE
feat(loom): drive the agent from the conversation view

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -117,6 +117,12 @@ export const putArtifact = (id: string, name: string, body: ArtifactWriteBody) =
 /** Availability of the session's embedded editor (code-server). */
 export const ideInfo = (id: string) => get(`/sessions/${id}/ide-info`) as Promise<IdeInfo>;
 
+/** Type a message into the session's agent pane and, by default, submit it with
+ *  Enter to trigger a round (the same primitive the `loom` CLI's `send` wraps).
+ *  Requires a live terminal — a torn-down or orphaned session 409s. */
+export const sendMessage = (id: string, text: string, submit = true) =>
+  post(`/sessions/${id}/send`, { text, submit });
+
 // --- Agent environment variables -------------------------------------------
 
 import type { EnvVar } from './types';

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -28,7 +28,14 @@ const errorMsg = ref('');
 // folds, scroll, and highlight) from a fresh load (mount / session switch /
 // manual Refresh: reset them). On a preserved refresh a transient fetch error is
 // swallowed — the rendered log stays put and the next edge (or Refresh) recovers.
+//
+// A monotonic token guards against out-of-order responses: a session switch or a
+// fast auto-refresh can leave an earlier fetch in flight, and its late response
+// must not clobber a newer load's transcript. Each call claims the next token
+// and abandons its result once a newer load has started.
+let loadSeq = 0;
 async function load({ preserve = false }: { preserve?: boolean } = {}) {
+  const seq = ++loadSeq;
   if (!preserve) {
     state.value = 'loading';
     // Fold keys are per-render row indices (`ctx-0`, `tg-1-0`) and the highlight
@@ -40,9 +47,11 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
   const stick = preserve && nearBottom();
   try {
     const data = (await get(`/sessions/${id.value}/conversation`)) as IrisLog;
+    if (seq !== loadSeq) return;
     log.value = data;
     state.value = data && data.messages.length ? 'ready' : 'empty';
   } catch (e) {
+    if (seq !== loadSeq) return;
     // A 404 means nothing's been recorded (a shell session, or not yet) — that's
     // an empty state, not an error worth shouting about.
     const msg = (e as Error).message ?? '';
@@ -54,6 +63,7 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
     }
   }
   await nextTick();
+  if (seq !== loadSeq) return;
   // Chat behaviour: only follow the conversation to the newest message when the
   // reader was already at the foot — never yank them down out of the history.
   if (stick) scrollToBottom();
@@ -119,12 +129,13 @@ const composerVisible = computed(
 );
 
 async function submitPrompt() {
-  const text = draft.value.trim();
-  if (!text || sending.value) return;
+  // Trim only to decide emptiness — send the raw draft so intentional leading
+  // indentation or newlines in a multi-line prompt reach the agent unchanged.
+  if (!draft.value.trim() || sending.value) return;
   sending.value = true;
   sendError.value = '';
   try {
-    await sendMessage(id.value, text);
+    await sendMessage(id.value, draft.value);
     draft.value = '';
     scheduleRefresh();
   } catch (e) {

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -1,33 +1,45 @@
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, watch, nextTick } from 'vue';
-import { get } from '../api';
-import type { IrisLog, IrisBlock } from '../types';
+import { ref, reactive, computed, onMounted, onUnmounted, watch, nextTick } from 'vue';
+import { get, sendMessage } from '../api';
+import type { IrisLog, IrisBlock, Session } from '../types';
+import { canSend } from '../lib/sessionState';
 import MarkdownView from './MarkdownView.vue';
 
-// The Conversation tab: the agent's chat with the model, rendered for review.
-// Reads the normalized iris log from `GET /sessions/{id}/conversation` (live
-// transcript when present, else the capture archived on teardown) and renders it
-// as a *skimmable* log — prose stays in full view, while the agent's machinery
-// (tool calls + outputs, thinking, injected context) folds away behind compact
-// one-liners. Runs of the same tool call are run-length collapsed (`10× TaskCreate`)
-// so a burst of bookkeeping never buries the conversation, and a right-hand
-// prompt index lets a reviewer jump straight to any user turn.
-const props = defineProps<{ id: string }>();
+// The Conversation tab: the agent's chat with the model, rendered for review and
+// — while the agent is live — driven. Reads the normalized iris log from
+// `GET /sessions/{id}/conversation` (live transcript when present, else the
+// capture archived on teardown) and renders it as a *skimmable* log — prose
+// stays in full view, while the agent's machinery (tool calls + outputs,
+// thinking, injected context) folds away behind compact one-liners. Runs of the
+// same tool call are run-length collapsed (`10× TaskCreate`) so a burst of
+// bookkeeping never buries the conversation, and a right-hand prompt index lets
+// a reviewer jump straight to any user turn. A composer at the foot sends a new
+// prompt straight to the agent's terminal, and the log auto-refreshes on the
+// agent's lifecycle edges so a reply lands without a manual reload.
+const props = defineProps<{ session: Session }>();
+const id = computed(() => props.session.id);
 
 type LoadState = 'loading' | 'ready' | 'empty' | 'error';
 const log = ref<IrisLog | null>(null);
 const state = ref<LoadState>('loading');
 const errorMsg = ref('');
 
-async function load() {
-  state.value = 'loading';
-  // Fold keys are per-render row indices (`ctx-0`, `tg-1-0`) and the highlight
-  // tracks this session's turns — so reset both when the session changes, or the
-  // next session would inherit the previous one's open folds and active anchor.
-  open.value = new Set();
-  activeAnchor.value = '';
+// `preserve` distinguishes an auto-refresh (a new turn landed: keep the reader's
+// folds, scroll, and highlight) from a fresh load (mount / session switch /
+// manual Refresh: reset them). On a preserved refresh a transient fetch error is
+// swallowed — the rendered log stays put and the next edge (or Refresh) recovers.
+async function load({ preserve = false }: { preserve?: boolean } = {}) {
+  if (!preserve) {
+    state.value = 'loading';
+    // Fold keys are per-render row indices (`ctx-0`, `tg-1-0`) and the highlight
+    // tracks this session's turns — so reset both on a fresh load, or the next
+    // session would inherit the previous one's open folds and active anchor.
+    open.value = new Set();
+    activeAnchor.value = '';
+  }
+  const stick = preserve && nearBottom();
   try {
-    const data = (await get(`/sessions/${props.id}/conversation`)) as IrisLog;
+    const data = (await get(`/sessions/${id.value}/conversation`)) as IrisLog;
     log.value = data;
     state.value = data && data.messages.length ? 'ready' : 'empty';
   } catch (e) {
@@ -36,17 +48,91 @@ async function load() {
     const msg = (e as Error).message ?? '';
     if (/not found|conversation/i.test(msg)) {
       state.value = 'empty';
-    } else {
+    } else if (!preserve) {
       errorMsg.value = msg;
       state.value = 'error';
     }
   }
   await nextTick();
+  // Chat behaviour: only follow the conversation to the newest message when the
+  // reader was already at the foot — never yank them down out of the history.
+  if (stick) scrollToBottom();
   updateActive();
 }
 
-onMounted(load);
-watch(() => props.id, load);
+// ── Live auto-refresh ───────────────────────────────────────────────────────
+// A live session's transcript grows turn by turn. We re-fetch it on the agent's
+// lifecycle edges — `status` and `tag` events fire on every working/waiting/idle
+// hook, i.e. at each turn boundary — so the view tracks the agent without a
+// manual reload. Same per-session SSE stream the rest of the detail page rides;
+// coalesced through a short debounce so a burst of edges is a single fetch.
+let source: EventSource | null = null;
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+function scheduleRefresh() {
+  if (refreshTimer) return;
+  refreshTimer = setTimeout(() => {
+    refreshTimer = null;
+    // Only when there's something rendered (or an empty live session) — never
+    // clobber an error view or a manual load mid-flight.
+    if (state.value === 'ready' || state.value === 'empty') load({ preserve: true });
+  }, 400);
+}
+function openStream() {
+  source = new EventSource(`/api/sessions/${id.value}/events`);
+  for (const kind of ['status', 'tag']) source.addEventListener(kind, scheduleRefresh);
+}
+function closeStream() {
+  source?.close();
+  source = null;
+  if (refreshTimer) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+onMounted(() => {
+  load();
+  openStream();
+});
+onUnmounted(closeStream);
+// A session switch re-opens both the log and its stream against the new id.
+watch(
+  () => id.value,
+  () => {
+    closeStream();
+    load();
+    openStream();
+  },
+);
+
+// ── Composer ────────────────────────────────────────────────────────────────
+// Send a new prompt straight into the agent's pane (POST /send → type + Enter).
+// Shown only while the agent is live (`canSend`); a torn-down session keeps the
+// read-only log with no composer. After a send the auto-refresh (driven by the
+// agent's own working/idle hooks) brings the new turn in; we also nudge a
+// refresh so it shows promptly.
+const draft = ref('');
+const sending = ref(false);
+const sendError = ref('');
+const composerVisible = computed(
+  () => canSend(props.session) && (state.value === 'ready' || state.value === 'empty'),
+);
+
+async function submitPrompt() {
+  const text = draft.value.trim();
+  if (!text || sending.value) return;
+  sending.value = true;
+  sendError.value = '';
+  try {
+    await sendMessage(id.value, text);
+    draft.value = '';
+    scheduleRefresh();
+  } catch (e) {
+    sendError.value = (e as Error).message ?? 'Failed to send';
+  } finally {
+    sending.value = false;
+  }
+}
 
 // ── The render model ────────────────────────────────────────────────────────
 // We flatten the message/block stream into a flat list of `Row`s the template
@@ -224,6 +310,19 @@ function toggleAll() {
 const convScroll = ref<HTMLElement | null>(null);
 const activeAnchor = ref('');
 
+// Whether the stream is scrolled to (near) its foot — the cue for whether an
+// auto-refresh should follow new content down. A missing scroll root counts as
+// "at the bottom" (nothing scrolled yet).
+function nearBottom(): boolean {
+  const el = convScroll.value;
+  if (!el) return true;
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+}
+function scrollToBottom() {
+  const el = convScroll.value;
+  if (el) el.scrollTop = el.scrollHeight;
+}
+
 // The "current" prompt is the last user turn scrolled to (or past) the top of
 // the viewport — so the index highlight tracks the turn you're reading.
 function updateActive() {
@@ -355,9 +454,11 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
 
     <p v-if="state === 'loading'" class="text-sm text-muted">Loading conversation…</p>
     <p v-else-if="state === 'error'" class="text-sm text-block">{{ errorMsg }}</p>
-    <p v-else-if="state === 'empty'" class="text-sm text-muted">
-      No conversation recorded for this session yet.
-    </p>
+    <!-- flex-1 so the composer below (when the agent is live) still pins to the
+         foot rather than floating under this one line. -->
+    <div v-else-if="state === 'empty'" class="flex min-h-0 flex-1 flex-col">
+      <p class="text-sm text-muted">No conversation recorded for this session yet.</p>
+    </div>
 
     <div v-else class="flex min-h-0 flex-1 gap-4">
       <!-- The conversation stream. -->
@@ -400,7 +501,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
               <span v-if="row.time" class="font-normal text-muted">{{ shortTime(row.time) }}</span>
             </header>
             <template v-for="(b, j) in row.blocks" :key="j">
-              <MarkdownView v-if="b.kind === 'text'" :id="props.id" path="" :source="b.text" />
+              <MarkdownView v-if="b.kind === 'text'" :id="id" path="" :source="b.text" />
               <p v-else-if="b.kind === 'image'" class="text-xs italic text-muted">[image]</p>
             </template>
           </section>
@@ -408,7 +509,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
           <!-- Assistant prose. No role heading — the boxed/accented user turns
                are the dividers, so the agent's replies just flow as plain text. -->
           <div v-else-if="row.type === 'text'" class="px-3">
-            <MarkdownView :id="props.id" path="" :source="row.text" />
+            <MarkdownView :id="id" path="" :source="row.text" />
           </div>
 
           <!-- Thinking — folded. -->
@@ -502,6 +603,39 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
         </ul>
       </nav>
     </div>
+
+    <!-- Composer — send a new prompt straight to the agent's terminal. Enter
+         sends; Shift+Enter inserts a newline. Hidden once the agent is gone, so
+         a torn-down session stays a read-only log. -->
+    <form
+      v-if="composerVisible"
+      class="mt-3 shrink-0 border-t border-line pt-3"
+      data-testid="conversation-composer"
+      @submit.prevent="submitPrompt"
+    >
+      <p v-if="sendError" class="mb-1.5 text-xs text-block" data-testid="composer-error">
+        {{ sendError }}
+      </p>
+      <div class="flex items-end gap-2">
+        <textarea
+          v-model="draft"
+          rows="2"
+          :disabled="sending"
+          placeholder="Send a message to the agent…  (Enter to send, Shift+Enter for a newline)"
+          data-testid="composer-input"
+          class="max-h-40 w-full flex-1 resize-y rounded bg-input px-2.5 py-2 text-sm outline-none focus:ring-1 ring-accent"
+          @keydown.enter.exact.prevent="submitPrompt"
+        ></textarea>
+        <button
+          type="submit"
+          class="btn-primary shrink-0 px-3 py-2 text-sm"
+          :disabled="sending || !draft.trim()"
+          data-testid="composer-send"
+        >
+          {{ sending ? 'Sending…' : 'Send' }}
+        </button>
+      </div>
+    </form>
   </div>
 </template>
 

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -183,6 +183,16 @@ export function quietTags(s: Session): Tag[] {
 // "Idle"; and (2) sub-agent or shell pane activity under an idle mark is, by
 // design, still "resting" (see monitor `apply_hook`), not a reason to retract it.
 const LIVE_STATUSES = new Set(['launching', 'running']);
+
+// Whether the session still has a live agent pane to type into — the gate for
+// the conversation composer. `POST /sessions/{id}/send` 409s once the terminal
+// is gone (orphaned / done / error / archived), so the composer only shows while
+// the agent is launching or running. Reuses LIVE_STATUSES: the same "the agent
+// is here" notion as the idle mark.
+export function canSend(s: Session): boolean {
+  return LIVE_STATUSES.has(s.status);
+}
+
 export function idleTag(s: Session): Tag | null {
   if (!LIVE_STATUSES.has(s.status)) return null;
   if (loudTags(s).length > 0) return null;

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -213,7 +213,7 @@ onUnmounted(() => {
              archived capture). Mounted only when selected; it fetches on its
              own and re-fetches via its Refresh button. -->
         <div v-if="tab === 'conversation'" class="h-full">
-          <SessionConversation :id="props.id" />
+          <SessionConversation :session="ws" />
         </div>
       </div>
     </div>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -397,7 +397,12 @@ backed by `GET /api/sessions/{id}/conversation` (`chatlog::conversation` →
 the live transcript when present, else the archived `chat.json`). The Vue viewer
 renders the iris log natively — user/assistant turns, collapsible thinking, and
 each tool call with its result — so a session stays reviewable in the UI after
-its terminal is gone.
+its terminal is gone. While the agent is still live the tab is also drivable: a
+composer at its foot sends a new prompt straight to the agent pane via `POST
+/api/sessions/{id}/send` (type + Enter), and the log auto-refreshes on the
+agent's lifecycle edges (the `status`/`tag` SSE events that fire at each
+turn boundary), so a reply lands without a manual reload. The composer hides
+once the terminal is gone (orphaned/done/archived), leaving the read-only log.
 
 Orphan detection is independent: if the session's supervisor is no longer alive,
 the session becomes `orphaned` and is eligible for `loom adopt`.

--- a/e2e/tests/conversation.spec.ts
+++ b/e2e/tests/conversation.spec.ts
@@ -108,4 +108,62 @@ test.describe('conversation view', () => {
     await expect(items.nth(2)).toHaveAttribute('data-active', 'true');
     await expect(items.first()).toHaveAttribute('data-active', 'false');
   });
+
+  // The composer drives the live agent: a live (`running`) session shows a text
+  // box at the foot that types a new prompt straight into the agent pane.
+  test('the composer sends a new prompt to the agent and clears the input', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await openConversation(page, weaver);
+
+    await expect(page.getByTestId('conversation-composer')).toBeVisible();
+    const input = page.getByTestId('composer-input');
+    await input.fill('please run the tests');
+    await page.getByTestId('composer-send').click();
+
+    // The input clears once the send resolves…
+    await expect(input).toHaveValue('');
+    // …and the backend recorded the `nudge` audit event for the typed text (the
+    // send → type-into-the-pane primitive that `POST /sessions/{id}/send` wraps).
+    await expect
+      .poll(async () => {
+        const res = await fetch(`${weaver.baseUrl}/api/sessions/${s.id}/log`);
+        const log = (await res.json()) as { kind: string; data: { text?: string } }[];
+        return log.some((e) => e.kind === 'nudge' && e.data?.text === 'please run the tests');
+      })
+      .toBe(true);
+  });
+
+  // The tab follows a live session: a new turn landing in the transcript shows
+  // up without a manual Refresh, driven off the agent's lifecycle SSE edges.
+  test('the log auto-refreshes when the agent reaches a turn boundary', async ({ page, weaver }) => {
+    const s = await weaver.seedSession({ goal: 'demo', name: 'conv-live' });
+    await weaver.seedConversation(s, demoLog());
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
+    await page.locator('[data-tab="conversation"]').click();
+    await expect(page.getByTestId('conversation')).toBeVisible();
+    await expect(page.getByText('A fresh reply just landed.')).toHaveCount(0);
+
+    // A reply the reviewer hasn't seen is appended to the captured log…
+    const base = demoLog();
+    const grown = {
+      ...base,
+      messages: [
+        ...base.messages,
+        {
+          role: 'assistant',
+          timestamp: '2026-06-21T10:12:00.000Z',
+          blocks: [{ kind: 'text', text: 'A fresh reply just landed.' }],
+        },
+      ],
+    };
+    await weaver.seedConversation(s, grown);
+
+    // …and an agent lifecycle edge (an `idle` hook → a `tag` SSE event) makes the
+    // tab re-fetch on its own — no Refresh click.
+    await weaver.hook(s, 'idle');
+    await expect(page.getByText('A fresh reply just landed.')).toBeVisible({ timeout: 15_000 });
+  });
 });


### PR DESCRIPTION
The Conversation tab was a read-only review surface. This makes it drivable while the agent is live.

A composer at the foot of the tab sends a new prompt straight into the agent's terminal pane via `POST /api/sessions/{id}/send` — the same type-and-Enter primitive the `loom` CLI's `send` wraps. Enter sends; Shift+Enter inserts a newline.

The log now auto-refreshes on the agent's lifecycle edges: the `status`/`tag` SSE events that fire on every working/waiting/idle hook (i.e. at each turn boundary), re-fetched on the same per-session stream the rest of the detail page already rides, debounced so a burst of edges is one fetch. A refresh preserves the reader's open folds, highlight, and scroll, and only follows the conversation down to the newest message when they were already at the foot — so a reply lands without a manual reload and without yanking them out of the history.

The composer shows only while the agent is live (`launching`/`running`); once the terminal is gone (orphaned/done/archived) the tab stays a read-only log. Send errors (e.g. a 409 with no live terminal) surface inline.

Backend was already complete — `/send`, `/conversation`, and the events SSE all existed; this is the frontend wiring plus the `canSend` gate and a doc note. Covered by two new Playwright specs (composer send → `nudge` recorded; auto-refresh on an idle hook), both green, full e2e suite green.

Part of #252