### PR TITLE
fix: deploy boot regression, owner-fallback, ambient-cred leak, App-token clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,6 +2908,7 @@ name = "weaver-core"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "rand",
  "serde",

--- a/README.md
+++ b/README.md
@@ -299,9 +299,11 @@ TLS-terminating reverse proxy. Access is then gated three ways:
   `auth.trust_loopback false` behind a *same-host* proxy — see below.)
 - **GitHub or password login** for the web UI. The login screen offers
   "Continue with GitHub" once an OAuth app is configured, plus username/password.
-  A fresh install approves one user — **`rjpower`** on GitHub by default
-  (override with `LOOM_OWNER_GITHUB` at first run). Add more, set your password,
-  and configure GitHub sign-in under **Settings → Account**.
+  A fresh install approves exactly one user — whichever GitHub login you set as
+  `LOOM_OWNER_GITHUB` before first run. There is no default; leave it unset and
+  no owner is seeded, so GitHub sign-in won't work until it's set. Add more
+  users, set your password, and configure GitHub sign-in under **Settings →
+  Account**.
 - **API tokens** for automation — the `LOOM_TOKEN` a CI job or a remote `loom`
   CLI presents as a bearer. Mint one under **Settings → Tokens** or:
 
@@ -391,7 +393,7 @@ placeholder page), `cargo test --workspace` runs the backend suites, and `cd e2e
 - `WEAVER_API` — loom URL the `loom` CLI talks to (default `http://127.0.0.1:7878`)
 - `WEAVER_BRANCH` — override the branch resolver (set by `loom session launch` in the worktree)
 - `LOOM_TOKEN` — bearer token the `loom` CLI / automation sends (see [Authentication](#authentication))
-- `LOOM_OWNER_GITHUB` — GitHub login seeded as the owner on a fresh database (default `rjpower`)
+- `LOOM_OWNER_GITHUB` — GitHub login seeded as the owner on a fresh database. No default; leave it unset and no owner is seeded (GitHub sign-in won't work until it's set).
 - `LOOM_GITHUB_CLIENT_ID` / `LOOM_GITHUB_CLIENT_SECRET` — GitHub OAuth app credentials
 - `LOOM_GITHUB_WEBHOOK_SECRET` — shared secret for the inbound GitHub trigger; until set, the webhook rejects every delivery ([docs/github-trigger.md](docs/github-trigger.md))
 - `WEAVER_REPOS_DIR` — managed repo store root (default `$WEAVER_HOME/repos`)

--- a/crates/loom/src/auth.rs
+++ b/crates/loom/src/auth.rs
@@ -803,17 +803,40 @@ mod tests {
         assert!(!verify_password("hunter2", "not-a-hash"));
     }
 
-    #[tokio::test]
-    async fn seeded_owner_is_the_primary_user() {
+    /// `db::connect_in_memory`, with `LOOM_OWNER_GITHUB` set for the duration of
+    /// the call so `seed_owner` seeds `owner` — since it no longer defaults to
+    /// a real login (fail-closed on an unset env var), every test below that
+    /// relies on a pre-seeded owner sets one explicitly. The caller must be
+    /// `#[serial]`: the env var is process-global.
+    async fn connect_in_memory_with_owner(owner: &str) -> Db {
+        std::env::set_var("LOOM_OWNER_GITHUB", owner);
         let db = db::connect_in_memory().await.unwrap();
+        std::env::remove_var("LOOM_OWNER_GITHUB");
+        db
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn unset_owner_seeds_no_user_at_all() {
+        std::env::remove_var("LOOM_OWNER_GITHUB");
+        let db = db::connect_in_memory().await.unwrap();
+        assert_eq!(primary_user(&db).await.unwrap(), None);
+        assert!(list_users(&db).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn seeded_owner_is_the_primary_user() {
+        let db = connect_in_memory_with_owner("rjpower").await;
         assert_eq!(primary_user(&db).await.unwrap().as_deref(), Some("rjpower"));
         let u = user_by_github(&db, "RJPower").await.unwrap();
         assert_eq!(u.map(|u| u.username), Some("rjpower".to_string()));
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn token_lifecycle_create_lookup_revoke() {
-        let db = db::connect_in_memory().await.unwrap();
+        let db = connect_in_memory_with_owner("rjpower").await;
         let (plain, info) = create_token(&db, "rjpower", "ci", None).await.unwrap();
 
         let p = lookup_token(&db, &plain)
@@ -830,8 +853,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn expired_token_does_not_resolve() {
-        let db = db::connect_in_memory().await.unwrap();
+        let db = connect_in_memory_with_owner("rjpower").await;
         let (plain, info) = create_token(&db, "rjpower", "old", Some(30)).await.unwrap();
         // Fresh token resolves; backdate its expiry and it no longer does.
         assert!(lookup_token(&db, &plain).await.unwrap().is_some());
@@ -844,8 +868,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn local_token_is_hidden_and_unrevocable() {
-        let db = db::connect_in_memory().await.unwrap();
+        let db = connect_in_memory_with_owner("rjpower").await;
         let (plain, info) =
             create_token_kind(&db, "rjpower", LOCAL_TOKEN_NAME, None, TokenKind::Local)
                 .await
@@ -859,8 +884,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn sessions_resolve_then_clear_on_logout() {
-        let db = db::connect_in_memory().await.unwrap();
+        let db = connect_in_memory_with_owner("rjpower").await;
         let cookie = create_session(&db, "rjpower").await.unwrap();
         assert_eq!(
             lookup_session(&db, &cookie)
@@ -874,8 +900,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn password_login_and_user_management() {
-        let db = db::connect_in_memory().await.unwrap();
+        let db = connect_in_memory_with_owner("rjpower").await;
         // The seeded owner has no password yet.
         assert!(verify_login(&db, "rjpower", "x").await.unwrap().is_none());
         set_password(&db, "rjpower", Some("s3cret")).await.unwrap();
@@ -898,8 +925,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn local_token_is_minted_once_and_reused() {
-        let db = db::connect_in_memory().await.unwrap();
+        let db = connect_in_memory_with_owner("rjpower").await;
         // No file is read in-memory; mint goes through the create path twice and
         // each ensures a working bearer for the same owner.
         let first = register_then_lookup(&db).await;

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -118,8 +118,10 @@ enum Cmd {
         cmd: SetupCmd,
     },
 
-    /// The typed `loom.toml` `loom setup` writes, and everything derived from
-    /// it.
+    /// The typed `loom.toml` `loom setup` writes and everything derived from
+    /// it, plus `set` — a direct-to-sqlite write of the daemon's own runtime
+    /// `settings` table (the same keys `weaver config set` exposes over
+    /// HTTP), with no server required.
     ///
     /// `loom.toml` is the single authored source of truth for every
     /// credential/setting — the shared contract a deploy (e.g. the GCP
@@ -128,6 +130,7 @@ enum Cmd {
     ///     loom config render-env                # -> deploy/standalone/.env
     ///     loom config secret-names               # the secret fields' ENV_NAMEs
     ///     loom config push-secrets --backend gcp --project my-project
+    ///     loom config set auth.cookie_secure true  # direct-to-sqlite, no server needed
     Config {
         #[command(subcommand)]
         cmd: ConfigCmd,
@@ -376,6 +379,14 @@ struct GithubAppOpts {
     /// account.
     #[arg(long)]
     org: Option<String>,
+    /// The GitHub login approved to sign in first (`LOOM_OWNER_GITHUB`).
+    /// Required with `--org`: an org install's App is owned by the org, but
+    /// the first approved sign-in needs an individual login, which the org's
+    /// own login isn't — prompted for interactively if omitted. Optional
+    /// without `--org`, where it defaults to your own account (the one that
+    /// confirms App creation).
+    #[arg(long)]
+    owner: Option<String>,
     /// Local port for the manifest-flow confirmation callback. `0` (default)
     /// picks a free port; pin one when you're tunnelling in to a remote host
     /// (e.g. `ssh -L 8765:localhost:8765 …`, then `--port 8765`).
@@ -412,6 +423,13 @@ struct ConfigPathOpts {
 /// against — see [`Cmd::Config`]. `render-env` and `push-secrets` resolve
 /// every field from `loom.toml` *or* a same-named env var (env wins) — set
 /// one to override a single invocation without editing the file.
+///
+/// `set` is a different contract — the runtime `settings` table
+/// (`weaver_core::config::REGISTRY`, the same one `weaver config set` writes
+/// over HTTP) rather than `loom.toml` — written straight to the daemon's
+/// sqlite database with no server needed. This is what
+/// `deploy/standalone/docker-compose.yml`'s `loom-init` uses to seed the
+/// security-relevant auth settings before loom itself starts listening.
 #[derive(Subcommand)]
 enum ConfigCmd {
     /// Render `loom.toml` as a dotenv file (e.g. `deploy/standalone/.env`).
@@ -421,6 +439,14 @@ enum ConfigCmd {
     /// Push each secret field's value to a secret-manager backend. Never
     /// echoes a value.
     PushSecrets(PushSecretsOpts),
+    /// Set a runtime setting directly in the sqlite `settings` table — no
+    /// running server needed (unlike `weaver config set`, which needs one).
+    Set {
+        /// Dotted key, e.g. `auth.cookie_secure` (see the settings pane, or
+        /// `weaver_core::config::REGISTRY`, for the full list).
+        key: String,
+        value: String,
+    },
 }
 
 #[derive(Args)]
@@ -747,6 +773,36 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
         .clone()
         .unwrap_or_else(|| default_app_name(&base_url));
 
+    // `--org` needs an explicit owner: the manifest flow's own confirming
+    // account (`conv.owner.login`, used below when this is `None`) is the org
+    // itself for an org install, which isn't a usable `LOOM_OWNER_GITHUB` — a
+    // fresh database with no owner seeded locks everyone out (see
+    // `db::seed_owner`). Checked before opening the callback listener so a
+    // non-interactive, misconfigured run fails fast rather than after the
+    // operator has already gone through the browser confirmation.
+    let org_owner: Option<String> = match (
+        &opts.org,
+        opts.owner
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty()),
+    ) {
+        (Some(_), Some(o)) => Some(o.to_string()),
+        (Some(org), None) => {
+            use std::io::IsTerminal;
+            if std::io::stdin().is_terminal() {
+                Some(prompt_owner(org)?)
+            } else {
+                bail!(
+                    "--org {org} needs --owner <your-github-login> — an org install's App is \
+                     owned by the org, but the first approved sign-in needs an individual \
+                     login, which the org's own login isn't"
+                );
+            }
+        }
+        (None, owner) => owner.map(str::to_string),
+    };
+
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", opts.port))
         .await
         .with_context(|| format!("binding the local callback server on port {}", opts.port))?;
@@ -854,33 +910,26 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
 
     let domain = host_from_base_url(&base_url);
     let app_id = conv.id.to_string();
-    let mut updates: Vec<(&str, &str)> = vec![
+    // For a personal install the confirming account (`conv.owner.login`) *is*
+    // the right owner; for `--org` it's the org's own login, so `org_owner`
+    // (required, resolved above) is used instead.
+    let owner_login = org_owner.as_deref().unwrap_or(conv.owner.login.as_str());
+    let updates: Vec<(&str, &str)> = vec![
         ("LOOM_GITHUB_APP_ID", app_id.as_str()),
         ("LOOM_GITHUB_APP_PRIVATE_KEY", conv.pem.as_str()),
         ("LOOM_GITHUB_WEBHOOK_SECRET", conv.webhook_secret.as_str()),
         ("LOOM_GITHUB_CLIENT_ID", conv.client_id.as_str()),
         ("LOOM_GITHUB_CLIENT_SECRET", conv.client_secret.as_str()),
         ("LOOM_DOMAIN", domain),
+        ("LOOM_OWNER_GITHUB", owner_login),
     ];
-    if opts.org.is_none() {
-        updates.push(("LOOM_OWNER_GITHUB", conv.owner.login.as_str()));
-    }
     loom::loom_config::upsert(&opts.config.config, &updates)
         .context("writing the App credentials into loom.toml")?;
     println!(
-        "Also wrote them, plus LOOM_DOMAIN, to {} — run `loom config render-env` to produce a \
-         deploy `.env` from it.",
+        "Also wrote them, plus LOOM_DOMAIN and LOOM_OWNER_GITHUB ({owner_login}), to {} — run \
+         `loom config render-env` to produce a deploy `.env` from it.",
         opts.config.config.display()
     );
-    if opts.org.is_some() {
-        println!(
-            "Not writing LOOM_OWNER_GITHUB — the App is owned by the {} organization, but that \
-             setting needs the individual GitHub login for the first approved sign-in, which an \
-             org login isn't — set it yourself in {}.",
-            conv.owner.login,
-            opts.config.config.display()
-        );
-    }
 
     println!();
     println!("Next steps:");
@@ -978,6 +1027,27 @@ async fn cmd_setup_secrets(opts: SecretsOpts) -> Result<()> {
     Ok(())
 }
 
+/// Prompt (plain, not hidden — a GitHub login isn't a secret) for the
+/// individual owner login an `--org` install needs, since the org itself
+/// can't be `LOOM_OWNER_GITHUB`.
+fn prompt_owner(org: &str) -> Result<String> {
+    use std::io::Write;
+    print!(
+        "The App will be owned by the {org} organization, but the first approved sign-in needs \
+         your individual GitHub login (LOOM_OWNER_GITHUB) — enter it: "
+    );
+    std::io::stdout().flush().ok();
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .context("reading the owner login")?;
+    let owner = input.trim().to_string();
+    if owner.is_empty() {
+        bail!("an owner GitHub login is required for an --org install");
+    }
+    Ok(owner)
+}
+
 /// Prompt for a secret without echoing it to the terminal. An empty answer
 /// means "skip" (leave the current value, if any, alone).
 fn prompt_secret(name: &str) -> Result<Option<String>> {
@@ -997,6 +1067,41 @@ async fn run_config(cmd: ConfigCmd) -> Result<()> {
         ConfigCmd::RenderEnv(opts) => cmd_config_render_env(opts),
         ConfigCmd::SecretNames(opts) => cmd_config_secret_names(opts),
         ConfigCmd::PushSecrets(opts) => cmd_config_push_secrets(opts).await,
+        ConfigCmd::Set { key, value } => cmd_config_set(key, value).await,
+    }
+}
+
+/// `loom config set` — write one runtime setting straight into the sqlite
+/// `settings` table, no running server needed. The direct-db counterpart to
+/// `weaver config set`, which does the same thing over `PATCH /api/settings`
+/// against a running daemon — the form a deploy's boot sequence needs, since
+/// it must seed the auth settings *before* loom starts listening.
+async fn cmd_config_set(key: String, value: String) -> Result<()> {
+    if let Err(why) = weaver_core::config::validate(&key, &value) {
+        bail!("{key}: {why}");
+    }
+    let db = loom::db::connect(&weaver_core::db::default_db_path())
+        .await
+        .context("opening loom's database")?;
+    weaver_core::config::apply(&db, &[(key.clone(), Some(value))])
+        .await
+        .with_context(|| format!("writing setting '{key}'"))?;
+    println!("set {key}");
+    Ok(())
+}
+
+/// Warn to stderr, naming each field, when an ambient env var silently
+/// outranked `loom.toml` for this run — the footgun a deploy workstation hits
+/// when a personal `GH_TOKEN`/`ANTHROPIC_API_KEY` etc. happens to be exported
+/// (see `loom_config::resolve_reporting_shadows`).
+fn warn_shadowed_env(shadowed: &[&str], config_path: &std::path::Path) {
+    for name in shadowed {
+        eprintln!(
+            "warning: ambient env var {name} overrides the value for {name} already set in {} \
+             for this run — that's the value being rendered/pushed. Unset {name}, or edit the \
+             file, if that's not what you want.",
+            config_path.display()
+        );
     }
 }
 
@@ -1004,8 +1109,9 @@ async fn run_config(cmd: ConfigCmd) -> Result<()> {
 /// override) and write it out as a dotenv file, the only place the
 /// field→`ENV_NAME` mapping is applied.
 fn cmd_config_render_env(opts: RenderEnvOpts) -> Result<()> {
-    let config = loom::loom_config::resolve(&opts.config.config)
+    let (config, shadowed) = loom::loom_config::resolve_reporting_shadows(&opts.config.config)
         .with_context(|| format!("loading {}", opts.config.config.display()))?;
+    warn_shadowed_env(&shadowed, &opts.config.config);
     let rendered = loom::loom_config::render_env(&config);
     if opts.out == "-" {
         print!("{rendered}");
@@ -1040,8 +1146,9 @@ fn cmd_config_secret_names(opts: ConfigPathOpts) -> Result<()> {
 /// Manager backend, secret id == `ENV_NAME`. Values travel over the
 /// subprocess's stdin, never a command-line argument or a log line.
 async fn cmd_config_push_secrets(opts: PushSecretsOpts) -> Result<()> {
-    let config = loom::loom_config::resolve(&opts.config.config)
+    let (config, shadowed) = loom::loom_config::resolve_reporting_shadows(&opts.config.config)
         .with_context(|| format!("loading {}", opts.config.config.display()))?;
+    warn_shadowed_env(&shadowed, &opts.config.config);
     let mut pushed = Vec::new();
     let mut skipped = Vec::new();
     for field in loom::loom_config::FIELDS.iter().filter(|f| f.secret) {
@@ -2570,6 +2677,42 @@ mod tests {
         assert!(body.contains("\"\"\"scaffolded — "));
         // A second `new` of the same name refuses rather than clobbering.
         assert!(cmd_overlooker_new("scaffolded".to_string()).await.is_err());
+        std::env::remove_var("WEAVER_HOME");
+    }
+
+    /// `loom config set` writes straight to the sqlite `settings` table — no
+    /// HTTP, no running server — the fix for the deploy `loom-init` one-shot,
+    /// which must seed the auth settings before loom starts listening.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn config_set_writes_directly_to_sqlite_with_no_server() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("WEAVER_HOME", home.path());
+
+        cmd_config_set("auth.cookie_secure".to_string(), "true".to_string())
+            .await
+            .unwrap();
+
+        let db = loom::db::connect(&weaver_core::db::default_db_path())
+            .await
+            .unwrap();
+        assert_eq!(
+            weaver_core::config::get(&db, "auth.cookie_secure")
+                .await
+                .as_deref(),
+            Some("true")
+        );
+
+        // An invalid value for a registered (bool) key is rejected before
+        // touching the database.
+        let err = cmd_config_set("auth.cookie_secure".to_string(), "sideways".to_string())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("auth.cookie_secure"),
+            "error should name the key: {err}"
+        );
+
         std::env::remove_var("WEAVER_HOME");
     }
 

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -228,18 +228,32 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
     Ok(())
 }
 
-/// Seed the approved-user allowlist with the deploy owner so a fresh database is
-/// usable immediately: GitHub login works for exactly this one identity until
-/// more users are added. The login defaults to `rjpower` and can be overridden
-/// at first run with `LOOM_OWNER_GITHUB`. `INSERT OR IGNORE` makes this a no-op
-/// once the row (or any same-username row) exists, so it never clobbers later
-/// edits — including a password the owner has set.
+/// Seed the approved-user allowlist with the deploy owner named by
+/// `LOOM_OWNER_GITHUB`, so a fresh database is usable immediately: GitHub login
+/// works for exactly this one identity until more users are added.
+/// `INSERT OR IGNORE` makes this a no-op once the row (or any same-username
+/// row) exists, so it never clobbers later edits — including a password the
+/// owner has set.
+///
+/// Fails closed: with `LOOM_OWNER_GITHUB` unset or empty, no owner is seeded at
+/// all — a warning is logged and GitHub/loopback login simply has no `users`
+/// row to resolve to until the operator sets it (see [`crate::auth::primary_user`]
+/// returning `None`). This never falls back to a real login (e.g. the
+/// maintainer's own), which would hand an internet-facing deploy's sole owner
+/// slot to someone other than its operator.
 async fn seed_owner(pool: &Db) -> Result<()> {
     let owner = std::env::var("LOOM_OWNER_GITHUB")
         .ok()
         .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "rjpower".to_string());
+        .filter(|s| !s.is_empty());
+    let Some(owner) = owner else {
+        tracing::warn!(
+            "LOOM_OWNER_GITHUB is not set — no owner user was seeded. No one can log in until \
+             you set LOOM_OWNER_GITHUB and restart the daemon (seeding re-runs on every start, \
+             so no fresh migration is needed)."
+        );
+        return Ok(());
+    };
     sqlx::query("INSERT OR IGNORE INTO users (username, github_login) VALUES (?, ?)")
         .bind(&owner)
         .bind(&owner)

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -267,8 +267,9 @@ impl GithubApp {
     }
 
     /// Resolve `owner/name` to an installation and return a valid token for it —
-    /// the two-step the REST gateway methods share.
-    async fn token_for_repo(&self, owner: &str, name: &str) -> Result<String> {
+    /// the two-step the REST gateway methods share, and what `crate::repo`
+    /// mints a per-clone credential from.
+    pub(crate) async fn token_for_repo(&self, owner: &str, name: &str) -> Result<String> {
         let installation_id = self.installation_id(owner, name).await?;
         self.installation_token(installation_id).await
     }

--- a/crates/loom/src/loom_config.rs
+++ b/crates/loom/src/loom_config.rs
@@ -195,13 +195,31 @@ pub fn load(path: &Path) -> Result<LoomConfig> {
 /// resolves against; see the module docs for why the *authoring* path
 /// ([`load`]/[`upsert`]) doesn't do this.
 pub fn resolve(path: &Path) -> Result<LoomConfig> {
+    Ok(resolve_reporting_shadows(path)?.0)
+}
+
+/// [`resolve`], plus the `ENV_NAME`s where an ambient env var overrode a
+/// *different* value already present in `path` — the footgun on a deploy
+/// workstation, where a personal `GH_TOKEN`/`ANTHROPIC_API_KEY` etc. is
+/// commonly exported and would otherwise silently outrank `loom.toml` in
+/// exactly the run that pushes secrets to the shared deploy. `render-env` and
+/// `push-secrets` (`bin/loom.rs`) use this instead of bare [`resolve`] so they
+/// can warn; a value that merely fills in a field the file never had isn't a
+/// shadow (nothing on disk was overridden), so it's excluded.
+pub fn resolve_reporting_shadows(path: &Path) -> Result<(LoomConfig, Vec<&'static str>)> {
     let mut config = load(path)?;
+    let mut shadowed = Vec::new();
     for f in FIELDS {
         if let Ok(value) = std::env::var(f.env_name) {
+            if let Some(existing) = f.get(&config) {
+                if existing != value {
+                    shadowed.push(f.env_name);
+                }
+            }
             f.set(&mut config, value);
         }
     }
-    Ok(config)
+    Ok((config, shadowed))
 }
 
 /// Serialize `config` to TOML and write it to `path` (0600 — it can hold
@@ -259,6 +277,37 @@ mod tests {
         let config = upsert(&path, &[("GH_TOKEN", "ghp_new")]).unwrap();
         assert_eq!(config.domain.as_deref(), Some("loom.example.com"));
         assert_eq!(config.gh_token.as_deref(), Some("ghp_new"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_reporting_shadows_flags_only_a_genuinely_overridden_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("loom.toml");
+        upsert(
+            &path,
+            &[
+                ("LOOM_TLS_EMAIL", "from-file@example.com"),
+                ("LOOM_DOMAIN", "loom.example.com"),
+            ],
+        )
+        .unwrap();
+
+        // Shadows the file's value.
+        std::env::set_var("LOOM_TLS_EMAIL", "from-env@example.com");
+        // Same value as the file — not a shadow, nothing actually changes.
+        std::env::set_var("LOOM_DOMAIN", "loom.example.com");
+        // Fills in a field the file never had — not a shadow either.
+        std::env::set_var("HOST_UID", "1001");
+
+        let (resolved, shadowed) = resolve_reporting_shadows(&path).unwrap();
+
+        std::env::remove_var("LOOM_TLS_EMAIL");
+        std::env::remove_var("LOOM_DOMAIN");
+        std::env::remove_var("HOST_UID");
+
+        assert_eq!(resolved.tls_email.as_deref(), Some("from-env@example.com"));
+        assert_eq!(shadowed, vec!["LOOM_TLS_EMAIL"]);
     }
 
     #[test]

--- a/crates/loom/src/repo.rs
+++ b/crates/loom/src/repo.rs
@@ -250,7 +250,17 @@ pub enum ResolveError {
 /// `input` is a slug or URL; it is parsed strictly (traversal rejected), looked
 /// up in the registered allowlist (an unregistered repo is refused — the trigger
 /// boundary), then cloned-if-absent / fetched. Returns the managed checkout path.
-pub async fn resolve_clone(db: &Db, input: &str) -> std::result::Result<PathBuf, ResolveError> {
+///
+/// `app` (when the GitHub App is configured and installed on the repo) mints a
+/// short-lived installation token for the clone/fetch — least-privilege, in
+/// place of the ambient shared `GH_TOKEN` credential helper. Any failure to
+/// mint one (unconfigured App, no installation on this repo, API error) is
+/// non-fatal: it falls back to the ambient helper, same as `app: None`.
+pub async fn resolve_clone(
+    db: &Db,
+    input: &str,
+    app: Option<&crate::github_app::GithubApp>,
+) -> std::result::Result<PathBuf, ResolveError> {
     let slug = parse_slug(input).map_err(ResolveError::BadRequest)?;
     let slug_str = slug.slug();
     let registered = get_registered(db, &slug_str)
@@ -262,7 +272,22 @@ pub async fn resolve_clone(db: &Db, input: &str) -> std::result::Result<PathBuf,
             ))
         })?;
     let dest = PathBuf::from(&registered.path);
-    git::clone(&registered.remote_url, &dest)
+    let token = match app {
+        Some(app) => match app.token_for_repo(&slug.owner, &slug.name).await {
+            Ok(token) => Some(token),
+            Err(e) => {
+                tracing::debug!(
+                    repo = %slug_str,
+                    error = %e,
+                    "no GitHub App installation token for repo; falling back to the ambient \
+                     credential helper"
+                );
+                None
+            }
+        },
+        None => None,
+    };
+    git::clone(&registered.remote_url, &dest, token.as_deref())
         .await
         .map_err(|e| ResolveError::Clone(format!("cloning {slug_str}: {e}")))?;
     Ok(dest)
@@ -400,12 +425,12 @@ mod tests {
 
         // Unregistered → BadRequest, no clone attempted.
         assert!(matches!(
-            resolve_clone(&db, "ghost/repo").await,
+            resolve_clone(&db, "ghost/repo", None).await,
             Err(ResolveError::BadRequest(_))
         ));
         // Traversal → BadRequest before any lookup.
         assert!(matches!(
-            resolve_clone(&db, "../etc").await,
+            resolve_clone(&db, "../etc", None).await,
             Err(ResolveError::BadRequest(_))
         ));
 
@@ -444,14 +469,60 @@ mod tests {
         .await
         .unwrap();
 
-        let path = resolve_clone(&db, "acme/widgets").await.unwrap();
+        let path = resolve_clone(&db, "acme/widgets", None).await.unwrap();
         assert_eq!(path, dest);
         assert!(
             dest.join(".git").exists(),
             "repo was cloned to the managed path"
         );
         // Idempotent: a second resolve fetches into the existing clone.
-        resolve_clone(&db, "acme/widgets").await.unwrap();
+        resolve_clone(&db, "acme/widgets", None).await.unwrap();
+    }
+
+    /// An unconfigured GitHub App (`Some(&app)`, but no App id/key stored) can't
+    /// mint an installation token — `resolve_clone` must fall back to the
+    /// ambient credential helper rather than fail the whole clone.
+    #[tokio::test]
+    async fn resolve_clone_falls_back_when_the_app_cannot_mint_a_token() {
+        let db = connect_in_memory().await.unwrap();
+
+        let src = tempfile::tempdir().unwrap();
+        let sdir = src.path();
+        run_git(sdir, &["init", "-q", "-b", "main"]).await;
+        run_git(sdir, &["config", "user.email", "t@t.t"]).await;
+        run_git(sdir, &["config", "user.name", "t"]).await;
+        std::fs::write(sdir.join("README.md"), "hi\n").unwrap();
+        run_git(sdir, &["add", "-A"]).await;
+        run_git(sdir, &["commit", "-q", "-m", "init"]).await;
+        let bare = tempfile::tempdir().unwrap();
+        let bare_path = bare.path().join("origin.git");
+        run_git(
+            sdir,
+            &[
+                "clone",
+                "--bare",
+                "-q",
+                &sdir.to_string_lossy(),
+                &bare_path.to_string_lossy(),
+            ],
+        )
+        .await;
+
+        let dest_root = tempfile::tempdir().unwrap();
+        let dest = dest_root.path().join("acme").join("gizmos");
+        register(
+            &db,
+            "acme/gizmos",
+            &bare_path.to_string_lossy(),
+            &dest.to_string_lossy(),
+        )
+        .await
+        .unwrap();
+
+        let app = crate::github_app::GithubApp::new(db.clone());
+        let path = resolve_clone(&db, "acme/gizmos", Some(&app)).await.unwrap();
+        assert_eq!(path, dest);
+        assert!(dest.join(".git").exists());
     }
 
     /// Run `git` in `dir` for the resolve test (the crate has no test-only git

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -380,7 +380,7 @@ pub(crate) async fn create_session_core(
     // directly; otherwise fork from `cwd`'s repo (the default). The traversal /
     // allowlist gate lives in `repo::resolve_clone`.
     let repo_root = match req.repo.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-        Some(input) => repo::resolve_clone(&st.db, input)
+        Some(input) => repo::resolve_clone(&st.db, input, st.trigger.app())
             .await
             .map_err(|e| match e {
                 repo::ResolveError::BadRequest(m) => AppError::bad_request(m),

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -70,6 +70,9 @@ async fn hook_event_drives_session_status() {
     let home = TestHome(tempfile::tempdir().unwrap());
     std::env::set_var("WEAVER_HOME", home.0.path());
     std::env::set_var("WEAVER_TAPESTRY_BIN", tapestry_bin());
+    // `seed_owner` no longer defaults to a real login — this test's requests
+    // ride loopback trust, which needs a seeded owner to resolve to.
+    std::env::set_var("LOOM_OWNER_GITHUB", "rjpower");
 
     let repo = tempfile::tempdir().unwrap();
     sh(repo.path(), "git", &["init", "-b", "main"]);

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -132,6 +132,9 @@ impl TestServer {
         let home = tempfile::tempdir().unwrap();
         std::env::set_var("WEAVER_HOME", home.path());
         std::env::set_var("WEAVER_TAPESTRY_BIN", tapestry_bin());
+        // `seed_owner` no longer defaults to a real login — the suite's requests
+        // ride loopback trust, which needs a seeded owner to resolve to.
+        std::env::set_var("LOOM_OWNER_GITHUB", "rjpower");
 
         let repo = tempfile::tempdir().unwrap();
         init_repo(repo.path());

--- a/crates/loom/tests/repo_setup.rs
+++ b/crates/loom/tests/repo_setup.rs
@@ -86,6 +86,9 @@ async fn start_server() -> (TestHome, loom::client::Client, db::Db, String) {
     let home = TestHome(tempfile::tempdir().unwrap());
     std::env::set_var("WEAVER_HOME", home.0.path());
     std::env::set_var("WEAVER_TAPESTRY_BIN", tapestry_bin());
+    // `seed_owner` no longer defaults to a real login — this suite's requests
+    // ride loopback trust, which needs a seeded owner to resolve to.
+    std::env::set_var("LOOM_OWNER_GITHUB", "rjpower");
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/weaver-core/Cargo.toml
+++ b/crates/weaver-core/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1"
+base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 rand = "0.9"
 serde = { version = "1", features = ["derive"] }

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -13,11 +13,20 @@ pub struct DiffStat {
 }
 
 async fn git(dir: &Path, args: &[&str]) -> Result<String> {
+    git_with_envs(dir, args, &[]).await
+}
+
+/// Same as [`git`], plus extra environment variables for the subprocess — how a
+/// short-lived credential is threaded into one invocation (see
+/// [`token_auth_envs`]) without ever appearing in `args` (which the failure log
+/// below prints).
+async fn git_with_envs(dir: &Path, args: &[&str], envs: &[(&str, String)]) -> Result<String> {
     tracing::debug!(?args, dir = %dir.display(), "running git");
     let out = Command::new("git")
         .arg("-C")
         .arg(dir)
         .args(args)
+        .envs(envs.iter().map(|(k, v)| (*k, v.as_str())))
         .output()
         .await
         .context("failed to spawn git")?;
@@ -63,15 +72,40 @@ pub async fn repo_root(dir: &Path) -> Result<PathBuf> {
     Ok(PathBuf::from(first))
 }
 
+/// Environment variables that make one git invocation authenticate with
+/// `token` over HTTPS, via git's env-var config mechanism
+/// (`GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n`, since git 2.31) rather than a CLI
+/// arg or a persisted `.git/config` entry — so the token never appears in
+/// `argv` (visible to `ps`, and to the `args`-logging `git()`/`git_with_envs`
+/// failure path above), a process listing, or the repo's remote URL. Scoped to
+/// this one subprocess only; nothing is written to disk.
+fn token_auth_envs(token: &str) -> Vec<(&'static str, String)> {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    let header = format!(
+        "AUTHORIZATION: basic {}",
+        STANDARD.encode(format!("x-access-token:{token}"))
+    );
+    vec![
+        ("GIT_CONFIG_COUNT", "1".to_string()),
+        ("GIT_CONFIG_KEY_0", "http.extraheader".to_string()),
+        ("GIT_CONFIG_VALUE_0", header),
+    ]
+}
+
 /// Clone `url` into `dest`, or fetch into it when `dest` is already a clone —
 /// idempotent, so two session launches racing to acquire the same managed repo
-/// converge instead of one erroring on a populated directory. Authentication
-/// rides the ambient git credential helper (the deploy image wires `GH_TOKEN`);
-/// no credentials are passed or stored here.
-pub async fn clone(url: &str, dest: &Path) -> Result<()> {
+/// converge instead of one erroring on a populated directory.
+///
+/// `token` authenticates this one clone/fetch with a caller-supplied credential
+/// (e.g. a GitHub App installation token) via [`token_auth_envs`]. Pass `None`
+/// to fall back to the ambient git credential helper (the deploy image wires
+/// `GH_TOKEN`) — the only behavior before per-call tokens existed, still used
+/// for repos with no App installation.
+pub async fn clone(url: &str, dest: &Path, token: Option<&str>) -> Result<()> {
+    let envs = token.map(token_auth_envs).unwrap_or_default();
     // An existing clone (its `.git` is present) is refreshed, not re-cloned.
     if dest.join(".git").exists() {
-        git(dest, &["fetch", "--all", "--prune"]).await?;
+        git_with_envs(dest, &["fetch", "--all", "--prune"], &envs).await?;
         tracing::info!(dest = %dest.display(), "fetched existing clone");
         return Ok(());
     }
@@ -85,6 +119,7 @@ pub async fn clone(url: &str, dest: &Path) -> Result<()> {
     let dest_str = dest.to_string_lossy();
     let out = Command::new("git")
         .args(["clone", url, &dest_str])
+        .envs(envs.iter().map(|(k, v)| (*k, v.as_str())))
         .output()
         .await
         .context("failed to spawn git clone")?;
@@ -568,6 +603,26 @@ pub async fn read_blob(work_dir: &Path, rev: &str, path: &str) -> Result<Option<
 mod tests {
     use super::*;
 
+    /// The env-var-borne `http.extraheader` decodes to exactly
+    /// `x-access-token:<token>` — the Basic-auth shape a GitHub App
+    /// installation token expects — and nothing about it (an `Authorization`
+    /// header, a config key) leaks into a persisted git config, since these are
+    /// only ever passed as subprocess env, never written to `.git/config`.
+    #[test]
+    fn token_auth_envs_carries_a_correctly_shaped_extraheader() {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        let envs = token_auth_envs("ghs_abc123");
+        let pairs: std::collections::HashMap<_, _> = envs.into_iter().collect();
+        assert_eq!(pairs["GIT_CONFIG_COUNT"], "1");
+        assert_eq!(pairs["GIT_CONFIG_KEY_0"], "http.extraheader");
+        let header = &pairs["GIT_CONFIG_VALUE_0"];
+        let encoded = header
+            .strip_prefix("AUTHORIZATION: basic ")
+            .expect("header should be a Basic auth line");
+        let decoded = String::from_utf8(STANDARD.decode(encoded).unwrap()).unwrap();
+        assert_eq!(decoded, "x-access-token:ghs_abc123");
+    }
+
     async fn run(dir: &Path, args: &[&str]) -> String {
         git(dir, args).await.unwrap()
     }
@@ -659,7 +714,7 @@ mod tests {
         // First call clones into a nested <root>/owner/name path (parent created).
         let root = tempfile::tempdir().unwrap();
         let dest = root.path().join("acme").join("widgets");
-        clone(&bare_url, &dest).await.unwrap();
+        clone(&bare_url, &dest, None).await.unwrap();
         assert!(dest.join(".git").exists(), "clone made a working clone");
         assert!(dest.join("a.txt").exists(), "clone checked out content");
 
@@ -671,7 +726,7 @@ mod tests {
 
         // Idempotent: the second call fetches rather than erroring, and the new
         // commit is now reachable via origin.
-        clone(&bare_url, &dest).await.unwrap();
+        clone(&bare_url, &dest, None).await.unwrap();
         assert!(
             commit_exists(&dest, &second).await,
             "fetch pulled the new remote commit into the existing clone"

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -40,6 +40,10 @@ impl Env {
     async fn start() -> Self {
         let home = tempfile::tempdir().unwrap();
         std::env::set_var("WEAVER_HOME", home.path());
+        // `seed_owner` no longer defaults to a real login — this suite's
+        // requests (the `weaver` CLI, over loopback) need a seeded owner to
+        // resolve to.
+        std::env::set_var("LOOM_OWNER_GITHUB", "rjpower");
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -11,7 +11,7 @@ name: loom
 services:
   # One-shot: seed the security-relevant auth settings into the shared sqlite DB
   # BEFORE loom starts, so an internet-exposed deploy never comes up trusting
-  # loopback or minting a non-Secure session cookie. `weaver config set` writes
+  # loopback or minting a non-Secure session cookie. `loom config set` writes
   # the settings table directly — no running server needed — then exits; loom
   # waits on its success. Idempotent: it re-runs on every `up` and just rewrites
   # the same three values. (See ../README.md "Security posture".)
@@ -32,9 +32,9 @@ services:
       - sh
       - -ceu
       - |
-        weaver config set auth.trust_loopback false
-        weaver config set auth.cookie_secure true
-        weaver config set auth.base_url "https://$$LOOM_DOMAIN"
+        loom config set auth.trust_loopback false
+        loom config set auth.cookie_secure true
+        loom config set auth.base_url "https://$$LOOM_DOMAIN"
 
   loom:
     image: ${LOOM_IMAGE:-loom:latest}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -486,12 +486,14 @@ A request that resolves to none of these gets `401`; the SPA's router guard
 turns that into the login screen.
 
 **The allowlist.** `users` rows are the approved operators. A fresh database is
-seeded with one owner — `github_login = rjpower` by default, overridable at
-first run with `LOOM_OWNER_GITHUB`. GitHub login only succeeds for a login that
-matches a `users` row; an unknown identity is authenticated by GitHub but
-rejected by loom. A user may have a `github_login`, a `password_hash` (argon2),
-or both. All approved users are equal — there is no role hierarchy, matching the
-single-operator scale.
+seeded with one owner — whichever GitHub login `LOOM_OWNER_GITHUB` names at
+first run. There is no default: leave it unset and no owner row is seeded at
+all, so GitHub login has no `users` row to match until it's set (fail closed,
+rather than seed a real maintainer login onto an internet-facing deploy).
+GitHub login only succeeds for a login that matches a `users` row; an unknown
+identity is authenticated by GitHub but rejected by loom. A user may have a
+`github_login`, a `password_hash` (argon2), or both. All approved users are
+equal — there is no role hierarchy, matching the single-operator scale.
 
 **GitHub OAuth** is configured per-deploy: register an OAuth app and set its id
 and secret via Settings → Account or the `LOOM_GITHUB_CLIENT_ID` /
@@ -582,7 +584,7 @@ builtins are stdlib-only and need neither).
 | `WEAVER_API` | loom URL (both sides — server binds, `weaver`/`loom` CLI clients talk) | `http://127.0.0.1:7878` |
 | `WEAVER_BRANCH` | the current branch key, set by `loom session launch` in the worktree — the only source `weaver` uses; unset, every `weaver` command fails with a friendly error | — |
 | `LOOM_TOKEN` | bearer token the `weaver`/`loom` CLIs and automation send; falls back to the machine-local token file on the same host | — |
-| `LOOM_OWNER_GITHUB` | GitHub login seeded as the owner on a fresh database | `rjpower` |
+| `LOOM_OWNER_GITHUB` | GitHub login seeded as the owner on a fresh database; unset seeds no owner at all | — |
 | `LOOM_GITHUB_CLIENT_ID` / `LOOM_GITHUB_CLIENT_SECRET` | GitHub OAuth app credentials (override the settings-stored values) | — |
 | `WEAVER_TAPESTRY_DIR` | directory holding tapestry's per-session control sockets | `$WEAVER_HOME/sock` |
 | `WEAVER_TAPESTRY_BIN` | the `tapestry` supervisor binary loom re-execs (else a sibling of `loom`); set by the tests | sibling of `loom` |


### PR DESCRIPTION
## Summary

Four deploy-correctness bugs found in the post-merge review of the shared-loom work (all on top of fresh `main`):

- **P0 — the standalone/GCP deploy couldn't boot.** `deploy/standalone/docker-compose.yml`'s `loom-init` one-shot ran `weaver config set …` before loom's server was up. #105 made `weaver` an HTTP-only client, so that `PATCH /api/settings` had nowhere to land — loom-init exited non-zero and loom+caddy never started. Fixed by adding `loom config set <key> <value>`, a direct-to-sqlite write (loom, unlike weaver, opens the db directly — no HTTP needed), and switching loom-init to it.
- **P1 — hardcoded `rjpower` owner fallback.** `seed_owner` defaulted the sole approved user to the maintainer's own GitHub login when `LOOM_OWNER_GITHUB` was unset — on someone else's internet-facing deploy that's a lockout by default. Now fails closed: no owner is seeded, with a clear warning logged. `loom setup github-app --org <o>` now requires (or interactively prompts for) an explicit `--owner`, since an org's own login can't be `LOOM_OWNER_GITHUB`.
- **P1 — ambient workstation secrets could silently shadow `loom.toml`.** `loom_config::resolve()` let ambient env win over the file with no indication which source was in effect — exactly the risk on `render-env`/`push-secrets`, which push credentials into the shared deploy. Added `resolve_reporting_shadows`, used by both commands to warn to stderr, naming any field an ambient env var overrode.
- **P2 — GitHub App installation token now wires into clone.** `git::clone` rode the ambient shared `GH_TOKEN` credential helper even when a repo has a GitHub App installation. `clone` takes an optional per-call token now, injected via git's env-var config mechanism (`GIT_CONFIG_KEY_n`/`_VALUE_n`) so it never touches argv, a persisted git config, or a log line. `repo::resolve_clone` mints one from the App when configured/installed and falls back to the ambient helper otherwise (unconfigured App, no installation, or an API error).

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-targets --locked -- -D warnings` (`scripts/pre-commit.sh`)
- [x] `cargo build --workspace --locked`
- [x] `cargo test --workspace --locked` — all suites green, including the full loom integration suite and the new/updated tests:
  - `loom config set` direct-db write + validation rejection
  - `seed_owner` fail-closed (no owner seeded when `LOOM_OWNER_GITHUB` unset) + updated auth.rs fixtures that now set it explicitly
  - `resolve_reporting_shadows` flags only a genuinely-overridden field
  - `resolve_clone` falls back to the ambient credential helper when the App can't mint a token
  - `token_auth_envs` produces the correct Basic-auth header
- [x] Docs updated: `deploy/standalone/docker-compose.yml` comment, root README + `docs/ARCHITECTURE.md` (no more "default `rjpower`")