### PR TITLE
feat(loom): per-user GitHub tokens + clone-a-repo from New Session

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -87,6 +87,29 @@ export const listRepos = () => get('/repos') as Promise<ManagedRepo[]>;
 export const registerRepo = (repo: string) =>
   post('/repos', { repo }) as Promise<ManagedRepo>;
 
+// --- Your GitHub token (per-user) ------------------------------------------
+
+/** Whether the signed-in user has set a personal GitHub token. The token itself
+ *  is write-only — set/cleared but never read back. */
+export interface GithubTokenStatus {
+  set: boolean;
+  updated_at: string | null;
+}
+
+/** Whether you've set a personal GitHub token (`GET /api/auth/github-token`). */
+export const getMyGithubToken = () =>
+  get('/auth/github-token') as Promise<GithubTokenStatus>;
+
+/** Set/replace your personal GitHub token, injected as GH_TOKEN into the
+ *  sessions you launch so your agents act as you (`PUT /api/auth/github-token`).
+ *  Returns the refreshed status (never the token). */
+export const setMyGithubToken = (token: string) =>
+  put('/auth/github-token', { token }) as Promise<GithubTokenStatus>;
+
+/** Clear your personal GitHub token; your sessions fall back to the shared
+ *  ambient token (`DELETE /api/auth/github-token`). */
+export const deleteMyGithubToken = () => del('/auth/github-token');
+
 interface RepoEnvEnvelope {
   repo_root: string;
   env: RepoEnvVar[];

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -48,6 +48,51 @@ async function savePassword() {
   }
 }
 
+// -- Your GitHub token ------------------------------------------------------
+// A personal fine-grained PAT, injected as GH_TOKEN into the sessions this user
+// launches, so their agents' `git push` / `gh` act as them (not the shared
+// ambient token). Write-only: we render only whether it's set, never the value.
+const PAT_CREATE_URL = 'https://github.com/settings/personal-access-tokens/new';
+const ghToken = ref('');
+const ghTokenStatus = ref<api.GithubTokenStatus | null>(null);
+
+async function loadMyGithubToken() {
+  try {
+    ghTokenStatus.value = await api.getMyGithubToken();
+  } catch (e) {
+    fail(e);
+  }
+}
+
+async function saveMyGithubToken() {
+  if (!ghToken.value.trim()) return;
+  busy.value = true;
+  try {
+    ghTokenStatus.value = await api.setMyGithubToken(ghToken.value.trim());
+    ghToken.value = '';
+    ok('GitHub token saved — your new sessions will act as you.');
+  } catch (e) {
+    fail(e);
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function clearMyGithubToken() {
+  if (!confirm('Remove your GitHub token? Your sessions will fall back to the shared token.'))
+    return;
+  busy.value = true;
+  try {
+    await api.deleteMyGithubToken();
+    ghTokenStatus.value = { set: false, updated_at: null };
+    ok('GitHub token removed.');
+  } catch (e) {
+    fail(e);
+  } finally {
+    busy.value = false;
+  }
+}
+
 // -- Approved users ---------------------------------------------------------
 const users = ref<User[]>([]);
 const newUser = ref('');
@@ -190,6 +235,7 @@ async function logout() {
 }
 
 onMounted(() => {
+  loadMyGithubToken();
   loadUsers();
   loadOwners();
   loadGithub();
@@ -244,6 +290,51 @@ onMounted(() => {
             @click="savePassword"
           >
             Update
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Your GitHub token -->
+    <section>
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
+        Your GitHub token
+      </h2>
+      <div class="rounded-md border border-line bg-surface px-3 py-2.5">
+        <p class="text-xs text-muted mb-2">
+          A fine-grained token your sessions use for <code class="font-mono">git push</code> and
+          <code class="font-mono">gh</code>, so your agents act as you.
+          <a class="text-accent underline" :href="PAT_CREATE_URL" target="_blank" rel="noopener">
+            Create one</a>
+          with <span class="font-medium">Contents</span> and
+          <span class="font-medium">Pull requests</span> read/write on the repos you work in.
+          <span :class="ghTokenStatus?.set ? 'text-accent' : 'text-faint'">
+            {{ ghTokenStatus?.set ? 'Set.' : 'Not set — sessions use the shared token.' }}
+          </span>
+        </p>
+        <div class="flex flex-wrap items-center gap-2">
+          <input
+            v-model="ghToken"
+            type="password"
+            autocomplete="off"
+            placeholder="github_pat_…"
+            class="flex-1 rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+            @keyup.enter="saveMyGithubToken"
+          />
+          <button
+            class="btn-primary px-3 py-1.5 text-xs"
+            :disabled="busy || !ghToken.trim()"
+            @click="saveMyGithubToken"
+          >
+            Save
+          </button>
+          <button
+            v-if="ghTokenStatus?.set"
+            class="btn-secondary px-2.5 py-1 text-xs"
+            :disabled="busy"
+            @click="clearMyGithubToken"
+          >
+            Clear
           </button>
         </div>
       </div>

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { get, post, listAgents } from '../api';
-import type { Session, RecentRepo, RepoBranch, AgentMetadata } from '../types';
+import { get, post, listAgents, listRepos, registerRepo } from '../api';
+import type { Session, RecentRepo, RepoBranch, AgentMetadata, ManagedRepo } from '../types';
 import StatusBadge from '../components/StatusBadge.vue';
 import SignalChip from '../components/SignalChip.vue';
 import IdleChip from '../components/IdleChip.vue';
@@ -234,11 +234,59 @@ function repoName(path: string): string {
   return path.replace(/\/+$/, '').split('/').pop() || path;
 }
 
+// Registered managed repos (the clone allowlist). Loaded once on mount so the
+// form can both offer them and tell when a typed slug still needs registering.
+const managedRepos = ref<ManagedRepo[]>([]);
+async function loadManagedRepos() {
+  try {
+    managedRepos.value = await listRepos();
+  } catch {
+    // The managed-repo suggestions are a convenience; ignore failures here.
+  }
+}
+
+// A GitHub `owner/name` slug or a clone URL — something loom can register and
+// clone, as opposed to a local path that already exists on the server.
+const REPO_SLUG = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
+function looksLikeRemoteRepo(s: string): boolean {
+  const q = s.trim();
+  return REPO_SLUG.test(q) || /^https?:\/\//.test(q) || q.startsWith('git@');
+}
+
+// The typed repo when it's a remote ref we could clone and isn't registered yet
+// — the target of the "add & clone" affordance. Empty otherwise.
+const cloneCandidate = computed(() => {
+  const q = repo.value.trim();
+  if (!looksLikeRemoteRepo(q)) return '';
+  const known = managedRepos.value.some((r) => r.slug === q || r.remote_url === q);
+  return known ? '' : q;
+});
+
 // Recently-used repos, narrowed to those matching what the user has typed.
 const repoMatches = computed(() => {
   const q = repo.value.trim().toLowerCase();
   return recentRepos.value.filter((r) => r.repo_root.toLowerCase().includes(q));
 });
+
+const cloningRepo = ref(false);
+// Register the typed slug/URL in the managed store (the clone is lazy — it
+// happens on first session create), then select it so create() sends it as a
+// managed `repo`.
+async function addAndCloneRepo() {
+  const q = cloneCandidate.value;
+  if (!q) return;
+  cloningRepo.value = true;
+  try {
+    const added = await registerRepo(q);
+    await loadManagedRepos();
+    repo.value = added.slug;
+    repoFocused.value = false;
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    cloningRepo.value = false;
+  }
+}
 
 const branchMatches = computed(() => {
   const q = existingBranch.value.trim().toLowerCase();
@@ -350,14 +398,31 @@ async function create() {
   if (branchMode.value === 'existing' && !existingBranch.value.trim()) return;
   creating.value = true;
   try {
+    const repoInput = repo.value.trim();
     const body: Record<string, unknown> = {
-      cwd: repo.value,
       title: title.value || undefined,
       goal: goal.value,
       agent: agent.value || undefined,
       model: model.value || undefined,
       effort: effort.value || undefined,
     };
+    // A GitHub owner/name slug or URL routes through the managed `repo` path
+    // (allowlist-checked, cloned-if-absent server-side); anything else is a local
+    // path that forks from the repo already at that `cwd` (including a managed
+    // repo picked by its on-disk path). A slug that isn't registered yet is added
+    // first, so typing one and hitting Create just works — same as the dropdown's
+    // "Clone new repo" affordance.
+    if (looksLikeRemoteRepo(repoInput)) {
+      if (
+        !managedRepos.value.some((r) => r.slug === repoInput || r.remote_url === repoInput)
+      ) {
+        await registerRepo(repoInput);
+        await loadManagedRepos();
+      }
+      body.repo = repoInput;
+    } else {
+      body.cwd = repoInput;
+    }
     if (branchMode.value === 'existing') {
       body.existing_branch = existingBranch.value.trim();
     } else {
@@ -387,6 +452,7 @@ async function create() {
 // The recent-repos list only feeds the create form; fetch it once on first
 // mount (kept alive, so this never re-runs) and after each create.
 loadRecentRepos();
+loadManagedRepos();
 loadAgents();
 </script>
 
@@ -482,7 +548,8 @@ loadAgents();
         <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted">Repository</h2>
         <div class="relative">
           <label class="block text-xs text-muted mb-1">
-            Repository path (on the server)
+            Repository — a server path, or a GitHub
+            <span class="font-mono">owner/name</span> to clone
             <span v-if="recentRepos.length" class="text-faint">— or pick a recent one</span>
           </label>
           <input
@@ -490,16 +557,29 @@ loadAgents();
             @focus="repoFocused = true"
             @input="repoFocused = true"
             @blur="repoFocused = false"
-            placeholder="/home/you/code/project"
+            placeholder="owner/name or /home/you/code/project"
             autocomplete="loom-repo"
             spellcheck="false"
             class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
           />
           <ul
-            v-if="repoFocused && repoMatches.length"
+            v-if="repoFocused && (repoMatches.length || cloneCandidate)"
             data-testid="recent-repos"
             class="absolute left-0 right-0 z-10 mt-1 max-h-56 overflow-auto rounded border border-line bg-input shadow-lg"
           >
+            <li v-if="cloneCandidate">
+              <button
+                type="button"
+                data-testid="clone-repo"
+                @mousedown.prevent="addAndCloneRepo"
+                :disabled="cloningRepo"
+                class="flex w-full items-center gap-2 px-2 py-1.5 text-left text-accent hover:bg-subtle disabled:opacity-60"
+              >
+                <span class="shrink-0 text-sm">＋ Clone new repo</span>
+                <span class="min-w-0 truncate text-xs font-mono text-muted">{{ cloneCandidate }}</span>
+                <span v-if="cloningRepo" class="ml-auto shrink-0 text-2xs text-faint">adding…</span>
+              </button>
+            </li>
             <li v-for="r in repoMatches" :key="r.repo_root">
               <button
                 type="button"

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -178,6 +178,20 @@ CREATE TABLE IF NOT EXISTS github_owners (
     login      TEXT PRIMARY KEY COLLATE NOCASE,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
+
+-- A user's own GitHub token (a fine-grained PAT they paste into their account
+-- pane), injected as GH_TOKEN into the interactive sessions that user launches
+-- so an agent's `git push` / `gh` acts as *them* rather than as the shared
+-- ambient GH_TOKEN from the deploy env. Write-only over the API (status +
+-- timestamp, never the token), like `repo_env` — blast-radius reduction, not
+-- isolation (any agent in the shared container can still read the exported
+-- GH_TOKEN; see the shared-loom design §6.4). One row per user; dropped with the
+-- user via ON DELETE CASCADE.
+CREATE TABLE IF NOT EXISTS user_github_tokens (
+    username   TEXT PRIMARY KEY REFERENCES users(username) ON DELETE CASCADE,
+    token      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
 "#;
 
 /// Open the shared database and apply loom's additional tables on top of the

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -31,6 +31,7 @@ pub mod session;
 pub mod setup;
 pub mod shell;
 pub mod terminal;
+pub mod user_token;
 pub mod web;
 
 pub use web::AppState;

--- a/crates/loom/src/user_token.rs
+++ b/crates/loom/src/user_token.rs
@@ -1,0 +1,156 @@
+//! A user's own GitHub token (a fine-grained PAT), stored in the
+//! `user_github_tokens` table.
+//!
+//! When that user launches an interactive session, loom injects the token as
+//! `GH_TOKEN` into the session env ([`crate::web::sessions::create_session_core`]),
+//! overriding the shared ambient `GH_TOKEN` from the deploy env — so the agent's
+//! `git push` / `gh` act as *that user*. Combined with the per-user commit author
+//! identity loom already sets ([`crate::auth::commit_identity`]), both the commit
+//! and the push are attributed to them.
+//!
+//! The value is **write-only** over the API: callers learn only *that* a token is
+//! set and when it changed, never the token itself — the same treatment
+//! [`crate::repo_env`] gives per-repo secrets. This is blast-radius reduction, not
+//! isolation: in loom's single shared container any agent can still read the
+//! exported `GH_TOKEN` (shared-loom design §6.4).
+
+use anyhow::Result;
+use serde::Serialize;
+use sqlx::Row;
+
+use crate::db::{now_iso, Db};
+
+/// Whether a user has a token set, and when it last changed — the write-only
+/// status the account pane renders and the API returns. Never the token.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TokenStatus {
+    pub set: bool,
+    pub updated_at: Option<String>,
+}
+
+/// The stored token for `username`, if any. The *only* reader of the value; used
+/// at session launch and never exposed over the API.
+pub async fn get(db: &Db, username: &str) -> Result<Option<String>> {
+    let row = sqlx::query("SELECT token FROM user_github_tokens WHERE username = ?")
+        .bind(username)
+        .fetch_optional(db)
+        .await?;
+    Ok(row.map(|r| r.get::<String, _>("token")))
+}
+
+/// Whether `username` has a token set, plus its timestamp — the write-only view.
+pub async fn status(db: &Db, username: &str) -> Result<TokenStatus> {
+    let row = sqlx::query("SELECT updated_at FROM user_github_tokens WHERE username = ?")
+        .bind(username)
+        .fetch_optional(db)
+        .await?;
+    Ok(match row {
+        Some(r) => TokenStatus {
+            set: true,
+            updated_at: Some(r.get::<String, _>("updated_at")),
+        },
+        None => TokenStatus {
+            set: false,
+            updated_at: None,
+        },
+    })
+}
+
+/// Upsert `username`'s token.
+pub async fn set(db: &Db, username: &str, token: &str) -> Result<()> {
+    let now = now_iso();
+    sqlx::query(
+        "INSERT INTO user_github_tokens (username, token, updated_at) VALUES (?, ?, ?)
+         ON CONFLICT(username) DO UPDATE
+           SET token = excluded.token, updated_at = excluded.updated_at",
+    )
+    .bind(username)
+    .bind(token)
+    .bind(&now)
+    .execute(db)
+    .await?;
+    tracing::debug!(username, "user github token set");
+    Ok(())
+}
+
+/// Delete `username`'s token. Removing an absent token is a no-op (`false`).
+pub async fn remove(db: &Db, username: &str) -> Result<bool> {
+    let res = sqlx::query("DELETE FROM user_github_tokens WHERE username = ?")
+        .bind(username)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn seed_user(db: &Db, username: &str) {
+        sqlx::query("INSERT INTO users (username) VALUES (?)")
+            .bind(username)
+            .execute(db)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_get_status_remove_round_trip() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        seed_user(&db, "alice").await;
+
+        // Absent: status reports unset, get returns None.
+        assert_eq!(
+            status(&db, "alice").await.unwrap(),
+            TokenStatus {
+                set: false,
+                updated_at: None
+            }
+        );
+        assert!(get(&db, "alice").await.unwrap().is_none());
+
+        // Set: get returns the value; status reports set with a timestamp, but
+        // the value is only ever readable through `get` (never `status`).
+        set(&db, "alice", "github_pat_abc").await.unwrap();
+        assert_eq!(
+            get(&db, "alice").await.unwrap().as_deref(),
+            Some("github_pat_abc")
+        );
+        let st = status(&db, "alice").await.unwrap();
+        assert!(st.set);
+        assert!(st.updated_at.is_some());
+
+        // Upsert replaces in place.
+        set(&db, "alice", "github_pat_rotated").await.unwrap();
+        assert_eq!(
+            get(&db, "alice").await.unwrap().as_deref(),
+            Some("github_pat_rotated")
+        );
+
+        // Remove, then removing again is a no-op.
+        assert!(remove(&db, "alice").await.unwrap());
+        assert!(!remove(&db, "alice").await.unwrap());
+        assert!(get(&db, "alice").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn tokens_are_scoped_per_user() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        seed_user(&db, "alice").await;
+        seed_user(&db, "bob").await;
+
+        set(&db, "alice", "alice-tok").await.unwrap();
+        set(&db, "bob", "bob-tok").await.unwrap();
+
+        assert_eq!(
+            get(&db, "alice").await.unwrap().as_deref(),
+            Some("alice-tok")
+        );
+        assert_eq!(get(&db, "bob").await.unwrap().as_deref(), Some("bob-tok"));
+
+        // Removing one leaves the other untouched.
+        remove(&db, "alice").await.unwrap();
+        assert!(get(&db, "alice").await.unwrap().is_none());
+        assert_eq!(get(&db, "bob").await.unwrap().as_deref(), Some("bob-tok"));
+    }
+}

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -16,6 +16,7 @@ use weaver_api::{
 
 use crate::auth::{self, Principal};
 use crate::config;
+use crate::user_token;
 
 use super::{ApiResult, AppError, AppState};
 
@@ -369,6 +370,53 @@ pub(super) async fn set_own_password(
         ));
     }
     auth::set_password(&st.db, &principal.username, Some(&body.new_password)).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// -- Per-user GitHub token ---------------------------------------------------
+// The caller's own GitHub token (a fine-grained PAT), injected as GH_TOKEN into
+// the sessions they launch so their agents' `git push` / `gh` act as them (see
+// `crate::user_token`). Self-service: every handler acts on the authenticated
+// principal, never an arbitrary username. Write-only — the token is never read
+// back over the API.
+
+/// Body for `PUT /api/auth/github-token`.
+#[derive(Debug, Deserialize)]
+pub(super) struct SetGithubTokenReq {
+    token: String,
+}
+
+/// `GET /api/auth/github-token` — whether the caller has set a personal GitHub
+/// token, and when (status only; the token itself is never returned).
+pub(super) async fn get_github_token(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+) -> ApiResult<Json<user_token::TokenStatus>> {
+    Ok(Json(user_token::status(&st.db, &principal.username).await?))
+}
+
+/// `PUT /api/auth/github-token` — set/replace the caller's personal GitHub token.
+/// Returns the refreshed status (never the token).
+pub(super) async fn set_github_token(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Json(body): Json<SetGithubTokenReq>,
+) -> ApiResult<Json<user_token::TokenStatus>> {
+    let token = body.token.trim();
+    if token.is_empty() {
+        return Err(AppError::bad_request("a token is required"));
+    }
+    user_token::set(&st.db, &principal.username, token).await?;
+    Ok(Json(user_token::status(&st.db, &principal.username).await?))
+}
+
+/// `DELETE /api/auth/github-token` — clear the caller's personal GitHub token;
+/// their sessions then fall back to the shared ambient GH_TOKEN.
+pub(super) async fn delete_github_token(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+) -> ApiResult<StatusCode> {
+    user_token::remove(&st.db, &principal.username).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -629,6 +629,14 @@ pub fn router(state: AppState) -> Router {
         .route("/auth/tokens", get(list_tokens).post(create_token))
         .route("/auth/tokens/{id}", delete(revoke_token))
         .route("/auth/password", post(set_own_password))
+        // The caller's own GitHub token (a fine-grained PAT), injected as
+        // GH_TOKEN into the sessions they launch so their agents act as them.
+        .route(
+            "/auth/github-token",
+            get(get_github_token)
+                .put(set_github_token)
+                .delete(delete_github_token),
+        )
         .route("/auth/users", get(list_users).post(add_user))
         .route("/auth/users/{username}", delete(remove_user))
         .route(

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -262,6 +262,30 @@ async fn launch_env(
     env
 }
 
+/// Overlay the launching user's personal GitHub token onto `env` as `GH_TOKEN`,
+/// so the session's `git push` / `gh` act as that user (their pushes and PRs are
+/// attributed to them, matching the per-user commit identity loom already sets).
+/// Precedence mirrors the commit-identity handling: only for a launch that
+/// carries a `created_by` principal (webhook/warm/adopt keep the shared ambient
+/// token), and only if no higher env layer (`repo_env` / `agent_env` / the repo
+/// file) already set `GH_TOKEN` — an explicit value wins. Best-effort: a lookup
+/// failure is logged, never fatal, so a token-store hiccup can't block a launch.
+async fn apply_user_github_token(
+    db: &Db,
+    env: &mut Vec<(String, String)>,
+    created_by: Option<&str>,
+) {
+    let Some(username) = created_by else { return };
+    if env.iter().any(|(k, _)| k == "GH_TOKEN") {
+        return;
+    }
+    match crate::user_token::get(db, username).await {
+        Ok(Some(token)) => env.push(("GH_TOKEN".to_string(), token)),
+        Ok(None) => {}
+        Err(e) => tracing::warn!(%username, "failed to load user github token: {e}"),
+    }
+}
+
 /// The configured wall-clock budget for a repo setup run.
 async fn setup_timeout(db: &Db) -> std::time::Duration {
     let secs = config::get(db, "setup.timeout_secs")
@@ -758,6 +782,11 @@ pub(crate) async fn create_session_core(
             Err(e) => tracing::warn!(%username, "failed to resolve commit identity: {e}"),
         }
     }
+
+    // Run the launching user's git/gh as themselves: overlay their personal
+    // GitHub token as GH_TOKEN (design §6.3, "Level B"). See
+    // `apply_user_github_token` for the precedence rules.
+    apply_user_github_token(&st.db, &mut extra_env, created_by.as_deref()).await;
 
     // Per-repo setup: run the repo's committed `[setup]` script in the worktree
     // before the agent starts — but ONLY for an allowlisted (registered) repo,
@@ -1894,6 +1923,67 @@ pub(super) async fn preview_session(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    async fn seed_user(db: &Db, username: &str) {
+        sqlx::query("INSERT INTO users (username) VALUES (?)")
+            .bind(username)
+            .execute(db)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn user_github_token_injected_as_gh_token() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        seed_user(&db, "alice").await;
+        crate::user_token::set(&db, "alice", "ghp_alice")
+            .await
+            .unwrap();
+
+        let mut env = vec![("FOO".to_string(), "bar".to_string())];
+        apply_user_github_token(&db, &mut env, Some("alice")).await;
+        assert!(
+            env.iter().any(|(k, v)| k == "GH_TOKEN" && v == "ghp_alice"),
+            "the launching user's token is exported as GH_TOKEN"
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_gh_token_layer_wins_over_user_token() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        seed_user(&db, "alice").await;
+        crate::user_token::set(&db, "alice", "ghp_alice")
+            .await
+            .unwrap();
+
+        // A repo/operator env layer already set GH_TOKEN: it must survive untouched
+        // and stay the single GH_TOKEN entry (no duplicate appended).
+        let mut env = vec![("GH_TOKEN".to_string(), "repo-token".to_string())];
+        apply_user_github_token(&db, &mut env, Some("alice")).await;
+        let gh: Vec<&(String, String)> = env.iter().filter(|(k, _)| k == "GH_TOKEN").collect();
+        assert_eq!(gh.len(), 1, "no duplicate GH_TOKEN is appended");
+        assert_eq!(gh[0].1, "repo-token", "the explicit layer wins");
+    }
+
+    #[tokio::test]
+    async fn gh_token_untouched_without_token_or_principal() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        seed_user(&db, "alice").await;
+
+        // A user with no token set → nothing injected.
+        let mut env = vec![("FOO".to_string(), "bar".to_string())];
+        apply_user_github_token(&db, &mut env, Some("alice")).await;
+        assert!(!env.iter().any(|(k, _)| k == "GH_TOKEN"));
+
+        // A launch with no `created_by` (webhook/warm) → nothing injected, even
+        // though a token now exists.
+        crate::user_token::set(&db, "alice", "ghp_alice")
+            .await
+            .unwrap();
+        let mut env2 = vec![("FOO".to_string(), "bar".to_string())];
+        apply_user_github_token(&db, &mut env2, None).await;
+        assert!(!env2.iter().any(|(k, _)| k == "GH_TOKEN"));
+    }
 
     #[tokio::test]
     async fn create_tracking_issue_sources_parent_and_reuses_claims() {

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -325,6 +325,10 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
         WEAVER_DB: dbPath,
         WEAVER_TAPESTRY_BIN: join(WEAVER_ROOT, 'target', 'debug', 'tapestry'),
         RUST_LOG: 'loom=warn,weaver_core=warn',
+        // Seed an operator: loom refuses to boot with no owner configured, and
+        // loopback trust authenticates every test request as this primary user
+        // (so the page is signed in without an OAuth round-trip).
+        LOOM_OWNER_GITHUB: 'loom-e2e-owner',
       };
 
       // Bind to a random free port (0) and parse the actual port from stdout.


### PR DESCRIPTION
## Per-user GitHub tokens (shared-loom design §6.3, "Level B")

Each user saves a fine-grained GitHub token in **Account settings**; loom
injects it as `GH_TOKEN` into that user's sessions, so the agent's `git push` /
`gh` act **as them** — their pushes and PRs are attributed to them, matching the
per-user commit identity loom already sets (`auth::commit_identity`, Level A).

The token is **write-only over the API**: callers learn only *whether* a token
is set and when it changed, never the value (same treatment `repo_env` gives
per-repo secrets). This is blast-radius reduction, not isolation — in loom's
single shared container any agent can still read the exported `GH_TOKEN`.

- New `user_github_tokens` table + `user_token` module (`get`/`status`/`set`/`remove`).
- Self-service `GET`/`PUT`/`DELETE /api/auth/github-token`, each acting on the
  authenticated caller.
- `create_session_core` overlays the launching user's token as `GH_TOKEN` — only
  for a launch with a `created_by` principal, and only if no higher env layer
  (repo/operator) already set it (an explicit value wins). Extracted into
  `apply_user_github_token`.
- Account panel: a "Your GitHub token" section — set / clear, set-or-not status,
  and a link to GitHub's fine-grained PAT page with the Contents + Pull-requests
  read/write guidance.

## Clone a repo from the New Session form

The Repository field now accepts a GitHub `owner/name` (or URL). A **"Clone new
repo"** dropdown item appears for an unregistered slug and registers it
(allowlist-checked, lazily cloned on launch). Typing an unregistered slug and
hitting **Create** auto-registers it too, so both paths just work. A server path
still forks from the repo already at that `cwd`, unchanged.

## Also: unbreak the e2e fixture

Since #110, loom **refuses to boot without an operator**, which left the e2e
fixture unable to start loom at all (CI skips e2e, so this was invisible). The
fixture now seeds `LOOM_OWNER_GITHUB`; loopback trust then authenticates each
test request as that primary user.

## Testing
- `cargo test -p loom` — `user_token` round-trip/scoping + `apply_user_github_token`
  injection/precedence/no-op tests pass; clippy + fmt clean.
- Frontend `rspack build` + `tsc --noEmit` clean.
- Visual: e2e screenshot spec drove the clone dropdown and the Account token
  panel in **both themes** — verified rendering.