### PR TITLE
feat(loom): attribute each session to the principal that launched it

### DIFF
--- a/crates/loom/frontend/src/components/SessionDetailsPopover.vue
+++ b/crates/loom/frontend/src/components/SessionDetailsPopover.vue
@@ -53,6 +53,10 @@ function close() {
           <dt class="w-16 shrink-0 text-faint">github</dt>
           <dd class="min-w-0 break-all font-mono text-muted">{{ ws.github_repo }}</dd>
         </div>
+        <div v-if="ws.created_by" class="flex gap-2">
+          <dt class="w-16 shrink-0 text-faint">created by</dt>
+          <dd class="min-w-0 break-all font-mono text-muted">{{ ws.created_by }}</dd>
+        </div>
       </dl>
       <!-- Lifecycle actions (Adopt / Archive / Remove), supplied by the header.
            Kept here so destructive, low-frequency operations live one click

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -86,6 +86,11 @@ export interface Session {
    *  threads by it; a child whose parent is absent (archived, or never tracked)
    *  renders at the top level. Stamped on the session row at launch. */
   parent_id: string | null;
+  /** The principal (username) that launched this session — attribution for the
+   *  shared team board. null for engine-created sessions (the concierge, warm
+   *  overlooker sessions) and rows predating the column. A tracking/UX field, not
+   *  a security boundary: the fleet stays co-owned by everyone authenticated. */
+  created_by: string | null;
   /** The tracking issue opened for this session's task at launch (the handle
    *  the launcher follows). Only set on the create response. */
   tracking_issue: number | null;

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -846,6 +846,15 @@ loadAgents();
         <!-- Ref: machine identity, mono, pushed far-right and receding. -->
         <div class="shrink-0 text-right">
           <span class="block truncate font-mono text-2xs text-faint">{{ s.branch.branch }}</span>
+          <!-- Attribution: who/what launched this session — a subtle provenance
+               label on the shared board. Absent for older rows. -->
+          <span
+            v-if="s.created_by"
+            class="block truncate text-2xs text-faint"
+            :title="`Launched by ${s.created_by}`"
+          >
+            by <span class="font-mono">{{ s.created_by }}</span>
+          </span>
           <!-- PR snapshot (if any) — a quiet link straight to the GitHub PR. -->
           <GithubStatus v-if="s.branch.github" :gh="s.branch.github" compact class="mt-0.5 justify-end" />
           <router-link

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -31,6 +31,12 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- from the fleet listing and the survey scope, and its restart adoption is
     -- governed by `overlooker.adopt_warm`, independent of `server.auto_adopt`.
     managed_by         TEXT,
+    -- The principal (username) that launched this session — attribution for the
+    -- shared team board. NULL for engine-created sessions (warm overlooker
+    -- sessions) and rows that predate the column. A tracking/UX field, never a
+    -- security boundary: the fleet stays co-owned, this just records who/what
+    -- launched each session.
+    created_by         TEXT,
     created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_active_branch
@@ -173,6 +179,13 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
     // ordinary fleet session. Sessions predating the column stay NULL (they are
     // all ordinary fleet sessions, as they were before warm sessions existed).
     add_column_if_missing(pool, "sessions", "managed_by", "TEXT").await?;
+    // The principal (username) that launched this session — attribution for the
+    // shared team board. NULL for engine-created sessions and rows predating the
+    // column. (The `sessions` table is created here in `migrate_loom`, after the
+    // weaver-core numbered migrations have already run, so a `sessions` column is
+    // added here rather than as a numbered migration in weaver-core/migrations —
+    // matching `model`/`effort`/`parent_branch_id`/`managed_by` above.)
+    add_column_if_missing(pool, "sessions", "created_by", "TEXT").await?;
     seed_owner(pool).await?;
     Ok(())
 }

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -747,6 +747,7 @@ mod tests {
                 github_repo: None,
                 parent_branch_id: None,
                 managed_by: None,
+                created_by: None,
             },
         )
         .await

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -366,6 +366,7 @@ mod tests {
             created_at: created_at.to_string(),
             parent_branch_id: None,
             managed_by: None,
+            created_by: None,
         }
     }
 

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -35,6 +35,12 @@ pub struct Session {
     /// restart adoption is governed by `overlooker.adopt_warm` rather than
     /// `server.auto_adopt`.
     pub managed_by: Option<String>,
+    /// The principal (username) that launched this session — attribution for the
+    /// shared team board. `None` for engine-created sessions (warm overlooker
+    /// sessions) and rows that predate the column. Stamped once at creation from
+    /// the resolving [`crate::auth::Principal`]; a tracking/UX field, never a
+    /// security boundary.
+    pub created_by: Option<String>,
 }
 
 /// Session **lifecycle** states — the mechanical, orchestrator-owned axis: is
@@ -78,6 +84,9 @@ pub struct NewSession {
     /// The owning overlooker id for an engine-managed (warm) session, or `None`
     /// for an ordinary fleet session. See [`Session::managed_by`].
     pub managed_by: Option<String>,
+    /// The principal (username) that launched this session, or `None` for an
+    /// engine-created (warm) session. See [`Session::created_by`].
+    pub created_by: Option<String>,
 }
 
 pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
@@ -85,8 +94,8 @@ pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
     sqlx::query(
         "INSERT INTO sessions
          (id, branch_id, work_dir, term_session, agent_kind, model, effort, status,
-          github_repo, parent_branch_id, managed_by, last_activity_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          github_repo, parent_branch_id, managed_by, created_by, last_activity_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&s.id)
     .bind(&s.branch_id)
@@ -99,6 +108,7 @@ pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
     .bind(&s.github_repo)
     .bind(&s.parent_branch_id)
     .bind(&s.managed_by)
+    .bind(&s.created_by)
     .bind(&now)
     .bind(&now)
     .execute(db)
@@ -276,6 +286,7 @@ mod tests {
             github_repo: None,
             parent_branch_id: None,
             managed_by: managed_by.map(str::to_string),
+            created_by: None,
         }
     }
 

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -226,6 +226,7 @@ async fn session_view(db: &Db, session: &Session, branch: &Branch) -> ApiResult<
         created_at: session.created_at.clone(),
         updated_at: branch.updated_at.clone(),
         parent_id: session.parent_branch_id.clone(),
+        created_by: session.created_by.clone(),
         tracking_issue: None,
         branch: bv,
     })
@@ -636,9 +637,16 @@ async fn get_session(
 
 async fn create_session(
     State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
     Json(req): Json<CreateReq>,
 ) -> ApiResult<Json<SessionView>> {
-    Ok(Json(create_session_core(st, req).await?))
+    // Attribute the session to whoever the auth middleware resolved: a human
+    // (cookie/token) → their username; a loopback/local-token call → the owner;
+    // a future webhook → its bot principal. Read from the `Principal`, never
+    // hardcoded and never client-supplied.
+    Ok(Json(
+        create_session_core(st, req, Some(principal.username)).await?,
+    ))
 }
 
 /// Resolve the **runtime** a session of `agent_kind` launches with. Every kind is
@@ -699,7 +707,14 @@ fn initial_status(runtime: &str) -> &'static str {
 /// The session-creation core, shared by `POST /api/sessions` and the Chat
 /// surface's concierge get-or-create ([`get_chat`]). Returns the view directly so
 /// the caller can shape its own response.
-async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionView> {
+///
+/// `created_by` is the launching principal's username (attribution for the shared
+/// board), or `None` for a system launch with no user behind it (the concierge).
+async fn create_session_core(
+    st: AppState,
+    req: CreateReq,
+    created_by: Option<String>,
+) -> ApiResult<SessionView> {
     let cwd = PathBuf::from(&req.cwd);
     let repo_root = git::repo_root(&cwd)
         .await
@@ -1035,6 +1050,7 @@ async fn create_session_core(st: AppState, req: CreateReq) -> ApiResult<SessionV
             github_repo: github_repo.clone(),
             parent_branch_id: parent.as_ref().map(|b| b.id.clone()),
             managed_by: None,
+            created_by,
         },
     )
     .await?;
@@ -1135,7 +1151,9 @@ async fn create_concierge(st: AppState) -> ApiResult<SessionView> {
         title: Some("Fleet concierge".to_string()),
         ..Default::default()
     };
-    create_session_core(st, req).await
+    // The concierge is a system singleton, not a user's workstream (and is hidden
+    // from the fleet board), so it carries no creator attribution.
+    create_session_core(st, req, None).await
 }
 
 /// `POST /api/chat/reset` — start a clean conversation with the concierge. The
@@ -1653,6 +1671,8 @@ pub async fn create_warm_session(
             github_repo: None,
             parent_branch_id: None,
             managed_by: Some(overlooker.id.clone()),
+            // Engine-created infrastructure, no user behind it.
+            created_by: None,
         },
     )
     .await?;

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -1272,6 +1272,7 @@ async fn insert_managed_session(
             github_repo: None,
             parent_branch_id: None,
             managed_by: Some(overlooker_id.to_string()),
+            created_by: None,
         },
     )
     .await

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -525,6 +525,54 @@ async fn adopt_recreates_killed_session() {
     client.delete(&format!("/api/sessions/{id}")).await.unwrap();
 }
 
+/// A session records the principal that launched it (`created_by`) — attribution
+/// for the shared board. The value is read from the resolving `Principal` (here
+/// the loopback owner the harness authenticates as), stored on the row at create
+/// time, and survives a re-list (and a get-by-id) unchanged.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_records_its_creating_principal() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    // Who the harness authenticates as — the resolved principal for these calls.
+    // Asserting against this (rather than a hardcoded name) proves attribution is
+    // read from the Principal, not pinned to one user.
+    let me = client.get("/api/auth/me").await.unwrap();
+    let who = me["username"].as_str().unwrap().to_string();
+    assert!(!who.is_empty(), "the loopback caller resolves to a user");
+
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "attributed work", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        ws["created_by"].as_str(),
+        Some(who.as_str()),
+        "the create response attributes the session to the launching principal"
+    );
+
+    // Stored, not recomputed: the attribution is still there on a plain list…
+    let list = client.get("/api/sessions").await.unwrap();
+    let row = list
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["id"] == id.as_str())
+        .expect("session in list");
+    assert_eq!(row["created_by"].as_str(), Some(who.as_str()));
+
+    // …and on a get-by-id.
+    let got = client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(got["created_by"].as_str(), Some(who.as_str()));
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
 /// A delegated launch records its launcher as the session's tree parent
 /// (`parent_id`); a top-level launch has none. The link is stored on the session
 /// row at create time, so it survives a re-list unchanged.

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -126,6 +126,11 @@ pub struct SessionView {
     /// Branch id of the session that **launched** this one — the parent in the
     /// dashboard's session tree — or `null` for a top-level session.
     pub parent_id: Option<String>,
+    /// The principal (username) that launched this session — attribution for the
+    /// shared team board. `null` for engine-created sessions (the concierge, warm
+    /// overlooker sessions) and rows that predate the column. A tracking/UX field,
+    /// not a security boundary: the fleet stays co-owned by everyone authenticated.
+    pub created_by: Option<String>,
     /// The tracking issue opened for this session's task at launch (the handle
     /// handed back to whoever launched it). Only populated on the create
     /// response; `None` on the list/get/patch paths, which don't recompute it.


### PR DESCRIPTION
Record who or what launched each session and surface it on the dashboard — the attribution piece of the shared team loom effort (weaver issue #337).

A nullable created_by column on sessions, set from the Principal the auth middleware already resolves (threaded into create_session), exposed on SessionView, mirrored by hand into the frontend types, and shown as a subtle "by <user>" label on the fleet list plus a "created by" row in the session details popover.

This is tracking/UX only, not a security boundary: the fleet stays co-owned by everyone authenticated. Attribution is read from the Principal, never hardcoded and never client-supplied — a human resolves to their username, a loopback/local-token call to the owner, and a future GitHub webhook to its bot principal. Engine launches (the concierge, warm overlooker sessions) carry no creator.

The column is added in loom's migrate_loom (add_column_if_missing) rather than a weaver-core numbered migration: the sessions table is loom-owned and created after the weaver-core migrations run, so an ALTER TABLE sessions there would fail on a fresh database. This matches how model/effort/parent_branch_id/managed_by were added.