### PR TITLE
feat(loom): self-contained standalone deploy with bundled TLS proxy

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,206 @@
+# Deploying loom
+
+loom ships as a single container image (the repo-root `Dockerfile`). How you put
+a TLS front-door in front of it is the choice this directory captures.
+
+| Path | Front-door | Use it when |
+|---|---|---|
+| **[`standalone/`](standalone/)** | **bundled** (Caddy, automatic HTTPS) | You want one self-contained, internet-facing host. **Start here.** |
+| repo-root `docker-compose.yml` | external (a Caddy you already run) | You already operate a shared reverse proxy on a `web` network (the maintainer "halcyon" setup). |
+| cloud / cluster | — | Future work — see [below](#future-cloud--cluster). |
+
+The rest of this README documents the **standalone** stack. It exposes loom to
+the internet, so its front-door and auth settings are wired for untrusted
+exposure out of the box.
+
+## What the standalone stack runs
+
+[`standalone/docker-compose.yml`](standalone/docker-compose.yml) brings up three
+services:
+
+- **caddy** — a [Caddy](https://caddyserver.com) front-door. It is the only
+  service that publishes ports (`80`/`443`). It obtains and renews a real TLS
+  certificate for your domain automatically, terminates TLS, and reverse-proxies
+  everything to loom — including the WebSocket terminal. See
+  [`standalone/Caddyfile`](standalone/Caddyfile).
+- **loom-init** — a one-shot that seeds the security-relevant auth settings into
+  the database before loom starts (see [Security posture](#security-posture)),
+  then exits.
+- **loom** — the loom daemon, bound to `0.0.0.0:7878` *inside* the compose
+  network only. It is never published to the host; the only way in is through
+  Caddy.
+
+loom drives the agents your sessions run (`gh`, `git`, `claude`, `uv`, an
+embedded VS Code), so the image is large and self-contained.
+
+## Prerequisites
+
+- A host with Docker and the Compose plugin, reachable from the internet on
+  ports **80 and 443**.
+- A **domain** whose DNS `A`/`AAAA` record points at the host. Caddy needs `:80`
+  reachable for the ACME challenge and your domain resolving to the host *before*
+  first start, or the certificate won't issue.
+- The credentials in the [env reference](#required-environment) — at minimum a
+  `GH_TOKEN`, a webhook secret, and an Anthropic key (or an interactive Claude
+  login).
+
+## Quick start
+
+```sh
+cd deploy/standalone
+cp .env.example .env
+$EDITOR .env                 # fill in LOOM_DOMAIN, GH_TOKEN, the secrets…
+
+docker compose up -d --build # builds the image, then starts the stack
+docker compose logs -f caddy # watch the certificate get issued
+```
+
+Then open `https://<LOOM_DOMAIN>` and [log in](#first-run-login).
+
+To validate the config without starting anything:
+
+```sh
+docker compose config -q                              # compose parses
+docker run --rm -v "$PWD/Caddyfile:/c:ro" \
+  -e LOOM_DOMAIN=loom.example.com caddy:2 \
+  caddy validate --config /c --adapter caddyfile      # Caddyfile is well-formed
+```
+
+## Required environment
+
+All of these live in `deploy/standalone/.env` (template:
+[`.env.example`](standalone/.env.example)). Compose reads the file both to
+interpolate the compose file and as each container's `env_file`.
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `LOOM_DOMAIN` | **yes** | Public domain Caddy serves and gets a cert for (e.g. `loom.team.dev`); `localhost` for local testing. Also seeded as `auth.base_url`. |
+| `LOOM_OWNER_GITHUB` | **yes** | GitHub login seeded as the first approved user on a fresh database. |
+| `GH_TOKEN` | **yes** | GitHub token loom uses to clone private repos, push branches, and reply to `@loom` comments. |
+| `LOOM_GITHUB_WEBHOOK_SECRET` | for `@loom` | Shared secret for the inbound webhook; must match the secret on the GitHub webhook. Until set, the webhook rejects every delivery. |
+| `ANTHROPIC_API_KEY` | for Claude | API key for the Claude agents. Alternatively log in interactively (see [first-run](#claude-authentication)). |
+| `HOST_UID` / `HOST_GID` | no (1000) | uid:gid the image runs as — matters only if you bind-mount a host dir. |
+| `LOOM_TLS_EMAIL` | no | ACME contact for cert-expiry notices; only used if you uncomment the global block in the Caddyfile. |
+| `LOOM_GITHUB_CLIENT_ID` / `_SECRET` | for login | GitHub OAuth app — the owner's only way to sign in on a fresh DB (see [first-run](#first-run-login)). Callback: `https://<LOOM_DOMAIN>/api/auth/github/callback`. |
+| `LOOM_IMAGE` | no | Override the image tag (defaults to the locally-built `loom:latest`). |
+
+## Security posture
+
+This deploy is reachable by anyone on the internet, so two auth settings must
+differ from their single-user defaults. The **loom-init** service sets them in
+the database automatically on every `up`, so the secure posture is not something
+you can forget to apply:
+
+- **`auth.trust_loopback = false`** — off, the default trusts requests from the
+  loopback interface as the machine owner with no login. (Caddy reaches loom over
+  the compose network, not loopback, so proxied traffic is unaffected either way;
+  turning it off is defense-in-depth against anything that can reach the daemon
+  locally.)
+- **`auth.cookie_secure = true`** — marks the login cookie `Secure` so the
+  browser only sends it over the HTTPS Caddy terminates.
+- **`auth.base_url = https://<LOOM_DOMAIN>`** — the canonical public origin, used
+  for the GitHub OAuth callback and trusted by the terminal's WebSocket
+  origin check.
+
+Background on these knobs is in the repo
+[README "Authentication"](../README.md#authentication) and
+[docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md). To change one after the fact:
+
+```sh
+docker compose exec loom weaver config set auth.trust_loopback false
+```
+
+Access past the front-door is then gated by GitHub/password login for the UI and
+bearer tokens for automation — see the repo README.
+
+## First-run login
+
+The only account that can log in on a fresh database is `LOOM_OWNER_GITHUB`, and
+it has no password yet — so **GitHub sign-in is the way in**. Since the loopback
+trust that bootstraps a local install is off here (see above), set up OAuth
+before first start:
+
+1. Register a GitHub OAuth app with callback
+   `https://<LOOM_DOMAIN>/api/auth/github/callback`, and put its credentials in
+   `.env` as `LOOM_GITHUB_CLIENT_ID` / `LOOM_GITHUB_CLIENT_SECRET`
+   (`docker compose up -d` to apply).
+2. Open `https://<LOOM_DOMAIN>` and **Continue with GitHub** as
+   `LOOM_OWNER_GITHUB`.
+3. Once in, approve teammates, set a password for password-login, and mint
+   automation tokens under **Settings → Account / Tokens**.
+
+For automation, the `loom` CLI inside the container is already authenticated as
+the owner (via the machine-local token loom injects), so it works without a
+login — e.g. `docker compose exec loom loom token add ci`.
+
+### Claude authentication
+
+If you did not set `ANTHROPIC_API_KEY`, log in to Claude once interactively; the
+credentials persist in `~/.claude.json` on the `loom_home` volume:
+
+```sh
+docker compose exec loom claude    # follow the prompts, then exit
+```
+
+## Wire the `@loom` GitHub trigger
+
+Commenting **`@loom work on this`** on an issue launches a session. To enable it:
+
+1. **Register the repo** in loom's managed store (the clone allowlist). From the
+   host, using a token minted under Settings → Tokens:
+
+   ```sh
+   curl -X POST https://<LOOM_DOMAIN>/api/repos \
+     -H "Authorization: Bearer $LOOM_TOKEN" \
+     -H 'content-type: application/json' \
+     -d '{"repo":"owner/name"}'
+   ```
+
+2. **Add the webhook** on the repo or org (**Settings → Webhooks → Add webhook**):
+   - **Payload URL** — `https://<LOOM_DOMAIN>/api/github/webhook`
+   - **Content type** — `application/json`
+   - **Secret** — the same value as `LOOM_GITHUB_WEBHOOK_SECRET`
+   - **Events** — *Let me select individual events* → **Issue comments** only
+
+Full behaviour, authorization rules, and hardening notes:
+[docs/github-trigger.md](../docs/github-trigger.md).
+
+## Where state lives
+
+Everything persistent is in named Docker volumes (survive `up`/`down`/recreate;
+removed only by `docker compose down -v` or `docker volume rm`):
+
+| Volume | Mount | Holds |
+|---|---|---|
+| `loom_home` | `/home/app` | The sqlite db (`~/.weaver/weaver.db`), the machine-local loom token, `~/.claude.json`, and the managed repo store (`WEAVER_REPOS_DIR`, default `~/.weaver/repos`) — the repos the `@loom` trigger clones and their worktrees. |
+| `uv` | `/opt/uv` | uv's managed Python interpreters and wheel cache. |
+| `caddy_data` | `/data` | Issued TLS certificates and the ACME account — back this up to avoid re-issuing on every fresh host. |
+| `caddy_config` | `/config` | Caddy's autosaved config. |
+
+The managed repo store lives inside `loom_home` (not its own volume) so the
+non-root `app` user the image runs as can write to it: a fresh standalone named
+volume would mount root-owned. To put repos on their own disk, point
+`WEAVER_REPOS_DIR` at a **bind mount** of a host directory you've `chown`ed to
+`HOST_UID:HOST_GID` instead.
+
+## Operations
+
+```sh
+docker compose ps                       # service status
+docker compose logs -f loom             # daemon logs
+docker compose exec loom bash           # a shell in the container
+docker compose pull caddy && \
+  docker compose up -d --build          # update: rebuild loom, refresh Caddy
+docker compose down                     # stop (keeps volumes/state)
+docker compose down -v                  # stop and DELETE all state
+```
+
+## Future: cloud / cluster
+
+A multi-host cloud/cluster deploy is intentionally **not** included here. It is
+not a manifest exercise: loom sessions are stateful PTYs (a long-lived terminal
+per session) that do not survive being rescheduled, so spreading sessions across
+workers is coupled to the per-session isolation model (Model 2 in the shared-loom
+design, weaver issue #337), not to packaging. That is a separate design. Until
+then, the standalone single-host stack is the supported way to run a shared team
+loom.

--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -1,0 +1,53 @@
+# deploy/standalone/.env — copy to `.env` and fill in. NEVER commit the real one
+# (the repo .gitignore already excludes every `.env`). Compose reads this file
+# both to interpolate the compose file and as each container's env_file.
+#
+# Values without a sensible default are required; the stack refuses to start
+# without LOOM_DOMAIN.
+
+# ── Front-door ────────────────────────────────────────────────────────────────
+# The public domain whose DNS A/AAAA record points at this host. Caddy obtains a
+# Let's Encrypt certificate for it automatically. For local testing use
+# `localhost` (Caddy then uses its own internal CA — the browser warns; expected).
+LOOM_DOMAIN=loom.example.com
+# Optional ACME contact for CA expiry notices. Only used if you uncomment the
+# global block in ./Caddyfile.
+LOOM_TLS_EMAIL=you@example.com
+
+# ── Host user (file ownership of anything that reaches the host) ───────────────
+# The image runs as this uid:gid. Set to the user that should own files if you
+# later bind-mount a host directory; the defaults are fine for named volumes.
+HOST_UID=1000
+HOST_GID=1000
+
+# ── Team owner ────────────────────────────────────────────────────────────────
+# GitHub login seeded as the first approved user on a fresh database. This is the
+# only account that can log in until it approves others.
+LOOM_OWNER_GITHUB=your-github-login
+
+# ── Credentials the agents and integrations need ──────────────────────────────
+# A GitHub token loom uses to clone private repos, push branches, and reply to
+# `@loom` comments (the `gh` CLI and the git credential helper read it).
+GH_TOKEN=ghp_your_token
+
+# Shared secret for the inbound `@loom work on this` webhook. MUST equal the
+# secret you configure on the GitHub webhook. Until it is set the webhook rejects
+# every delivery. Generate one with:  openssl rand -hex 32
+LOOM_GITHUB_WEBHOOK_SECRET=replace-with-a-long-random-string
+
+# Anthropic API key for the Claude agents. Alternatively leave it blank and run a
+# one-time interactive login that persists on the loom_home volume:
+#   docker compose exec loom claude
+ANTHROPIC_API_KEY=sk-ant-your-key
+
+# ── GitHub sign-in ────────────────────────────────────────────────────────────
+# The owner's only way to log in on a fresh database (loopback trust is off for
+# this internet-facing deploy). Register an OAuth app with callback
+#   https://<LOOM_DOMAIN>/api/auth/github/callback
+# and set both here before first start. See ../README.md "First-run login".
+LOOM_GITHUB_CLIENT_ID=
+LOOM_GITHUB_CLIENT_SECRET=
+
+# ── Image tag (optional) ──────────────────────────────────────────────────────
+# The locally-built image is tagged loom:latest. Override to pin a registry image.
+# LOOM_IMAGE=loom:latest

--- a/deploy/standalone/Caddyfile
+++ b/deploy/standalone/Caddyfile
@@ -1,0 +1,33 @@
+# Caddyfile — the bundled TLS-terminating front-door for the standalone loom
+# deploy. Caddy provisions and renews a real certificate for $LOOM_DOMAIN
+# automatically (ACME over the published :80/:443), terminates TLS, and reverse-
+# proxies every request to the loom container on the internal compose network.
+#
+# $LOOM_DOMAIN is injected from .env by docker-compose.yml. For local testing set
+# LOOM_DOMAIN=localhost — Caddy then signs with its own internal CA instead of
+# reaching Let's Encrypt (your browser warns about the self-signed cert; expected).
+#
+# Optional: to receive certificate-expiry notices from the CA, uncomment this
+# global block and set an address (or leave LOOM_TLS_EMAIL in .env and keep the
+# {$LOOM_TLS_EMAIL} form).
+# {
+# 	email {$LOOM_TLS_EMAIL}
+# }
+
+{$LOOM_DOMAIN} {
+	# A single upstream: the loom daemon, reached by its compose service name.
+	# Caddy's reverse_proxy is all loom needs from a front-door:
+	#
+	#   * WebSocket terminal — it transparently proxies Upgrade requests (it
+	#     detects `Connection: Upgrade` and streams both directions), so the
+	#     xterm.js terminal at /api/sessions/{id}/terminal works with no extra
+	#     config.
+	#   * Origin/host checks — Caddy preserves the inbound Host header upstream by
+	#     default AND adds X-Forwarded-For / -Proto / -Host. loom's terminal
+	#     handshake requires both: it accepts the WS Origin when it matches the
+	#     request Host *and* an X-Forwarded-* header proves the request transited a
+	#     proxy (see crates/loom/src/terminal.rs / docs/browser-terminal.md). The
+	#     X-Forwarded-Proto=https also lets loom build correct https:// OAuth
+	#     callback URLs.
+	reverse_proxy loom:7878
+}

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -1,0 +1,88 @@
+# Self-contained, internet-facing loom deploy (Model 1, single shared container).
+#
+# Unlike the repo-root docker-compose.yml — which attaches to an EXTERNAL `web`
+# network and assumes a Caddy front-door already exists on the host — this stack
+# OWNS its front-door: a bundled Caddy terminates TLS for $LOOM_DOMAIN and is the
+# only service that publishes ports. loom itself is never bound on the host.
+#
+# Full guide, env reference, and first-run steps: ../README.md
+name: loom
+
+services:
+  # One-shot: seed the security-relevant auth settings into the shared sqlite DB
+  # BEFORE loom starts, so an internet-exposed deploy never comes up trusting
+  # loopback or minting a non-Secure session cookie. `weaver config set` writes
+  # the settings table directly — no running server needed — then exits; loom
+  # waits on its success. Idempotent: it re-runs on every `up` and just rewrites
+  # the same three values. (See ../README.md "Security posture".)
+  loom-init:
+    image: ${LOOM_IMAGE:-loom:latest}
+    build: &loom_build
+      context: ../..
+      args:
+        HOST_UID: ${HOST_UID:-1000}
+        HOST_GID: ${HOST_GID:-1000}
+    env_file: .env
+    restart: "no"
+    volumes:
+      - loom_home:/home/app
+    # $$LOOM_DOMAIN is escaped from compose so the *container* shell expands it
+    # from the env_file — keeping the domain in one place (.env).
+    command:
+      - sh
+      - -ceu
+      - |
+        weaver config set auth.trust_loopback false
+        weaver config set auth.cookie_secure true
+        weaver config set auth.base_url "https://$$LOOM_DOMAIN"
+
+  loom:
+    image: ${LOOM_IMAGE:-loom:latest}
+    build: *loom_build
+    restart: unless-stopped
+    env_file: .env
+    depends_on:
+      loom-init:
+        condition: service_completed_successfully
+    expose:
+      - "7878" # internal to the compose network only — never published
+    volumes:
+      # Persisted HOME for the container user. Everything stateful lives here and
+      # is owned by the `app` user the image runs as:
+      #   * the weaver sqlite db + the 0600 machine-local loom token (~/.weaver),
+      #   * ~/.claude.json (so a one-time `claude` login survives a recreate),
+      #   * the managed repo store the @loom webhook clones into
+      #     (WEAVER_REPOS_DIR, default ~/.weaver/repos) — inspect with
+      #     `docker compose exec loom ls .weaver/repos`.
+      # Kept inside this volume on purpose: a fresh *separate* named volume would
+      # mount root-owned (the image has no such dir to seed ownership from), and
+      # the non-root app user could not clone into it.
+      - loom_home:/home/app
+      # uv's managed interpreters + wheel cache, for Python repos the agents work
+      # in (UV_PYTHON_INSTALL_DIR / UV_CACHE_DIR point here; the Dockerfile
+      # pre-creates /opt/uv owned by app so this volume seeds writable).
+      - uv:/opt/uv
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    environment:
+      # Consumed by the Caddyfile. Fails fast if LOOM_DOMAIN is unset.
+      LOOM_DOMAIN: ${LOOM_DOMAIN:?set LOOM_DOMAIN in deploy/standalone/.env}
+      LOOM_TLS_EMAIL: ${LOOM_TLS_EMAIL:-}
+    ports:
+      - "80:80"     # ACME HTTP-01 challenge + the HTTP->HTTPS redirect
+      - "443:443"   # HTTPS
+      - "443:443/udp" # HTTP/3 (QUIC)
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data     # issued certs + ACME account — survive a recreate
+      - caddy_config:/config
+    depends_on:
+      - loom
+
+volumes:
+  loom_home:
+  uv:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
Adds a self-contained, internet-facing single-host deploy for loom under `deploy/standalone/`, the front-door piece of the shared-team-loom effort (#337, design §6.5). The core workflow — managed repo store, attribution, the `@loom` webhook trigger — is already on main; this gives it somewhere to run.

## What is here

- `deploy/standalone/docker-compose.yml` — a stack with three services: a bundled **Caddy** front-door (automatic HTTPS) that terminates TLS for a domain and reverse-proxies to `loom:7878`; a one-shot **loom-init**; and **loom** itself, bound only on the internal compose network (no published host port).
- `deploy/standalone/Caddyfile` — minimal reverse proxy. Caddy transparently proxies the WebSocket terminal upgrade, preserves the inbound `Host`, and adds `X-Forwarded-*` — both of which loom’s terminal origin check requires behind a proxy.
- `deploy/standalone/.env.example` — every secret/knob the stack needs.
- `deploy/README.md` — the deploy guide.

## Secure by default for untrusted exposure

The deploy faces the internet, so the `loom-init` one-shot seeds the security-relevant auth settings into the shared sqlite DB *before* loom starts — `auth.trust_loopback=false`, `auth.cookie_secure=true`, and `auth.base_url=https://<domain>`. Wiring these into the stack (rather than a documented post-install `docker exec`) means the hardened posture cannot be forgotten. The managed repo store stays inside the app-owned home volume because a fresh standalone named volume would mount root-owned and the non-root container user could not clone into it.

## Does not touch the existing path

The repo-root `docker-compose.yml` and `Dockerfile` (the external-proxy "halcyon" flow) are unchanged — this adds a second option. A cloud/cluster deploy is noted as future work coupled to per-session isolation (Model 2), not a manifest exercise.

## Validation

`docker compose config` parses and `caddy validate` accepts the Caddyfile; `./scripts/pre-commit.sh` is green (no Rust/TS changes, so the agent lint self-skips).

Part of #337.