### PR TITLE
feat(loom): inbound GitHub webhook trigger (@loom work on this)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1248,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "async-trait",
  "axum",
  "base64",
  "chrono",
@@ -1236,6 +1257,7 @@ dependencies = [
  "croner",
  "futures-util",
  "hex",
+ "hmac",
  "hyper",
  "hyper-util",
  "percent-encoding",

--- a/README.md
+++ b/README.md
@@ -247,6 +247,16 @@ weaver config set github.poll false               # stop polling GitHub entirely
 Polling is a quiet no-op for repositories without a GitHub remote, or wherever
 `gh` is not installed — nothing to configure to opt out there.
 
+### Trigger sessions from issues
+
+Comment **`@loom work on this`** on a GitHub issue and loom launches a session
+against that repo, seeded from the issue, and replies with a link to it. GitHub
+delivers the comment to `POST /api/github/webhook`, which verifies the delivery's
+HMAC signature, authorizes the commenter (a loom operator or a repo writer), and
+only acts on repos in the managed allowlist. Set `LOOM_GITHUB_WEBHOOK_SECRET` and
+point a repo/org webhook at `{base}/api/github/webhook` (issue-comment events,
+`application/json`). See [docs/github-trigger.md](docs/github-trigger.md).
+
 ## REST API (brief)
 
 Loom serves a JSON API under `/api`; the Vue SPA is the primary consumer.
@@ -261,6 +271,9 @@ Loom serves a JSON API under `/api`; the Vue SPA is the primary consumer.
   `GET PATCH DELETE /api/issues/{id}`
 - `GET /api/repos/recent`, `GET /api/repos/branches?cwd=…`,
   `GET POST /api/repos/issues?repo_root=…` (the repo-wide board / backlog)
+- `GET POST /api/repos` (the managed repo store / clone allowlist)
+- `POST /api/github/webhook` (the inbound GitHub trigger; HMAC-authenticated,
+  outside the login middleware — see [docs/github-trigger.md](docs/github-trigger.md))
 - `GET PATCH /api/settings`
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the shape of `SessionView`.
@@ -378,3 +391,5 @@ placeholder page), `cargo test --workspace` runs the backend suites, and `cd e2e
 - `LOOM_TOKEN` — bearer token the `loom` CLI / automation sends (see [Authentication](#authentication))
 - `LOOM_OWNER_GITHUB` — GitHub login seeded as the owner on a fresh database (default `rjpower`)
 - `LOOM_GITHUB_CLIENT_ID` / `LOOM_GITHUB_CLIENT_SECRET` — GitHub OAuth app credentials
+- `LOOM_GITHUB_WEBHOOK_SECRET` — shared secret for the inbound GitHub trigger; until set, the webhook rejects every delivery ([docs/github-trigger.md](docs/github-trigger.md))
+- `WEAVER_REPOS_DIR` — managed repo store root (default `$WEAVER_HOME/repos`)

--- a/crates/loom/Cargo.toml
+++ b/crates/loom/Cargo.toml
@@ -20,6 +20,9 @@ tapestry = { path = "../tapestry" }
 anyhow = "1"
 # Password hashing for the user/password login path (the OWASP-recommended KDF).
 argon2 = "0.5"
+# Trait objects with async methods — the GitHub trigger's gateway abstraction
+# (`GithubApi`), so the `gh`-backed implementation and a test fake share a type.
+async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
@@ -28,6 +31,10 @@ clap_complete = "4"
 futures-util = "0.3"
 # Hex-encode the SHA-256 digests we store for API tokens and session cookies.
 hex = "0.4"
+# HMAC-SHA256 for verifying the GitHub webhook signature (`X-Hub-Signature-256`).
+# `Mac::verify_slice` is a constant-time compare, so the verification can't be
+# turned into a timing oracle.
+hmac = "0.12"
 # Reverse-proxying the embedded code-server (crate::ide): a pooled HTTP client
 # (hyper-util legacy) for the asset/API plane, and hyper's low-level conn for the
 # transparent WebSocket-upgrade passthrough (extension host + integrated terminal).
@@ -70,3 +77,10 @@ axum = { version = "0.8", features = ["ws"] }
 # env (WEAVER_HOME / WEAVER_API / WEAVER_TAPESTRY_BIN), so they must not run
 # concurrently within the test binary; `#[serial]` serializes them.
 serial_test = "3"
+# The webhook suite forges a valid `X-Hub-Signature-256` (hmac/sha2/hex) and
+# installs a fake `GithubApi` (async-trait, anyhow::Result) into the test server.
+anyhow = "1"
+async-trait = "0.1"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -60,6 +60,15 @@ CREATE TABLE IF NOT EXISTS repos (
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
+-- Processed GitHub webhook deliveries, keyed on the `X-GitHub-Delivery` GUID.
+-- The receiver records each delivery before acting on it and treats a repeat as
+-- a no-op, so a replayed (or GitHub-retried) delivery never launches a second
+-- session. Append-only; rows are cheap and can be pruned by age later.
+CREATE TABLE IF NOT EXISTS processed_deliveries (
+    delivery_id TEXT PRIMARY KEY,
+    received_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
 -- The latest GitHub snapshot for a branch: the pull request loom found for it
 -- (via the `gh` CLI) plus its review/check rollup. One row per branch, replaced
 -- on each poll; it is optional context, gone the moment the branch row is.

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -757,6 +757,7 @@ mod tests {
             bus: events::EventBus::new(),
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
+            trigger: crate::github_trigger::GithubTrigger::production(),
         };
         Fixture {
             _repo: repo,

--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -1,0 +1,578 @@
+//! The inbound GitHub trigger: a webhook that turns an `@loom work on this`
+//! issue comment into a session and replies with its URL (shared-loom design
+//! §6.3). This is the **untrusted-input boundary** — the receiver is exposed to
+//! the internet, so every step here is a gate:
+//!
+//! 1. **Authenticate the delivery cryptographically.** GitHub signs each
+//!    delivery with HMAC-SHA256 over the raw body; [`verify_signature`] checks it
+//!    with a constant-time compare. A request without a valid signature is
+//!    rejected before its body is even parsed.
+//! 2. **Dedupe** on the `X-GitHub-Delivery` GUID ([`record_delivery`]) so a
+//!    replayed or GitHub-retried delivery never launches a second session.
+//! 3. **Filter** to `issue_comment`/`created`, ignoring the bot's own comments.
+//! 4. **Parse** a fixed command prefix ([`is_trigger`]) — no free-text in v1.
+//! 5. **Authorize the commenter** ([`authorize`]): a known loom operator, or
+//!    someone with write/admin on the repo (checked via the GitHub API). Anyone
+//!    else is silently ignored; a per-repo rate limit blunts spam.
+//!
+//! The HTTP glue that sequences these (and then creates the session + replies)
+//! lives in [`crate::web::github_webhook`], which has access to the session
+//! create path; the security primitives live here so they can be unit-tested in
+//! isolation. External GitHub calls (the permission check and the reply) go
+//! through the [`GithubApi`] gateway so a test can substitute a fake for `gh`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use sha2::Sha256;
+use std::sync::Arc;
+use tokio::process::Command;
+
+use crate::auth;
+use crate::db::Db;
+use weaver_core::config;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// The settings key (read via env-or-DB) holding the webhook's shared secret.
+/// Kept **out** of the settings registry, like the OAuth client secret, so it is
+/// never returned by `GET /api/settings`; set it through the environment.
+pub const WEBHOOK_SECRET_KEY: &str = "github.webhook_secret";
+/// The settings key for the optional bot login whose own comments are ignored.
+pub const BOT_LOGIN_KEY: &str = "github.bot_login";
+
+/// Read `LOOM_GITHUB_WEBHOOK_SECRET`, else the `github.webhook_secret` setting.
+/// Empty means the webhook is **not configured** — the receiver then rejects
+/// every delivery (it cannot verify a signature without it).
+pub async fn webhook_secret(db: &Db) -> String {
+    env_or_setting(db, "LOOM_GITHUB_WEBHOOK_SECRET", WEBHOOK_SECRET_KEY).await
+}
+
+/// The trigger phrase a comment must begin with, from the
+/// `github.trigger_phrase` setting (default `@loom work on this`).
+pub async fn trigger_phrase(db: &Db) -> String {
+    let phrase = config::get_or(
+        db,
+        "github.trigger_phrase",
+        config::DEFAULT_GITHUB_TRIGGER_PHRASE,
+    )
+    .await
+    .trim()
+    .to_string();
+    if phrase.is_empty() {
+        config::DEFAULT_GITHUB_TRIGGER_PHRASE.to_string()
+    } else {
+        phrase
+    }
+}
+
+/// The bot's own GitHub login, whose comments are ignored to prevent a
+/// self-trigger loop. `LOOM_GITHUB_BOT_LOGIN`, else the `github.bot_login`
+/// setting; `None` when unset (the command-prefix filter is the real guard, so
+/// this is defence in depth and optional).
+pub async fn bot_login(db: &Db) -> Option<String> {
+    let login = env_or_setting(db, "LOOM_GITHUB_BOT_LOGIN", BOT_LOGIN_KEY).await;
+    let login = login.trim();
+    (!login.is_empty()).then(|| login.to_string())
+}
+
+/// `env`, else the `key` setting; empty when neither is set. (Mirrors the OAuth
+/// secret resolution in [`crate::auth`], kept private to each module.)
+async fn env_or_setting(db: &Db, env: &str, key: &str) -> String {
+    if let Ok(v) = std::env::var(env) {
+        let v = v.trim().to_string();
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    config::get(db, key).await.unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification — the cryptographic authentication of every delivery.
+// ---------------------------------------------------------------------------
+
+/// Verify GitHub's `X-Hub-Signature-256` over the **raw** request body. The
+/// header is `sha256=<hex>`; we recompute HMAC-SHA256 of `body` keyed by
+/// `secret` and compare in constant time ([`Mac::verify_slice`]). Returns
+/// `false` — never panicking — for an empty secret (not configured), a missing
+/// or malformed header, or any mismatch.
+///
+/// `body` MUST be the bytes exactly as received: the signature is over the wire
+/// bytes, so re-serializing a parsed JSON value would change the digest.
+pub fn verify_signature(secret: &str, body: &[u8], header: Option<&str>) -> bool {
+    if secret.is_empty() {
+        return false;
+    }
+    let Some(header) = header else {
+        return false;
+    };
+    let Some(hex_sig) = header.trim().strip_prefix("sha256=") else {
+        return false;
+    };
+    let Ok(provided) = hex::decode(hex_sig.trim()) else {
+        return false;
+    };
+    // `new_from_slice` only errors on a key length HMAC can't take; SHA-256's
+    // block construction accepts any key, so this never fails for a real secret.
+    let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(body);
+    mac.verify_slice(&provided).is_ok()
+}
+
+// ---------------------------------------------------------------------------
+// Command + payload parsing.
+// ---------------------------------------------------------------------------
+
+/// Whether `body` begins with the trigger `phrase`, ignoring leading whitespace
+/// and case. The match is anchored to the **start** so a quote of an earlier
+/// comment, or the phrase buried mid-text, does not trigger.
+pub fn is_trigger(body: &str, phrase: &str) -> bool {
+    let body = body.trim_start().to_lowercase();
+    let phrase = phrase.trim().to_lowercase();
+    !phrase.is_empty() && body.starts_with(&phrase)
+}
+
+/// The `issue_comment` webhook payload, narrowed to the fields the trigger uses.
+/// Deserialized from the verified raw body, so these values are trusted (they
+/// came from GitHub, not the caller).
+#[derive(Debug, Deserialize)]
+pub struct IssueCommentEvent {
+    /// `created` | `edited` | `deleted` — only `created` is acted on.
+    pub action: String,
+    pub issue: IssuePayload,
+    pub comment: CommentPayload,
+    pub repository: RepoPayload,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IssuePayload {
+    pub number: i64,
+    #[serde(default)]
+    pub title: String,
+    /// GitHub sends `null` for an empty issue body, so this is an `Option`.
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommentPayload {
+    #[serde(default)]
+    pub body: String,
+    pub user: UserPayload,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserPayload {
+    #[serde(default)]
+    pub login: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoPayload {
+    /// `owner/name`.
+    pub full_name: String,
+}
+
+impl IssueCommentEvent {
+    /// Parse an `issue_comment` payload from the raw (already signature-verified)
+    /// body.
+    pub fn parse(body: &[u8]) -> Result<Self> {
+        serde_json::from_slice(body).context("parsing issue_comment payload")
+    }
+
+    /// The seed text for the session goal: the issue title, plus its body when
+    /// present.
+    pub fn goal_seed(&self) -> String {
+        match self.issue.body.as_deref().map(str::trim) {
+            Some(b) if !b.is_empty() => format!("{}\n\n{}", self.issue.title, b),
+            _ => self.issue.title.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency.
+// ---------------------------------------------------------------------------
+
+/// Record a delivery GUID, returning `true` only the **first** time it is seen.
+/// A repeat (a replay, or a GitHub retry of a delivery we already handled)
+/// returns `false`, so the caller treats it as a no-op.
+pub async fn record_delivery(db: &Db, delivery_id: &str) -> Result<bool> {
+    let res = sqlx::query("INSERT OR IGNORE INTO processed_deliveries (delivery_id) VALUES (?)")
+        .bind(delivery_id)
+        .execute(db)
+        .await
+        .context("recording webhook delivery")?;
+    Ok(res.rows_affected() > 0)
+}
+
+// ---------------------------------------------------------------------------
+// Commenter authorization — the untrusted boundary.
+// ---------------------------------------------------------------------------
+
+/// A GitHub login is `[A-Za-z0-9-]` (no leading/trailing hyphen, but we only
+/// need the charset). Reject anything else before interpolating it into a
+/// `gh api` path, and treat it as unauthorized.
+fn valid_login(login: &str) -> bool {
+    !login.is_empty()
+        && login.len() <= 39
+        && login.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
+/// Whether `login` may trigger a session on `owner/name`. Authorized iff the
+/// login is a known loom operator (on the allowlist, checked with no GitHub
+/// call), **or** has write/admin permission on the repo (checked via the
+/// `GithubApi` gateway). Fails **closed**: a malformed login, an unknown user,
+/// read/none permission, or any gateway error all deny.
+pub async fn authorize(db: &Db, gh: &dyn GithubApi, owner: &str, name: &str, login: &str) -> bool {
+    if !valid_login(login) {
+        tracing::warn!(login, "rejecting trigger from a malformed GitHub login");
+        return false;
+    }
+    // A known loom operator (their GitHub login is on the allowlist) is trusted
+    // without spending a GitHub API call.
+    match auth::user_by_github(db, login).await {
+        Ok(Some(_)) => return true,
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(error = %e, login, "loom-user lookup failed; falling back to repo permission")
+        }
+    }
+    // Otherwise require write/admin on the repo itself.
+    match gh.collaborator_permission(owner, name, login).await {
+        Ok(perm) => {
+            let ok = matches!(perm.as_str(), "admin" | "maintain" | "write");
+            if !ok {
+                tracing::info!(
+                    login,
+                    owner,
+                    name,
+                    perm,
+                    "trigger denied: insufficient repo permission"
+                );
+            }
+            ok
+        }
+        Err(e) => {
+            // Most often a 404 (the login is not a collaborator); also any gh
+            // failure. Either way, deny.
+            tracing::info!(error = %e, login, owner, name, "trigger denied: permission check failed");
+            false
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-repo rate limit — a simple sliding window to blunt issue-comment spam.
+// ---------------------------------------------------------------------------
+
+/// The window over which [`GithubTrigger::check_rate_limit`] counts triggers.
+const RATE_WINDOW: Duration = Duration::from_secs(60);
+/// The most triggers a single repo may fire within [`RATE_WINDOW`] before
+/// further ones are dropped. Generous enough that ordinary use never trips it;
+/// low enough that a comment flood cannot fan out into unbounded API calls and
+/// session launches. The trade-off (shared-loom design §6.3): a spammer can
+/// exhaust a repo's budget and briefly lock out legitimate triggers on it.
+const RATE_MAX: usize = 20;
+
+// ---------------------------------------------------------------------------
+// The GitHub gateway — the two external operations the trigger performs.
+// ---------------------------------------------------------------------------
+
+/// The GitHub operations the trigger needs, behind a trait so the `gh`-backed
+/// implementation ([`GhCli`]) and a test fake are interchangeable. Both use the
+/// ambient `GH_TOKEN`; replacing `gh` with GitHub-App installation tokens is the
+/// planned hardening (design §6.3).
+#[async_trait::async_trait]
+pub trait GithubApi: Send + Sync {
+    /// The permission `login` has on `owner/name` — `admin` | `maintain` |
+    /// `write` | `read` | `none`. Errors (e.g. a 404 for a non-collaborator)
+    /// propagate so the caller can fail closed.
+    async fn collaborator_permission(&self, owner: &str, name: &str, login: &str)
+        -> Result<String>;
+    /// Post a comment on `issue` of `repo` (`owner/name`).
+    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()>;
+}
+
+/// The production [`GithubApi`]: shells out to the `gh` CLI with the ambient
+/// `GH_TOKEN`.
+pub struct GhCli;
+
+#[async_trait::async_trait]
+impl GithubApi for GhCli {
+    async fn collaborator_permission(
+        &self,
+        owner: &str,
+        name: &str,
+        login: &str,
+    ) -> Result<String> {
+        let path = format!("repos/{owner}/{name}/collaborators/{login}/permission");
+        gh_capture(&["api", &path, "-q", ".permission"]).await
+    }
+
+    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
+        let number = issue.to_string();
+        gh_capture(&["issue", "comment", &number, "--repo", repo, "--body", body])
+            .await
+            .map(|_| ())
+    }
+}
+
+/// Run `gh args…` (no repo working dir — every call passes `--repo` or a full
+/// API path), returning trimmed stdout. A non-zero exit is an error carrying the
+/// trimmed stderr.
+async fn gh_capture(args: &[&str]) -> Result<String> {
+    tracing::debug!(args = %args.join(" "), "running gh (trigger)");
+    let out = Command::new("gh")
+        .args(args)
+        .output()
+        .await
+        .context("failed to spawn gh (is the GitHub CLI installed?)")?;
+    if !out.status.success() {
+        bail!(
+            "gh {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Shared trigger state held on [`crate::web::AppState`]: the GitHub gateway and
+/// the per-repo rate limiter. One instance per server; the gateway is an `Arc`
+/// so a test can install a fake.
+pub struct GithubTrigger {
+    gh: Arc<dyn GithubApi>,
+    /// Per-repo trigger timestamps, pruned to [`RATE_WINDOW`] on each check.
+    limiter: Mutex<HashMap<String, Vec<Instant>>>,
+}
+
+impl GithubTrigger {
+    /// The production trigger, backed by the `gh` CLI.
+    pub fn production() -> Arc<Self> {
+        Self::with_gateway(Arc::new(GhCli))
+    }
+
+    /// A trigger backed by an arbitrary [`GithubApi`] — the seam tests use to
+    /// substitute a fake for `gh`.
+    pub fn with_gateway(gh: Arc<dyn GithubApi>) -> Arc<Self> {
+        Arc::new(Self {
+            gh,
+            limiter: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// The GitHub gateway, for the permission check and the reply.
+    pub fn gh(&self) -> &dyn GithubApi {
+        self.gh.as_ref()
+    }
+
+    /// Record a trigger attempt for `repo` and report whether it is within the
+    /// rate budget. Returns `false` once a repo has fired [`RATE_MAX`] triggers
+    /// inside [`RATE_WINDOW`]; the dropped attempt is the caller's no-op.
+    pub fn check_rate_limit(&self, repo: &str) -> bool {
+        let now = Instant::now();
+        let mut map = self.limiter.lock().expect("rate-limiter mutex poisoned");
+        let hits = map.entry(repo.to_string()).or_default();
+        hits.retain(|t| now.duration_since(*t) < RATE_WINDOW);
+        if hits.len() >= RATE_MAX {
+            return false;
+        }
+        hits.push(now);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compute the hex `X-Hub-Signature-256` value a real GitHub delivery would
+    /// carry for `(secret, body)`.
+    fn sign(secret: &str, body: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+    }
+
+    #[test]
+    fn verify_signature_accepts_a_correct_signature() {
+        let secret = "s3cr3t";
+        let body = br#"{"action":"created"}"#;
+        let header = sign(secret, body);
+        assert!(verify_signature(secret, body, Some(&header)));
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampering_and_bad_input() {
+        let secret = "s3cr3t";
+        let body = br#"{"action":"created"}"#;
+        let good = sign(secret, body);
+
+        // Wrong secret.
+        assert!(!verify_signature("other", body, Some(&good)));
+        // Body changed after signing.
+        assert!(!verify_signature(
+            secret,
+            br#"{"action":"deleted"}"#,
+            Some(&good)
+        ));
+        // Missing header.
+        assert!(!verify_signature(secret, body, None));
+        // Wrong algorithm prefix / malformed header.
+        assert!(!verify_signature(secret, body, Some("sha1=deadbeef")));
+        assert!(!verify_signature(secret, body, Some(&good[7..]))); // no "sha256=" prefix
+        assert!(!verify_signature(secret, body, Some("sha256=nothex")));
+        // An empty secret (unconfigured) never verifies, even with a header that
+        // matches the empty-key HMAC.
+        let empty_key_sig = sign("", body);
+        assert!(!verify_signature("", body, Some(&empty_key_sig)));
+    }
+
+    #[test]
+    fn is_trigger_anchors_to_the_start_ignoring_case_and_lead_space() {
+        let phrase = "@loom work on this";
+        assert!(is_trigger("@loom work on this issue please", phrase));
+        assert!(is_trigger("  @LOOM Work On This", phrase));
+        assert!(is_trigger("@loom work on this", phrase));
+        // Not at the start → ignored (e.g. quoting someone else).
+        assert!(!is_trigger("> @loom work on this", phrase));
+        assert!(!is_trigger("please @loom work on this", phrase));
+        assert!(!is_trigger("just a normal comment", phrase));
+        // An empty phrase never matches (guards a misconfigured setting).
+        assert!(!is_trigger("anything", ""));
+    }
+
+    #[test]
+    fn parse_extracts_fields_and_seeds_the_goal() {
+        let raw = br#"{
+            "action": "created",
+            "issue": {"number": 7, "title": "Fix the bug", "body": "It crashes"},
+            "comment": {"body": "@loom work on this", "user": {"login": "alice"}},
+            "repository": {"full_name": "acme/widgets"}
+        }"#;
+        let ev = IssueCommentEvent::parse(raw).unwrap();
+        assert_eq!(ev.action, "created");
+        assert_eq!(ev.issue.number, 7);
+        assert_eq!(ev.comment.user.login, "alice");
+        assert_eq!(ev.repository.full_name, "acme/widgets");
+        assert_eq!(ev.goal_seed(), "Fix the bug\n\nIt crashes");
+
+        // A null issue body is tolerated; the seed falls back to the title.
+        let raw = br#"{
+            "action": "created",
+            "issue": {"number": 1, "title": "Title only", "body": null},
+            "comment": {"body": "@loom work on this", "user": {"login": "bob"}},
+            "repository": {"full_name": "acme/widgets"}
+        }"#;
+        let ev = IssueCommentEvent::parse(raw).unwrap();
+        assert_eq!(ev.goal_seed(), "Title only");
+    }
+
+    #[test]
+    fn valid_login_rejects_path_tricks() {
+        assert!(valid_login("octocat"));
+        assert!(valid_login("a-b-c"));
+        assert!(!valid_login(""));
+        assert!(!valid_login("../etc"));
+        assert!(!valid_login("a/b"));
+        assert!(!valid_login("has space"));
+        assert!(!valid_login(&"x".repeat(40)));
+    }
+
+    #[tokio::test]
+    async fn record_delivery_is_idempotent() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        assert!(
+            record_delivery(&db, "guid-1").await.unwrap(),
+            "first sighting is new"
+        );
+        assert!(
+            !record_delivery(&db, "guid-1").await.unwrap(),
+            "replay is a no-op"
+        );
+        assert!(
+            record_delivery(&db, "guid-2").await.unwrap(),
+            "a different delivery is new"
+        );
+    }
+
+    /// A fake gateway recording the permission it should report and any comments
+    /// posted, for the authorization and (integration) reply paths.
+    #[derive(Default)]
+    struct FakeGh {
+        permission: Mutex<String>,
+        fail_permission: Mutex<bool>,
+        comments: Mutex<Vec<(String, i64, String)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl GithubApi for FakeGh {
+        async fn collaborator_permission(&self, _o: &str, _n: &str, _l: &str) -> Result<String> {
+            if *self.fail_permission.lock().unwrap() {
+                bail!("simulated 404");
+            }
+            Ok(self.permission.lock().unwrap().clone())
+        }
+        async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
+            self.comments
+                .lock()
+                .unwrap()
+                .push((repo.to_string(), issue, body.to_string()));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn authorize_trusts_loom_users_and_repo_writers_only() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        // A known loom operator is trusted with no GitHub call.
+        auth::add_user(&db, "alice", Some("alice-gh"), None)
+            .await
+            .unwrap();
+        let gh = FakeGh::default();
+        *gh.permission.lock().unwrap() = "none".to_string();
+        assert!(authorize(&db, &gh, "acme", "widgets", "alice-gh").await);
+
+        // A stranger with write/admin is allowed; with read/none is denied.
+        for (perm, allowed) in [
+            ("admin", true),
+            ("write", true),
+            ("read", false),
+            ("none", false),
+        ] {
+            *gh.permission.lock().unwrap() = perm.to_string();
+            assert_eq!(
+                authorize(&db, &gh, "acme", "widgets", "stranger").await,
+                allowed,
+                "permission {perm} should be allowed={allowed}"
+            );
+        }
+
+        // A failed permission check fails closed.
+        *gh.fail_permission.lock().unwrap() = true;
+        assert!(!authorize(&db, &gh, "acme", "widgets", "stranger").await);
+
+        // A malformed login is denied before any call.
+        assert!(!authorize(&db, &gh, "acme", "widgets", "../etc").await);
+    }
+
+    #[test]
+    fn rate_limit_caps_a_repo_then_lets_others_through() {
+        let t = GithubTrigger::with_gateway(Arc::new(FakeGh::default()));
+        for _ in 0..RATE_MAX {
+            assert!(t.check_rate_limit("acme/widgets"));
+        }
+        // The next one over the budget is dropped...
+        assert!(!t.check_rate_limit("acme/widgets"));
+        // ...but a different repo has its own budget.
+        assert!(t.check_rate_limit("acme/other"));
+    }
+}

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -15,6 +15,7 @@ pub mod client;
 pub mod db;
 pub mod endpoint;
 pub mod github;
+pub mod github_trigger;
 pub mod ide;
 pub mod monitor;
 pub mod overlooker;

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -1383,6 +1383,7 @@ mod tests {
             bus: events::EventBus::new(),
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
+            trigger: crate::github_trigger::GithubTrigger::production(),
         };
         let o = ov::create(
             &state.db,
@@ -1596,6 +1597,7 @@ rnd.finish("counted to %d" % n)
             bus: events::EventBus::new(),
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
+            trigger: crate::github_trigger::GithubTrigger::production(),
         };
         // A reactive overlooker (no cron) — the scheduled half of the timer skips
         // it; only the wake half should fire it.

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -80,6 +80,7 @@ pub async fn run(addr: &str) -> Result<()> {
         bus: EventBus::new(),
         addr: actual.to_string(),
         ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
+        trigger: crate::github_trigger::GithubTrigger::production(),
     };
 
     let server_state = ServerState {

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -2765,10 +2765,14 @@ async fn register_repo(
 /// [`crate::github_trigger`].
 ///
 /// Status discipline: a missing/invalid signature is a hard **401** (a real
-/// misconfiguration GitHub should surface as a failed delivery). Everything past
-/// that returns **200** — a non-trigger comment, a replay, an unauthorized
-/// commenter, a non-allowlisted repo, or a rate-limited repo are all quiet
-/// no-ops, so GitHub does not retry a delivery we deliberately ignored.
+/// misconfiguration GitHub should surface as a failed delivery). Two further
+/// non-2xx cases past that are deliberate, not no-ops: a delivery with no
+/// `X-GitHub-Delivery` GUID is malformed (**400** — without it idempotency is
+/// impossible), and a failure to record the delivery is transient (**5xx**, so
+/// GitHub *should* retry). Every *business-logic* outcome — a non-trigger
+/// comment, a replay, an unauthorized commenter, a non-allowlisted repo, a
+/// rate-limited repo — returns **200**, so GitHub does not retry a delivery we
+/// deliberately ignored.
 async fn github_webhook(State(st): State<AppState>, headers: HeaderMap, body: Bytes) -> Response {
     // 1. Authenticate the delivery: HMAC-SHA256 over the RAW body bytes (never a
     //    re-serialized parse). An empty secret means the webhook is unconfigured,
@@ -2786,12 +2790,14 @@ async fn github_webhook(State(st): State<AppState>, headers: HeaderMap, body: By
         return (StatusCode::UNAUTHORIZED, "invalid signature").into_response();
     }
 
-    // The body is now trusted (GitHub-signed). Past here, problems are 200
-    // no-ops; `ok()` is the acknowledge-and-ignore reply.
+    // The body is now trusted (GitHub-signed). Every *business-logic* outcome
+    // past here is a 200 no-op via `ok()`; the only non-2xx exceptions below are
+    // a malformed delivery (no GUID → 400) and a transient store error (→ 5xx).
     let ok = || (StatusCode::OK, "ok").into_response();
 
-    // 2. Idempotency: dedupe on the delivery GUID. A delivery without one can't
-    //    be deduped (a malformed request); a repeat is a no-op.
+    // 2. Idempotency: dedupe on the delivery GUID. A genuine GitHub delivery
+    //    always carries one; its absence is a malformed request we reject (400),
+    //    since without it idempotency is impossible. A repeat GUID is a no-op.
     let Some(delivery) = headers
         .get("x-github-delivery")
         .and_then(|v| v.to_str().ok())

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -94,7 +94,8 @@ use crate::db::Db;
 use crate::events::{Event, EventBus};
 use crate::session::{self as session_mod, NewSession, Session};
 use crate::{
-    agent, agent_env, backend, config, db, events, git, github, overlooker as ov_engine, repo,
+    agent, agent_env, backend, config, db, events, git, github, github_trigger,
+    overlooker as ov_engine, repo,
 };
 use weaver_api::{
     AddUserReq, AgentOneshotReq, ArtifactMeta, ArtifactRefs, ArtifactView, ArtifactWriteBody,
@@ -119,6 +120,10 @@ pub struct AppState {
     pub addr: String,
     /// Per-session embedded code-server lifecycle + reverse-proxy registry.
     pub ide: std::sync::Arc<crate::ide::IdeManager>,
+    /// The inbound GitHub trigger: its GitHub gateway (the `gh`-backed default)
+    /// and per-repo rate limiter. Shared across requests; a test swaps in a fake
+    /// gateway via [`crate::github_trigger::GithubTrigger::with_gateway`].
+    pub trigger: std::sync::Arc<crate::github_trigger::GithubTrigger>,
 }
 
 // ---------------------------------------------------------------------------
@@ -402,7 +407,11 @@ pub fn router(state: AppState) -> Router {
         .route("/auth/login", post(auth_login))
         .route("/auth/logout", post(auth_logout))
         .route("/auth/github/login", get(github_login))
-        .route("/auth/github/callback", get(github_callback));
+        .route("/auth/github/callback", get(github_callback))
+        // The inbound GitHub webhook. Deliberately OUTSIDE `require_auth`: it is
+        // authenticated cryptographically by the HMAC signature it carries, not
+        // by a loom principal. The handler is the untrusted-input boundary.
+        .route("/github/webhook", post(github_webhook));
 
     // Everything else requires an authenticated principal — a bearer token, a
     // session cookie, or a trusted-loopback request — gated by `require_auth`.
@@ -2749,6 +2758,159 @@ async fn register_repo(
     Ok(Json(managed))
 }
 
+/// `POST /api/github/webhook` — the inbound GitHub trigger (shared-loom design
+/// §6.3). **Public** (outside `require_auth`): every delivery is authenticated by
+/// the HMAC signature GitHub carries on it, not by a loom principal. This handler
+/// is the untrusted-input boundary; it sequences the gates implemented in
+/// [`crate::github_trigger`].
+///
+/// Status discipline: a missing/invalid signature is a hard **401** (a real
+/// misconfiguration GitHub should surface as a failed delivery). Everything past
+/// that returns **200** — a non-trigger comment, a replay, an unauthorized
+/// commenter, a non-allowlisted repo, or a rate-limited repo are all quiet
+/// no-ops, so GitHub does not retry a delivery we deliberately ignored.
+async fn github_webhook(State(st): State<AppState>, headers: HeaderMap, body: Bytes) -> Response {
+    // 1. Authenticate the delivery: HMAC-SHA256 over the RAW body bytes (never a
+    //    re-serialized parse). An empty secret means the webhook is unconfigured,
+    //    so it cannot verify anything — reject.
+    let secret = github_trigger::webhook_secret(&st.db).await;
+    if secret.is_empty() {
+        tracing::warn!("github webhook hit but no webhook secret is configured");
+        return (StatusCode::UNAUTHORIZED, "webhook not configured").into_response();
+    }
+    let sig = headers
+        .get("x-hub-signature-256")
+        .and_then(|v| v.to_str().ok());
+    if !github_trigger::verify_signature(&secret, &body, sig) {
+        tracing::warn!("github webhook signature verification failed");
+        return (StatusCode::UNAUTHORIZED, "invalid signature").into_response();
+    }
+
+    // The body is now trusted (GitHub-signed). Past here, problems are 200
+    // no-ops; `ok()` is the acknowledge-and-ignore reply.
+    let ok = || (StatusCode::OK, "ok").into_response();
+
+    // 2. Idempotency: dedupe on the delivery GUID. A delivery without one can't
+    //    be deduped (a malformed request); a repeat is a no-op.
+    let Some(delivery) = headers
+        .get("x-github-delivery")
+        .and_then(|v| v.to_str().ok())
+    else {
+        tracing::warn!("github webhook missing X-GitHub-Delivery");
+        return (StatusCode::BAD_REQUEST, "missing delivery id").into_response();
+    };
+    match github_trigger::record_delivery(&st.db, delivery).await {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::info!(delivery, "github webhook: duplicate delivery ignored");
+            return ok();
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "github webhook: recording delivery failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "delivery store error").into_response();
+        }
+    }
+
+    // 3. Filter to issue_comment / created. Other events (incl. the setup `ping`)
+    //    and edited/deleted comments are acknowledged and ignored.
+    if headers.get("x-github-event").and_then(|v| v.to_str().ok()) != Some("issue_comment") {
+        return ok();
+    }
+    let event = match github_trigger::IssueCommentEvent::parse(&body) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(error = %e, "github webhook: unparseable issue_comment payload");
+            return ok();
+        }
+    };
+    if event.action != "created" {
+        return ok();
+    }
+
+    // 4. Ignore the bot's own comments (no self-trigger loop), then require the
+    //    fixed command prefix.
+    let author = event.comment.user.login.trim().to_string();
+    if let Some(bot) = github_trigger::bot_login(&st.db).await {
+        if author.eq_ignore_ascii_case(&bot) {
+            return ok();
+        }
+    }
+    let phrase = github_trigger::trigger_phrase(&st.db).await;
+    if !github_trigger::is_trigger(&event.comment.body, &phrase) {
+        return ok();
+    }
+
+    // Validate the repo identifier (defence — it is GitHub's, but the on-disk
+    // path derives from it) and split it into owner/name.
+    let slug = match repo::parse_slug(&event.repository.full_name) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(repo = %event.repository.full_name, error = %e, "github webhook: bad repo slug");
+            return ok();
+        }
+    };
+
+    // 5. Rate-limit per repo BEFORE the (costly) authorization API call, so a
+    //    comment flood cannot fan out into unbounded GitHub calls and launches.
+    if !st.trigger.check_rate_limit(&slug.slug()) {
+        tracing::warn!(repo = %slug.slug(), "github webhook: per-repo rate limit hit, dropping");
+        return ok();
+    }
+
+    // 6. Authorize the commenter (the untrusted boundary): a known loom operator,
+    //    or a write/admin collaborator on the repo. Unauthorized → silent no-op;
+    //    replying would amplify spam across a flood of comments.
+    if !github_trigger::authorize(&st.db, st.trigger.gh(), &slug.owner, &slug.name, &author).await {
+        tracing::info!(login = %author, repo = %slug.slug(), "github webhook: commenter not authorized");
+        return ok();
+    }
+
+    // 7. Acquire the repo (it must be in the managed allowlist — `resolve_clone`
+    //    rejects others) and create the session, seeded from the issue carried in
+    //    the trusted payload. Seeding title/goal from the payload (not a `gh`
+    //    re-fetch) means the managed clone needs no reachable GitHub remote.
+    //    Attribute the launch to the webhook bot, annotated with the triggering
+    //    GitHub login (`created_by`, from PR #94) — tracking, not a boundary.
+    let req = CreateReq {
+        repo: Some(slug.slug()),
+        title: Some(event.issue.title.clone()),
+        goal: Some(event.goal_seed()),
+        ..Default::default()
+    };
+    let created_by = format!("github-webhook ({author})");
+    let view = match create_session_core(st.clone(), req, Some(created_by)).await {
+        Ok(v) => v,
+        Err(e) => {
+            // A non-allowlisted repo lands here (a BadRequest from resolve_clone),
+            // as does a clone/launch failure. Acknowledge; don't make GitHub retry.
+            tracing::warn!(repo = %slug.slug(), error = ?e, "github webhook: session create failed");
+            return ok();
+        }
+    };
+
+    // 8. Reply on the issue with the live session URL.
+    let base = external_base(&st, &headers)
+        .await
+        .unwrap_or_else(|| format!("http://{}", st.addr));
+    let reply = format!("On it — {base}/s/{}", view.id);
+    if let Err(e) = st
+        .trigger
+        .gh()
+        .post_issue_comment(&slug.slug(), event.issue.number, &reply)
+        .await
+    {
+        tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: posting reply failed");
+    }
+    tracing::info!(
+        session = %view.id,
+        repo = %slug.slug(),
+        issue = event.issue.number,
+        login = %author,
+        "github webhook: launched session"
+    );
+    ok()
+}
+
 #[derive(Debug, Deserialize)]
 struct BranchesQuery {
     cwd: String,
@@ -3787,6 +3949,7 @@ mod tests {
             bus: crate::events::EventBus::new(),
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
+            trigger: crate::github_trigger::GithubTrigger::production(),
         };
         let child = branch_mod::upsert(&db, "/r", "weaver/child", "main")
             .await

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -87,6 +87,7 @@ async fn hook_event_drives_session_status() {
         bus: EventBus::new(),
         addr: addr.to_string(),
         ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
+        trigger: loom::github_trigger::GithubTrigger::production(),
     };
     tokio::spawn(server::serve(state, listener));
 

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -113,6 +113,19 @@ impl TestServer {
     /// answer `/api/health`. The caller must be `#[serial]`: setup writes
     /// process-global env.
     pub async fn start() -> Self {
+        Self::start_inner(None).await
+    }
+
+    /// Like [`start`](Self::start) but installs `gh` as the GitHub trigger's
+    /// gateway, so the webhook suite can drive the permission check + reply with
+    /// a fake instead of the real `gh` CLI.
+    pub async fn start_with_github(
+        gh: std::sync::Arc<dyn loom::github_trigger::GithubApi>,
+    ) -> Self {
+        Self::start_inner(Some(gh)).await
+    }
+
+    async fn start_inner(gh: Option<std::sync::Arc<dyn loom::github_trigger::GithubApi>>) -> Self {
         // Isolate weaver state in a temp home (its own db) for the lifetime of
         // the test; that home also scopes the `tapestry` socket dir. Point loom
         // at the sibling supervisor binary.
@@ -126,11 +139,16 @@ impl TestServer {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let pool = db::connect(&db::default_db_path()).await.unwrap();
+        let trigger = match gh {
+            Some(gh) => loom::github_trigger::GithubTrigger::with_gateway(gh),
+            None => loom::github_trigger::GithubTrigger::production(),
+        };
         let state = AppState {
             db: pool,
             bus: EventBus::new(),
             addr: addr.to_string(),
             ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
+            trigger,
         };
         // The overlooker master switch ships on by default, but these tests
         // drive the engine directly and must not race the background loop that

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -23,3 +23,4 @@ mod sessions;
 mod shell;
 mod terminal;
 mod typed_client;
+mod webhook;

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -40,6 +40,7 @@ async fn engine_state(ts: &TestServer) -> AppState {
         bus: EventBus::new(),
         addr: ts.addr.to_string(),
         ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
+        trigger: loom::github_trigger::GithubTrigger::production(),
     }
 }
 

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -1,0 +1,338 @@
+//! The inbound GitHub trigger end-to-end over HTTP: a signed `issue_comment`
+//! delivery to `POST /api/github/webhook` turns `@loom work on this` into a
+//! session and replies with its URL. The security boundary is exercised here —
+//! a bad/missing signature is a hard 401, a replay is a no-op, a non-trigger or
+//! unauthorized comment launches nothing.
+//!
+//! No network and no real `gh`: the clone source is a *local bare repo* and the
+//! GitHub gateway (permission check + reply) is a recording fake installed into
+//! the server via [`TestServer::start_with_github`].
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use hmac::{Hmac, Mac};
+use serde_json::json;
+use serial_test::serial;
+use sha2::Sha256;
+
+use crate::fixtures::{sh, TestServer};
+
+const SECRET: &str = "test-webhook-secret";
+
+/// Forge the `X-Hub-Signature-256` value a genuine GitHub delivery carries for
+/// `(secret, body)`.
+fn sign(secret: &str, body: &[u8]) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+/// A recording GitHub gateway standing in for `gh`: it reports a configurable
+/// repo permission and captures every reply posted.
+#[derive(Default)]
+struct FakeGithub {
+    permission: Mutex<String>,
+    comments: Mutex<Vec<(String, i64, String)>>,
+}
+
+#[async_trait::async_trait]
+impl loom::github_trigger::GithubApi for FakeGithub {
+    async fn collaborator_permission(
+        &self,
+        _o: &str,
+        _n: &str,
+        _l: &str,
+    ) -> anyhow::Result<String> {
+        Ok(self.permission.lock().unwrap().clone())
+    }
+    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> anyhow::Result<()> {
+        self.comments
+            .lock()
+            .unwrap()
+            .push((repo.to_string(), issue, body.to_string()));
+        Ok(())
+    }
+}
+
+/// Boot a test server with the webhook secret set and a fake GitHub gateway
+/// installed, returning both so a test can drive permission/replies.
+async fn boot() -> (TestServer, Arc<FakeGithub>) {
+    std::env::set_var("LOOM_GITHUB_WEBHOOK_SECRET", SECRET);
+    let fake = Arc::new(FakeGithub::default());
+    let ts = TestServer::start_with_github(fake.clone()).await;
+    (ts, fake)
+}
+
+/// Lay out a bare repo whose path tail is `acme/widgets` (so the registered slug
+/// is `acme/widgets`) and return its `file://` clone URL. Mirrors the repo-store
+/// suite; kept local so the two don't share a fixture.
+fn make_bare_remote(root: &Path) -> String {
+    let work = root.join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    sh(&work, "git", &["init", "-q", "-b", "main"]);
+    sh(&work, "git", &["config", "user.email", "t@t.test"]);
+    sh(&work, "git", &["config", "user.name", "Test"]);
+    std::fs::write(work.join("README.md"), "hello\n").unwrap();
+    sh(&work, "git", &["add", "."]);
+    sh(&work, "git", &["commit", "-q", "-m", "init"]);
+
+    let bare = root.join("acme").join("widgets");
+    std::fs::create_dir_all(bare.parent().unwrap()).unwrap();
+    sh(
+        &work,
+        "git",
+        &[
+            "clone",
+            "--bare",
+            "-q",
+            &work.to_string_lossy(),
+            &bare.to_string_lossy(),
+        ],
+    );
+    format!("file://{}", bare.display())
+}
+
+/// Register `acme/widgets` (pointing at a local bare remote) into the managed
+/// allowlist, and make new sessions launch the fast `shell` agent. Returns the
+/// remotes tempdir, which must stay alive until the clone has happened.
+async fn prepare_repo(ts: &TestServer) -> tempfile::TempDir {
+    let remotes = tempfile::tempdir().unwrap();
+    let url = make_bare_remote(remotes.path());
+    ts.client
+        .post("/api/repos", json!({ "repo": url }))
+        .await
+        .unwrap();
+    // The webhook builds a CreateReq with no agent, so it uses `agent.default`;
+    // pin it to `shell` so the test doesn't try to launch a real claude.
+    ts.client
+        .patch("/api/settings", json!({ "agent.default": "shell" }))
+        .await
+        .unwrap();
+    remotes
+}
+
+/// The raw JSON body of an `issue_comment.created` carrying `comment` from
+/// `login` on issue `number` of `acme/widgets`.
+fn trigger_body(login: &str, number: i64, comment: &str) -> Vec<u8> {
+    json!({
+        "action": "created",
+        "issue": {"number": number, "title": "Make it faster", "body": "perf please"},
+        "comment": {"body": comment, "user": {"login": login}},
+        "repository": {"full_name": "acme/widgets"}
+    })
+    .to_string()
+    .into_bytes()
+}
+
+/// POST a delivery to the webhook. `sig` is sent as `X-Hub-Signature-256` when
+/// `Some`; the body bytes are sent verbatim (so a caller-computed signature over
+/// the same bytes stays valid).
+async fn post(
+    ts: &TestServer,
+    delivery: &str,
+    sig: Option<String>,
+    body: &[u8],
+) -> reqwest::Response {
+    let mut req = reqwest::Client::new()
+        .post(format!("http://{}/api/github/webhook", ts.addr))
+        .header("X-GitHub-Event", "issue_comment")
+        .header("X-GitHub-Delivery", delivery)
+        .header("Content-Type", "application/json")
+        .body(body.to_vec());
+    if let Some(sig) = sig {
+        req = req.header("X-Hub-Signature-256", sig);
+    }
+    req.send().await.unwrap()
+}
+
+/// How many sessions the fleet listing shows.
+async fn session_count(ts: &TestServer) -> usize {
+    ts.client
+        .get("/api/sessions")
+        .await
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .len()
+}
+
+/// A missing signature, and one computed with the wrong secret, are both
+/// rejected with 401 — and nothing is launched.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bad_and_missing_signature_are_rejected() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+    let body = trigger_body("alice", 1, "@loom work on this");
+
+    // No signature header at all.
+    let resp = post(&ts, "d-nosig", None, &body).await;
+    assert_eq!(resp.status(), 401, "missing signature must be unauthorized");
+
+    // A signature over the right body but with the wrong secret.
+    let wrong = sign("not-the-secret", &body);
+    let resp = post(&ts, "d-wrongsig", Some(wrong), &body).await;
+    assert_eq!(
+        resp.status(),
+        401,
+        "wrong-secret signature must be unauthorized"
+    );
+
+    assert_eq!(
+        session_count(&ts).await,
+        0,
+        "no session from a rejected delivery"
+    );
+    assert!(
+        fake.comments.lock().unwrap().is_empty(),
+        "no reply from a rejected delivery"
+    );
+}
+
+/// A correctly-signed comment that is not the trigger phrase is acknowledged
+/// (200) but launches nothing.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_trigger_comment_is_ignored() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+    *fake.permission.lock().unwrap() = "admin".to_string();
+
+    let body = trigger_body("alice", 1, "just a normal comment, nothing to see");
+    let resp = post(&ts, "d-chatter", Some(sign(SECRET, &body)), &body).await;
+    assert_eq!(resp.status(), 200, "a non-trigger comment is acknowledged");
+    assert_eq!(
+        session_count(&ts).await,
+        0,
+        "no session from a non-trigger comment"
+    );
+    assert!(fake.comments.lock().unwrap().is_empty());
+}
+
+/// A commenter with only read access (and not a loom user) is refused: nothing
+/// launches and, to avoid amplifying spam, no reply is posted.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unauthorized_commenter_is_rejected() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+    *fake.permission.lock().unwrap() = "read".to_string();
+
+    let body = trigger_body("stranger", 5, "@loom work on this");
+    let resp = post(&ts, "d-stranger", Some(sign(SECRET, &body)), &body).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "an unauthorized trigger is acknowledged, not errored"
+    );
+    assert_eq!(
+        session_count(&ts).await,
+        0,
+        "an unauthorized commenter launches nothing"
+    );
+    assert!(
+        fake.comments.lock().unwrap().is_empty(),
+        "no reply to an unauthorized commenter"
+    );
+}
+
+/// The happy path: an authorized write/admin commenter triggers a session, and
+/// loom replies on the issue with the live session URL.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn happy_path_creates_session_and_replies() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+    *fake.permission.lock().unwrap() = "admin".to_string();
+    assert_eq!(session_count(&ts).await, 0);
+
+    let body = trigger_body("stranger", 42, "@loom work on this please");
+    let resp = post(&ts, "d-happy", Some(sign(SECRET, &body)), &body).await;
+    assert_eq!(resp.status(), 200);
+
+    // A session now exists, seeded from the issue title.
+    let sessions = ts.client.get("/api/sessions").await.unwrap();
+    let sessions = sessions.as_array().unwrap();
+    assert_eq!(
+        sessions.len(),
+        1,
+        "the trigger launched exactly one session"
+    );
+    let session = &sessions[0];
+    let id = session["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        session["branch"]["title"].as_str(),
+        Some("Make it faster"),
+        "the session title is seeded from the issue"
+    );
+    assert_eq!(
+        session["created_by"].as_str(),
+        Some("github-webhook (stranger)"),
+        "the session is attributed to the webhook bot, annotated with the triggering login"
+    );
+
+    // loom replied on the triggering issue with the session URL.
+    let comments = fake.comments.lock().unwrap().clone();
+    assert_eq!(comments.len(), 1, "exactly one reply");
+    let (repo, issue, reply) = &comments[0];
+    assert_eq!(repo, "acme/widgets");
+    assert_eq!(*issue, 42);
+    assert!(
+        reply.starts_with("On it — http://"),
+        "reply leads with the cue: {reply}"
+    );
+    assert!(
+        reply.contains(&format!("/s/{id}")),
+        "reply links the session: {reply}"
+    );
+
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+/// A replayed (or GitHub-retried) delivery with a GUID we've already processed
+/// is a no-op: no second session, no second reply.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replayed_delivery_is_a_noop() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+    *fake.permission.lock().unwrap() = "admin".to_string();
+
+    let body = trigger_body("stranger", 9, "@loom work on this");
+    let sig = sign(SECRET, &body);
+
+    let resp = post(&ts, "d-replay", Some(sig.clone()), &body).await;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        session_count(&ts).await,
+        1,
+        "first delivery launches a session"
+    );
+
+    // The exact same delivery again — same GUID, body, signature.
+    let resp = post(&ts, "d-replay", Some(sig), &body).await;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        session_count(&ts).await,
+        1,
+        "the replay launches nothing new"
+    );
+    assert_eq!(
+        fake.comments.lock().unwrap().len(),
+        1,
+        "the replay posts no second reply"
+    );
+
+    let id = ts.client.get("/api/sessions").await.unwrap()[0]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -30,6 +30,9 @@ pub const DEFAULT_GITHUB_POLL: bool = true;
 /// Whether loom archives a session automatically once its pull request merges.
 /// On by default — a merged branch's worktree has served its purpose.
 pub const DEFAULT_GITHUB_ARCHIVE_ON_MERGE: bool = true;
+/// The phrase an `issue_comment` must begin with to trigger a loom session via
+/// the GitHub webhook. Fixed (not free-text) in v1 to shrink the abuse surface.
+pub const DEFAULT_GITHUB_TRIGGER_PHRASE: &str = "@loom work on this";
 /// The palette the browser terminal (xterm.js) renders with. `dark` keeps the
 /// classic black background; `light` swaps in a light, readable palette.
 pub const DEFAULT_TERMINAL_THEME: &str = "dark";
@@ -186,6 +189,20 @@ pub const REGISTRY: &[SettingSpec] = &[
             GitHub polling.",
         kind: SettingKind::Bool,
         default: "true",
+        group: "GitHub",
+        options: &[],
+    },
+    SettingSpec {
+        key: "github.trigger_phrase",
+        label: "GitHub trigger phrase",
+        description: "The exact phrase an issue comment must begin with for the \
+            GitHub webhook to launch a session against that repo (e.g. \
+            `@loom work on this`). Matched case-insensitively against the start \
+            of the comment; kept fixed rather than free-text to limit the abuse \
+            surface. The webhook is only active once `LOOM_GITHUB_WEBHOOK_SECRET` \
+            is configured.",
+        kind: SettingKind::String,
+        default: DEFAULT_GITHUB_TRIGGER_PHRASE,
         group: "GitHub",
         options: &[],
     },

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -1,0 +1,90 @@
+# GitHub trigger (`@loom work on this`)
+
+loom turns an issue comment into a session. Comment **`@loom work on this`** on a
+GitHub issue and loom launches a session against that repo — seeded from the
+issue — and replies on the issue with a link to the live session
+(`On it — {base}/s/{id}`).
+
+This is an internet-exposed, untrusted-input endpoint. Two gates protect it:
+every delivery is verified cryptographically (HMAC), and the commenter is
+authorized before anything is launched.
+
+## How it works
+
+GitHub delivers `issue_comment` events to `POST /api/github/webhook`. The
+receiver, in order:
+
+1. **Verifies the signature.** It recomputes HMAC-SHA256 over the raw request
+   body with the webhook secret and constant-time-compares it to
+   `X-Hub-Signature-256`. A missing or wrong signature is rejected with **401**.
+2. **Dedupes** on `X-GitHub-Delivery`. A replayed or GitHub-retried delivery is a
+   no-op, so a repeat never launches a second session.
+3. **Filters** to `issue_comment` / `action == created`. Edits, deletions, other
+   events, and the bot's own comments (set `github.bot_login`) are ignored.
+4. **Matches the command.** The comment must *begin* with the trigger phrase
+   (`github.trigger_phrase`, default `@loom work on this`), matched
+   case-insensitively. Fixed phrase only — no free-text in v1.
+5. **Authorizes the commenter.** They must be a known loom operator (their GitHub
+   login is on the allowlist) **or** have write/admin permission on the repo
+   (checked via `GET /repos/{owner}/{repo}/collaborators/{login}/permission`).
+   Anyone else is silently ignored. A per-repo rate limit blunts comment spam.
+6. **Resolves the repo** through the [managed repo store](#repo-allowlist) — only
+   a registered repo is cloned and launched against — and creates the session,
+   seeded with the issue title and body.
+7. **Replies** on the issue with the session URL.
+
+Everything past the signature check returns **200** whether or not it launched a
+session (a non-trigger comment, a replay, an unauthorized commenter, an
+unregistered repo, a rate-limited repo), so GitHub does not retry a delivery loom
+deliberately ignored.
+
+## Configure the webhook
+
+Set a shared secret in loom's environment (it is held outside the settings
+registry and never returned by `GET /api/settings`, like the OAuth client
+secret):
+
+```sh
+LOOM_GITHUB_WEBHOOK_SECRET=<a long random string>
+```
+
+Add a webhook on the repo or org (**Settings → Webhooks → Add webhook**):
+
+- **Payload URL** — `{base}/api/github/webhook`, where `{base}` is loom's public
+  URL (the same one `auth.base_url` names).
+- **Content type** — `application/json`.
+- **Secret** — the same value as `LOOM_GITHUB_WEBHOOK_SECRET`.
+- **Events** — "Let me select individual events" → **Issue comments** only.
+
+Until `LOOM_GITHUB_WEBHOOK_SECRET` is set the endpoint rejects every delivery
+(it cannot verify a signature without it).
+
+### Repo allowlist
+
+The trigger only acts on repos registered in the managed repo store, which
+doubles as the clone allowlist. Register one first:
+
+```sh
+curl -X POST {base}/api/repos -H 'Authorization: Bearer $LOOM_TOKEN' \
+  -H 'content-type: application/json' -d '{"repo":"owner/name"}'
+```
+
+A comment on an unregistered repo launches nothing.
+
+### Optional settings
+
+- `github.trigger_phrase` — the phrase a comment must begin with
+  (default `@loom work on this`). Settable in **Settings → GitHub** or
+  `weaver config set github.trigger_phrase "…"`.
+- `github.bot_login` (or `LOOM_GITHUB_BOT_LOGIN`) — a GitHub login whose own
+  comments are ignored, so a bot account can post without re-triggering itself.
+
+## Authentication and the planned hardening
+
+v1 authenticates the webhook with a shared secret and acts on GitHub through the
+ambient `GH_TOKEN` (the `gh` CLI) — the permission check and the reply both run
+as that token's identity. The planned hardening is a **GitHub App**: per-repo
+installation as the access allowlist, short-lived installation tokens for the API
+calls and the reply, and a distinct bot identity for attribution. The webhook
+receiver and its security controls (HMAC, idempotency, authorization) are
+unchanged by that move.


### PR DESCRIPTION
## What

The inbound GitHub trigger for the shared team loom (parent #337): comment
**`@loom work on this`** on a GitHub issue and loom launches a session against
that repo — seeded from the issue — and replies on the issue with a link to the
live session (`On it — {base}/s/{id}`).

GitHub delivers `issue_comment` events to a new **`POST /api/github/webhook`**,
registered **outside** `require_auth`. This is the security-critical,
internet-exposed, untrusted-input boundary, so it is authenticated
cryptographically (HMAC) and the commenter is authorized before anything runs.

## The gates (in order)

`crate::github_trigger` holds the testable primitives; `web::github_webhook`
sequences them:

1. **Signature** — recompute HMAC-SHA256 over the **raw** request body
   (captured as `axum::body::Bytes` before any JSON parse) and constant-time
   compare to `X-Hub-Signature-256`. Missing/bad signature → **401**. An
   unconfigured secret rejects every delivery.
2. **Idempotency** — dedupe on `X-GitHub-Delivery` (`processed_deliveries`
   table). A replayed or GitHub-retried delivery is a no-op.
3. **Filter** — `issue_comment` / `action == created` only; ignore the bot's own
   comments (`github.bot_login`).
4. **Command** — the comment must *begin* with a fixed phrase
   (`github.trigger_phrase`, default `@loom work on this`). No free-text in v1.
5. **Authorize the commenter** — a known loom operator, **or** write/admin on the
   repo (`GET /repos/{o}/{r}/collaborators/{login}/permission` via the ambient
   `GH_TOKEN`). **Fails closed.** A per-repo rate limit blunts comment spam.
6. **Acquire + create** — resolve the repo through the managed allowlist (#95;
   non-allowlisted repos are refused) and create the session, seeded from the
   issue in the trusted payload. Attributed to `github-webhook (<login>)` via
   `created_by` (#94).
7. **Reply** — post the session URL on the issue.

Everything past the signature check returns **200** (a non-trigger comment, a
replay, an unauthorized commenter, an unregistered repo, a rate-limited repo are
quiet no-ops) so GitHub doesn't retry a delivery loom deliberately ignored.

## Notable decisions

- **Secret outside the registry.** `github.webhook_secret` is read via
  `LOOM_GITHUB_WEBHOOK_SECRET` (env) or the settings table, never returned by
  `GET /api/settings` — same pattern as the OAuth client secret.
- **Gateway is a trait.** The two external GitHub calls (permission check +
  reply) go through `GithubApi`, so tests substitute a fake for `gh` and never
  touch the network.
- **At-most-once over retry-on-failure.** The delivery is recorded before
  session creation, so a GitHub retry can't create a duplicate session; the
  trade-off is no auto-retry on a transient create failure (the session is the
  costly side effect, so no-duplicate wins).
- **Unauthorized = silent.** No "not authorized" reply — replying to every
  unauthorized comment would amplify spam across a flood of deliveries.

## Tests

- Unit (`github_trigger`): signature accept/reject (tamper, wrong secret,
  missing/malformed header, empty secret), command anchoring, payload parse,
  login validation, delivery idempotency, authorize (loom-user vs write/admin vs
  read/none vs fail-closed), per-repo rate limit.
- Integration (`tests/integration/webhook.rs`, full server, local bare repo,
  fake gateway): bad/missing signature → 401; non-trigger ignored; unauthorized
  rejected (no session, no reply); **happy path** creates a session (attributed
  via `created_by`) and replies with the URL; replayed delivery is a no-op.

`./scripts/pre-commit.sh` (fmt + clippy + agent lint) and `cargo test
--workspace` are green; the agent lint review found nothing.

## Docs

`docs/github-trigger.md` — webhook URL, content-type, secret, the
issue-comment event to subscribe to, the repo allowlist, and that GitHub-App
installation tokens are the planned hardening. README + REST-API list updated.

## Scope / follow-ups (not this PR)

A full **GitHub App** with short-lived installation tokens (a real bot identity,
per-repo installation as the access allowlist, App-token API calls + reply) is
the planned hardening, per the design (§6.3). v1 is a secret-signed webhook over
the ambient `GH_TOKEN`.

Part of #337.
