### PR TITLE
feat(loom): rename, a live working cue, chat reset, and a leaner session list

### DIFF
--- a/crates/loom/CONCIERGE.md
+++ b/crates/loom/CONCIERGE.md
@@ -11,9 +11,14 @@ You reach the whole fleet through the `loom` and `weaver` CLIs, already on your
 
 ## Reading the fleet
 
-- `loom session ls` — the fleet: every session with its lifecycle, attention, and
-  last activity. Start here.
+- `loom session ls` — the fleet index: each live session's id, lifecycle,
+  attention, and title. Start here. It is an *index*, not the whole story:
+  archived (torn-down) sessions are hidden unless you pass `--archived`, and
+  `--search <text>` narrows a busy fleet to the sessions whose title, branch, or
+  goal matches. Pull one session's full detail with `poll`/`show`, don't expect
+  it in the list.
 - `loom session poll <id>` — one session in detail (lifecycle + attention + PR/CI).
+- `loom session show <id>` — the full record: goal, branch/base, dirs, PR, activity.
 - `loom session preview <id>` — a fast glance at its live screen: what it's doing
   *right now*. Cheap; reach for it first.
 - For *why* a session is where it is — what it decided, where it stalled — read
@@ -47,6 +52,8 @@ operator confirm in their next message.
 - `loom session send <id> "<message>"` — nudge a session: type a message into its
   agent and submit it (answer its question, redirect it, unstick it).
 - `loom session break <id>` — interrupt a session's current turn.
+- `loom session rename <id> "<title>"` — retitle a session (the one-line label
+  the operator skims by). Use it to keep the dashboard legible.
 - `loom session launch "<task>"` — spin up a *new* session for work the operator
   wants done. It prints a tracking issue; you can then `loom session poll` /
   `weaver issue wait` it and report back when it's done.

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -130,6 +130,10 @@ export const sendMessage = (id: string, text: string, submit = true) =>
  *  been used yet (the concierge needs one to live in). */
 export const getChat = () => get('/chat') as Promise<Session>;
 
+/** Start a clean conversation: archive the current concierge (capturing its
+ *  transcript) and launch a fresh one. Returns the new session view. */
+export const resetChat = () => post('/chat/reset') as Promise<Session>;
+
 // --- Agent environment variables -------------------------------------------
 
 import type { EnvVar } from './types';

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, computed, onMounted, onUnmounted, watch, nextTick } from 'vue';
 import { get, sendMessage } from '../api';
 import type { IrisLog, IrisBlock, Session } from '../types';
-import { canSend } from '../lib/sessionState';
+import { canSend, conversationState, TONE_TEXT } from '../lib/sessionState';
 import MarkdownView from './MarkdownView.vue';
 
 // The Conversation tab: the agent's chat with the model, rendered for review and
@@ -18,6 +18,39 @@ import MarkdownView from './MarkdownView.vue';
 // agent's lifecycle edges so a reply lands without a manual reload.
 const props = defineProps<{ session: Session }>();
 const id = computed(() => props.session.id);
+
+// ── Live agent state ─────────────────────────────────────────────────────────
+// A second, lighter view of the session itself, kept fresh off the same turn
+// edges as the transcript so the foot of the chat can show what the agent is
+// doing *right now* — a pulsing "Working…" while a turn runs, the loud state
+// when it needs the operator. Seeded from the prop (re-seeded when a parent
+// refreshes it, as the detail page does), and re-fetched on each SSE edge.
+const live = ref<Session>(props.session);
+watch(
+  () => props.session,
+  (s) => {
+    live.value = s;
+  },
+);
+async function refreshSession() {
+  try {
+    live.value = (await get(`/sessions/${id.value}`)) as Session;
+  } catch {
+    /* keep the last-known state; the next edge (or the parent) recovers */
+  }
+}
+// The derived conversation state (glyph + label + tone) — the same deriver the
+// detail header uses, so the chat and the dashboard read the agent identically.
+const convState = computed(() => conversationState(live.value));
+// Mid-turn: a live pane, running but not resting (no idle mark) and calm. This
+// is the "progress" cue the operator watches for after they hit Send.
+const agentWorking = computed(() => convState.value.label === 'Working');
+// Surface the status line only when it says something: the agent is working, or
+// it has raised a loud signal. A resting (Idle) agent shows nothing — the
+// composer placeholder already invites the next turn.
+const showAgentStatus = computed(
+  () => canSend(live.value) && (agentWorking.value || convState.value.tone !== 'muted'),
+);
 
 type LoadState = 'loading' | 'ready' | 'empty' | 'error';
 const log = ref<IrisLog | null>(null);
@@ -82,8 +115,11 @@ function scheduleRefresh() {
   if (refreshTimer) return;
   refreshTimer = setTimeout(() => {
     refreshTimer = null;
-    // Only when there's something rendered (or an empty live session) — never
-    // clobber an error view or a manual load mid-flight.
+    // A turn edge fired: refresh the live agent state (the "Working…" cue) and,
+    // when there's something rendered, the transcript. The session refresh is
+    // independent of the transcript load — it must run even on an error view so
+    // the status line tracks the agent.
+    refreshSession();
     if (state.value === 'ready' || state.value === 'empty') load({ preserve: true });
   }, 400);
 }
@@ -102,6 +138,7 @@ function closeStream() {
 
 onMounted(() => {
   load();
+  refreshSession();
   openStream();
 });
 onUnmounted(closeStream);
@@ -111,6 +148,7 @@ watch(
   () => {
     closeStream();
     load();
+    refreshSession();
     openStream();
   },
 );
@@ -615,6 +653,23 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
       </nav>
     </div>
 
+    <!-- Live agent status — the progress cue at the foot of the chat: a pulsing
+         "Working…" while a turn runs, the loud state when the agent needs the
+         operator. Hidden while the agent rests, so it only ever signals. -->
+    <div
+      v-if="showAgentStatus"
+      class="mt-3 flex shrink-0 items-center gap-1.5 text-xs font-medium"
+      :class="TONE_TEXT[convState.tone]"
+      data-testid="agent-status"
+      role="status"
+      aria-live="polite"
+    >
+      <span class="agent-glyph" :class="{ working: agentWorking }" aria-hidden="true">{{
+        convState.glyph
+      }}</span>
+      <span>{{ convState.label }}<span v-if="agentWorking">…</span></span>
+    </div>
+
     <!-- Composer — send a new prompt straight to the agent's terminal. Enter
          sends; Shift+Enter inserts a newline. Hidden once the agent is gone, so
          a torn-down session stays a read-only log. -->
@@ -654,6 +709,31 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
 /* Anchored user turns sit a touch below the top edge when jumped to. */
 .conv-anchor {
   scroll-margin-top: 0.5rem;
+}
+
+/* The live-status glyph pulses while the agent is mid-turn, so "Working…" reads
+   as motion, not a static label. Steady (no animation) for the loud states. */
+.agent-glyph {
+  display: inline-block;
+  font-size: 0.625rem;
+  line-height: 1;
+}
+.agent-glyph.working {
+  animation: agent-pulse 1.4s ease-in-out infinite;
+}
+@keyframes agent-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .agent-glyph.working {
+    animation: none;
+  }
 }
 
 /* The shared MarkdownView wraps prose in a padded, centred surface card — right

--- a/crates/loom/frontend/src/views/Chat.vue
+++ b/crates/loom/frontend/src/views/Chat.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import { getChat } from '../api';
+import { getChat, resetChat } from '../api';
 import type { Session } from '../types';
 import SessionConversation from '../components/SessionConversation.vue';
 
@@ -28,17 +28,67 @@ async function load() {
   }
 }
 
+// Reset the conversation: archive the current concierge (its transcript is kept
+// in history) and mount a fresh one. A two-step click guards the teardown — the
+// first arms it, the second confirms — so a stray click never wipes the agent's
+// context. The new session has a new id, so the keyed conversation remounts clean.
+const resetting = ref(false);
+const armed = ref(false);
+let disarmTimer: ReturnType<typeof setTimeout> | null = null;
+
+function armReset() {
+  armed.value = true;
+  if (disarmTimer) clearTimeout(disarmTimer);
+  disarmTimer = setTimeout(() => (armed.value = false), 4000);
+}
+
+async function reset() {
+  if (!armed.value) {
+    armReset();
+    return;
+  }
+  if (disarmTimer) clearTimeout(disarmTimer);
+  armed.value = false;
+  resetting.value = true;
+  errorMsg.value = '';
+  try {
+    session.value = await resetChat();
+    state.value = 'ready';
+  } catch (e) {
+    errorMsg.value = e instanceof Error ? e.message : String(e);
+    state.value = 'error';
+  } finally {
+    resetting.value = false;
+  }
+}
+
 onMounted(load);
 </script>
 
 <template>
   <div class="flex min-h-0 flex-1 flex-col px-5 py-3">
-    <header class="mb-3 shrink-0">
-      <h1 class="text-sm font-semibold text-fg">Chat</h1>
-      <p class="text-xs text-muted">
-        Ask the concierge about your fleet — stale sessions, what needs you — and
-        have it act on your behalf.
-      </p>
+    <header class="mb-3 flex shrink-0 items-start gap-3">
+      <div class="min-w-0 flex-1">
+        <h1 class="text-sm font-semibold text-fg">Chat</h1>
+        <p class="text-xs text-muted">
+          Ask the concierge about your fleet — stale sessions, what needs you — and
+          have it act on your behalf.
+        </p>
+      </div>
+      <!-- Reset: archive this concierge (its transcript is kept) and start a
+           fresh one. Two-step — the first click arms, the second confirms. -->
+      <button
+        v-if="state === 'ready'"
+        type="button"
+        class="btn-secondary shrink-0 px-2 py-0.5 text-xs"
+        :class="{ 'text-block': armed }"
+        :disabled="resetting"
+        :title="armed ? 'Click again to confirm — the current conversation is archived' : 'Start a fresh conversation'"
+        data-testid="chat-reset"
+        @click="reset"
+      >
+        {{ resetting ? 'Resetting…' : armed ? 'Confirm reset' : 'Reset' }}
+      </button>
     </header>
 
     <p v-if="state === 'loading'" class="text-sm text-muted">Waking the concierge…</p>

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -49,10 +49,12 @@ const busy = reactive<Record<number, boolean>>({});
 
 async function load() {
   try {
-    // Fetch everything (including closed) once; `showClosed` filters client-side.
+    // Fetch everything (including closed issues / archived sessions) once;
+    // `showClosed` filters client-side, and archived sessions still reference
+    // their issues. The API hides archived by default, so ask for them.
     const [iss, ses] = await Promise.all([
       listIssues(true),
-      get('/sessions') as Promise<Session[]>,
+      get('/sessions?archived=true') as Promise<Session[]>,
     ]);
     issues.value = iss;
     sessions.value = ses;

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -266,7 +266,10 @@ watch([repo, branchMode], ([, mode]) => {
 
 async function load() {
   try {
-    sessions.value = (await get('/sessions')) as Session[];
+    // The fleet view owns its own "show N archived" toggle, so it needs the
+    // full set — the API hides archived by default (for the agent's `ls`), so
+    // ask for them explicitly.
+    sessions.value = (await get('/sessions?archived=true')) as Session[];
     error.value = '';
   } catch (e) {
     error.value = (e as Error).message;

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -49,6 +49,7 @@ enum Cmd {
     ///     loom session send weaver/health "try the curl again"
     ///     loom session break weaver/health     # interrupt the current turn
     ///     loom session preview weaver/health   # peek at the terminal screen
+    ///     loom session rename weaver/health "Health endpoint + test"
     ///
     /// The three you reach for constantly have top-level shortcuts: `loom
     /// launch`, `loom ps`, `loom attach`.
@@ -208,7 +209,27 @@ enum SessionCmd {
         lines: usize,
     },
     /// List active sessions (also `loom ps`).
-    Ls,
+    ///
+    /// Archived (torn-down) sessions are hidden by default — pass `--archived`
+    /// to include them. `--search <text>` narrows to sessions whose title,
+    /// branch name, or goal contains the text. The list is an index: it shows
+    /// each session's id, lifecycle, attention, and title — pull the full detail
+    /// (goal, PR, dirs, activity) for one with `loom session show <id>`.
+    Ls {
+        /// Include archived (torn-down) sessions.
+        #[arg(long)]
+        archived: bool,
+        /// Case-insensitive substring filter over title / branch / goal.
+        #[arg(long)]
+        search: Option<String>,
+    },
+    /// Rename a session: set the one-line title shown on the dashboard.
+    Rename {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+        /// The new title. Multiple words are joined, so quoting is optional.
+        title: Vec<String>,
+    },
     /// Show one session's details.
     Show { branch: String },
     /// Attach your terminal to a session (also `loom attach`).
@@ -423,7 +444,7 @@ async fn run() -> Result<()> {
         Cmd::Overlooker { cmd } => run_overlooker(cmd).await,
         Cmd::Token { cmd } => run_token(cmd).await,
         Cmd::Launch(opts) => cmd_launch(opts.into()).await,
-        Cmd::Ps => cmd_ps().await,
+        Cmd::Ps => cmd_ps(false, None).await,
         Cmd::Attach { branch } => cmd_attach(branch).await,
         Cmd::Open => cmd_open().await,
         Cmd::Completions { shell } => {
@@ -474,7 +495,8 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
         } => cmd_session_send(session, message.join(" "), !no_enter).await,
         SessionCmd::Break { session } => cmd_session_break(session).await,
         SessionCmd::Preview { session, lines } => cmd_session_preview(session, lines).await,
-        SessionCmd::Ls => cmd_ps().await,
+        SessionCmd::Ls { archived, search } => cmd_ps(archived, search).await,
+        SessionCmd::Rename { session, title } => cmd_session_rename(session, title.join(" ")).await,
         SessionCmd::Show { branch } => cmd_show(branch).await,
         SessionCmd::Attach { branch } => cmd_attach(branch).await,
         SessionCmd::Archive { branch } => cmd_archive(branch).await,
@@ -1062,12 +1084,30 @@ async fn cmd_session_preview(key: String, lines: usize) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_ps() -> Result<()> {
+async fn cmd_ps(archived: bool, search: Option<String>) -> Result<()> {
     let client = client::default();
-    let list = client.get("/api/sessions").await?;
+    // Hide archived sessions by default; `--search` narrows by substring. Both
+    // ride the same query the dashboard uses, so the CLI and UI stay one surface.
+    let mut query = Vec::new();
+    if archived {
+        query.push("archived=true".to_string());
+    }
+    if let Some(s) = search.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        query.push(format!("q={}", encode_query(s)));
+    }
+    let path = if query.is_empty() {
+        "/api/sessions".to_string()
+    } else {
+        format!("/api/sessions?{}", query.join("&"))
+    };
+    let list = client.get(&path).await?;
     let rows = list.as_array().cloned().unwrap_or_default();
     if rows.is_empty() {
-        println!("no sessions — start one with `loom session launch \"<task>\"`");
+        let hint = match search {
+            Some(s) if !s.trim().is_empty() => format!("no sessions match '{}'", s.trim()),
+            _ => "no sessions — start one with `loom session launch \"<task>\"`".to_string(),
+        };
+        println!("{hint}");
         return Ok(());
     }
     println!(
@@ -1133,6 +1173,26 @@ async fn cmd_show(key: String) -> Result<()> {
     let client = client::default();
     let ws = client.get(&format!("/api/sessions/{key}")).await?;
     print_session(&ws);
+    Ok(())
+}
+
+/// `loom session rename` — set a session's one-line dashboard title via
+/// `PATCH /api/sessions/{key}`. The agent's parity with the dashboard's inline
+/// title edit: anything the operator can do from the UI, the concierge can do too.
+async fn cmd_session_rename(key: String, title: String) -> Result<()> {
+    let title = title.trim();
+    if title.is_empty() {
+        bail!("nothing to rename to — provide a new title");
+    }
+    let client = client::default();
+    let ws = client
+        .patch(&format!("/api/sessions/{key}"), json!({ "title": title }))
+        .await?;
+    println!(
+        "renamed {} → {}",
+        str_field(&ws, "id"),
+        branch_str(&ws, "title")
+    );
     Ok(())
 }
 

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -401,6 +401,7 @@ pub fn router(state: AppState) -> Router {
         // Sessions
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/chat", get(get_chat))
+        .route("/chat/reset", post(reset_chat))
         .route(
             "/sessions/{id}",
             get(get_session).patch(patch_session).delete(delete_session),
@@ -550,7 +551,26 @@ pub fn router(state: AppState) -> Router {
 // Session CRUD
 // ---------------------------------------------------------------------------
 
-async fn list_sessions(State(st): State<AppState>) -> ApiResult<Json<Vec<SessionView>>> {
+/// Query for `GET /api/sessions`: trim the fleet listing for the caller.
+#[derive(Debug, Default, Deserialize)]
+struct ListSessionsQuery {
+    /// Include archived (torn-down) sessions. Defaults to `false` — an archived
+    /// session is out of the active fleet, so the agent's `loom session ls` and
+    /// any survey see only live work unless they ask. The dashboard, which has
+    /// its own "show archived" toggle, opts in with `?archived=true`.
+    #[serde(default)]
+    archived: bool,
+    /// Case-insensitive substring filter over a session's title, branch name,
+    /// and goal — so the concierge can narrow a large fleet to the one it wants
+    /// (`loom session ls --search auth`). Absent/blank matches everything.
+    #[serde(default)]
+    q: Option<String>,
+}
+
+async fn list_sessions(
+    State(st): State<AppState>,
+    Query(q): Query<ListSessionsQuery>,
+) -> ApiResult<Json<Vec<SessionView>>> {
     // The fleet listing shows work, not infrastructure: engine-managed (warm)
     // sessions are excluded here, so neither the dashboard nor an overlooker
     // round's survey (scripts read this route) ever sees a watcher's own
@@ -563,13 +583,32 @@ async fn list_sessions(State(st): State<AppState>) -> ApiResult<Json<Vec<Session
         .into_iter()
         .filter_map(|o| o.warm_session_id)
         .collect();
+    // A blank `q` is no filter; otherwise match case-insensitively.
+    let needle =
+        q.q.as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_lowercase);
     let sessions = session_mod::list_visible(&st.db).await?;
     let mut views: Vec<SessionView> = Vec::with_capacity(sessions.len());
     for s in sessions {
         if warm.contains(&s.id) {
             continue;
         }
+        // Archived sessions are torn down — hidden unless the caller opts in.
+        if !q.archived && s.status == "archived" {
+            continue;
+        }
         if let Some(branch) = branch_mod::get(&st.db, &s.branch_id).await? {
+            if let Some(needle) = &needle {
+                // Match the identifiers a human searches by: the title, the branch
+                // name, and the goal.
+                let hay =
+                    format!("{} {} {}", branch.title, branch.branch, branch.goal).to_lowercase();
+                if !hay.contains(needle) {
+                    continue;
+                }
+            }
             views.push(session_view(&st.db, &s, &branch).await?);
         }
     }
@@ -985,6 +1024,14 @@ async fn get_chat(State(st): State<AppState>) -> ApiResult<Json<SessionView>> {
             .ok_or_else(|| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, "branch vanished"))?;
         return Ok(Json(session_view(&st.db, &session, &branch).await?));
     }
+    Ok(Json(create_concierge(st).await?))
+}
+
+/// Launch a fresh fleet concierge in the most-recently-used repo and return its
+/// view. The shared creation path behind [`get_chat`] (when none is live) and
+/// [`reset_chat`] (after the old one is archived). 400 when no repo has been
+/// used yet — the concierge needs a worktree to live in.
+async fn create_concierge(st: AppState) -> ApiResult<SessionView> {
     let home = repo::recent(&st.db, 1)
         .await?
         .into_iter()
@@ -1000,7 +1047,25 @@ async fn get_chat(State(st): State<AppState>) -> ApiResult<Json<SessionView>> {
         title: Some("Fleet concierge".to_string()),
         ..Default::default()
     };
-    Ok(Json(create_session_core(st, req).await?))
+    create_session_core(st, req).await
+}
+
+/// `POST /api/chat/reset` — start a clean conversation with the concierge. The
+/// live concierge (if any) is archived — its terminal and worktree torn down,
+/// its transcript captured to history — and a brand-new one is launched in its
+/// place, so the operator gets a fresh agent with none of the prior context.
+/// Returns the new session view, exactly as [`get_chat`] would.
+async fn reset_chat(State(st): State<AppState>) -> ApiResult<Json<SessionView>> {
+    if let Some(session) = session_mod::active_concierge(&st.db).await? {
+        if let Some(branch) = branch_mod::get(&st.db, &session.branch_id).await? {
+            // Best-effort teardown of the old concierge; a warning here must not
+            // block the fresh start the operator asked for.
+            if let Err(e) = archive(&st, &session, &branch).await {
+                tracing::warn!(session = %session.id, error = ?e, "reset: archiving old concierge failed");
+            }
+        }
+    }
+    Ok(Json(create_concierge(st).await?))
 }
 
 /// A line appended to a session's launch prompt telling the agent which weaver

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -236,6 +236,173 @@ async fn concierge_runtime_codex_launches_hookless() {
         .unwrap();
 }
 
+/// The fleet listing hides archived sessions by default (so the agent's `loom
+/// session ls` sees only live work), includes them on `?archived=true`, and
+/// narrows by substring on `?q=` — over the title, branch, and goal. A rename
+/// (PATCH title) is reflected in that search.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_hides_archived_by_default_and_searches() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let alpha = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "alpha search target", "cwd": ts.cwd(), "agent": "shell", "name": "alpha" }),
+        )
+        .await
+        .unwrap();
+    let alpha_id = alpha["id"].as_str().unwrap().to_string();
+
+    let beta = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "beta other work", "cwd": ts.cwd(), "agent": "shell", "name": "beta" }),
+        )
+        .await
+        .unwrap();
+    let beta_id = beta["id"].as_str().unwrap().to_string();
+
+    // Archive beta — it leaves the active fleet.
+    client
+        .post(&format!("/api/sessions/{beta_id}/archive"), json!({}))
+        .await
+        .unwrap();
+
+    // Default: only the live session, archived hidden.
+    let list = client.get("/api/sessions").await.unwrap();
+    let ids: Vec<&str> = list
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec![alpha_id.as_str()], "archived hidden by default");
+
+    // Opt in: both, beta marked archived.
+    let all = client.get("/api/sessions?archived=true").await.unwrap();
+    let all = all.as_array().unwrap();
+    assert_eq!(all.len(), 2, "?archived=true includes the archived session");
+    let beta_row = all.iter().find(|s| s["id"] == beta_id.as_str()).unwrap();
+    assert_eq!(beta_row["status"], "archived");
+
+    // Search over title / branch / goal, on the live set.
+    let hit = client.get("/api/sessions?q=alpha").await.unwrap();
+    assert_eq!(
+        hit.as_array().unwrap().len(),
+        1,
+        "alpha matches its goal/name"
+    );
+    let miss = client.get("/api/sessions?q=nope-nothing").await.unwrap();
+    assert!(miss.as_array().unwrap().is_empty(), "no match ⇒ empty");
+
+    // An archived session is excluded from a default search, included when asked.
+    let beta_hidden = client.get("/api/sessions?q=beta").await.unwrap();
+    assert!(
+        beta_hidden.as_array().unwrap().is_empty(),
+        "archived excluded from the default search"
+    );
+    let beta_shown = client
+        .get("/api/sessions?q=beta&archived=true")
+        .await
+        .unwrap();
+    assert_eq!(
+        beta_shown.as_array().unwrap().len(),
+        1,
+        "archived search opt-in finds beta"
+    );
+
+    // Renaming a session (the title PATCH the `loom session rename` CLI wraps) is
+    // reflected in the search.
+    client
+        .patch(
+            &format!("/api/sessions/{alpha_id}"),
+            json!({ "title": "renamed-zeta" }),
+        )
+        .await
+        .unwrap();
+    let renamed = client.get("/api/sessions?q=zeta").await.unwrap();
+    assert_eq!(
+        renamed.as_array().unwrap().len(),
+        1,
+        "rename is reflected in search"
+    );
+
+    client
+        .delete(&format!("/api/sessions/{alpha_id}"))
+        .await
+        .unwrap();
+    client
+        .delete(&format!("/api/sessions/{beta_id}"))
+        .await
+        .unwrap();
+}
+
+/// `POST /api/chat/reset` archives the live concierge (capturing its transcript
+/// to history) and launches a fresh one in its place — a new session id, the old
+/// one terminal/`archived`, and the singleton now resolving to the new one.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chat_reset_archives_and_starts_fresh() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+    // The concierge runs the Claude launch path (writes under $HOME) — isolate it.
+    let home = tempfile::tempdir().unwrap();
+    let _home = HomeGuard::set(home.path());
+
+    // A repo for the concierge to live in.
+    let work = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "ordinary work", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let work_id = work["id"].as_str().unwrap().to_string();
+
+    // The first concierge.
+    let chat = client.get("/api/chat").await.unwrap();
+    let chat_id = chat["id"].as_str().unwrap().to_string();
+    assert_eq!(chat["agent_kind"], "concierge");
+
+    // Reset: a brand-new concierge, with a different id.
+    let fresh = client.post("/api/chat/reset", json!({})).await.unwrap();
+    let fresh_id = fresh["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        fresh["agent_kind"], "concierge",
+        "the fresh one is a concierge"
+    );
+    assert_ne!(fresh_id, chat_id, "reset launches a new concierge");
+
+    // The old concierge is archived — kept as history, not deleted.
+    let old = client
+        .get(&format!("/api/sessions/{chat_id}"))
+        .await
+        .unwrap();
+    assert_eq!(
+        old["status"], "archived",
+        "reset archives the old concierge"
+    );
+
+    // get-or-create now resolves to the fresh one (a singleton again).
+    let again = client.get("/api/chat").await.unwrap();
+    assert_eq!(
+        again["id"].as_str().unwrap(),
+        fresh_id,
+        "the fresh concierge is the live singleton"
+    );
+
+    client
+        .delete(&format!("/api/sessions/{fresh_id}"))
+        .await
+        .unwrap();
+    client
+        .delete(&format!("/api/sessions/{work_id}"))
+        .await
+        .unwrap();
+}
+
 /// A session can be created with no goal at all — just a title.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/e2e/tests/conversation.spec.ts
+++ b/e2e/tests/conversation.spec.ts
@@ -135,6 +135,28 @@ test.describe('conversation view', () => {
       .toBe(true);
   });
 
+  // A live session surfaces a foot-of-chat progress cue: "Working…" while a turn
+  // runs, gone once the agent rests — so the operator sees something move after
+  // they send. Driven off the same lifecycle SSE edges as the transcript.
+  test('the live status line tracks Working ↔ idle', async ({ page, weaver }) => {
+    const s = await openConversation(page, weaver);
+    const status = page.getByTestId('agent-status');
+
+    // A running session with no idle mark reads as Working.
+    await expect(status).toBeVisible();
+    await expect(status).toContainText('Working');
+
+    // The agent goes idle (a finished-turn hook) → the cue retracts; a resting
+    // agent shows nothing, leaving the composer to invite the next turn.
+    await weaver.hook(s, 'idle');
+    await expect(status).toBeHidden();
+
+    // A new turn starts (a working hook) → the cue returns.
+    await weaver.hook(s, 'working');
+    await expect(status).toBeVisible();
+    await expect(status).toContainText('Working');
+  });
+
   // The tab follows a live session: a new turn landing in the transcript shows
   // up without a manual Refresh, driven off the agent's lifecycle SSE edges.
   test('the log auto-refreshes when the agent reaches a turn boundary', async ({ page, weaver }) => {


### PR DESCRIPTION
Rounds out the concierge's session management so the agent has parity with the dashboard and the chat reads as live. All API-first — the `loom` CLI and the Vue UI stay one surface over the REST API.

## What's here

| Ask | Change |
|-----|--------|
| **Rename** | `loom session rename <id> "<title>"` — wraps the `PATCH /api/sessions/{id}` the UI's inline rename already uses. No backend change needed; this gives the agent the parity. |
| **Working cue** | The conversation view shows a live `▶ Working…` line above the composer, derived from the same `conversationState` deriver the dashboard uses and kept fresh off the agent's lifecycle SSE edges. Hidden while the agent rests; loud states (blocked / needs-attention) surface too. |
| **Chat reset** | `POST /api/chat/reset` archives the live concierge (its transcript captured to history) and launches a fresh one. The chat header gets a two-step **Reset** button (arm → confirm) so a stray click never wipes context. |
| **Hide archived** | `GET /api/sessions` hides archived (torn-down) sessions by default; `?archived=true` includes them. `loom session ls` gains `--archived`. The dashboard keeps its "show N archived" toggle by opting in with `?archived=true`. |
| **Search** | `GET /api/sessions?q=<text>` filters case-insensitively over title / branch / goal; `loom session ls --search <text>`. |
| **Lean list** | `loom session ls` stays a one-line-per-session index (id · lifecycle · attention · title); full detail (goal, PR/CI, dirs, activity) is pulled per session with `poll` / `show`. Documented in `CONCIERGE.md` and the `ls` help. |

## Notes

- Archived sessions remain out of overlooker surveys by default (they're torn down — nothing to act on), which is the correct behavior; the single-session `GET /api/sessions/{id}` still resolves them.
- Each chat reset launches a fresh concierge branch (`fleet-concierge`, `-2`, …); archived concierges are hidden from the fleet by their kind, so they never clutter the list.

## Tests

- **Integration**: archived-hidden-by-default + `?archived=true` + `?q=` substring filtering + rename-reflected-in-search; chat reset archives the old concierge and the singleton resolves to the new one.
- **e2e**: the live status line tracks Working ↔ idle off the agent's hooks.
- Full loom suite (43) + conversation/list/issues e2e (25) green; `clippy` clean. Working cue eyeballed in both themes.
