### PR TITLE
feat(loom): park sessions awaiting external review (review-wait watch)

### DIFF
--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -9,6 +9,21 @@ export type Attention = 'ok' | 'attention' | 'blocked';
 // pill. Mirrors weaver-core's `ATTENTION_VALUES`.
 const SEVERITY: Record<string, number> = { attention: 1, blocked: 2 };
 
+// The quiet mirror of SEVERITY: values that PARK a row *below* the calm default
+// in the fleet sort. A parked session is waiting on an external actor (a human
+// PR reviewer, …) and needs nothing from the user, so the dashboard sinks it
+// under the live-but-calm rows a scanning user should look at first. Like
+// loudness, parking is value-driven — any key holding such a value parks, so a
+// watch picks its own axis key (e.g. `awaiting`) and the value carries the
+// meaning. Quiet by design (never a badge); the two ladders are disjoint.
+// Mirrors weaver-core's `PARKED_VALUES`.
+const PARKED: Record<string, number> = { review: -1 };
+
+// Sort rank below the calm default for a parked value, or 0 if it doesn't park.
+function parkOf(value: string | undefined): number {
+  return (value && PARKED[value]) || 0;
+}
+
 // The soothing, quiet `idle` mark loom stamps when an agent goes quiet (a
 // finished turn or a `waiting` lull): the calm "resting, no one needed" state.
 // It carries the quiet value `idle`, so it is never loud — an idle agent no
@@ -120,6 +135,29 @@ export function effectiveAttention(s: Session): EffectiveAttention {
   const top = [...pool].sort(louder)[0];
 
   return { ...markOf(s, top), stale };
+}
+
+// Whether a session is *parked*: calm (no loud signal) yet carrying a tag whose
+// value is on the PARKED ladder — work waiting on an external actor (a human PR
+// reviewer, …) that needs nothing from the user. A loud signal always wins: a
+// session that needs a human is never parked, however else it's tagged. Archived
+// sessions are never parked (they read through their own terminal badge).
+export function isParked(s: Session): boolean {
+  if (s.status === 'archived') return false;
+  if (loudTags(s).length > 0) return false;
+  return (s.branch.tags ?? []).some((t) => parkOf(t.value) < 0);
+}
+
+// The fleet-sort rank of a single session: the loud ladder raises a row (blocked
+// 2 > attention 1) via the resolved attention signal; a parked row sinks below
+// the calm default (-1); everything else is the calm default (0). SessionList
+// floats a thread to the max rank across its subtree, so a parked parent with
+// live children stays put — only a wholly-parked thread sinks to the bottom.
+export function priorityRank(s: Session): number {
+  const lvl = effectiveAttention(s).level;
+  if (lvl === 'blocked') return 2;
+  if (lvl === 'attention') return 1;
+  return isParked(s) ? -1 : 0;
 }
 
 // One loud tag surfaced as an individually-dismissable chip. Unlike

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -10,7 +10,7 @@ import TagPill from '../components/TagPill.vue';
 import GithubStatus from '../components/GithubStatus.vue';
 import ScratchPicker from '../components/ScratchPicker.vue';
 import { timeAgo } from '../lib/time';
-import { effectiveAttention, idleTag, lifecycleDot, messageOf, quietTags, signalChips } from '../lib/sessionState';
+import { effectiveAttention, idleTag, lifecycleDot, messageOf, priorityRank, quietTags, signalChips } from '../lib/sessionState';
 import { useFleet } from '../lib/sessionsStore';
 import { del } from '../api';
 
@@ -120,17 +120,18 @@ const treeRows = computed<TreeRow[]>(() => {
       roots.push(s);
     }
   }
-  // Attention rank for a single session: blocked is louder than attention is
-  // louder than ok. Used to float urgent threads to the top. Uses the resolved
-  // signal (agent's own report or a non-stale overlooker mark) so a triaged
-  // thread floats too — matching visibleSessions/counts above.
-  const rankOf = (s: Session): number => {
-    const lvl = effectiveAttention(s).level;
-    return lvl === 'blocked' ? 2 : lvl === 'attention' ? 1 : 0;
-  };
-  // Memoized max attention rank across a session's whole subtree (itself + all
-  // descendants), so a thread surfaces at the urgency of its loudest member.
-  // The cycle guard mirrors walk()'s: a parent link loop can't spin us forever.
+  // Render rank for a single session: blocked is louder than attention is louder
+  // than the calm default, and a parked row (waiting on an external reviewer —
+  // nothing for the user to do) sinks below it. Used to float urgent threads to
+  // the top and sink parked ones to the bottom. Uses the resolved signal (agent's
+  // own report or a non-stale overlooker mark) so a triaged thread floats too —
+  // matching visibleSessions/counts above.
+  const rankOf = (s: Session): number => priorityRank(s);
+  // Memoized max render rank across a session's whole subtree (itself + all
+  // descendants), so a thread surfaces at the urgency of its loudest member — and
+  // a parked parent with live (rank-0) children stays at the calm default rather
+  // than sinking the whole thread. The cycle guard mirrors walk()'s: a parent
+  // link loop can't spin us forever.
   const rankCache = new Map<string, number>();
   const ranking = new Set<string>();
   const subtreeRank = (s: Session): number => {

--- a/crates/loom/overlookers/review_wait.py
+++ b/crates/loom/overlookers/review_wait.py
@@ -1,0 +1,111 @@
+"""review-wait — park sessions waiting on an external human PR reviewer.
+
+When a session's pull request is open, not a draft, and needs a review that
+hasn't landed yet (GitHub ``review_decision == REVIEW_REQUIRED``), the ball is
+in the reviewer's court: there is nothing for the user to do. This watch marks
+such a session with a quiet ``awaiting: review`` tag, which both *labels* it
+(so a scanning user reads "awaiting review, no action mine") and *parks* it
+below the calm default in the fleet sort — its value sits on weaver's parked
+ladder (:data:`weaver_loom.PARKED_VALUES`), the quiet mirror of the loud
+attention ladder. The moment review lands (approved or changes requested), the
+PR merges, or the draft flag flips, the session may need someone again, so the
+mark is cleared and the row returns to its normal slot.
+
+The mark is the watch's own axis key (``awaiting``), distinct from the status
+watch's loud ``review`` mark ("ready for *you* to look at"), so the two never
+collide: a parked external-review wait and a "ready to review" nudge are
+different states. Reconciles on each PR transition it subscribes to, so the
+mark always reflects the current review state. Read-only without ``mark``
+(reports what it would park / un-park); honours ``dry_run`` likewise.
+
+Subscribes to the PR transitions that can start or end a review wait — the
+review decision changing (the core edge), a PR opening already needing review,
+and a PR merging (clear the mark) — each handing it just the one branch that
+changed instead of polling the fleet on a timer.
+"""
+
+from weaver_loom import PARKED_VALUES, Round
+
+#: The watch's own axis key. The value is :data:`REVIEW_VALUE`; the pair renders
+#: as a quiet ``awaiting: review`` pill and parks the row.
+AWAITING_KEY = "awaiting"
+
+#: The parked value the mark carries — on weaver's parked ladder, so the row
+#: sinks below the calm default. Sourced from the shared registry so it can't
+#: drift from the core / frontend definition.
+REVIEW_VALUE = "review"
+assert REVIEW_VALUE in PARKED_VALUES  # guards the mirror against drift
+
+#: Wake on the PR transitions that begin or end a review wait. The engine reads
+#: this in register mode.
+TRIGGERS = {"on": ["pr.review_changed", "pr.opened", "pr.merged"]}
+
+
+def waiting_for_review(github):
+    """Whether this PR is parked on an external reviewer: open, not a draft, and
+    review required but not yet given. A merged/closed PR, a draft, or a decided
+    review (approved / changes requested) is *not* waiting — the user may have
+    something to do."""
+    return (
+        github.get("pr_state") == "OPEN"
+        and not github.get("is_draft")
+        and github.get("review_decision") == "REVIEW_REQUIRED"
+    )
+
+
+def has_own_mark(session, name):
+    """Whether THIS watch's parked review mark is already on ``session`` — its
+    own ``(awaiting, review)`` tag, authored by this watch. Reconciles only its
+    own marks (never a human's manual tag of the same key), mirroring the status
+    watch's ownership rule."""
+    return any(
+        tag.get("key") == AWAITING_KEY
+        and tag.get("value") == REVIEW_VALUE
+        and tag.get("set_by") == name
+        for tag in (session.get("branch") or {}).get("tags") or []
+    )
+
+
+def main(rnd):
+    can_mark = rnd.can("mark")
+    parked = 0
+    cleared = 0
+
+    # Reactive on a PR transition: act on just the branch that changed. A manual
+    # run (no trigger branch) falls back to the whole scoped fleet, reconciling
+    # every session's review-wait mark in one pass.
+    for session in rnd.triggered_sessions():
+        sid = session["id"]
+        github = (session.get("branch") or {}).get("github") or {}
+        marked = has_own_mark(session, rnd.name)
+
+        if waiting_for_review(github):
+            if marked:
+                continue  # already parked — idempotent, no redundant write
+            pr = github.get("pr_number")
+            note = f"PR #{pr} review required — waiting on an external reviewer"
+            parked += 1
+            if can_mark and not rnd.dry_run:
+                rnd.client.set_tag(sid, AWAITING_KEY, REVIEW_VALUE, note, by=rnd.name)
+                rnd.did("park", session=sid, key=AWAITING_KEY, value=REVIEW_VALUE, note=note)
+            else:
+                rnd.would("park", session=sid, key=AWAITING_KEY, value=REVIEW_VALUE, note=note)
+        elif marked:
+            # No longer waiting (review landed, the PR merged, or it un-drafted):
+            # un-park so the row returns to its normal slot.
+            cleared += 1
+            if can_mark and not rnd.dry_run:
+                rnd.client.clear_tag(sid, AWAITING_KEY, by=rnd.name)
+                rnd.did("unpark", session=sid, key=AWAITING_KEY)
+            else:
+                rnd.would("unpark", session=sid, key=AWAITING_KEY)
+
+    if rnd.dry_run or not can_mark:
+        summary = f"surveyed {rnd.surveyed}, would park {parked}, would clear {cleared}"
+    else:
+        summary = f"surveyed {rnd.surveyed}, parked {parked}, cleared {cleared}"
+    rnd.finish(summary)
+
+
+if __name__ == "__main__":
+    Round.main(main, TRIGGERS)

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -90,6 +90,25 @@ pub const BUILTINS: &[BuiltinProgram] = &[
         default_capabilities: &["observe"],
     },
     BuiltinProgram {
+        name: "review-wait",
+        title: "Review wait",
+        description: "Park sessions waiting on an external human PR reviewer. \
+                      When a session's pull request is open, not a draft, and \
+                      needs a review that hasn't landed yet (GitHub \
+                      review_decision REVIEW_REQUIRED), the ball is in the \
+                      reviewer's court — nothing for the user to do. It stamps a \
+                      quiet `awaiting: review` tag that both labels the session \
+                      and sinks it below the calm default in the fleet sort, so \
+                      a scanning user skips past it. Clears the mark the moment \
+                      review lands, the PR merges, or the draft flag flips. \
+                      Needs `mark` to park / un-park.",
+        source: include_str!("../overlookers/review_wait.py"),
+        default_trigger: r#"{"on":["pr.review_changed","pr.opened","pr.merged"]}"#,
+        default_scope: "{}",
+        default_params: "{}",
+        default_capabilities: &["observe", "mark"],
+    },
+    BuiltinProgram {
         name: "archive-merged",
         title: "Archive merged",
         description: "Flag live sessions whose pull request has merged — \

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -884,10 +884,27 @@ async fn rest_lists_builtin_programs_and_validates_program_refs() {
         "builtin:status",
         "builtin:resume",
         "builtin:pr-label",
+        "builtin:review-wait",
         "builtin:archive-merged",
     ] {
         assert!(names.contains(&expected), "{expected} missing: {names:?}");
     }
+
+    // review-wait wakes on the review-decision edge and opts into `mark` so it
+    // can park / un-park the row (the others here are read-only).
+    let review = arr
+        .iter()
+        .find(|p| p["program"] == "builtin:review-wait")
+        .unwrap();
+    assert_eq!(review["defaults"]["trigger"]["on"][0], "pr.review_changed");
+    assert!(
+        review["defaults"]["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c == "mark"),
+        "review-wait requests the mark capability to park the row"
+    );
 
     // The resume builtin wakes on the quiet signals and opts into `nudge`.
     let resume = arr
@@ -1056,6 +1073,85 @@ async fn builtin_scripts_report_merged_and_unlabelled_prs() {
             .await
             .unwrap();
     }
+}
+
+/// review-wait end to end: the embedded script runs as a real `python3`
+/// subprocess against the live server and *mutates* — it parks a session whose
+/// PR awaits an external review (`REVIEW_REQUIRED`) with the quiet
+/// `awaiting: review` mark, and un-parks it once the review lands. Proves the
+/// wiring (script → REST → tag, attributed) and the park/un-park reconcile that
+/// pytest covers in isolation.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn review_wait_parks_and_unparks_a_session_awaiting_review() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
+    let ts = TestServer::start().await;
+    let state = engine_state(&ts).await;
+    let (sid, branch, _repo) = make_session(&ts, "review me").await;
+
+    // A PR open and awaiting an external review.
+    let mut snap = pr_snapshot("OPEN", 7);
+    snap.review_decision = Some("REVIEW_REQUIRED".to_string());
+    loom::github::upsert_status(&state.db, &branch, &snap)
+        .await
+        .unwrap();
+
+    enabled_overlooker(
+        &state,
+        ov::NewOverlooker {
+            name: "review-wait".to_string(),
+            program: "builtin:review-wait".to_string(),
+            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Park: the round stamps `awaiting: review`, attributed to the watch.
+    overlooker::fire_now(&state, "review-wait", false, "manual")
+        .await
+        .unwrap();
+    let view = ts
+        .client
+        .get(&format!("/api/sessions/{sid}"))
+        .await
+        .unwrap();
+    assert_eq!(
+        branch_tag_value(&view, "awaiting"),
+        "review",
+        "the session awaiting review is parked"
+    );
+    assert_eq!(
+        branch_tag(&view, "awaiting").unwrap()["set_by"],
+        "review-wait",
+        "the parked mark carries the watch's attribution"
+    );
+
+    // Review lands → un-park: the next round clears the watch's own mark.
+    snap.review_decision = Some("APPROVED".to_string());
+    loom::github::upsert_status(&state.db, &branch, &snap)
+        .await
+        .unwrap();
+    overlooker::fire_now(&state, "review-wait", false, "manual")
+        .await
+        .unwrap();
+    let view = ts
+        .client
+        .get(&format!("/api/sessions/{sid}"))
+        .await
+        .unwrap();
+    assert!(
+        branch_tag(&view, "awaiting").is_none(),
+        "the session is un-parked once the review lands"
+    );
+
+    ts.client
+        .delete(&format!("/api/sessions/{sid}"))
+        .await
+        .unwrap();
 }
 
 /// The LLM judgement path end to end: the status script calls the daemon's

--- a/crates/weaver-core/src/tags.rs
+++ b/crates/weaver-core/src/tags.rs
@@ -100,6 +100,26 @@ pub fn is_loud_value(value: &str) -> bool {
     ATTENTION_VALUES.contains(&value)
 }
 
+/// The quiet values that **park** a branch *below* the calm default in the
+/// dashboard's fleet sort — the opposite end of the ladder from
+/// [`ATTENTION_VALUES`]. A parked branch is waiting on an external actor (a human
+/// PR reviewer, a CI run) and needs nothing from the user, so a scanning user can
+/// skip past it: the dashboard sinks it under the live-but-calm rows it should
+/// look at first. The value names *what is awaited* (`review`, …); the key is the
+/// axis (e.g. the review watch's `awaiting`). Quiet by design — these never raise
+/// a badge — so a parked row renders as a plain pill, never a loud chip.
+/// Mirrored by the frontend's `PARKED` map and `weaver_loom.PARKED_VALUES`.
+pub const PARKED_VALUES: &[&str] = &["review"];
+
+/// Whether `value` parks a branch — i.e. it sits on the [`PARKED_VALUES`] ladder,
+/// sinking the row below the calm default in the fleet sort. Like
+/// [`is_loud_value`], the signal is **value-driven**: any key holding such a
+/// value parks, so a watch picks its own axis key and the value carries the
+/// meaning. A value is never both parked and loud (the two ladders are disjoint).
+pub fn is_parked_value(value: &str) -> bool {
+    PARKED_VALUES.contains(&value)
+}
+
 // ---------------------------------------------------------------------------
 // CRUD
 // ---------------------------------------------------------------------------
@@ -206,6 +226,23 @@ mod tests {
         assert!(!is_loud_value("ok"));
         // A free-form key may legitimately carry a loud value (the watch's marks).
         assert!(is_valid_value("review", "attention"));
+
+        // Parking is the value-driven mirror of loudness: a parked value sinks
+        // the row below the calm default, and the two ladders are disjoint (a
+        // value is never both). Parked values are quiet — never loud.
+        assert!(is_parked_value("review"));
+        assert!(!is_parked_value("attention"));
+        assert!(!is_parked_value("waiting"));
+        assert!(!is_loud_value("review"));
+        for v in PARKED_VALUES {
+            assert!(
+                !ATTENTION_VALUES.contains(v),
+                "ladders must stay disjoint: {v}"
+            );
+            assert!(!is_loud_value(v));
+        }
+        // A parked mark stores fine on a free-form axis key (any non-empty value).
+        assert!(is_valid_value("awaiting", "review"));
     }
 
     #[tokio::test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,7 +225,13 @@ top-level (`id`, `status`, `work_dir`, `term_session`, `agent_kind`, `model`,
 `(key, value)` annotation on a branch; the well-known keys are `attention` (the
 agent's self-report) and `triage` (an overlooker's assessment), and any other
 key is a free-form, quiet pill. Absence of a key is the calm/default state —
-there is no stored `ok` value; the list is empty for an unmarked branch.
+there is no stored `ok` value; the list is empty for an unmarked branch. The
+signal is **value-driven**, with a ladder on either side of calm: a value on the
+attention ladder (`attention`/`blocked`) raises the branch on the dashboard
+whatever its key, while a value on the *parked* ladder (`review` — the review
+watch's `awaiting: review` mark) sinks it *below* the calm default in the fleet
+sort, the quiet "waiting on an external actor, nothing for the user to do" end of
+the spectrum (`weaver_core::tags::{ATTENTION_VALUES, PARKED_VALUES}`).
 
 `SessionView::parent_id` is the branch id of the session that **launched** this
 one — the parent in loom's session tree — or `null` for a top-level session. It
@@ -523,10 +529,14 @@ A round runs the **program** the overlooker names:
   `builtin:status` (stamp a `triage` mark on each in-scope session, judging
   via the configured `prompt` through the daemon's one-shot agent when
   available, else mirroring the agent's own `attention` tag),
-  `builtin:pr-label` (flag sessions whose open PR lacks the loom label) and
-  `builtin:archive-merged` (flag live sessions whose PR has merged). The last
-  two are **read-only**: they record `would:` actions and mutate nothing — the
-  actual archive is still `github.archive_on_merge`, above. The Overlooker
+  `builtin:review-wait` (park a session whose open, non-draft PR awaits an
+  external review — `review_decision` `REVIEW_REQUIRED` — under a quiet
+  `awaiting: review` mark that sinks it below the calm default in the fleet
+  sort, and clear it once review lands, the PR merges, or it un-drafts; needs
+  `mark`), `builtin:pr-label` (flag sessions whose open PR lacks the loom label)
+  and `builtin:archive-merged` (flag live sessions whose PR has merged). The
+  last two are **read-only**: they record `would:` actions and mutate nothing —
+  the actual archive is still `github.archive_on_merge`, above. The Overlooker
   panel and `loom overlooker programs` list the registry; script sources
   render read-only (they ship with the binary).
 - **A custom program file** — an absolute path, conventionally

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -136,6 +136,42 @@ test.describe('session list view', () => {
     expect(updated.branch.tags.find((t) => t.key === 'priority')).toBeUndefined();
   });
 
+  test('a session awaiting external review is parked below the calm default', async ({
+    page,
+    weaver,
+  }) => {
+    // Three sessions, created oldest→newest: a parked one (its PR awaits an
+    // external reviewer), a plainly-calm one, and one the agent raised. The
+    // review watch parks the first by stamping the quiet `awaiting: review` mark.
+    const parked = await weaver.seedSession({ goal: 'Awaiting review', name: 'parked-low' });
+    const calm = await weaver.seedSession({ goal: 'Quietly working', name: 'calm-mid' });
+    const attn = await weaver.seedSession({ goal: 'Needs a decision', name: 'top-attn' });
+    await weaver.setTag(parked, 'awaiting', 'review', {
+      note: 'PR #7 review required — waiting on an external reviewer',
+      by: 'review-wait',
+    });
+    await weaver.setStatus(attn, 'attention', 'which approach?');
+
+    await page.goto(weaver.baseUrl);
+
+    // Sort order top→bottom: the raised row floats up, the parked row sinks below
+    // the calm default — so a scanning user meets what needs them first and the
+    // "nothing to do, waiting on a reviewer" row last.
+    const ids = await page
+      .getByTestId('session-card')
+      .evaluateAll((els) => els.map((e) => e.getAttribute('data-session-id')));
+    expect(ids).toEqual([attn.id, calm.id, parked.id]);
+
+    // The parked row carries the quiet `awaiting: review` pill (no loud chip) and
+    // does not count toward "needs attention" — the user has no action there.
+    const card = page.locator(`[data-session-id="${parked.id}"]`);
+    const pill = card.getByTestId('tag-pill');
+    await expect(pill).toContainText('awaiting');
+    await expect(pill).toContainText('review');
+    await expect(card.getByTestId('signal-chip')).toHaveCount(0);
+    await expect(page.getByTestId('filter-attention')).toContainText('1');
+  });
+
   test('clicking a card navigates to the detail view', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Navigate to me', name: 'nav-task' });
 

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -79,6 +79,15 @@ LOUD_VALUES = ("attention", "blocked")
 IDLE_KEY = "idle"
 IDLE_VALUE = "idle"
 
+#: The quiet values that **park** a session *below* the calm default in the
+#: dashboard's fleet sort — the opposite end of the ladder from
+#: :data:`LOUD_VALUES`. A parked session is waiting on an external actor (a human
+#: PR reviewer, …) and needs nothing from the user, so a scanning user skips past
+#: it. The value names what is awaited (``review``, …); a watch picks its own axis
+#: key and the value carries the meaning. Quiet by design — never a badge.
+#: Mirrors weaver-core's ``PARKED_VALUES``.
+PARKED_VALUES = ("review",)
+
 
 def parse_judgement(text):
     """Parse an agent judgement into ``(level, note)``, or ``None``.

--- a/python/weaver-loom/tests/test_review_wait_program.py
+++ b/python/weaver-loom/tests/test_review_wait_program.py
@@ -1,0 +1,225 @@
+"""The builtin review-wait program's decision logic, with no server required.
+
+Loads `crates/loom/overlookers/review_wait.py` straight from the repo and drives
+it with a stubbed client: the waiting-for-review predicate (open + not draft +
+REVIEW_REQUIRED), the park / un-park reconcile, ownership (it touches only its
+own marks), the capability + dry-run branches, and the summary all live here.
+The Rust integration suite keeps only the wiring proof — that the script runs
+under the engine against a live loom and its writes land attributed.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+from weaver_loom import PARKED_VALUES, Round
+
+OVERLOOKERS = Path(__file__).resolve().parents[3] / "crates" / "loom" / "overlookers"
+
+
+def load_program(name):
+    spec = importlib.util.spec_from_file_location(name, OVERLOOKERS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+review_wait = load_program("review_wait")
+
+NAME = "review-wait"
+
+
+class StubClient:
+    """The slice of Client the review-wait program touches, scripted per test."""
+
+    def __init__(self, capabilities=None, sessions=None):
+        self.capabilities = capabilities or []
+        self._sessions = sessions or []
+        self.calls = []
+
+    def can(self, cap):
+        return cap == "observe" or cap in self.capabilities
+
+    def sessions(self):
+        return self._sessions
+
+    def set_tag(self, key, tag_key, value, note="", by=None):
+        self.calls.append(("set_tag", key, tag_key, value, note, by))
+
+    def clear_tag(self, key, tag_key, by=None):
+        self.calls.append(("clear_tag", key, tag_key, by))
+
+
+def session(id, *, pr_state="OPEN", draft=False, review=None, pr=42,
+            marked_by=None, has_pr=True, status="running"):
+    """A session dict with an optional PR snapshot and an optional pre-existing
+    `awaiting: review` mark (attributed to `marked_by` — NAME for the watch's own
+    mark, anything else for a foreign/manual one)."""
+    branch = {"tags": [], "repo_root": "/r"}
+    if marked_by:
+        branch["tags"].append({"key": "awaiting", "value": "review", "set_by": marked_by})
+    if has_pr:
+        branch["github"] = {
+            "pr_state": pr_state, "is_draft": draft,
+            "review_decision": review, "pr_number": pr,
+        }
+    return {"id": id, "status": status, "branch": branch}
+
+
+def make_round(client, **config):
+    return Round(config={"name": NAME, **config}, client=client)
+
+
+def run_main(client, capsys, **config):
+    rnd = make_round(client, capabilities=client.capabilities, **config)
+    review_wait.main(rnd)
+    return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+
+
+def sets(client):
+    return [c for c in client.calls if c[0] == "set_tag"]
+
+
+def clears(client):
+    return [c for c in client.calls if c[0] == "clear_tag"]
+
+
+# -- the registry mirror -------------------------------------------------------
+
+
+def test_parked_value_is_drawn_from_the_shared_registry():
+    # The mark's value must stay on weaver's parked ladder, or the row wouldn't
+    # sink — the module asserts this at import, this pins it explicitly.
+    assert review_wait.REVIEW_VALUE in PARKED_VALUES
+
+
+# -- waiting_for_review predicate ----------------------------------------------
+
+
+def test_waiting_predicate_only_an_open_non_draft_review_required_pr():
+    waiting = review_wait.waiting_for_review
+    assert waiting({"pr_state": "OPEN", "is_draft": False, "review_decision": "REVIEW_REQUIRED"})
+    # Decided reviews, drafts, merged/closed PRs, and no PR are all NOT waiting.
+    assert not waiting({"pr_state": "OPEN", "is_draft": False, "review_decision": "APPROVED"})
+    assert not waiting({"pr_state": "OPEN", "is_draft": False, "review_decision": "CHANGES_REQUESTED"})
+    assert not waiting({"pr_state": "OPEN", "is_draft": True, "review_decision": "REVIEW_REQUIRED"})
+    assert not waiting({"pr_state": "MERGED", "is_draft": False, "review_decision": "REVIEW_REQUIRED"})
+    assert not waiting({"pr_state": "OPEN", "is_draft": False, "review_decision": None})
+    assert not waiting({})
+
+
+# -- main: park, idempotency, un-park ------------------------------------------
+
+
+def test_parks_a_session_awaiting_external_review(capsys):
+    client = StubClient(
+        capabilities=["mark"],
+        sessions=[session("s", review="REVIEW_REQUIRED", pr=7)],
+    )
+    result = run_main(client, capsys)
+    note = "PR #7 review required — waiting on an external reviewer"
+    assert ("set_tag", "s", "awaiting", "review", note, NAME) in client.calls
+    assert clears(client) == []
+    assert {"action": "park", "session": "s", "key": "awaiting",
+            "value": "review", "note": note} in result["actions"]
+    assert result["outcome"] == "ok"
+    assert result["summary"] == "surveyed 1, parked 1, cleared 0"
+
+
+def test_already_parked_is_idempotent(capsys):
+    # Its own mark is already present and the session is still waiting → no write.
+    client = StubClient(
+        capabilities=["mark"],
+        sessions=[session("s", review="REVIEW_REQUIRED", marked_by=NAME)],
+    )
+    result = run_main(client, capsys)
+    assert sets(client) == [] and clears(client) == []
+    assert result == {"outcome": "noop",
+                      "summary": "surveyed 1, parked 0, cleared 0", "actions": []}
+
+
+def test_unparks_once_review_lands(capsys):
+    # It parked earlier; the review came back approved → clear the mark.
+    client = StubClient(
+        capabilities=["mark"],
+        sessions=[session("s", review="APPROVED", marked_by=NAME)],
+    )
+    result = run_main(client, capsys)
+    assert ("clear_tag", "s", "awaiting", NAME) in client.calls
+    assert sets(client) == []
+    assert {"action": "unpark", "session": "s", "key": "awaiting"} in result["actions"]
+    assert result["summary"] == "surveyed 1, parked 0, cleared 1"
+
+
+def test_unparks_on_merge(capsys):
+    client = StubClient(
+        capabilities=["mark"],
+        sessions=[session("s", pr_state="MERGED", marked_by=NAME)],
+    )
+    run_main(client, capsys)
+    assert ("clear_tag", "s", "awaiting", NAME) in client.calls
+
+
+def test_changes_requested_is_not_parked(capsys):
+    # The agent has work to do — never park, and nothing to clear when unmarked.
+    client = StubClient(
+        capabilities=["mark"],
+        sessions=[session("s", review="CHANGES_REQUESTED")],
+    )
+    result = run_main(client, capsys)
+    assert sets(client) == [] and clears(client) == []
+    assert result["outcome"] == "noop"
+
+
+def test_session_without_a_pr_is_a_noop(capsys):
+    client = StubClient(capabilities=["mark"], sessions=[session("s", has_pr=False)])
+    result = run_main(client, capsys)
+    assert sets(client) == [] and clears(client) == []
+    assert result["outcome"] == "noop"
+
+
+# -- ownership: never touch a foreign mark -------------------------------------
+
+
+def test_leaves_a_foreign_awaiting_mark_untouched(capsys):
+    # A human manually set `awaiting: review`; the session is no longer waiting.
+    # The watch reconciles only its OWN marks, so it must not clear this one.
+    client = StubClient(
+        capabilities=["mark"],
+        sessions=[session("s", review="APPROVED", marked_by="manual")],
+    )
+    result = run_main(client, capsys)
+    assert clears(client) == []
+    assert result["outcome"] == "noop"
+
+
+# -- capabilities + dry-run ----------------------------------------------------
+
+
+def test_without_mark_capability_only_reports_would(capsys):
+    client = StubClient(sessions=[session("s", review="REVIEW_REQUIRED")])
+    result = run_main(client, capsys)
+    assert sets(client) == [] and clears(client) == []
+    assert result["actions"][0]["would"] == "park"
+    assert result["summary"] == "surveyed 1, would park 1, would clear 0"
+
+
+def test_dry_run_records_would_and_mutates_nothing(capsys):
+    client = StubClient(
+        capabilities=["mark"],
+        sessions=[
+            session("a", review="REVIEW_REQUIRED"),
+            session("b", review="APPROVED", marked_by=NAME),
+        ],
+    )
+    result = run_main(client, capsys, dry_run=True)
+    assert sets(client) == [] and clears(client) == []
+    woulds = {(a["would"], a["session"]) for a in result["actions"]}
+    assert woulds == {("park", "a"), ("unpark", "b")}
+    assert result["summary"] == "surveyed 2, would park 1, would clear 1"
+
+
+def test_empty_survey_is_a_noop(capsys):
+    result = run_main(StubClient(capabilities=["mark"]), capsys)
+    assert result == {"outcome": "noop",
+                      "summary": "surveyed 0, parked 0, cleared 0", "actions": []}


### PR DESCRIPTION
## Why

When a session's PR is open and **waiting on an external human reviewer**, there's nothing for the user to do — the ball is in the reviewer's court. But such a session looks the same as any other live row on the dashboard, so a scanning user can't tell it apart from work that needs them.

This makes that state legible at a glance: it **bumps the row's display priority down** and **tags it**, so a scanning user skips past it.

## What

A general render-priority mechanism, plus the watch that uses it for review-waits:

- **A value-driven *parked* ladder** — the quiet mirror of the existing loud `attention`/`blocked` ladder. A tag whose value sits on `PARKED_VALUES` (`review`) sinks its row *below* the calm default in the fleet sort instead of raising it above. Defined once in `weaver-core` (`is_parked_value`) and mirrored into `weaver_loom` (Python) and the frontend, exactly like the loudness ladder.
- **`builtin:review-wait`** — when a session's PR is open, non-draft, and GitHub's `review_decision == REVIEW_REQUIRED`, it stamps a quiet `awaiting: review` mark; it clears the mark the moment review lands, the PR merges, or it un-drafts. Reconciles on `pr.review_changed` / `pr.opened` / `pr.merged`, touches only its own marks, and is gated on the `mark` capability. It's an opt-in builtin (enable with `loom overlooker add review-wait --capabilities observe,mark` then `enable`, or from the Overlooker panel), consistent with the other builtins.
- **The sort** — `SessionList` ranks by `priorityRank` (parked = -1, below the calm 0). A parked *parent* with live children stays put (subtree max); only a wholly-parked thread sinks.

The `awaiting: review` mark uses its own axis key (distinct from the status watch's loud `review` mark), so a parked external-review wait and a "ready for *you* to look at" nudge never collide.

## Screenshot

Fleet list with one of each: raised (loud amber chip) floats to the top, calm in the middle, the parked `awaiting: review` row (quiet pill) sinks to the bottom.

## Tests

- pytest decision-logic suite for the watch (predicate, park/un-park reconcile, ownership, capability + dry-run); full `weaver_loom` suite green
- Rust: core unit (`is_parked_value`, ladder-disjointness), builtins registry/compile, and a new **end-to-end integration test** that runs the script under the engine and asserts it parks then un-parks a real session
- frontend `tsc --noEmit` clean; `cargo clippy -D warnings` clean
- a permanent e2e check asserting the parked row sinks and carries the quiet pill

Closes weaver issue #324.