### PR TITLE
feat(loom): trusted-owner allowlist to gate App-installed repos

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -241,7 +241,7 @@ export const restartShell = () => post('/shell/restart');
 
 // --- Authentication --------------------------------------------------------
 
-import type { Me, Token, CreatedToken, User, GithubConfig } from './types';
+import type { Me, Token, CreatedToken, User, Owner, GithubConfig } from './types';
 
 /** Who the caller is + which sign-in methods to offer. Never 401s. */
 export const getMe = () => get('/auth/me') as Promise<Me>;
@@ -283,6 +283,19 @@ export const addUser = (username: string, githubLogin?: string, password?: strin
 
 /** Remove an approved operator. */
 export const removeUser = (username: string) => del(`/auth/users/${encodeURIComponent(username)}`);
+
+/** The trusted-owner allowlist — GitHub accounts loom acts for via the trigger
+ *  (`GET /api/github/owners`). */
+export const listOwners = () => get('/github/owners') as Promise<Owner[]>;
+
+/** Trust a GitHub account (org or user) for the inbound trigger
+ *  (`POST /api/github/owners`). */
+export const addOwner = (login: string) =>
+  post('/github/owners', { login }) as Promise<Owner>;
+
+/** Stop trusting a GitHub account (`DELETE /api/github/owners/{login}`). */
+export const removeOwner = (login: string) =>
+  del(`/github/owners/${encodeURIComponent(login)}`);
 
 /** The GitHub OAuth app config (secret withheld). */
 export const getGithubConfig = () => get('/auth/github/config') as Promise<GithubConfig>;

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -3,7 +3,7 @@ import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import * as api from '../api';
 import { me, doLogout } from '../auth';
-import type { User, GithubConfig } from '../types';
+import type { User, Owner, GithubConfig } from '../types';
 
 // Account + access management: who you are, your password, the approved-user
 // allowlist, and the GitHub OAuth app config that powers "Continue with GitHub".
@@ -96,6 +96,51 @@ async function removeUser(u: User) {
   }
 }
 
+// -- Trusted GitHub owners --------------------------------------------------
+// The accounts (orgs or users) whose App installations the inbound trigger will
+// act for. This is what keeps a public GitHub App from letting a stranger's
+// installation drive loom, so only owners listed here are auto-trusted.
+const owners = ref<Owner[]>([]);
+const newOwner = ref('');
+
+async function loadOwners() {
+  try {
+    owners.value = await api.listOwners();
+  } catch (e) {
+    fail(e);
+  }
+}
+
+async function addOwner() {
+  if (!newOwner.value.trim()) return;
+  busy.value = true;
+  try {
+    await api.addOwner(newOwner.value.trim());
+    newOwner.value = '';
+    ok('Owner trusted.');
+    await loadOwners();
+  } catch (e) {
+    fail(e);
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function removeOwner(o: Owner) {
+  if (!confirm(`Stop trusting "${o.login}"? Their installations will no longer trigger loom.`))
+    return;
+  busy.value = true;
+  try {
+    await api.removeOwner(o.login);
+    ok('Owner removed.');
+    await loadOwners();
+  } catch (e) {
+    fail(e);
+  } finally {
+    busy.value = false;
+  }
+}
+
 // -- GitHub OAuth app -------------------------------------------------------
 const gh = ref<GithubConfig | null>(null);
 const ghClientId = ref('');
@@ -135,6 +180,7 @@ async function logout() {
 
 onMounted(() => {
   loadUsers();
+  loadOwners();
   loadGithub();
 });
 </script>
@@ -283,6 +329,55 @@ onMounted(() => {
           @click="addUser"
         >
           Approve user
+        </button>
+      </div>
+    </section>
+
+    <!-- Trusted GitHub owners -->
+    <section>
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
+        Authorized GitHub owners
+      </h2>
+      <p class="text-2xs text-faint mb-1.5">
+        Accounts (orgs or users) whose GitHub App installations may trigger loom. Only repos
+        owned by an account listed here are auto-trusted — this is what keeps a public App from
+        letting a stranger's installation drive loom.
+      </p>
+      <div class="overflow-hidden rounded-md border border-line bg-surface">
+        <div
+          v-for="o in owners"
+          :key="o.login"
+          class="flex items-center gap-3 border-b border-line px-3 py-2.5 last:border-0"
+        >
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-medium">{{ o.login }}</p>
+          </div>
+          <button
+            class="btn-secondary px-2.5 py-1 text-xs"
+            :disabled="busy"
+            @click="removeOwner(o)"
+          >
+            Remove
+          </button>
+        </div>
+        <div v-if="!owners.length" class="px-3 py-2.5 text-2xs text-faint">
+          No owners trusted yet.
+        </div>
+      </div>
+
+      <div class="mt-2 flex flex-wrap items-end gap-2">
+        <input
+          v-model="newOwner"
+          placeholder="GitHub org or user"
+          class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+          @keyup.enter="addOwner"
+        />
+        <button
+          class="btn-primary px-3 py-1.5 text-xs"
+          :disabled="busy || !newOwner.trim()"
+          @click="addOwner"
+        >
+          Trust owner
         </button>
       </div>
     </section>

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -517,6 +517,13 @@ export interface User {
   created_at: string;
 }
 
+/** One trusted GitHub owner — an account (org or user) whose App installations
+ *  the inbound trigger will act for. Mirrors `owners::Owner`. */
+export interface Owner {
+  login: string;
+  created_at: string;
+}
+
 /** One operator-managed agent environment variable. Exported into every
  *  interactive agent session loom launches. Mirrors `agent_env::EnvVar`. */
 export interface EnvVar {

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -928,6 +928,9 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
          Settings → Authorized GitHub owners."
     );
 
+    // Merge (don't overwrite) the allowlist, so re-running setup never silently
+    // drops owners an operator already added to loom.toml.
+    let allowed_owners = merged_allowed_owners(&opts.config.config, owner_login);
     let updates: Vec<(&str, &str)> = vec![
         ("LOOM_GITHUB_APP_ID", app_id.as_str()),
         ("LOOM_GITHUB_APP_PRIVATE_KEY", conv.pem.as_str()),
@@ -936,7 +939,7 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
         ("LOOM_GITHUB_CLIENT_SECRET", conv.client_secret.as_str()),
         ("LOOM_DOMAIN", domain),
         ("LOOM_OWNER_GITHUB", owner_login),
-        ("LOOM_ALLOWED_OWNERS", owner_login),
+        ("LOOM_ALLOWED_OWNERS", allowed_owners.as_str()),
     ];
     loom::loom_config::upsert(&opts.config.config, &updates)
         .context("writing the App credentials into loom.toml")?;
@@ -955,6 +958,25 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
     );
     println!("  2. Sign in at {base_url} with GitHub — the App's OAuth client now handles login.");
     Ok(())
+}
+
+/// The `LOOM_ALLOWED_OWNERS` value to write after adding `owner`: the owners
+/// already authored in `config_path` (if any) with `owner` appended when absent
+/// (case-insensitive). This makes writing the allowlist a **merge**, not an
+/// overwrite, so re-running setup never silently drops previously trusted
+/// owners. Returns a comma-separated list.
+fn merged_allowed_owners(config_path: &std::path::Path, owner: &str) -> String {
+    let existing = loom::loom_config::load(config_path)
+        .ok()
+        .and_then(|c| c.allowed_owners);
+    let mut owners: Vec<String> = existing
+        .as_deref()
+        .map(|s| loom::owners::split_logins(s).map(str::to_string).collect())
+        .unwrap_or_default();
+    if !owners.iter().any(|o| o.eq_ignore_ascii_case(owner)) {
+        owners.push(owner.to_string());
+    }
+    owners.join(", ")
 }
 
 /// The bare host from a `--base-url` like `https://loom.team.dev` or
@@ -2478,6 +2500,19 @@ mod tests {
             "loom-loom-team-dev"
         );
         assert_eq!(default_app_name("http://localhost:7878"), "loom-localhost");
+    }
+
+    #[test]
+    fn merged_allowed_owners_appends_without_dropping() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("loom.toml");
+        // No file yet → just the new owner.
+        assert_eq!(merged_allowed_owners(&path, "acme"), "acme");
+        // With an existing list, a new owner is appended and the rest kept.
+        loom::loom_config::upsert(&path, &[("LOOM_ALLOWED_OWNERS", "org-a, org-b")]).unwrap();
+        assert_eq!(merged_allowed_owners(&path, "acme"), "org-a, org-b, acme");
+        // An already-present owner (any case) is not duplicated.
+        assert_eq!(merged_allowed_owners(&path, "ORG-A"), "org-a, org-b");
     }
 
     /// clap's own consistency check over the full command tree — catches a

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -914,6 +914,20 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
     // the right owner; for `--org` it's the org's own login, so `org_owner`
     // (required, resolved above) is used instead.
     let owner_login = org_owner.as_deref().unwrap_or(conv.owner.login.as_str());
+
+    // Trust that account as a trusted owner, so its App installations are honored
+    // by the inbound trigger. This is what keeps a *public* App safe: only owners
+    // on this allowlist are auto-trusted, never a stranger who installs the App on
+    // their own repo. Written live to the running daemon here, and to loom.toml
+    // (`LOOM_ALLOWED_OWNERS`) below for a fresh DB. Add more in the UI later.
+    loom::owners::add(&db, owner_login)
+        .await
+        .context("trusting the App owner in the trusted-owner allowlist")?;
+    println!(
+        "Trusted GitHub owner '{owner_login}' for the inbound trigger — add more in \
+         Settings → Authorized GitHub owners."
+    );
+
     let updates: Vec<(&str, &str)> = vec![
         ("LOOM_GITHUB_APP_ID", app_id.as_str()),
         ("LOOM_GITHUB_APP_PRIVATE_KEY", conv.pem.as_str()),
@@ -922,6 +936,7 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
         ("LOOM_GITHUB_CLIENT_SECRET", conv.client_secret.as_str()),
         ("LOOM_DOMAIN", domain),
         ("LOOM_OWNER_GITHUB", owner_login),
+        ("LOOM_ALLOWED_OWNERS", owner_login),
     ];
     loom::loom_config::upsert(&opts.config.config, &updates)
         .context("writing the App credentials into loom.toml")?;

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -158,6 +158,19 @@ CREATE TABLE IF NOT EXISTS auth_sessions (
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     expires_at TEXT NOT NULL
 );
+
+-- The GitHub accounts (orgs or users) loom is authorized to act for via the
+-- inbound trigger: a row here is the "trusted owner" allowlist. It gates the
+-- "installation is the allowlist" auto-registration (`ensure_installed_repo_
+-- registered`) so that a *public* GitHub App — one anyone can install on their
+-- own repos — cannot make loom clone and run agents on a stranger's repo. Only a
+-- repo whose owner is listed here is auto-trusted; explicitly-registered repos
+-- (an operator's deliberate `POST /api/repos`) are unaffected. `login` is
+-- matched case-insensitively (GitHub logins are), like `users.github_login`.
+CREATE TABLE IF NOT EXISTS github_owners (
+    login      TEXT PRIMARY KEY COLLATE NOCASE,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
 "#;
 
 /// Open the shared database and apply loom's additional tables on top of the
@@ -225,6 +238,7 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
     // matching `model`/`effort`/`parent_branch_id`/`managed_by` above.)
     add_column_if_missing(pool, "sessions", "created_by", "TEXT").await?;
     seed_owner(pool).await?;
+    seed_owners(pool).await?;
     Ok(())
 }
 
@@ -260,6 +274,28 @@ async fn seed_owner(pool: &Db) -> Result<()> {
         .execute(pool)
         .await
         .with_context(|| format!("seeding owner user '{owner}'"))?;
+    Ok(())
+}
+
+/// Seed the trusted-owner allowlist (`github_owners`) so the inbound trigger is
+/// usable — and safe under a public App — immediately. The deploy owner's own
+/// account (`LOOM_OWNER_GITHUB`, covering the run-loom-on-my-own-repos case) plus
+/// every login in `LOOM_ALLOWED_OWNERS` (comma/space-separated — the orgs whose
+/// installations loom should honor) are inserted. `INSERT OR IGNORE` makes this a
+/// no-op once a row exists, so it never clobbers later web-flow edits.
+///
+/// Fails closed like [`seed_owner`]: there is no default login. With both env
+/// vars unset, nothing is seeded and no installation is auto-trusted until an
+/// operator adds an owner (in the UI or via config) — the allowlist never falls
+/// back to a real account.
+async fn seed_owners(pool: &Db) -> Result<()> {
+    let owner = std::env::var("LOOM_OWNER_GITHUB").unwrap_or_default();
+    let extra = std::env::var("LOOM_ALLOWED_OWNERS").unwrap_or_default();
+    for login in crate::owners::split_logins(&owner).chain(crate::owners::split_logins(&extra)) {
+        crate::owners::seed(pool, login)
+            .await
+            .with_context(|| format!("seeding trusted owner '{login}'"))?;
+    }
     Ok(())
 }
 

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -10,8 +10,10 @@
 //!    private key, that authenticates loom *as the App* for the next ~10 minutes.
 //! 2. **Resolve a repo to its installation** ([`GithubApp::installation_id`])
 //!    via `GET /repos/{owner}/{name}/installation`. A repo the App is installed
-//!    on is, by that fact, authorized — the installation *is* the access
-//!    allowlist (complementing the managed-repo table from #95).
+//!    on is authorized when its owner is a trusted owner ([`crate::owners`]) —
+//!    the installation *is* the access allowlist, gated on the owner so a public
+//!    App can't be driven by a stranger's install (complementing the managed-repo
+//!    table from #95).
 //! 3. **Exchange the JWT for an installation access token**
 //!    (`POST /app/installations/{id}/access_tokens`), **cached per installation
 //!    with its expiry** and refreshed once stale ([`GithubApp::installation_token`]).
@@ -276,15 +278,39 @@ impl GithubApp {
 
     // -- installation as allowlist ------------------------------------------
 
-    /// When the App is installed on `slug`, ensure that repo is in the managed
-    /// allowlist (idempotent), so the trigger's clone path accepts it — the
-    /// "installation *is* the allowlist" rule (§6.3), *complementing* the
-    /// explicitly-registered repos from #95. Best-effort and a no-op when the App
-    /// is unconfigured, the repo is already registered, or the App is not
-    /// installed on it (leaving the v1 repos-table allowlist to govern).
+    /// When the App is installed on `slug` **and** its owner is a trusted owner
+    /// ([`crate::owners`]), ensure that repo is in the managed allowlist
+    /// (idempotent), so the trigger's clone path accepts it — the "installation
+    /// *is* the allowlist" rule (§6.3), *complementing* the explicitly-registered
+    /// repos from #95. The trusted-owner gate is what keeps this safe under a
+    /// *public* App: a stranger's installation on their own repo is not honored,
+    /// because their account is not on the allowlist. Best-effort and a no-op when
+    /// the App is unconfigured, the owner is untrusted, the repo is already
+    /// registered, or the App is not installed on it (leaving the v1 repos-table
+    /// allowlist to govern).
     pub async fn ensure_installed_repo_registered(&self, slug: &RepoSlug) {
         if !self.is_configured().await {
             return;
+        }
+        // The trusted-owner gate: honor an installation as a grant only for an
+        // owner an operator has allowlisted (see `crate::owners`). This is what
+        // makes a *public* App safe — a stranger who installs it on their own
+        // repo is not on the list, so their repo is never auto-registered and the
+        // clone path (`resolve_clone`) rejects it. Fails closed on a store error.
+        match crate::owners::is_allowed(&self.db, &slug.owner).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::info!(
+                    owner = %slug.owner,
+                    repo = %slug.slug(),
+                    "not auto-registering: repo owner is not in the trusted-owner allowlist"
+                );
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(repo = %slug.slug(), error = %e, "trusted-owner check failed; not auto-registering");
+                return;
+            }
         }
         let slug_str = slug.slug();
         match crate::repo::get_registered(&self.db, &slug_str).await {
@@ -746,14 +772,16 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
 
     // -- installation as the allowlist (§6.3) -------------------------------
 
-    /// A repo the App is installed on is auto-registered into the managed
-    /// allowlist, so the trigger may clone it — the "installation is the
-    /// allowlist" rule, complementing the explicitly-registered repos.
+    /// A repo the App is installed on, *whose owner is a trusted owner*, is
+    /// auto-registered into the managed allowlist so the trigger may clone it —
+    /// the "installation is the allowlist" rule, complementing the
+    /// explicitly-registered repos.
     #[tokio::test]
     async fn installed_repo_is_auto_registered() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock.clone()).await;
         let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        crate::owners::add(&app.db, "acme").await.unwrap();
 
         let slug = crate::repo::parse_slug("acme/widgets").unwrap();
         assert!(
@@ -772,6 +800,28 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             .expect("the installed repo was added to the allowlist");
         assert_eq!(registered.slug, "acme/widgets");
         assert_eq!(registered.remote_url, "https://github.com/acme/widgets.git");
+    }
+
+    /// The trusted-owner gate: a repo the App is installed on is **not**
+    /// auto-registered when its owner is not on the allowlist — the protection
+    /// that keeps a public App from honoring a stranger's installation.
+    #[tokio::test]
+    async fn installed_repo_with_untrusted_owner_is_not_registered() {
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock.clone()).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        // Note: "stranger" is deliberately NOT added to the owner allowlist.
+
+        let slug = crate::repo::parse_slug("stranger/evil").unwrap();
+        app.ensure_installed_repo_registered(&slug).await;
+
+        assert!(
+            crate::repo::get_registered(&app.db, "stranger/evil")
+                .await
+                .unwrap()
+                .is_none(),
+            "an untrusted owner's repo must not be auto-registered"
+        );
     }
 
     /// When the App is unconfigured the auto-register step is inert: the v1

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -23,6 +23,7 @@ pub mod ide;
 pub mod loom_config;
 pub mod monitor;
 pub mod overlooker;
+pub mod owners;
 pub mod repo;
 pub mod repo_env;
 pub mod server;

--- a/crates/loom/src/loom_config.rs
+++ b/crates/loom/src/loom_config.rs
@@ -41,6 +41,12 @@ pub struct LoomConfig {
     pub domain: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner_github: Option<String>,
+    /// Extra GitHub accounts (orgs or users), comma/space-separated, whose App
+    /// installations loom should trust — the bootstrap trusted-owner allowlist.
+    /// The deploy `owner_github` is always trusted; this adds the orgs you run
+    /// loom for. Keeps a public App from honoring a stranger's installation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_owners: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_app_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -99,6 +105,12 @@ pub static FIELDS: &[FieldSpec] = &[
         secret: false,
         get_fn: |c| c.owner_github.as_deref(),
         set_fn: |c, v| c.owner_github = Some(v),
+    },
+    FieldSpec {
+        env_name: "LOOM_ALLOWED_OWNERS",
+        secret: false,
+        get_fn: |c| c.allowed_owners.as_deref(),
+        set_fn: |c, v| c.allowed_owners = Some(v),
     },
     FieldSpec {
         env_name: "LOOM_GITHUB_APP_ID",

--- a/crates/loom/src/owners.rs
+++ b/crates/loom/src/owners.rs
@@ -1,0 +1,210 @@
+//! The trusted-owner allowlist (`github_owners`): the GitHub accounts (orgs or
+//! users) loom is authorized to act for via the inbound trigger.
+//!
+//! This exists to make loom's GitHub App safe to run **public**. GitHub only lets
+//! a *private* App be installed on the account that owns it, so anyone wiring loom
+//! up across an account boundary (a personal App onto an org's repos) is pushed to
+//! flip the App public — at which point *anyone* can install it on their own
+//! repos. Loom's "an installation is a grant" rule ([`crate::github_app::
+//! GithubApp::ensure_installed_repo_registered`]) was only sound while the App was
+//! private; once public it would auto-trust strangers. This allowlist re-anchors
+//! that trust in an explicit set of owners rather than in "an installation
+//! exists": a repo is auto-registered from its installation **only** when its
+//! owner is listed here.
+//!
+//! The list is bootstrapped from `loom.toml` / the environment ([`crate::db`]'s
+//! `seed_owners`) and extended by an operator through the web flow (`POST
+//! /api/github/owners`). Logins are matched case-insensitively (the column is
+//! `COLLATE NOCASE`), as GitHub logins are.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use sqlx::Row;
+
+use crate::db::Db;
+
+/// One trusted owner — a GitHub account login loom will act for.
+#[derive(Debug, Clone, Serialize)]
+pub struct Owner {
+    pub login: String,
+    pub created_at: String,
+}
+
+/// A GitHub login is `[A-Za-z0-9-]`, 1–39 chars, no leading/trailing hyphen. We
+/// only enforce the charset and length (enough to keep junk out of the
+/// allowlist); GitHub is the authority on whether the account exists.
+pub fn valid_login(login: &str) -> bool {
+    let login = login.trim();
+    !login.is_empty()
+        && login.len() <= 39
+        && !login.starts_with('-')
+        && !login.ends_with('-')
+        && login.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
+/// Split a comma/whitespace-separated owner list (the `LOOM_ALLOWED_OWNERS`
+/// form) into individual trimmed, non-empty logins.
+pub fn split_logins(raw: &str) -> impl Iterator<Item = &str> {
+    raw.split([',', ' ', '\t', '\n', '\r'])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+/// Every trusted owner, newest first.
+pub async fn list(db: &Db) -> Result<Vec<Owner>> {
+    let rows =
+        sqlx::query("SELECT login, created_at FROM github_owners ORDER BY created_at DESC, login")
+            .fetch_all(db)
+            .await
+            .context("listing trusted owners")?;
+    Ok(rows
+        .into_iter()
+        .map(|r| Owner {
+            login: r.get("login"),
+            created_at: r.get("created_at"),
+        })
+        .collect())
+}
+
+/// Whether `login` is a trusted owner (case-insensitive). An empty/malformed
+/// login is never trusted.
+pub async fn is_allowed(db: &Db, login: &str) -> Result<bool> {
+    let login = login.trim();
+    if login.is_empty() {
+        return Ok(false);
+    }
+    let row = sqlx::query("SELECT 1 AS one FROM github_owners WHERE login = ?")
+        .bind(login)
+        .fetch_optional(db)
+        .await
+        .context("checking the trusted-owner allowlist")?;
+    Ok(row.is_some())
+}
+
+/// Add a trusted owner. Returns the stored row. Idempotent-ish: adding an
+/// existing login (any case) is an error from the caller's view only if you
+/// need the insert to be new; here we upsert-by-ignore then read it back.
+pub async fn add(db: &Db, login: &str) -> Result<Owner> {
+    let login = login.trim();
+    if !valid_login(login) {
+        anyhow::bail!("'{login}' is not a valid GitHub login");
+    }
+    sqlx::query("INSERT OR IGNORE INTO github_owners (login) VALUES (?)")
+        .bind(login)
+        .execute(db)
+        .await
+        .with_context(|| format!("adding trusted owner '{login}'"))?;
+    get(db, login)
+        .await?
+        .with_context(|| format!("trusted owner '{login}' vanished after insert"))
+}
+
+/// Read one owner back by login (case-insensitive), if present.
+pub async fn get(db: &Db, login: &str) -> Result<Option<Owner>> {
+    let row = sqlx::query("SELECT login, created_at FROM github_owners WHERE login = ?")
+        .bind(login.trim())
+        .fetch_optional(db)
+        .await
+        .context("reading a trusted owner")?;
+    Ok(row.map(|r| Owner {
+        login: r.get("login"),
+        created_at: r.get("created_at"),
+    }))
+}
+
+/// Remove a trusted owner. Returns whether a row was deleted.
+pub async fn remove(db: &Db, login: &str) -> Result<bool> {
+    let res = sqlx::query("DELETE FROM github_owners WHERE login = ?")
+        .bind(login.trim())
+        .execute(db)
+        .await
+        .with_context(|| format!("removing trusted owner '{login}'"))?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Seed one login into the allowlist (`INSERT OR IGNORE`), skipping anything
+/// malformed so a stray value in the bootstrap list can't fail startup.
+pub async fn seed(db: &Db, login: &str) -> Result<()> {
+    let login = login.trim();
+    if !valid_login(login) {
+        tracing::warn!(login, "ignoring malformed bootstrap owner login");
+        return Ok(());
+    }
+    sqlx::query("INSERT OR IGNORE INTO github_owners (login) VALUES (?)")
+        .bind(login)
+        .execute(db)
+        .await
+        .with_context(|| format!("seeding trusted owner '{login}'"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn db() -> Db {
+        crate::db::connect_in_memory().await.unwrap()
+    }
+
+    #[test]
+    fn valid_login_rules() {
+        assert!(valid_login("acme"));
+        assert!(valid_login("My-Org-1"));
+        assert!(!valid_login(""));
+        assert!(!valid_login("-lead"));
+        assert!(!valid_login("trail-"));
+        assert!(!valid_login("has space"));
+        assert!(!valid_login("bad/slug"));
+    }
+
+    #[test]
+    fn split_logins_splits_on_comma_and_space() {
+        let got: Vec<&str> = split_logins(" acme, widgets  co\nother ").collect();
+        assert_eq!(got, vec!["acme", "widgets", "co", "other"]);
+    }
+
+    #[tokio::test]
+    async fn add_list_remove_roundtrip() {
+        let db = db().await;
+        add(&db, "acme").await.unwrap();
+        add(&db, "widgets").await.unwrap();
+        let logins: Vec<String> = list(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|o| o.login)
+            .collect();
+        assert!(logins.contains(&"acme".to_string()));
+        assert!(logins.contains(&"widgets".to_string()));
+        assert!(remove(&db, "acme").await.unwrap());
+        assert!(!remove(&db, "acme").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn is_allowed_is_case_insensitive() {
+        let db = db().await;
+        add(&db, "Acme").await.unwrap();
+        assert!(is_allowed(&db, "acme").await.unwrap());
+        assert!(is_allowed(&db, "ACME").await.unwrap());
+        assert!(!is_allowed(&db, "widgets").await.unwrap());
+        assert!(!is_allowed(&db, "").await.unwrap());
+        // A second add differing only in case does not create a duplicate row.
+        add(&db, "acme").await.unwrap();
+        let acme_rows = list(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|o| o.login.eq_ignore_ascii_case("acme"))
+            .count();
+        assert_eq!(acme_rows, 1);
+    }
+
+    #[tokio::test]
+    async fn seed_ignores_malformed() {
+        let db = db().await;
+        seed(&db, "good-org").await.unwrap();
+        seed(&db, "bad slug").await.unwrap(); // ignored, not an error
+        assert!(is_allowed(&db, "good-org").await.unwrap());
+        assert!(!is_allowed(&db, "bad slug").await.unwrap());
+    }
+}

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -575,6 +575,10 @@ pub fn router(state: AppState) -> Router {
         .route("/agents", get(list_agents))
         // The managed repo store + clone allowlist (register/list).
         .route("/repos", get(list_repos).post(register_repo))
+        // The trusted-owner allowlist — GitHub accounts loom will act for via the
+        // inbound trigger (keeps a public App from trusting a stranger's install).
+        .route("/github/owners", get(list_owners).post(add_owner))
+        .route("/github/owners/{login}", delete(remove_owner))
         .route("/repos/recent", get(recent_repos))
         .route("/repos/branches", get(repo_branches))
         .route(

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -91,9 +91,16 @@ pub(super) async fn add_owner(
     State(st): State<AppState>,
     Json(req): Json<AddOwnerReq>,
 ) -> ApiResult<Json<owners::Owner>> {
-    let owner = owners::add(&st.db, &req.login)
-        .await
-        .map_err(|e| AppError::bad_request(e.to_string()))?;
+    // A malformed login is a client error (400); a storage failure from `add`
+    // then surfaces as 500 via `?`, so operators can tell a bad request apart
+    // from a server problem.
+    if !owners::valid_login(&req.login) {
+        return Err(AppError::bad_request(format!(
+            "'{}' is not a valid GitHub login",
+            req.login.trim()
+        )));
+    }
+    let owner = owners::add(&st.db, &req.login).await?;
     Ok(Json(owner))
 }
 

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -12,6 +12,7 @@ use weaver_api::CreateReq;
 
 use crate::git;
 use crate::github_trigger;
+use crate::owners;
 use crate::repo;
 
 use super::auth::external_base;
@@ -64,6 +65,48 @@ pub(super) async fn register_repo(
     let managed =
         repo::register(&st.db, &slug.slug(), &remote_url, &path.to_string_lossy()).await?;
     Ok(Json(managed))
+}
+
+// ---------------------------------------------------------------------------
+// Trusted-owner allowlist — the GitHub accounts loom will act for via the
+// inbound trigger. See `crate::owners`: this is what keeps a *public* GitHub App
+// from letting a stranger's installation drive loom.
+// ---------------------------------------------------------------------------
+
+/// `GET /api/github/owners` — the trusted-owner allowlist.
+pub(super) async fn list_owners(State(st): State<AppState>) -> ApiResult<Json<Vec<owners::Owner>>> {
+    Ok(Json(owners::list(&st.db).await?))
+}
+
+/// Body for `POST /api/github/owners`: a GitHub account login (org or user) to
+/// trust.
+#[derive(Debug, Deserialize)]
+pub(super) struct AddOwnerReq {
+    login: String,
+}
+
+/// `POST /api/github/owners` — trust a GitHub account. Idempotent: re-adding an
+/// existing login (any case) returns the stored row.
+pub(super) async fn add_owner(
+    State(st): State<AppState>,
+    Json(req): Json<AddOwnerReq>,
+) -> ApiResult<Json<owners::Owner>> {
+    let owner = owners::add(&st.db, &req.login)
+        .await
+        .map_err(|e| AppError::bad_request(e.to_string()))?;
+    Ok(Json(owner))
+}
+
+/// `DELETE /api/github/owners/{login}` — stop trusting a GitHub account.
+pub(super) async fn remove_owner(
+    State(st): State<AppState>,
+    axum::extract::Path(login): axum::extract::Path<String>,
+) -> ApiResult<StatusCode> {
+    if owners::remove(&st.db, &login).await? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AppError::not_found("owner"))
+    }
 }
 
 /// `POST /api/github/webhook` — the inbound GitHub trigger (shared-loom design

--- a/crates/loom/tests/integration/repos.rs
+++ b/crates/loom/tests/integration/repos.rs
@@ -163,3 +163,53 @@ async fn create_rejects_traversal_and_unregistered_repos() {
         "register traversal should 400, got {err}"
     );
 }
+
+/// The trusted-owner allowlist over the REST API: add, list, remove, and reject a
+/// malformed login. The deploy owner is seeded, so a freshly-added owner appears
+/// alongside it.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_owners_crud() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    // Add an owner.
+    let added = client
+        .post("/api/github/owners", json!({ "login": "acme" }))
+        .await
+        .unwrap();
+    assert_eq!(added["login"], "acme");
+
+    // It appears in the list (alongside the seeded deploy owner).
+    let list = client.get("/api/github/owners").await.unwrap();
+    let logins: Vec<&str> = list
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|o| o["login"].as_str().unwrap())
+        .collect();
+    assert!(
+        logins.contains(&"acme"),
+        "acme should be listed, got {logins:?}"
+    );
+
+    // A malformed login is a 400.
+    let err = client
+        .post("/api/github/owners", json!({ "login": "bad owner" }))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("400"), "malformed login should 400, got {err}");
+
+    // Remove it; a second remove is a 404.
+    client.delete("/api/github/owners/acme").await.unwrap();
+    let err = client
+        .delete("/api/github/owners/acme")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("404"),
+        "removing a missing owner should 404, got {err}"
+    );
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -85,7 +85,8 @@ and why; you don't hand-edit `.env` itself.
 | Variable | Required | Purpose |
 |---|---|---|
 | `LOOM_DOMAIN` | **yes** | Public domain Caddy serves and gets a cert for (e.g. `loom.team.dev`); `localhost` for local testing. Also seeded as `auth.base_url`. |
-| `LOOM_OWNER_GITHUB` | **yes** | GitHub login seeded as the first approved user on a fresh database. |
+| `LOOM_OWNER_GITHUB` | **yes** | GitHub login seeded as the first approved user on a fresh database. Also seeded as the first trusted owner for the `@loom` trigger. |
+| `LOOM_ALLOWED_OWNERS` | for `@loom` | Extra GitHub accounts (orgs or users), comma/space-separated, whose App installations the trigger will act for. Only repos owned by a trusted owner are auto-trusted — the safeguard that lets the App be public. Extend later in **Settings → Authorized GitHub owners**. |
 | `GH_TOKEN` | **yes** | GitHub token loom uses to clone private repos, push branches, and reply to `@loom` comments. |
 | `LOOM_GITHUB_WEBHOOK_SECRET` | for `@loom` | Shared secret for the inbound webhook; must match the secret on the GitHub webhook. Until set, the webhook rejects every delivery. |
 | `ANTHROPIC_API_KEY` | for Claude | API key for the Claude agents. Alternatively log in interactively (see [first-run](#claude-authentication)). |

--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -30,8 +30,15 @@ HOST_GID=1000
 
 # ── Team owner ────────────────────────────────────────────────────────────────
 # GitHub login seeded as the first approved user on a fresh database. This is the
-# only account that can log in until it approves others.
+# only account that can log in until it approves others. Also seeded as the first
+# trusted owner for the `@loom` trigger.
 LOOM_OWNER_GITHUB=your-github-login
+
+# GitHub accounts (orgs or users), comma/space-separated, whose App installations
+# the `@loom` trigger will act for — the safeguard that lets the App be public:
+# only repos owned by a trusted owner are auto-trusted. `LOOM_OWNER_GITHUB` is
+# always trusted; add the orgs you run loom for. Extend later in the UI.
+# LOOM_ALLOWED_OWNERS=your-org, your-other-org
 
 # ── Credentials the agents and integrations need ──────────────────────────────
 # A GitHub token loom uses to clone private repos, push branches, and reply to

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -74,8 +74,8 @@ Until `LOOM_GITHUB_WEBHOOK_SECRET` is set the endpoint rejects every delivery
 
 The trigger only acts on allowlisted repos. A repo is allowlisted when **either**
 it is registered in the managed repo store **or** the [GitHub App](#the-github-app)
-is installed on it (the installation *is* the grant — installing the App on a repo
-authorizes it, and loom auto-registers it into the store on first trigger).
+is installed on it **and** its owner is a [trusted owner](#trusted-owner-allowlist)
+— in which case loom auto-registers it into the store on first trigger.
 
 Register a repo explicitly with:
 
@@ -84,8 +84,31 @@ curl -X POST {base}/api/repos -H 'Authorization: Bearer $LOOM_TOKEN' \
   -H 'content-type: application/json' -d '{"repo":"owner/name"}'
 ```
 
-A comment on a repo that is neither registered nor App-installed launches
-nothing.
+A comment on a repo that is neither registered nor an App-installed repo under a
+trusted owner launches nothing.
+
+### Trusted-owner allowlist
+
+An installation counts as a grant only when the installing account is a **trusted
+owner** — a GitHub org or user in the `github_owners` allowlist. This is what makes
+the App safe to run **public**: GitHub only lets a *private* App be installed on
+the account that owns it, so wiring loom across an account boundary pushes you to
+make the App public, at which point anyone can install it. Anchoring auto-trust in
+an explicit owner list — rather than in "an installation exists" — keeps a
+stranger's installation from ever auto-registering their repo.
+
+The list is seeded at first run from the deploy owner (`LOOM_OWNER_GITHUB`) plus
+`LOOM_ALLOWED_OWNERS` (comma/space-separated), and the setup wizard adds the
+account the App was created under. Operators manage it in **Settings → Authorized
+GitHub owners** or over the API:
+
+```sh
+curl -X POST {base}/api/github/owners -H 'Authorization: Bearer $LOOM_TOKEN' \
+  -H 'content-type: application/json' -d '{"login":"your-org"}'
+```
+
+Explicitly registering a repo (`POST /api/repos`) is unaffected — that is an
+operator's deliberate act, already gated by the operator allowlist.
 
 ### Optional settings
 
@@ -101,9 +124,10 @@ A **GitHub App** is the hardened identity loom acts through. Instead of a
 long-lived, broadly-scoped shared `GH_TOKEN`, loom mints a **short-lived,
 least-privilege installation token** scoped to a single repo's installation for
 each GitHub call (the permission check and the reply), and treats the App's
-installations as the access allowlist. Tokens are signed from the App's private
-key (an RS256 JWT exchanged for an installation token via
-`POST /app/installations/{id}/access_tokens`) and cached until they near expiry.
+installations under a [trusted owner](#trusted-owner-allowlist) as the access
+allowlist. Tokens are signed from the App's private key (an RS256 JWT exchanged
+for an installation token via `POST /app/installations/{id}/access_tokens`) and
+cached until they near expiry.
 
 When the App is **not configured**, loom falls back to the ambient `GH_TOKEN`
 (the `gh` CLI), so the webhook works without it. The webhook receiver and its

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -20,6 +20,15 @@ domain = "loom.example.com"
 # the only account that can log in until it approves others.
 owner_github = "your-github-login"
 
+# GitHub accounts (orgs or users) whose App installations the inbound trigger
+# will act for — the bootstrap trusted-owner allowlist, comma/space-separated.
+# `owner_github` is always trusted; add the orgs whose repos you run loom for.
+# This is what keeps a *public* GitHub App from honoring a stranger's install:
+# only repos owned by a listed account are auto-trusted. `loom setup github-app`
+# adds the account the App was created under. Extend it later in the UI
+# (Settings → Authorized GitHub owners).
+# allowed_owners = "your-org, your-other-org"
+
 # The GitHub App loom acts through (webhook receiver, REST identity, and
 # "Sign in with GitHub"). `loom setup github-app` fills these four in for
 # you — hand-typing the private key PEM is impractical, so leave them unset


### PR DESCRIPTION
## Why

GitHub only lets a **private** App be installed on the account that owns it. Wiring loom across an account boundary (a personal App onto an org's repos) therefore pushes an operator to make the App **public** — at which point *anyone* can install it on their own repos.

Loom's "an installation is a grant" rule (`ensure_installed_repo_registered`) was only sound while the App was private: it auto-registers any App-installed repo into the clone allowlist. Once the App is public, a stranger who installs it on their own repo would pass every trigger gate (they have admin on their own repo, and the installation auto-allowlists it) and get loom to clone and run agents on their repo — on your server, with your credits.

## What

Anchor auto-trust in an explicit **trusted-owner allowlist** instead of in "an installation exists": an App-installed repo is auto-registered **only when its owner is a listed owner**. Explicit `POST /api/repos` registration is unchanged — that's an operator's deliberate act, already gated by the operator allowlist.

- **`github_owners` table** (`login COLLATE NOCASE`), seeded at first run from `LOOM_OWNER_GITHUB` + the new `LOOM_ALLOWED_OWNERS` (comma/space-separated). Fails closed like `seed_owner` (#107) — no default login. The setup wizard also live-seeds the account the App was created under (`owner_login`, which is the org for `--org`).
- **`owners` module** — `list/add/remove/is_allowed/seed`, plus web CRUD at `GET/POST/DELETE /api/github/owners` under `require_auth`.
- **The gate** — `ensure_installed_repo_registered` returns early unless the owner `is_allowed`, failing closed on error.
- **UI** — "Authorized GitHub owners" section in Settings (`AccountPanel.vue`), mirroring the operator-allowlist block.
- **Docs** — `docs/github-trigger.md` (new *Trusted-owner allowlist* section; qualified the "installation is the allowlist" claims), `deploy/README.md`, `loom.toml.example`, standalone `.env.example`.

## Tests

- `owners` unit tests: case-insensitivity, dedup, malformed-login rejection, seed-skips-malformed.
- Gate tests in `github_app`: a trusted owner's installed repo auto-registers; an **untrusted** owner's does not.
- `github_owners_crud` integration test over the REST API (add / list / reject malformed / remove / 404 on re-remove).

## Operator note

Since the allowlist now fails closed, make sure the account owning your repos is trusted: `LOOM_OWNER_GITHUB` covers your own login; add orgs via `LOOM_ALLOWED_OWNERS`, **Settings → Authorized GitHub owners**, or by re-running `loom setup github-app` (it live-seeds the App's owning account).
