### PR TITLE
feat(loom): managed repo store + clone for session launch

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -69,7 +69,18 @@ import type {
   ArtifactWriteBody,
   IdeInfo,
   AgentMetadata,
+  ManagedRepo,
 } from './types';
+
+// --- Managed repos ---------------------------------------------------------
+
+/** Every registered managed repo — the clone allowlist (`GET /api/repos`). */
+export const listRepos = () => get('/repos') as Promise<ManagedRepo[]>;
+
+/** Register a repo (a GitHub `owner/name` slug or clone URL) in the managed
+ *  store / allowlist (`POST /api/repos`). Returns the stored mapping. */
+export const registerRepo = (repo: string) =>
+  post('/repos', { repo }) as Promise<ManagedRepo>;
 
 interface AgentsEnvelope {
   agents: AgentMetadata[];

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -212,6 +212,19 @@ export interface RecentRepo {
   active_branches: number;
 }
 
+/** A repository registered in the managed repo store (`/api/repos`). The
+ *  slug→(remote, path) mapping doubles as the clone allowlist: only a registered
+ *  repo may be cloned for a session. Mirrors loom's `repo::ManagedRepo`. */
+export interface ManagedRepo {
+  /** Canonical GitHub `owner/name`. */
+  slug: string;
+  /** The clone source URL. */
+  remote_url: string;
+  /** The managed on-disk clone path. */
+  path: string;
+  created_at: string;
+}
+
 /** Branch listing returned by `/api/repos/branches?cwd=...` — distinct from
  *  the tracked-branch model: this enumerates git branches in a repo on disk. */
 export interface RepoBranch {

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -47,6 +47,19 @@ CREATE TABLE IF NOT EXISTS recent_repos (
     last_used_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
+-- Managed repositories: GitHub repos loom has cloned (or may clone) into the
+-- container-owned repo root (WEAVER_REPOS_DIR), laid out <owner>/<name>. The
+-- slug -> (remote_url, path) mapping doubles as the clone allowlist: only a repo
+-- registered here may be resolved and cloned for a session, the boundary the
+-- GitHub trigger relies on. Distinct from `recent_repos`, which only records
+-- bind-mounted local paths a session has used.
+CREATE TABLE IF NOT EXISTS repos (
+    slug       TEXT PRIMARY KEY,
+    remote_url TEXT NOT NULL,
+    path       TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
 -- The latest GitHub snapshot for a branch: the pull request loom found for it
 -- (via the `gh` CLI) plus its review/check rollup. One row per branch, replaced
 -- on each poll; it is optional context, gone the moment the branch row is.

--- a/crates/loom/src/repo.rs
+++ b/crates/loom/src/repo.rs
@@ -1,10 +1,13 @@
-//! Recently-used repositories, stored in the `recent_repos` table.
+//! Recently-used repositories (`recent_repos`) and the managed repo store
+//! (`repos`) loom clones into a container-owned root.
 
 use anyhow::Result;
 use serde::Serialize;
 use sqlx::FromRow;
+use std::path::{Path, PathBuf};
 
 use crate::db::{now_iso, Db};
+use weaver_core::git;
 
 #[derive(Debug, Clone, Serialize, FromRow)]
 pub struct RecentRepo {
@@ -42,6 +45,209 @@ pub async fn recent(db: &Db, limit: i64) -> Result<Vec<RecentRepo>> {
     .await?;
     tracing::debug!(count = rows.len(), "listed recent repos");
     Ok(rows)
+}
+
+// ---------------------------------------------------------------------------
+// Managed repo store — repos loom clones into a container-owned root and may
+// launch sessions against. The `repos` table doubles as the clone allowlist:
+// only a registered slug may be resolved and cloned (the boundary the future
+// GitHub trigger relies on). See the shared-loom design, §6.2.
+// ---------------------------------------------------------------------------
+
+/// The managed repo root: `WEAVER_REPOS_DIR`, else `$WEAVER_HOME/repos`. Clones
+/// are laid out `<root>/<owner>/<name>`.
+pub fn repos_dir() -> PathBuf {
+    if let Ok(p) = std::env::var("WEAVER_REPOS_DIR") {
+        let p = p.trim();
+        if !p.is_empty() {
+            return PathBuf::from(p);
+        }
+    }
+    weaver_core::db::weaver_home().join("repos")
+}
+
+/// A validated GitHub `owner/name` slug. The on-disk managed path is derived
+/// from this, so each component is strictly validated against path traversal
+/// before a `RepoSlug` can be constructed (see [`parse_slug`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoSlug {
+    pub owner: String,
+    pub name: String,
+}
+
+impl RepoSlug {
+    /// The canonical `owner/name` form — the `repos` table primary key.
+    pub fn slug(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+    /// The managed clone path under `root` (`<root>/<owner>/<name>`).
+    pub fn path(&self, root: &Path) -> PathBuf {
+        root.join(&self.owner).join(&self.name)
+    }
+    /// The canonical GitHub HTTPS clone URL for a bare `owner/name` reference.
+    pub fn github_url(&self) -> String {
+        format!("https://github.com/{}/{}.git", self.owner, self.name)
+    }
+}
+
+/// Whether a (trimmed) repo reference is a URL/scp form rather than a bare
+/// `owner/name` slug.
+fn is_url_ref(s: &str) -> bool {
+    s.contains("://") || (s.contains('@') && s.contains(':'))
+}
+
+/// One path component is a safe repo identifier segment: non-empty, not a `.` or
+/// `..` traversal element, and limited to GitHub's owner/name charset. This is
+/// the gate that makes `<root>/<owner>/<name>` impossible to escape.
+fn valid_segment(s: &str) -> bool {
+    !s.is_empty()
+        && s != "."
+        && s != ".."
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+/// Parse a repo reference — a bare `owner/name` slug or a GitHub URL — into a
+/// validated [`RepoSlug`]. The bare form must be *exactly* `owner/name`: this is
+/// the untrusted input the create path and GitHub trigger accept, so anything
+/// else (`..`, an absolute path, extra segments) is rejected. A URL form
+/// (`https://…`, `git@…:…`, `file://…`) is reduced to the trailing two path
+/// components. Either way both components are strictly validated, so the derived
+/// path can never escape the managed root. Returns the rejection reason on
+/// failure (the caller maps it to a 400).
+pub fn parse_slug(input: &str) -> Result<RepoSlug, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("repo identifier is empty".into());
+    }
+    let reject = || format!("'{input}' is not a clean owner/name repo identifier");
+
+    // A URL/scp reference is reduced to its path; a bare slug is used verbatim.
+    let (owner, name) = if is_url_ref(trimmed) {
+        let path_part = if let Some((_, rest)) = trimmed.split_once("://") {
+            // scheme://host/owner/name → drop the host segment.
+            rest.split_once('/').map(|(_, p)| p).unwrap_or("")
+        } else {
+            // scp form git@host:owner/name → keep the part after the last ':'.
+            trimmed.rsplit_once(':').map(|(_, p)| p).unwrap_or("")
+        };
+        let path_part = path_part.trim_matches('/');
+        let path_part = path_part.strip_suffix(".git").unwrap_or(path_part);
+        let segs: Vec<&str> = path_part.split('/').filter(|s| !s.is_empty()).collect();
+        match segs.as_slice() {
+            [.., o, n] => (o.to_string(), n.to_string()),
+            _ => return Err(reject()),
+        }
+    } else {
+        // Bare form: exactly `owner/name` — no leading slash (absolute), no extra
+        // segments. `split('/')` keeps empties, so `/abs`, `a/b/c`, and a trailing
+        // slash all fail the two-element match.
+        let s = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+        match s.split('/').collect::<Vec<_>>().as_slice() {
+            [o, n] => (o.to_string(), n.to_string()),
+            _ => return Err(reject()),
+        }
+    };
+    if !valid_segment(&owner) || !valid_segment(&name) {
+        return Err(reject());
+    }
+    Ok(RepoSlug { owner, name })
+}
+
+/// The clone URL to register for a repo reference: a bare `owner/name` resolves
+/// to its canonical GitHub HTTPS remote; an explicit URL is kept as given.
+pub fn remote_url_for(input: &str, slug: &RepoSlug) -> String {
+    let trimmed = input.trim();
+    if is_url_ref(trimmed) {
+        trimmed.to_string()
+    } else {
+        slug.github_url()
+    }
+}
+
+/// A repo registered in the managed store — the slug → (remote, path) mapping
+/// that also serves as the clone allowlist.
+#[derive(Debug, Clone, Serialize, FromRow)]
+pub struct ManagedRepo {
+    /// Canonical GitHub `owner/name`.
+    pub slug: String,
+    /// The clone source URL.
+    pub remote_url: String,
+    /// The managed on-disk clone path.
+    pub path: String,
+    pub created_at: String,
+}
+
+/// Register (or update the remote/path of) a managed repo, returning the row.
+pub async fn register(db: &Db, slug: &str, remote_url: &str, path: &str) -> Result<ManagedRepo> {
+    sqlx::query(
+        "INSERT INTO repos (slug, remote_url, path) VALUES (?, ?, ?)
+         ON CONFLICT(slug) DO UPDATE SET
+             remote_url = excluded.remote_url,
+             path = excluded.path",
+    )
+    .bind(slug)
+    .bind(remote_url)
+    .bind(path)
+    .execute(db)
+    .await?;
+    get_registered(db, slug)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("registered repo '{slug}' vanished"))
+}
+
+/// Every registered repo, newest first — the clone allowlist.
+pub async fn list_registered(db: &Db) -> Result<Vec<ManagedRepo>> {
+    let rows = sqlx::query_as::<_, ManagedRepo>(
+        "SELECT slug, remote_url, path, created_at FROM repos ORDER BY created_at DESC, slug",
+    )
+    .fetch_all(db)
+    .await?;
+    tracing::debug!(count = rows.len(), "listed managed repos");
+    Ok(rows)
+}
+
+/// One registered repo by slug, or `None` when it is not in the allowlist.
+pub async fn get_registered(db: &Db, slug: &str) -> Result<Option<ManagedRepo>> {
+    let row = sqlx::query_as::<_, ManagedRepo>(
+        "SELECT slug, remote_url, path, created_at FROM repos WHERE slug = ?",
+    )
+    .bind(slug)
+    .fetch_optional(db)
+    .await?;
+    Ok(row)
+}
+
+/// How a managed-repo resolution can fail, so the web layer maps each cause to
+/// the right HTTP status.
+#[derive(Debug)]
+pub enum ResolveError {
+    /// A malformed identifier or one not in the allowlist — the caller's fault (400).
+    BadRequest(String),
+    /// The clone/fetch itself failed (e.g. the remote is unreachable) — upstream (502).
+    Clone(String),
+}
+
+/// Resolve a managed-repo reference to its on-disk clone, ensuring it is present.
+/// `input` is a slug or URL; it is parsed strictly (traversal rejected), looked
+/// up in the registered allowlist (an unregistered repo is refused — the trigger
+/// boundary), then cloned-if-absent / fetched. Returns the managed checkout path.
+pub async fn resolve_clone(db: &Db, input: &str) -> std::result::Result<PathBuf, ResolveError> {
+    let slug = parse_slug(input).map_err(ResolveError::BadRequest)?;
+    let slug_str = slug.slug();
+    let registered = get_registered(db, &slug_str)
+        .await
+        .map_err(|e| ResolveError::Clone(e.to_string()))?
+        .ok_or_else(|| {
+            ResolveError::BadRequest(format!(
+                "repo '{slug_str}' is not registered — register it via POST /api/repos first"
+            ))
+        })?;
+    let dest = PathBuf::from(&registered.path);
+    git::clone(&registered.remote_url, &dest)
+        .await
+        .map_err(|e| ResolveError::Clone(format!("cloning {slug_str}: {e}")))?;
+    Ok(dest)
 }
 
 #[cfg(test)]
@@ -83,5 +289,163 @@ mod tests {
             record_use(&db, &format!("/code/r{i}")).await.unwrap();
         }
         assert_eq!(recent(&db, 3).await.unwrap().len(), 3);
+    }
+
+    #[test]
+    fn parse_slug_accepts_clean_owner_name_and_urls() {
+        // The bare canonical form.
+        let s = parse_slug("acme/widgets").unwrap();
+        assert_eq!((s.owner.as_str(), s.name.as_str()), ("acme", "widgets"));
+        assert_eq!(s.slug(), "acme/widgets");
+        assert_eq!(s.github_url(), "https://github.com/acme/widgets.git");
+        assert_eq!(
+            s.path(Path::new("/srv/repos")),
+            Path::new("/srv/repos/acme/widgets")
+        );
+
+        // URL forms reduce to their trailing owner/name; `.git` is stripped.
+        for url in [
+            "https://github.com/acme/widgets",
+            "https://github.com/acme/widgets.git",
+            "http://github.com/acme/widgets/",
+            "git@github.com:acme/widgets.git",
+            "file:///tmp/store/acme/widgets",
+        ] {
+            assert_eq!(
+                parse_slug(url).unwrap().slug(),
+                "acme/widgets",
+                "url: {url}"
+            );
+        }
+
+        // A dot is legal inside a name (e.g. `repo.js`).
+        assert_eq!(parse_slug("acme/repo.js").unwrap().name, "repo.js");
+    }
+
+    #[test]
+    fn parse_slug_rejects_traversal_and_malformed() {
+        for bad in [
+            "",
+            "owner",                          // one segment
+            "a/b/c",                          // three segments
+            "owner/name/",                    // trailing slash
+            "/etc/passwd",                    // absolute path
+            "../etc",                         // parent traversal
+            "owner/..",                       // traversal in name
+            "../../root",                     // deep traversal
+            "owner/na me",                    // space (bad charset)
+            "https://github.com/a/../../etc", // traversal in url tail
+        ] {
+            assert!(parse_slug(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn register_lists_and_gets() {
+        let db = connect_in_memory().await.unwrap();
+        let r = register(
+            &db,
+            "acme/widgets",
+            "https://example/acme/widgets.git",
+            "/srv/acme/widgets",
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.slug, "acme/widgets");
+        assert_eq!(r.remote_url, "https://example/acme/widgets.git");
+        assert_eq!(r.path, "/srv/acme/widgets");
+
+        assert!(get_registered(&db, "acme/widgets").await.unwrap().is_some());
+        assert!(get_registered(&db, "ghost/repo").await.unwrap().is_none());
+        assert_eq!(list_registered(&db).await.unwrap().len(), 1);
+
+        // Re-registering the same slug updates the remote/path, not a duplicate.
+        register(
+            &db,
+            "acme/widgets",
+            "https://example/acme/widgets2.git",
+            "/srv/acme/w2",
+        )
+        .await
+        .unwrap();
+        let rows = list_registered(&db).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].remote_url, "https://example/acme/widgets2.git");
+    }
+
+    /// `resolve_clone` refuses an unregistered repo (the allowlist boundary) and a
+    /// traversal identifier, and on a registered repo clones it from the (local,
+    /// no-network) remote into the managed path.
+    #[tokio::test]
+    async fn resolve_clone_enforces_allowlist_then_clones() {
+        let db = connect_in_memory().await.unwrap();
+
+        // Unregistered → BadRequest, no clone attempted.
+        assert!(matches!(
+            resolve_clone(&db, "ghost/repo").await,
+            Err(ResolveError::BadRequest(_))
+        ));
+        // Traversal → BadRequest before any lookup.
+        assert!(matches!(
+            resolve_clone(&db, "../etc").await,
+            Err(ResolveError::BadRequest(_))
+        ));
+
+        // Build a local bare repo to act as the remote (no network).
+        let src = tempfile::tempdir().unwrap();
+        let sdir = src.path();
+        run_git(sdir, &["init", "-q", "-b", "main"]).await;
+        run_git(sdir, &["config", "user.email", "t@t.t"]).await;
+        run_git(sdir, &["config", "user.name", "t"]).await;
+        std::fs::write(sdir.join("README.md"), "hi\n").unwrap();
+        run_git(sdir, &["add", "-A"]).await;
+        run_git(sdir, &["commit", "-q", "-m", "init"]).await;
+        let bare = tempfile::tempdir().unwrap();
+        let bare_path = bare.path().join("origin.git");
+        run_git(
+            sdir,
+            &[
+                "clone",
+                "--bare",
+                "-q",
+                &sdir.to_string_lossy(),
+                &bare_path.to_string_lossy(),
+            ],
+        )
+        .await;
+
+        // Register the slug pointing at the local bare remote, with a managed dest.
+        let dest_root = tempfile::tempdir().unwrap();
+        let dest = dest_root.path().join("acme").join("widgets");
+        register(
+            &db,
+            "acme/widgets",
+            &bare_path.to_string_lossy(),
+            &dest.to_string_lossy(),
+        )
+        .await
+        .unwrap();
+
+        let path = resolve_clone(&db, "acme/widgets").await.unwrap();
+        assert_eq!(path, dest);
+        assert!(
+            dest.join(".git").exists(),
+            "repo was cloned to the managed path"
+        );
+        // Idempotent: a second resolve fetches into the existing clone.
+        resolve_clone(&db, "acme/widgets").await.unwrap();
+    }
+
+    /// Run `git` in `dir` for the resolve test (the crate has no test-only git
+    /// helper of its own; `weaver_core::git` exposes only typed operations).
+    async fn run_git(dir: &Path, args: &[&str]) {
+        let status = tokio::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .status()
+            .await
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
     }
 }

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -489,6 +489,8 @@ pub fn router(state: AppState) -> Router {
         )
         // Misc
         .route("/agents", get(list_agents))
+        // The managed repo store + clone allowlist (register/list).
+        .route("/repos", get(list_repos).post(register_repo))
         .route("/repos/recent", get(recent_repos))
         .route("/repos/branches", get(repo_branches))
         .route(
@@ -715,10 +717,24 @@ async fn create_session_core(
     req: CreateReq,
     created_by: Option<String>,
 ) -> ApiResult<SessionView> {
-    let cwd = PathBuf::from(&req.cwd);
-    let repo_root = git::repo_root(&cwd)
-        .await
-        .map_err(|e| AppError::bad_request(e.to_string()))?;
+    // Resolve the repo root. An explicit managed `repo` (a slug/URL) is
+    // allowlist-checked and cloned-if-absent into the managed store, then used
+    // directly; otherwise fork from `cwd`'s repo (the default). The traversal /
+    // allowlist gate lives in `repo::resolve_clone`.
+    let repo_root = match req.repo.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(input) => repo::resolve_clone(&st.db, input)
+            .await
+            .map_err(|e| match e {
+                repo::ResolveError::BadRequest(m) => AppError::bad_request(m),
+                repo::ResolveError::Clone(m) => AppError::new(StatusCode::BAD_GATEWAY, m),
+            })?,
+        None => {
+            let cwd = PathBuf::from(&req.cwd);
+            git::repo_root(&cwd)
+                .await
+                .map_err(|e| AppError::bad_request(e.to_string()))?
+        }
+    };
     // Canonicalize so repo identity matches the `weaver` CLI's resolver — issues
     // are keyed on this path and the two binaries must agree on it.
     let repo_root = repo_root.canonicalize().unwrap_or(repo_root);
@@ -2702,6 +2718,35 @@ async fn recent_repos(
 ) -> ApiResult<Json<Vec<repo::RecentRepo>>> {
     let limit = q.limit.unwrap_or(10).clamp(1, 50);
     Ok(Json(repo::recent(&st.db, limit).await?))
+}
+
+/// `GET /api/repos` — the registered managed repos (the clone allowlist).
+async fn list_repos(State(st): State<AppState>) -> ApiResult<Json<Vec<repo::ManagedRepo>>> {
+    Ok(Json(repo::list_registered(&st.db).await?))
+}
+
+/// Body for `POST /api/repos`: a repo reference — a GitHub `owner/name` slug or a
+/// clone URL — to add to the managed store / allowlist.
+#[derive(Debug, Deserialize)]
+struct RegisterRepoReq {
+    repo: String,
+}
+
+/// `POST /api/repos` — register a repo in the managed store. The reference is
+/// parsed to a clean `owner/name` slug (traversal rejected → 400); the clone URL
+/// is the canonical GitHub HTTPS remote for a bare slug, or the URL as given.
+/// The clone itself is lazy — it happens on first use (session create),
+/// idempotently — so registering is just adding to the allowlist.
+async fn register_repo(
+    State(st): State<AppState>,
+    Json(req): Json<RegisterRepoReq>,
+) -> ApiResult<Json<repo::ManagedRepo>> {
+    let slug = repo::parse_slug(&req.repo).map_err(AppError::bad_request)?;
+    let remote_url = repo::remote_url_for(&req.repo, &slug);
+    let path = slug.path(&repo::repos_dir());
+    let managed =
+        repo::register(&st.db, &slug.slug(), &remote_url, &path.to_string_lossy()).await?;
+    Ok(Json(managed))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -17,6 +17,7 @@ mod env;
 mod ide;
 mod overlookers;
 mod pane;
+mod repos;
 mod scratch;
 mod sessions;
 mod shell;

--- a/crates/loom/tests/integration/repos.rs
+++ b/crates/loom/tests/integration/repos.rs
@@ -1,0 +1,165 @@
+//! The managed repo store over the REST API: register a repo into the allowlist,
+//! then launch a session with `{repo: "owner/name"}` so loom clones it into the
+//! managed store and forks the worktree from the clone — no `cwd`. Plus the
+//! security gates: traversal identifiers and non-allowlisted repos are rejected.
+//!
+//! The clone source is a *local bare repo* (registered via a `file://` URL), so
+//! these tests never touch the network.
+
+use serde_json::json;
+use serial_test::serial;
+
+use crate::fixtures::{sh, TestServer};
+
+/// Lay out a bare repo at `<root>/acme/widgets` (so its trailing path is the
+/// `acme/widgets` slug) with a single commit on `main`, and return its
+/// `file://` clone URL.
+fn make_bare_remote(root: &std::path::Path) -> String {
+    // A throwaway working repo with one commit.
+    let work = root.join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    sh(&work, "git", &["init", "-q", "-b", "main"]);
+    sh(&work, "git", &["config", "user.email", "t@t.test"]);
+    sh(&work, "git", &["config", "user.name", "Test"]);
+    std::fs::write(work.join("README.md"), "hello\n").unwrap();
+    sh(&work, "git", &["add", "."]);
+    sh(&work, "git", &["commit", "-q", "-m", "init"]);
+
+    // Bare-clone it to <root>/acme/widgets — the path whose tail is the slug.
+    let bare = root.join("acme").join("widgets");
+    std::fs::create_dir_all(bare.parent().unwrap()).unwrap();
+    sh(
+        &work,
+        "git",
+        &[
+            "clone",
+            "--bare",
+            "-q",
+            &work.to_string_lossy(),
+            &bare.to_string_lossy(),
+        ],
+    );
+    format!("file://{}", bare.display())
+}
+
+/// Register a repo, then create a session against it by slug (no `cwd`): loom
+/// clones the registered remote into the managed store and forks the worktree
+/// from that managed checkout.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn register_then_launch_clones_into_managed_store() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let remotes = tempfile::tempdir().unwrap();
+    let remote_url = make_bare_remote(remotes.path());
+
+    // Register the repo via the URL form — slug derives to `acme/widgets`.
+    let reg = client
+        .post("/api/repos", json!({ "repo": remote_url }))
+        .await
+        .unwrap();
+    assert_eq!(reg["slug"], "acme/widgets");
+    assert_eq!(reg["remote_url"], remote_url);
+
+    // It shows up in the allowlist listing.
+    let list = client.get("/api/repos").await.unwrap();
+    let list = list.as_array().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["slug"], "acme/widgets");
+
+    // Launch by slug, with no cwd: loom clones the repo and uses it as the root.
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "managed clone", "repo": "acme/widgets", "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+    let work_dir = ws["work_dir"].as_str().unwrap().to_string();
+    let repo_root = ws["branch"]["repo_root"].as_str().unwrap().to_string();
+
+    // The repo root is the managed clone path; the worktree lives under it.
+    let managed = loom::repo::repos_dir().join("acme").join("widgets");
+    assert!(
+        std::path::Path::new(&work_dir).join(".git").exists(),
+        "worktree was not created in the managed clone"
+    );
+    assert!(
+        work_dir.contains("/acme/widgets/.worktrees/"),
+        "worktree should live in the managed repo, got {work_dir}"
+    );
+    assert!(
+        std::path::Path::new(&repo_root).ends_with("acme/widgets")
+            || repo_root == managed.canonicalize().unwrap().to_string_lossy(),
+        "repo_root should be the managed clone, got {repo_root}"
+    );
+    assert!(
+        managed.join(".git").exists(),
+        "managed clone exists on disk"
+    );
+
+    // A second launch against the same slug reuses the clone (idempotent fetch).
+    let ws2 = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "managed clone two", "repo": "acme/widgets", "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id2 = ws2["id"].as_str().unwrap().to_string();
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+    client
+        .delete(&format!("/api/sessions/{id2}"))
+        .await
+        .unwrap();
+}
+
+/// Security: a traversal identifier and a non-allowlisted repo are both rejected
+/// with a 400 before any clone is attempted.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_rejects_traversal_and_unregistered_repos() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    // Traversal / malformed identifiers — rejected by the strict slug parse.
+    for bad in ["../etc", "/etc/passwd", "a/b/c", "owner/.."] {
+        let err = client
+            .post("/api/sessions", json!({ "repo": bad, "agent": "shell" }))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("400"),
+            "traversal id {bad:?} should be a 400, got {err}"
+        );
+    }
+
+    // A clean slug that is not registered — refused by the allowlist boundary.
+    let err = client
+        .post(
+            "/api/sessions",
+            json!({ "repo": "ghost/repo", "agent": "shell" }),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("400") && err.contains("not registered"),
+        "unregistered repo should be a 400, got {err}"
+    );
+
+    // Registration itself rejects a traversal identifier.
+    let err = client
+        .post("/api/repos", json!({ "repo": "../escape" }))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("400"),
+        "register traversal should 400, got {err}"
+    );
+}

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -418,7 +418,17 @@ pub struct ScratchUpload {
 /// Body for `POST /api/sessions`: launch a new session.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CreateReq {
+    /// The repo to fork the session's worktree from, as a local path. Ignored
+    /// when `repo` (a managed repo) is set; otherwise required.
+    #[serde(default)]
     pub cwd: String,
+    /// An optional **managed** repository to launch against: a GitHub `owner/name`
+    /// slug or URL. When set, loom resolves it against the registered repo
+    /// allowlist, clones it into the managed repo store if absent (else fetches),
+    /// and uses that checkout as the repo root — `cwd` is then ignored. Unset (the
+    /// default) keeps the historical behaviour: fork from `cwd`'s repo.
+    #[serde(default)]
+    pub repo: Option<String>,
     #[serde(default)]
     pub title: Option<String>,
     #[serde(default)]

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -63,6 +63,45 @@ pub async fn repo_root(dir: &Path) -> Result<PathBuf> {
     Ok(PathBuf::from(first))
 }
 
+/// Clone `url` into `dest`, or fetch into it when `dest` is already a clone —
+/// idempotent, so two session launches racing to acquire the same managed repo
+/// converge instead of one erroring on a populated directory. Authentication
+/// rides the ambient git credential helper (the deploy image wires `GH_TOKEN`);
+/// no credentials are passed or stored here.
+pub async fn clone(url: &str, dest: &Path) -> Result<()> {
+    // An existing clone (its `.git` is present) is refreshed, not re-cloned.
+    if dest.join(".git").exists() {
+        git(dest, &["fetch", "--all", "--prune"]).await?;
+        tracing::info!(dest = %dest.display(), "fetched existing clone");
+        return Ok(());
+    }
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("creating repo parent {}", parent.display()))?;
+    }
+    // `git clone` has no working tree to `-C` into yet, so it is spawned directly
+    // rather than through the `git()` helper.
+    let dest_str = dest.to_string_lossy();
+    let out = Command::new("git")
+        .args(["clone", url, &dest_str])
+        .output()
+        .await
+        .context("failed to spawn git clone")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        tracing::warn!(
+            url,
+            dest = %dest.display(),
+            stderr = %truncate(stderr.trim(), 500),
+            "git clone failed"
+        );
+        bail!("git clone failed: {}", stderr.trim());
+    }
+    tracing::info!(url, dest = %dest.display(), "cloned repo");
+    Ok(())
+}
+
 /// Ensure `pattern` is present in the repository's `.git/info/exclude`, so
 /// that (for example) the in-repo `.worktrees/` directory is not reported as
 /// untracked content. This is local-only and never touches a tracked file.
@@ -582,6 +621,61 @@ mod tests {
         let clean = changed_files(dir, &since).await.unwrap();
         assert_eq!(clean.len(), 1);
         assert_eq!(clean[0].path, "mine.txt");
+    }
+
+    /// `clone` acquires a repo into a fresh dest, then is idempotent: a second
+    /// call fetches into the existing clone (picking up new commits) instead of
+    /// failing on the populated directory. Uses a local bare repo as the remote —
+    /// no network.
+    #[tokio::test]
+    async fn clone_then_fetch_is_idempotent() {
+        // A working source repo with one commit.
+        let src = tempfile::tempdir().unwrap();
+        let sdir = src.path();
+        run(sdir, &["init", "-q", "-b", "main"]).await;
+        run(sdir, &["config", "user.email", "t@t.t"]).await;
+        run(sdir, &["config", "user.name", "t"]).await;
+        std::fs::write(sdir.join("a.txt"), "a\n").unwrap();
+        run(sdir, &["add", "-A"]).await;
+        commit(sdir, "init").await;
+
+        // A bare clone of it acts as the clonable remote.
+        let bare = tempfile::tempdir().unwrap();
+        let bare_path = bare.path().join("origin.git");
+        let out = Command::new("git")
+            .args([
+                "clone",
+                "--bare",
+                "-q",
+                &sdir.to_string_lossy(),
+                &bare_path.to_string_lossy(),
+            ])
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success(), "bare clone of the source failed");
+        let bare_url = bare_path.to_string_lossy().to_string();
+
+        // First call clones into a nested <root>/owner/name path (parent created).
+        let root = tempfile::tempdir().unwrap();
+        let dest = root.path().join("acme").join("widgets");
+        clone(&bare_url, &dest).await.unwrap();
+        assert!(dest.join(".git").exists(), "clone made a working clone");
+        assert!(dest.join("a.txt").exists(), "clone checked out content");
+
+        // Advance the remote with a second commit.
+        std::fs::write(sdir.join("b.txt"), "b\n").unwrap();
+        run(sdir, &["add", "-A"]).await;
+        let second = commit(sdir, "second").await;
+        run(sdir, &["push", "-q", &bare_url, "main"]).await;
+
+        // Idempotent: the second call fetches rather than erroring, and the new
+        // commit is now reachable via origin.
+        clone(&bare_url, &dest).await.unwrap();
+        assert!(
+            commit_exists(&dest, &second).await,
+            "fetch pulled the new remote commit into the existing clone"
+        );
     }
 
     /// With no `origin` remote, the launch base degrades to the local current


### PR DESCRIPTION
Add a managed repo store so loom can launch a session against a repo it has never seen, cloning it on demand — the repo-acquisition half of the shared-team-loom effort (§6.2 of the design).

## What

- `git::clone(url, dest)` in weaver-core: idempotent — fetches when `dest` is already a clone, clones otherwise. Auth rides the ambient git credential helper already wired in the image; no new auth.
- A `repos` table (loom db) mapping a GitHub `owner/name` slug to a managed clone path + remote URL, rooted at `WEAVER_REPOS_DIR` (default `$WEAVER_HOME/repos`, laid out `<owner>/<name>`). The table doubles as the clone allowlist.
- `GET /api/repos` (list) and `POST /api/repos` (register a slug or URL) for authenticated users, mirrored in the frontend types + api client.
- `CreateReq` gains an optional `repo` field (slug or URL). When set, `create_session_core` resolves it, allowlist-checks it, clones-if-absent (else fetches), and uses the managed checkout as the repo root. `cwd` still works and stays the default.

## Security

Untrusted input is the only threat modelled here (the future GitHub trigger relies on this boundary): a repo identifier that is not a clean `owner/name` (`..`, an absolute path, traversal, extra segments) is rejected with 400, and a slug not in the allowlist is rejected with 400 before any clone.

## Tests

Unit: `git::clone` idempotency against a local bare repo; strict slug parsing (accepts owner/name + GitHub URLs, rejects traversal); the register/list/get roundtrip; and `resolve_clone` enforcing the allowlist then cloning. Integration: register a repo (via a `file://` local bare repo, no network) then `POST /api/sessions {repo}` with no cwd clones and launches; traversal and unregistered repos are rejected.

Part of #337.