### PR TITLE
Concierge: a conversational meta-layer over the fleet, + Phase 0 (#280)

### DIFF
--- a/crates/loom/CONCIERGE.md
+++ b/crates/loom/CONCIERGE.md
@@ -1,0 +1,58 @@
+# You are the fleet concierge
+
+You are a **concierge** for a loom fleet: an agent the operator chats with to
+understand and steer *all their other sessions*. You are not here to do a coding
+task on this branch — you have no deliverable here, no PR to open, no tracking
+issue to close. Ignore the weaver "finish via PR" workflow; it is not yours. Your
+job is to answer questions about the fleet and act on the operator's behalf.
+
+You reach the whole fleet through the `loom` and `weaver` CLIs, already on your
+`PATH` and authenticated (`$WEAVER_API` + `$LOOM_TOKEN` are set). No setup needed.
+
+## Reading the fleet
+
+- `loom session ls` — the fleet: every session with its lifecycle, attention, and
+  last activity. Start here.
+- `loom session poll <id>` — one session in detail (lifecycle + attention + PR/CI).
+- `loom session preview <id>` — a fast glance at its live screen: what it's doing
+  *right now*. Cheap; reach for it first.
+- For *why* a session is where it is — what it decided, where it stalled — read
+  deeper (its recent screen with `--lines`, or its conversation).
+- `weaver issue ls` / `weaver issue show <n>` — the task boards.
+
+A session key is an id, branch name, or `repo:branch`.
+
+## Judging "stale" vs. "needs me"
+
+- **Stale / resting:** `running` but quietly `idle`, with an old last-activity and
+  no loud attention. It finished a turn and is waiting for a nudge nobody gave.
+- **Needs me:** a loud `attention` or `blocked` — the agent (or a watcher) is
+  asking for the operator. That's a call, not a rest.
+
+Don't conflate them: idle is calm; attention is a request. Surface the loud ones
+first.
+
+## Always link
+
+Refer to a session as a markdown link to `/s/<id>` so the operator can click
+straight to it — e.g. `[auth-refactor](/s/ab12)`. Name its repo and branch too so
+the reference reads on its own.
+
+## Acting on the operator's behalf
+
+You can act, but you are a concierge, not a cowboy — **summarise and point
+first**. Before you change anything, say what you'll do and why, and let the
+operator confirm in their next message.
+
+- `loom session send <id> "<message>"` — nudge a session: type a message into its
+  agent and submit it (answer its question, redirect it, unstick it).
+- `loom session break <id>` — interrupt a session's current turn.
+- `loom session launch "<task>"` — spin up a *new* session for work the operator
+  wants done. It prints a tracking issue; you can then `loom session poll` /
+  `weaver issue wait` it and report back when it's done.
+
+## Style
+
+Be concise and concrete. Lead with the answer, link the sessions involved, and
+end with a clear next step or a question. You hold the whole fleet in view; the
+operator has one question — bridge the two.

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -123,6 +123,13 @@ export const ideInfo = (id: string) => get(`/sessions/${id}/ide-info`) as Promis
 export const sendMessage = (id: string, text: string, submit = true) =>
   post(`/sessions/${id}/send`, { text, submit });
 
+// --- Chat (the fleet concierge) --------------------------------------------
+
+/** Get-or-create the singleton fleet concierge and return its session view —
+ *  what the Chat surface mounts its conversation against. 400s when no repo has
+ *  been used yet (the concierge needs one to live in). */
+export const getChat = () => get('/chat') as Promise<Session>;
+
 // --- Agent environment variables -------------------------------------------
 
 import type { EnvVar } from './types';

--- a/crates/loom/frontend/src/components/AppRail.vue
+++ b/crates/loom/frontend/src/components/AppRail.vue
@@ -38,6 +38,17 @@ const MAIN: RailItem[] = [
     paths: ['M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z', 'M12 11a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z'],
   },
   {
+    to: '/chat',
+    label: 'Chat',
+    title: 'Chat — ask the concierge about your fleet and steer it',
+    match: (p) => p.startsWith('/chat'),
+    // messages-square — a conversation about the looms.
+    paths: [
+      'M14 9a2 2 0 0 1-2 2H6l-4 4V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2Z',
+      'M18 9h2a2 2 0 0 1 2 2v11l-4-4h-6a2 2 0 0 1-2-2v-1',
+    ],
+  },
+  {
     to: '/overlookers',
     label: 'Watch',
     title: 'Overlookers — watch agents over the fleet',

--- a/crates/loom/frontend/src/main.ts
+++ b/crates/loom/frontend/src/main.ts
@@ -16,6 +16,7 @@ import Settings from './views/Settings.vue';
 import Issues from './views/Issues.vue';
 import Overlookers from './views/Overlookers.vue';
 import OverlookerDetail from './views/OverlookerDetail.vue';
+import Chat from './views/Chat.vue';
 import Shell from './views/Shell.vue';
 import Login from './views/Login.vue';
 import { me, loadMe } from './auth';
@@ -34,6 +35,7 @@ const router = createRouter({
     { path: '/s/:id/artifacts', component: Artifacts, props: true },
     { path: '/s/:id/artifacts/:name', component: Artifacts, props: true },
     { path: '/issues', component: Issues },
+    { path: '/chat', component: Chat },
     { path: '/overlookers', component: Overlookers },
     { path: '/overlookers/:id', component: OverlookerDetail, props: true },
     { path: '/shell', component: Shell },

--- a/crates/loom/frontend/src/views/Chat.vue
+++ b/crates/loom/frontend/src/views/Chat.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { getChat } from '../api';
+import type { Session } from '../types';
+import SessionConversation from '../components/SessionConversation.vue';
+
+// The Chat surface: a conversation with the fleet **concierge** — an agent that
+// holds the whole fleet in view and that you ask about your other sessions
+// ("any stale sessions?", "what needs me?") and steer them through. The
+// concierge is a normal loom session (hidden from the fleet list by its kind);
+// `GET /api/chat` get-or-creates the singleton and we mount the existing
+// drivable conversation against it — its composer already sends turns to the
+// live agent and auto-refreshes on each reply.
+type LoadState = 'loading' | 'ready' | 'error';
+const state = ref<LoadState>('loading');
+const session = ref<Session | null>(null);
+const errorMsg = ref('');
+
+async function load() {
+  state.value = 'loading';
+  errorMsg.value = '';
+  try {
+    session.value = await getChat();
+    state.value = 'ready';
+  } catch (e) {
+    errorMsg.value = e instanceof Error ? e.message : String(e);
+    state.value = 'error';
+  }
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="flex min-h-0 flex-1 flex-col px-5 py-3">
+    <header class="mb-3 shrink-0">
+      <h1 class="text-sm font-semibold text-fg">Chat</h1>
+      <p class="text-xs text-muted">
+        Ask the concierge about your fleet — stale sessions, what needs you — and
+        have it act on your behalf.
+      </p>
+    </header>
+
+    <p v-if="state === 'loading'" class="text-sm text-muted">Waking the concierge…</p>
+
+    <div v-else-if="state === 'error'" class="text-sm">
+      <p class="text-block">{{ errorMsg }}</p>
+      <button type="button" class="btn-secondary mt-2 px-2 py-0.5 text-xs" @click="load">
+        Retry
+      </button>
+    </div>
+
+    <!-- The concierge is a session, so the standard drivable conversation view
+         is the whole chat: skimmable log + a composer that sends to the agent. -->
+    <SessionConversation
+      v-else-if="session"
+      :key="session.id"
+      :session="session"
+      class="min-h-0 flex-1"
+    />
+  </div>
+</template>

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -66,7 +66,9 @@ fn inner_command(
     };
     match agent_kind {
         "shell" | "none" => String::new(),
-        "claude" => match mode {
+        // The concierge is a Claude agent with a fleet-ops primer (see
+        // `is_claude_runtime`): same command, hooks, and launch gates.
+        k if is_claude_runtime(k) => match mode {
             LaunchMode::Adopt => format!("claude --continue{args}"),
             LaunchMode::Fresh => match goal_file {
                 Some(f) => format!("claude{args} \"$(cat '{}')\"", f.display()),
@@ -78,6 +80,29 @@ fn inner_command(
             None => other.to_string(),
         },
     }
+}
+
+/// The agent kind for the fleet **concierge** — a Claude agent seeded with the
+/// [`concierge_primer`] instead of a workstream goal, hidden from the fleet list
+/// and resolved as a singleton by the Chat surface.
+pub const CONCIERGE_KIND: &str = "concierge";
+
+/// Whether `agent_kind` runs the Claude runtime — the `claude` command plus the
+/// weaver hooks and first-run launch gates. The `concierge` kind is Claude with a
+/// different opening prompt, so it rides the same launch path; everything else is
+/// run as a bare command name.
+pub fn is_claude_runtime(agent_kind: &str) -> bool {
+    matches!(agent_kind, "claude" | "concierge")
+}
+
+/// The builtin concierge primer — how the fleet concierge explores and acts on
+/// the fleet. Catted in at build time like [`weaver_core::agent::builtin_weaver_md`],
+/// and used as a concierge session's opening prompt.
+const BUILTIN_CONCIERGE_MD: &str = include_str!("../CONCIERGE.md");
+
+/// The concierge primer text, seeded as a concierge session's opening prompt.
+pub fn concierge_primer() -> &'static str {
+    BUILTIN_CONCIERGE_MD
 }
 
 /// Wrap a value in single quotes for safe `export NAME=…` in the launch script,
@@ -138,7 +163,7 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
         .map(|d| d.join("weaver").display().to_string())
         .unwrap_or_else(|| "weaver".to_string());
 
-    if spec.agent_kind == "claude" {
+    if is_claude_runtime(spec.agent_kind) {
         // Both steps are best-effort — a failure shouldn't abort the launch — but
         // log it, since a silent failure here resurfaces only as a stalled agent.
         if let Err(e) = install_hooks(spec.work_dir, &weaver_bin).await {
@@ -505,6 +530,28 @@ mod tests {
         assert!(script.contains("export WEAVER_API='http://h:1'; "));
         assert!(script.contains("claude \"$(cat '/x/goal.txt')\"; "));
         assert!(script.ends_with("exec \"${SHELL:-/bin/sh}\""));
+    }
+
+    #[test]
+    fn concierge_runs_the_claude_command_with_its_primer() {
+        // The concierge kind is Claude with a different opening prompt: it must
+        // produce the same `claude "$(cat …)"` invocation, not try to exec a
+        // `concierge` binary.
+        assert!(is_claude_runtime(CONCIERGE_KIND));
+        let script = launch_script(
+            CONCIERGE_KIND,
+            Some(Path::new("/x/goal.txt")),
+            &[],
+            None,
+            LaunchMode::Fresh,
+            "",
+        );
+        assert!(
+            script.contains("claude \"$(cat '/x/goal.txt')\"; "),
+            "got: {script}"
+        );
+        // And the primer it is seeded with is the real fleet-ops doc.
+        assert!(concierge_primer().contains("fleet concierge"));
     }
 
     #[test]

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -54,8 +54,12 @@ pub enum LaunchMode {
     Adopt,
 }
 
+/// Build the shell command that launches one session's agent. `runtime` is the
+/// **resolved runtime** — the binary to actually run, which for the concierge
+/// role-kind is the `concierge.runtime` setting (claude|codex), and for every
+/// other kind is the kind itself.
 fn inner_command(
-    agent_kind: &str,
+    runtime: &str,
     goal_file: Option<&Path>,
     mode: LaunchMode,
     claude_args: &str,
@@ -64,16 +68,21 @@ fn inner_command(
         "" => String::new(),
         a => format!(" {a}"),
     };
-    match agent_kind {
+    match runtime {
         "shell" | "none" => String::new(),
-        // The concierge is a Claude agent with a fleet-ops primer (see
-        // `is_claude_runtime`): same command, hooks, and launch gates.
-        k if is_claude_runtime(k) => match mode {
+        "claude" => match mode {
             LaunchMode::Adopt => format!("claude --continue{args}"),
             LaunchMode::Fresh => match goal_file {
                 Some(f) => format!("claude{args} \"$(cat '{}')\"", f.display()),
                 None => format!("claude{args}"),
             },
+        },
+        // Codex takes its opening prompt as a positional arg, like claude. It has
+        // no scoped "continue this worktree's session" flag, so on adopt we
+        // re-launch fresh (re-reading the primer) rather than resuming.
+        "codex" => match goal_file {
+            Some(f) => format!("codex \"$(cat '{}')\"", f.display()),
+            None => "codex".to_string(),
         },
         other => match goal_file {
             Some(f) => format!("{other} '{}'", f.display()),
@@ -82,17 +91,19 @@ fn inner_command(
     }
 }
 
-/// The agent kind for the fleet **concierge** — a Claude agent seeded with the
-/// [`concierge_primer`] instead of a workstream goal, hidden from the fleet list
-/// and resolved as a singleton by the Chat surface.
+/// The agent kind that marks a session as the fleet **concierge** — seeded with
+/// the [`concierge_primer`] instead of a workstream goal, hidden from the fleet
+/// list, and resolved as a singleton by the Chat surface. This is the session's
+/// *role*; the runtime it actually launches (claude|codex) is the separate
+/// `concierge.runtime` setting, resolved before launch.
 pub const CONCIERGE_KIND: &str = "concierge";
 
-/// Whether `agent_kind` runs the Claude runtime — the `claude` command plus the
-/// weaver hooks and first-run launch gates. The `concierge` kind is Claude with a
-/// different opening prompt, so it rides the same launch path; everything else is
-/// run as a bare command name.
-pub fn is_claude_runtime(agent_kind: &str) -> bool {
-    matches!(agent_kind, "claude" | "concierge")
+/// Whether a resolved `runtime` runs the Claude runtime — the `claude` command
+/// plus the weaver lifecycle hooks and first-run launch gates. Only Claude fires
+/// the hooks today, so this also decides whether a session starts `launching`
+/// (a hook will promote it) or `running` (no hooks — it is live on launch).
+pub fn is_claude_runtime(runtime: &str) -> bool {
+    runtime == "claude"
 }
 
 /// The builtin concierge primer — how the fleet concierge explores and acts on
@@ -115,7 +126,7 @@ fn sh_single_quote(value: &str) -> String {
 }
 
 pub fn launch_script(
-    agent_kind: &str,
+    runtime: &str,
     goal_file: Option<&Path>,
     env: &[(&str, &str)],
     weaver_dir: Option<&Path>,
@@ -129,7 +140,7 @@ pub fn launch_script(
     for (k, v) in env {
         script.push_str(&format!("export {k}={}; ", sh_single_quote(v)));
     }
-    let inner = inner_command(agent_kind, goal_file, mode, claude_args);
+    let inner = inner_command(runtime, goal_file, mode, claude_args);
     if !inner.is_empty() {
         script.push_str(&inner);
         script.push_str("; ");
@@ -143,7 +154,10 @@ pub struct LaunchSpec<'a> {
     /// The branch id — the agent uses this to resolve "its" branch via
     /// `$WEAVER_BRANCH`.
     pub branch_id: &'a str,
-    pub agent_kind: &'a str,
+    /// The resolved **runtime** to launch — the agent binary (claude|codex|shell|
+    /// a bare command), already resolved from the stored kind (so a concierge
+    /// carries its `concierge.runtime`, not the literal `concierge`).
+    pub runtime: &'a str,
     pub work_dir: &'a Path,
     pub term_session: &'a str,
     pub goal_file: Option<&'a Path>,
@@ -163,7 +177,10 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
         .map(|d| d.join("weaver").display().to_string())
         .unwrap_or_else(|| "weaver".to_string());
 
-    if is_claude_runtime(spec.agent_kind) {
+    // Only the Claude runtime wires weaver's lifecycle hooks and needs its
+    // first-run gates pre-cleared. Codex (and any bare command) gets neither — it
+    // runs, but reports no working/idle status through weaver yet.
+    if is_claude_runtime(spec.runtime) {
         // Both steps are best-effort — a failure shouldn't abort the launch — but
         // log it, since a silent failure here resurfaces only as a stalled agent.
         if let Err(e) = install_hooks(spec.work_dir, &weaver_bin).await {
@@ -201,7 +218,7 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
         env.push((k.as_str(), v.as_str()));
     }
     let script = launch_script(
-        spec.agent_kind,
+        spec.runtime,
         spec.goal_file,
         &env,
         weaver_dir,
@@ -210,7 +227,7 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
     );
     tracing::debug!(
         branch = spec.branch_id,
-        agent_kind = spec.agent_kind,
+        runtime = spec.runtime,
         session = spec.term_session,
         ?mode,
         "launching agent session"
@@ -220,7 +237,7 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
         .with_context(|| format!("terminal: launching session {}", spec.term_session))?;
     tracing::info!(
         branch = spec.branch_id,
-        agent_kind = spec.agent_kind,
+        runtime = spec.runtime,
         session = spec.term_session,
         ?mode,
         "agent launched"
@@ -533,13 +550,23 @@ mod tests {
     }
 
     #[test]
-    fn concierge_runs_the_claude_command_with_its_primer() {
-        // The concierge kind is Claude with a different opening prompt: it must
-        // produce the same `claude "$(cat …)"` invocation, not try to exec a
-        // `concierge` binary.
-        assert!(is_claude_runtime(CONCIERGE_KIND));
-        let script = launch_script(
-            CONCIERGE_KIND,
+    fn concierge_kind_is_a_role_not_a_runtime() {
+        // The `concierge` string marks a role; it is not a runtime, so it must be
+        // resolved (to claude|codex) before launch and never reach the command
+        // builder. `is_claude_runtime` only matches the actual Claude runtime.
+        assert!(is_claude_runtime("claude"));
+        assert!(!is_claude_runtime(CONCIERGE_KIND));
+        assert!(!is_claude_runtime("codex"));
+        // The primer the concierge is seeded with is the real fleet-ops doc.
+        assert!(concierge_primer().contains("fleet concierge"));
+    }
+
+    #[test]
+    fn codex_runtime_runs_codex_with_its_prompt() {
+        // A concierge resolved to the codex runtime launches `codex "$(cat …)"`,
+        // seeding the primer as codex's opening prompt.
+        let fresh = launch_script(
+            "codex",
             Some(Path::new("/x/goal.txt")),
             &[],
             None,
@@ -547,11 +574,22 @@ mod tests {
             "",
         );
         assert!(
-            script.contains("claude \"$(cat '/x/goal.txt')\"; "),
-            "got: {script}"
+            fresh.contains("codex \"$(cat '/x/goal.txt')\"; "),
+            "got: {fresh}"
         );
-        // And the primer it is seeded with is the real fleet-ops doc.
-        assert!(concierge_primer().contains("fleet concierge"));
+        // Codex has no scoped resume, so adopt re-launches fresh with the primer.
+        let adopt = launch_script(
+            "codex",
+            Some(Path::new("/x/goal.txt")),
+            &[],
+            None,
+            LaunchMode::Adopt,
+            "",
+        );
+        assert!(
+            adopt.contains("codex \"$(cat '/x/goal.txt')\"; "),
+            "got: {adopt}"
+        );
     }
 
     #[test]

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -142,17 +142,37 @@ pub async fn list(db: &Db) -> Result<Vec<Session>> {
     Ok(rows)
 }
 
-/// The **fleet** sessions only — ordinary work, with engine-managed (warm)
-/// sessions excluded. Warm sessions are infrastructure a watcher keeps for its
-/// across-round memory, not work to show or survey, so the dashboard `/sessions`
+/// The **fleet** sessions only — ordinary work, with infrastructure sessions
+/// excluded: engine-managed (warm) overlooker sessions, and the fleet
+/// **concierge** (the Chat agent, which watches the fleet rather than being part
+/// of it). Neither is work to show or survey, so the dashboard `/sessions`
 /// listing and an overlooker round's scope survey both read this list.
 pub async fn list_visible(db: &Db) -> Result<Vec<Session>> {
     let rows = sqlx::query_as::<_, Session>(
-        "SELECT * FROM sessions WHERE managed_by IS NULL ORDER BY created_at DESC",
+        "SELECT * FROM sessions
+         WHERE managed_by IS NULL AND agent_kind != ?
+         ORDER BY created_at DESC",
     )
+    .bind(crate::agent::CONCIERGE_KIND)
     .fetch_all(db)
     .await?;
     Ok(rows)
+}
+
+/// The live fleet **concierge** session, if one exists and is not terminal. The
+/// Chat surface resolves its singleton through this — find the running concierge,
+/// else create one. Hidden from [`list_visible`], so it never shows in the fleet.
+pub async fn active_concierge(db: &Db) -> Result<Option<Session>> {
+    let row = sqlx::query_as::<_, Session>(
+        "SELECT * FROM sessions
+         WHERE agent_kind = ? AND status NOT IN ('done', 'error', 'archived')
+         ORDER BY created_at DESC
+         LIMIT 1",
+    )
+    .bind(crate::agent::CONCIERGE_KIND)
+    .fetch_optional(db)
+    .await?;
+    Ok(row)
 }
 
 /// Every engine-managed (warm) session — those owned by an overlooker. The

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -591,6 +591,30 @@ async fn create_session(
     Ok(Json(create_session_core(st, req).await?))
 }
 
+/// Resolve the **runtime** a session of `agent_kind` launches with. Every kind is
+/// its own runtime, except the concierge role-kind, which launches whatever
+/// `concierge.runtime` names (claude|codex). Keeps the stored kind (the role)
+/// separate from the binary that runs.
+async fn launch_runtime(db: &Db, agent_kind: &str) -> String {
+    if agent_kind == agent::CONCIERGE_KIND {
+        config::get_or(db, "concierge.runtime", config::DEFAULT_CONCIERGE_RUNTIME).await
+    } else {
+        agent_kind.to_string()
+    }
+}
+
+/// A freshly launched session's lifecycle status. A Claude runtime starts
+/// `launching` because its `SessionStart`/work hook will promote it to `running`;
+/// a hookless runtime (shell, codex, a bare command) never gets that hook, so it
+/// is `running` from the start rather than stuck `launching`.
+fn initial_status(runtime: &str) -> &'static str {
+    if agent::is_claude_runtime(runtime) {
+        "launching"
+    } else {
+        "running"
+    }
+}
+
 /// The session-creation core, shared by `POST /api/sessions` and the Chat
 /// surface's concierge get-or-create ([`get_chat`]). Returns the view directly so
 /// the caller can shape its own response.
@@ -885,10 +909,13 @@ async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionV
     let base_args = config::get_or(&st.db, "agent.claude_args", "").await;
     let claude_args = agent::combine_args(&base_args, &model, &effort);
     let extra_env = agent_env::pairs(&st.db).await.unwrap_or_default();
+    // The stored kind is the role; the runtime is what we actually launch (the
+    // concierge resolves to its `concierge.runtime` setting).
+    let runtime = launch_runtime(&st.db, &agent).await;
     agent::launch(
         &agent::LaunchSpec {
             branch_id: &branch.id,
-            agent_kind: &agent,
+            runtime: &runtime,
             work_dir: &work_dir,
             term_session: &term_session,
             goal_file: goal_file.as_deref(),
@@ -901,11 +928,9 @@ async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionV
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let status = if matches!(agent.as_str(), "shell" | "none") {
-        "running"
-    } else {
-        "launching"
-    };
+    // Only a Claude runtime emits the hook that promotes `launching` → `running`;
+    // a hookless runtime (shell, codex, a bare command) is live on launch.
+    let status = initial_status(&runtime);
     let session = session_mod::insert(
         &st.db,
         &NewSession {
@@ -1442,10 +1467,11 @@ pub async fn create_warm_session(
     let base_args = config::get_or(&st.db, "agent.claude_args", "").await;
     let claude_args = agent::combine_args(&base_args, &overlooker.model, &overlooker.effort);
     let extra_env = agent_env::pairs(&st.db).await.unwrap_or_default();
+    // A warm session never carries the concierge role, so its runtime is its kind.
     agent::launch(
         &agent::LaunchSpec {
             branch_id: &branch.id,
-            agent_kind: &agent,
+            runtime: &agent,
             work_dir: &work_dir,
             term_session: &term_session,
             goal_file: goal_file.as_deref(),
@@ -1458,11 +1484,7 @@ pub async fn create_warm_session(
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let status = if matches!(agent.as_str(), "shell" | "none") {
-        "running"
-    } else {
-        "launching"
-    };
+    let status = initial_status(&agent);
     let session = session_mod::insert(
         &st.db,
         &NewSession {
@@ -1515,10 +1537,11 @@ pub async fn adopt(st: &AppState, session: &Session, branch: &Branch) -> Result<
     let base_args = config::get_or(&st.db, "agent.claude_args", "").await;
     let claude_args = agent::combine_args(&base_args, &session.model, &session.effort);
     let extra_env = agent_env::pairs(&st.db).await.unwrap_or_default();
+    let runtime = launch_runtime(&st.db, &session.agent_kind).await;
     agent::launch(
         &agent::LaunchSpec {
             branch_id: &branch.id,
-            agent_kind: &session.agent_kind,
+            runtime: &runtime,
             work_dir: &work_dir,
             term_session: &session.term_session,
             goal_file: goal_file.as_deref(),
@@ -1530,13 +1553,16 @@ pub async fn adopt(st: &AppState, session: &Session, branch: &Branch) -> Result<
     )
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    session_mod::set_status(&st.db, &session.id, "launching").await?;
+    // A hookless runtime (codex, a bare command) won't get the hook that would
+    // promote `launching` → `running`, so mark it live now rather than stranding it.
+    let status = initial_status(&runtime);
+    session_mod::set_status(&st.db, &session.id, status).await?;
     events::record(
         &st.db,
         &st.bus,
         &branch.id,
         "status",
-        json!({ "status": "launching", "reason": "session adopted" }),
+        json!({ "status": status, "reason": "session adopted" }),
     )
     .await
     .ok();

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -400,6 +400,7 @@ pub fn router(state: AppState) -> Router {
     let protected = Router::new()
         // Sessions
         .route("/sessions", get(list_sessions).post(create_session))
+        .route("/chat", get(get_chat))
         .route(
             "/sessions/{id}",
             get(get_session).patch(patch_session).delete(delete_session),
@@ -587,6 +588,13 @@ async fn create_session(
     State(st): State<AppState>,
     Json(req): Json<CreateReq>,
 ) -> ApiResult<Json<SessionView>> {
+    Ok(Json(create_session_core(st, req).await?))
+}
+
+/// The session-creation core, shared by `POST /api/sessions` and the Chat
+/// surface's concierge get-or-create ([`get_chat`]). Returns the view directly so
+/// the caller can shape its own response.
+async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionView> {
     let cwd = PathBuf::from(&req.cwd);
     let repo_root = git::repo_root(&cwd)
         .await
@@ -599,6 +607,10 @@ async fn create_session(
         Some(a) => a,
         None => config::get_or(&st.db, "agent.default", config::DEFAULT_AGENT).await,
     };
+    // The concierge is the fleet Chat agent, not a workstream: it gets the
+    // fleet-ops primer as its opening prompt and no tracking issue (it has no
+    // deliverable to track), and is hidden from the fleet list by its kind.
+    let is_concierge = agent == agent::CONCIERGE_KIND;
 
     // Normalize and validate the model / effort selections. Blank means
     // "inherit the configured default"; anything non-blank must be known.
@@ -817,18 +829,22 @@ async fn create_session(
     // Open this session's tracking issue before the launch prompt is written,
     // so the agent can be told its issue number. When an agent delegated this
     // work (`parent_branch`), the parent becomes the issue's `source_branch`.
-    let tracking_issue = create_tracking_issue(
-        &st,
-        &branch,
-        parent_branch_name.as_deref(),
-        &title,
-        &goal,
-        &description,
-        github_repo.as_deref(),
-        github_issue,
-        claimed_issue_id,
-    )
-    .await?;
+    let tracking_issue = if is_concierge {
+        None
+    } else {
+        create_tracking_issue(
+            &st,
+            &branch,
+            parent_branch_name.as_deref(),
+            &title,
+            &goal,
+            &description,
+            github_repo.as_deref(),
+            github_issue,
+            claimed_issue_id,
+        )
+        .await?
+    };
 
     let session_id = branch_mod::new_id();
     let run_dir = db::run_dir(&session_id);
@@ -841,14 +857,20 @@ async fn create_session(
     // the dashboard.
     let scratch_names = write_initial_scratch(&work_dir, &req.scratch).await?;
     let mut prompt_parts: Vec<String> = Vec::new();
-    if !goal.is_empty() {
-        prompt_parts.push(goal.clone());
-    }
-    if let Some(note) = scratch_note(&scratch_names) {
-        prompt_parts.push(note);
-    }
-    if let Some(id) = tracking_issue {
-        prompt_parts.push(tracking_note(id));
+    if is_concierge {
+        // The concierge's opening prompt is its fleet-ops primer — no goal text,
+        // scratch, or tracking note.
+        prompt_parts.push(agent::concierge_primer().to_string());
+    } else {
+        if !goal.is_empty() {
+            prompt_parts.push(goal.clone());
+        }
+        if let Some(note) = scratch_note(&scratch_names) {
+            prompt_parts.push(note);
+        }
+        if let Some(id) = tracking_issue {
+            prompt_parts.push(tracking_note(id));
+        }
     }
     let launch_prompt = prompt_parts.join("\n\n");
     let goal_file = if launch_prompt.is_empty() {
@@ -924,7 +946,36 @@ async fn create_session(
 
     let mut view = session_view(&st.db, &session, &branch).await?;
     view.tracking_issue = tracking_issue;
-    Ok(Json(view))
+    Ok(view)
+}
+
+/// `GET /api/chat` — the Chat surface's concierge. Get-or-create the singleton
+/// fleet concierge: return the live one if it exists, else launch a new concierge
+/// session in the most-recently-used repo (its home — it doesn't touch the code,
+/// but the session machinery needs a worktree). 400 when there is no repo yet.
+async fn get_chat(State(st): State<AppState>) -> ApiResult<Json<SessionView>> {
+    if let Some(session) = session_mod::active_concierge(&st.db).await? {
+        let branch = branch_mod::get(&st.db, &session.branch_id)
+            .await?
+            .ok_or_else(|| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, "branch vanished"))?;
+        return Ok(Json(session_view(&st.db, &session, &branch).await?));
+    }
+    let home = repo::recent(&st.db, 1)
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            AppError::bad_request(
+                "the concierge needs a repo to live in — open a session in a repo first",
+            )
+        })?;
+    let req = CreateReq {
+        cwd: home.repo_root,
+        agent: Some(agent::CONCIERGE_KIND.to_string()),
+        title: Some("Fleet concierge".to_string()),
+        ..Default::default()
+    };
+    Ok(Json(create_session_core(st, req).await?))
 }
 
 /// A line appended to a session's launch prompt telling the agent which weaver

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -158,6 +158,10 @@ async fn chat_get_or_creates_a_hidden_singleton_concierge() {
     let chat = client.get("/api/chat").await.unwrap();
     let chat_id = chat["id"].as_str().unwrap().to_string();
     assert_eq!(chat["agent_kind"], "concierge");
+    assert_eq!(
+        chat["status"], "launching",
+        "the default (claude) concierge waits for its first hook to go running"
+    );
     assert!(
         chat["tracking_issue"].is_null(),
         "concierge has no tracking issue"
@@ -178,6 +182,50 @@ async fn chat_get_or_creates_a_hidden_singleton_concierge() {
     assert_eq!(list.len(), 1, "concierge must not appear in the fleet list");
     assert_eq!(list[0]["id"].as_str().unwrap(), work_id);
 
+    client
+        .delete(&format!("/api/sessions/{chat_id}"))
+        .await
+        .unwrap();
+    client
+        .delete(&format!("/api/sessions/{work_id}"))
+        .await
+        .unwrap();
+}
+
+/// `concierge.runtime = codex` points the concierge at the hookless Codex
+/// runtime, so it launches `running` immediately (no weaver hook will promote it)
+/// while keeping the `concierge` role.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concierge_runtime_codex_launches_hookless() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+    let home = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(home.path());
+
+    let work = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "ordinary work", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let work_id = work["id"].as_str().unwrap().to_string();
+
+    // Point the concierge at codex.
+    client
+        .patch("/api/settings", json!({ "concierge.runtime": "codex" }))
+        .await
+        .unwrap();
+
+    let chat = client.get("/api/chat").await.unwrap();
+    assert_eq!(chat["agent_kind"], "concierge", "still the concierge role");
+    assert_eq!(
+        chat["status"], "running",
+        "a hookless (codex) runtime is live on launch, not stuck launching"
+    );
+
+    let chat_id = chat["id"].as_str().unwrap().to_string();
     client
         .delete(&format!("/api/sessions/{chat_id}"))
         .await
@@ -248,9 +296,13 @@ async fn adopt_recreates_killed_session() {
         .post(&format!("/api/sessions/{id}/adopt"), json!({}))
         .await
         .unwrap();
+    // A shell runtime is hookless, so adopt brings it straight back `running`
+    // (the same status it launches with) rather than stranding it in `launching`
+    // waiting for a promotion hook that never fires. A claude adopt stays
+    // `launching` until its first hook.
     assert_eq!(
-        adopted["status"], "launching",
-        "adopt sets status launching"
+        adopted["status"], "running",
+        "a hookless (shell) session adopts straight to running"
     );
     assert!(
         backend::has_session(&session).await,

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -6,7 +6,7 @@ use serial_test::serial;
 
 use loom::backend;
 
-use crate::fixtures::{sh, TestServer};
+use crate::fixtures::{sh, HomeGuard, TestServer};
 
 /// Creating a session provisions a worktree + terminal session and records the repo;
 /// deleting it tears the terminal session down and releases the repo's active count.
@@ -123,6 +123,69 @@ async fn launch_forks_from_fresh_origin_default() {
 
     let id = ws["id"].as_str().unwrap().to_string();
     client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// The Chat surface's concierge (`GET /api/chat`) is get-or-created as a
+/// singleton, hidden from the fleet list, and needs a repo to live in.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chat_get_or_creates_a_hidden_singleton_concierge() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+    // The concierge runs the Claude launch path (hooks + first-run gates), which
+    // writes under $HOME — isolate it so the test can't touch the real home.
+    let home = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(home.path());
+
+    // With no repo used yet, there is nowhere for the concierge to live.
+    assert!(
+        client.get("/api/chat").await.is_err(),
+        "no repo yet ⇒ GET /api/chat should fail"
+    );
+
+    // Record a repo by launching an ordinary session.
+    let work = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "ordinary work", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let work_id = work["id"].as_str().unwrap().to_string();
+
+    // First GET creates the concierge — a `concierge`-kind session, no tracking
+    // issue (it has no deliverable to track).
+    let chat = client.get("/api/chat").await.unwrap();
+    let chat_id = chat["id"].as_str().unwrap().to_string();
+    assert_eq!(chat["agent_kind"], "concierge");
+    assert!(
+        chat["tracking_issue"].is_null(),
+        "concierge has no tracking issue"
+    );
+    assert_ne!(chat_id, work_id);
+
+    // Second GET returns the *same* session — a singleton, not a fresh one.
+    let again = client.get("/api/chat").await.unwrap();
+    assert_eq!(
+        again["id"].as_str().unwrap(),
+        chat_id,
+        "the concierge is a singleton"
+    );
+
+    // It is hidden from the fleet list — only the ordinary session shows.
+    let list = client.get("/api/sessions").await.unwrap();
+    let list = list.as_array().unwrap();
+    assert_eq!(list.len(), 1, "concierge must not appear in the fleet list");
+    assert_eq!(list[0]["id"].as_str().unwrap(), work_id);
+
+    client
+        .delete(&format!("/api/sessions/{chat_id}"))
+        .await
+        .unwrap();
+    client
+        .delete(&format!("/api/sessions/{work_id}"))
+        .await
+        .unwrap();
 }
 
 /// A session can be created with no goal at all — just a title.

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -14,6 +14,9 @@ use sqlx::Row;
 use crate::db::{now_iso, Db};
 
 pub const DEFAULT_AGENT: &str = "claude";
+/// The agent that backs the fleet Chat concierge when `concierge.runtime` is
+/// unset. Claude is the default because only it fires weaver's lifecycle hooks.
+pub const DEFAULT_CONCIERGE_RUNTIME: &str = "claude";
 /// Whether the server adopts orphaned sessions on startup. Off by default:
 /// the operator opts in via `weaver config set server.auto_adopt true`.
 pub const DEFAULT_AUTO_ADOPT: bool = false;
@@ -104,6 +107,20 @@ pub const REGISTRY: &[SettingSpec] = &[
         default: "",
         group: "Agents",
         options: &[],
+    },
+    SettingSpec {
+        key: "concierge.runtime",
+        label: "Concierge agent",
+        description: "Which agent backs the fleet Chat concierge. `claude` runs \
+            the Claude Code TUI with full weaver status hooks. `codex` runs Codex: \
+            its conversation still renders in the Chat view, but Codex does not \
+            fire weaver's lifecycle hooks, so the concierge shows no live \
+            working/idle status and the Chat view won't auto-refresh on each \
+            reply (use the Refresh button).",
+        kind: SettingKind::Enum,
+        default: DEFAULT_CONCIERGE_RUNTIME,
+        group: "Agents",
+        options: &["claude", "codex"],
     },
     SettingSpec {
         key: "server.auto_adopt",

--- a/docs/plans/meta-chat.md
+++ b/docs/plans/meta-chat.md
@@ -81,9 +81,8 @@ companion plays a different role: the one who *knows where everything is*, point
 you to what needs you, and runs an errand on your behalf. That is a
 **concierge**. It is the working noun in the code and the API (`agent_kind =
 "concierge"`); the UI surface is plainly labelled **Chat** (what the user does
-there). ("The gaffer" — the Lancashire mill foreman you'd report to — is the
-themed alternative if we'd rather keep the dialect; see
-[Open questions](#open-questions).)
+there). (Decided over the themed `gaffer` — the Lancashire mill foreman — for
+legibility; `overlooker` already carries the dialect.)
 
 - A **concierge** is the fleet-aware chat agent.
 - A **chat** is one conversation with it.
@@ -99,14 +98,14 @@ themed alternative if we'd rather keep the dialect; see
    sends a prompt straight into the agent and auto-refreshes on its turn edges.
    Chatting with the fleet is *turn-taking with an agent*, which loom already
    does.
-2. **It reaches the fleet through an MCP server over the REST API — one seam,
-   now four consumers.** A new `loom mcp` stdio server exposes the fleet as typed
-   tools (`fleet_list`, `session_preview`, `session_conversation`,
-   `session_diff`, `session_nudge`, `session_launch`, `session_link`, …), each a
-   thin proxy to an existing `/api` route, authenticated by the machine-local
-   `$LOOM_TOKEN` loom already injects. It is the same API the overlooker binding
-   and the `loom` CLI wrap — typed tools just suit an agent better than parsing
-   CLI text.
+2. **It reaches the fleet through the tools it already has — the `loom`/`weaver`
+   CLI — and, later, a typed MCP.** A concierge session has `loom` and `weaver`
+   on `PATH` with `$WEAVER_API` + `$LOOM_TOKEN` injected, so `loom session
+   ls/preview/poll/send/launch` and `weaver issue ls` give it the *whole* fleet —
+   read and act — on day one, no new server. A `loom mcp` stdio server that turns
+   those same routes into typed tools is the **follow-up** ergonomics layer (no
+   Rust MCP crate is vendored today, so it is real work, not a free reuse); it is
+   not on the critical path for a working concierge.
 3. **Auto-hooked at launch.** Launching a concierge installs its `mcpServers`
    block into `.claude/settings.local.json` (the same merge `install_hooks`
    already does for the status hooks), injects `$LOOM_TOKEN`, grants its
@@ -142,9 +141,9 @@ flowchart TD
       oneshot["agent/oneshot + session launch"]
     end
 
-    concierge["Concierge session<br/>(agent_kind=concierge, worktree+terminal)"]
-    concierge -->|MCP stdio| mcp["loom mcp<br/>fleet tools"]
-    mcp -->|"$LOOM_TOKEN, /api/*"| rest
+    concierge["Concierge session<br/>(agent_kind=concierge → Claude runtime)"]
+    concierge -->|"loom/weaver CLI (MCP later)"| mcp["fleet tools<br/>$LOOM_TOKEN, /api/*"]
+    mcp --> rest
     engine -->|same /api| rest
 
     rest -->|reads| fleet["Fleet sessions<br/>(preview · diff · conversation · issues · tags · PR)"]
@@ -159,71 +158,73 @@ The concierge is just another out-of-process consumer of the REST API — like t
 overlooker binding and the `loom` CLI — wrapped this time as MCP tools and driven
 by a conversation instead of a cron tick.
 
-## The fleet tool surface: an MCP server over the REST API
+## The fleet tool surface: the CLI now, a typed MCP later
 
 The user asked for "MCP or readmes for an agent to understand how to explore
-loom." Both have a place, but they sit at different layers:
+loom." The honest answer after checking the code: **the CLI is already the whole
+surface**, and an MCP is a later ergonomics upgrade.
 
-- **MCP is the primary surface.** An agent reasons over *typed, structured* tool
-  results far better than over scraped CLI text. The fleet is already fully
-  described by the REST API and `frontend/types.ts`; an MCP server is the
-  thinnest possible adapter that turns each route into a tool. New `loom mcp`
-  subcommand: a stdio MCP server that proxies to `$WEAVER_API` with the
-  machine-local token. It holds no state the API doesn't — same discipline as
-  `weaver_loom`.
-- **The CLI is the always-available fallback.** A concierge session has `loom`
-  and `weaver` on `PATH`, so `loom session preview <id>`, `weaver issue ls`, and
-  friends still work for anything the MCP doesn't cover — "the CLI *is* the API
-  mirror," as the overlooker plan puts it.
-- **The primer is the tips.** `CONCIERGE.md` (below) is the "readme" — not an
-  API reference (the tools are self-describing) but *judgement*: which tool to
-  reach for, and how to read what it returns.
+- **The CLI is the v1 surface.** A concierge session has `loom` and `weaver` on
+  `PATH` with `$WEAVER_API` + `$LOOM_TOKEN` injected, so it can already read and
+  act on the entire fleet: `loom session ls` (the fleet), `loom session preview
+  <id>` (a screen glance), `loom session poll/wait/send/break <id>` (observe and
+  drive), `loom session launch "<task>"` (spawn work), and `weaver issue ls/show`
+  (the boards). "The CLI *is* the API mirror," as the overlooker plan puts it — so
+  a working concierge needs *no new tool surface at all*.
+- **The primer is the tips.** `CONCIERGE.md` (below) is the "readme" — not an API
+  reference but *judgement*: which command to reach for, and how to read what it
+  returns.
+- **The MCP is the follow-up.** Typed, structured tool results suit an agent
+  better than scraped CLI text, so a `loom mcp` stdio server that wraps the same
+  routes is worth building — but it is net-new (no Rust MCP crate is vendored) and
+  strictly an upgrade, so it lands *after* the CLI-based concierge ships. When it
+  does, it gates on the capability set the same way `weaver_loom._gate` does.
 
-The tool set maps one-to-one onto routes that already exist (so the MCP is
-implementation, not new API):
+The fleet a concierge reads/acts on maps onto routes/commands that already exist —
+note there is **no** `/sessions/{id}/diff` route today (a thing the overstated
+ARCHITECTURE table implies); "what did it change" comes from the conversation or
+`git` in the worktree, not a diff endpoint:
 
-| MCP tool | Route today | Capability |
-|---|---|---|
-| `fleet_list` (filter: attention / idle / repo / lifecycle) | `GET /api/sessions` | observe |
-| `session_get` | `GET /api/sessions/{id}` | observe |
-| `session_preview` (fast screen glance) | `GET /api/sessions/{id}/preview?lines=N` | observe |
-| `session_conversation` (deep read / summary) | `GET /api/sessions/{id}/conversation` | observe |
-| `session_diff` (what it changed) | `GET /api/sessions/{id}/diff` | observe |
-| `session_issues` / `fleet_issues` | `GET /api/branches/{id}/issues`, `GET /api/issues` | observe |
-| `session_link` (canonical `session:<id>` ref + `/s/<id>` URL) | pure | observe |
-| `session_nudge` | `POST /api/sessions/{id}/send` | **nudge** |
-| `session_interrupt` | `POST /api/sessions/{id}/interrupt` | **interrupt** |
-| `session_launch` (returns the tracking issue) | `POST /api/sessions` | **launch** |
-| `overlooker_draft` / `_dry_run` / `_register` | `…/overlookers` + `{dry_run}` | **launch** |
-
-The capability column is enforced **in the MCP server**, the same place
-`weaver_loom._gate` enforces it — a concierge granted only `observe`+`nudge`
-cannot launch, no matter what the model asks.
+| What the concierge does | CLI today | REST | Later MCP tool |
+|---|---|---|---|
+| list the fleet (filter attention/idle/repo) | `loom session ls` | `GET /api/sessions` | `fleet_list` |
+| one session | `loom session poll <id>` | `GET /api/sessions/{id}` | `session_get` |
+| fast screen glance | `loom session preview <id>` | `GET …/preview?lines=N` | `session_preview` |
+| deep read / summarise | (read its log) | `GET …/conversation` | `session_conversation` |
+| the boards | `weaver issue ls` | `GET /api/issues` | `fleet_issues` |
+| nudge a session | `loom session send <id> …` | `POST …/send` | `session_nudge` |
+| interrupt a turn | `loom session break <id>` | `POST …/interrupt` | `session_interrupt` |
+| launch a workstream | `loom session launch …` | `POST /api/sessions` | `session_launch` |
+| link to a session | write `/s/<id>` | — | `session_link` |
 
 ## The concierge as a session kind
 
-A new `agent_kind = "concierge"` rides the existing launch path
-(`agent::launch`, the `sessions` table, `launch_script`), with three deltas at
-launch time, all on seams that already exist:
+`agent_kind` *selects the agent command* — only `"claude"` gets the Claude hooks
+and launch-gates; any other value is run as an executable name. So the concierge
+is a new kind that **maps to the Claude runtime**: `agent_kind = "concierge"`
+runs the same `claude` command and takes the same `install_hooks` +
+`seed_claude_launch_gates` path as a normal claude session, and is *distinguished*
+from it only as a marker — what hides it from the fleet, finds the singleton, and
+selects its primer. Two deltas at launch, both small:
 
-1. **Install the MCP.** Extend the hook-install step (`install_hooks` already
-   merges into `.claude/settings.local.json`) to also merge an `mcpServers`
-   entry: `loom mcp --base $WEAVER_API`. `$LOOM_TOKEN` is already injected into
-   the session's subprocess env, so the server authenticates with zero config —
-   even behind a reverse proxy with loopback trust off.
-2. **Seed the primer.** The `CONCIERGE.md` doc is injected the way `WEAVER.md`
-   is — through the `SessionStart` primer (`session_primer`) — so a fresh or
-   resumed concierge always re-reads its role and tips.
-3. **Grant capabilities.** The session row carries the concierge's capability set
-   (default `observe`, `link`, `nudge`, `launch`; `interrupt` opt-in), which the
-   MCP reads to gate its tools. Because a human confirms each action in the chat,
-   the default is more permissive than an autonomous overlooker's — but the
-   ladder and the audit trail are identical.
+1. **Seed the primer.** The concierge's opening prompt is the `CONCIERGE.md`
+   primer (the launch path already writes a `goal.txt` opening prompt; for a
+   concierge that text *is* the primer). Because the primer lands in the branch
+   goal, `weaver summary` replays it after a compaction — durable orientation
+   with zero new primer machinery. The normal `WEAVER.md` session primer still
+   injects, so the concierge also knows the weaver-session basics it lives in.
+2. **No withheld capabilities.** With launch-by-default at single-operator scale,
+   the concierge holds the full ladder; the permission gate is the conversation,
+   so there is **no per-session capability column** to add for v1. (A later
+   unattended/multi-user mode adds one — the overlooker's binding already gates
+   in-process, so the pattern exists when needed.)
 
-Lifecycle reuse is the point: the concierge is **hidden from the fleet list**
-(like the overlooker's warm session), **orphan/adopts across a loom restart**, and
-its history *is* its conversation — already captured and rendered by the
-Conversation tab.
+Lifecycle reuse is the point: the concierge rides launch, the live terminal,
+orphan/adopt, and the already-drivable Conversation tab unchanged. It is
+**identified and hidden from the fleet by its `agent_kind`** — *not* by the
+overlooker's `managed_by` field, which carries adoption/archival semantics the
+concierge must not inherit. A one-line filter drops `agent_kind = "concierge"`
+from the session list; the **Chat** view finds the singleton by the same kind.
 
 **Singleton to start.** One persistent concierge ("the fleet chat") that the
 **Chat** view opens, auto-created on first use. Matches the single-operator auth
@@ -233,22 +234,22 @@ and loom already lists many.
 
 ### The primer (`CONCIERGE.md`) — the tips
 
-The judgement an agent needs that the tools don't encode. Sketch:
+The judgement an agent needs that the commands don't encode. Sketch:
 
-- **Glance vs. deep-read.** `session_preview` (the live screen, cheap) is for a
-  fast read of *what a session is doing right now*; `session_conversation` (the
-  normalized log) is for *what it has done and decided* — use it to summarise.
-  `session_diff` for the code; `branch.github` for PR/CI state.
+- **Glance vs. deep-read.** `loom session preview <id>` (the live screen, cheap)
+  is for a fast read of *what a session is doing right now*; the conversation log
+  is for *what it has done and decided* — use it to summarise. `branch.github`
+  (in `loom session poll`) for PR/CI state.
 - **Reading staleness.** A session is likely stale when it is `running` but
   carries the quiet `idle` tag and its `last_activity_at` is old, with no loud
   `attention`. "Needs me" is the loud `attention`/`triage` ladder. Don't confuse
   the two: idle is calm, attention is a call.
-- **Always link.** Refer to a session as `session:<id>` so the user can click
-  through; name the repo and branch so the reference is legible.
-- **Be a concierge, not a cowboy.** Summarise and point first. Before you
-  `nudge`/`interrupt`/`launch`, say what you'll do and why, and let the user
-  confirm in the next turn. You have the whole fleet in view — the user has one
-  question; bridge the two.
+- **Always link.** Refer to a session as a `/s/<id>` markdown link so the user
+  can click through; name the repo and branch so the reference is legible.
+- **Be a concierge, not a cowboy.** Summarise and point first. Before you nudge,
+  interrupt, or launch, say what you'll do and why, and let the user confirm in
+  the next turn. You have the whole fleet in view — the user has one question;
+  bridge the two.
 
 ## The Chat surface (UI)
 
@@ -256,31 +257,34 @@ API-first ([[ui-built-on-rest-api]]), and mostly *assembly of parts that exist*:
 
 - **A top-level rail entry, `Chat`** — sibling of Sessions / Issues / **Watch** /
   Shell (a `messages-square` glyph). Routes to `/chat`.
-- **The view reuses `SessionConversation.vue` verbatim** — the skimmable iris-log
-  renderer with the foot composer. The composer already POSTs to
-  `/sessions/{id}/send` (type + Enter) and auto-refreshes on the agent's turn
-  edges, so the chat round-trip is *already solved*; `/chat` just resolves (or
-  creates) the singleton concierge session and mounts the component against it.
-- **Linkified session references.** Teach the conversation's `MarkdownView` to
-  project `session:<id>` into a live chip — title + lifecycle/attention dot,
-  linking to `/s/<id>` — exactly as smartdoc renders a `#41` issue chip from the
-  ledger. This is the one genuinely new bit of rendering, and it is the
-  "produces links to a session" requirement.
+- **The view reuses `SessionConversation.vue`** — the skimmable iris-log renderer
+  with the foot composer. The composer already POSTs to `/sessions/{id}/send`
+  (type + Enter) and auto-refreshes on the agent's turn edges, so the chat
+  round-trip is *already solved*; `/chat` get-or-creates the singleton concierge
+  and mounts the component against it.
+- **Session links.** v1: the concierge writes plain `/s/<id>` markdown links,
+  which navigate to the session. The *polished* form — projecting a `session:<id>`
+  reference into a live status chip (title + attention dot), the way smartdoc
+  renders a `#41` issue chip — is a follow-up: it needs a real ref-projection map
+  plus dompurify/click handling in `MarkdownView`, not just a regex, so it does
+  not gate the first cut.
 
 ## Producing links & acting on your behalf
 
-Two tiers of action, both reusing existing primitives, both audited:
+Two tiers of action, both reusing existing primitives:
 
-- **Nudge / interrupt an existing session.** `session_nudge` →
-  `POST /sessions/{id}/send` types a message into a watched session's agent;
-  `session_interrupt` → `POST /sessions/{id}/interrupt` stops its turn. "Tell the
-  auth session to rebase on main" becomes one gated tool call, recorded as a
-  `nudge` event with the concierge as author.
-- **Launch a new workstream.** `session_launch` → `POST /api/sessions` forks a
-  fresh session for work the user wants done, and returns its **tracking issue**.
-  The concierge can then watch it (`weaver issue wait` / `session_get`) and report
-  back in a later turn — "the flaky-test fix is `session:cd34`; it opened a PR,
-  CI is green."
+- **Nudge / interrupt an existing session.** `loom session send <id> …` (→
+  `POST /sessions/{id}/send`) types a message into a watched session's agent;
+  `loom session break <id>` (→ `POST …/interrupt`) stops its turn. "Tell the auth
+  session to rebase on main" becomes one command. (Audit parity is a follow-up:
+  `send` already records a `nudge` event with `by`, but `interrupt` records none
+  and a launch isn't attributed to the concierge — closing that gap is a small
+  API change, [C6](#tasks).)
+- **Launch a new workstream.** `loom session launch "<task>"` (→
+  `POST /api/sessions`) forks a fresh session for work the user wants done, and
+  returns its **tracking issue**. The concierge can then watch it (`weaver issue
+  wait` / `loom session poll`) and report back in a later turn — "the flaky-test
+  fix is /s/cd34; it opened a PR, CI is green."
 
 The concierge **does not write the `triage` tag** — that is the overlooker's
 fact, and two actors authoring one fact is the anti-pattern the overlooker plan
@@ -314,80 +318,95 @@ ladder over the same API:
 End to end, on the singleton concierge:
 
 1. You open **Chat** and type the question. The composer sends it into the
-   concierge session (reused `/send`); the Conversation tab will stream the reply.
-2. The concierge calls `fleet_list` → `GET /api/sessions`. It filters to
-   `running` sessions carrying the quiet `idle` tag with an old
-   `last_activity_at` and no loud `attention` — its staleness heuristic from the
-   primer.
-3. For each candidate it calls `session_preview` (and `session_conversation` when
-   it needs to know *why* it stalled — waiting on a prompt? wedged on a failing
-   test?).
-4. It replies in plain language with **clickable** references:
-   > Two look stale. `session:ab12` (weaver / *auth-refactor*) finished its turn
-   > 3 h ago waiting for review — its PR is green. `session:cd34` (loom /
-   > *flaky-e2e*) has been re-running the same test for 40 min with no progress.
-   > Want me to nudge cd34 to try a different approach, or leave it?
-5. You reply "nudge it." The concierge calls `session_nudge` (gated by the
-   `nudge` capability) → `POST /sessions/cd34/send`, recorded as a `nudge` event
-   attributed to the concierge, and confirms.
+   concierge session (reused `/send`); the Conversation tab streams the reply.
+2. The concierge runs `loom session ls` and filters to `running` sessions
+   carrying the quiet `idle` tag with an old `last_activity_at` and no loud
+   `attention` — its staleness heuristic from the primer.
+3. For each candidate it runs `loom session preview <id>` (and reads the
+   conversation when it needs to know *why* it stalled — waiting on a prompt?
+   wedged on a failing test?).
+4. It replies in plain language with clickable links:
+   > Two look stale. /s/ab12 (weaver / *auth-refactor*) finished its turn 3 h ago
+   > waiting for review — its PR is green. /s/cd34 (loom / *flaky-e2e*) has been
+   > re-running the same test for 40 min with no progress. Want me to nudge cd34
+   > to try a different approach, or leave it?
+5. You reply "nudge it." The concierge runs `loom session send cd34 "…"` (recorded
+   as a `nudge` event) and confirms.
 
-No new survey engine, no new agent runtime, no new status axis — a conversation
-over the API the fleet already exposes.
+No new survey engine, no new agent runtime, no new status axis, and — for the
+first cut — no new tool surface: a conversation over the CLI the fleet already
+exposes.
+
+## Peer review (codex)
+
+A codex pass over the codebase corrected three overstated seams, now folded in
+above: `agent_kind` selects the *command* (so the concierge maps to the Claude
+runtime, not a free-standing kind); the hidden/warm lifecycle is overlooker-
+specific (`managed_by`), so the concierge is hidden by its **kind** instead; and
+there is no `/sessions/{id}/diff` route. It also flagged that the capability
+column, the MCP server, the `session:<id>` chip, and interrupt/launch audit
+attribution are all net-new — which is why the plan below ships the concierge on
+the **existing CLI** first and defers those. Verdict: *ship with fixes*.
 
 ## Tasks
 
-Each task has a stable id; `deps:` edges define the delivery sequence. They
-materialise into weaver issues when the design is agreed (the overlooker plan's
-convention). `T2`/`T3` are the only genuinely new runtime; the rest is assembly.
+Each task has a stable id; `deps:` edges define the delivery sequence. The Phase-0
+set (C1–C3) is deliberately the *tight* cut — a working, fleet-acting concierge
+with **no new runtime, server, or schema**, just a kind that maps to Claude, a
+primer, and a view.
 
-### C1 — `loom mcp`: the fleet tool server  `value: high`  `deps: —`
-A stdio MCP server (new `loom mcp` subcommand) proxying the read routes
-(`fleet_list`, `session_get/preview/conversation/diff/issues`, `session_link`) to
-`$WEAVER_API` with `$LOOM_TOKEN`. Read-only first. Acceptance: an MCP client lists
-the fleet and reads a session's conversation through the server.
+### C1 — `concierge` kind mapped to the Claude runtime  `value: high`  `deps: —`
+In `agent.rs`, `agent_kind = "concierge"` runs the `claude` command and takes the
+`install_hooks` + `seed_claude_launch_gates` path (today gated on `=="claude"`).
+No schema change; no capability column (full ladder, prompt-level confirmation).
+Acceptance: launching a concierge boots a real Claude agent with weaver hooks.
 
-### C2 — The `concierge` agent kind + auto-hook at launch  `value: high`  `deps: C1`
-`agent_kind = "concierge"` on the launch path; extend `install_hooks` to also
-merge the `mcpServers` block; seed the `CONCIERGE.md` primer via `session_primer`;
-carry a capability set on the session row. Acceptance: launching a concierge yields
-a session whose agent can call the fleet tools unprompted.
+### C2 — `CONCIERGE.md` primer + primer-as-opening-prompt  `value: high`  `deps: —`
+The tips doc (`include_str!`'d into loom): glance vs. deep-read via `loom session
+preview`, the staleness heuristic, always-link with `/s/<id>`, propose-then-act,
+and the `loom`/`weaver` commands it drives the fleet with. The concierge launch
+path uses it as the opening prompt. Acceptance: a fresh concierge knows how to
+survey and act on the fleet without being told.
 
-### C3 — `CONCIERGE.md` primer  `value: high`  `deps: —`
-The tips doc (glance vs. deep-read, staleness heuristic, always-link, propose-then-
-act), `include_str!`'d like `WEAVER.md`. Acceptance: a fresh concierge re-reads it
-on `SessionStart`.
+### C3 — The Chat view + get-or-create + hide-by-kind  `value: high`  `deps: C1, C2`
+A `/chat` rail entry + route; a `GET /api/chat` handler that get-or-creates the
+singleton concierge (in the most-recent repo) and returns its `SessionView`; the
+view mounts `SessionConversation.vue` against it; `SessionList` filters out
+`agent_kind == "concierge"`. Acceptance: Chat opens a working conversation with
+the fleet agent; the concierge does not appear in the fleet list.
 
-### C4 — The Chat view + singleton resolution  `value: high`  `deps: C2`
-A `/chat` route + rail entry that resolves (or creates) the singleton concierge and
-mounts `SessionConversation.vue` against it; the concierge hidden from the fleet
-list. Acceptance: Chat opens a working conversation with the fleet agent.
+### C4 — `loom mcp`: a typed fleet tool server  `value: med`  `deps: C1`
+A stdio MCP server (new `loom mcp` subcommand, a new MCP dep) wrapping the read +
+act routes as typed tools, installed into the concierge's
+`.claude/settings.local.json` (extend `install_hooks` to also merge `mcpServers`,
+preserving any existing entry). Strictly an ergonomics upgrade over the CLI.
+Acceptance: the concierge lists and reads the fleet through typed tools.
 
-### C5 — `session:<id>` linkified references  `value: med`  `deps: C4`
+### C5 — `session:<id>` linkified chips  `value: med`  `deps: C3`
 Project `session:<id>` into a live status chip linking to `/s/<id>` in the
-conversation `MarkdownView` (the smartdoc `#41` machinery, for sessions); a
-`session_link` tool returns the canonical ref. Acceptance: a concierge reply's
-session references render as clickable chips.
+conversation `MarkdownView` — a real ref-projection map plus dompurify/click
+handling, not a regex. Acceptance: a concierge reply's session references render
+as clickable status chips.
 
-### C6 — Action tools: nudge / interrupt / launch  `value: med`  `deps: C2`
-The capability-gated mutating tools over `…/send`, `…/interrupt`, and
-`POST /api/sessions`; each records an `events` row attributed to the concierge.
-Acceptance: with the capability granted, the concierge nudges and launches; without
-it, the tool is refused.
+### C6 — Action audit parity  `value: med`  `deps: C1`
+Record an `events` row (attributed to the actor) for `interrupt`, and attribute a
+concierge-driven `launch`, so every action the concierge takes is auditable like a
+`nudge` is today. Acceptance: interrupt and launch show in the touched session's
+activity with an author.
 
-### C7 — Overlooker authoring from chat  `value: low`  `deps: C6, overlooker T8`
-`overlooker_draft/dry_run/register` tools so "ping me whenever a PR goes red"
-becomes a drafted, dry-run, registered overlooker. The Chat ⇄ Watch convergence.
-Acceptance: the concierge scaffolds and dry-runs an overlooker against the live
-fleet from a chat turn.
+### C7 — Overlooker authoring from chat  `value: low`  `deps: C4, overlooker T8`
+The concierge drafts/dry-runs/registers an overlooker so "ping me whenever a PR
+goes red" becomes a real watch. The Chat ⇄ Watch convergence. Acceptance: the
+concierge scaffolds and dry-runs an overlooker from a chat turn.
 
 ## Rollout
 
-- **Phase 0 — Read-only concierge.** C1 (MCP reads), C3 (primer), C2 (kind +
-  auto-hook), C4 (Chat view). First milestone: you can *ask about* the fleet and
-  get linked, summarised answers. No mutation yet — safe by construction.
-- **Phase 1 — Links & action.** C5 (clickable refs), C6 (nudge/interrupt/launch on
-  the gated ladder). The concierge can now *act on your behalf*, with you
-  confirming each step.
+- **Phase 0 — A working concierge (the tight cut).** C1 (kind → Claude), C2
+  (primer), C3 (Chat view + get-or-create). First milestone: you open Chat, ask
+  "any stale sessions?", and get a linked, summarised answer — and it can nudge or
+  launch on your say-so, all over the existing CLI. No new server, schema, or dep.
+- **Phase 1 — Ergonomics & polish.** C4 (typed MCP), C5 (session chips), C6 (audit
+  parity). Sharper tools and clickable chips over the same working concierge.
 - **Phase 2 — Convergence.** C7 (author overlookers from chat). Chat becomes the
   front door to Watch.
 
@@ -406,11 +425,17 @@ fleet from a chat turn.
 - **Not multi-tenant yet.** One singleton concierge at the single-operator scale;
   many named chats is a later, additive step.
 
+## Decisions
+
+- **Name** — `concierge` in the code/API, **Chat** in the UI. The themed `gaffer`
+  is dropped for legibility.
+- **Default capabilities** — the full ladder (`observe`, `link`, `nudge`,
+  `interrupt`, `launch`), because the operator drives it turn by turn; the
+  conversation is the permission gate. A later unattended/multi-user mode can dial
+  it back per concierge.
+
 ## Open questions
 
-- **Name.** `concierge`/`Chat` (clear) vs. the themed `gaffer` (the Lancashire
-  mill foreman, matching `overlooker`'s dialect). Recommend `concierge` in the
-  code, **Chat** in the UI; open to the themed noun.
 - **Worktree-backed vs. lightweight chat.** A concierge-as-session gets a worktree
   it mostly doesn't use. The alternative — a bespoke `chats` table driven by a
   multi-turn variant of `agent/oneshot`, no worktree — is *lighter* but
@@ -423,6 +448,3 @@ fleet from a chat turn.
   definition rather than each rolling their own.
 - **Singleton scope.** One concierge per machine, per operator, or per repo? Start
   global (single-operator scale); scope later if it earns its keep.
-- **How permissive a default.** Because a human confirms each turn, is
-  `launch`-by-default acceptable, or should the first cut ship `observe`+`nudge`
-  only and make `launch` an explicit grant? Lean conservative for Phase 1.

--- a/docs/plans/meta-chat.md
+++ b/docs/plans/meta-chat.md
@@ -200,12 +200,14 @@ ARCHITECTURE table implies); "what did it change" comes from the conversation or
 ## The concierge as a session kind
 
 `agent_kind` *selects the agent command* — only `"claude"` gets the Claude hooks
-and launch-gates; any other value is run as an executable name. So the concierge
-is a new kind that **maps to the Claude runtime**: `agent_kind = "concierge"`
-runs the same `claude` command and takes the same `install_hooks` +
-`seed_claude_launch_gates` path as a normal claude session, and is *distinguished*
-from it only as a marker — what hides it from the fleet, finds the singleton, and
-selects its primer. Two deltas at launch, both small:
+and launch-gates; any other value is run as an executable name. The concierge is a
+new kind, but `agent_kind = "concierge"` is a **role marker**, not a runtime: it is
+what hides the session from the fleet, finds the singleton, and selects the primer.
+The runtime it *actually* launches is resolved separately from the
+**`concierge.runtime`** setting (claude default, codex opt-in — see below), so the
+role and the binary stay decoupled. With the default, the concierge runs the same
+`claude` command and takes the same `install_hooks` + `seed_claude_launch_gates`
+path as a normal claude session. Two deltas at launch, both small:
 
 1. **Seed the primer.** The concierge's opening prompt is the `CONCIERGE.md`
    primer (the launch path already writes a `goal.txt` opening prompt; for a
@@ -231,6 +233,21 @@ from the session list; the **Chat** view finds the singleton by the same kind.
 scale and the user's "a new Chat tab which gives us an agent." Multiple named
 chats (one per investigation) are a clean later extension — a chat is a session,
 and loom already lists many.
+
+### Runtime: claude (default) or codex
+
+The **`concierge.runtime`** setting (Agents group; enum `claude` | `codex`,
+default `claude`) chooses the agent that backs the concierge — the one place the
+role-vs-runtime split surfaces to the operator. `claude` is the full-fidelity
+path: the Claude Code TUI with weaver's lifecycle hooks, so the Chat view shows
+live working/idle status and auto-refreshes on each reply. `codex` runs Codex with
+the same primer-as-opening-prompt — its conversation renders in the Chat view
+(transcript support already exists), but **Codex does not fire weaver's hooks**, so
+the concierge gets no live status and the view won't auto-refresh per reply (use
+Refresh). A codex-backed session therefore launches `running` (it is live
+immediately) rather than `launching` (which waits for a hook that never comes), and
+its launch skips `install_hooks` / `seed_claude_launch_gates` (Codex reads
+neither). Wiring Codex into the weaver status hooks is the obvious Phase-1 upgrade.
 
 ### The primer (`CONCIERGE.md`) — the tips
 
@@ -433,6 +450,11 @@ concierge scaffolds and dry-runs an overlooker from a chat turn.
   `interrupt`, `launch`), because the operator drives it turn by turn; the
   conversation is the permission gate. A later unattended/multi-user mode can dial
   it back per concierge.
+- **Role vs. runtime** — `agent_kind = "concierge"` is the *role* (hidden, singleton,
+  primed); the *runtime* is the `concierge.runtime` setting (claude default, codex
+  opt-in). Keeping them separate means a runtime swap moves nothing else, and codex
+  rides the existing transcript support. The known cost — no live status for codex
+  until its hooks are wired — is documented in the setting and on the Chat view.
 
 ## Open questions
 

--- a/docs/plans/meta-chat.md
+++ b/docs/plans/meta-chat.md
@@ -1,0 +1,428 @@
+---
+plan: meta-chat
+status: proposal
+---
+
+# The Concierge — a conversational meta-layer over the fleet
+
+A weaver [plan](../structured-projects.md) (weaver issue #280): the design
+surface for a **Chat** layer that lets you *talk to an agent about the other
+sessions*. This file owns the *structure* — the problem, the architecture, the
+tasks and their dependencies; the issue ledger owns the *state*. Nothing here
+ships yet — it is the design of record to build against. The [Tasks](#tasks)
+materialise into weaver issues when the design is agreed.
+
+## Problem & goal
+
+You launch a handful of sessions over a morning, wander off, and come back to a
+wall of cards. You *can* read the fleet — every session's screen, diff,
+conversation, PR, and tags are one REST call away — but the only thing that
+turns that raw state into an answer is **you**, clicking through tabs. The
+questions you actually have are in plain language:
+
+- *"Are there any stale sessions I should know about?"*
+- *"Which of these need me, and why?"*
+- *"What did the auth-refactor session actually change?"*
+- *"Spin up a session to fix the flaky e2e test, and tell me when it's done."*
+
+[The overlooker](overlooker.md) answers the *push* half of this: it wakes on a
+timer, surveys the fleet, and stamps a `triage` mark on what looks stuck. But an
+overlooker can't be *asked*. It runs a fixed program on a schedule; it can't
+hold a conversation, follow a hunch, or do the one-off investigation you only
+thought of just now. The missing primitive is the **pull** half: an agent that
+**holds the whole fleet in its head**, that you **converse with on demand**, and
+that can **act on your behalf** — read a session and summarise it, point you
+straight at the one that needs you, nudge a stuck one, or launch a new workstream
+and watch it for you.
+
+The goal: a **Chat** surface — a top-level view, sibling to the session list —
+backed by a fleet-aware agent that is *auto-hooked into loom* the moment it
+starts, so you can ask about the floor and have it answer, link, and act.
+
+## The insight: the overlooker's conversational twin
+
+The overlooker design already did the hard architectural thinking, and it lands
+on the exact seam this feature needs:
+
+> Everything loom can do is a REST route; an out-of-process agent reaches the
+> fleet only through that API, with a **capability-gated** client over it and a
+> **bounded, audited intervention ladder** (observe → mark → nudge → interrupt →
+> launch). The daemon stays the single owner of the live runtime.
+
+That is *already built*: `python/weaver-loom` is a capability-gated `Client` over
+the REST API; `POST /api/agent/oneshot` is the env-stripped headless-agent
+primitive; the overlooker engine is the autonomous consumer of it.
+
+So the concierge is **not a new subsystem — it is a second front-end on the same
+substrate.** Two ways to drive one fleet API:
+
+| | **Watch** (overlooker) | **Chat** (concierge) |
+|---|---|---|
+| Trigger | a cron tick or a fleet event | a message you type |
+| Cadence | autonomous, scheduled | on-demand, interactive |
+| Output | a `triage` mark on a branch | a reply in a conversation |
+| Memory | per-round lookaside state | a running conversation |
+| Reaches the fleet via | the bound REST API | the **same** bound REST API |
+| Acts via | the capability ladder | the **same** capability ladder |
+
+They are siblings in the nav rail (the rail already pairs them: **Watch** is an
+eye over the looms; **Chat** is the conversation about them) and they *converge*:
+the most natural way to *create* an overlooker — "ping me whenever a session goes
+red" — is to **ask the concierge to draft one for you** (the overlooker plan
+already calls for agent-authored overlookers via the CLI). Chat is how you reach
+into the fleet right now; Watch is how you ask it to keep an eye out for you.
+The concierge is the front door to both.
+
+## The name
+
+The mill metaphor runs through weaver — `loom`, `weaver`, `tapestry`, and the
+**overlooker** who walks the rows and tends the looms. The conversational
+companion plays a different role: the one who *knows where everything is*, points
+you to what needs you, and runs an errand on your behalf. That is a
+**concierge**. It is the working noun in the code and the API (`agent_kind =
+"concierge"`); the UI surface is plainly labelled **Chat** (what the user does
+there). ("The gaffer" — the Lancashire mill foreman you'd report to — is the
+themed alternative if we'd rather keep the dialect; see
+[Open questions](#open-questions).)
+
+- A **concierge** is the fleet-aware chat agent.
+- A **chat** is one conversation with it.
+- The **fleet tools** are the MCP surface it reaches the fleet through.
+
+## TL;DR
+
+1. **A concierge is a session, not a new runtime.** It is a normal loom session
+   of a new `agent_kind = "concierge"` — its own worktree, terminal supervisor,
+   and lifecycle — so it reuses the **entire** session machinery: launch, the
+   live terminal, orphan/adopt across a restart, and — the big win — the
+   **already-drivable [Conversation tab](../ARCHITECTURE.md)**, whose composer
+   sends a prompt straight into the agent and auto-refreshes on its turn edges.
+   Chatting with the fleet is *turn-taking with an agent*, which loom already
+   does.
+2. **It reaches the fleet through an MCP server over the REST API — one seam,
+   now four consumers.** A new `loom mcp` stdio server exposes the fleet as typed
+   tools (`fleet_list`, `session_preview`, `session_conversation`,
+   `session_diff`, `session_nudge`, `session_launch`, `session_link`, …), each a
+   thin proxy to an existing `/api` route, authenticated by the machine-local
+   `$LOOM_TOKEN` loom already injects. It is the same API the overlooker binding
+   and the `loom` CLI wrap — typed tools just suit an agent better than parsing
+   CLI text.
+3. **Auto-hooked at launch.** Launching a concierge installs its `mcpServers`
+   block into `.claude/settings.local.json` (the same merge `install_hooks`
+   already does for the status hooks), injects `$LOOM_TOKEN`, grants its
+   capability set, and seeds a **`CONCIERGE.md` primer** — the analogue of
+   `WEAVER.md` — full of *tips*: how to glance at a session fast (`preview`),
+   read it deep (`conversation`), judge staleness (`last_activity_at` + the
+   `idle`/`attention` tags), and link to it. It boots already knowing the fleet.
+4. **It produces links you can click.** The concierge answers with live
+   **`session:<id>` references** that the conversation renderer projects into
+   status chips linking to `/s/<id>` — the smartdoc `#41`-issue-chip machinery,
+   pointed at sessions. "Look into `session:ab12`" becomes a click.
+5. **It acts on your behalf, on the bounded ladder, with you in the loop.**
+   `observe`/`link` are always on; `nudge`, `interrupt`, and `launch` are
+   capability-gated and — because a human is *right there in the chat* — confirmed
+   conversationally before they fire. Every action is an `events` row, exactly
+   like an overlooker's.
+6. **It never authors another actor's facts.** The agent owns its `attention`
+   tag; the overlooker owns `triage`. The concierge **talks** — its findings live
+   in the conversation, not as a third writer fighting over the same tag.
+
+The rest argues each point.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    user["You — Chat view (/chat)"] -->|type a message| convo
+    convo["Conversation composer<br/>(reused: POST /sessions/{id}/send)"] --> concierge
+
+    subgraph daemon["loom daemon — sole runtime owner"]
+      rest["REST + SSE API (web.rs)"]
+      engine["Overlooker engine<br/>(autonomous consumer)"]
+      oneshot["agent/oneshot + session launch"]
+    end
+
+    concierge["Concierge session<br/>(agent_kind=concierge, worktree+terminal)"]
+    concierge -->|MCP stdio| mcp["loom mcp<br/>fleet tools"]
+    mcp -->|"$LOOM_TOKEN, /api/*"| rest
+    engine -->|same /api| rest
+
+    rest -->|reads| fleet["Fleet sessions<br/>(preview · diff · conversation · issues · tags · PR)"]
+    rest -->|nudge / interrupt / launch| fleet
+    concierge -->|session:&lt;id&gt; refs| convo
+    rest --> actions["events (audit) + tags"]
+
+    style daemon fill:#0d1117,stroke:#30363d,color:#c9d1d9
+```
+
+The concierge is just another out-of-process consumer of the REST API — like the
+overlooker binding and the `loom` CLI — wrapped this time as MCP tools and driven
+by a conversation instead of a cron tick.
+
+## The fleet tool surface: an MCP server over the REST API
+
+The user asked for "MCP or readmes for an agent to understand how to explore
+loom." Both have a place, but they sit at different layers:
+
+- **MCP is the primary surface.** An agent reasons over *typed, structured* tool
+  results far better than over scraped CLI text. The fleet is already fully
+  described by the REST API and `frontend/types.ts`; an MCP server is the
+  thinnest possible adapter that turns each route into a tool. New `loom mcp`
+  subcommand: a stdio MCP server that proxies to `$WEAVER_API` with the
+  machine-local token. It holds no state the API doesn't — same discipline as
+  `weaver_loom`.
+- **The CLI is the always-available fallback.** A concierge session has `loom`
+  and `weaver` on `PATH`, so `loom session preview <id>`, `weaver issue ls`, and
+  friends still work for anything the MCP doesn't cover — "the CLI *is* the API
+  mirror," as the overlooker plan puts it.
+- **The primer is the tips.** `CONCIERGE.md` (below) is the "readme" — not an
+  API reference (the tools are self-describing) but *judgement*: which tool to
+  reach for, and how to read what it returns.
+
+The tool set maps one-to-one onto routes that already exist (so the MCP is
+implementation, not new API):
+
+| MCP tool | Route today | Capability |
+|---|---|---|
+| `fleet_list` (filter: attention / idle / repo / lifecycle) | `GET /api/sessions` | observe |
+| `session_get` | `GET /api/sessions/{id}` | observe |
+| `session_preview` (fast screen glance) | `GET /api/sessions/{id}/preview?lines=N` | observe |
+| `session_conversation` (deep read / summary) | `GET /api/sessions/{id}/conversation` | observe |
+| `session_diff` (what it changed) | `GET /api/sessions/{id}/diff` | observe |
+| `session_issues` / `fleet_issues` | `GET /api/branches/{id}/issues`, `GET /api/issues` | observe |
+| `session_link` (canonical `session:<id>` ref + `/s/<id>` URL) | pure | observe |
+| `session_nudge` | `POST /api/sessions/{id}/send` | **nudge** |
+| `session_interrupt` | `POST /api/sessions/{id}/interrupt` | **interrupt** |
+| `session_launch` (returns the tracking issue) | `POST /api/sessions` | **launch** |
+| `overlooker_draft` / `_dry_run` / `_register` | `…/overlookers` + `{dry_run}` | **launch** |
+
+The capability column is enforced **in the MCP server**, the same place
+`weaver_loom._gate` enforces it — a concierge granted only `observe`+`nudge`
+cannot launch, no matter what the model asks.
+
+## The concierge as a session kind
+
+A new `agent_kind = "concierge"` rides the existing launch path
+(`agent::launch`, the `sessions` table, `launch_script`), with three deltas at
+launch time, all on seams that already exist:
+
+1. **Install the MCP.** Extend the hook-install step (`install_hooks` already
+   merges into `.claude/settings.local.json`) to also merge an `mcpServers`
+   entry: `loom mcp --base $WEAVER_API`. `$LOOM_TOKEN` is already injected into
+   the session's subprocess env, so the server authenticates with zero config —
+   even behind a reverse proxy with loopback trust off.
+2. **Seed the primer.** The `CONCIERGE.md` doc is injected the way `WEAVER.md`
+   is — through the `SessionStart` primer (`session_primer`) — so a fresh or
+   resumed concierge always re-reads its role and tips.
+3. **Grant capabilities.** The session row carries the concierge's capability set
+   (default `observe`, `link`, `nudge`, `launch`; `interrupt` opt-in), which the
+   MCP reads to gate its tools. Because a human confirms each action in the chat,
+   the default is more permissive than an autonomous overlooker's — but the
+   ladder and the audit trail are identical.
+
+Lifecycle reuse is the point: the concierge is **hidden from the fleet list**
+(like the overlooker's warm session), **orphan/adopts across a loom restart**, and
+its history *is* its conversation — already captured and rendered by the
+Conversation tab.
+
+**Singleton to start.** One persistent concierge ("the fleet chat") that the
+**Chat** view opens, auto-created on first use. Matches the single-operator auth
+scale and the user's "a new Chat tab which gives us an agent." Multiple named
+chats (one per investigation) are a clean later extension — a chat is a session,
+and loom already lists many.
+
+### The primer (`CONCIERGE.md`) — the tips
+
+The judgement an agent needs that the tools don't encode. Sketch:
+
+- **Glance vs. deep-read.** `session_preview` (the live screen, cheap) is for a
+  fast read of *what a session is doing right now*; `session_conversation` (the
+  normalized log) is for *what it has done and decided* — use it to summarise.
+  `session_diff` for the code; `branch.github` for PR/CI state.
+- **Reading staleness.** A session is likely stale when it is `running` but
+  carries the quiet `idle` tag and its `last_activity_at` is old, with no loud
+  `attention`. "Needs me" is the loud `attention`/`triage` ladder. Don't confuse
+  the two: idle is calm, attention is a call.
+- **Always link.** Refer to a session as `session:<id>` so the user can click
+  through; name the repo and branch so the reference is legible.
+- **Be a concierge, not a cowboy.** Summarise and point first. Before you
+  `nudge`/`interrupt`/`launch`, say what you'll do and why, and let the user
+  confirm in the next turn. You have the whole fleet in view — the user has one
+  question; bridge the two.
+
+## The Chat surface (UI)
+
+API-first ([[ui-built-on-rest-api]]), and mostly *assembly of parts that exist*:
+
+- **A top-level rail entry, `Chat`** — sibling of Sessions / Issues / **Watch** /
+  Shell (a `messages-square` glyph). Routes to `/chat`.
+- **The view reuses `SessionConversation.vue` verbatim** — the skimmable iris-log
+  renderer with the foot composer. The composer already POSTs to
+  `/sessions/{id}/send` (type + Enter) and auto-refreshes on the agent's turn
+  edges, so the chat round-trip is *already solved*; `/chat` just resolves (or
+  creates) the singleton concierge session and mounts the component against it.
+- **Linkified session references.** Teach the conversation's `MarkdownView` to
+  project `session:<id>` into a live chip — title + lifecycle/attention dot,
+  linking to `/s/<id>` — exactly as smartdoc renders a `#41` issue chip from the
+  ledger. This is the one genuinely new bit of rendering, and it is the
+  "produces links to a session" requirement.
+
+## Producing links & acting on your behalf
+
+Two tiers of action, both reusing existing primitives, both audited:
+
+- **Nudge / interrupt an existing session.** `session_nudge` →
+  `POST /sessions/{id}/send` types a message into a watched session's agent;
+  `session_interrupt` → `POST /sessions/{id}/interrupt` stops its turn. "Tell the
+  auth session to rebase on main" becomes one gated tool call, recorded as a
+  `nudge` event with the concierge as author.
+- **Launch a new workstream.** `session_launch` → `POST /api/sessions` forks a
+  fresh session for work the user wants done, and returns its **tracking issue**.
+  The concierge can then watch it (`weaver issue wait` / `session_get`) and report
+  back in a later turn — "the flaky-test fix is `session:cd34`; it opened a PR,
+  CI is green."
+
+The concierge **does not write the `triage` tag** — that is the overlooker's
+fact, and two actors authoring one fact is the anti-pattern the overlooker plan
+is built to avoid. Its findings live in the conversation. If a durable mark is
+ever wanted, it writes its *own* typed key (loudness lives in the value, not the
+key), never `attention` or `triage`.
+
+## Capabilities & safety
+
+The concierge inherits the overlooker's safety frame wholesale — it is the same
+ladder over the same API:
+
+- **The intervention ladder, enforced at the MCP boundary.** `observe`/`link`
+  always on; `nudge`/`interrupt`/`launch` gated. A tool call past the granted set
+  is refused before it hits the API.
+- **Human-in-the-loop by construction.** Unlike an autonomous overlooker, every
+  concierge action is bracketed by a user turn — it proposes, you confirm. That
+  is what makes a more permissive default capability set safe.
+- **No recursion.** A concierge's `fleet_list` excludes concierge and overlooker
+  sessions; it cannot act on a watcher. Watchers don't watch watchers, and the
+  concierge doesn't drive itself.
+- **Everything is an event.** Every nudge, interrupt, and launch is an `events`
+  row with the concierge as author — the same audit trail the overlooker round
+  history renders, visible on the touched session's activity.
+- **Kill switches.** Archiving the concierge session tears it down like any
+  other; a `concierge.enabled` (or reuse `overlooker.enabled`-style) setting gates
+  the feature.
+
+## Worked example: "any stale sessions I should know about?"
+
+End to end, on the singleton concierge:
+
+1. You open **Chat** and type the question. The composer sends it into the
+   concierge session (reused `/send`); the Conversation tab will stream the reply.
+2. The concierge calls `fleet_list` → `GET /api/sessions`. It filters to
+   `running` sessions carrying the quiet `idle` tag with an old
+   `last_activity_at` and no loud `attention` — its staleness heuristic from the
+   primer.
+3. For each candidate it calls `session_preview` (and `session_conversation` when
+   it needs to know *why* it stalled — waiting on a prompt? wedged on a failing
+   test?).
+4. It replies in plain language with **clickable** references:
+   > Two look stale. `session:ab12` (weaver / *auth-refactor*) finished its turn
+   > 3 h ago waiting for review — its PR is green. `session:cd34` (loom /
+   > *flaky-e2e*) has been re-running the same test for 40 min with no progress.
+   > Want me to nudge cd34 to try a different approach, or leave it?
+5. You reply "nudge it." The concierge calls `session_nudge` (gated by the
+   `nudge` capability) → `POST /sessions/cd34/send`, recorded as a `nudge` event
+   attributed to the concierge, and confirms.
+
+No new survey engine, no new agent runtime, no new status axis — a conversation
+over the API the fleet already exposes.
+
+## Tasks
+
+Each task has a stable id; `deps:` edges define the delivery sequence. They
+materialise into weaver issues when the design is agreed (the overlooker plan's
+convention). `T2`/`T3` are the only genuinely new runtime; the rest is assembly.
+
+### C1 — `loom mcp`: the fleet tool server  `value: high`  `deps: —`
+A stdio MCP server (new `loom mcp` subcommand) proxying the read routes
+(`fleet_list`, `session_get/preview/conversation/diff/issues`, `session_link`) to
+`$WEAVER_API` with `$LOOM_TOKEN`. Read-only first. Acceptance: an MCP client lists
+the fleet and reads a session's conversation through the server.
+
+### C2 — The `concierge` agent kind + auto-hook at launch  `value: high`  `deps: C1`
+`agent_kind = "concierge"` on the launch path; extend `install_hooks` to also
+merge the `mcpServers` block; seed the `CONCIERGE.md` primer via `session_primer`;
+carry a capability set on the session row. Acceptance: launching a concierge yields
+a session whose agent can call the fleet tools unprompted.
+
+### C3 — `CONCIERGE.md` primer  `value: high`  `deps: —`
+The tips doc (glance vs. deep-read, staleness heuristic, always-link, propose-then-
+act), `include_str!`'d like `WEAVER.md`. Acceptance: a fresh concierge re-reads it
+on `SessionStart`.
+
+### C4 — The Chat view + singleton resolution  `value: high`  `deps: C2`
+A `/chat` route + rail entry that resolves (or creates) the singleton concierge and
+mounts `SessionConversation.vue` against it; the concierge hidden from the fleet
+list. Acceptance: Chat opens a working conversation with the fleet agent.
+
+### C5 — `session:<id>` linkified references  `value: med`  `deps: C4`
+Project `session:<id>` into a live status chip linking to `/s/<id>` in the
+conversation `MarkdownView` (the smartdoc `#41` machinery, for sessions); a
+`session_link` tool returns the canonical ref. Acceptance: a concierge reply's
+session references render as clickable chips.
+
+### C6 — Action tools: nudge / interrupt / launch  `value: med`  `deps: C2`
+The capability-gated mutating tools over `…/send`, `…/interrupt`, and
+`POST /api/sessions`; each records an `events` row attributed to the concierge.
+Acceptance: with the capability granted, the concierge nudges and launches; without
+it, the tool is refused.
+
+### C7 — Overlooker authoring from chat  `value: low`  `deps: C6, overlooker T8`
+`overlooker_draft/dry_run/register` tools so "ping me whenever a PR goes red"
+becomes a drafted, dry-run, registered overlooker. The Chat ⇄ Watch convergence.
+Acceptance: the concierge scaffolds and dry-runs an overlooker against the live
+fleet from a chat turn.
+
+## Rollout
+
+- **Phase 0 — Read-only concierge.** C1 (MCP reads), C3 (primer), C2 (kind +
+  auto-hook), C4 (Chat view). First milestone: you can *ask about* the fleet and
+  get linked, summarised answers. No mutation yet — safe by construction.
+- **Phase 1 — Links & action.** C5 (clickable refs), C6 (nudge/interrupt/launch on
+  the gated ladder). The concierge can now *act on your behalf*, with you
+  confirming each step.
+- **Phase 2 — Convergence.** C7 (author overlookers from chat). Chat becomes the
+  front door to Watch.
+
+## Non-goals
+
+- **Not a new agent runtime.** A concierge is a session; it reuses launch, the
+  terminal, orphan/adopt, and the drivable Conversation tab. We add a tool server
+  and a primer, not a parallel agent loop.
+- **Not a new status axis.** The concierge talks; it never writes `attention` or
+  `triage`. Two actors never author one fact.
+- **Not a second fleet API.** The MCP wraps the existing REST routes — one seam,
+  one more consumer beside the overlooker binding and the `loom` CLI.
+- **Not autonomous.** The concierge acts only inside a conversation, each action
+  confirmed by a user turn. The autonomous watcher is the overlooker; this is its
+  on-demand twin.
+- **Not multi-tenant yet.** One singleton concierge at the single-operator scale;
+  many named chats is a later, additive step.
+
+## Open questions
+
+- **Name.** `concierge`/`Chat` (clear) vs. the themed `gaffer` (the Lancashire
+  mill foreman, matching `overlooker`'s dialect). Recommend `concierge` in the
+  code, **Chat** in the UI; open to the themed noun.
+- **Worktree-backed vs. lightweight chat.** A concierge-as-session gets a worktree
+  it mostly doesn't use. The alternative — a bespoke `chats` table driven by a
+  multi-turn variant of `agent/oneshot`, no worktree — is *lighter* but
+  *reinvents* the conversation viewer, the composer, the terminal, and
+  orphan/adopt. Recommend session-backed (maximal reuse, ships fastest); revisit if
+  the empty worktree grates.
+- **Staleness as a server signal.** The concierge computes staleness client-side
+  from `last_activity_at` + tags. The overlooker plan (T7) also wants a synthetic
+  `session.stale` event — if that lands, both consumers should share one
+  definition rather than each rolling their own.
+- **Singleton scope.** One concierge per machine, per operator, or per repo? Start
+  global (single-operator scale); scope later if it earns its keep.
+- **How permissive a default.** Because a human confirms each turn, is
+  `launch`-by-default acceptable, or should the first cut ship `observe`+`nudge`
+  only and make `launch` an explicit grant? Lean conservative for Phase 1.


### PR DESCRIPTION
A **Chat** surface backed by a fleet-aware **concierge** agent — the on-demand, conversational twin of the autonomous [overlooker](docs/plans/overlooker.md). You open Chat, ask *"any stale sessions I should know about?"* or *"what needs me?"*, and it surveys the fleet, links the sessions involved, and can nudge or launch on your say-so.

This PR has both the **design of record** (`docs/plans/meta-chat.md`, also a weaver artifact) and a **working Phase 0**.

## The idea

The concierge and the overlooker are two front-ends on one substrate (the capability-gated REST/CLI fleet API): the overlooker is **push** (autonomous, scheduled, stamps a `triage` mark), the concierge is **pull** (you ask it, it answers and acts). So this is a second front-end, not a new runtime.

## Peer review (codex)

The design was reviewed by codex against the codebase. Verdict *ship with fixes*; three overstated seams were corrected in the doc **and** the implementation:
- `agent_kind` selects the *command* → the concierge **maps to the Claude runtime**, not a standalone kind.
- the hidden/warm lifecycle is overlooker-specific (`managed_by`) → the concierge **hides by its kind**.
- there is no `/sessions/{id}/diff` route → dropped; it reads via preview/conversation.

Combined with launch-by-default (operator drives it turn by turn), that tightened Phase 0 to **no new server, schema, or dependency**.

## What Phase 0 ships

- **`CONCIERGE.md`** — a fleet-ops primer: survey via `loom session ls/preview`, the stale-vs-needs-me heuristic, always-link `/s/<id>`, propose-then-act.
- **`agent.rs`** — `agent_kind = "concierge"` maps to the Claude runtime (command + hooks + launch gates); `concierge_primer()`.
- **`session.rs`** — `list_visible` hides the concierge from the fleet; `active_concierge` finds the singleton.
- **`web.rs`** — concierge launches with the primer as its opening prompt (no tracking issue); `GET /api/chat` get-or-creates the singleton in the most-recent repo.
- **frontend** — a `Chat` rail entry + `/chat` view that reuses the drivable `SessionConversation` component; `getChat()`.

The concierge drives the whole fleet through the `loom`/`weaver` CLI it already has on PATH, so a working "chat about your sessions" agent ships now. Typed MCP tools, `session:<id>` link chips, and action audit parity are Phase-1 follow-ups (tracked in the plan, C4–C6).

## Tests

Unit (concierge → Claude command mapping) + integration (`GET /api/chat` get-or-creates a hidden singleton with no tracking issue). Full `sessions` integration suite passes; fmt + clippy + agent lint clean.

## Review notes

Frontend validation is the rspack build (no separate typecheck step in this repo); the Chat view is a composition of already-styled, already-tested components.