### PR TITLE
fix(loom): boot the fleet concierge primed-but-idle, not auto-responding

### DIFF
--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -58,9 +58,16 @@ pub enum LaunchMode {
 /// **resolved runtime** — the binary to actually run, which for the concierge
 /// role-kind is the `concierge.runtime` setting (claude|codex), and for every
 /// other kind is the kind itself.
+///
+/// `goal_file` is the **positional** opening prompt (catted in as the operator's
+/// first message); `primer_file` is system *context* appended via
+/// `--append-system-prompt-file`. They are mutually distinct: a normal session
+/// carries a `goal_file`, the concierge carries a `primer_file` (so it boots
+/// primed but idle, taking no turn until the operator speaks). At most one is set.
 fn inner_command(
     runtime: &str,
     goal_file: Option<&Path>,
+    primer_file: Option<&Path>,
     mode: LaunchMode,
     claude_args: &str,
 ) -> String {
@@ -70,21 +77,41 @@ fn inner_command(
     };
     match runtime {
         "shell" | "none" => String::new(),
-        "claude" => match mode {
-            LaunchMode::Adopt => format!("claude --continue{args}"),
-            LaunchMode::Fresh => match goal_file {
+        "claude" => match (mode, primer_file) {
+            // Primed-but-idle: the primer rides in as system context, not a
+            // positional prompt, so claude waits for the operator's first message
+            // instead of taking a turn on launch. Re-appended on adopt because the
+            // system prompt is reconstructed per launch — `--continue` resumes the
+            // conversation, but the appended context is not persisted with it.
+            (LaunchMode::Adopt, Some(p)) => {
+                format!(
+                    "claude --continue{args} --append-system-prompt-file '{}'",
+                    p.display()
+                )
+            }
+            (LaunchMode::Fresh, Some(p)) => {
+                format!("claude{args} --append-system-prompt-file '{}'", p.display())
+            }
+            (LaunchMode::Adopt, None) => format!("claude --continue{args}"),
+            (LaunchMode::Fresh, None) => match goal_file {
                 Some(f) => format!("claude{args} \"$(cat '{}')\"", f.display()),
                 None => format!("claude{args}"),
             },
         },
         // Codex takes its opening prompt as a positional arg, like claude. It has
         // no scoped "continue this worktree's session" flag, so on adopt we
-        // re-launch fresh (re-reading the primer) rather than resuming.
-        "codex" => match goal_file {
+        // re-launch fresh (re-reading the prompt) rather than resuming. It also has
+        // no `--append-system-prompt-file` equivalent and no WEAVER.md hook, so a
+        // codex concierge's primer is still seeded *positionally* (falling back to
+        // `primer_file`) and it will take a turn on boot. Making codex boot idle is
+        // a documented follow-up.
+        "codex" => match goal_file.or(primer_file) {
             Some(f) => format!("codex \"$(cat '{}')\"", f.display()),
             None => "codex".to_string(),
         },
-        other => match goal_file {
+        // A bare command likewise only takes a positional prompt, so fall back to
+        // the primer if that is all this session carries.
+        other => match goal_file.or(primer_file) {
             Some(f) => format!("{other} '{}'", f.display()),
             None => other.to_string(),
         },
@@ -128,6 +155,7 @@ fn sh_single_quote(value: &str) -> String {
 pub fn launch_script(
     runtime: &str,
     goal_file: Option<&Path>,
+    primer_file: Option<&Path>,
     env: &[(&str, &str)],
     weaver_dir: Option<&Path>,
     mode: LaunchMode,
@@ -140,7 +168,7 @@ pub fn launch_script(
     for (k, v) in env {
         script.push_str(&format!("export {k}={}; ", sh_single_quote(v)));
     }
-    let inner = inner_command(runtime, goal_file, mode, claude_args);
+    let inner = inner_command(runtime, goal_file, primer_file, mode, claude_args);
     if !inner.is_empty() {
         script.push_str(&inner);
         script.push_str("; ");
@@ -160,7 +188,15 @@ pub struct LaunchSpec<'a> {
     pub runtime: &'a str,
     pub work_dir: &'a Path,
     pub term_session: &'a str,
+    /// The **positional** opening prompt catted in as the operator's first
+    /// message. A normal session carries this; the concierge does not (it uses
+    /// [`Self::primer_file`] instead, so it boots idle).
     pub goal_file: Option<&'a Path>,
+    /// System *context* appended via `--append-system-prompt-file` (claude
+    /// runtime). The concierge's fleet-ops primer rides in here so it boots primed
+    /// but takes no turn until the operator speaks. Distinct from `goal_file`;
+    /// at most one is set.
+    pub primer_file: Option<&'a Path>,
     pub server_addr: &'a str,
     pub claude_args: &'a str,
     /// Operator-managed environment variables ([`crate::agent_env`]) exported
@@ -220,6 +256,7 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
     let script = launch_script(
         spec.runtime,
         spec.goal_file,
+        spec.primer_file,
         &env,
         weaver_dir,
         mode,
@@ -530,7 +567,7 @@ mod tests {
 
     #[test]
     fn shell_script_just_execs_a_shell() {
-        let script = launch_script("shell", None, &[], None, LaunchMode::Fresh, "");
+        let script = launch_script("shell", None, None, &[], None, LaunchMode::Fresh, "");
         assert_eq!(script, "exec \"${SHELL:-/bin/sh}\"");
     }
 
@@ -539,6 +576,7 @@ mod tests {
         let script = launch_script(
             "claude",
             Some(Path::new("/x/goal.txt")),
+            None,
             &[("WEAVER_API", "http://h:1")],
             None,
             LaunchMode::Fresh,
@@ -547,6 +585,46 @@ mod tests {
         assert!(script.contains("export WEAVER_API='http://h:1'; "));
         assert!(script.contains("claude \"$(cat '/x/goal.txt')\"; "));
         assert!(script.ends_with("exec \"${SHELL:-/bin/sh}\""));
+    }
+
+    #[test]
+    fn concierge_primer_rides_in_as_system_prompt_not_a_positional() {
+        // A concierge launches with its primer as appended system context and NO
+        // positional prompt, so it boots primed but idle (takes no turn until the
+        // operator speaks). Fresh and adopt both append the primer.
+        let fresh = launch_script(
+            "claude",
+            None,
+            Some(Path::new("/x/primer.txt")),
+            &[],
+            None,
+            LaunchMode::Fresh,
+            "",
+        );
+        assert_eq!(
+            fresh,
+            "claude --append-system-prompt-file '/x/primer.txt'; exec \"${SHELL:-/bin/sh}\""
+        );
+        // No positional `$(cat …)` prompt — that is what made it take a turn on boot.
+        assert!(!fresh.contains("$(cat"), "got: {fresh}");
+
+        // Adopt re-appends the primer (the system prompt is rebuilt per launch) and
+        // resumes the conversation with --continue.
+        let adopt = launch_script(
+            "claude",
+            None,
+            Some(Path::new("/x/primer.txt")),
+            &[],
+            None,
+            LaunchMode::Adopt,
+            "",
+        );
+        assert_eq!(
+            adopt,
+            "claude --continue --append-system-prompt-file '/x/primer.txt'; \
+             exec \"${SHELL:-/bin/sh}\""
+        );
+        assert!(!adopt.contains("$(cat"), "got: {adopt}");
     }
 
     #[test]
@@ -568,6 +646,7 @@ mod tests {
         let fresh = launch_script(
             "codex",
             Some(Path::new("/x/goal.txt")),
+            None,
             &[],
             None,
             LaunchMode::Fresh,
@@ -581,6 +660,7 @@ mod tests {
         let adopt = launch_script(
             "codex",
             Some(Path::new("/x/goal.txt")),
+            None,
             &[],
             None,
             LaunchMode::Adopt,
@@ -593,11 +673,33 @@ mod tests {
     }
 
     #[test]
+    fn codex_concierge_still_seeds_the_primer_positionally() {
+        // Codex has no `--append-system-prompt-file`, so a codex concierge (primer
+        // in `primer_file`, no `goal_file`) falls back to seeding the primer as a
+        // positional prompt — it still takes a turn on boot. Making codex boot idle
+        // is a documented follow-up.
+        let fresh = launch_script(
+            "codex",
+            None,
+            Some(Path::new("/x/primer.txt")),
+            &[],
+            None,
+            LaunchMode::Fresh,
+            "",
+        );
+        assert!(
+            fresh.contains("codex \"$(cat '/x/primer.txt')\"; "),
+            "got: {fresh}"
+        );
+    }
+
+    #[test]
     fn env_values_with_single_quotes_are_escaped() {
         // An operator env var whose value contains a single quote must not break
         // out of the `export NAME='…'` assignment.
         let script = launch_script(
             "shell",
+            None,
             None,
             &[("MSG", "it's \"quoted\"")],
             None,
@@ -640,6 +742,7 @@ mod tests {
         let script = launch_script(
             "claude",
             Some(Path::new("/x/goal.txt")),
+            None,
             &[],
             None,
             LaunchMode::Adopt,

--- a/crates/loom/src/shell.rs
+++ b/crates/loom/src/shell.rs
@@ -73,7 +73,7 @@ async fn shell_script(st: &AppState, branch_id: Option<&str>) -> String {
 
     let loom_exe = std::env::current_exe().ok();
     let weaver_dir = loom_exe.as_deref().and_then(Path::parent);
-    agent::launch_script("shell", None, &env, weaver_dir, LaunchMode::Adopt, "")
+    agent::launch_script("shell", None, None, &env, weaver_dir, LaunchMode::Adopt, "")
 }
 
 /// Ensure the scratch-shell supervisor is up, spawning it if not. Idempotent: a

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -919,12 +919,17 @@ async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionV
     // launch prompt (goal.txt) only, so they reach the agent without cluttering
     // the dashboard.
     let scratch_names = write_initial_scratch(&work_dir, &req.scratch).await?;
-    let mut prompt_parts: Vec<String> = Vec::new();
-    if is_concierge {
-        // The concierge's opening prompt is its fleet-ops primer — no goal text,
-        // scratch, or tracking note.
-        prompt_parts.push(agent::concierge_primer().to_string());
+    // The concierge boots primed-but-idle: its fleet-ops primer is injected as
+    // system *context* (primer.txt → `--append-system-prompt-file`), not as a
+    // positional opening prompt, so it takes no turn until the operator sends the
+    // first message. A normal session's goal/scratch/tracking note ride in as the
+    // positional prompt (goal.txt) that seeds its first turn.
+    let (goal_file, primer_file) = if is_concierge {
+        let f = run_dir.join("primer.txt");
+        tokio::fs::write(&f, agent::concierge_primer()).await?;
+        (None, Some(f))
     } else {
+        let mut prompt_parts: Vec<String> = Vec::new();
         if !goal.is_empty() {
             prompt_parts.push(goal.clone());
         }
@@ -934,14 +939,15 @@ async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionV
         if let Some(id) = tracking_issue {
             prompt_parts.push(tracking_note(id));
         }
-    }
-    let launch_prompt = prompt_parts.join("\n\n");
-    let goal_file = if launch_prompt.is_empty() {
-        None
-    } else {
-        let f = run_dir.join("goal.txt");
-        tokio::fs::write(&f, &launch_prompt).await?;
-        Some(f)
+        let launch_prompt = prompt_parts.join("\n\n");
+        let goal_file = if launch_prompt.is_empty() {
+            None
+        } else {
+            let f = run_dir.join("goal.txt");
+            tokio::fs::write(&f, &launch_prompt).await?;
+            Some(f)
+        };
+        (goal_file, None)
     };
 
     let term_session = format!("weaver-{session_id}");
@@ -958,6 +964,7 @@ async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionV
             work_dir: &work_dir,
             term_session: &term_session,
             goal_file: goal_file.as_deref(),
+            primer_file: primer_file.as_deref(),
             server_addr: &st.addr,
             claude_args: &claude_args,
             extra_env: &extra_env,
@@ -1540,6 +1547,8 @@ pub async fn create_warm_session(
             work_dir: &work_dir,
             term_session: &term_session,
             goal_file: goal_file.as_deref(),
+            // A warm overlooker session is never the concierge, so no primer.
+            primer_file: None,
             server_addr: &st.addr,
             claude_args: &claude_args,
             extra_env: &extra_env,
@@ -1591,13 +1600,17 @@ pub async fn adopt(st: &AppState, session: &Session, branch: &Branch) -> Result<
             session.work_dir
         )));
     }
+    // A normal session persists its positional prompt in goal.txt; the concierge
+    // persists its primer in primer.txt instead (re-appended as system context so
+    // it stays primed-but-idle across adopt). Each session carries exactly one.
+    let run_dir = db::run_dir(&session.id);
+    let primer_file = {
+        let f = run_dir.join("primer.txt");
+        f.exists().then_some(f)
+    };
     let goal_file = {
-        let f = db::run_dir(&session.id).join("goal.txt");
-        if f.exists() {
-            Some(f)
-        } else {
-            None
-        }
+        let f = run_dir.join("goal.txt");
+        f.exists().then_some(f)
     };
     let base_args = config::get_or(&st.db, "agent.claude_args", "").await;
     let claude_args = agent::combine_args(&base_args, &session.model, &session.effort);
@@ -1610,6 +1623,7 @@ pub async fn adopt(st: &AppState, session: &Session, branch: &Branch) -> Result<
             work_dir: &work_dir,
             term_session: &session.term_session,
             goal_file: goal_file.as_deref(),
+            primer_file: primer_file.as_deref(),
             server_addr: &st.addr,
             claude_args: &claude_args,
             extra_env: &extra_env,


### PR DESCRIPTION
## Problem

The fleet concierge (a loom session with `agent_kind=concierge`) started working the instant its Chat opened, before the operator typed anything. Its `CONCIERGE.md` primer was delivered as a **positional prompt** — written into `goal.txt` and catted into `claude "$(cat …)"`. Claude Code reads a positional prompt as the operator's first user message, so the concierge immediately took a turn on a brand-new chat.

## Fix

Launch the concierge with **no positional prompt** and inject the primer as system **context** via `--append-system-prompt-file <primer>` instead. It now boots fully primed but idle, waiting for the operator's first real message — the behaviour the meta-chat plan's worked example wants ("You open Chat and type the question").

### Changes

- **`crates/loom/src/agent.rs`** — thread a new `primer_file: Option<&Path>` through `LaunchSpec`, `launch_script()`, and `inner_command()`, kept distinct from `goal_file` (the positional prompt). For the `claude` runtime:
  - Fresh → `claude … --append-system-prompt-file '<primer>'` (no positional)
  - Adopt → `claude --continue … --append-system-prompt-file '<primer>'`, re-appended because the system prompt is rebuilt per launch, so the primer survives adopt/relaunch.
- **`crates/loom/src/web.rs`** — the concierge writes `run_dir/primer.txt` and passes it as `primer_file` with `goal_file = None`; `adopt()` re-derives `primer_file` from the persisted `primer.txt`. Normal and warm-overlooker sessions are unchanged.

### Out of scope: codex

The `codex` runtime (`concierge.runtime=codex`) has no `--append-system-prompt-file` equivalent and no `WEAVER.md` hook, so a codex concierge still seeds its primer **positionally** (it falls back to `primer_file`) and will take a turn on boot. Making codex boot idle is a documented follow-up, called out in a code comment.

## Why the primer no longer needs to live in `goal.txt`

A concierge's branch goal is already empty (`req.goal` is empty, so `set_goal` is skipped), and the primer only ever lived in `goal.txt` for the positional launch. The appended system prompt is always-present and survives compaction, so orientation is preserved; the `WEAVER.md` SessionStart hook still injects the weaver-session basics.

## Tests

- New `agent.rs` unit tests: a concierge-style launch (`primer_file` set, `goal_file` None) renders `--append-system-prompt-file '<path>'` with **no** `"$(cat …)"` positional, on both Fresh and Adopt; plus a codex-fallback test confirming codex still seeds positionally.
- Existing normal-session / adopt / codex tests updated for the new signature and stay green.
- `cargo test -p loom` (160 tests) and `cargo build --workspace` pass.

Verified that `claude 2.1.191` supports `--append-system-prompt-file`, it is not gated to `--print`, and launching `claude` with no positional prompt starts an idle interactive session.

Background analysis and root cause are tracked in weaver-tracker issue 287.
