### PR TITLE
feat(loom): GitHub App installation tokens for the webhook trigger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1193,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1281,7 @@ dependencies = [
  "hmac",
  "hyper",
  "hyper-util",
+ "jsonwebtoken",
  "percent-encoding",
  "rand",
  "reqwest",
@@ -1368,6 +1390,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1532,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1943,6 +2006,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2307,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/crates/loom/Cargo.toml
+++ b/crates/loom/Cargo.toml
@@ -31,6 +31,9 @@ clap_complete = "4"
 futures-util = "0.3"
 # Hex-encode the SHA-256 digests we store for API tokens and session cookies.
 hex = "0.4"
+# Sign the GitHub App JWT (RS256) we exchange for short-lived installation
+# tokens — the hardening that replaces the ambient GH_TOKEN (crate::github_app).
+jsonwebtoken = "9"
 # HMAC-SHA256 for verifying the GitHub webhook signature (`X-Hub-Signature-256`).
 # `Mac::verify_slice` is a constant-time compare, so the verification can't be
 # turned into a timing oracle.

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -752,12 +752,13 @@ mod tests {
         )
         .await
         .unwrap();
+        let trigger = crate::github_trigger::GithubTrigger::production(db.clone());
         let state = AppState {
             db,
             bus: events::EventBus::new(),
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
-            trigger: crate::github_trigger::GithubTrigger::production(),
+            trigger,
         };
         Fixture {
             _repo: repo,

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -1,0 +1,830 @@
+//! The GitHub **App** identity (shared-loom design §6.3): the hardening that
+//! replaces the v1 webhook's reliance on a long-lived, over-scoped ambient
+//! `GH_TOKEN` with **short-lived, least-privilege, per-installation** tokens.
+//!
+//! An App is configured with an `app_id` and an RSA **private key** (a PEM,
+//! held outside the settings registry like the OAuth client secret — never
+//! returned by `GET /api/settings`). From those two secrets loom can:
+//!
+//! 1. **Mint an App JWT** ([`build_app_jwt`]) — an RS256 token, signed with the
+//!    private key, that authenticates loom *as the App* for the next ~10 minutes.
+//! 2. **Resolve a repo to its installation** ([`GithubApp::installation_id`])
+//!    via `GET /repos/{owner}/{name}/installation`. A repo the App is installed
+//!    on is, by that fact, authorized — the installation *is* the access
+//!    allowlist (complementing the managed-repo table from #95).
+//! 3. **Exchange the JWT for an installation access token**
+//!    (`POST /app/installations/{id}/access_tokens`), **cached per installation
+//!    with its expiry** and refreshed once stale ([`GithubApp::installation_token`]).
+//!
+//! [`GithubApp`] implements the [`GithubApi`] gateway the trigger calls for the
+//! commenter permission check and the issue reply, performing both over the
+//! **REST API with the installation token** instead of the `gh` CLI. When the
+//! App is **not configured** it transparently **falls back** to the ambient
+//! `GH_TOKEN` path ([`GhCli`]), so the v1 flow keeps working unchanged.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+
+use crate::github_trigger::{GhCli, GithubApi};
+use crate::repo::RepoSlug;
+use weaver_core::db::Db;
+
+/// Settings key (env-overridable) holding the App's numeric id.
+pub const APP_ID_KEY: &str = "github.app_id";
+/// Settings key (env-overridable) holding the App's RSA private key PEM. Like
+/// the OAuth client secret, this is **never** returned by `GET /api/settings`.
+pub const APP_PRIVATE_KEY_KEY: &str = "github.app_private_key";
+
+/// The production GitHub REST base. Overridable per-instance only for tests.
+const DEFAULT_API_BASE: &str = "https://api.github.com";
+/// GitHub requires a `User-Agent`; identify loom's App client.
+const USER_AGENT: &str = "loom-github-app";
+const GH_ACCEPT: &str = "application/vnd.github+json";
+const GH_API_VERSION: &str = "2022-11-28";
+
+/// JWT validity: GitHub caps an App JWT at 10 minutes; 9 leaves headroom.
+const JWT_TTL_SECS: i64 = 9 * 60;
+/// Backdate `iat` to tolerate a small clock skew between loom and GitHub.
+const CLOCK_SKEW_SECS: i64 = 60;
+/// Treat an installation token as stale this long *before* its real expiry, so
+/// a token never lapses mid-request.
+const TOKEN_EXPIRY_SKEW_SECS: i64 = 60;
+
+// ---------------------------------------------------------------------------
+// App JWT — RS256, signed with the App private key.
+// ---------------------------------------------------------------------------
+
+/// The registered claims of an App JWT: issued-at, expiry, and the App id as
+/// issuer (GitHub accepts the id as a string).
+#[derive(Debug, Serialize, Deserialize)]
+struct AppJwtClaims {
+    iat: i64,
+    exp: i64,
+    iss: String,
+}
+
+/// Build (and RS256-sign) an App JWT for `app_id` using `private_key_pem`,
+/// anchored at `now_unix` (seconds since the epoch). Split from the clock so it
+/// is deterministic in tests. `iat` is backdated [`CLOCK_SKEW_SECS`] and `exp`
+/// is [`JWT_TTL_SECS`] out, both within GitHub's 10-minute ceiling. Errors when
+/// the PEM is not a usable RSA private key.
+pub fn build_app_jwt(app_id: i64, private_key_pem: &str, now_unix: i64) -> Result<String> {
+    let claims = AppJwtClaims {
+        iat: now_unix - CLOCK_SKEW_SECS,
+        exp: now_unix + JWT_TTL_SECS,
+        iss: app_id.to_string(),
+    };
+    let key = EncodingKey::from_rsa_pem(private_key_pem.as_bytes())
+        .context("parsing the GitHub App private key (expected an RSA PEM)")?;
+    encode(&Header::new(Algorithm::RS256), &claims, &key).context("signing the App JWT")
+}
+
+// ---------------------------------------------------------------------------
+// Installation token cache.
+// ---------------------------------------------------------------------------
+
+/// One installation access token plus the instant it expires.
+#[derive(Debug, Clone)]
+struct CachedToken {
+    token: String,
+    expires_at: DateTime<Utc>,
+}
+
+impl CachedToken {
+    /// Whether this token is still safe to use at `now` (with a refresh margin).
+    fn is_fresh(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at > now + Duration::seconds(TOKEN_EXPIRY_SKEW_SECS)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The App client.
+// ---------------------------------------------------------------------------
+
+/// loom's GitHub App client: mints App JWTs, exchanges them for per-installation
+/// access tokens (cached until expiry), and performs the trigger's GitHub calls
+/// over REST with those tokens — falling back to `gh` when the App is
+/// unconfigured. One instance per server, shared behind an `Arc`.
+pub struct GithubApp {
+    db: Db,
+    http: reqwest::Client,
+    /// REST base (no trailing slash). `https://api.github.com` in production.
+    api_base: String,
+    /// Per-installation token cache, keyed by installation id.
+    tokens: Mutex<HashMap<i64, CachedToken>>,
+    /// The ambient-`GH_TOKEN` gateway used when the App is not configured.
+    fallback: Arc<dyn GithubApi>,
+}
+
+impl GithubApp {
+    /// The production client: the real GitHub API, falling back to the `gh` CLI.
+    pub fn new(db: Db) -> Self {
+        Self::with_parts(db, DEFAULT_API_BASE.to_string(), Arc::new(GhCli))
+    }
+
+    /// Construct with an explicit API base and fallback gateway — the seam tests
+    /// use to point at a mock GitHub and observe the fallback.
+    pub fn with_parts(db: Db, api_base: String, fallback: Arc<dyn GithubApi>) -> Self {
+        let http = reqwest::Client::builder()
+            .user_agent(USER_AGENT)
+            .build()
+            .expect("building the GitHub App HTTP client");
+        Self {
+            db,
+            http,
+            api_base: api_base.trim_end_matches('/').to_string(),
+            tokens: Mutex::new(HashMap::new()),
+            fallback,
+        }
+    }
+
+    // -- configuration ------------------------------------------------------
+
+    /// The App id: `LOOM_GITHUB_APP_ID`, else the `github.app_id` setting; `None`
+    /// when unset or non-numeric.
+    pub async fn app_id(&self) -> Option<i64> {
+        config_value(&self.db, "LOOM_GITHUB_APP_ID", APP_ID_KEY)
+            .await?
+            .parse()
+            .ok()
+    }
+
+    /// The App private key PEM: `LOOM_GITHUB_APP_PRIVATE_KEY`, else the
+    /// `github.app_private_key` setting; `None` when unset.
+    pub async fn private_key(&self) -> Option<String> {
+        config_value(&self.db, "LOOM_GITHUB_APP_PRIVATE_KEY", APP_PRIVATE_KEY_KEY).await
+    }
+
+    /// Whether the App is fully configured (both id and private key present). The
+    /// switch between the App path and the `gh`-fallback path.
+    pub async fn is_configured(&self) -> bool {
+        self.app_id().await.is_some() && self.private_key().await.is_some()
+    }
+
+    /// A freshly-signed App JWT for the configured App.
+    async fn current_jwt(&self) -> Result<String> {
+        let app_id = self
+            .app_id()
+            .await
+            .ok_or_else(|| anyhow!("GitHub App id is not configured"))?;
+        let pem = self
+            .private_key()
+            .await
+            .ok_or_else(|| anyhow!("GitHub App private key is not configured"))?;
+        build_app_jwt(app_id, &pem, Utc::now().timestamp())
+    }
+
+    // -- installation resolution + tokens -----------------------------------
+
+    /// The installation id of the App on `owner/name`
+    /// (`GET /repos/{owner}/{name}/installation`). Success doubles as the proof
+    /// that the App is installed on — and so authorized for — the repo. Errors
+    /// (e.g. a 404 when the App is not installed) propagate so callers fail closed.
+    pub async fn installation_id(&self, owner: &str, name: &str) -> Result<i64> {
+        let jwt = self.current_jwt().await?;
+        let url = format!("{}/repos/{owner}/{name}/installation", self.api_base);
+        let resp = self
+            .http
+            .get(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(&jwt)
+            .send()
+            .await
+            .context("requesting the repo installation")?;
+        let resp = check_status(resp, "resolving the repo installation").await?;
+        let body: InstallationResponse = resp
+            .json()
+            .await
+            .context("parsing the installation response")?;
+        Ok(body.id)
+    }
+
+    /// A valid installation access token for `installation_id`, minting (and
+    /// caching) a fresh one only when none is cached or the cached one is near
+    /// expiry. The cached-token fast path holds the lock only briefly and never
+    /// across the network call.
+    pub async fn installation_token(&self, installation_id: i64) -> Result<String> {
+        if let Some(token) = self.cached_token(installation_id) {
+            return Ok(token);
+        }
+        let jwt = self.current_jwt().await?;
+        let fresh = self.fetch_installation_token(&jwt, installation_id).await?;
+        let token = fresh.token.clone();
+        self.tokens
+            .lock()
+            .expect("token cache mutex poisoned")
+            .insert(installation_id, fresh);
+        Ok(token)
+    }
+
+    /// The cached token for `installation_id`, if one is present and still fresh.
+    fn cached_token(&self, installation_id: i64) -> Option<String> {
+        let now = Utc::now();
+        let map = self.tokens.lock().expect("token cache mutex poisoned");
+        map.get(&installation_id)
+            .filter(|t| t.is_fresh(now))
+            .map(|t| t.token.clone())
+    }
+
+    /// Exchange `jwt` for an installation access token via
+    /// `POST /app/installations/{id}/access_tokens`.
+    async fn fetch_installation_token(
+        &self,
+        jwt: &str,
+        installation_id: i64,
+    ) -> Result<CachedToken> {
+        let url = format!(
+            "{}/app/installations/{installation_id}/access_tokens",
+            self.api_base
+        );
+        let resp = self
+            .http
+            .post(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(jwt)
+            .send()
+            .await
+            .context("requesting an installation access token")?;
+        let resp = check_status(resp, "minting an installation token").await?;
+        let body: InstallationTokenResponse = resp
+            .json()
+            .await
+            .context("parsing the installation token response")?;
+        let expires_at = DateTime::parse_from_rfc3339(&body.expires_at)
+            .context("parsing the installation token expiry")?
+            .with_timezone(&Utc);
+        Ok(CachedToken {
+            token: body.token,
+            expires_at,
+        })
+    }
+
+    /// Resolve `owner/name` to an installation and return a valid token for it —
+    /// the two-step the REST gateway methods share.
+    async fn token_for_repo(&self, owner: &str, name: &str) -> Result<String> {
+        let installation_id = self.installation_id(owner, name).await?;
+        self.installation_token(installation_id).await
+    }
+
+    // -- installation as allowlist ------------------------------------------
+
+    /// When the App is installed on `slug`, ensure that repo is in the managed
+    /// allowlist (idempotent), so the trigger's clone path accepts it — the
+    /// "installation *is* the allowlist" rule (§6.3), *complementing* the
+    /// explicitly-registered repos from #95. Best-effort and a no-op when the App
+    /// is unconfigured, the repo is already registered, or the App is not
+    /// installed on it (leaving the v1 repos-table allowlist to govern).
+    pub async fn ensure_installed_repo_registered(&self, slug: &RepoSlug) {
+        if !self.is_configured().await {
+            return;
+        }
+        let slug_str = slug.slug();
+        match crate::repo::get_registered(&self.db, &slug_str).await {
+            // Already allowlisted — nothing to do, and no GitHub call needed.
+            Ok(Some(_)) => return,
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(repo = %slug_str, error = %e, "checking the repo allowlist failed");
+                return;
+            }
+        }
+        // Only auto-register a repo the App is actually installed on.
+        let installation_id = match self.installation_id(&slug.owner, &slug.name).await {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::debug!(repo = %slug_str, error = %e, "repo has no App installation; not auto-registering");
+                return;
+            }
+        };
+        let path = slug.path(&crate::repo::repos_dir());
+        match crate::repo::register(
+            &self.db,
+            &slug_str,
+            &slug.github_url(),
+            &path.to_string_lossy(),
+        )
+        .await
+        {
+            Ok(_) => tracing::info!(
+                repo = %slug_str,
+                installation = installation_id,
+                "auto-registered an App-installed repo into the managed allowlist"
+            ),
+            Err(e) => {
+                tracing::warn!(repo = %slug_str, error = %e, "auto-registering the installed repo failed")
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl GithubApi for GithubApp {
+    async fn collaborator_permission(
+        &self,
+        owner: &str,
+        name: &str,
+        login: &str,
+    ) -> Result<String> {
+        if !self.is_configured().await {
+            return self
+                .fallback
+                .collaborator_permission(owner, name, login)
+                .await;
+        }
+        let token = self.token_for_repo(owner, name).await?;
+        let url = format!(
+            "{}/repos/{owner}/{name}/collaborators/{login}/permission",
+            self.api_base
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("requesting the collaborator permission")?;
+        let resp = check_status(resp, "checking the collaborator permission").await?;
+        let body: PermissionResponse = resp
+            .json()
+            .await
+            .context("parsing the collaborator permission response")?;
+        Ok(body.permission)
+    }
+
+    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
+        if !self.is_configured().await {
+            return self.fallback.post_issue_comment(repo, issue, body).await;
+        }
+        let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
+        let token = self.token_for_repo(&slug.owner, &slug.name).await?;
+        let url = format!(
+            "{}/repos/{}/{}/issues/{issue}/comments",
+            self.api_base, slug.owner, slug.name
+        );
+        let resp = self
+            .http
+            .post(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "body": body }))
+            .send()
+            .await
+            .context("posting the issue comment")?;
+        check_status(resp, "posting the issue comment").await?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// REST response shapes + helpers.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct InstallationResponse {
+    id: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallationTokenResponse {
+    token: String,
+    /// RFC 3339, e.g. `2016-07-11T22:14:10Z`.
+    expires_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PermissionResponse {
+    permission: String,
+}
+
+/// `env`, else the `key` setting; `None` when neither holds a non-empty value.
+/// Mirrors the OAuth-secret resolution in [`crate::auth`].
+async fn config_value(db: &Db, env: &str, key: &str) -> Option<String> {
+    if let Ok(v) = std::env::var(env) {
+        let v = v.trim().to_string();
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    let v = weaver_core::config::get(db, key).await?.trim().to_string();
+    (!v.is_empty()).then_some(v)
+}
+
+/// Turn a non-2xx GitHub response into an error carrying the (trimmed) body, so
+/// the caller can log and fail closed; pass a 2xx response through untouched.
+async fn check_status(resp: reqwest::Response, what: &str) -> Result<reqwest::Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let body = resp.text().await.unwrap_or_default();
+    bail!("{what}: GitHub returned {status}: {}", body.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::extract::{Json, Path, State};
+    use axum::http::{HeaderMap, StatusCode};
+    use axum::routing::{get, post};
+    use axum::Router;
+    use jsonwebtoken::{decode, DecodingKey, Validation};
+    use serde_json::{json, Value};
+
+    /// A throwaway RSA keypair (PKCS#8 PEM) used only by these tests to sign and
+    /// verify App JWTs. Never a real credential.
+    const TEST_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDaaguBS++TNGq8
+erDndgGPa553S+MqsFQ2E8mAadAaEsDSZSz7PqrLbdf8zGBGL7Ehzye2acTPt6Fo
+3z5AmazjTN6RcdAzWoq7q990extzliW9mKv9PY88olpTB7VTUPDBtRaKghcgVRKY
+m014jt/1cbZ97nOZHa9wmExP7R98PC1ewZ3qYbXL+i1T6zIFDzfB3aY6px1VI9qJ
+umDzPojzg0Lg9g1We7j8l+J7zngPhoEwRuwjCw1EiCTWyp6GqhHkOvqkFOyd/1C5
+PQI3x9JS4HkL0OMXzumDdizIuuqyda3rikufWUJ7qhy9pIanR4vYYCLb8RZMCnz5
+cXRmeogLAgMBAAECggEAWFRaosea8+VW5TKZKIJIzz+uroA6NqFo7RXDf/NK/cBn
+yq6wKkuFtw+NMedVaA0RjaLBZLwRpA+Xb1oZSvbbPHFx8VAd6ybKxGsVy32d9Hjc
+enir1ZZ3vwXJkZqkcjVhqHUb0Jgb0i+VfbIQ+piNai26p+MvTNT8hoSRGCHFge/1
+AlDGufKPaMqE91BYUdBN8eGjTJlaVbLJM2XQxLEtcNhfBHaGgFuqWHJJuYoXX2IU
+EbG9jjVzX8zx6Kp8rF8k4H0Y6LzhTjEEbBIHkUQqv5PS6qajDOSeT3pSF0Hb5CWL
+LQ/gG9Y9ttN/D2lOd3IiATU6hnBfjHqO4YhleU91gQKBgQDvvaGZxToIStgEX+bS
++jhriUiHgw4xCv+kz5eok0thl/fnsM5aKZDeMEvzhNoBZotWEu18xKC8rfV1orj7
+LDTH3RN1N3AY06ebYb2DWX9sqe+7P/Y/T6C/b0/R2/yP1vGkUgRpUIUZi7wy9Mkc
+4qd7KYalYplFSxXU8Y3uocJLgwKBgQDpOiTMBRMwD4aiZ/M4doyenByuYbQ1yKmX
+QtaRVBvHIp3TTGIC2l7j4FeoYQL7Uh02NI1KlpACB54uakVbu9xHotZLpXWsCxLV
+l5Io/OxnyZANA6EEfdk2U0ZAyrS+K6He67XR0DJqfd15jvowCgJXH0lrlsFjdp6e
+81dwbNCC2QKBgHiXxOAaq3RcYYjhzLQ3lYXSSp+PtuXIiIuYuMrdPL/ct6Dd+Q61
+dd+uH6ZhH2Aw+snTP47RQaFnR99iePYvaGVYuV7vAf4bCWZJphCaRlScrrBcHjv+
+i/d/wIDpzYN1NZvYfcuT6z/MYGCpbTiQcnqrisVKcZq/iD3TO/fbemaNAoGBAJKL
+STG0gqDxMHx9anLw8lx65P6hP5WH1x/HDIFWYvnWA2sQFImMYpE2ln2jLzdxGg/E
+J39VaXkNBlRNy/Te7oNIivQPLAgFETmKOnlsqrJwEQZMYHEtDj23R25QsA7J5bTn
+UGBcPEFzgqTttMBYma3aZ8yldjAkCXkAl9F5Xe7JAoGAStxmRJTtYWpyU84wFvWA
+Tm6lfFMOJWNssPbj8PaqekEG8CALxgG4C/KNWbB0sO6OSs3U1ihEQINSbbX0Y15F
+hlbeI/D+Z+U3ASALKlIsZTEuz+5fTKByEa0bezukkMPD0GJU6vj4ik6MIwEZJVWG
+8MEpYrwHIf1vyElxCHpJAqs=
+-----END PRIVATE KEY-----";
+
+    const TEST_PUBLIC_KEY: &str = "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2moLgUvvkzRqvHqw53YB
+j2ued0vjKrBUNhPJgGnQGhLA0mUs+z6qy23X/MxgRi+xIc8ntmnEz7ehaN8+QJms
+40zekXHQM1qKu6vfdHsbc5YlvZir/T2PPKJaUwe1U1DwwbUWioIXIFUSmJtNeI7f
+9XG2fe5zmR2vcJhMT+0ffDwtXsGd6mG1y/otU+syBQ83wd2mOqcdVSPaibpg8z6I
+84NC4PYNVnu4/Jfie854D4aBMEbsIwsNRIgk1sqehqoR5Dr6pBTsnf9QuT0CN8fS
+UuB5C9DjF87pg3YsyLrqsnWt64pLn1lCe6ocvaSGp0eL2GAi2/EWTAp8+XF0ZnqI
+CwIDAQAB
+-----END PUBLIC KEY-----";
+
+    const TEST_APP_ID: i64 = 123456;
+
+    // -- JWT ----------------------------------------------------------------
+
+    /// The minted App JWT verifies against the public key and carries the
+    /// expected issuer and a sane iat/exp window (RS256, ≤10-minute TTL).
+    #[test]
+    fn app_jwt_is_well_formed_and_verifiable() {
+        // Anchor at the real clock so the freshly-minted token is unexpired and
+        // `validate_exp` (below) genuinely passes.
+        let now = Utc::now().timestamp();
+        let token = build_app_jwt(TEST_APP_ID, TEST_PRIVATE_KEY, now).unwrap();
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_issuer(&[TEST_APP_ID.to_string()]);
+        // Anchor expiry validation to the token's own clock window.
+        validation.validate_exp = true;
+        validation.leeway = 0;
+        let key = DecodingKey::from_rsa_pem(TEST_PUBLIC_KEY.as_bytes()).unwrap();
+        let data = decode::<AppJwtClaims>(&token, &key, &validation).unwrap();
+
+        assert_eq!(data.claims.iss, TEST_APP_ID.to_string());
+        // iat is backdated for skew; exp is within GitHub's 10-minute ceiling.
+        assert_eq!(data.claims.iat, now - CLOCK_SKEW_SECS);
+        assert_eq!(data.claims.exp, now + JWT_TTL_SECS);
+        assert!(data.claims.exp - data.claims.iat <= 600);
+    }
+
+    /// A wrong public key (a tampered-with or mismatched App) fails verification.
+    #[test]
+    fn app_jwt_rejects_a_mismatched_key() {
+        let token = build_app_jwt(TEST_APP_ID, TEST_PRIVATE_KEY, 1_700_000_000).unwrap();
+        let other = "-----BEGIN PUBLIC KEY-----
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
+0Q0G0t0Q0G0t0Q0G0t0Q0G0t0Q0G0t0Q0G0t0Q0G0t0Q0G0t0CAwEAAQ==
+-----END PUBLIC KEY-----";
+        let validation = Validation::new(Algorithm::RS256);
+        // A malformed/mismatched key must not verify (either parse or verify fails).
+        let verified = DecodingKey::from_rsa_pem(other.as_bytes())
+            .ok()
+            .and_then(|k| decode::<AppJwtClaims>(&token, &k, &validation).ok());
+        assert!(verified.is_none());
+    }
+
+    #[test]
+    fn app_jwt_rejects_a_bad_private_key() {
+        assert!(build_app_jwt(TEST_APP_ID, "not a pem", 0).is_err());
+    }
+
+    // -- mock GitHub --------------------------------------------------------
+
+    /// Shared state for the mock GitHub server: how many tokens it has minted,
+    /// the expiry it stamps on them, and the comments it received.
+    struct MockState {
+        token_mints: AtomicUsize,
+        /// Offset from now stamped as the token's `expires_at` (seconds). Negative
+        /// → already expired, to exercise refresh.
+        expiry_offset_secs: i64,
+        comments: Mutex<Vec<Value>>,
+        last_comment_auth: Mutex<Option<String>>,
+    }
+
+    impl MockState {
+        fn new(expiry_offset_secs: i64) -> Arc<Self> {
+            Arc::new(Self {
+                token_mints: AtomicUsize::new(0),
+                expiry_offset_secs,
+                comments: Mutex::new(Vec::new()),
+                last_comment_auth: Mutex::new(None),
+            })
+        }
+    }
+
+    async fn mock_access_tokens(State(s): State<Arc<MockState>>) -> Json<Value> {
+        s.token_mints.fetch_add(1, Ordering::SeqCst);
+        let exp = Utc::now() + Duration::seconds(s.expiry_offset_secs);
+        Json(json!({ "token": "ghs_installation_token", "expires_at": exp.to_rfc3339() }))
+    }
+
+    async fn mock_installation() -> Json<Value> {
+        Json(json!({ "id": 42 }))
+    }
+
+    async fn mock_permission() -> Json<Value> {
+        Json(json!({ "permission": "write" }))
+    }
+
+    async fn mock_comments(
+        State(s): State<Arc<MockState>>,
+        Path((owner, name, issue)): Path<(String, String, i64)>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> StatusCode {
+        *s.last_comment_auth.lock().unwrap() = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        s.comments.lock().unwrap().push(json!({
+            "repo": format!("{owner}/{name}"),
+            "issue": issue,
+            "body": body["body"],
+        }));
+        StatusCode::CREATED
+    }
+
+    /// Spawn the mock GitHub REST server on a random port; returns its base URL.
+    async fn spawn_mock(state: Arc<MockState>) -> String {
+        let app = Router::new()
+            .route(
+                "/app/installations/{id}/access_tokens",
+                post(mock_access_tokens),
+            )
+            .route("/repos/{owner}/{name}/installation", get(mock_installation))
+            .route(
+                "/repos/{owner}/{name}/collaborators/{login}/permission",
+                get(mock_permission),
+            )
+            .route(
+                "/repos/{owner}/{name}/issues/{issue}/comments",
+                post(mock_comments),
+            )
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    /// A recording fallback gateway, standing in for the `gh`/`GH_TOKEN` path, to
+    /// prove the App delegates to it when unconfigured.
+    #[derive(Default)]
+    struct RecordingFallback {
+        permission_calls: Mutex<Vec<(String, String, String)>>,
+        comment_calls: Mutex<Vec<(String, i64, String)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl GithubApi for RecordingFallback {
+        async fn collaborator_permission(&self, o: &str, n: &str, l: &str) -> Result<String> {
+            self.permission_calls.lock().unwrap().push((
+                o.to_string(),
+                n.to_string(),
+                l.to_string(),
+            ));
+            Ok("admin".to_string())
+        }
+        async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
+            self.comment_calls
+                .lock()
+                .unwrap()
+                .push((repo.to_string(), issue, body.to_string()));
+            Ok(())
+        }
+    }
+
+    /// A configured `GithubApp` pointed at `api_base`, with the App id + test
+    /// private key written to its (in-memory) settings — never via env, so unit
+    /// tests stay parallel-safe.
+    async fn configured_app(api_base: String, fallback: Arc<dyn GithubApi>) -> GithubApp {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        weaver_core::config::apply(
+            &db,
+            &[
+                (APP_ID_KEY.to_string(), Some(TEST_APP_ID.to_string())),
+                (
+                    APP_PRIVATE_KEY_KEY.to_string(),
+                    Some(TEST_PRIVATE_KEY.to_string()),
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+        GithubApp::with_parts(db, api_base, fallback)
+    }
+
+    // -- installation token exchange + caching ------------------------------
+
+    /// A minted token is reused while fresh: a second request inside its lifetime
+    /// hits the cache, not the GitHub token endpoint.
+    #[tokio::test]
+    async fn installation_token_is_cached_while_fresh() {
+        let mock = MockState::new(3600); // expires an hour out
+        let base = spawn_mock(mock.clone()).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+
+        let t1 = app.installation_token(42).await.unwrap();
+        let t2 = app.installation_token(42).await.unwrap();
+        assert_eq!(t1, "ghs_installation_token");
+        assert_eq!(t1, t2);
+        assert_eq!(
+            mock.token_mints.load(Ordering::SeqCst),
+            1,
+            "the second call reused the cached token"
+        );
+    }
+
+    /// A token at/after its expiry is never served from cache: each request
+    /// re-mints, so an expired token is refreshed rather than reused.
+    #[tokio::test]
+    async fn installation_token_refreshes_once_expired() {
+        let mock = MockState::new(-10); // already expired (inside the skew window)
+        let base = spawn_mock(mock.clone()).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+
+        app.installation_token(42).await.unwrap();
+        app.installation_token(42).await.unwrap();
+        assert_eq!(
+            mock.token_mints.load(Ordering::SeqCst),
+            2,
+            "an expired token is re-minted, not reused"
+        );
+    }
+
+    // -- REST gateway calls -------------------------------------------------
+
+    /// The permission check goes over REST with an installation token (resolve
+    /// installation → mint token → GET permission).
+    #[tokio::test]
+    async fn collaborator_permission_uses_rest() {
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock.clone()).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+
+        let perm = app
+            .collaborator_permission("acme", "widgets", "octocat")
+            .await
+            .unwrap();
+        assert_eq!(perm, "write");
+        assert_eq!(
+            mock.token_mints.load(Ordering::SeqCst),
+            1,
+            "an installation token was minted for the call"
+        );
+    }
+
+    /// The reply posts over REST, authenticated with the installation token.
+    #[tokio::test]
+    async fn post_issue_comment_uses_installation_token() {
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock.clone()).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+
+        app.post_issue_comment("acme/widgets", 7, "On it — http://loom/s/abc")
+            .await
+            .unwrap();
+
+        let comments = mock.comments.lock().unwrap().clone();
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0]["repo"], "acme/widgets");
+        assert_eq!(comments[0]["issue"], 7);
+        assert_eq!(comments[0]["body"], "On it — http://loom/s/abc");
+        // The request carried the minted installation token, not the App JWT.
+        assert_eq!(
+            mock.last_comment_auth.lock().unwrap().clone(),
+            Some("Bearer ghs_installation_token".to_string()),
+        );
+    }
+
+    // -- installation as the allowlist (§6.3) -------------------------------
+
+    /// A repo the App is installed on is auto-registered into the managed
+    /// allowlist, so the trigger may clone it — the "installation is the
+    /// allowlist" rule, complementing the explicitly-registered repos.
+    #[tokio::test]
+    async fn installed_repo_is_auto_registered() {
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock.clone()).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+
+        let slug = crate::repo::parse_slug("acme/widgets").unwrap();
+        assert!(
+            crate::repo::get_registered(&app.db, "acme/widgets")
+                .await
+                .unwrap()
+                .is_none(),
+            "not registered to begin with"
+        );
+
+        app.ensure_installed_repo_registered(&slug).await;
+
+        let registered = crate::repo::get_registered(&app.db, "acme/widgets")
+            .await
+            .unwrap()
+            .expect("the installed repo was added to the allowlist");
+        assert_eq!(registered.slug, "acme/widgets");
+        assert_eq!(registered.remote_url, "https://github.com/acme/widgets.git");
+    }
+
+    /// When the App is unconfigured the auto-register step is inert: the v1
+    /// repos-table allowlist alone governs.
+    #[tokio::test]
+    async fn unconfigured_app_does_not_auto_register() {
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock.clone()).await;
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let app = GithubApp::with_parts(db, base, Arc::new(RecordingFallback::default()));
+
+        let slug = crate::repo::parse_slug("acme/widgets").unwrap();
+        app.ensure_installed_repo_registered(&slug).await;
+
+        assert!(
+            crate::repo::get_registered(&app.db, "acme/widgets")
+                .await
+                .unwrap()
+                .is_none(),
+            "an unconfigured App registers nothing"
+        );
+        assert_eq!(mock.token_mints.load(Ordering::SeqCst), 0);
+    }
+
+    // -- fallback when unconfigured -----------------------------------------
+
+    /// With no App configured, the gateway falls back to the ambient-`GH_TOKEN`
+    /// path (`gh`) and never touches the REST API.
+    #[tokio::test]
+    async fn falls_back_to_gh_when_unconfigured() {
+        // A mock that would record a mint if (wrongly) reached.
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock.clone()).await;
+        let fallback = Arc::new(RecordingFallback::default());
+        // An empty db and no env → not configured.
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let app = GithubApp::with_parts(db, base, fallback.clone());
+
+        assert!(!app.is_configured().await);
+
+        let perm = app
+            .collaborator_permission("acme", "widgets", "octocat")
+            .await
+            .unwrap();
+        app.post_issue_comment("acme/widgets", 7, "hi")
+            .await
+            .unwrap();
+
+        // The fallback handled both calls…
+        assert_eq!(perm, "admin");
+        assert_eq!(fallback.permission_calls.lock().unwrap().len(), 1);
+        assert_eq!(fallback.comment_calls.lock().unwrap().len(), 1);
+        // …and the REST API was never reached.
+        assert_eq!(mock.token_mints.load(Ordering::SeqCst), 0);
+        assert!(mock.comments.lock().unwrap().is_empty());
+    }
+}

--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -350,21 +350,35 @@ async fn gh_capture(args: &[&str]) -> Result<String> {
 /// so a test can install a fake.
 pub struct GithubTrigger {
     gh: Arc<dyn GithubApi>,
+    /// The GitHub **App** client, when production-built: the same object the
+    /// `gh` gateway points at, kept concretely so the webhook can query
+    /// installations (the implicit allowlist, §6.3). `None` when a test installs
+    /// a bare [`GithubApi`] fake via [`with_gateway`](Self::with_gateway).
+    app: Option<Arc<crate::github_app::GithubApp>>,
     /// Per-repo trigger timestamps, pruned to [`RATE_WINDOW`] on each check.
     limiter: Mutex<HashMap<String, Vec<Instant>>>,
 }
 
 impl GithubTrigger {
-    /// The production trigger, backed by the `gh` CLI.
-    pub fn production() -> Arc<Self> {
-        Self::with_gateway(Arc::new(GhCli))
+    /// The production trigger: a GitHub **App** gateway that mints short-lived
+    /// installation tokens for the permission check and reply, falling back to
+    /// the `gh` CLI (ambient `GH_TOKEN`) when the App is unconfigured.
+    pub fn production(db: crate::db::Db) -> Arc<Self> {
+        let app = Arc::new(crate::github_app::GithubApp::new(db));
+        Arc::new(Self {
+            gh: app.clone(),
+            app: Some(app),
+            limiter: Mutex::new(HashMap::new()),
+        })
     }
 
     /// A trigger backed by an arbitrary [`GithubApi`] — the seam tests use to
-    /// substitute a fake for `gh`.
+    /// substitute a fake for `gh`. No App handle, so the installation-allowlist
+    /// step is a no-op.
     pub fn with_gateway(gh: Arc<dyn GithubApi>) -> Arc<Self> {
         Arc::new(Self {
             gh,
+            app: None,
             limiter: Mutex::new(HashMap::new()),
         })
     }
@@ -372,6 +386,12 @@ impl GithubTrigger {
     /// The GitHub gateway, for the permission check and the reply.
     pub fn gh(&self) -> &dyn GithubApi {
         self.gh.as_ref()
+    }
+
+    /// The GitHub App client, when one is configured on this trigger — the
+    /// webhook uses it to treat an App-installed repo as implicitly allowlisted.
+    pub fn app(&self) -> Option<&crate::github_app::GithubApp> {
+        self.app.as_deref()
     }
 
     /// Record a trigger attempt for `repo` and report whether it is within the

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -15,6 +15,7 @@ pub mod client;
 pub mod db;
 pub mod endpoint;
 pub mod github;
+pub mod github_app;
 pub mod github_trigger;
 pub mod ide;
 pub mod monitor;

--- a/crates/loom/src/overlooker.rs
+++ b/crates/loom/src/overlooker.rs
@@ -1378,12 +1378,13 @@ mod tests {
     /// An `AppState` over a fresh in-memory db plus an overlooker registered on
     /// `program` — the minimum for a [`fire`] round to run a script end to end.
     async fn script_fixture(program: &str) -> (AppState, Overlooker) {
+        let db = crate::db::connect_in_memory().await.unwrap();
         let state = AppState {
-            db: crate::db::connect_in_memory().await.unwrap(),
+            trigger: crate::github_trigger::GithubTrigger::production(db.clone()),
+            db,
             bus: events::EventBus::new(),
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
-            trigger: crate::github_trigger::GithubTrigger::production(),
         };
         let o = ov::create(
             &state.db,
@@ -1592,12 +1593,13 @@ rnd.finish("counted to %d" % n)
     /// overlooker the scheduled timer would otherwise never visit.
     #[tokio::test]
     async fn timer_fires_a_due_wake_once_and_clears_it() {
+        let db = crate::db::connect_in_memory().await.unwrap();
         let state = AppState {
-            db: crate::db::connect_in_memory().await.unwrap(),
+            trigger: crate::github_trigger::GithubTrigger::production(db.clone()),
+            db,
             bus: events::EventBus::new(),
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
-            trigger: crate::github_trigger::GithubTrigger::production(),
         };
         // A reactive overlooker (no cron) — the scheduled half of the timer skips
         // it; only the wake half should fire it.

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -75,12 +75,13 @@ pub async fn run(addr: &str) -> Result<()> {
     tracing::debug!(addr = %actual, "listener bound");
 
     let db = db::connect(&db::default_db_path()).await?;
+    let trigger = crate::github_trigger::GithubTrigger::production(db.clone());
     let state = AppState {
         db,
         bus: EventBus::new(),
         addr: actual.to_string(),
         ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
-        trigger: crate::github_trigger::GithubTrigger::production(),
+        trigger,
     };
 
     let server_state = ServerState {

--- a/crates/loom/src/web.rs
+++ b/crates/loom/src/web.rs
@@ -2871,6 +2871,16 @@ async fn github_webhook(State(st): State<AppState>, headers: HeaderMap, body: By
         return ok();
     }
 
+    // 6a. A repo the GitHub App is installed on is implicitly authorized to
+    //     trigger (design §6.3): auto-register it into the managed allowlist so
+    //     the clone path below accepts it, *complementing* the explicitly
+    //     registered repos from #95. A no-op when the App is unconfigured, the
+    //     repo is already registered, or the App is not installed on it — so the
+    //     v1 repos-table allowlist still governs the ambient-`GH_TOKEN` flow.
+    if let Some(app) = st.trigger.app() {
+        app.ensure_installed_repo_registered(&slug).await;
+    }
+
     // 7. Acquire the repo (it must be in the managed allowlist — `resolve_clone`
     //    rejects others) and create the session, seeded from the issue carried in
     //    the trusted payload. Seeding title/goal from the payload (not a `gh`
@@ -3955,7 +3965,7 @@ mod tests {
             bus: crate::events::EventBus::new(),
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
-            trigger: crate::github_trigger::GithubTrigger::production(),
+            trigger: crate::github_trigger::GithubTrigger::production(db.clone()),
         };
         let child = branch_mod::upsert(&db, "/r", "weaver/child", "main")
             .await

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -87,7 +87,7 @@ async fn hook_event_drives_session_status() {
         bus: EventBus::new(),
         addr: addr.to_string(),
         ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
-        trigger: loom::github_trigger::GithubTrigger::production(),
+        trigger: loom::github_trigger::GithubTrigger::production(pool.clone()),
     };
     tokio::spawn(server::serve(state, listener));
 

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -141,7 +141,7 @@ impl TestServer {
         let pool = db::connect(&db::default_db_path()).await.unwrap();
         let trigger = match gh {
             Some(gh) => loom::github_trigger::GithubTrigger::with_gateway(gh),
-            None => loom::github_trigger::GithubTrigger::production(),
+            None => loom::github_trigger::GithubTrigger::production(pool.clone()),
         };
         let state = AppState {
             db: pool,

--- a/crates/loom/tests/integration/overlookers.rs
+++ b/crates/loom/tests/integration/overlookers.rs
@@ -36,11 +36,11 @@ use crate::fixtures::{branch_tag, branch_tag_value, TestServer};
 async fn engine_state(ts: &TestServer) -> AppState {
     let pool = db::connect(&db::default_db_path()).await.unwrap();
     AppState {
+        trigger: loom::github_trigger::GithubTrigger::production(pool.clone()),
         db: pool,
         bus: EventBus::new(),
         addr: ts.addr.to_string(),
         ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
-        trigger: loom::github_trigger::GithubTrigger::production(),
     }
 }
 

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -29,9 +29,14 @@ receiver, in order:
    (checked via `GET /repos/{owner}/{repo}/collaborators/{login}/permission`).
    Anyone else is silently ignored. A per-repo rate limit blunts comment spam.
 6. **Resolves the repo** through the [managed repo store](#repo-allowlist) — only
-   a registered repo is cloned and launched against — and creates the session,
+   an allowlisted repo is cloned and launched against — and creates the session,
    seeded with the issue title and body.
 7. **Replies** on the issue with the session URL.
+
+The permission check (step 5) and the reply (step 7) reach GitHub through the
+[GitHub App](#the-github-app) when one is configured — with a short-lived,
+per-installation token — and otherwise through the `gh` CLI's ambient
+`GH_TOKEN`.
 
 Everything past the signature check returns **200** whether or not it launched a
 session (a non-trigger comment, a replay, an unauthorized commenter, an
@@ -61,15 +66,20 @@ Until `LOOM_GITHUB_WEBHOOK_SECRET` is set the endpoint rejects every delivery
 
 ### Repo allowlist
 
-The trigger only acts on repos registered in the managed repo store, which
-doubles as the clone allowlist. Register one first:
+The trigger only acts on allowlisted repos. A repo is allowlisted when **either**
+it is registered in the managed repo store **or** the [GitHub App](#the-github-app)
+is installed on it (the installation *is* the grant — installing the App on a repo
+authorizes it, and loom auto-registers it into the store on first trigger).
+
+Register a repo explicitly with:
 
 ```sh
 curl -X POST {base}/api/repos -H 'Authorization: Bearer $LOOM_TOKEN' \
   -H 'content-type: application/json' -d '{"repo":"owner/name"}'
 ```
 
-A comment on an unregistered repo launches nothing.
+A comment on a repo that is neither registered nor App-installed launches
+nothing.
 
 ### Optional settings
 
@@ -79,12 +89,53 @@ A comment on an unregistered repo launches nothing.
 - `github.bot_login` (or `LOOM_GITHUB_BOT_LOGIN`) — a GitHub login whose own
   comments are ignored, so a bot account can post without re-triggering itself.
 
-## Authentication and the planned hardening
+## The GitHub App
 
-v1 authenticates the webhook with a shared secret and acts on GitHub through the
-ambient `GH_TOKEN` (the `gh` CLI) — the permission check and the reply both run
-as that token's identity. The planned hardening is a **GitHub App**: per-repo
-installation as the access allowlist, short-lived installation tokens for the API
-calls and the reply, and a distinct bot identity for attribution. The webhook
-receiver and its security controls (HMAC, idempotency, authorization) are
-unchanged by that move.
+A **GitHub App** is the hardened identity loom acts through. Instead of a
+long-lived, broadly-scoped shared `GH_TOKEN`, loom mints a **short-lived,
+least-privilege installation token** scoped to a single repo's installation for
+each GitHub call (the permission check and the reply), and treats the App's
+installations as the access allowlist. Tokens are signed from the App's private
+key (an RS256 JWT exchanged for an installation token via
+`POST /app/installations/{id}/access_tokens`) and cached until they near expiry.
+
+When the App is **not configured**, loom falls back to the ambient `GH_TOKEN`
+(the `gh` CLI), so the webhook works without it. The webhook receiver and its
+security controls (HMAC, idempotency, authorization) are identical either way —
+the App only changes which credential the two outbound GitHub calls use.
+
+### Create the App
+
+Under **Settings → Developer settings → GitHub Apps → New GitHub App**:
+
+- **Webhook** — set the **URL** to `{base}/api/github/webhook` (loom's public URL,
+  the same `auth.base_url` names) and the **Secret** to the value you put in
+  `LOOM_GITHUB_WEBHOOK_SECRET`.
+- **Repository permissions:**
+  - **Issues** — Read & write (read the comment, post the reply).
+  - **Contents** — Read & write (clone the repo, and push the work branch).
+  - **Metadata** — Read-only (mandatory; granted automatically).
+- **Subscribe to events** — **Issue comment**.
+- After creating it, **generate a private key** (downloads a `.pem`) and note the
+  **App ID**.
+
+Then **install** the App on each repo (or org) loom should act on — the
+installation is what authorizes a repo to trigger.
+
+### Configure loom
+
+Provide the App id and private key through the environment (both held outside the
+settings registry, never returned by `GET /api/settings`, like the OAuth client
+secret):
+
+```sh
+LOOM_GITHUB_APP_ID=<the App ID>
+# The PEM, newlines preserved (e.g. "$(cat app.private-key.pem)").
+LOOM_GITHUB_APP_PRIVATE_KEY=<the private-key PEM>
+```
+
+With both set, loom uses the App for the permission check and the reply and
+treats App-installed repos as allowlisted. With either unset it falls back to the
+ambient `GH_TOKEN`. (Cloning still uses the ambient git credentials; granting the
+App **Contents** access keeps a single least-privilege credential set as the
+deploy migrates off the shared PAT.)


### PR DESCRIPTION
Hardens the `@loom` GitHub trigger (#96) with a proper GitHub App identity: short-lived, least-privilege, per-installation tokens in place of the long-lived, over-scoped ambient `GH_TOKEN`. Part of the shared team loom effort (#337, design §5/§6.3).

## What

A new `crates/loom/src/github_app.rs`:

- **App config** — `github.app_id` + the App private-key PEM, held outside the settings registry (never returned by `GET /api/settings`, like the OAuth client secret), overridable via `LOOM_GITHUB_APP_ID` / `LOOM_GITHUB_APP_PRIVATE_KEY`.
- **Installation tokens** — mints an RS256 App JWT (`jsonwebtoken`), exchanges it for an installation access token (`POST /app/installations/{id}/access_tokens`), and caches the token per installation until it nears expiry, refreshing on demand.
- **REST gateway** — implements the trigger's `GithubApi` (the commenter permission check and the issue reply) over the REST API with the installation token instead of the `gh` CLI. When the App is unconfigured it falls back to the ambient `GH_TOKEN`, so the v1 flow is unchanged.
- **Installation as allowlist** — resolving `owner/repo` to its installation id (`GET /repos/{owner}/{repo}/installation`) proves the App is installed; the webhook auto-registers such a repo into the managed allowlist (#95), complementing rather than replacing the `repos` table.

## Tests

Rust unit tests in `github_app.rs` (no real GitHub — a mock REST server and an in-test RSA keypair): JWT is well-formed and verifies against the public key; installation-token exchange with caching and refresh-on-expiry; permission check and reply over REST with the installation token; auto-registration of an installed repo; and graceful fallback to `gh` when the App is unconfigured. The existing webhook integration suite is unchanged and green.

## Docs

`docs/github-trigger.md` documents creating and installing the App — required permissions (Issues read/write, Contents read/write, Metadata read), the `issue_comment` subscription, the webhook URL + secret, and the `LOOM_GITHUB_APP_ID` / `LOOM_GITHUB_APP_PRIVATE_KEY` env config.

Part of #337. Closes #348.
