### PR TITLE
fix(deploy): install Claude Code on the writable volume so it self-updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,23 @@ RUN set -eux; \
       > /etc/apt/sources.list.d/google-cloud-sdk.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends nodejs git ca-certificates gh google-cloud-cli tini; \
-    npm i -g @anthropic-ai/claude-code; \
     rm -rf /var/lib/apt/lists/*
+
+# Claude Code — the agent runtime loom's sessions launch — is installed in two
+# places on purpose:
+#
+#   * a baked *fallback* here under /opt/claude (root-owned, deliberately kept
+#     OFF /usr/local/bin and placed last on PATH, so it never shadows the
+#     writable copy). It exists only so a brand-new or offline container still
+#     has a working `claude`.
+#   * the real copy the entrypoint lays down at first boot into the app user's
+#     $HOME/.local — on the persisted loom_home volume, so it is writable. That
+#     one wins on PATH, and because it lives on a writable volume Claude Code's
+#     background auto-updater works and the updates survive container recreates.
+#
+# A bare `npm i -g @anthropic-ai/claude-code` (the old approach) lands in the
+# read-only, root-owned npm global dir and makes Claude report it "can't update".
+RUN npm install -g @anthropic-ai/claude-code --prefix /opt/claude
 
 # code-server — the per-session embedded VS Code that `crate::ide` spawns and
 # reverse-proxies (one rooted at each worktree, behind loom's auth). The `.deb`
@@ -92,6 +107,17 @@ ARG HOST_GID=1000
 # still aborts the build instead of being masked by `|| true`.
 RUN if ! getent group "${HOST_GID}" >/dev/null; then groupadd -g "${HOST_GID}" app; fi; \
     useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -d /home/app -s /bin/bash app
+
+# Set $HOME explicitly: the entrypoint and Claude's installer resolve
+# $HOME/.local, and `USER app` alone doesn't reliably export HOME.
+ENV HOME=/home/app
+# The writable, self-updating Claude install and any client packages added at
+# runtime live under the app user's persisted $HOME, ahead of the baked fallback
+# on PATH. NPM_CONFIG_PREFIX points `npm i -g` at a home dir too, so new CLI
+# packages can be installed live (and persist on the loom_home volume) without an
+# image rebuild — only OS/apt packages still need one.
+ENV NPM_CONFIG_PREFIX=/home/app/.npm-global \
+    PATH=/home/app/.local/bin:/home/app/.npm-global/bin:${PATH}:/opt/claude/bin
 
 # Where uv keeps its managed interpreters and wheel cache. Kept off /home/app so
 # the (large) Python builds don't bloat the home volume and can be reset on their
@@ -131,6 +157,28 @@ git config --system url.https://github.com/.insteadOf git@github.com:
 git config --system url.https://github.com/.insteadOf ssh://git@github.com/
 EOF
 
+# Container entrypoint: before the daemon starts, make sure the writable,
+# self-updating Claude install exists on the persisted $HOME volume, then hand
+# off to the CMD. Runs the install only for `loom server …` — one-shot admin
+# commands (`loom config set`, `loom setup`, the compose init service) skip it.
+RUN <<'EOF'
+cat > /usr/local/bin/loom-entrypoint <<'SH'
+#!/bin/sh
+set -eu
+if [ "${1:-}" = loom ] && [ "${2:-}" = server ] && [ ! -x "$HOME/.local/bin/claude" ]; then
+  echo "loom: installing self-updating Claude Code into $HOME/.local ..." >&2
+  # Use the baked fallback's own installer to write the native build onto the
+  # writable volume; Claude then auto-updates itself in place. Pin with
+  # CLAUDE_CODE_VERSION (stable|latest|<version>; default stable). Non-fatal:
+  # loom still boots on failure and agents use the baked fallback meanwhile.
+  claude install "${CLAUDE_CODE_VERSION:-stable}" \
+    || echo "loom: WARNING: Claude install failed; using baked fallback for now" >&2
+fi
+exec "$@"
+SH
+chmod +x /usr/local/bin/loom-entrypoint
+EOF
+
 # loom resolves the tapestry PTY supervisor as a sibling of its own binary
 # (current_exe dir + /tapestry), so the two must land in the same directory.
 COPY --from=build /out/loom     /usr/local/bin/loom
@@ -153,8 +201,10 @@ EXPOSE 7878
 # they shell out to `gh`, `sleep`, MCP servers, etc. and routinely detach, so
 # those processes reparent to PID 1 when their immediate parent exits. With no
 # init to `wait()` on them they pile up as zombies for the container's whole
-# lifetime. tini reaps them and forwards signals through to loom.
-ENTRYPOINT ["/usr/bin/tini", "--"]
+# lifetime. tini reaps them and forwards signals through to loom. loom-entrypoint
+# runs first (ensuring the writable Claude install) and then `exec`s the CMD, so
+# loom still ends up as tini's direct child for the reaping above to work.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/loom-entrypoint"]
 # `server run` is the foreground daemon (REST API + Vue UI + monitor loop); bind
 # off loopback so the Caddy container can reach it over the `web` network.
 CMD ["loom", "server", "run", "--addr", "0.0.0.0:7878"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,21 +61,13 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends nodejs git ca-certificates gh google-cloud-cli tini; \
     rm -rf /var/lib/apt/lists/*
 
-# Claude Code — the agent runtime loom's sessions launch — is installed in two
-# places on purpose:
-#
-#   * a baked *fallback* here under /opt/claude (root-owned, deliberately kept
-#     OFF /usr/local/bin and placed last on PATH, so it never shadows the
-#     writable copy). It exists only so a brand-new or offline container still
-#     has a working `claude`.
-#   * the real copy the entrypoint lays down at first boot into the app user's
-#     $HOME/.local — on the persisted loom_home volume, so it is writable. That
-#     one wins on PATH, and because it lives on a writable volume Claude Code's
-#     background auto-updater works and the updates survive container recreates.
-#
-# A bare `npm i -g @anthropic-ai/claude-code` (the old approach) lands in the
-# read-only, root-owned npm global dir and makes Claude report it "can't update".
-RUN npm install -g @anthropic-ai/claude-code --prefix /opt/claude
+# Claude Code — the agent runtime loom's sessions launch — is deliberately NOT
+# baked into the image. The container runs as a non-root user, so a Claude
+# installed into the read-only system dirs (what `npm i -g` does) can't
+# auto-update and reports it's "installed in a read-only location". Instead
+# loom-entrypoint (below) runs Claude's own installer at first boot into the app
+# user's $HOME/.local — on the persisted loom_home volume, so it is writable,
+# auto-updates itself in place, and the updates survive container recreates.
 
 # code-server — the per-session embedded VS Code that `crate::ide` spawns and
 # reverse-proxies (one rooted at each worktree, behind loom's auth). The `.deb`
@@ -111,13 +103,13 @@ RUN if ! getent group "${HOST_GID}" >/dev/null; then groupadd -g "${HOST_GID}" a
 # Set $HOME explicitly: the entrypoint and Claude's installer resolve
 # $HOME/.local, and `USER app` alone doesn't reliably export HOME.
 ENV HOME=/home/app
-# The writable, self-updating Claude install and any client packages added at
-# runtime live under the app user's persisted $HOME, ahead of the baked fallback
-# on PATH. NPM_CONFIG_PREFIX points `npm i -g` at a home dir too, so new CLI
-# packages can be installed live (and persist on the loom_home volume) without an
-# image rebuild — only OS/apt packages still need one.
+# The writable, self-updating Claude install (see loom-entrypoint) and any client
+# packages added at runtime live under the app user's persisted $HOME, early on
+# PATH. NPM_CONFIG_PREFIX points `npm i -g` at a home dir too, so new CLI packages
+# can be installed live (and persist on the loom_home volume) without an image
+# rebuild — only OS/apt packages still need one.
 ENV NPM_CONFIG_PREFIX=/home/app/.npm-global \
-    PATH=/home/app/.local/bin:/home/app/.npm-global/bin:${PATH}:/opt/claude/bin
+    PATH=/home/app/.local/bin:/home/app/.npm-global/bin:${PATH}
 
 # Where uv keeps its managed interpreters and wheel cache. Kept off /home/app so
 # the (large) Python builds don't bloat the home volume and can be reset on their
@@ -167,12 +159,15 @@ cat > /usr/local/bin/loom-entrypoint <<'SH'
 set -eu
 if [ "${1:-}" = loom ] && [ "${2:-}" = server ] && [ ! -x "$HOME/.local/bin/claude" ]; then
   echo "loom: installing self-updating Claude Code into $HOME/.local ..." >&2
-  # Use the baked fallback's own installer to write the native build onto the
-  # writable volume; Claude then auto-updates itself in place. Pin with
-  # CLAUDE_CODE_VERSION (stable|latest|<version>; default stable). Non-fatal:
-  # loom still boots on failure and agents use the baked fallback meanwhile.
-  claude install "${CLAUDE_CODE_VERSION:-stable}" \
-    || echo "loom: WARNING: Claude install failed; using baked fallback for now" >&2
+  # The stock native installer drops claude into $HOME/.local/bin (writable, on
+  # the volume); Claude then auto-updates itself in place. Pin with
+  # CLAUDE_CODE_VERSION (stable|latest|<version>; default stable). `curl | bash`
+  # can't surface a download failure through the pipe, so check the binary landed
+  # rather than trusting the exit status. Non-fatal: loom still boots either way;
+  # agents just lack `claude` until a boot with network installs it.
+  curl -fsSL https://claude.ai/install.sh | bash -s -- "${CLAUDE_CODE_VERSION:-stable}" || true
+  [ -x "$HOME/.local/bin/claude" ] \
+    || echo "loom: WARNING: Claude install failed (offline?); agents lack 'claude' until a later boot installs it" >&2
 fi
 exec "$@"
 SH

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -288,7 +288,7 @@ removed only by `docker compose down -v` or `docker volume rm`):
 
 | Volume | Mount | Holds |
 |---|---|---|
-| `loom_home` | `/home/app` | The sqlite db (`~/.weaver/weaver.db`), the machine-local loom token, `~/.claude.json`, and the managed repo store (`WEAVER_REPOS_DIR`, default `~/.weaver/repos`) — the repos the `@loom` trigger clones and their worktrees. |
+| `loom_home` | `/home/app` | The sqlite db (`~/.weaver/weaver.db`), the machine-local loom token, `~/.claude.json`, the self-updating Claude Code install (`~/.local`) and any client packages added at runtime (`~/.npm-global`, `~/.local/bin`; see [Agent runtime](#agent-runtime--client-packages)), and the managed repo store (`WEAVER_REPOS_DIR`, default `~/.weaver/repos`) — the repos the `@loom` trigger clones and their worktrees. |
 | `uv` | `/opt/uv` | uv's managed Python interpreters and wheel cache. |
 | `caddy_data` | `/data` | Issued TLS certificates and the ACME account — back this up to avoid re-issuing on every fresh host. |
 | `caddy_config` | `/config` | Caddy's autosaved config. |
@@ -298,6 +298,38 @@ non-root `app` user the image runs as can write to it: a fresh standalone named
 volume would mount root-owned. To put repos on their own disk, point
 `WEAVER_REPOS_DIR` at a **bind mount** of a host directory you've `chown`ed to
 `HOST_UID:HOST_GID` instead.
+
+## Agent runtime & client packages
+
+The agent tooling the image ships splits by how it updates:
+
+- **Claude Code updates itself, no image rebuild.** The container runs as a
+  non-root user, so a Claude installed into the read-only system dirs could not
+  auto-update ("installed in a read-only location"). Instead, the daemon
+  installs Claude Code into the persisted `loom_home` volume
+  (`~/.local/bin/claude`) the first time it starts, and Claude auto-updates
+  itself in place from then on — updates land without a rebuild and survive
+  `up`/`down`/recreate. The image also carries a baked fallback under
+  `/opt/claude` (kept last on `PATH`) so a fresh or offline container still has
+  a working `claude` before the volume copy exists. Pin the tracked build by
+  setting `CLAUDE_CODE_VERSION` (`stable` — the default — `latest`, or an exact
+  version like `2.1.198`) in the `loom` service's `environment:` in
+  [`docker-compose.yml`](standalone/docker-compose.yml); force one live with
+  `docker compose exec loom claude install <version> --force`.
+
+- **Adding more client packages at runtime.** `~/.local/bin` and a home npm
+  prefix (`~/.npm-global/bin`) are on `PATH` and on the `loom_home` volume, so
+  the operator (or an agent) can install extra CLIs live and have them persist
+  across recreates:
+
+  ```sh
+  docker compose exec loom npm i -g <package>      # node CLIs → ~/.npm-global
+  docker compose exec loom uv tool install <tool>  # python CLIs → ~/.local/bin
+  ```
+
+  Only OS/system packages (`apt-get`) still need an image rebuild — the system
+  dirs are read-only to the non-root user. Add those to the
+  [`Dockerfile`](../Dockerfile) and rerun `docker compose up -d --build`.
 
 ## Operations
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -305,15 +305,14 @@ The agent tooling the image ships splits by how it updates:
 
 - **Claude Code updates itself, no image rebuild.** The container runs as a
   non-root user, so a Claude installed into the read-only system dirs could not
-  auto-update ("installed in a read-only location"). Instead, the daemon
-  installs Claude Code into the persisted `loom_home` volume
-  (`~/.local/bin/claude`) the first time it starts, and Claude auto-updates
-  itself in place from then on — updates land without a rebuild and survive
-  `up`/`down`/recreate. The image also carries a baked fallback under
-  `/opt/claude` (kept last on `PATH`) so a fresh or offline container still has
-  a working `claude` before the volume copy exists. Pin the tracked build by
-  setting `CLAUDE_CODE_VERSION` (`stable` — the default — `latest`, or an exact
-  version like `2.1.198`) in the `loom` service's `environment:` in
+  auto-update ("installed in a read-only location"). Instead, the first time the
+  daemon starts it runs Claude's native installer into the persisted `loom_home`
+  volume (`~/.local/bin/claude`), and Claude auto-updates itself in place from
+  then on — updates land without a rebuild and survive `up`/`down`/recreate. That
+  first install needs network (the deploy needs it anyway); if it fails loom
+  still comes up and installs on a later boot. Pin the tracked build with
+  `CLAUDE_CODE_VERSION` (`stable` — the default — `latest`, or an exact version
+  like `2.1.198`) in the `loom` service's `environment:` in
   [`docker-compose.yml`](standalone/docker-compose.yml); force one live with
   `docker compose exec loom claude install <version> --force`.
 


### PR DESCRIPTION
## Problem

The deploy image installed Claude Code with `npm i -g @anthropic-ai/claude-code`, which lands in the **root-owned npm global dir** and is baked into a read-only image layer. The container runs as the non-root `app` user, so Claude's auto-updater can't write there — it reports it's *"installed in a read-only location"* and can't update. The only way to refresh Claude was rebuilding the image.

This answers the questions in #375:

- **Install on the mutable data volume at start time?** Yes — that's what this does.
- **Was it only updated on docker rebuild?** For Claude, yes, previously. Not anymore.
- **What if the operator wants a new client package?** Now supported live, no rebuild.

## Fix

Install Claude Code the **normal-user way** — into `$HOME/.local` on the persisted `loom_home` volume — but at container start, because that path is a Docker volume (a `RUN`-baked copy is shadowed for any existing volume, and only a copy on the volume can persist self-updates).

- **`loom-entrypoint` installs Claude at first boot.** It runs Claude's stock native installer (`curl -fsSL https://claude.ai/install.sh | bash`) into `~/.local` the first time the daemon starts; Claude auto-updates itself in place from then on, updates survive `up`/`down`/recreate, and an **existing deploy is migrated on next boot** (its volume is never re-seeded from the image). Runs **only for `loom server …`** — the `loom-init` one-shot and `docker compose run` admin commands skip it. Non-fatal: `curl | bash` can't report a download failure through the pipe, so it checks the binary landed and warns without blocking loom's boot. First boot needs network (the deploy needs it anyway).
- **Nothing is baked into `/usr/local/bin`.** loom's agent launch-script prepends the loom-binary dir to `$PATH` — to give agents the sibling `weaver` CLI, not for claude — so a `claude` there would shadow the writable copy. `~/.local/bin` is early on `PATH` instead.
- **Runtime client packages.** `~/.local/bin` and a home npm prefix (`~/.npm-global`, via `NPM_CONFIG_PREFIX`) are on `PATH` and on the volume, so the operator or an agent can `npm i -g <pkg>` / `uv tool install <tool>` live and have them persist. Only OS/`apt` packages still need a rebuild.
- **Pinning.** `CLAUDE_CODE_VERSION` (`stable` default / `latest` / exact version) in the `loom` service's `environment:`.

Docs: new *"Agent runtime & client packages"* section in `deploy/README.md` plus the state-volume table.

> The second commit drops an earlier `/opt/claude` offline fallback as over-engineering (the deploy needs network anyway) — see its message.

## Verification

CI doesn't build the image, so this was validated locally against a real build of the modified `Dockerfile`:

- `docker build` succeeds; pre-commit (`cargo fmt` / `clippy` / `vue-tsc`) clean; `shellcheck` clean on the entrypoint.
- In the built image: runs as `app`, `PATH` leads with `~/.local/bin` + `~/.npm-global/bin`, **no `/opt/claude`**, no `claude` baked anywhere.
- Entrypoint: `loom server …` runs `install.sh` (verified it lands a writable, app-owned `~/.local/bin/claude → versions/<v>` that a fresh shell resolves and runs) then execs the CMD; `loom-init` / admin / passthrough commands skip it; an offline install failure is non-fatal (warns, still boots).

Closes #375.
