### PR TITLE
chore(lint): decouple agent lint review from the pre-commit hook

### DIFF
--- a/.agents/skills/pull-request.md
+++ b/.agents/skills/pull-request.md
@@ -17,7 +17,7 @@ green are not optional.
 WIP checkpoint: **1, 2, 4, 5, 7**, stop. Full list before opening/updating a PR.
 
 1. Self-review the diff.
-2. Gate — `./scripts/pre-commit.sh` (fmt + clippy + staged lint).
+2. Gate — `./scripts/pre-commit.sh` (fmt + clippy). Not the lint review — that's step 6.
 3. Tests when warranted — `cargo test --workspace`; `cd e2e && npm test` for UI.
 4. Stage the specific files.
 5. Commit. ← clean checkpoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,12 @@ Test placement: pure program/module logic lives in pytest
 tests prove wiring against a live server — don't duplicate logic across them.
 
 Run `./scripts/pre-commit.sh` before committing — the fmt + clippy gate CI
-enforces, plus an [agent lint review](docs/lint.md): a headless `claude`
-sub-agent that errors on the slop fmt/clippy can't catch, and self-skips when
-`claude` is absent (so CI runs only fmt+clippy). Wire it up with `git config
-core.hooksPath .githooks`. Build/test internals and the Playwright setup live in
+enforces; wire it up as a hook with `git config core.hooksPath .githooks`.
+Separately, as a step in the commit → PR flow (see the `pull-request` skill), run
+the [agent lint review](docs/lint.md) — `scripts/lint-review.py`, a headless
+`claude` sub-agent that errors on the slop fmt/clippy can't catch. It's kept out
+of the commit hook on purpose, so a slow or flaky agent never sits in the commit
+path. Build/test internals and the Playwright setup live in
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Don't disturb the user's live loom

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,30 +84,31 @@ if one hangs, look for stray `tapestry supervise` processes.
 
 ### Agent lint review
 
-After the fmt + clippy gate, `scripts/pre-commit.sh` runs
-`scripts/lint-review.py` — a self-contained `uv run` script (the call is gated on
-`uv` being on PATH, so the CI lint job, which has neither `uv` nor an agent, runs
-only fmt + clippy). It catches the *agent slop* fmt and clippy can't — the
-judgement calls: naming, API shape, dead/speculative code, duplication, and
-comment/test quality. It builds one prompt from the [`docs/lint.md`](lint.md)
-catalog (`wl-...` rules) plus the diff and pipes it to a headless `claude -p`
-sub-agent, run as a fresh session — the calling session's `CLAUDE_CODE_*` /
-`ANTHROPIC_API_KEY` markers are stripped so it neither nests in the caller's
-transcript nor bills the metered API. It parses the findings and **errors on any
-at or above a confidence threshold**; the rest print as advisory.
+`scripts/lint-review.py` — a self-contained `uv run` script — catches the *agent
+slop* fmt and clippy can't: the judgement calls of naming, API shape,
+dead/speculative code, duplication, and comment/test quality. It builds one
+prompt from the [`docs/lint.md`](lint.md) catalog (`wl-...` rules) plus the diff
+and pipes it to a headless `claude -p` sub-agent, run as a fresh session — the
+calling session's `CLAUDE_CODE_*` / `ANTHROPIC_API_KEY` markers are stripped so
+it neither nests in the caller's transcript nor bills the metered API. It parses
+the findings and **errors on any at or above a confidence threshold**; the rest
+print as advisory.
 
-`pre-commit.sh` reviews the **staged** diff (`--staged`); run `lint-review.py`
-bare to review the whole branch against its merge-base with `main`. It
-**self-skips** (exit 0, never blocks a commit) when `claude` isn't on PATH, when
-there are no Rust/TS/Vue changes, or when the agent times out or errors — so CI,
-which has no agent, runs only the fmt+clippy gate, and a flaky agent can't wedge
-every commit. Only real findings block.
+It is **not** wired into the pre-commit hook. `scripts/pre-commit.sh` stays a
+fast fmt + clippy gate identical to CI; the lint review is a separate, explicit
+step in the commit → PR flow — agents run it via the `pull-request` skill after
+committing and before opening the PR. Keeping the agent out of the commit path
+means a slow or flaky review never wedges a commit. Run `scripts/lint-review.py`
+to review the whole branch against its merge-base with `main`.
+
+It **self-skips** (exit 0) when `claude` isn't on PATH, when there are no
+Rust/TS/Vue changes, or when the agent times out or errors — so a flaky or
+absent agent can't block progress, and only real findings do.
 
 Knobs: `WEAVER_SKIP_AGENT_LINT=1` to skip a run, `WEAVER_LINT_MIN_CONFIDENCE`
 (default `0.9`), `WEAVER_LINT_AGENT_CMD` (default `claude -p`), and
 `WEAVER_LINT_TIMEOUT` (default `600`s). Suppress a false positive with a trailing
-`// wl-allow: <code>` on the cited line; bypass the whole hook once with `git
-commit --no-verify`.
+`// wl-allow: <code>` on the cited line.
 
 ### End-to-end (Playwright)
 

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -782,8 +782,8 @@ For an agent running this catalog against a diff.
 Pick the diff that applies, typically the current branch versus its merge-base
 with `main`, unless the caller requests a tighter set:
 
-- Feature branch: `git diff $(git merge-base origin/main HEAD)...HEAD -- '*.rs' '*.ts' '*.vue'`
-- Pre-commit (staged only): `git diff --cached -- '*.rs' '*.ts' '*.vue'`
+- Feature branch (the default `scripts/lint-review.py` scope): `git diff $(git merge-base origin/main HEAD)...HEAD -- '*.rs' '*.ts' '*.vue'`
+- Staged only: `git diff --cached -- '*.rs' '*.ts' '*.vue'`
 - A specific PR: `gh pr diff <number> -- '*.rs' '*.ts' '*.vue'`
 - A named file or two: read the file in full.
 

--- a/scripts/lint-review.py
+++ b/scripts/lint-review.py
@@ -12,19 +12,22 @@ prints back. `cargo fmt` / `clippy` own the mechanical checks; this catches the
 judgement-call slop an LLM coding agent tends to leave behind — naming, shape,
 dead code, duplication, comment/test quality. See docs/lint.md.
 
+Run it as a step in the commit → PR flow (the `pull-request` skill), after you
+commit and before you open the PR. It is deliberately NOT wired into the
+pre-commit hook — that stays a fast fmt + clippy gate (scripts/pre-commit.sh),
+so a slow or flaky review never sits in the commit path. It reviews the whole
+branch against its merge-base with main.
+
 Usage:
   scripts/lint-review.py            # review this branch vs its merge-base with main
-  scripts/lint-review.py --staged   # review only staged changes (the pre-commit path)
 
 Exit status:
   0  no blocking findings — or the review was skipped (see below)
   1  one or more findings at/above the blocking confidence threshold
 
-The review SKIPS (exit 0, never blocks a commit) when it can't run a clean pass:
-`claude` not on PATH, no in-scope changes, the agent timing out, or the agent
-itself erroring. A flaky or absent agent must not wedge every commit — only real
-findings block. This is also why CI (no `claude` on PATH) is unaffected: there
-it simply skips.
+The review SKIPS (exit 0) when it can't run a clean pass: `claude` not on PATH,
+no in-scope changes, the agent timing out, or the agent itself erroring. A flaky
+or absent agent must not block progress — only real findings do.
 
 Knobs (env vars):
   WEAVER_SKIP_AGENT_LINT=1            skip the review entirely
@@ -33,7 +36,7 @@ Knobs (env vars):
   WEAVER_LINT_TIMEOUT=600             seconds before the agent run is abandoned
 
 Escape hatch for a false positive: add `// wl-allow: <code>` on the cited line
-(see docs/lint.md), or bypass the whole hook once with `git commit --no-verify`.
+(see docs/lint.md).
 """
 
 import argparse
@@ -79,12 +82,8 @@ def run(cmd: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, capture_output=True, text=True)
 
 
-def select_diff(staged: bool) -> tuple[str, str]:
+def select_diff() -> tuple[str, str]:
     """Return (diff, human-readable scope), or skip if there's nothing to review."""
-    if staged:
-        diff = run(["git", "diff", "--cached", "-U15", "--", *GLOBS]).stdout
-        return diff, "staged changes"
-
     # Diff the working tree against the merge-base so the review covers all branch
     # work, committed or not. Resolve the base leniently: a fresh clone may lack
     # origin/main, a detached worktree may lack a remote at all.
@@ -114,9 +113,9 @@ def parse_min_confidence() -> float:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Run the docs/lint.md catalog over a diff via a headless agent.")
-    ap.add_argument("--staged", action="store_true", help="review only staged changes (the pre-commit path)")
-    args = ap.parse_args()
+    # No flags: the review always covers the branch vs its merge-base with main.
+    # parse_args() still handles -h/--help and rejects stray arguments.
+    argparse.ArgumentParser(description="Run the docs/lint.md catalog over the branch diff via a headless agent.").parse_args()
 
     os.chdir(run(["git", "rev-parse", "--show-toplevel"]).stdout.strip())
 
@@ -132,7 +131,7 @@ def main() -> int:
     min_conf = parse_min_confidence()
     timeout = int(os.environ.get("WEAVER_LINT_TIMEOUT", "600"))
 
-    diff, scope = select_diff(args.staged)
+    diff, scope = select_diff()
     if not diff.strip():
         skip(f"no Rust/TS/Vue changes in {scope}")
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -8,6 +8,11 @@
 #   - the CI `lint` job (.github/workflows/ci.yml),
 # so a commit that passes locally passes CI. Bypass the hook for one commit with
 # `git commit --no-verify`.
+#
+# The agentic lint review (scripts/lint-review.py) is deliberately NOT run here:
+# it is a separate, explicit step in the commit → PR flow (see the `pull-request`
+# skill and AGENTS.md). Keeping the agent out of the commit hook keeps this gate
+# fast and identical to CI, so a slow or flaky review never sits in the commit path.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -23,16 +28,3 @@ echo "▶ cargo clippy --workspace --all-targets --locked -- -D warnings"
 cargo clippy --workspace --all-targets --locked -- -D warnings
 
 echo "✓ fmt + clippy clean"
-
-# Agent lint review: a headless Claude sub-agent applies the docs/lint.md catalog
-# to the staged diff and errors on the agent-slop it can't be linted for
-# mechanically (naming, shape, dead code, comments, tests). lint-review.py is a
-# `uv run` script and self-skips when `claude` isn't on PATH or there are no
-# staged Rust/TS/Vue changes; we gate it on `uv` here so the CI lint job (no uv,
-# no agent) runs only the fmt+clippy gate above. Disable it for a run with
-# WEAVER_SKIP_AGENT_LINT=1; tune it via the env vars in lint-review.py.
-if command -v uv >/dev/null 2>&1; then
-  "$(git rev-parse --show-toplevel)/scripts/lint-review.py" --staged
-else
-  echo "  ⓘ agent lint skipped: uv not found on PATH (needed to run lint-review.py)"
-fi


### PR DESCRIPTION
The agentic lint review no longer runs inside the pre-commit hook. `scripts/pre-commit.sh` is now purely the fmt + clippy gate, identical to what CI runs — so committing is fast and a slow or flaky `claude` sub-agent can never sit in the commit path.

The review (`scripts/lint-review.py`) becomes a separate, explicit step in the commit → PR flow: agents run it via the `pull-request` skill after committing and before opening the PR, reviewing the whole branch against its merge-base with `main`.

- `scripts/pre-commit.sh`: drop the agent-lint block; it now runs only fmt + clippy.
- `scripts/lint-review.py`: drop the `--staged` mode (its only caller was the hook) and the pre-commit framing in its docs.
- `AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/lint.md`, `.agents/skills/pull-request.md`: describe the review as a separate step, not a hook stage.

Part of #357.