### PR TITLE
fix(loom): preserve recovered sessions after PR merge

### DIFF
--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -26,6 +26,7 @@ use crate::web::AppState;
 use crate::{branch as branch_mod, config, events};
 use weaver_core::branch::Branch;
 use weaver_core::github::GithubStatus;
+use weaver_core::tags;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Issue {
@@ -428,7 +429,14 @@ async fn apply_snapshot(
         }
     }
 
-    if archive_on_merge && snap.pr_state == "MERGED" && !session_mod::is_terminal(&session.status) {
+    let recovered = tags::get(&state.db, &branch.id, tags::RECOVERED_KEY)
+        .await?
+        .is_some();
+    if archive_on_merge
+        && snap.pr_state == "MERGED"
+        && !session_mod::is_terminal(&session.status)
+        && !recovered
+    {
         // The merge is already on the record as a `github` event (above) and the
         // archive records a `status` event, so no extra log line is needed.
         match crate::web::archive(state, session, branch).await {
@@ -813,6 +821,48 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.pr_state, "MERGED");
+    }
+
+    #[tokio::test]
+    async fn merged_pr_does_not_archive_a_recovered_session() {
+        let f = fixture().await;
+        tags::set(
+            &f.state.db,
+            &f.branch.id,
+            tags::RECOVERED_KEY,
+            tags::RECOVERED_VALUE,
+            "session recovered",
+            "loom",
+        )
+        .await
+        .unwrap();
+        let issue = weaver_core::issue::add(
+            &f.state.db,
+            &weaver_core::issue::NewIssue {
+                repo_root: f.branch.repo_root.clone(),
+                claimed_branch: Some(f.branch.branch.clone()),
+                title: "keep working".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        apply_snapshot(&f.state, &f.session, &f.branch, &snapshot("MERGED"), true)
+            .await
+            .unwrap();
+
+        let session = session_mod::get(&f.state.db, &f.session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "running");
+        assert!(f.work_dir.exists());
+        let open_issue = weaver_core::issue::get(&f.state.db, issue.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(open_issue.status, "open");
     }
 
     #[tokio::test]

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -431,7 +431,7 @@ async fn apply_snapshot(
 
     let recovered = tags::get(&state.db, &branch.id, tags::RECOVERED_KEY)
         .await?
-        .is_some();
+        .is_some_and(|tag| tag.value == tags::RECOVERED_VALUE);
     if archive_on_merge
         && snap.pr_state == "MERGED"
         && !session_mod::is_terminal(&session.status)
@@ -863,6 +863,32 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(open_issue.status, "open");
+    }
+
+    #[tokio::test]
+    async fn malformed_recovered_tag_does_not_suppress_archive_on_merge() {
+        let f = fixture().await;
+        tags::set(
+            &f.state.db,
+            &f.branch.id,
+            tags::RECOVERED_KEY,
+            "false",
+            "manual",
+            "manual",
+        )
+        .await
+        .unwrap();
+
+        apply_snapshot(&f.state, &f.session, &f.branch, &snapshot("MERGED"), true)
+            .await
+            .unwrap();
+
+        let session = session_mod::get(&f.state.db, &f.session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "archived");
+        assert!(!f.work_dir.exists());
     }
 
     #[tokio::test]

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1691,7 +1691,6 @@ async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<()
             .map_err(|e| AppError::bad_request(e.to_string()))?;
     }
 
-    resume_agent(st, session, branch, "session recovered").await?;
     tags::set(
         &st.db,
         &branch.id,
@@ -1712,6 +1711,7 @@ async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<()
     )
     .await
     .ok();
+    resume_agent(st, session, branch, "session recovered").await?;
     Ok(())
 }
 

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1691,7 +1691,28 @@ async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<()
             .map_err(|e| AppError::bad_request(e.to_string()))?;
     }
 
-    resume_agent(st, session, branch, "session recovered").await
+    resume_agent(st, session, branch, "session recovered").await?;
+    tags::set(
+        &st.db,
+        &branch.id,
+        tags::RECOVERED_KEY,
+        tags::RECOVERED_VALUE,
+        "session recovered",
+        "loom",
+    )
+    .await?;
+    events::record_tag(
+        &st.db,
+        &st.bus,
+        &branch.id,
+        tags::RECOVERED_KEY,
+        tags::RECOVERED_VALUE,
+        "session recovered",
+        "loom",
+    )
+    .await
+    .ok();
+    Ok(())
 }
 
 pub(super) async fn recover_session(

--- a/crates/loom/tests/integration/recover.rs
+++ b/crates/loom/tests/integration/recover.rs
@@ -60,6 +60,12 @@ async fn recover_rebuilds_worktree_and_resumes() {
     assert_eq!(rec["status"], "running");
     assert_eq!(rec["work_dir"], work_dir);
     assert_eq!(rec["term_session"], term_session);
+    let tags = rec["branch"]["tags"].as_array().unwrap();
+    assert!(
+        tags.iter()
+            .any(|tag| tag["key"] == "recovered" && tag["value"] == "true"),
+        "recover should stamp a quiet recovered tag"
+    );
     assert!(
         Path::new(&work_dir).exists(),
         "recover should rebuild the worktree on disk"

--- a/crates/weaver-core/src/tags.rs
+++ b/crates/weaver-core/src/tags.rs
@@ -64,6 +64,14 @@ pub const IDLE_KEY: &str = "idle";
 /// [`ATTENTION_VALUES`]), so it renders soothing rather than loud.
 pub const IDLE_VALUE: &str = "idle";
 
+/// A quiet lifecycle mark stamped when an archived session is recovered. The
+/// GitHub PR poller uses this to avoid immediately re-archiving a session whose
+/// already-merged PR is still visible.
+pub const RECOVERED_KEY: &str = "recovered";
+
+/// The fixed value the [`RECOVERED_KEY`] tag carries.
+pub const RECOVERED_VALUE: &str = "true";
+
 /// The loud keys: those that raise an attention signal on the dashboard. Any
 /// other key is quiet (a deletable pill) — including the soothing [`IDLE_KEY`].
 pub const LOUD_KEYS: &[&str] = &[ATTENTION_KEY, TRIAGE_KEY];
@@ -217,6 +225,9 @@ mod tests {
         assert!(!is_loud(IDLE_KEY));
         assert!(!is_loud_value(IDLE_VALUE));
         assert!(is_valid_value(IDLE_KEY, IDLE_VALUE));
+        assert!(!is_loud(RECOVERED_KEY));
+        assert!(!is_loud_value(RECOVERED_VALUE));
+        assert!(is_valid_value(RECOVERED_KEY, RECOVERED_VALUE));
 
         // Loudness is value-driven: any key holding a ladder value is loud (a
         // watch's typed `review`/`stuck`), while a quiet value never is.


### PR DESCRIPTION
Recovering an archived session now stamps a quiet recovered tag on the branch. The GitHub PR poller checks that tag before archive-on-merge, so a recovered session whose PR is already merged stays live instead of being immediately re-archived.

The recovery API response exposes the tag through the existing branch tag surface, and the GitHub snapshot tests cover both the normal archive-on-merge path and the recovered-session guard.

Tracks weaver issue #370.