### PR TITLE
feat(loom): reflect the single GitHub App in settings; gate vue-tsc

### DIFF
--- a/crates/loom/frontend/package-lock.json
+++ b/crates/loom/frontend/package-lock.json
@@ -34,7 +34,8 @@
         "postcss-loader": "^8.2.1",
         "rspack-vue-loader": "^17.5.0",
         "tailwindcss": "^4.2.1",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vue-tsc": "^3.3.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1138,6 +1139,35 @@
         "d3-transition": "^3.0.1"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.35",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
@@ -1193,6 +1223,22 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.6.tgz",
+      "integrity": "sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.0",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.35",
@@ -1297,6 +1343,13 @@
       "workspaces": [
         "addons/*"
       ]
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -2605,6 +2658,13 @@
         "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -2661,6 +2721,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -2672,6 +2739,19 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
@@ -2944,6 +3024,13 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue": {
       "version": "3.5.35",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
@@ -2978,6 +3065,23 @@
       },
       "peerDependencies": {
         "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.6.tgz",
+      "integrity": "sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.6"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     }
   }

--- a/crates/loom/frontend/package.json
+++ b/crates/loom/frontend/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "build": "rspack build --mode production",
-    "dev": "rspack serve --mode development"
+    "dev": "rspack serve --mode development",
+    "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
@@ -34,6 +35,7 @@
     "postcss-loader": "^8.2.1",
     "rspack-vue-loader": "^17.5.0",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vue-tsc": "^3.3.6"
   }
 }

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -297,10 +297,10 @@ export const addOwner = (login: string) =>
 export const removeOwner = (login: string) =>
   del(`/github/owners/${encodeURIComponent(login)}`);
 
-/** The GitHub OAuth app config (secret withheld). */
+/** The GitHub App / sign-in config (secret withheld). */
 export const getGithubConfig = () => get('/auth/github/config') as Promise<GithubConfig>;
 
-/** Set the OAuth client id, and optionally the secret (omit to leave it). */
+/** Set the sign-in OAuth client id, and optionally the secret (omit to leave it). */
 export const setGithubConfig = (clientId: string, clientSecret?: string) =>
   put('/auth/github/config', {
     client_id: clientId,

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import * as api from '../api';
 import { me, doLogout } from '../auth';
 import type { User, Owner, GithubConfig } from '../types';
 
 // Account + access management: who you are, your password, the approved-user
-// allowlist, and the GitHub OAuth app config that powers "Continue with GitHub".
+// allowlist, and the single GitHub App that backs loom — its OAuth client powers
+// "Continue with GitHub", and the same App drives the `@loom` trigger.
 const router = useRouter();
 const error = ref('');
 const notice = ref('');
@@ -141,10 +142,20 @@ async function removeOwner(o: Owner) {
   }
 }
 
-// -- GitHub OAuth app -------------------------------------------------------
+// -- GitHub App -------------------------------------------------------------
+// One GitHub App backs loom: its OAuth client id/secret power "Continue with
+// GitHub", and the same App's id + private key power the `@loom` trigger. The
+// usual way to set it up is `loom setup github-app`; the id/secret below stay
+// editable for the manual path (or a login-only classic OAuth app).
 const gh = ref<GithubConfig | null>(null);
 const ghClientId = ref('');
 const ghClientSecret = ref('');
+
+// The App's public GitHub page, when we know its slug (recorded by
+// `loom setup github-app`). A hand-configured App has an id but no slug.
+const appUrl = computed(() =>
+  gh.value?.app_slug ? `https://github.com/apps/${gh.value.app_slug}` : '',
+);
 
 async function loadGithub() {
   try {
@@ -238,15 +249,49 @@ onMounted(() => {
       </div>
     </section>
 
-    <!-- GitHub sign-in -->
+    <!-- GitHub App -->
     <section>
       <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
-        GitHub sign-in
+        GitHub App
       </h2>
       <div class="rounded-md border border-line bg-surface px-3 py-2.5">
+        <!-- App identity: one App powers both sign-in and the @loom trigger. -->
+        <div v-if="gh?.app_configured" class="mb-2">
+          <p class="text-sm">
+            <span class="text-accent">✓</span>
+            <a
+              v-if="appUrl"
+              :href="appUrl"
+              target="_blank"
+              rel="noopener"
+              class="font-medium text-accent hover:underline"
+              >{{ gh.app_slug }}</a
+            >
+            <span v-else class="font-medium">GitHub App</span>
+            <span class="text-faint"> · App ID {{ gh.app_id }}</span>
+          </p>
+          <p class="text-xs text-muted mt-0.5">
+            One GitHub App powers both sign-in and the <code class="font-mono">@loom</code>
+            trigger. Manage it with <code class="font-mono">loom setup github-app</code>.
+          </p>
+        </div>
+        <p v-else class="text-xs text-muted mb-2">
+          No GitHub App configured. Run
+          <code class="font-mono">loom setup github-app --base-url &lt;your loom URL&gt;</code>
+          to register one — it wires up sign-in and the <code class="font-mono">@loom</code>
+          trigger in a single step. You can also paste sign-in credentials manually below.
+        </p>
+
+        <!-- Sign-in (OAuth) credentials: the App's OAuth client, editable for
+             the manual path or a login-only classic OAuth app. -->
+        <p class="text-2xs font-semibold uppercase tracking-wider text-muted mt-3 mb-1">
+          Sign-in credentials
+        </p>
         <p class="text-xs text-muted mb-2">
-          Register an OAuth app on GitHub with the callback
-          <code class="font-mono">{{ gh?.callback_path }}</code>, then paste its id and secret.
+          <template v-if="gh?.app_configured">The same App's</template>
+          <template v-else>The</template>
+          OAuth client, with callback
+          <code class="font-mono">{{ gh?.callback_path }}</code>. Powers "Continue with GitHub".
           <span :class="gh?.configured ? 'text-accent' : 'text-faint'">
             {{ gh?.configured ? 'Configured.' : 'Not configured.' }}
           </span>

--- a/crates/loom/frontend/src/components/AgentTerminal.vue
+++ b/crates/loom/frontend/src/components/AgentTerminal.vue
@@ -216,7 +216,7 @@ function wsUrl(): string {
   return `${base}${path}`;
 }
 
-function inputFrame(data: string): Uint8Array {
+function inputFrame(data: string): Uint8Array<ArrayBuffer> {
   const bytes = new TextEncoder().encode(data);
   const out = new Uint8Array(bytes.length + 1);
   out[0] = OP_INPUT;
@@ -224,7 +224,7 @@ function inputFrame(data: string): Uint8Array {
   return out;
 }
 
-function resizeFrame(cols: number, rows: number): Uint8Array {
+function resizeFrame(cols: number, rows: number): Uint8Array<ArrayBuffer> {
   const b = new Uint8Array(5);
   b[0] = OP_RESIZE;
   b[1] = (cols >> 8) & 0xff;
@@ -234,7 +234,7 @@ function resizeFrame(cols: number, rows: number): Uint8Array {
   return b;
 }
 
-function sendOpen(buf: Uint8Array) {
+function sendOpen(buf: Uint8Array<ArrayBuffer>) {
   if (ws && ws.readyState === WebSocket.OPEN) ws.send(buf);
 }
 

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -522,7 +522,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
         type="button"
         class="btn-secondary shrink-0 px-2 py-0.5 text-xs"
         :disabled="state === 'loading'"
-        @click="load"
+        @click="load()"
       >
         Refresh
       </button>

--- a/crates/loom/frontend/src/env.d.ts
+++ b/crates/loom/frontend/src/env.d.ts
@@ -4,6 +4,14 @@ declare module '*.vue' {
   export default component;
 }
 
+// Side-effect style imports carry no types: our own global stylesheet and
+// xterm's bundled CSS (`*.css`), plus the pure-CSS `@fontsource` packages the
+// entrypoint pulls in for the app fonts. The bundler (rspack) turns these into
+// real assets; here they only need to type-check as opaque modules.
+declare module '*.css';
+declare module '@fontsource/*';
+declare module '@fontsource-variable/*';
+
 // markdown-it-task-lists ships no type declarations; it's a standard
 // markdown-it plugin (a `PluginWithOptions`-shaped function).
 declare module 'markdown-it-task-lists' {

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -532,11 +532,19 @@ export interface EnvVar {
   updated_at: string;
 }
 
-/** The GitHub OAuth app config (secret withheld). Mirrors `GithubConfigView`. */
+/**
+ * The GitHub App / sign-in config (secret withheld). Mirrors `GithubConfigView`.
+ * A single GitHub App backs loom: its OAuth client powers sign-in
+ * (`configured`/`client_id`), and the same App's id + private key power the
+ * `@loom` trigger (`app_configured`/`app_id`).
+ */
 export interface GithubConfig {
   configured: boolean;
   client_id: string;
   callback_path: string;
+  app_configured: boolean;
+  app_id: string;
+  app_slug: string;
 }
 
 // --- Conversation log (iris format) ----------------------------------------

--- a/crates/loom/src/auth.rs
+++ b/crates/loom/src/auth.rs
@@ -673,6 +673,15 @@ async fn env_or_setting(db: &Db, env: &str, key: &str) -> String {
     crate::config::get(db, key).await.unwrap_or_default()
 }
 
+/// The configured OAuth client id (env-or-settings), or an empty string when
+/// unset. The public half of the sign-in credential — shown in the settings UI.
+/// Resolved the same way as [`github_oauth`] so the two never disagree (a deploy
+/// that sets `LOOM_GITHUB_CLIENT_ID` in its env reports the live id, not a
+/// blank, even though nothing was written to the settings table).
+pub async fn oauth_client_id(db: &Db) -> String {
+    env_or_setting(db, "LOOM_GITHUB_CLIENT_ID", GH_CLIENT_ID_KEY).await
+}
+
 /// The GitHub OAuth app config, or `None` when sign-in-with-GitHub is not set
 /// up. Reads `LOOM_GITHUB_CLIENT_ID`/`_SECRET` first, then the settings table.
 pub async fn github_oauth(db: &Db) -> Option<GithubOAuth> {

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1332,6 +1332,7 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
     let allowed_owners = merged_allowed_owners(&opts.config.config, trusted_owner);
     let updates: Vec<(&str, &str)> = vec![
         ("LOOM_GITHUB_APP_ID", app_id.as_str()),
+        ("LOOM_GITHUB_APP_SLUG", conv.slug.as_str()),
         ("LOOM_GITHUB_APP_PRIVATE_KEY", conv.pem.as_str()),
         ("LOOM_GITHUB_WEBHOOK_SECRET", conv.webhook_secret.as_str()),
         ("LOOM_GITHUB_CLIENT_ID", conv.client_id.as_str()),

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -41,9 +41,11 @@ pub const APP_ID_KEY: &str = "github.app_id";
 /// Settings key (env-overridable) holding the App's RSA private key PEM. Like
 /// the OAuth client secret, this is **never** returned by `GET /api/settings`.
 pub const APP_PRIVATE_KEY_KEY: &str = "github.app_private_key";
-/// Settings key holding the App's URL slug (from the manifest conversion). Not
-/// used at runtime — recorded so `loom setup` can deep-link to the App's GitHub
-/// settings/install pages when updating an already-configured App.
+/// Settings key (env-overridable) holding the App's URL slug (e.g. `loom-acme`,
+/// from the manifest conversion). Public and non-secret. Read at runtime via
+/// [`app_slug`] so the settings view can name the App and link to
+/// `github.com/apps/{slug}`, and recorded so `loom setup` can deep-link to the
+/// App's GitHub settings/install pages when updating an already-configured App.
 pub const APP_SLUG_KEY: &str = "github.app_slug";
 /// Settings key holding the org login that owns the App, when it's an org-owned
 /// App (empty for a personal App). Together with [`APP_SLUG_KEY`] it picks the
@@ -113,6 +115,44 @@ impl CachedToken {
 }
 
 // ---------------------------------------------------------------------------
+// Configuration resolution (env-or-setting).
+//
+// These `db`-only resolvers are the single source of truth for "is the App
+// configured, and what is its public identity" — shared by the [`GithubApp`]
+// client (via the delegating methods below) and the settings view
+// ([`crate::web`]), so both agree on what the trigger will actually use.
+// ---------------------------------------------------------------------------
+
+/// The App id from `LOOM_GITHUB_APP_ID`, else the `github.app_id` setting;
+/// `None` when unset or non-numeric.
+pub async fn app_id(db: &Db) -> Option<i64> {
+    config_value(db, "LOOM_GITHUB_APP_ID", APP_ID_KEY)
+        .await?
+        .parse()
+        .ok()
+}
+
+/// The App private key PEM from `LOOM_GITHUB_APP_PRIVATE_KEY`, else the
+/// `github.app_private_key` setting; `None` when unset.
+pub async fn private_key(db: &Db) -> Option<String> {
+    config_value(db, "LOOM_GITHUB_APP_PRIVATE_KEY", APP_PRIVATE_KEY_KEY).await
+}
+
+/// The App slug from `LOOM_GITHUB_APP_SLUG`, else the `github.app_slug` setting;
+/// `None` when unset. Only `loom setup github-app` records it, so a
+/// hand-configured App may have the id and key set but no slug — callers fall
+/// back to the id.
+pub async fn app_slug(db: &Db) -> Option<String> {
+    config_value(db, "LOOM_GITHUB_APP_SLUG", APP_SLUG_KEY).await
+}
+
+/// Whether the App is fully configured (both id and private key present) — the
+/// switch between the App path and the `gh`-fallback path.
+pub async fn is_configured(db: &Db) -> bool {
+    app_id(db).await.is_some() && private_key(db).await.is_some()
+}
+
+// ---------------------------------------------------------------------------
 // The App client.
 // ---------------------------------------------------------------------------
 
@@ -158,22 +198,19 @@ impl GithubApp {
     /// The App id: `LOOM_GITHUB_APP_ID`, else the `github.app_id` setting; `None`
     /// when unset or non-numeric.
     pub async fn app_id(&self) -> Option<i64> {
-        config_value(&self.db, "LOOM_GITHUB_APP_ID", APP_ID_KEY)
-            .await?
-            .parse()
-            .ok()
+        app_id(&self.db).await
     }
 
     /// The App private key PEM: `LOOM_GITHUB_APP_PRIVATE_KEY`, else the
     /// `github.app_private_key` setting; `None` when unset.
     pub async fn private_key(&self) -> Option<String> {
-        config_value(&self.db, "LOOM_GITHUB_APP_PRIVATE_KEY", APP_PRIVATE_KEY_KEY).await
+        private_key(&self.db).await
     }
 
     /// Whether the App is fully configured (both id and private key present). The
     /// switch between the App path and the `gh`-fallback path.
     pub async fn is_configured(&self) -> bool {
-        self.app_id().await.is_some() && self.private_key().await.is_some()
+        is_configured(&self.db).await
     }
 
     /// A freshly-signed App JWT for the configured App.

--- a/crates/loom/src/loom_config.rs
+++ b/crates/loom/src/loom_config.rs
@@ -49,6 +49,11 @@ pub struct LoomConfig {
     pub allowed_owners: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_app_id: Option<String>,
+    /// The App's slug (e.g. `loom-acme`) — public, non-secret. Lets the settings
+    /// UI name the App and link to it; carried alongside the id so the env-based
+    /// deploy path surfaces it too.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_app_slug: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_app_private_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -117,6 +122,12 @@ pub static FIELDS: &[FieldSpec] = &[
         secret: false,
         get_fn: |c| c.github_app_id.as_deref(),
         set_fn: |c, v| c.github_app_id = Some(v),
+    },
+    FieldSpec {
+        env_name: "LOOM_GITHUB_APP_SLUG",
+        secret: false,
+        get_fn: |c| c.github_app_slug.as_deref(),
+        set_fn: |c, v| c.github_app_slug = Some(v),
     },
     FieldSpec {
         env_name: "LOOM_GITHUB_APP_PRIVATE_KEY",

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -440,7 +440,10 @@ pub(super) async fn remove_user(
     }
 }
 
-// -- GitHub OAuth app config -------------------------------------------------
+// -- GitHub App / sign-in config ---------------------------------------------
+// One GitHub App backs loom: its OAuth client powers sign-in (`configured` /
+// `client_id`), and the same App's id + private key power the `@loom` trigger
+// (`app_configured` / `app_id` / `app_slug`).
 
 async fn github_config_view(st: &AppState) -> ApiResult<GithubConfigView> {
     // Both the OAuth client id and the App identity are resolved env-or-settings
@@ -469,7 +472,8 @@ pub(super) async fn get_github_config(
     Ok(Json(github_config_view(&st).await?))
 }
 
-/// `PUT /api/auth/github/config` — set the OAuth app id (and, optionally, secret).
+/// `PUT /api/auth/github/config` — set the sign-in OAuth client id (and,
+/// optionally, its secret).
 pub(super) async fn put_github_config(
     State(st): State<AppState>,
     Json(body): Json<SetGithubConfigReq>,

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -443,13 +443,22 @@ pub(super) async fn remove_user(
 // -- GitHub OAuth app config -------------------------------------------------
 
 async fn github_config_view(st: &AppState) -> ApiResult<GithubConfigView> {
-    let client_id = config::get(&st.db, auth::GH_CLIENT_ID_KEY)
+    // Both the OAuth client id and the App identity are resolved env-or-settings
+    // (via `auth`/`github_app`), so an env-configured deploy reports its live
+    // values instead of blanks read from an empty settings table.
+    let app_id = crate::github_app::app_id(&st.db)
         .await
+        .map(|id| id.to_string())
         .unwrap_or_default();
     Ok(GithubConfigView {
         configured: auth::github_oauth(&st.db).await.is_some(),
-        client_id,
+        client_id: auth::oauth_client_id(&st.db).await,
         callback_path: GITHUB_CALLBACK_PATH.to_string(),
+        app_configured: crate::github_app::is_configured(&st.db).await,
+        app_id,
+        app_slug: crate::github_app::app_slug(&st.db)
+            .await
+            .unwrap_or_default(),
     })
 }
 

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -880,16 +880,31 @@ pub struct AddUserReq {
     pub password: Option<String>,
 }
 
-/// `GET /api/auth/github/config` — the GitHub sign-in setup, secret withheld.
+/// `GET /api/auth/github/config` — the GitHub App / sign-in setup, secret
+/// withheld. loom is driven by a single GitHub App (see [the GitHub
+/// trigger](../../../docs/github-trigger.md)): its OAuth client powers
+/// "Sign in with GitHub" (`configured`/`client_id`), and the same App's id and
+/// private key power the `@loom` trigger (`app_configured`/`app_id`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GithubConfigView {
     /// Whether both a client id and secret are present (sign-in is live).
     pub configured: bool,
-    /// The OAuth app's client id (public). Empty when unset.
+    /// The OAuth client id (public). Empty when unset. Read from env-or-settings,
+    /// so an env-configured deploy reports the live value, not a blank.
     pub client_id: String,
-    /// The callback path to register on the GitHub OAuth app
+    /// The callback path to register on the App's OAuth client
     /// (`/api/auth/github/callback`).
     pub callback_path: String,
+    /// Whether the App identity (id **and** private key) is configured — i.e.
+    /// the `@loom` trigger acts through the App rather than the ambient
+    /// `GH_TOKEN`. The same App normally backs sign-in above.
+    pub app_configured: bool,
+    /// The App's numeric id (public). Empty when unset.
+    pub app_id: String,
+    /// The App's slug (e.g. `loom-acme`), for its name and a
+    /// `github.com/apps/{slug}` link. Empty when unknown (e.g. a hand-configured
+    /// App, or one set up before the slug was recorded).
+    pub app_slug: String,
 }
 
 /// Body for `PUT /api/auth/github/config`. The secret is write-only — send it to

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Shared pre-commit / CI gate: formatting and lints must both pass.
+# Shared pre-commit / CI gate: Rust formatting + lints and the frontend
+# typecheck must all pass.
 #
 # This is the single source of truth for "is the tree clean?". It is run by:
 #   - the git pre-commit hook (.githooks/pre-commit), enabled per-clone with
@@ -27,4 +28,22 @@ fi
 echo "▶ cargo clippy --workspace --all-targets --locked -- -D warnings"
 cargo clippy --workspace --all-targets --locked -- -D warnings
 
-echo "✓ fmt + clippy clean"
+# Frontend typecheck (vue-tsc). The clippy step above compiled loom, whose
+# build.rs runs `npm install` — so node_modules is normally present by now; we
+# install it here only for a fresh or Rust-only checkout that skipped that
+# (build.rs writes a placeholder and skips install when npm is absent). Skipped
+# entirely when npm isn't installed, matching build.rs's tolerance — CI always
+# has npm, so the gate is still enforced there.
+frontend="crates/loom/frontend"
+if command -v npm >/dev/null 2>&1; then
+  echo "▶ vue-tsc --noEmit ($frontend)"
+  if [ ! -d "$frontend/node_modules" ]; then
+    echo "  installing frontend deps (npm install)…"
+    npm --prefix "$frontend" install
+  fi
+  npm --prefix "$frontend" run typecheck
+  echo "✓ fmt + clippy + typecheck clean"
+else
+  echo "▶ vue-tsc typecheck — skipped (npm not found)"
+  echo "✓ fmt + clippy clean"
+fi


### PR DESCRIPTION
## Why

The GitHub settings section (Settings → Account) told operators to *"Register an OAuth app on GitHub"* — a standalone app. But loom is driven by a **single GitHub App** (`loom setup github-app`) whose OAuth client *also* powers "Continue with GitHub". So an operator who deployed a GitHub App saw a confusing, seemingly-empty "OAuth app" that didn't match what they set up.

There was also a real bug: `client_id` was read from the **settings table only**, while the "Configured" badge read **env-or-settings**. A deploy that sets `LOOM_GITHUB_CLIENT_ID` via `.env` (the documented `render-env` path) therefore showed **"Configured" with a blank client id** — the "empty OAuth app" that prompted this.

## What

**Reflect the one App.**
- `GET /api/auth/github/config` now also returns `app_configured`, `app_id`, and `app_slug` (App name + `github.com/apps/{slug}` link). `client_id` and the App fields resolve **env-or-settings**, so an env/`.env` deploy reports live values, not blanks.
- `loom setup github-app` records the App slug (settings + `loom.toml` `LOOM_GITHUB_APP_SLUG`), so it flows through `render-env` to the daemon.
- The panel is rewritten as **"GitHub App"**: shows the App's name/id/link, explains it backs both sign-in and the `@loom` trigger, and reframes the client id/secret as *that App's* sign-in credentials (still editable for the manual / login-only path).

| Configured | Not configured |
|---|---|
| `✓ loom-acme · App ID 123456` + link; client id shows the env value | `loom setup github-app` guidance; manual fields |

**Fix + enforce the frontend typecheck** (`vue-tsc` was failing on pre-existing gaps and wasn't gated):
- Ambient module decls for `*.css` / `@fontsource(-variable)` imports; type the terminal frame buffers as `Uint8Array<ArrayBuffer>`; stop binding the click event into `load()`'s options arg.
- Add `vue-tsc` as a devDependency + `npm run typecheck`, and run it in `scripts/pre-commit.sh` (the shared git-hook + CI `lint` gate) so this can't regress.

## Testing
- `cargo fmt` + `cargo clippy --workspace --all-targets` + `vue-tsc --noEmit` — all clean (via `scripts/pre-commit.sh`).
- `cargo test -p loom` — green.
- Visual check via a temp Playwright spec: both the configured and not-configured panel states render correctly (env-configured `client_id` now displays).