### PR TITLE
feat(loom): launch sessions into the right repo (--repo + concierge docs)

### DIFF
--- a/crates/loom/CONCIERGE.md
+++ b/crates/loom/CONCIERGE.md
@@ -56,7 +56,26 @@ operator confirm in their next message.
   the operator skims by). Use it to keep the dashboard legible.
 - `loom session launch "<task>"` — spin up a *new* session for work the operator
   wants done. It prints a tracking issue; you can then `loom session poll` /
-  `weaver issue wait` it and report back when it's done.
+  `weaver issue wait` it and report back when it's done. Launch from the right
+  checkout — see below.
+
+## Launching sessions in the right workspace
+
+`loom session launch` has no `--repo` or `--workspace` flag: it cuts the new
+worktree from the mainline of whatever checkout you run it in. To launch a
+session for repo X, `cd` into X's checkout *first*. The repos live under
+`/home/power/code/<repo>/` — e.g. `marin`, `tunix`, `marin-experiments`. So for
+marin work, `cd /home/power/code/marin` before `loom session launch`, or the
+session lands in whatever repo you happened to be in.
+
+The branch is always namespaced `weaver/<slug>` regardless of repo, so the
+branch name won't tell you where it landed. After launching, check the printed
+`dir:` line sits under the intended repo's `.worktrees/` — if you wanted marin
+but it reads `/home/power/code/weaver/.worktrees/...`, you launched from the
+wrong checkout.
+
+`iris` and `grug` are subsystems inside the marin monorepo, not separate repos —
+launch their work from the marin checkout.
 
 ## Style
 

--- a/crates/loom/CONCIERGE.md
+++ b/crates/loom/CONCIERGE.md
@@ -56,26 +56,26 @@ operator confirm in their next message.
   the operator skims by). Use it to keep the dashboard legible.
 - `loom session launch "<task>"` — spin up a *new* session for work the operator
   wants done. It prints a tracking issue; you can then `loom session poll` /
-  `weaver issue wait` it and report back when it's done. Launch from the right
-  checkout — see below.
+  `weaver issue wait` it and report back when it's done. Pass `--repo` so it
+  lands in the right repo — see below.
 
 ## Launching sessions in the right workspace
 
-`loom session launch` has no `--repo` or `--workspace` flag: it cuts the new
-worktree from the mainline of whatever checkout you run it in. To launch a
-session for repo X, `cd` into X's checkout *first*. The repos live under
-`/home/power/code/<repo>/` — e.g. `marin`, `tunix`, `marin-experiments`. So for
-marin work, `cd /home/power/code/marin` before `loom session launch`, or the
-session lands in whatever repo you happened to be in.
+`loom session launch` cuts the new worktree from the mainline of *one* repo,
+defaulting to whatever checkout you run it in. Say which repo explicitly: pass
+`--repo <path>` pointing at (any directory inside) the target checkout, or `cd`
+into it first. The repos live under `/home/power/code/<repo>/` — e.g. `marin`,
+`tunix`, `marin-experiments`. So for marin work:
+
+    loom session launch --repo /home/power/code/marin "<task>"
 
 The branch is always namespaced `weaver/<slug>` regardless of repo, so the
 branch name won't tell you where it landed. After launching, check the printed
 `dir:` line sits under the intended repo's `.worktrees/` — if you wanted marin
-but it reads `/home/power/code/weaver/.worktrees/...`, you launched from the
-wrong checkout.
+but it reads `/home/power/code/weaver/.worktrees/...`, it went to the wrong repo.
 
 `iris` and `grug` are subsystems inside the marin monorepo, not separate repos —
-launch their work from the marin checkout.
+launch their work into the marin checkout.
 
 ## Style
 

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -396,6 +396,12 @@ struct LaunchOpts {
     /// (see `weaver config get agent.default`).
     #[arg(long)]
     agent: Option<String>,
+    /// Repo to launch into: a path to (any directory inside) the target repo's
+    /// checkout. The new worktree is cut from this repo's mainline. Defaults to
+    /// the current directory — so without it you launch into whatever repo you
+    /// happen to be standing in, which is the wrong one when you mean another.
+    #[arg(long)]
+    repo: Option<std::path::PathBuf>,
     /// Branch to fork the new worktree from. Defaults to a freshly-fetched
     /// `origin/<default branch>` (the repo's mainline), so new work starts from
     /// the latest upstream rather than the launching checkout.
@@ -806,6 +812,7 @@ struct LaunchArgs {
     goal: String,
     name: Option<String>,
     agent: Option<String>,
+    repo: Option<std::path::PathBuf>,
     base: Option<String>,
     title: Option<String>,
     issue: Option<i64>,
@@ -821,6 +828,7 @@ impl From<LaunchOpts> for LaunchArgs {
             goal: o.task.join(" "),
             name: o.name,
             agent: o.agent,
+            repo: o.repo,
             base: o.base,
             title: o.title,
             issue: o.issue,
@@ -853,6 +861,21 @@ const LAUNCH_HINT: &str = "nothing to do — give the agent a task or something 
   loom session launch --name <slug> --agent shell      # an empty named worktree (no task)
 See `loom session launch --help` for all options.";
 
+/// The directory a launch forks from — `--repo` if given, else the current
+/// directory. `loom session launch` has no separate repo selector beyond this:
+/// the server resolves the target repo from this path (its main worktree), so
+/// any directory inside the intended checkout works. We canonicalize, which
+/// anchors a relative `--repo` to the CLI's cwd (not the daemon's) and turns a
+/// typo into a clear error here rather than an opaque server-side failure.
+fn resolve_launch_cwd(repo: Option<&std::path::Path>) -> Result<std::path::PathBuf> {
+    match repo {
+        Some(p) => p
+            .canonicalize()
+            .with_context(|| format!("--repo path not found: {}", p.display())),
+        None => std::env::current_dir().context("could not read the current directory"),
+    }
+}
+
 async fn cmd_launch(a: LaunchArgs) -> Result<()> {
     if launch_underspecified(&a) {
         bail!("{LAUNCH_HINT}");
@@ -861,6 +884,7 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
         goal,
         name,
         agent,
+        repo,
         base,
         title,
         issue,
@@ -870,7 +894,7 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
         effort,
     } = a;
     let client = client::default();
-    let cwd = std::env::current_dir()?;
+    let cwd = resolve_launch_cwd(repo.as_deref())?;
     // When an agent in a weaver session runs `loom session launch`,
     // `$WEAVER_BRANCH` is its own branch id — pass it so the tracking issue is
     // attributed to the launching (parent) agent. A human shell launch leaves it
@@ -1851,6 +1875,7 @@ mod tests {
             goal: String::new(),
             name: None,
             agent: None,
+            repo: None,
             base: None,
             title: None,
             issue: None,
@@ -1859,6 +1884,23 @@ mod tests {
             model: None,
             effort: None,
         }
+    }
+
+    #[test]
+    fn resolve_launch_cwd_honors_repo_and_rejects_a_bad_path() {
+        // No `--repo` falls back to the current directory.
+        let here = std::env::current_dir().unwrap();
+        assert_eq!(resolve_launch_cwd(None).unwrap(), here);
+
+        // `--repo` selects (and canonicalizes) the given checkout.
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_launch_cwd(Some(dir.path())).unwrap(),
+            dir.path().canonicalize().unwrap()
+        );
+
+        // A typo'd `--repo` fails here, not as an opaque server error.
+        assert!(resolve_launch_cwd(Some(&dir.path().join("nope"))).is_err());
     }
 
     #[test]

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -104,22 +104,22 @@ history, and you can hand it off or revisit it later.
 
 ## Launching sessions in the right workspace
 
-`loom session launch` has no `--repo` or `--workspace` flag: it cuts the new
-worktree from the mainline of whatever checkout you run it in. To launch a
-session for repo X, `cd` into X's checkout *first*. The repos live under
-`/home/power/code/<repo>/` — e.g. `marin`, `tunix`, `marin-experiments`. So for
-marin work, `cd /home/power/code/marin` before `loom session launch`, or the
-session forks from the repo you happened to be in (`--base` only pins the
-branch, not the repo).
+`loom session launch` cuts the new worktree from the mainline of *one* repo,
+defaulting to whatever checkout you run it in. Say which repo explicitly: pass
+`--repo <path>` pointing at (any directory inside) the target checkout, or `cd`
+into it first (`--base` only pins the branch, not the repo). The repos live
+under `/home/power/code/<repo>/` — e.g. `marin`, `tunix`, `marin-experiments`.
+So for marin work:
+
+    loom session launch --repo /home/power/code/marin "<task>"
 
 The branch is always namespaced `weaver/<slug>` regardless of repo, so the
 branch name won't tell you where it landed. After launching, check the printed
 `dir:` line sits under the intended repo's `.worktrees/` — if you wanted marin
-but it reads `/home/power/code/weaver/.worktrees/...`, you launched from the
-wrong checkout.
+but it reads `/home/power/code/weaver/.worktrees/...`, it went to the wrong repo.
 
 `iris` and `grug` are subsystems inside the marin monorepo, not separate repos —
-launch their work from the marin checkout.
+launch their work into the marin checkout.
 
 ## Signalling your status
 

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -102,6 +102,25 @@ This duplicates some of a coding agent's builtin sub-agents, but a weaver
 sub-session is fully decoupled: it survives independently, has its own git
 history, and you can hand it off or revisit it later.
 
+## Launching sessions in the right workspace
+
+`loom session launch` has no `--repo` or `--workspace` flag: it cuts the new
+worktree from the mainline of whatever checkout you run it in. To launch a
+session for repo X, `cd` into X's checkout *first*. The repos live under
+`/home/power/code/<repo>/` — e.g. `marin`, `tunix`, `marin-experiments`. So for
+marin work, `cd /home/power/code/marin` before `loom session launch`, or the
+session forks from the repo you happened to be in (`--base` only pins the
+branch, not the repo).
+
+The branch is always namespaced `weaver/<slug>` regardless of repo, so the
+branch name won't tell you where it landed. After launching, check the printed
+`dir:` line sits under the intended repo's `.worktrees/` — if you wanted marin
+but it reads `/home/power/code/weaver/.worktrees/...`, you launched from the
+wrong checkout.
+
+`iris` and `grug` are subsystems inside the marin monorepo, not separate repos —
+launch their work from the marin checkout.
+
 ## Signalling your status
 
 The user scans the dashboard for sessions that need them. Keep your status


### PR DESCRIPTION
## Why

`loom session launch` had **no repo selector** — it always forked the new git worktree from the mainline of whatever checkout the command ran in (`std::env::current_dir()` → repo root → that repo's freshly-fetched mainline). A concierge running from the weaver checkout recently launched two marin sessions, which silently landed as `weaver/...` worktrees under `/home/power/code/weaver/.worktrees` instead of marin.

## What

**Root-cause fix — `loom session launch --repo <path>`** (`crates/loom/src/bin/loom.rs`): point it at any directory inside the target repo's checkout and the worktree is cut from *that* repo's mainline. The CLI canonicalizes the path — anchoring a relative `--repo` to the CLI's cwd (not the daemon's) and failing fast on a typo — then sends it as the `cwd` the server already resolves the repo from, so **no server change** is needed. The web API already accepted an arbitrary `cwd`; this just closes the CLI gap. `cd`-into-the-checkout-first still works and remains the documented fallback.

**Docs** — add a tight "Launching sessions in the right workspace" section to both guides that ship embedded (`include_str!`) in the binaries:

- **`crates/loom/CONCIERGE.md`** — the fleet-concierge primer (the agent that hit the mistake).
- **`crates/weaver-core/WEAVER.md`** — the `weaver readme` guide.

Each section leads with `--repo`, notes the branch is always `weaver/<slug>` regardless of repo (so verify the printed `dir:` lands under the intended repo's `.worktrees/`), and that `iris`/`grug` are subsystems inside the marin monorepo — launch their work into the marin checkout.

## Tests

- New unit test `resolve_launch_cwd_honors_repo_and_rejects_a_bad_path` (fallback to cwd, `--repo` canonicalization, typo rejection).
- `cargo clippy -p loom`, `cargo fmt`, and the full `loom` bin unit suite (incl. the clap consistency check) pass locally.