### PR TITLE
fix(loom): concierge boots Idle, not a stuck "Working…"

### DIFF
--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -546,7 +546,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
           >
             <header class="mb-1 flex items-center gap-2 text-xs font-medium text-accent">
               <span class="turn-badge">{{ row.n }}</span>
-              <span>🧑 User</span>
+              <span>▍ You</span>
               <span v-if="row.time" class="font-normal text-muted">{{ shortTime(row.time) }}</span>
             </header>
             <template v-for="(b, j) in row.blocks" :key="j">

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -1007,6 +1007,43 @@ async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionV
     )
     .await
     .ok();
+
+    // The concierge boots primed-but-idle: with no positional prompt it takes no
+    // turn on launch, so claude's `Stop`/`Notification` hooks never fire and the
+    // soothing `idle` mark that those hooks stamp is never set — leaving a freshly
+    // booted concierge reading "Working…" forever though it is doing nothing.
+    // Stamp the mark ourselves at creation so it reads the calm "Idle" it actually
+    // is. The lifecycle then self-heals: the operator's first message fires the
+    // `working` hook (which clears this), and each finished turn re-stamps it. A
+    // normal session seeds a positional prompt and runs a turn on launch, so its
+    // own hooks drive this mark — only the idle-booting concierge needs the seed.
+    if is_concierge {
+        if let Err(e) = tags::set(
+            &st.db,
+            &branch.id,
+            tags::IDLE_KEY,
+            tags::IDLE_VALUE,
+            "",
+            "agent",
+        )
+        .await
+        {
+            tracing::warn!(branch = %branch.id, error = %e, "failed to stamp concierge idle mark");
+        } else {
+            events::record_tag(
+                &st.db,
+                &st.bus,
+                &branch.id,
+                tags::IDLE_KEY,
+                tags::IDLE_VALUE,
+                "",
+                "agent",
+            )
+            .await
+            .ok();
+        }
+    }
+
     tracing::info!(
         branch = %branch.id,
         session = %session.id,

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -162,6 +162,15 @@ async fn chat_get_or_creates_a_hidden_singleton_concierge() {
         chat["status"], "launching",
         "the default (claude) concierge waits for its first hook to go running"
     );
+    // It boots primed-but-idle (no positional prompt ⇒ no turn ⇒ no `Stop` hook),
+    // so creation seeds the soothing `idle` mark itself — otherwise the chat would
+    // read "Working…" forever though the agent is doing nothing.
+    let tags = chat["branch"]["tags"].as_array().unwrap();
+    assert!(
+        tags.iter()
+            .any(|t| t["key"] == "idle" && t["value"] == "idle"),
+        "a freshly booted concierge carries the idle mark so it reads Idle, not Working: {tags:?}"
+    );
     assert!(
         chat["tracking_issue"].is_null(),
         "concierge has no tracking issue"


### PR DESCRIPTION
## What

Since #88 the fleet concierge boots **primed-but-idle**: it launches with its primer as appended system context (`--append-system-prompt-file`) and **no positional prompt**, so claude takes no turn on boot.

The side effect this PR fixes: because claude never runs a turn, its `Stop`/`Notification` hooks never fire, so the soothing `idle` mark those hooks normally stamp is never set. With no idle mark and a live (`launching`) status, `conversationState` derives **"Working…"** — so a freshly opened Chat sat pulsing "Working…" forever though the agent was doing nothing.

## Fix

Seed the `idle` mark at concierge creation (`create_session_core`, the path behind `GET /api/chat` and `POST /api/chat/reset`) so it reads the calm **"Idle"** it actually is. The lifecycle self-heals from there:

- the operator's first message fires the `working` hook → clears the mark
- each finished turn's `Stop` hook → re-stamps it

Normal sessions seed a positional prompt and run a turn on launch, so their own hooks drive this mark — only the idle-booting concierge needs the seed. The fix is gated on `is_concierge`, so nothing else changes.

## Also

Swap the cartoonish `🧑 User` turn label in the conversation view for a restrained `▍ You`, matching the geometric-glyph aesthetic (`●▶✓◦`) used elsewhere.

## Tests

- Extended `chat_get_or_creates_a_hidden_singleton_concierge` to assert a freshly booted concierge carries the `idle` mark (so it reads Idle, not Working).
- `cargo test -p loom` — 43 passed.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings` — clean.
- Frontend `rspack build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)