### PR TITLE
feat(loom): remove artifacts + auto-embed image files

### DIFF
--- a/.agents/skills/smartdoc.md
+++ b/.agents/skills/smartdoc.md
@@ -9,6 +9,9 @@ An artifact is a document you write *to weaver*, not the repo: a design, a
 report, a diagram, a plan. It is versioned, survives archive, and is rendered by
 loom for the user to read. `weaver artifact write <name> [<file>]` (stdin with
 `-`) prints a dashboard URL — hand it to the user in your status or a PR comment.
+An image file (`.png`, `.jpg`, `.svg`, …) is auto-embedded as a base64 data-URI
+markdown doc so it renders inline — pass the image straight to `write`, no
+hand-rolled data URI. `weaver artifact rm <name>` removes one and its history.
 
 ## When to write one
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ name = "weaver"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "clap",
  "clap_complete",

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -114,6 +114,11 @@ export const getArtifact = (id: string, name: string, rev?: number) =>
 export const putArtifact = (id: string, name: string, body: ArtifactWriteBody) =>
   put(`/sessions/${id}/artifacts/${encodeURIComponent(name)}`, body) as Promise<ArtifactView>;
 
+/** Delete an artifact and its whole revision history — the row the session sees
+ *  for that name (its branch-scoped one, else the repo-shared). */
+export const deleteArtifact = (id: string, name: string) =>
+  del(`/sessions/${id}/artifacts/${encodeURIComponent(name)}`);
+
 /** Availability of the session's embedded editor (code-server). */
 export const ideInfo = (id: string) => get(`/sessions/${id}/ide-info`) as Promise<IdeInfo>;
 

--- a/crates/loom/frontend/src/views/Artifacts.vue
+++ b/crates/loom/frontend/src/views/Artifacts.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import type * as Monaco from 'monaco-editor';
-import { get, getArtifacts, getArtifact, putArtifact } from '../api';
+import { get, getArtifacts, getArtifact, putArtifact, deleteArtifact } from '../api';
 import type { Session, ArtifactMeta, ArtifactView } from '../types';
 import { theme } from '../theme';
 import { loadMonaco, monacoTheme, languageForPath } from '../monaco';
@@ -60,6 +60,7 @@ const loading = ref(false);
 const viewError = ref('');
 const editing = ref(false);
 const saving = ref(false);
+const removing = ref(false);
 
 // Markdown gets the rendered Preview; other kinds show source in Monaco.
 const isMarkdown = computed(() => (view.value?.meta.kind ?? 'markdown') === 'markdown');
@@ -196,6 +197,42 @@ async function save() {
   }
 }
 
+// --- Delete ----------------------------------------------------------------
+
+// Remove the open artifact (every revision). After it's gone, fall back to the
+// next artifact in the list, or the empty state when none remain.
+async function remove() {
+  if (!view.value || removing.value) return;
+  const name = selected.value;
+  const count = view.value.versions.length;
+  if (
+    !confirm(
+      `Delete artifact "${name}" and all ${count} revision${count === 1 ? '' : 's'}? ` +
+        `This cannot be undone.`,
+    )
+  )
+    return;
+  removing.value = true;
+  viewError.value = '';
+  try {
+    await deleteArtifact(props.id, name);
+    view.value = null;
+    teardownEditor();
+    await loadList();
+    const next = list.value[0]?.name;
+    if (next) {
+      await openArtifact(next);
+    } else {
+      selected.value = '';
+      router.replace(`/s/${props.id}/artifacts`);
+    }
+  } catch (e) {
+    viewError.value = (e as Error).message;
+  } finally {
+    removing.value = false;
+  }
+}
+
 // --- Scope badge -----------------------------------------------------------
 
 function scopeBadge(a: ArtifactMeta): { label: string; title: string } {
@@ -216,6 +253,17 @@ function openStream() {
     // mid-edit), refresh the viewer to its new latest.
     if (d?.name && d.name === selected.value && !editing.value) {
       openArtifact(selected.value).catch(() => {});
+    }
+  });
+  source.addEventListener('artifact_deleted', (e) => {
+    const d = JSON.parse((e as MessageEvent).data).data as { name?: string };
+    loadList().catch(() => {});
+    // The open artifact was removed elsewhere (CLI, or another tab) — clear the
+    // viewer back to the empty state. Our own delete already advanced the view.
+    if (d?.name && d.name === selected.value) {
+      view.value = null;
+      teardownEditor();
+      selected.value = '';
     }
   });
 }
@@ -338,6 +386,14 @@ onUnmounted(() => {
               <template v-if="!editing">
                 <button class="btn-secondary px-2.5 py-1 text-xs" :disabled="!onLatest" @click="edit">
                   Edit
+                </button>
+                <button
+                  class="btn-danger px-2.5 py-1 text-xs"
+                  data-testid="artifact-delete"
+                  :disabled="removing"
+                  @click="remove"
+                >
+                  {{ removing ? 'Deleting…' : 'Delete' }}
                 </button>
               </template>
               <template v-else>

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -427,7 +427,9 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{id}/artifacts", get(list_artifacts))
         .route(
             "/sessions/{id}/artifacts/{name}",
-            get(get_artifact).put(write_artifact),
+            get(get_artifact)
+                .put(write_artifact)
+                .delete(delete_artifact),
         )
         .route(
             "/sessions/{id}/scratch",
@@ -1952,6 +1954,31 @@ async fn write_artifact(
     Ok(Json(
         artifact_view(&st.db, &branch.repo_root, &a, None).await?,
     ))
+}
+
+/// Delete an artifact and its whole revision history. Resolves the name the way
+/// the session sees it (its own branch-scoped row, else the repo-shared one — the
+/// single row the list shows for that name), so deleting from the UI removes
+/// exactly the artifact displayed. Broadcasts `artifact_deleted` for live refresh.
+async fn delete_artifact(
+    State(st): State<AppState>,
+    Path((key, name)): Path<(String, String)>,
+) -> ApiResult<Json<Value>> {
+    let (_, branch) = require_session(&st.db, &key).await?;
+    let a = artifact::get(&st.db, &branch.repo_root, &branch.id, &name)
+        .await?
+        .ok_or_else(|| AppError::not_found("artifact"))?;
+    artifact::delete(&st.db, a.id).await?;
+    events::record(
+        &st.db,
+        &st.bus,
+        &branch.id,
+        "artifact_deleted",
+        json!({ "name": a.name, "branch_id": a.branch_id }),
+    )
+    .await
+    .ok();
+    Ok(Json(json!({ "deleted": true, "name": a.name })))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -33,9 +33,12 @@ It is on your `PATH`. From anywhere in the worktree you can run:
 - `weaver artifact write <name> [<file>]` — write a versioned document to
   weaver (a design, a report, a diagram, a plan) for the user to read. Prints a
   dashboard URL to hand them. Reads stdin with `-`; `--repo` makes it
-  repo-shared so a fan-out of child sessions sees one copy. `weaver artifact ls`
-  lists this branch's plus the shared ones; `weaver artifact show <name> [--rev
-  N]` prints content.
+  repo-shared so a fan-out of child sessions sees one copy. An image file
+  (`.png`, `.svg`, …) is embedded as a base64 data-URI markdown doc, so it
+  renders inline — just `weaver artifact write shot screenshot.png`. `weaver
+  artifact ls` lists this branch's plus the shared ones; `weaver artifact show
+  <name> [--rev N]` prints content; `weaver artifact rm <name>` removes it and
+  its history (`--repo` targets the shared one).
 - `weaver goal set <file|->` — set the branch goal from a file or stdin (long
   markdown goals without the shell-quoting pain). `weaver goal` prints it.
 - Division of labor: **goal = the charter (what to do); issues = the only task

--- a/crates/weaver-core/src/artifact.rs
+++ b/crates/weaver-core/src/artifact.rs
@@ -297,6 +297,25 @@ pub async fn list_for_repo(db: &Db, repo_root: &str) -> Result<Vec<Artifact>> {
     Ok(rows)
 }
 
+/// Delete an artifact and its entire revision history, by envelope id. Removing
+/// an artifact removes the whole document — every snapshot goes with it.
+///
+/// Foreign keys aren't enabled on the pool, so the `artifact_versions` cascade
+/// won't fire — clear the versions explicitly before dropping the envelope.
+pub async fn delete(db: &Db, id: i64) -> Result<()> {
+    let mut tx = db.begin().await?;
+    sqlx::query("DELETE FROM artifact_versions WHERE artifact_id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("DELETE FROM artifacts WHERE id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -458,5 +477,29 @@ mod tests {
         // The scoped one is still at rev 1.
         let scoped_now = get(&db, "/r", "b1", "plan").await.unwrap().unwrap();
         assert_eq!(scoped_now.rev, 1);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_envelope_and_every_revision() {
+        let db = db().await;
+        // A shared `plan` and a same-named branch-scoped one, the scoped with
+        // history, so we can prove delete is targeted and takes all revisions.
+        let shared = wr(&db, None, "plan", "Shared", "s", "agent").await;
+        wr(&db, Some("b1"), "plan", "Mine v1", "v1", "agent").await;
+        let scoped = wr(&db, Some("b1"), "plan", "Mine v2", "v2", "user").await;
+        assert_eq!(scoped.rev, 2);
+
+        delete(&db, scoped.id).await.unwrap();
+
+        // The scoped envelope and both its revisions are gone.
+        assert!(get_by_id(&db, scoped.id).await.unwrap().is_none());
+        assert!(version(&db, scoped.id, 1).await.unwrap().is_none());
+        assert!(version(&db, scoped.id, 2).await.unwrap().is_none());
+        assert!(history(&db, scoped.id).await.unwrap().is_empty());
+
+        // The shared `plan` is untouched — `get` from b1 now falls back to it.
+        let resolved = get(&db, "/r", "b1", "plan").await.unwrap().unwrap();
+        assert_eq!(resolved.id, shared.id);
+        assert_eq!(resolved.title, "Shared");
     }
 }

--- a/crates/weaver/Cargo.toml
+++ b/crates/weaver/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/bin/weaver.rs"
 [dependencies]
 weaver-core = { path = "../weaver-core" }
 anyhow = "1"
+base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -236,6 +236,11 @@ enum GoalCmd {
 enum ArtifactCmd {
     /// Write an artifact: append a new revision (creating it if absent). Reads
     /// `<file>`, or stdin when `<file>` is `-` or omitted.
+    ///
+    /// An image file (`.png`, `.jpg`, `.gif`, `.webp`, `.svg`, …; raster formats
+    /// are also recognised from stdin by their magic bytes) is embedded as a
+    /// base64 data-URI in a markdown wrapper, so it renders inline in loom — no
+    /// need to hand-roll the data URI.
     Write {
         /// The artifact name (its identity within the scope), e.g. `plan`.
         name: String,
@@ -244,7 +249,8 @@ enum ArtifactCmd {
         /// A human title for the artifact (envelope metadata).
         #[arg(long, default_value = "")]
         title: String,
-        /// The content kind; defaults to `markdown`.
+        /// The content kind; defaults to `markdown`. Ignored for image files,
+        /// which are always wrapped as markdown.
         #[arg(long, default_value = "markdown")]
         kind: String,
         /// Publish repo-shared (visible to every branch) instead of scoping it
@@ -269,6 +275,17 @@ enum ArtifactCmd {
         /// Print the envelope metadata instead of the content.
         #[arg(long)]
         meta: bool,
+    },
+    /// Remove an artifact and its entire revision history. Resolves the name
+    /// branch-scoped first, then repo-shared (what `show` would display); pass
+    /// `--repo` to target the repo-shared one when a branch copy shadows it.
+    Rm {
+        /// The artifact name to remove.
+        name: String,
+        /// Remove the repo-shared artifact (`branch_id IS NULL`) of this name,
+        /// not the branch-scoped one.
+        #[arg(long)]
+        repo: bool,
     },
 }
 
@@ -374,6 +391,84 @@ fn read_file_or_stdin(path: Option<&str>) -> Result<String> {
             Ok(buf)
         }
     }
+}
+
+/// Read raw bytes from a file path, or stdin when `path` is `None` or `"-"`. The
+/// binary-safe twin of [`read_file_or_stdin`], used where content may be an image.
+fn read_bytes_or_stdin(path: Option<&str>) -> Result<Vec<u8>> {
+    use std::io::Read;
+    match path {
+        Some(p) if p != "-" => std::fs::read(p).map_err(|e| anyhow!("reading {p}: {e}")),
+        _ => {
+            let mut buf = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut buf)
+                .map_err(|e| anyhow!("reading stdin: {e}"))?;
+            Ok(buf)
+        }
+    }
+}
+
+/// The largest image we embed inline. base64 inflates by ~⅓, and the data URI
+/// rides in the artifact's content column / JSON views / SSE — a few MB is a
+/// generous ceiling for a screenshot or diagram; past it, downscale first.
+const MAX_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+
+/// The image MIME type for a filename's extension, or `None` if it isn't a
+/// recognised image extension. Case-insensitive.
+fn image_mime_from_ext(name: &str) -> Option<&'static str> {
+    let ext = name.rsplit_once('.').map(|(_, e)| e.to_ascii_lowercase())?;
+    Some(match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        "avif" => "image/avif",
+        "bmp" => "image/bmp",
+        "ico" => "image/x-icon",
+        _ => return None,
+    })
+}
+
+/// Sniff a raster image's MIME type from its leading magic bytes — for content
+/// read from stdin, where there is no extension to go by. Only the unambiguous
+/// binary formats are sniffed; text-ish SVG is recognised by extension alone, so
+/// that markdown which merely embeds an `<svg>` is never mistaken for an image.
+fn image_mime_from_magic(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        Some("image/png")
+    } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("image/gif")
+    } else if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else {
+        None
+    }
+}
+
+/// If `bytes` is a recognised image (by `filename` extension, else raster magic
+/// bytes), wrap it as a markdown document embedding it as a base64 data URI, so
+/// it renders inline in loom with no binary storage. `None` means "not an image
+/// — treat as text". `alt` is the image's alt text (the artifact title or name).
+fn embed_image_markdown(alt: &str, filename: Option<&str>, bytes: &[u8]) -> Result<Option<String>> {
+    use base64::Engine;
+    let mime = filename
+        .and_then(image_mime_from_ext)
+        .or_else(|| image_mime_from_magic(bytes));
+    let Some(mime) = mime else { return Ok(None) };
+    if bytes.len() > MAX_IMAGE_BYTES {
+        bail!(
+            "image is {:.1} MB; the inline limit is {} MB — downscale it first",
+            bytes.len() as f64 / (1024.0 * 1024.0),
+            MAX_IMAGE_BYTES / (1024 * 1024)
+        );
+    }
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    let alt = if alt.is_empty() { "image" } else { alt };
+    Ok(Some(format!("![{alt}](data:{mime};base64,{b64})\n")))
 }
 
 /// Print the goal, or set it. With no subcommand prints the current goal;
@@ -1125,7 +1220,28 @@ async fn cmd_artifact(cmd: ArtifactCmd) -> Result<()> {
             kind,
             repo,
         } => {
-            let content = read_file_or_stdin(file.as_deref())?;
+            let raw = read_bytes_or_stdin(file.as_deref())?;
+            let alt = if title.trim().is_empty() {
+                name.trim()
+            } else {
+                title.trim()
+            };
+            // An image is auto-wrapped as a base64 data-URI markdown doc (kind
+            // forced to markdown so loom renders it inline); everything else is
+            // stored as text under the requested kind.
+            let (kind, content): (String, String) =
+                match embed_image_markdown(alt, file.as_deref(), &raw)? {
+                    Some(md) => ("markdown".to_string(), md),
+                    None => {
+                        let text = String::from_utf8(raw).map_err(|_| {
+                            anyhow!(
+                                "artifact content is not valid UTF-8 — \
+                                 only text and image files are supported"
+                            )
+                        })?;
+                        (kind.trim().to_string(), text)
+                    }
+                };
             // `--repo` writes the repo-shared scope (branch_id = NULL); otherwise
             // the artifact is scoped to this branch.
             let branch_id = (!repo).then_some(b.id.as_str());
@@ -1135,7 +1251,7 @@ async fn cmd_artifact(cmd: ArtifactCmd) -> Result<()> {
                     repo_root: &b.repo_root,
                     branch_id,
                     name: name.trim(),
-                    kind: kind.trim(),
+                    kind: &kind,
                     title: title.trim(),
                     content: &content,
                     author: "agent",
@@ -1223,6 +1339,29 @@ async fn cmd_artifact(cmd: ArtifactCmd) -> Result<()> {
                     a.name
                 ),
             }
+        }
+        ArtifactCmd::Rm { name, repo } => {
+            // `--repo` targets the repo-shared row explicitly; the default
+            // resolves branch-scoped first, then shared — what `show` displays.
+            let a = if repo {
+                artifact::get_shared(&db, &b.repo_root, name.trim()).await?
+            } else {
+                artifact::get(&db, &b.repo_root, &b.id, name.trim()).await?
+            }
+            .ok_or_else(|| anyhow!("no artifact '{}' — see `weaver artifact ls`", name.trim()))?;
+            artifact::delete(&db, a.id).await?;
+            events::record_local(
+                &db,
+                &b.id,
+                "artifact_deleted",
+                json!({ "name": a.name, "branch_id": a.branch_id }),
+            )
+            .await?;
+            let scope = match &a.branch_id {
+                Some(bid) => format!("branch {bid}"),
+                None => "repo-shared".to_string(),
+            };
+            println!("deleted {} ({scope}, was rev {})", a.name, a.rev);
         }
     }
     Ok(())
@@ -1476,5 +1615,74 @@ mod tests {
     fn truncate_respects_the_max_length() {
         assert_eq!(truncate("short", 10), "short");
         assert_eq!(truncate("a very long string", 6), "a ver…");
+    }
+
+    #[test]
+    fn image_extensions_map_to_mime_case_insensitively() {
+        assert_eq!(image_mime_from_ext("shot.png"), Some("image/png"));
+        assert_eq!(image_mime_from_ext("./a/b/Photo.JPG"), Some("image/jpeg"));
+        assert_eq!(image_mime_from_ext("logo.svg"), Some("image/svg+xml"));
+        assert_eq!(image_mime_from_ext("anim.webp"), Some("image/webp"));
+        // Not images: plain docs and extension-less names.
+        assert_eq!(image_mime_from_ext("design.md"), None);
+        assert_eq!(image_mime_from_ext("plan"), None);
+    }
+
+    #[test]
+    fn raster_magic_bytes_are_sniffed_but_text_is_not() {
+        assert_eq!(
+            image_mime_from_magic(b"\x89PNG\r\n\x1a\n....."),
+            Some("image/png")
+        );
+        assert_eq!(
+            image_mime_from_magic(&[0xFF, 0xD8, 0xFF, 0x00]),
+            Some("image/jpeg")
+        );
+        assert_eq!(image_mime_from_magic(b"GIF89a..."), Some("image/gif"));
+        assert_eq!(
+            image_mime_from_magic(b"RIFF\0\0\0\0WEBPVP8 "),
+            Some("image/webp")
+        );
+        // Markdown that merely contains an <svg> is text, never sniffed as image.
+        assert_eq!(image_mime_from_magic(b"# Notes\n<svg>...</svg>\n"), None);
+    }
+
+    #[test]
+    fn embed_wraps_an_image_and_passes_text_through() {
+        // A PNG by extension → a markdown image with a base64 data URI + alt text.
+        let png = b"\x89PNG\r\n\x1a\nzzzz";
+        let md = embed_image_markdown("My shot", Some("shot.png"), png)
+            .unwrap()
+            .expect("png embeds");
+        assert!(md.starts_with("![My shot](data:image/png;base64,"));
+        assert!(md.trim_end().ends_with(')'));
+
+        // Extension-less stdin still embeds via magic bytes; empty alt → "image".
+        let md = embed_image_markdown("", None, png)
+            .unwrap()
+            .expect("magic embeds");
+        assert!(md.starts_with("![image](data:image/png;base64,"));
+
+        // SVG (text) embeds by extension so it renders as an image, not source.
+        let svg = b"<svg xmlns='http://www.w3.org/2000/svg'></svg>";
+        let md = embed_image_markdown("d", Some("d.svg"), svg)
+            .unwrap()
+            .expect("svg embeds");
+        assert!(md.starts_with("![d](data:image/svg+xml;base64,"));
+
+        // Non-image content is left for the text path.
+        assert!(embed_image_markdown("notes", Some("notes.md"), b"# Hi")
+            .unwrap()
+            .is_none());
+        assert!(embed_image_markdown("notes", None, b"plain text")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn embed_rejects_an_oversized_image() {
+        let mut big = b"\x89PNG\r\n\x1a\n".to_vec();
+        big.resize(MAX_IMAGE_BYTES + 1, 0);
+        assert!(embed_image_markdown("x", Some("x.png"), &big).is_err());
     }
 }

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -114,8 +114,11 @@ the survey above:
   agent/user edits safe — last write is a new revision, not a lost update.
 - **Kind-typed, markdown-first.** `kind` defaults to `markdown` (GFM +
   mermaid via the existing `MarkdownView`); other kinds render as source
-  until they earn a renderer. Binary kinds (screenshots) are a deliberate
-  v2.
+  until they earn a renderer. Images (screenshots, diagrams) need no blob
+  store: `write` recognises an image file — by extension, or by magic bytes
+  on stdin — and embeds it as a base64 data-URI inside a markdown wrapper,
+  which `MarkdownView` already renders inline (the renderer passes `data:`
+  URIs through untouched; DOMPurify permits them on `<img>`).
 - **URL-addressable.** `weaver artifact write` prints the dashboard URL
   (`/s/<session>/artifacts/<name>`) so the agent can hand it to the user in
   a status message or PR comment — the Amp-thread lesson: the URL is the
@@ -162,15 +165,22 @@ CLI and API, in the house idiom:
 weaver artifact write <name> [<file>]    # stdin with '-'; --title, --kind, --repo
 weaver artifact ls [--repo]              # this branch's + shared; --repo for all
 weaver artifact show <name> [--rev N]    # content; --meta for the envelope
+weaver artifact rm <name> [--repo]       # remove it + its history; --repo = shared
 
-GET  /api/sessions/{id}/artifacts                 # list: branch-scoped + shared
-GET  /api/sessions/{id}/artifacts/{name}?rev=N    # content + projected refs (below)
-PUT  /api/sessions/{id}/artifacts/{name}          # user edit -> new revision
+GET    /api/sessions/{id}/artifacts                 # list: branch-scoped + shared
+GET    /api/sessions/{id}/artifacts/{name}?rev=N    # content + projected refs (below)
+PUT    /api/sessions/{id}/artifacts/{name}          # user edit -> new revision
+DELETE /api/sessions/{id}/artifacts/{name}          # remove it + its history
 ```
 
 Each write records an `artifact_written` event (`{name, rev, title}`) through
-the existing bus, so the SSE stream, the activity feed, and overlookers see
-it with no new plumbing.
+the existing bus, and a delete records `artifact_deleted` (`{name, branch_id}`),
+so the SSE stream, the activity feed, and overlookers see both with no new
+plumbing. `rm`/DELETE resolve the name the way `show` does (branch-scoped first,
+then repo-shared — the single row the listing shows), so removing from the UI
+takes exactly the artifact on screen; `--repo` targets the shared row when a
+branch copy shadows it. Removing an artifact removes every revision — history is
+not individually prunable.
 
 Artifacts are the outbound twin of `scratch/`: scratch is material the user
 hands the agent; artifacts are documents the agent hands the user. Scratch
@@ -322,8 +332,11 @@ Each step shippable alone:
 
 ## Open questions
 
-- **Binary kinds** (screenshots, the Cursor "demo artifact" pattern): needs
-  blob storage and a raw route; v2, the seam (`kind`) is reserved.
+- **Binary kinds** (screenshots, the Cursor "demo artifact" pattern):
+  resolved by embedding — `write` wraps an image as a base64 data-URI markdown
+  doc (cap: 10 MB raw), so it renders inline with no blob store or raw route.
+  A dedicated binary column stays a future option if large media ever warrants
+  it; for kilobyte-to-low-megabyte screenshots, embedding is enough.
 - **Cross-branch reads in the CLI**: `artifact ls --repo` covers discovery;
   is a branch-qualified `show` needed, or do shared artifacts cover fan-out?
 - **Promote** timing, per above.

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -124,13 +124,18 @@ export interface WeaverFixture {
   seedConversation(session: Session, log: unknown): Promise<void>;
   /** Write an artifact via `weaver artifact write` — creates it on first call,
    *  appends an immutable revision after. Content is piped on stdin; `--repo`
-   *  publishes it repo-shared instead of scoping it to the branch. */
+   *  publishes it repo-shared instead of scoping it to the branch. A `Buffer`
+   *  exercises the binary path — an image is sniffed from its magic bytes and
+   *  embedded as a base64 data-URI markdown doc. */
   writeArtifact(
     session: Session,
     name: string,
-    content: string,
+    content: string | Buffer,
     opts?: { title?: string; repo?: boolean },
   ): Promise<void>;
+  /** Remove an artifact via `weaver artifact rm` — drops it and its whole
+   *  history. `--repo` targets the repo-shared row when a branch copy shadows it. */
+  removeArtifact(session: Session, name: string, opts?: { repo?: boolean }): Promise<void>;
   /** Set (upsert) a free-form label on an issue via `PUT …/issues/{id}/tags/{key}`. */
   tagIssue(id: number, key: string, value: string): Promise<Issue>;
   /** GET /api/issues (cross-repo board). */
@@ -488,6 +493,15 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
         execFileSync(WEAVER_BINARY, args, {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
           input: content,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+      },
+
+      async removeArtifact(session, name, opts) {
+        const args = ['artifact', 'rm', name];
+        if (opts?.repo) args.push('--repo');
+        execFileSync(WEAVER_BINARY, args, {
+          env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
           stdio: ['pipe', 'pipe', 'pipe'],
         });
       },

--- a/e2e/tests/artifacts.spec.ts
+++ b/e2e/tests/artifacts.spec.ts
@@ -107,6 +107,59 @@ test.describe('artifacts surface', () => {
     // Back in preview, the edited content shows.
     await expect(page.locator('.markdown-body')).toContainText('A user revision.');
   });
+
+  test('deleting an artifact removes it and falls back to the next', async ({ page, weaver }) => {
+    const session = await weaver.seedSession({ goal: 'cleanup', name: 'artifacts-delete' });
+    await weaver.writeArtifact(session, 'keep', '# Keep me\n', { title: 'Keep' });
+    await weaver.writeArtifact(session, 'scratch', '# Throwaway\n', { title: 'Scratch' });
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}/artifacts/scratch`);
+    await expect(page.locator('.markdown-body h1')).toContainText('Throwaway');
+
+    // Confirm the destructive prompt, then delete.
+    page.once('dialog', (d) => d.accept());
+    await page.getByTestId('artifact-delete').click();
+
+    // The row is gone and the viewer falls back to the remaining `keep`.
+    await expect(page.locator('[data-artifact="scratch"]')).toHaveCount(0);
+    await expect(page.locator('[data-artifact="keep"]')).toBeVisible();
+    await expect(page.locator('.markdown-body h1')).toContainText('Keep me');
+  });
+
+  test('a CLI `artifact rm` removes it and the list updates over SSE', async ({ page, weaver }) => {
+    const session = await weaver.seedSession({ goal: 'cli rm', name: 'artifacts-cli-rm' });
+    await weaver.writeArtifact(session, 'doomed', '# Doomed\n', { title: 'Doomed' });
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}/artifacts/doomed`);
+    await expect(page.locator('[data-artifact="doomed"]')).toBeVisible();
+    await expect(page.locator('.markdown-body h1')).toContainText('Doomed');
+
+    // Remove it out-of-band via the CLI; the `artifact_deleted` event is
+    // re-broadcast over SSE and the list updates without a reload.
+    await weaver.removeArtifact(session, 'doomed');
+    await expect(page.locator('[data-artifact="doomed"]')).toHaveCount(0, { timeout: 15_000 });
+  });
+
+  test('an image file is embedded as a base64 data-URI and renders inline', async ({
+    page,
+    weaver,
+  }) => {
+    const session = await weaver.seedSession({ goal: 'shots', name: 'artifacts-image' });
+    // A 1×1 transparent PNG, piped as raw bytes (no extension): the CLI sniffs
+    // it from its magic bytes and wraps it as a base64 data-URI markdown doc.
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64',
+    );
+    await weaver.writeArtifact(session, 'shot', png, { title: 'Screenshot' });
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}/artifacts/shot`);
+
+    // Preview renders the embedded image inline (alt = the title), src a data URI.
+    const img = page.locator('.markdown-body img');
+    await expect(img).toHaveAttribute('src', /^data:image\/png;base64,/);
+    await expect(img).toHaveAttribute('alt', 'Screenshot');
+  });
 });
 
 test.describe('overview', () => {


### PR DESCRIPTION
Adds two capabilities to the artifact subsystem (weaver issue #322).

## 1. Remove artifacts — full stack
- **weaver-core**: `artifact::delete(db, id)` drops the envelope and every revision (transactional; FKs aren't enabled on the pool, so versions are cleared explicitly, mirroring `issue::delete`).
- **CLI**: `weaver artifact rm <name> [--repo]` — resolves the name exactly like `show` (branch-scoped first, then repo-shared); `--repo` targets the shared row when a branch copy shadows it. Prints what scope/rev was removed and records an `artifact_deleted` event.
- **API**: `DELETE /api/sessions/{id}/artifacts/{name}` — resolves the row the session sees (the one the listing shows), deletes it, broadcasts `artifact_deleted`.
- **loom UI**: a red-outlined **Delete** button in the viewer toolbar (confirm guard) that falls back to the next artifact or the empty state. The `artifact_deleted` SSE event keeps the list and an open viewer live when something is removed from the CLI or another tab.

## 2. Image / SVG artifacts — auto-embed, no schema change
`weaver artifact write shot foo.png` detects an image (by extension, or by magic bytes when piped on stdin) and embeds it as a base64 `data:` URI inside a markdown wrapper. `MarkdownView` already renders that inline — it passes `data:` URIs through untouched and DOMPurify permits them on `<img>` — so screenshots and diagrams render with **no blob storage, no raw route, and no hand-rolled data URI**. Capped at 10 MB raw. This resolves the "binary kinds = v2" open question the design doc had parked, the cheaper way.

## Tests
- Unit: `artifact::delete` (targeted, takes all revisions, leaves the shared shadow intact); image-embed helpers (extension + magic-byte detection, SVG-by-extension-only, oversize rejection).
- e2e: UI delete with fallback, CLI `rm` propagating over SSE, and an embedded PNG rendering inline.
- Also verified: clippy `-D warnings`, fmt, `cargo build --locked`, the loom suite (43), the rspack SPA build, and a manual screenshot check of the toolbar + inline image in both themes.

## Docs
`docs/artifacts.md` (CLI/API surface, the embed mechanism, the resolved binary-kinds question), `WEAVER.md`, and the smartdoc skill.