### PR TITLE
feat(loom): recover archived sessions — rebuild worktree + resume agent

### DIFF
--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -37,7 +37,7 @@ const actions = useSessionActions(
   () => props.ws.id,
   () => emit('reload'),
 );
-const { busy, notice, error, rename, clearTag, adopt, archive, remove } = actions;
+const { busy, notice, error, rename, clearTag, adopt, archive, recover, remove } = actions;
 
 const showDetails = ref(false);
 
@@ -162,6 +162,16 @@ const quiet = computed(() => quietTags(props.ws));
                   @click="adopt"
                 >
                   {{ busy === 'adopt' ? 'Adopting…' : 'Adopt' }}
+                </button>
+                <!-- Recover brings a torn-down (archived) session back: rebuild
+                     its worktree from the kept branch and resume the agent. -->
+                <button
+                  v-if="ws.status === 'archived'"
+                  class="rounded bg-subtle px-3 py-1.5 text-xs text-accent ring-1 ring-inset ring-accent/30 hover:bg-subtle-hover"
+                  :disabled="busy === 'recover'"
+                  @click="recover"
+                >
+                  {{ busy === 'recover' ? 'Recovering…' : 'Recover' }}
                 </button>
                 <button
                   v-if="ws.status !== 'archived'"

--- a/crates/loom/frontend/src/lib/sessionActions.ts
+++ b/crates/loom/frontend/src/lib/sessionActions.ts
@@ -11,6 +11,8 @@ import { post, patch, del } from '../api';
 //                  clearing the agent's `attention` is how a human marks it calm
 //   adopt        — recreate the terminal for an orphaned session
 //   archive      — tear down terminal + worktree, keep the branch/history
+//   recover      — rebuild an archived session's worktree and resume its agent
+//                  (the inverse of archive — reuses the kept branch/history)
 //   remove        — delete the session entirely, then route back to the list
 //
 // `reload` is called after any write that mutates server state the page shows,
@@ -73,6 +75,13 @@ export function useSessionActions(getId: () => string, reload: () => void | Prom
       await reload();
     });
 
+  const recover = () =>
+    act('recover', async () => {
+      await post(`/sessions/${getId()}/recover`);
+      notice.value = 'Session recovered — worktree rebuilt and agent resumed.';
+      await reload();
+    });
+
   const remove = () =>
     act('remove', async () => {
       if (!confirm('Remove this session, its worktree and terminal session?')) return;
@@ -80,5 +89,5 @@ export function useSessionActions(getId: () => string, reload: () => void | Prom
       router.push('/');
     });
 
-  return { busy, notice, error, rename, clearTag, adopt, archive, remove };
+  return { busy, notice, error, rename, clearTag, adopt, archive, recover, remove };
 }

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -292,6 +292,8 @@ enum SessionCmd {
     Archive { branch: String },
     /// Recreate the terminal session for an orphaned session.
     Adopt { branch: String },
+    /// Recover an archived session: rebuild its worktree and resume the agent.
+    Recover { branch: String },
     /// Remove a session (worktree + terminal + DB row).
     Rm {
         branch: String,
@@ -684,6 +686,7 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
         SessionCmd::Attach { branch } => cmd_attach(branch).await,
         SessionCmd::Archive { branch } => cmd_archive(branch).await,
         SessionCmd::Adopt { branch } => cmd_adopt(branch).await,
+        SessionCmd::Recover { branch } => cmd_recover(branch).await,
         SessionCmd::Rm {
             branch,
             keep_branch,
@@ -2180,6 +2183,11 @@ async fn cmd_session_wait(
 /// or orphaned lifecycle, or — unless `lifecycle_only` — a raised attention.
 fn wake_reason(ws: &Value, key: &str, lifecycle_only: bool) -> Option<String> {
     let status = str_field(ws, "status");
+    if status == "archived" {
+        return Some(format!(
+            "session {key} is archived — its worktree was torn down (try `loom session recover {key}`)"
+        ));
+    }
     if is_terminal_status(status) {
         return Some(format!("session {key} is {status} — finished"));
     }
@@ -2474,6 +2482,22 @@ async fn cmd_adopt(key: String) -> Result<()> {
         .await?;
     println!(
         "adopted session {}  ({})",
+        str_field(&ws, "id"),
+        branch_str(&ws, "name")
+    );
+    println!("  status:  {}", str_field(&ws, "status"));
+    println!("  session: {}", str_field(&ws, "term_session"));
+    println!("  attach:  loom attach {}", str_field(&ws, "id"));
+    Ok(())
+}
+
+async fn cmd_recover(key: String) -> Result<()> {
+    let client = client::default();
+    let ws = client
+        .post(&format!("/api/sessions/{key}/recover"), json!({}))
+        .await?;
+    println!(
+        "recovered session {}  ({})",
         str_field(&ws, "id"),
         branch_str(&ws, "name")
     );

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -5,7 +5,8 @@
 //! * `/api/sessions` — list + create active sessions (each session is one
 //!   terminal + one agent attached to a branch).
 //! * `/api/sessions/{id}` — GET / PATCH / DELETE a single session, plus the
-//!   action subroutes `/archive`, `/adopt`, `/tags/{key}` (PUT to set a tag,
+//!   action subroutes `/archive`, `/adopt`, `/recover` (rebuild the worktree of
+//!   an archived session and resume its agent), `/tags/{key}` (PUT to set a tag,
 //!   DELETE to clear it), `/log`, `/events`, and `/terminal` (a WebSocket
 //!   bridged to the session's terminal via a PTY — see `crate::terminal`).
 //!   Interacting with the agent (keystrokes, keys, TUIs) happens entirely over
@@ -458,6 +459,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/sessions/{id}/archive", post(archive_session))
         .route("/sessions/{id}/adopt", post(adopt_session))
+        .route("/sessions/{id}/recover", post(recover_session))
         .route("/sessions/{id}/github", post(refresh_github_session))
         .route("/sessions/{id}/raw", get(raw_session))
         // Embedded VS Code (code-server), reverse-proxied per session. `ide-info`

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1509,7 +1509,10 @@ pub(crate) async fn create_warm_session(
     Ok(session)
 }
 
-/// Recreate an orphaned session's terminal and resume its agent.
+/// Recreate an orphaned session's terminal and resume its agent. The worktree is
+/// expected to still be on disk (an orphaned session only lost its terminal); a
+/// missing worktree is an error here — recovering a *torn-down* (archived)
+/// session, which rebuilds the worktree first, goes through [`recover`].
 pub(crate) async fn adopt(
     st: &AppState,
     session: &Session,
@@ -1527,6 +1530,22 @@ pub(crate) async fn adopt(
             session.work_dir
         )));
     }
+    resume_agent(st, session, branch, "session adopted").await
+}
+
+/// Re-launch a session's agent in a worktree that already exists on disk: the
+/// shared tail of [`adopt`] (orphaned → resume) and [`recover`] (archived →
+/// rebuild the worktree, then resume). `reason` is the status event's reason
+/// string. Setup is never re-run here — the worktree is already provisioned; this
+/// only resumes the agent (Claude via `--continue`, so it reloads its prior
+/// conversation from the same cwd).
+async fn resume_agent(
+    st: &AppState,
+    session: &Session,
+    branch: &Branch,
+    reason: &str,
+) -> Result<(), AppError> {
+    let work_dir = PathBuf::from(&session.work_dir);
     // A normal session persists its positional prompt in goal.txt; the concierge
     // persists its primer in primer.txt instead (re-appended as system context so
     // it stays primed-but-idle across adopt). Each session carries exactly one.
@@ -1590,7 +1609,7 @@ pub(crate) async fn adopt(
         &st.bus,
         &branch.id,
         "status",
-        json!({ "status": status, "reason": "session adopted" }),
+        json!({ "status": status, "reason": reason }),
     )
     .await
     .ok();
@@ -1603,6 +1622,55 @@ pub(super) async fn adopt_session(
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
     adopt(&st, &session, &branch).await?;
+    let (session, branch) = require_session(&st.db, &session.id).await?;
+    Ok(Json(session_view(&st.db, &session, &branch).await?))
+}
+
+/// Recover an archived session: rebuild its worktree from the kept branch, then
+/// resume the agent — the inverse of [`archive`]. Where archive tears the worktree
+/// down but keeps the branch (and its commits), the session row, and the history,
+/// recover checks that branch back out at the same worktree path and re-launches
+/// the agent (resuming the prior Claude conversation with `--continue`, exactly as
+/// [`adopt`] does). The session rejoins the active fleet.
+async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<(), AppError> {
+    if backend::has_session(&session.term_session).await {
+        return Err(AppError::conflict(
+            "session already has a running terminal process",
+        ));
+    }
+    let repo_root = PathBuf::from(&branch.repo_root);
+    let work_dir = PathBuf::from(&session.work_dir);
+
+    // Rebuild the worktree if archive removed it. Archive keeps the branch, but a
+    // later manual `git branch -D` could have deleted it — refuse clearly rather
+    // than let the checkout fail cryptically.
+    if !work_dir.exists() {
+        if !git::branch_exists(&repo_root, &branch.branch).await {
+            return Err(AppError::bad_request(format!(
+                "branch '{}' no longer exists — cannot recover",
+                branch.branch
+            )));
+        }
+        // Clear any stale worktree registration at this path first: archive's
+        // forced remove deregisters, but a manual `rm -rf` of the dir would leave
+        // git's admin entry behind and reject re-adding the same path.
+        git::worktree_prune(&repo_root).await.ok();
+        tokio::fs::create_dir_all(repo_root.join(".worktrees")).await?;
+        git::ensure_excluded(&repo_root, ".worktrees/").await.ok();
+        git::worktree_add_existing(&repo_root, &work_dir, &branch.branch)
+            .await
+            .map_err(|e| AppError::bad_request(e.to_string()))?;
+    }
+
+    resume_agent(st, session, branch, "session recovered").await
+}
+
+pub(super) async fn recover_session(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<SessionView>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    recover(&st, &session, &branch).await?;
     let (session, branch) = require_session(&st.db, &session.id).await?;
     Ok(Json(session_view(&st.db, &session, &branch).await?))
 }

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -17,6 +17,7 @@ mod env;
 mod ide;
 mod overlookers;
 mod pane;
+mod recover;
 mod repos;
 mod scratch;
 mod sessions;

--- a/crates/loom/tests/integration/recover.rs
+++ b/crates/loom/tests/integration/recover.rs
@@ -1,0 +1,115 @@
+//! Recovering an archived session is the inverse of archiving: it rebuilds the
+//! worktree from the kept branch and resumes the agent, flipping the row back out
+//! of the terminal `archived` state and into the live fleet — the same shape as
+//! adopting an orphaned session, but starting from a torn-down worktree.
+
+use std::path::Path;
+
+use serde_json::json;
+use serial_test::serial;
+
+use loom::backend;
+
+use crate::fixtures::TestServer;
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recover_rebuilds_worktree_and_resumes() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let sess = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "recover me", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = sess["id"].as_str().unwrap().to_string();
+    let term_session = sess["term_session"].as_str().unwrap().to_string();
+    let work_dir = sess["work_dir"].as_str().unwrap().to_string();
+    assert!(
+        Path::new(&work_dir).exists(),
+        "worktree should exist on launch"
+    );
+
+    // Archive tears the worktree down but keeps the branch + row.
+    let res = client
+        .post(&format!("/api/sessions/{id}/archive"), json!({}))
+        .await
+        .unwrap();
+    assert_eq!(res["archived"], true);
+    assert!(
+        !Path::new(&work_dir).exists(),
+        "archive should remove the worktree"
+    );
+    assert!(
+        !backend::has_session(&term_session).await,
+        "archive should kill the terminal session"
+    );
+    let view = client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(view["status"], "archived");
+
+    // Recover rebuilds the worktree and resumes the agent at the same path.
+    let rec = client
+        .post(&format!("/api/sessions/{id}/recover"), json!({}))
+        .await
+        .unwrap();
+    // The row is live again (shell is hookless, so it comes up `running`), on the
+    // same worktree path and terminal session.
+    assert_eq!(rec["status"], "running");
+    assert_eq!(rec["work_dir"], work_dir);
+    assert_eq!(rec["term_session"], term_session);
+    assert!(
+        Path::new(&work_dir).exists(),
+        "recover should rebuild the worktree on disk"
+    );
+    assert!(
+        backend::has_session(&term_session).await,
+        "recover should recreate the terminal session"
+    );
+    // The kept branch is what got checked back out — recover never re-forks.
+    assert!(
+        weaver_core::git::branch_exists(ts.repo_path(), "weaver/recover-me").await,
+        "recover reuses the archived branch"
+    );
+
+    // A recovered session is a normal live session again: it shows in the fleet
+    // without the archived opt-in.
+    let fleet = client.get("/api/sessions").await.unwrap();
+    assert!(
+        fleet
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|s| s["id"] == id.as_str()),
+        "recovered session rejoins the default fleet listing"
+    );
+}
+
+/// Recovering a session whose terminal is still live is refused — recover is for
+/// a torn-down session, not a hijack of a running one (the same guard adopt uses).
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recover_refuses_a_live_session() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let sess = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "still running", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = sess["id"].as_str().unwrap().to_string();
+
+    let err = client
+        .post(&format!("/api/sessions/{id}/recover"), json!({}))
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("running terminal"),
+        "recover should reject a session with a live terminal: {err}"
+    );
+}

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -315,6 +315,16 @@ pub async fn worktree_remove(repo_root: &Path, path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Prune stale worktree administrative entries (`git worktree prune`) — drop
+/// registrations whose working directory is gone, so a later `worktree_add*` at
+/// the same path is not rejected as "already registered". Idempotent: a no-op
+/// when nothing is stale. Used when re-checking out a branch whose worktree was
+/// torn down (e.g. recovering an archived session).
+pub async fn worktree_prune(repo_root: &Path) -> Result<()> {
+    git(repo_root, &["worktree", "prune"]).await?;
+    Ok(())
+}
+
 pub async fn delete_branch(repo_root: &Path, branch: &str) -> Result<()> {
     git(repo_root, &["branch", "-D", branch]).await?;
     tracing::info!(%branch, "branch deleted");


### PR DESCRIPTION
Archive tears down a session's terminal and worktree but keeps the branch, its commits, the session row, and the history. Recover is its inverse: it checks the kept branch back out at the same worktree path and resumes the agent (Claude via `--continue`, so it reloads its prior conversation from the same cwd) — the archived-session counterpart to adopting an orphaned one.

- web/sessions.rs: extract the shared `resume_agent` tail from `adopt`, add `recover` (guard terminal dead, rebuild worktree, prune stale registration, re-check-out branch, resume) + `recover_session` handler.
- web/mod.rs: POST /api/sessions/{id}/recover.
- weaver-core/git.rs: add `worktree_prune` so a manually-removed worktree dir can't block re-adding the same path.
- frontend: `recover` action + a Recover button shown for archived sessions.
- loom CLI: `loom session recover <key>`, plus a wait-hint pointing archived sessions at it.
- tests: archive→recover round-trip + live-session refusal guard.