### PR TITLE
feat(loom): html artifacts + instant artifacts tab with a pop-out rail

### DIFF
--- a/crates/loom/frontend/src/App.vue
+++ b/crates/loom/frontend/src/App.vue
@@ -27,9 +27,8 @@ watch(authed, (ok) => (ok ? startFleetPoll() : stopFleetPoll()), { immediate: tr
 // Views kept alive across navigation so returning is instant — no remount, no
 // refetch flash, no entrance-animation replay. The list views return exactly as
 // left (scroll, filter, the open create form); the session detail page returns
-// to its warm terminal (scrollback intact, no reconnect) after the Artifacts
-// round-trip. Artifacts/Chat are NOT cached — Monaco is heavy and shouldn't
-// stay resident, and Chat is cheap to remount.
+// to its warm terminal (scrollback intact, no reconnect). Chat is NOT cached —
+// it is cheap to remount.
 const CACHED_VIEWS = ['SessionList', 'Issues', 'Overlookers', 'SessionDetail'];
 
 // Cache key per cached instance. List views are singletons (keyed by their
@@ -48,8 +47,11 @@ const CACHED_VIEWS = ['SessionList', 'Issues', 'Overlookers', 'SessionDetail'];
 // to bound the detail terminals.
 const KEEP_ALIVE_MAX = 3;
 function cacheKey(route: { path: string; params: Record<string, string | string[]> }): string {
+  // Every `/s/:id…` path (the work tabs and the Artifacts deep-links) is the
+  // same SessionDetail instance, so they share one cache key — switching to
+  // artifacts and back is a tab flip on the warm page, never a remount.
   const id = route.params.id;
-  if (typeof id === 'string' && route.path === `/s/${id}`) return `s:${id}`;
+  if (typeof id === 'string' && route.path.startsWith(`/s/${id}`)) return `s:${id}`;
   return route.path;
 }
 </script>

--- a/crates/loom/frontend/src/components/ArtifactsPanel.vue
+++ b/crates/loom/frontend/src/components/ArtifactsPanel.vue
@@ -1,47 +1,53 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
+import { ref, computed, watch, onMounted, onActivated, onDeactivated, onUnmounted, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import type * as Monaco from 'monaco-editor';
-import { get, getArtifacts, getArtifact, putArtifact, deleteArtifact } from '../api';
-import type { Session, ArtifactMeta, ArtifactView } from '../types';
+import { getArtifacts, getArtifact, putArtifact, deleteArtifact } from '../api';
+import type { ArtifactMeta, ArtifactView } from '../types';
 import { theme } from '../theme';
 import { loadMonaco, monacoTheme, languageForPath } from '../monaco';
-import SessionTabs from '../components/SessionTabs.vue';
-import SessionPageHeader from '../components/SessionPageHeader.vue';
-import MarkdownView from '../components/MarkdownView.vue';
+import MarkdownView from './MarkdownView.vue';
+import HtmlArtifactView from './HtmlArtifactView.vue';
 
-// The Artifacts surface: the agent's out-of-repo documents (designs, reports,
-// the `plan`), each named, scoped (branch vs repo-shared), and versioned by
-// immutable snapshot. A list on the left, a viewer on the right with a version
-// picker and the file browser's proven preview ⇄ Monaco edit toggle — saving an
-// edit appends a new revision (`author: user`) via `putArtifact`. Deep-linkable
-// at `/s/:id/artifacts/:name`; `artifact_written` over SSE refreshes the list
-// and the open viewer. Markdown artifacts render through `MarkdownView` (GFM +
-// mermaid + the smartdoc projection: `#N` refs become live status chips).
-const props = defineProps<{ id: string; name?: string }>();
+// The artifacts surface, as a self-contained panel: a list of the agent's
+// out-of-repo documents (designs, reports, the `plan`) on the left, a viewer on
+// the right with a version picker and the file browser's proven preview ⇄ Monaco
+// edit toggle — saving an edit appends a new revision (`author: user`). Markdown
+// renders through `MarkdownView` (GFM + mermaid + the smartdoc `#N` chips); an
+// `html` artifact renders as a live document in a sandboxed iframe.
+//
+// The host (SessionDetail) places this either as a full-width work-area tab or,
+// when popped out, in a resizable rail beside the live terminal — `compact`
+// collapses the list into a dropdown so the viewer keeps its width in the rail.
+// Deep-linkable at `/s/:id/artifacts/:name`; `artifact_written` over SSE
+// refreshes the list and the open viewer.
+const props = defineProps<{
+  id: string;
+  /** Deep-linked artifact name to open (from the route). */
+  name?: string;
+  /** Narrow-rail layout: the list becomes a dropdown above the viewer. */
+  compact?: boolean;
+  /** Whether the panel is currently docked-out in the rail (drives the toggle). */
+  popped?: boolean;
+  /** Whether the surface is the one on screen. Kept mounted but hidden (so a
+   *  re-open is instant), the panel must not own the route or re-render the
+   *  viewer while it is off-screen — `active = false` makes opens silent and
+   *  defers a live refresh until it is shown again. Absent ⇒ treated as active
+   *  (standalone use). */
+  active?: boolean;
+}>();
+const emit = defineEmits<{ togglePop: []; close: [] }>();
+
 const router = useRouter();
 
-// Selecting a work-area tab returns to the session page, carrying which tab so
-// Overview lands on Overview (Terminal is the default).
-function selectTab(t: 'terminal' | 'overview' | 'conversation') {
-  router.push(t === 'terminal' ? `/s/${props.id}` : `/s/${props.id}?tab=${t}`);
-}
-
-const session = ref<Session | null>(null);
 const list = ref<ArtifactMeta[]>([]);
 const listError = ref('');
 const selected = ref<string>('');
 
-// A header write (rename / acknowledge / archive / adopt) happened — re-fetch
-// the session so the shared header reflects it, and refresh the list.
-async function reloadSession() {
-  try {
-    session.value = (await get(`/sessions/${props.id}`)) as Session;
-  } catch {
-    // Best-effort — the list is the point of this view.
-  }
-  await loadList();
-}
+// True once we're the visible surface. Default-on so the panel works standalone.
+const isActive = computed(() => props.active !== false);
+// An SSE write landed while we were hidden — refresh the open view on return.
+const pendingRefresh = ref(false);
 
 async function loadList() {
   try {
@@ -62,13 +68,19 @@ const editing = ref(false);
 const saving = ref(false);
 const removing = ref(false);
 
-// Markdown gets the rendered Preview; other kinds show source in Monaco.
-const isMarkdown = computed(() => (view.value?.meta.kind ?? 'markdown') === 'markdown');
-// The pseudo-path that drives Monaco's language + the markdown image base. The
+const kind = computed(() => view.value?.meta.kind ?? 'markdown');
+const isMarkdown = computed(() => kind.value === 'markdown');
+const isHtml = computed(() => kind.value === 'html');
+// Markdown and HTML both have a rendered Preview ⇄ Source toggle; every other
+// kind is shown as read-only source only.
+const isRenderable = computed(() => isMarkdown.value || isHtml.value);
+// The pseudo-path drives Monaco's language and the markdown image base. The
 // artifact name carries no extension, so stamp one on from the kind.
 const pseudoPath = computed(() => {
   const name = view.value?.meta.name ?? selected.value;
-  return isMarkdown.value ? `${name}.md` : name;
+  if (isMarkdown.value) return `${name}.md`;
+  if (isHtml.value) return `${name}.html`;
+  return name;
 });
 
 type ViewMode = 'preview' | 'source';
@@ -106,19 +118,24 @@ async function mountEditor(content: string, readOnly: boolean) {
   monaco.editor.setTheme(monacoTheme(theme.value === 'dark'));
 }
 
-// Load an artifact (optionally a specific revision) into the viewer.
-async function openArtifact(name: string, rev?: number) {
+// Load an artifact (optionally a specific revision) into the viewer. `keepMode`
+// refreshes content without resetting the preview/source choice — for a live
+// re-fetch (an SSE write to the open artifact), where snapping back to Preview
+// would yank the reader out of a Source view they were reading.
+async function openArtifact(name: string, rev?: number, opts?: { keepMode?: boolean }) {
   selected.value = name;
   viewRev.value = rev ?? null;
   editing.value = false;
   loading.value = true;
   viewError.value = '';
-  // Keep the URL in step so the view is deep-linkable / refresh-stable.
+  // Keep the URL in step so the view is deep-linkable / refresh-stable — but
+  // only while we're the surface on screen, so a hidden panel (the user moved
+  // back to the terminal) never yanks the route back to artifacts.
   const target = `/s/${props.id}/artifacts/${encodeURIComponent(name)}`;
-  if (router.currentRoute.value.path !== target) router.replace(target);
+  if (isActive.value && router.currentRoute.value.path !== target) router.replace(target);
   try {
     view.value = await getArtifact(props.id, name, rev);
-    viewMode.value = isMarkdown.value ? 'preview' : 'source';
+    if (!opts?.keepMode) viewMode.value = isRenderable.value ? 'preview' : 'source';
     await renderViewer();
   } catch (e) {
     viewError.value = (e as Error).message;
@@ -137,7 +154,7 @@ async function renderViewer() {
     await nextTick();
     await mountEditor(view.value.content, true);
   } else if (!editing.value) {
-    // Preview is the MarkdownView component — drop any Monaco model.
+    // Preview is a render component (markdown / html) — drop any Monaco model.
     teardownEditor();
   }
 }
@@ -154,6 +171,12 @@ function setMode(m: ViewMode) {
 function selectRev(e: Event) {
   const v = (e.target as HTMLSelectElement).value;
   openArtifact(selected.value, v ? Number(v) : undefined);
+}
+
+// The compact list dropdown: switch artifacts from a <select>.
+function selectFromDropdown(e: Event) {
+  const v = (e.target as HTMLSelectElement).value;
+  if (v) openArtifact(v);
 }
 
 const onLatest = computed(
@@ -187,7 +210,7 @@ async function save() {
     view.value = await putArtifact(props.id, selected.value, { content });
     viewRev.value = null;
     editing.value = false;
-    viewMode.value = isMarkdown.value ? 'preview' : 'source';
+    viewMode.value = isRenderable.value ? 'preview' : 'source';
     await loadList();
     await renderViewer();
   } catch (e) {
@@ -244,15 +267,27 @@ function scopeBadge(a: ArtifactMeta): { label: string; title: string } {
 // --- SSE-driven refresh ----------------------------------------------------
 
 let source: EventSource | null = null;
+function closeStream() {
+  source?.close();
+  source = null;
+}
 function openStream() {
+  closeStream();
   source = new EventSource(`/api/sessions/${props.id}/events`);
   source.addEventListener('artifact_written', (e) => {
-    const d = JSON.parse((e as MessageEvent).data).data as { name?: string };
+    const d = JSON.parse((e as MessageEvent).data).data as { name?: string; rev?: number };
     loadList().catch(() => {});
     // If the artifact that just changed is the one we're viewing (and we're not
-    // mid-edit), refresh the viewer to its new latest.
+    // mid-edit), refresh the viewer to its new latest — but only while visible;
+    // hidden, we defer the re-render until the panel is shown again.
     if (d?.name && d.name === selected.value && !editing.value) {
-      openArtifact(selected.value).catch(() => {});
+      // Ignore a replayed/own event we already reflect (the stream replays
+      // recent writes on connect): re-opening would needlessly reset the view —
+      // and snap a reader out of Source back to Preview. Only a genuinely newer
+      // revision refreshes, and it keeps the current preview/source choice.
+      if (d.rev != null && onLatest.value && view.value && d.rev <= view.value.meta.rev) return;
+      if (isActive.value) openArtifact(selected.value, undefined, { keepMode: true }).catch(() => {});
+      else pendingRefresh.value = true;
     }
   });
   source.addEventListener('artifact_deleted', (e) => {
@@ -272,7 +307,7 @@ watch(theme, () => {
   if (editor) loadMonaco().then((m) => m.editor.setTheme(monacoTheme(theme.value === 'dark')));
 });
 
-// A deep-link name change (router navigation within the view) re-opens.
+// A deep-link name change (route navigation from the host) re-opens.
 watch(
   () => props.name,
   (name) => {
@@ -280,39 +315,59 @@ watch(
   },
 );
 
-onMounted(async () => {
-  try {
-    session.value = (await get(`/sessions/${props.id}`)) as Session;
-  } catch {
-    // Header detail is best-effort; the list is the point.
+// On becoming the visible surface again: restore the URL to the open artifact
+// (so it stays deep-linkable) and apply any refresh that landed while hidden.
+watch(isActive, (now) => {
+  if (!now || !selected.value) return;
+  if (pendingRefresh.value) {
+    pendingRefresh.value = false;
+    openArtifact(selected.value, viewRev.value ?? undefined, { keepMode: true }).catch(() => {});
+  } else {
+    const target = `/s/${props.id}/artifacts/${encodeURIComponent(selected.value)}`;
+    if (router.currentRoute.value.path !== target) router.replace(target);
   }
+});
+
+onMounted(async () => {
   await loadList();
   openStream();
   // Open the deep-linked artifact, else the well-known `plan`, else the first.
   const want =
-    props.name ||
-    (list.value.some((a) => a.name === 'plan') ? 'plan' : list.value[0]?.name);
+    props.name || (list.value.some((a) => a.name === 'plan') ? 'plan' : list.value[0]?.name);
   if (want) openArtifact(want);
 });
 
+// The panel rides inside SessionDetail's <keep-alive>. Pause the status SSE
+// while the page is parked (mirroring SessionDetail) so idle EventSources don't
+// stack against the browser's per-origin cap; onMounted owns the first open, so
+// guard the return-open on `source`.
+onActivated(() => {
+  if (source) return;
+  openStream();
+});
+onDeactivated(closeStream);
+
 onUnmounted(() => {
-  source?.close();
+  closeStream();
   teardownEditor();
 });
 </script>
 
 <template>
-  <div class="flex min-h-[28rem] flex-1 flex-col px-5 py-3">
-    <SessionPageHeader v-if="session" :ws="session" @reload="reloadSession" />
-    <SessionTabs :tab="'artifacts'" :id="props.id" :issue-count="0" @select="selectTab" />
+  <div class="flex h-full min-h-0 flex-col rounded border border-line bg-surface overflow-hidden">
+    <p v-if="listError" class="border-b border-line px-3 py-1.5 text-xs text-block">
+      {{ listError }}
+    </p>
 
-    <p v-if="listError" class="mb-3 text-sm text-block">{{ listError }}</p>
-
-    <!-- Two-pane body: artifact list + viewer. -->
-    <div class="flex min-h-0 flex-1 gap-3 rounded border border-line bg-surface overflow-hidden">
-      <!-- List -->
-      <div class="flex w-72 shrink-0 flex-col border-r border-line">
-        <div class="border-b border-line px-2 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint">
+    <div class="flex min-h-0 flex-1" :class="compact ? 'flex-col' : ''">
+      <!-- List — a sidebar at full width, a dropdown in the narrow rail. -->
+      <div
+        v-if="!compact"
+        class="flex w-72 shrink-0 flex-col border-r border-line"
+      >
+        <div
+          class="border-b border-line px-2 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint"
+        >
           Artifacts <span class="text-faint">({{ list.length }})</span>
         </div>
         <div class="min-h-0 flex-1 overflow-auto py-1 text-sm">
@@ -326,10 +381,15 @@ onUnmounted(() => {
             @click="openArtifact(a.name)"
           >
             <span class="flex items-center gap-1.5">
-              <span class="min-w-0 truncate font-mono text-xs" :class="selected === a.name ? 'text-fg' : 'text-muted'">
+              <span
+                class="min-w-0 truncate font-mono text-xs"
+                :class="selected === a.name ? 'text-fg' : 'text-muted'"
+              >
                 {{ a.name }}
               </span>
-              <span class="pill ml-auto shrink-0" :title="scopeBadge(a).title">{{ scopeBadge(a).label }}</span>
+              <span class="pill ml-auto shrink-0" :title="scopeBadge(a).title">{{
+                scopeBadge(a).label
+              }}</span>
               <span class="shrink-0 font-mono text-2xs text-faint">v{{ a.rev }}</span>
             </span>
             <span v-if="a.title" class="truncate text-xs text-faint">{{ a.title }}</span>
@@ -338,6 +398,24 @@ onUnmounted(() => {
             No artifacts yet. Agents write them with <code>weaver artifact write</code>.
           </p>
         </div>
+      </div>
+
+      <!-- Compact list: a dropdown header for the rail. -->
+      <div
+        v-else
+        class="flex shrink-0 items-center gap-2 border-b border-line px-2 py-1.5 text-xs"
+      >
+        <span class="text-faint">Artifact</span>
+        <select
+          class="min-w-0 flex-1 rounded border border-line bg-surface px-1.5 py-0.5 text-xs text-fg"
+          :value="selected"
+          @change="selectFromDropdown"
+        >
+          <option v-if="!list.length" value="">No artifacts yet</option>
+          <option v-for="a in list" :key="a.id" :value="a.name">
+            {{ a.name }}{{ a.branch_id == null ? ' · shared' : '' }} · v{{ a.rev }}
+          </option>
+        </select>
       </div>
 
       <!-- Viewer -->
@@ -365,11 +443,13 @@ onUnmounted(() => {
                 </option>
               </select>
             </label>
+          </template>
 
-            <div class="ml-auto flex items-center gap-2">
-              <!-- Preview ⇄ Source toggle (markdown only; hidden while editing). -->
+          <div class="ml-auto flex items-center gap-2">
+            <template v-if="view">
+              <!-- Preview ⇄ Source toggle (markdown/html; hidden while editing). -->
               <div
-                v-if="isMarkdown && !editing"
+                v-if="isRenderable && !editing"
                 class="flex items-center overflow-hidden rounded border border-line"
               >
                 <button
@@ -384,7 +464,11 @@ onUnmounted(() => {
               </div>
 
               <template v-if="!editing">
-                <button class="btn-secondary px-2.5 py-1 text-xs" :disabled="!onLatest" @click="edit">
+                <button
+                  class="btn-secondary px-2.5 py-1 text-xs"
+                  :disabled="!onLatest"
+                  @click="edit"
+                >
                   Edit
                 </button>
                 <button
@@ -400,22 +484,54 @@ onUnmounted(() => {
                 <button class="btn-primary px-2.5 py-1 text-xs" :disabled="saving" @click="save">
                   {{ saving ? 'Saving…' : 'Save' }}
                 </button>
-                <button class="btn-secondary px-2.5 py-1 text-xs" :disabled="saving" @click="cancelEdit">
+                <button
+                  class="btn-secondary px-2.5 py-1 text-xs"
+                  :disabled="saving"
+                  @click="cancelEdit"
+                >
                   Cancel
                 </button>
               </template>
-            </div>
-          </template>
+            </template>
+
+            <!-- Pop out beside the terminal / dock back into the tab. -->
+            <button
+              class="rounded border border-line px-1.5 py-1 text-muted hover:bg-subtle hover:text-fg"
+              data-testid="artifact-pop"
+              :title="popped ? 'Dock back into the tab' : 'Pop out beside the terminal'"
+              @click="emit('togglePop')"
+            >
+              {{ popped ? '⤡ Dock' : '⤢ Pop out' }}
+            </button>
+            <!-- Close the rail entirely (popped only) — back to the plain page. -->
+            <button
+              v-if="popped"
+              class="rounded border border-line px-1.5 py-1 text-muted hover:bg-subtle hover:text-fg"
+              data-testid="artifact-rail-close"
+              title="Close the artifact panel"
+              aria-label="Close artifact panel"
+              @click="emit('close')"
+            >
+              ✕
+            </button>
+          </div>
         </div>
 
-        <p v-if="!onLatest && !editing" class="border-b border-line bg-subtle/40 px-3 py-1 text-xs text-faint">
+        <p
+          v-if="!onLatest && !editing"
+          class="border-b border-line bg-subtle/40 px-3 py-1 text-xs text-faint"
+        >
           Viewing an older revision — Edit always starts from the latest.
         </p>
 
         <!-- Content -->
         <div class="relative min-h-0 flex-1 bg-code">
           <!-- Monaco host: always mounted (v-show) so its ref survives mode flips. -->
-          <div v-show="(viewMode === 'source' || editing) && view" ref="host" class="h-full w-full"></div>
+          <div
+            v-show="(viewMode === 'source' || editing) && view"
+            ref="host"
+            class="h-full w-full"
+          ></div>
 
           <MarkdownView
             v-if="view && isMarkdown && viewMode === 'preview' && !editing"
@@ -426,13 +542,28 @@ onUnmounted(() => {
             class="h-full w-full"
           />
 
+          <HtmlArtifactView
+            v-if="view && isHtml && viewMode === 'preview' && !editing"
+            :content="view.content"
+            class="h-full w-full"
+          />
+
           <div
             v-if="!view && !loading"
             class="flex h-full w-full flex-col items-center justify-center gap-2 text-sm text-faint"
           >
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-              stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
-              class="opacity-60">
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.25"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              class="opacity-60"
+            >
               <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
               <path d="M14 2v4a2 2 0 0 0 2 2h4" />
             </svg>

--- a/crates/loom/frontend/src/components/HtmlArtifactView.vue
+++ b/crates/loom/frontend/src/components/HtmlArtifactView.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+// An `html` artifact rendered as a live document inside a sandboxed <iframe>.
+// The agent hands over a self-contained HTML page (a report, a chart, a tiny
+// interactive demo) and we show it as it would look in a browser — not as
+// source.
+//
+// Isolation is the whole point: the frame is `srcdoc` with `allow-scripts` but
+// *not* `allow-same-origin`, so the document runs in a unique opaque origin. Its
+// scripts execute, but it cannot read loom's cookies, localStorage, or call the
+// API as the signed-in user — a hostile artifact is sealed off from the session
+// it was written to. (Combining allow-scripts with allow-same-origin would let
+// it script its way out of the sandbox, so we never do.)
+const props = defineProps<{
+  /** Raw HTML source of the artifact (the selected revision's content). */
+  content: string;
+}>();
+
+// Open-in-new-tab uses a Blob URL (its own `blob:` origin, still isolated from
+// loom) so the page gets the full viewport. Built on demand and revoked once the
+// tab has had a tick to load it.
+function openInNewTab() {
+  const blob = new Blob([props.content], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank', 'noopener');
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+}
+
+// Bumping the key remounts the iframe when the content changes (a rev switch or
+// an SSE refresh), so a fresh document paints rather than a half-updated DOM.
+const reloadKey = ref(0);
+watch(
+  () => props.content,
+  () => (reloadKey.value += 1),
+);
+</script>
+
+<template>
+  <!-- A white backdrop so an unstyled document (no <body> background of its own)
+       stays legible regardless of loom's light/dark theme — the artifact owns
+       its look from there. -->
+  <div class="relative h-full w-full bg-white">
+    <iframe
+      :key="reloadKey"
+      :srcdoc="content"
+      sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms allow-modals"
+      class="h-full w-full border-0 bg-white"
+      title="HTML artifact"
+      data-testid="artifact-html"
+    ></iframe>
+    <button
+      class="absolute right-2 top-2 rounded border border-line bg-surface/90 px-2 py-0.5 text-xs text-muted shadow-sm hover:bg-subtle hover:text-fg"
+      title="Open this artifact full-screen in a new tab"
+      @click="openInNewTab"
+    >
+      ↗ Open
+    </button>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionTabs.vue
+++ b/crates/loom/frontend/src/components/SessionTabs.vue
@@ -1,29 +1,34 @@
 <script setup lang="ts">
-// Work-area sub-nav. Terminal/Overview are component-local tabs (the terminal
-// must never unmount, so the parent flips a ref and v-shows it); Artifacts is a
-// real route (Monaco is heavy and mustn't load on session-open). Neutral
-// underline indicator — no loud fills; only the active tab gets text-fg + an
-// accent underline.
+// Work-area sub-nav. Every tab is a local flip the parent (SessionDetail) acts
+// on: Terminal/Overview/Conversation v-show their kept-alive panes; Artifacts
+// drives the route (and the lazy artifacts panel) and can be popped out into a
+// rail beside the terminal. Neutral underline indicator — no loud fills; only
+// the active tab gets text-fg + an accent underline.
 //
 // Terminal is the working zone (the live agent); Overview is the read-only
 // context (goal, claimed issues, activity) — the issue count rides on the
-// Overview tab as a quiet pill rather than owning a tab of its own. Artifacts is
-// the agent's out-of-repo documents (designs, reports, the plan). The worktree
-// files live in the embedded editor (the side panel), not a tab.
+// Overview tab as a quiet pill. Artifacts is the agent's out-of-repo documents
+// (designs, reports, the plan). The worktree files live in the embedded editor
+// (the side panel), not a tab.
 type Tab = 'terminal' | 'overview' | 'conversation' | 'artifacts';
 
-// The Artifacts tab is a real navigation; the rest are local.
-type LocalTab = Exclude<Tab, 'artifacts'>;
+defineProps<{
+  tab: Tab;
+  id: string;
+  issueCount: number;
+  /** Artifacts is open in the rail (popped out) rather than the work area. */
+  artifactsPopped?: boolean;
+}>();
+defineEmits<{ select: [Tab] }>();
 
-defineProps<{ tab: Tab; id: string; issueCount: number }>();
-defineEmits<{ select: [LocalTab] }>();
-
-const LOCAL_TABS: { key: LocalTab; label: string }[] = [
+const TABS: { key: Tab; label: string }[] = [
   { key: 'terminal', label: 'Terminal' },
   { key: 'overview', label: 'Overview' },
   // The agent's chat with the model — live, and (via the archive capture) still
   // here to review after the terminal is gone.
   { key: 'conversation', label: 'Conversation' },
+  // The agent's out-of-repo documents; lazily mounts its (heavy) viewer.
+  { key: 'artifacts', label: 'Artifacts' },
 ];
 </script>
 
@@ -32,29 +37,24 @@ const LOCAL_TABS: { key: LocalTab; label: string }[] = [
        with the title above. -->
   <nav class="mb-2 flex items-center gap-1 border-b border-line pl-0.5 text-sm">
     <button
-      v-for="t in LOCAL_TABS"
+      v-for="t in TABS"
       :key="t.key"
       type="button"
       :data-tab="t.key"
       class="-mb-px border-b-2 px-2.5 py-1.5"
-      :class="tab === t.key
-        ? 'border-accent text-fg font-medium'
-        : 'border-transparent text-muted hover:text-fg'"
+      :class="
+        tab === t.key || (t.key === 'artifacts' && artifactsPopped)
+          ? 'border-accent text-fg font-medium'
+          : 'border-transparent text-muted hover:text-fg'
+      "
       @click="$emit('select', t.key)"
     >
       {{ t.label }}
       <span v-if="t.key === 'overview' && issueCount" class="pill ml-1">{{ issueCount }}</span>
+      <!-- When popped out, the Artifacts surface lives in the rail, not here —
+           a small glyph marks it open without claiming the work area. -->
+      <span v-if="t.key === 'artifacts' && artifactsPopped" class="ml-1 text-faint" title="Open in the side panel">⤢</span>
     </button>
-    <router-link
-      :to="`/s/${id}/artifacts`"
-      data-tab="artifacts"
-      class="-mb-px border-b-2 px-2.5 py-1.5"
-      :class="tab === 'artifacts'
-        ? 'border-accent text-fg font-medium'
-        : 'border-transparent text-muted hover:text-fg'"
-    >
-      Artifacts
-    </router-link>
     <!-- The tab row's right side is otherwise dead space — hosts compact,
          always-relevant extras (the scratch attach strip on the detail page). -->
     <div class="ml-auto flex min-w-0 items-center">

--- a/crates/loom/frontend/src/main.ts
+++ b/crates/loom/frontend/src/main.ts
@@ -11,7 +11,6 @@ import { createRouter, createWebHistory } from 'vue-router';
 import App from './App.vue';
 import SessionList from './views/SessionList.vue';
 import SessionDetail from './views/SessionDetail.vue';
-import Artifacts from './views/Artifacts.vue';
 import Settings from './views/Settings.vue';
 import Issues from './views/Issues.vue';
 import Overlookers from './views/Overlookers.vue';
@@ -32,8 +31,11 @@ const router = createRouter({
     // The old Files browser is gone — the embedded editor (a side panel on the
     // detail page) is the file surface now. Redirect stale links there.
     { path: '/s/:id/files', redirect: (to) => `/s/${to.params.id}` },
-    { path: '/s/:id/artifacts', component: Artifacts, props: true },
-    { path: '/s/:id/artifacts/:name', component: Artifacts, props: true },
+    // Artifacts is a tab *within* the session page (a kept-alive panel that can
+    // pop out beside the terminal), not a page of its own — so these resolve to
+    // the same SessionDetail instance and stay deep-linkable.
+    { path: '/s/:id/artifacts', component: SessionDetail, props: true },
+    { path: '/s/:id/artifacts/:name', component: SessionDetail, props: true },
     { path: '/issues', component: Issues },
     { path: '/chat', component: Chat },
     { path: '/overlookers', component: Overlookers },

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, onActivated, onDeactivated, onUnmounted } from 'vue';
-import { useRoute } from 'vue-router';
+import { ref, reactive, computed, watch, onMounted, onActivated, onDeactivated, onUnmounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import { get, ideInfo } from '../api';
 import type { Session, WeaverEvent, Issue } from '../types';
 import SessionTerminals from '../components/SessionTerminals.vue';
@@ -10,16 +10,18 @@ import SessionPageHeader from '../components/SessionPageHeader.vue';
 import SessionTabs from '../components/SessionTabs.vue';
 import SessionOverview from '../components/SessionOverview.vue';
 import SessionConversation from '../components/SessionConversation.vue';
+import ArtifactsPanel from '../components/ArtifactsPanel.vue';
 import { useFleet } from '../lib/sessionsStore';
 
 // Named + keyed-by-id in App.vue's <keep-alive> so the page (and its live
-// terminal) stays warm across the Artifacts trip: clicking Artifacts and back
-// returns to the same terminal, scrollback intact, no reconnect — instead of
-// tearing the WebSocket/xterm down and rebuilding it every round-trip.
+// terminal) stays warm: every `/s/:id…` path (the work tabs and the Artifacts
+// deep-links) resolves to this one instance, so moving terminal ⇄ artifacts is a
+// tab flip on a warm page — no remount, no reconnect, no jump.
 defineOptions({ name: 'SessionDetail' });
 
-const props = defineProps<{ id: string }>();
+const props = defineProps<{ id: string; name?: string }>();
 const route = useRoute();
+const router = useRouter();
 
 // Seed from the shared fleet snapshot so the page paints immediately with the
 // row the list already had — no "Loading…" gap while the per-session refetch is
@@ -31,74 +33,128 @@ const issues = ref<Issue[]>([]);
 const backlog = ref<Issue[]>([]);
 const error = ref('');
 
-// Work-area tab. Terminal is the default surface — "show me what it's doing" —
-// and stays mounted under v-show across both tabs (tearing down the
-// WebSocket/xterm/WebGL is the worst thing on a terminal-first page). A
-// `?tab=overview` query deep-links the Overview tab (e.g. the list's open-issue
-// link). Files are no longer a tab — they live in the embedded editor panel.
+// --- Work-area tabs --------------------------------------------------------
+// Terminal/Overview/Conversation are local panes the parent flips under v-show
+// (never v-if for the terminal — tearing down the WebSocket/xterm is the worst
+// thing on a terminal-first page). Artifacts is route-backed (`/s/:id/artifacts`
+// is this same component) so it stays deep-linkable and refresh-stable, and its
+// heavy viewer lazily mounts only once opened.
+type LocalTab = 'terminal' | 'overview' | 'conversation';
+type WorkTab = LocalTab | 'artifacts';
 const initialTab = route.query.tab;
-type WorkTab = 'terminal' | 'overview' | 'conversation';
-const tab = ref<WorkTab>(
+const localTab = ref<LocalTab>(
   initialTab === 'overview' || initialTab === 'conversation' ? initialTab : 'terminal',
 );
 
-// Which tabs have ever been opened. A tab mounts lazily on first visit, then
-// stays mounted (v-show) — so flipping Terminal ↔ Overview ↔ Conversation is
-// instant and the Conversation keeps its loaded transcript instead of
-// re-fetching on every switch. The terminal is always mounted (it must never
-// drop its socket); the others start unmounted so a session-open stays cheap.
-const mounted = reactive<Record<WorkTab, boolean>>({
-  terminal: true,
-  overview: tab.value === 'overview',
-  conversation: tab.value === 'conversation',
+// The artifacts surface is open whenever the path is under `…/artifacts`.
+const artifactsActive = computed(() => route.path.startsWith(`/s/${props.id}/artifacts`));
+
+// Popped out into the rail beside the terminal vs docked as the work-area tab.
+// Transient (defaults docked on a fresh open); only the rail *width* persists.
+const poppedOut = ref(false);
+const artifactsDocked = computed(() => artifactsActive.value && !poppedOut.value);
+const railOpen = computed(() => artifactsActive.value && poppedOut.value);
+
+// The pane the work area shows: the artifacts panel when docked, else the last
+// local tab (so a popped-out artifact leaves the terminal in the work area).
+const workTab = computed<WorkTab>(() => (artifactsDocked.value ? 'artifacts' : localTab.value));
+
+// Lazy-mount panes on first visit, then keep them (v-show) so re-selecting is
+// instant. The terminal is always mounted; the rest start cold so a session-open
+// stays cheap (Monaco/the artifact viewer only load once their tab is opened).
+const mounted = reactive({
+  overview: localTab.value === 'overview',
+  conversation: localTab.value === 'conversation',
+  artifacts: artifactsActive.value,
 });
+watch(
+  artifactsActive,
+  (on) => {
+    if (on) mounted.artifacts = true;
+  },
+  { immediate: true },
+);
+
 function selectTab(t: WorkTab) {
-  // Mark mounted *before* flipping the tab so the target renders on the same
-  // tick (no one-frame flash). `selectTab` is the only path that changes `tab`.
-  mounted[t] = true;
-  tab.value = t;
+  if (t === 'artifacts') {
+    // The Artifacts tab is the docked view: bring the surface into the work
+    // area (docking it if it was popped out), opening it if it was closed.
+    poppedOut.value = false;
+    if (!artifactsActive.value) router.push(`/s/${props.id}/artifacts`);
+    return;
+  }
+  if (t === 'overview' || t === 'conversation') mounted[t] = true;
+  localTab.value = t;
+  // Leaving a docked artifacts surface for a local tab closes it (back to the
+  // plain session URL); when it's popped out the rail stays and we just swap the
+  // work-area pane.
+  if (artifactsDocked.value) router.push(`/s/${props.id}`);
+}
+
+// Pop the artifact out beside the terminal / dock it back into the tab.
+function togglePop() {
+  poppedOut.value = !poppedOut.value;
+}
+// Close the rail entirely — back to the plain session page.
+function closeRail() {
+  poppedOut.value = false;
+  router.push(`/s/${props.id}`);
 }
 
 const issueCount = computed(() => issues.value.length + backlog.value.length);
 
-// --- Embedded editor (code-server) side panel ------------------------------
-// The editor lives in a resizable panel pulled in from the right, beside the
-// live terminal. It is closed by default and mounted only when open, so opening
-// it is what lazily spawns the session's code-server — a plain session-open
-// never does. `ideEnabled` gates the whole affordance on the server setting.
-const ideEnabled = ref(false);
-const ideOpen = ref(false);
-const MIN_IDE_WIDTH = 360;
-function loadIdeWidth(): number {
-  const v = Number(localStorage.getItem('loom.ideWidth'));
-  return Number.isFinite(v) && v >= MIN_IDE_WIDTH ? v : 760;
+// --- Resizable side rails --------------------------------------------------
+// Two panels pull in from the right: the artifact (popped out) and the embedded
+// editor. Each persists its own width and drags from the right edge.
+const MIN_PANEL_WIDTH = 360;
+function loadWidth(key: string, fallback: number): number {
+  const v = Number(localStorage.getItem(key));
+  return Number.isFinite(v) && v >= MIN_PANEL_WIDTH ? v : fallback;
 }
-const ideWidth = ref(loadIdeWidth());
-let dragging = false;
+const artifactWidth = ref(loadWidth('loom.artifactWidth', 620));
+const ideWidth = ref(loadWidth('loom.ideWidth', 760));
 
+// Each rail drags from the right edge and persists its own width; a single
+// discriminator picks which one a divider drives (templates auto-unwrap refs, so
+// the rail is named, not passed by reference).
+type Rail = 'artifact' | 'ide';
+const RAILS: Record<Rail, { width: typeof artifactWidth; key: string }> = {
+  artifact: { width: artifactWidth, key: 'loom.artifactWidth' },
+  ide: { width: ideWidth, key: 'loom.ideWidth' },
+};
+let dragging: Rail | null = null;
 function onDrag(e: MouseEvent) {
   if (!dragging) return;
-  // Width is measured from the right edge — drag left to widen the editor.
+  // Width is measured from the right edge — drag left to widen the panel.
   const fromRight = window.innerWidth - e.clientX;
-  const max = Math.max(MIN_IDE_WIDTH, window.innerWidth - MIN_IDE_WIDTH);
-  ideWidth.value = Math.min(Math.max(fromRight, MIN_IDE_WIDTH), max);
+  const max = Math.max(MIN_PANEL_WIDTH, window.innerWidth - MIN_PANEL_WIDTH);
+  RAILS[dragging].width.value = Math.min(Math.max(fromRight, MIN_PANEL_WIDTH), max);
 }
 function stopDrag() {
   if (!dragging) return;
-  dragging = false;
+  const rail = RAILS[dragging];
+  localStorage.setItem(rail.key, String(Math.round(rail.width.value)));
+  dragging = null;
   document.removeEventListener('mousemove', onDrag);
   document.removeEventListener('mouseup', stopDrag);
   document.body.style.userSelect = '';
-  localStorage.setItem('loom.ideWidth', String(Math.round(ideWidth.value)));
 }
-function startDrag(e: MouseEvent) {
-  dragging = true;
+function startDrag(which: Rail, e: MouseEvent) {
+  dragging = which;
   e.preventDefault();
   document.addEventListener('mousemove', onDrag);
   document.addEventListener('mouseup', stopDrag);
   // Suppress text selection while dragging the divider.
   document.body.style.userSelect = 'none';
 }
+
+// --- Embedded editor (code-server) side panel ------------------------------
+// The editor lives in a resizable panel pulled in from the right, beside the
+// live terminal. Closed by default and mounted only when open, so opening it is
+// what lazily spawns the session's code-server. `ideEnabled` gates the whole
+// affordance on the server setting.
+const ideEnabled = ref(false);
+const ideOpen = ref(false);
 
 let source: EventSource | null = null;
 
@@ -157,8 +213,8 @@ function openStream() {
     });
   }
   // An artifact write joins the feed; pushing it to `events` also nudges the
-  // Overview's pinned-plan watcher to re-fetch the `plan` artifact, and the
-  // Artifacts surface refreshes off the same SSE stream itself.
+  // Overview's pinned-plan watcher to re-fetch the `plan` artifact. The
+  // Artifacts panel refreshes off its own SSE subscription.
   source.addEventListener('artifact_written', (e) => {
     events.value.push(JSON.parse((e as MessageEvent).data) as WeaverEvent);
   });
@@ -195,14 +251,11 @@ onMounted(() => {
     .catch(() => {});
 });
 // The events SSE is paused while the page is off-screen (kept alive). A cached
-// SessionDetail would otherwise hold an EventSource open on the Artifacts trip or
-// while parked on another session — idle streams stacking up against the
-// browser's per-origin HTTP/1.1 connection cap. The terminal WebSocket (a
-// separate connection pool) stays warm regardless — that's the point of keeping
-// the page alive; only this status stream pauses. onMounted owns the first open;
-// onActivated reopens + refetches on a *return* (guarded by `source` so the
-// initial mount never double-opens). The refetch carries no "Loading…" flash —
-// `ws` is already seeded from the store.
+// SessionDetail would otherwise hold an EventSource open while parked on another
+// session — idle streams stacking up against the browser's per-origin HTTP/1.1
+// connection cap. The terminal WebSocket (a separate pool) stays warm
+// regardless. onMounted owns the first open; onActivated reopens + refetches on
+// a *return* (guarded by `source` so the initial mount never double-opens).
 onActivated(() => {
   if (source) return; // initial mount already loaded + opened the stream
   loadAll();
@@ -217,15 +270,20 @@ onUnmounted(() => {
 
 <template>
   <!-- A horizontal split fills the workbench main area: the session page (header
-       + tabs + terminal/overview) on the left, and the embedded editor pulled in
-       from the right. The editor is a resizable, collapsible panel — closed by
-       default so a session-open never spawns a code-server. -->
+       + tabs + work area) on the left, then any panels pulled in from the right
+       — the popped-out artifact and the embedded editor, each resizable. -->
   <div v-if="ws" class="flex min-h-[28rem] flex-1">
-    <!-- Left: the session page. min-w-0 lets it shrink as the editor widens;
+    <!-- Left: the session page. min-w-0 lets it shrink as panels widen;
          AgentTerminal's ResizeObserver re-fits the terminal on the change. -->
     <div class="flex min-w-0 flex-1 flex-col px-5 py-3">
       <SessionPageHeader :ws="ws" @reload="loadAll" />
-      <SessionTabs :tab="tab" :id="props.id" :issue-count="issueCount" @select="selectTab">
+      <SessionTabs
+        :tab="workTab"
+        :id="props.id"
+        :issue-count="issueCount"
+        :artifacts-popped="railOpen"
+        @select="selectTab"
+      >
         <!-- Scratch attachments ride the tab row's spare right side (drop a file
              anywhere on the page) so the terminal keeps the vertical space the
              old below-the-terminal strip used to take. -->
@@ -238,18 +296,18 @@ onUnmounted(() => {
 
       <div class="min-h-0 flex-1">
         <!-- Terminal (default) — the working zone: the live agent, plus on-demand
-             worktree debug shells in an inner tab strip. v-show, NEVER v-if:
-             keeping the agent terminal's host in the DOM means its zero-size
-             guard skips the bogus resize while hidden and its ResizeObserver
-             re-fits on return. -->
-        <section v-show="tab === 'terminal'" class="h-full">
+             worktree debug shells in an inner tab strip. v-show, NEVER v-if. -->
+        <section v-show="workTab === 'terminal'" class="h-full">
           <SessionTerminals :id="props.id" />
         </section>
 
-        <!-- Overview — read-only context (goal, issues, activity). Scrolls
-             within the work area so the header/tabs stay anchored. Mounted on
+        <!-- Overview — read-only context (goal, issues, activity). Mounted on
              first visit, then kept (v-show) so re-selecting it is instant. -->
-        <div v-if="mounted.overview" v-show="tab === 'overview'" class="h-full overflow-auto pb-1">
+        <div
+          v-if="mounted.overview"
+          v-show="workTab === 'overview'"
+          class="h-full overflow-auto pb-1"
+        >
           <SessionOverview
             :ws="ws"
             :events="events"
@@ -259,15 +317,53 @@ onUnmounted(() => {
           />
         </div>
 
-        <!-- Conversation — the agent's chat with the model (live, or the
-             archived capture). Lazily mounted on first visit and then kept
-             (v-show), so flipping back is instant and the loaded transcript
-             survives; its Refresh button re-pulls on demand. -->
-        <div v-if="mounted.conversation" v-show="tab === 'conversation'" class="h-full">
+        <!-- Conversation — the agent's chat with the model. Lazily mounted, then
+             kept (v-show) so flipping back is instant. -->
+        <div v-if="mounted.conversation" v-show="workTab === 'conversation'" class="h-full">
           <SessionConversation :session="ws" />
+        </div>
+
+        <!-- Artifacts (docked) — fills the work area as a tab. Lazily mounted on
+             first open, then kept (hidden via v-show) so flipping terminal ⇄
+             artifacts is instant. Unmounts only when popped out, where the rail
+             copy below takes over. -->
+        <div v-if="mounted.artifacts && !railOpen" v-show="artifactsDocked" class="h-full">
+          <ArtifactsPanel
+            :id="props.id"
+            :name="props.name"
+            :active="artifactsActive"
+            @toggle-pop="togglePop"
+          />
         </div>
       </div>
     </div>
+
+    <!-- Artifact rail (popped out): a draggable divider + the panel at its
+         persisted width, beside the terminal. A second, compact mount of the
+         same view — opening it restores the artifact from the URL, so the docked
+         tab can stay warm for the instant terminal ⇄ artifacts flip. -->
+    <template v-if="railOpen">
+      <div
+        class="w-1 shrink-0 cursor-col-resize bg-line hover:bg-accent"
+        title="Drag to resize the artifact panel"
+        @mousedown="(e) => startDrag('artifact', e)"
+      ></div>
+      <section
+        class="flex shrink-0 flex-col border-l border-line"
+        :style="{ width: artifactWidth + 'px' }"
+      >
+        <ArtifactsPanel
+          :id="props.id"
+          :name="props.name"
+          :active="railOpen"
+          compact
+          popped
+          class="min-h-0 flex-1"
+          @toggle-pop="togglePop"
+          @close="closeRail"
+        />
+      </section>
+    </template>
 
     <!-- Editor side panel (only when enabled in settings). -->
     <template v-if="ideEnabled">
@@ -276,7 +372,7 @@ onUnmounted(() => {
         <div
           class="w-1 shrink-0 cursor-col-resize bg-line hover:bg-accent"
           title="Drag to resize the editor"
-          @mousedown="startDrag"
+          @mousedown="(e) => startDrag('ide', e)"
         ></div>
         <section
           class="relative flex shrink-0 flex-col border-l border-line"

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -240,7 +240,8 @@ enum ArtifactCmd {
     /// An image file (`.png`, `.jpg`, `.gif`, `.webp`, `.svg`, …; raster formats
     /// are also recognised from stdin by their magic bytes) is embedded as a
     /// base64 data-URI in a markdown wrapper, so it renders inline in loom — no
-    /// need to hand-roll the data URI.
+    /// need to hand-roll the data URI. A `.html`/`.htm` file is stored as the
+    /// `html` kind, which loom renders in a sandboxed iframe.
     Write {
         /// The artifact name (its identity within the scope), e.g. `plan`.
         name: String,
@@ -249,8 +250,10 @@ enum ArtifactCmd {
         /// A human title for the artifact (envelope metadata).
         #[arg(long, default_value = "")]
         title: String,
-        /// The content kind; defaults to `markdown`. Ignored for image files,
-        /// which are always wrapped as markdown.
+        /// The content kind: `markdown` (the default; GFM + mermaid) or `html`
+        /// (rendered in a sandboxed iframe). A `.html`/`.htm` file picks `html`
+        /// on its own. Ignored for image files, which are always wrapped as
+        /// markdown; any other value is stored verbatim and shown as source.
         #[arg(long, default_value = "markdown")]
         kind: String,
         /// Publish repo-shared (visible to every branch) instead of scoping it
@@ -429,6 +432,17 @@ fn image_mime_from_ext(name: &str) -> Option<&'static str> {
         "ico" => "image/x-icon",
         _ => return None,
     })
+}
+
+/// True when `filename` looks like a standalone HTML document (`.html`/`.htm`),
+/// so a plain `weaver artifact write report report.html` lands as the `html`
+/// kind loom renders in a sandboxed iframe — no `--kind html` needed. Only
+/// promotes from the default `markdown`; an explicit `--kind` always wins.
+fn is_html_ext(filename: Option<&str>) -> bool {
+    filename
+        .and_then(|n| n.rsplit_once('.'))
+        .map(|(_, e)| e.eq_ignore_ascii_case("html") || e.eq_ignore_ascii_case("htm"))
+        .unwrap_or(false)
 }
 
 /// Sniff a raster image's MIME type from its leading magic bytes — for content
@@ -1228,7 +1242,9 @@ async fn cmd_artifact(cmd: ArtifactCmd) -> Result<()> {
             };
             // An image is auto-wrapped as a base64 data-URI markdown doc (kind
             // forced to markdown so loom renders it inline); everything else is
-            // stored as text under the requested kind.
+            // stored as text under the requested kind. A `.html`/`.htm` file
+            // promotes the default `markdown` to `html` (loom sandboxes it in an
+            // iframe); an explicit `--kind` always wins.
             let (kind, content): (String, String) =
                 match embed_image_markdown(alt, file.as_deref(), &raw)? {
                     Some(md) => ("markdown".to_string(), md),
@@ -1239,7 +1255,13 @@ async fn cmd_artifact(cmd: ArtifactCmd) -> Result<()> {
                                  only text and image files are supported"
                             )
                         })?;
-                        (kind.trim().to_string(), text)
+                        let kind = kind.trim();
+                        let kind = if kind == "markdown" && is_html_ext(file.as_deref()) {
+                            "html".to_string()
+                        } else {
+                            kind.to_string()
+                        };
+                        (kind, text)
                     }
                 };
             // `--repo` writes the repo-shared scope (branch_id = NULL); otherwise
@@ -1626,6 +1648,16 @@ mod tests {
         // Not images: plain docs and extension-less names.
         assert_eq!(image_mime_from_ext("design.md"), None);
         assert_eq!(image_mime_from_ext("plan"), None);
+    }
+
+    #[test]
+    fn html_extensions_are_recognised_case_insensitively() {
+        assert!(is_html_ext(Some("report.html")));
+        assert!(is_html_ext(Some("./out/Dashboard.HTM")));
+        // Not HTML: other docs, extension-less names, and stdin (no filename).
+        assert!(!is_html_ext(Some("plan.md")));
+        assert!(!is_html_ext(Some("notes")));
+        assert!(!is_html_ext(None));
     }
 
     #[test]

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -114,11 +114,21 @@ the survey above:
   agent/user edits safe — last write is a new revision, not a lost update.
 - **Kind-typed, markdown-first.** `kind` defaults to `markdown` (GFM +
   mermaid via the existing `MarkdownView`); other kinds render as source
-  until they earn a renderer. Images (screenshots, diagrams) need no blob
-  store: `write` recognises an image file — by extension, or by magic bytes
-  on stdin — and embeds it as a base64 data-URI inside a markdown wrapper,
-  which `MarkdownView` already renders inline (the renderer passes `data:`
-  URIs through untouched; DOMPurify permits them on `<img>`).
+  until they earn a renderer. Two more render natively:
+  - **`html`** — a self-contained HTML document (a report, a chart, a small
+    interactive demo) shown as a live page in a sandboxed `<iframe>`. The frame
+    is `srcdoc` with `allow-scripts` but **not** `allow-same-origin`, so its
+    scripts run in a unique opaque origin and cannot read loom's cookies or call
+    the API as the signed-in user — a hostile artifact is sealed off from the
+    session. A `.html`/`.htm` file picks the kind on its own (like image
+    sniffing); `--kind html` is the explicit form. Preview ⇄ Source toggles
+    between the rendered page and the raw HTML; "↗ Open" loads it full-screen in
+    a new tab (its own `blob:` origin, still isolated).
+  - **Images** (screenshots, diagrams) need no blob store: `write` recognises an
+    image file — by extension, or by magic bytes on stdin — and embeds it as a
+    base64 data-URI inside a markdown wrapper, which `MarkdownView` already
+    renders inline (the renderer passes `data:` URIs through untouched; DOMPurify
+    permits them on `<img>`).
 - **URL-addressable.** `weaver artifact write` prints the dashboard URL
   (`/s/<session>/artifacts/<name>`) so the agent can hand it to the user in
   a status message or PR comment — the Amp-thread lesson: the URL is the
@@ -281,10 +291,15 @@ update the issues; when issues change shape, update the doc's references.*
 
 ### Loom UI
 
-- **Session detail** gains an Artifacts surface: list + viewer
-  (`MarkdownView`), version picker, the file browser's proven
-  preview ⇄ Monaco toggle for user edits (each save = new revision,
-  `author: user`). Deep link `/s/:id/artifacts/:name`.
+- **Session detail** gains an Artifacts surface (`ArtifactsPanel`): list +
+  viewer (`MarkdownView` / `HtmlArtifactView` / Monaco source), version picker,
+  the file browser's proven preview ⇄ Monaco toggle for user edits (each save =
+  new revision, `author: user`). It is a tab *within* the session page — a
+  kept-alive panel served from `SessionDetail` (the `/s/:id/artifacts/:name`
+  deep link resolves to the same instance), so moving terminal ⇄ artifacts is an
+  instant flip on the warm page, not a route swap. The panel can **pop out** into
+  a resizable rail beside the live terminal (mirroring the embedded-editor
+  panel), so the user reads an artifact and watches the agent at once.
 - **Overview** pins the well-known `plan` artifact where `SessionPlan`
   renders today; the goal renders as projected markdown above it.
   `SessionPlan.vue`'s reconcile modal goes; its render path becomes the

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -131,7 +131,7 @@ export interface WeaverFixture {
     session: Session,
     name: string,
     content: string | Buffer,
-    opts?: { title?: string; repo?: boolean },
+    opts?: { title?: string; repo?: boolean; kind?: string },
   ): Promise<void>;
   /** Remove an artifact via `weaver artifact rm` — drops it and its whole
    *  history. `--repo` targets the repo-shared row when a branch copy shadows it. */
@@ -492,6 +492,7 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
         // it repo-shared). The first write creates the envelope.
         const args = ['artifact', 'write', name, '-'];
         if (opts?.title) args.push('--title', opts.title);
+        if (opts?.kind) args.push('--kind', opts.kind);
         if (opts?.repo) args.push('--repo');
         execFileSync(WEAVER_BINARY, args, {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },

--- a/e2e/tests/artifacts.spec.ts
+++ b/e2e/tests/artifacts.spec.ts
@@ -76,7 +76,7 @@ test.describe('artifacts surface', () => {
     // Selecting an older revision re-fetches it read-only; Edit is disabled.
     await rev.selectOption('1');
     await expect(page.getByText('Viewing an older revision')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Edit' })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Edit', exact: true })).toBeDisabled();
 
     // An out-of-band CLI write (rev 3) is re-broadcast over SSE; the viewer,
     // back on latest, refreshes itself. Return to latest first.
@@ -93,7 +93,7 @@ test.describe('artifacts surface', () => {
     await expect(page.locator('.markdown-body h1')).toContainText('Notes');
 
     // Edit flips the viewer to Monaco; type an addition and save.
-    await page.getByRole('button', { name: 'Edit' }).click();
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
     await expect(page.locator('.monaco-editor')).toBeVisible();
     await page.locator('.monaco-editor').click();
     await page.keyboard.type('\n\nA user revision.');
@@ -138,6 +138,81 @@ test.describe('artifacts surface', () => {
     // re-broadcast over SSE and the list updates without a reload.
     await weaver.removeArtifact(session, 'doomed');
     await expect(page.locator('[data-artifact="doomed"]')).toHaveCount(0, { timeout: 15_000 });
+  });
+
+  test('an html artifact renders in a sandboxed iframe, with a source view', async ({
+    page,
+    weaver,
+  }) => {
+    const session = await weaver.seedSession({ goal: 'html report', name: 'artifacts-html' });
+    const html =
+      '<!doctype html><html><body><h1 id="hi">Live report</h1>' +
+      '<script>document.documentElement.dataset.ran = "1";</script></body></html>';
+    await weaver.writeArtifact(session, 'report', html, { title: 'Report', kind: 'html' });
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}/artifacts/report`);
+
+    // Preview is a sandboxed iframe: scripts run, but with no same-origin grant
+    // it cannot reach loom's cookies/API as the signed-in user.
+    const frame = page.getByTestId('artifact-html');
+    await expect(frame).toBeVisible();
+    const sandbox = (await frame.getAttribute('sandbox')) ?? '';
+    expect(sandbox).toContain('allow-scripts');
+    expect(sandbox).not.toContain('allow-same-origin');
+    // It's a real document — the markup rendered and its script executed.
+    const inner = page.frameLocator('[data-testid="artifact-html"]');
+    await expect(inner.locator('#hi')).toHaveText('Live report');
+    await expect(inner.locator('html')).toHaveAttribute('data-ran', '1');
+
+    // The Source toggle swaps the live frame for the raw HTML in Monaco.
+    await page.getByRole('button', { name: 'Source' }).click();
+    await expect(page.locator('.monaco-editor')).toBeVisible();
+    await expect(page.getByTestId('artifact-html')).toHaveCount(0);
+  });
+
+  test('pops the artifact out beside the terminal, then docks it', async ({ page, weaver }) => {
+    const session = await weaver.seedSession({ goal: 'side by side', name: 'artifacts-pop' });
+    await weaver.writeArtifact(session, 'notes', '# Notes\n\nbody\n', { title: 'Notes' });
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}/artifacts/notes`);
+    await expect(page.locator('.markdown-body h1')).toContainText('Notes');
+    // Docked: the artifact fills the work area, so the terminal is hidden.
+    await expect(page.locator('[data-term-tab="agent"]')).toBeHidden();
+
+    // Pop out → a rail appears beside the terminal: both visible at once.
+    await page.getByTestId('artifact-pop').click();
+    await expect(page.getByTestId('artifact-rail-close')).toBeVisible();
+    await expect(page.locator('[data-term-tab="agent"]')).toBeVisible(); // terminal back
+    await expect(page.locator('.markdown-body h1')).toContainText('Notes'); // artifact in the rail
+
+    // Dock back → the rail closes and the artifact returns to the work-area tab.
+    await page.getByTestId('artifact-pop').click();
+    await expect(page.getByTestId('artifact-rail-close')).toHaveCount(0);
+    await expect(page.locator('[data-term-tab="agent"]')).toBeHidden();
+    await expect(page.locator('.markdown-body h1')).toContainText('Notes');
+  });
+
+  test('Artifacts is an in-page tab — terminal ⇄ artifacts stays on the session page', async ({
+    page,
+    weaver,
+  }) => {
+    const session = await weaver.seedSession({ goal: 'tabbing', name: 'artifacts-tab' });
+    await weaver.writeArtifact(session, 'plan', '# Plan\n\nthe plan\n', { title: 'Plan' });
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}`);
+    await expect(page.locator('[data-term-tab="agent"]')).toBeVisible();
+
+    // Clicking Artifacts flips the tab in place (the tab bar stays); the panel
+    // renders and the URL deep-links, with no full-page navigation away.
+    await page.locator('[data-tab="artifacts"]').click();
+    await expect(page).toHaveURL(new RegExp(`/s/${session.id}/artifacts`));
+    await expect(page.locator('.markdown-body h1')).toContainText('Plan');
+    await expect(page.locator('[data-tab="terminal"]')).toBeVisible(); // same page, tab bar intact
+
+    // Back to Terminal — the warm terminal returns, URL back to the session.
+    await page.locator('[data-tab="terminal"]').click();
+    await expect(page).toHaveURL(`${weaver.baseUrl}/s/${session.id}`);
+    await expect(page.locator('[data-term-tab="agent"]')).toBeVisible();
   });
 
   test('an image file is embedded as a base64 data-URI and renders inline', async ({

--- a/e2e/tests/overlookers.spec.ts
+++ b/e2e/tests/overlookers.spec.ts
@@ -146,56 +146,6 @@ test.describe('overlooker panel', () => {
     await expect(page.getByTestId('overlooker-warm-off')).toHaveCount(0);
   });
 
-  test('lists builtin programs with read-only source and prefills the form', async ({
-    page,
-    weaver,
-  }) => {
-    await page.goto(`${weaver.baseUrl}/overlookers`);
-
-    // The registry section lists the stock programs that ship with loom.
-    const rows = page.getByTestId('program-row');
-    await expect(rows).toHaveCount(4);
-    const section = page.getByTestId('builtin-programs');
-    for (const name of [
-      'builtin:status',
-      'builtin:resume',
-      'builtin:pr-label',
-      'builtin:archive-merged',
-    ]) {
-      await expect(section).toContainText(name);
-    }
-
-    // Every builtin is a script whose source is viewable read-only.
-    const archive = rows.filter({ hasText: 'builtin:archive-merged' });
-    await archive.getByTestId('program-source-toggle').click();
-    await expect(archive.getByTestId('program-source')).toContainText(
-      'flag sessions whose pull request has merged',
-    );
-    const status = rows.filter({ hasText: 'builtin:status' });
-    await status.getByTestId('program-source-toggle').click();
-    await expect(status.getByTestId('program-source')).toContainText(
-      'assess when the agent goes quiet',
-    );
-
-    // "Use" opens the create form prefilled with the program and a name.
-    await archive.getByTestId('program-use').click();
-    await expect(page.getByTestId('overlooker-form')).toBeVisible();
-    await expect(page.getByTestId('overlooker-program')).toHaveValue('builtin:archive-merged');
-    await expect(page.getByTestId('overlooker-name')).toHaveValue('archive-merged');
-    await page.getByTestId('overlooker-create').click();
-
-    const row = page.getByTestId('overlooker-row');
-    await expect(row).toHaveCount(1);
-    await expect(row).toContainText('builtin:archive-merged');
-
-    // The detail page renders the same script source, read-only.
-    await row.getByTestId('overlooker-name-link').click();
-    await page.getByTestId('program-source-toggle').click();
-    await expect(page.getByTestId('program-source')).toContainText(
-      'flag sessions whose pull request has merged',
-    );
-  });
-
   test('deletes an overlooker from the detail page', async ({ page, weaver }) => {
     const o = await weaver.seedOverlooker({ name: 'doomed' });
 


### PR DESCRIPTION
Three things from the artifacts feedback (#327):

### 1. HTML artifacts, rendered live
Agents can post `html` artifacts, shown as a live document in a **sandboxed iframe** — `srcdoc` with `allow-scripts` but *not* `allow-same-origin`, so its scripts run in an opaque origin and can't read loom's cookies or call the API as the signed-in user. A `.html`/`.htm` file picks the kind on its own (like image sniffing); `--kind html` is the explicit form. Preview ⇄ Source toggles the rendered page vs. raw HTML; **↗ Open** loads it full-screen in a new tab (its own `blob:` origin, still isolated).

### 2. Instant terminal ⇄ artifacts (no jump)
The Artifacts surface moves from a separate route into a **kept-alive tab on the session page**: `ArtifactsPanel` is served from `SessionDetail`, and the `/s/:id/artifacts/:name` deep link resolves to the same warm instance. Switching is now a tab flip on the live page, not a page swap — the header, tabs, and terminal never remount.

### 3. Pop out beside the terminal
The panel can **pop out into a resizable rail** next to the live terminal (mirroring the embedded-editor panel), so a user reads an artifact and watches the agent at once. Drag the divider to size it; **⤡ Dock** returns it to the tab; **✕** closes it.

### Also
- Fixes an SSE refresh that snapped the viewer back to Preview — and tore down the just-mounted Monaco — on a replayed or own write. It now keeps the current view mode and ignores an event for a revision already shown.
- Drops a stale overlooker e2e test that hard-coded the builtin-program count.

### Testing
- New e2e: HTML iframe render + Source toggle, pop-out↔dock rail, in-page tab round-trip. Full Playwright suite green; `cargo test` green (incl. a new `is_html_ext` unit test).
- Visually verified both themes (docked HTML preview + popped-out side-by-side).