### PR TITLE
feat(loom): custom agents table; drop the builtin shell agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ weaver CLI ──HTTP (REST)──▶ loom server run
                                 ├─ sqlite ─▶ ~/.weaver/weaver.db
                                 ├─ axum REST + SSE (127.0.0.1:7878)
                                 ├─ terminal supervisors + git worktree wrappers
-                                ├─ agent launcher (Claude / shell / custom command)
+                                ├─ agent launcher (Claude / Codex / custom agents)
                                 ├─ background monitor (status, orphan detection, hook ingest)
                                 ├─ background summarizer (headless agent → branch description)
                                 └─ Vue SPA at /
@@ -162,8 +162,9 @@ into parallel sub-sessions and poll or block on them the same way a human does.
 `loom session launch --model <model> --effort <effort>` (both also selectors in
 the web create form) pins the session's model selector and reasoning effort.
 The selected agent type advertises its available models/efforts and translates
-them into its own launch flags (`claude` and `codex` are built in; `shell`
-ignores them). Both are stored per session, so adopting a recovered session
+them into its own launch flags (`claude` and `codex` are built in; a custom
+agent takes no model/effort selectors). Both are stored per session, so adopting
+a recovered session
 resumes with the same settings. Omit either to use the configured default, or
 the runtime's own default when no configured default is set.
 
@@ -354,7 +355,7 @@ weaver config rm agent.default
 Notable settings:
 
 - `agent.default` — agent kind launched for a new session when `loom session
-  launch` is given no `--agent` (`claude`, `codex`, or `shell`).
+  launch` is given no `--agent` (`claude`, `codex`, or any custom agent).
 - `agent.model` / `agent.effort` — default model and reasoning effort for new
   sessions. The Settings UI populates these from the selected agent type.
 - `concierge.runtime` / `concierge.model` / `concierge.effort` — agent, model,

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -69,6 +69,8 @@ import type {
   ArtifactWriteBody,
   IdeInfo,
   AgentMetadata,
+  CustomAgent,
+  CustomAgentInput,
   ManagedRepo,
   Thread,
   NewThreadBody,
@@ -138,10 +140,34 @@ export const deleteRepoEnv = (repoRoot: string, name: string) =>
 
 interface AgentsEnvelope {
   agents: AgentMetadata[];
+  custom: CustomAgent[];
   default_agent: string;
 }
 
 export const listAgents = () => get('/agents') as Promise<AgentsEnvelope>;
+
+interface CustomAgentsEnvelope {
+  custom: CustomAgent[];
+}
+
+/** Define a new custom agent (`POST /api/agents/custom`). Returns the refreshed
+ *  custom-agent list. */
+export const createCustomAgent = (body: CustomAgentInput) =>
+  (post('/agents/custom', body) as Promise<CustomAgentsEnvelope>).then((r) => r.custom);
+
+/** Replace an existing custom agent's definition (`PUT /api/agents/custom/:name`;
+ *  the name is immutable). Returns the refreshed list. */
+export const updateCustomAgent = (name: string, body: CustomAgentInput) =>
+  (put(`/agents/custom/${encodeURIComponent(name)}`, body) as Promise<CustomAgentsEnvelope>).then(
+    (r) => r.custom,
+  );
+
+/** Delete a custom agent (`DELETE /api/agents/custom/:name`). Returns the
+ *  refreshed list. */
+export const deleteCustomAgent = (name: string) =>
+  (del(`/agents/custom/${encodeURIComponent(name)}`) as Promise<CustomAgentsEnvelope>).then(
+    (r) => r.custom,
+  );
 
 /** Every issue across every repo — the Issues pane's cross-repo board. Pass
  *  `all` to include closed issues. */

--- a/crates/loom/frontend/src/components/CustomAgentsPanel.vue
+++ b/crates/loom/frontend/src/components/CustomAgentsPanel.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { CustomAgent, CustomAgentInput } from '../types';
+import { createCustomAgent, updateCustomAgent, deleteCustomAgent } from '../api';
+import ToggleSwitch from './ToggleSwitch.vue';
+
+const props = defineProps<{ agents: CustomAgent[] }>();
+const emit = defineEmits<{ reload: [] }>();
+
+// `null` = the form is closed; a string = editing that agent by name; '' = adding
+// a new one. `draft` holds the in-progress definition.
+const editing = ref<string | null>(null);
+const draft = ref<CustomAgentInput>(blank());
+const busy = ref(false);
+const error = ref('');
+
+function blank(): CustomAgentInput {
+  return { name: '', label: '', setup: '', launch: '', resume: '', reports_status: false };
+}
+
+const isNew = computed(() => editing.value === '');
+const open = computed(() => editing.value !== null);
+
+function startAdd() {
+  editing.value = '';
+  draft.value = blank();
+  error.value = '';
+}
+
+function startEdit(agent: CustomAgent) {
+  editing.value = agent.name;
+  draft.value = {
+    name: agent.name,
+    label: agent.label,
+    setup: agent.setup,
+    launch: agent.launch,
+    resume: agent.resume,
+    reports_status: agent.reports_status,
+  };
+  error.value = '';
+}
+
+function cancel() {
+  editing.value = null;
+  error.value = '';
+}
+
+async function save() {
+  busy.value = true;
+  error.value = '';
+  try {
+    if (isNew.value) {
+      await createCustomAgent(draft.value);
+    } else {
+      await updateCustomAgent(editing.value as string, draft.value);
+    }
+    editing.value = null;
+    emit('reload');
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function remove(agent: CustomAgent) {
+  if (!window.confirm(`Delete the custom agent "${agent.label}" (${agent.name})?`)) return;
+  busy.value = true;
+  error.value = '';
+  try {
+    await deleteCustomAgent(agent.name);
+    if (editing.value === agent.name) editing.value = null;
+    emit('reload');
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<template>
+  <section class="rounded-md border border-line bg-surface">
+    <div class="flex flex-wrap items-center gap-3 border-b border-line px-3 py-2">
+      <div class="min-w-0">
+        <h3 class="text-sm font-semibold">Custom agents</h3>
+        <p class="text-xs text-muted">
+          Wire up an agent loom doesn't ship by naming the shell commands it runs at each launch
+          stage. It then appears in the agent picker beside Claude and Codex.
+        </p>
+      </div>
+      <button
+        v-if="!open || !isNew"
+        class="btn-secondary ml-auto px-2.5 py-1 text-xs"
+        :disabled="busy"
+        data-testid="custom-agent-add"
+        @click="startAdd"
+      >
+        Add agent
+      </button>
+    </div>
+
+    <p v-if="error" class="border-b border-line px-3 py-2 text-xs text-block">{{ error }}</p>
+
+    <!-- Existing custom agents -->
+    <ul v-if="props.agents.length" class="divide-y divide-line">
+      <li
+        v-for="agent in props.agents"
+        :key="agent.name"
+        class="flex flex-wrap items-center gap-2 px-3 py-2"
+      >
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium">{{ agent.label }}</span>
+            <code class="font-mono text-2xs text-faint">{{ agent.name }}</code>
+            <span
+              v-if="agent.reports_status"
+              class="rounded bg-ok-soft px-1.5 py-0.5 text-2xs text-ok"
+            >
+              hooks
+            </span>
+          </div>
+          <p class="truncate font-mono text-2xs text-muted">
+            {{ agent.launch || agent.setup || '(bare shell)' }}
+          </p>
+        </div>
+        <div class="ml-auto flex items-center gap-1.5">
+          <button
+            class="btn-secondary px-2 py-1 text-xs"
+            :disabled="busy"
+            @click="startEdit(agent)"
+          >
+            Edit
+          </button>
+          <button
+            class="btn-secondary px-2 py-1 text-xs text-block"
+            :disabled="busy"
+            @click="remove(agent)"
+          >
+            Delete
+          </button>
+        </div>
+      </li>
+    </ul>
+    <p v-else-if="!open" class="px-3 py-3 text-xs text-muted">No custom agents yet.</p>
+
+    <!-- Add / edit form -->
+    <form v-if="open" class="space-y-3 border-t border-line px-3 py-3" @submit.prevent="save">
+      <div class="grid gap-3 sm:grid-cols-2">
+        <label class="block">
+          <span class="text-2xs font-semibold uppercase tracking-wider text-muted">Name</span>
+          <input
+            v-model="draft.name"
+            :disabled="!isNew"
+            placeholder="aider"
+            data-testid="custom-agent-name"
+            class="mt-1 w-full rounded bg-input px-2 py-1.5 font-mono text-sm outline-none ring-accent focus:ring-1 disabled:opacity-60"
+          />
+          <span class="mt-0.5 block text-2xs text-faint">
+            Id used in the agent list. Letters, digits, hyphens; fixed once created.
+          </span>
+        </label>
+        <label class="block">
+          <span class="text-2xs font-semibold uppercase tracking-wider text-muted">Label</span>
+          <input
+            v-model="draft.label"
+            placeholder="Aider"
+            data-testid="custom-agent-label"
+            class="mt-1 w-full rounded bg-input px-2 py-1.5 text-sm outline-none ring-accent focus:ring-1"
+          />
+        </label>
+      </div>
+
+      <label class="block">
+        <span class="text-2xs font-semibold uppercase tracking-wider text-muted">
+          Setup / install hooks
+        </span>
+        <textarea
+          v-model="draft.setup"
+          rows="2"
+          placeholder="Runs in the worktree before launch — e.g. write a config or install status hooks. Optional."
+          class="mt-1 w-full rounded bg-input px-2 py-1.5 font-mono text-xs outline-none ring-accent focus:ring-1"
+        ></textarea>
+      </label>
+
+      <label class="block">
+        <span class="text-2xs font-semibold uppercase tracking-wider text-muted">
+          Launch command
+        </span>
+        <input
+          v-model="draft.launch"
+          placeholder="aider --message"
+          data-testid="custom-agent-launch"
+          class="mt-1 w-full rounded bg-input px-2 py-1.5 font-mono text-sm outline-none ring-accent focus:ring-1"
+        />
+        <span class="mt-0.5 block text-2xs text-faint">
+          The fresh-session command; the goal is appended as a quoted argument. Leave blank for a
+          bare shell.
+        </span>
+      </label>
+
+      <label class="block">
+        <span class="text-2xs font-semibold uppercase tracking-wider text-muted">
+          Resume command
+        </span>
+        <input
+          v-model="draft.resume"
+          placeholder="aider --continue"
+          class="mt-1 w-full rounded bg-input px-2 py-1.5 font-mono text-sm outline-none ring-accent focus:ring-1"
+        />
+        <span class="mt-0.5 block text-2xs text-faint">
+          Used when resuming an existing worktree (no goal). Blank reuses the launch command.
+        </span>
+      </label>
+
+      <div class="flex items-center gap-2">
+        <ToggleSwitch
+          :model-value="draft.reports_status"
+          @update:model-value="draft.reports_status = $event"
+        />
+        <span class="text-xs text-muted">
+          Reports status via weaver hooks
+          <span class="text-faint">
+            — off: the session is <code>running</code> immediately, with no live working/idle state.
+          </span>
+        </span>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <button
+          type="submit"
+          class="btn-primary px-2.5 py-1 text-xs disabled:opacity-50"
+          :disabled="busy"
+          data-testid="custom-agent-save"
+        >
+          {{ isNew ? 'Add agent' : 'Save' }}
+        </button>
+        <button type="button" class="btn-secondary px-2.5 py-1 text-xs" :disabled="busy" @click="cancel">
+          Cancel
+        </button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -110,6 +110,37 @@ export interface AgentMetadata {
   accepts_raw_model: boolean;
   supports_hooks: boolean;
   supports_concierge: boolean;
+  /** True for the builtin `claude`/`codex`; false for an operator-defined custom
+   *  agent (which the UI may edit or delete). */
+  builtin: boolean;
+}
+
+/** An operator-defined custom agent: the shell commands loom runs at each launch
+ *  stage. Mirrors `custom_agents::CustomAgent`. Returned by `GET /api/agents`
+ *  (the `custom` array) and round-tripped by the Agents settings editor. */
+export interface CustomAgent {
+  name: string;
+  label: string;
+  /** Shell run in the worktree before launch — e.g. installing status hooks. */
+  setup: string;
+  /** Fresh-session launch command; the goal is appended as an argument. */
+  launch: string;
+  /** Adopt/resume command (no goal). Blank reuses `launch`. */
+  resume: string;
+  /** Whether the agent fires weaver's lifecycle hooks. */
+  reports_status: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/** The editable fields the Agents editor sends to create/update a custom agent. */
+export interface CustomAgentInput {
+  name: string;
+  label: string;
+  setup: string;
+  launch: string;
+  resume: string;
+  reports_status: boolean;
 }
 
 /** An issue belongs to a repo (`repo_root`). `claimed_branch` is the branch

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -2,12 +2,13 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { get, patch, listAgents } from '../api';
-import type { AgentMetadata, SettingView } from '../types';
+import type { AgentMetadata, CustomAgent, SettingView } from '../types';
 import ToggleSwitch from '../components/ToggleSwitch.vue';
 import TokensPanel from '../components/TokensPanel.vue';
 import AccountPanel from '../components/AccountPanel.vue';
 import EnvPanel from '../components/EnvPanel.vue';
 import AgentProfileEditor from '../components/AgentProfileEditor.vue';
+import CustomAgentsPanel from '../components/CustomAgentsPanel.vue';
 import SettingFieldRow from '../components/SettingFieldRow.vue';
 
 const route = useRoute();
@@ -132,6 +133,7 @@ function categoryFromQuery(q: unknown): Category {
 const category = ref<Category>(categoryFromQuery(route.query.tab));
 const settings = ref<SettingView[]>([]);
 const agents = ref<AgentMetadata[]>([]);
+const customAgents = ref<CustomAgent[]>([]);
 const drafts = ref<Record<string, string>>({});
 const error = ref('');
 const notice = ref('');
@@ -241,11 +243,26 @@ async function load() {
     }
     settings.value = res.settings;
     agents.value = agentRes.agents;
+    customAgents.value = agentRes.custom;
     drafts.value = Object.fromEntries(res.settings.map((s) => [s.key, s.value]));
     sanitizeAgentDrafts();
     error.value = '';
   } catch (e) {
     settings.value = [];
+    error.value = (e as Error).message;
+  }
+}
+
+// Refresh the agent lists after a custom agent is added/edited/removed, without
+// disturbing the settings drafts. A new or deleted agent changes the picker
+// (`agents`) as well as the custom list, so both are refetched.
+async function reloadAgents() {
+  try {
+    const res = await listAgents();
+    agents.value = res.agents;
+    customAgents.value = res.custom;
+    sanitizeAgentDrafts();
+  } catch (e) {
     error.value = (e as Error).message;
   }
 }
@@ -431,6 +448,7 @@ onMounted(load);
             @save="saveKeys(profileKeys(profile.id), profile.title)"
             @reset="resetKeys(profileKeys(profile.id), profile.title)"
           />
+          <CustomAgentsPanel :agents="customAgents" @reload="reloadAgents" />
         </div>
 
         <div v-else class="space-y-3">

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -2,7 +2,7 @@
 //! headless agent** (`POST /api/agent/oneshot`) — a fresh, env-stripped agent
 //! run for a judgement call.
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::future::Future;
@@ -10,23 +10,46 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
 use crate::backend;
+use crate::custom_agents::CustomAgent;
+use crate::db::Db;
 use weaver_core::agent::hooks_json;
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AgentChoice {
-    pub id: &'static str,
-    pub label: &'static str,
+    pub id: String,
+    pub label: String,
 }
 
+impl AgentChoice {
+    /// Materialize a builtin's static `(id, label)` table into the owned choices
+    /// the metadata carries.
+    fn list(pairs: &[(&str, &str)]) -> Vec<AgentChoice> {
+        pairs
+            .iter()
+            .map(|(id, label)| AgentChoice {
+                id: (*id).to_string(),
+                label: (*label).to_string(),
+            })
+            .collect()
+    }
+}
+
+/// What the agent picker and the settings validators need to know about one
+/// agent: its id, label, the model/effort choices it offers, and a few capability
+/// flags. Built fresh per call, so it can describe a DB-backed custom agent as
+/// easily as a builtin.
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentMetadata {
-    pub kind: &'static str,
-    pub label: &'static str,
-    pub models: &'static [AgentChoice],
-    pub efforts: &'static [AgentChoice],
+    pub kind: String,
+    pub label: String,
+    pub models: Vec<AgentChoice>,
+    pub efforts: Vec<AgentChoice>,
     pub accepts_raw_model: bool,
     pub supports_hooks: bool,
     pub supports_concierge: bool,
+    /// True for the code-shipped `claude`/`codex`; false for an operator-defined
+    /// custom agent (which the UI may edit or delete).
+    pub builtin: bool,
 }
 
 pub struct AgentInstance {
@@ -50,142 +73,134 @@ pub trait AgentType: Sync {
 
 pub struct ClaudeAgentType;
 pub struct CodexAgentType;
-pub struct ShellAgentType;
-pub struct CustomCommandAgentType {
-    command: String,
+
+/// A [`CustomAgent`] row wrapped as an [`AgentType`]: its stages drive the launch
+/// script, and its metadata is derived from the stored fields.
+pub struct CustomAgentType {
+    agent: CustomAgent,
 }
 
-impl CustomCommandAgentType {
-    pub fn new(command: impl Into<String>) -> Self {
-        Self {
-            command: command.into(),
-        }
+impl CustomAgentType {
+    pub fn new(agent: CustomAgent) -> Self {
+        Self { agent }
     }
 }
 
-const MODEL_CHOICES: &[AgentChoice] = &[
-    AgentChoice {
-        id: "haiku",
-        label: "Haiku",
-    },
-    AgentChoice {
-        id: "sonnet",
-        label: "Sonnet",
-    },
-    AgentChoice {
-        id: "opus",
-        label: "Opus",
-    },
-    AgentChoice {
-        id: "fable",
-        label: "Fable",
-    },
+const MODEL_CHOICES: &[(&str, &str)] = &[
+    ("haiku", "Haiku"),
+    ("sonnet", "Sonnet"),
+    ("opus", "Opus"),
+    ("fable", "Fable"),
 ];
 
-const CODEX_MODEL_CHOICES: &[AgentChoice] = &[
-    AgentChoice {
-        id: "gpt-5.5",
-        label: "GPT-5.5",
-    },
-    AgentChoice {
-        id: "gpt-5.4",
-        label: "GPT-5.4",
-    },
-    AgentChoice {
-        id: "gpt-5.4-mini",
-        label: "GPT-5.4 Mini",
-    },
-    AgentChoice {
-        id: "gpt-5.3-codex-spark",
-        label: "GPT-5.3 Codex Spark",
-    },
+const CODEX_MODEL_CHOICES: &[(&str, &str)] = &[
+    ("gpt-5.5", "GPT-5.5"),
+    ("gpt-5.4", "GPT-5.4"),
+    ("gpt-5.4-mini", "GPT-5.4 Mini"),
+    ("gpt-5.3-codex-spark", "GPT-5.3 Codex Spark"),
 ];
 
-const EFFORT_CHOICES: &[AgentChoice] = &[
-    AgentChoice {
-        id: "low",
-        label: "Low",
-    },
-    AgentChoice {
-        id: "medium",
-        label: "Medium",
-    },
-    AgentChoice {
-        id: "high",
-        label: "High",
-    },
-    AgentChoice {
-        id: "xhigh",
-        label: "X-High",
-    },
-    AgentChoice {
-        id: "max",
-        label: "Max",
-    },
+const EFFORT_CHOICES: &[(&str, &str)] = &[
+    ("low", "Low"),
+    ("medium", "Medium"),
+    ("high", "High"),
+    ("xhigh", "X-High"),
+    ("max", "Max"),
 ];
 
-const CODEX_EFFORT_CHOICES: &[AgentChoice] = &[
-    AgentChoice {
-        id: "low",
-        label: "Low",
-    },
-    AgentChoice {
-        id: "medium",
-        label: "Medium",
-    },
-    AgentChoice {
-        id: "high",
-        label: "High",
-    },
-    AgentChoice {
-        id: "xhigh",
-        label: "X-High",
-    },
+const CODEX_EFFORT_CHOICES: &[(&str, &str)] = &[
+    ("low", "Low"),
+    ("medium", "Medium"),
+    ("high", "High"),
+    ("xhigh", "X-High"),
 ];
 
 static CLAUDE_AGENT_TYPE: ClaudeAgentType = ClaudeAgentType;
 static CODEX_AGENT_TYPE: CodexAgentType = CodexAgentType;
-static SHELL_AGENT_TYPE: ShellAgentType = ShellAgentType;
 
-pub fn agent_type(kind: &str) -> Option<&'static dyn AgentType> {
+/// The builtin agent for `kind`, if it names one (`claude`/`codex`). Custom
+/// agents live in the database and are resolved by [`resolve`]; this covers only
+/// the code-shipped runtimes, which need no DB lookup.
+pub fn builtin_agent_type(kind: &str) -> Option<&'static dyn AgentType> {
     match kind {
         "claude" => Some(&CLAUDE_AGENT_TYPE),
         "codex" => Some(&CODEX_AGENT_TYPE),
-        "shell" | "none" => Some(&SHELL_AGENT_TYPE),
         _ => None,
     }
 }
 
-pub fn agent_metadata() -> Vec<AgentMetadata> {
-    [
-        &CLAUDE_AGENT_TYPE as &dyn AgentType,
-        &CODEX_AGENT_TYPE as &dyn AgentType,
-        &SHELL_AGENT_TYPE as &dyn AgentType,
-    ]
-    .into_iter()
-    .map(AgentType::metadata)
-    .collect()
+/// The builtin agents' metadata, in picker order.
+pub fn builtin_metadata() -> Vec<AgentMetadata> {
+    [&CLAUDE_AGENT_TYPE as &dyn AgentType, &CODEX_AGENT_TYPE]
+        .into_iter()
+        .map(AgentType::metadata)
+        .collect()
 }
 
-pub fn accepts_model(runtime: &str, model: &str) -> bool {
-    agent_type(runtime)
-        .map(|agent| validate_model(&agent.metadata(), model).is_ok())
-        .unwrap_or(false)
+/// A launchable agent resolved from a kind: either a builtin static type or a
+/// database-backed custom agent (owned, since it carries the row's commands).
+pub enum ResolvedAgent {
+    Builtin(&'static dyn AgentType),
+    Custom(CustomAgentType),
 }
 
-pub fn accepts_effort(runtime: &str, effort: &str) -> bool {
-    agent_type(runtime)
-        .map(|agent| validate_effort(&agent.metadata(), effort).is_ok())
-        .unwrap_or(false)
+impl ResolvedAgent {
+    pub fn as_type(&self) -> &dyn AgentType {
+        match self {
+            ResolvedAgent::Builtin(t) => *t,
+            ResolvedAgent::Custom(c) => c,
+        }
+    }
 }
 
-pub fn starts_from_hook(runtime: &str) -> bool {
-    agent_type(runtime)
-        .map(|agent| agent.metadata().supports_hooks)
-        .unwrap_or(false)
+/// Resolve `kind` to a launchable agent: a builtin first, then a custom agent
+/// from the `custom_agents` table. `Ok(None)` means no agent by that name.
+pub async fn resolve(db: &Db, kind: &str) -> Result<Option<ResolvedAgent>> {
+    if let Some(t) = builtin_agent_type(kind) {
+        return Ok(Some(ResolvedAgent::Builtin(t)));
+    }
+    Ok(crate::custom_agents::get(db, kind)
+        .await?
+        .map(|a| ResolvedAgent::Custom(CustomAgentType::new(a))))
 }
 
-fn validate_model(metadata: &AgentMetadata, model: &str) -> Result<(), String> {
+/// Every agent's metadata — the builtins followed by the operator's custom agents
+/// (name order). What `GET /api/agents` lists and the picker renders.
+pub async fn agent_metadata(db: &Db) -> Result<Vec<AgentMetadata>> {
+    let mut out = builtin_metadata();
+    for a in crate::custom_agents::list(db).await? {
+        out.push(CustomAgentType::new(a).metadata());
+    }
+    Ok(out)
+}
+
+/// The metadata for one agent kind, or `None` when it names no agent.
+pub async fn metadata_for(db: &Db, kind: &str) -> Result<Option<AgentMetadata>> {
+    Ok(resolve(db, kind).await?.map(|r| r.as_type().metadata()))
+}
+
+/// Whether `kind` names a known agent (builtin or custom).
+pub async fn exists(db: &Db, kind: &str) -> bool {
+    matches!(metadata_for(db, kind).await, Ok(Some(_)))
+}
+
+/// The lifecycle status a freshly launched session of `runtime` starts in. An
+/// agent that fires weaver's hooks starts `launching` (its SessionStart/work hook
+/// promotes it to `running`); a hookless agent (codex, most custom agents) never
+/// gets that hook, so it is `running` from the start rather than stuck
+/// `launching`. An unknown runtime is treated as hookless.
+pub async fn initial_status(db: &Db, runtime: &str) -> &'static str {
+    let hooked = matches!(metadata_for(db, runtime).await, Ok(Some(m)) if m.supports_hooks);
+    if hooked {
+        "launching"
+    } else {
+        "running"
+    }
+}
+
+/// Check that `model` is one of `metadata`'s offered choices (blank is always
+/// allowed — it means the agent's own default). A key-free reason on mismatch.
+pub fn validate_model(metadata: &AgentMetadata, model: &str) -> Result<(), String> {
     let model = model.trim();
     if model.is_empty() {
         return Ok(());
@@ -197,7 +212,9 @@ fn validate_model(metadata: &AgentMetadata, model: &str) -> Result<(), String> {
     }
 }
 
-fn validate_effort(metadata: &AgentMetadata, effort: &str) -> Result<(), String> {
+/// Check that `effort` is one of `metadata`'s offered choices (blank is always
+/// allowed — the agent's own default). A key-free reason on mismatch.
+pub fn validate_effort(metadata: &AgentMetadata, effort: &str) -> Result<(), String> {
     let effort = effort.trim();
     if effort.is_empty() {
         return Ok(());
@@ -299,15 +316,40 @@ fn codex_command(ctx: &AgentLaunchContext<'_>) -> String {
     }
 }
 
-fn shell_command(_ctx: &AgentLaunchContext<'_>) -> String {
-    String::new()
+/// The inner launch command for a custom agent: its `setup` stage (if any), then
+/// the stage command for this `mode`. Fresh runs `launch` with the goal file
+/// appended as a positional argument (mirroring the builtin runtimes); adopt runs
+/// `resume` with no goal, falling back to `launch`-with-goal when `resume` is
+/// blank. An empty result execs a bare shell — a setup-only or command-less agent.
+fn custom_command(agent: &CustomAgent, ctx: &AgentLaunchContext<'_>, mode: LaunchMode) -> String {
+    let launch_with_goal = |cmd: &str| match ctx.goal_file.or(ctx.primer_file) {
+        // The goal *content* is passed as a positional argument, mirroring the
+        // builtin runtimes (`claude "$(cat …)"`), not the file path.
+        Some(f) if !cmd.is_empty() => format!("{cmd} \"$(cat {})\"", sh_single_quote_path(f)),
+        _ => cmd.to_string(),
+    };
+    let command = match mode {
+        LaunchMode::Fresh => launch_with_goal(agent.launch.trim()),
+        LaunchMode::Adopt => {
+            let resume = agent.resume.trim();
+            if resume.is_empty() {
+                launch_with_goal(agent.launch.trim())
+            } else {
+                resume.to_string()
+            }
+        }
+    };
+    join_shell(&[agent.setup.trim(), command.as_str()])
 }
 
-fn custom_command(command: &str, ctx: &AgentLaunchContext<'_>) -> String {
-    match ctx.goal_file.or(ctx.primer_file) {
-        Some(f) => format!("{command} {}", sh_single_quote_path(f)),
-        None => command.to_string(),
-    }
+/// Join non-empty shell fragments with `; ` so they run in sequence.
+fn join_shell(parts: &[&str]) -> String {
+    parts
+        .iter()
+        .map(|p| p.trim())
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 /// Whether a session's terminal is being created for the first time or
@@ -340,37 +382,28 @@ pub struct AgentLaunchContext<'a> {
 impl AgentType for ClaudeAgentType {
     fn metadata(&self) -> AgentMetadata {
         AgentMetadata {
-            kind: "claude",
-            label: "Claude",
-            models: MODEL_CHOICES,
-            efforts: EFFORT_CHOICES,
+            kind: "claude".to_string(),
+            label: "Claude".to_string(),
+            models: AgentChoice::list(MODEL_CHOICES),
+            efforts: AgentChoice::list(EFFORT_CHOICES),
             accepts_raw_model: false,
             supports_hooks: true,
             supports_concierge: true,
+            builtin: true,
         }
     }
 
     fn create<'a>(&'a self, ctx: AgentLaunchContext<'a>) -> AgentFuture<'a> {
         Box::pin(async move {
             prepare_claude(&ctx).await;
-            start_terminal(
-                &ctx,
-                self.metadata().kind,
-                &claude_command(&ctx, LaunchMode::Fresh),
-            )
-            .await
+            start_terminal(&ctx, "claude", &claude_command(&ctx, LaunchMode::Fresh)).await
         })
     }
 
     fn adopt<'a>(&'a self, ctx: AgentLaunchContext<'a>) -> AgentFuture<'a> {
         Box::pin(async move {
             prepare_claude(&ctx).await;
-            start_terminal(
-                &ctx,
-                self.metadata().kind,
-                &claude_command(&ctx, LaunchMode::Adopt),
-            )
-            .await
+            start_terminal(&ctx, "claude", &claude_command(&ctx, LaunchMode::Adopt)).await
         })
     }
 }
@@ -378,125 +411,54 @@ impl AgentType for ClaudeAgentType {
 impl AgentType for CodexAgentType {
     fn metadata(&self) -> AgentMetadata {
         AgentMetadata {
-            kind: "codex",
-            label: "Codex",
-            models: CODEX_MODEL_CHOICES,
-            efforts: CODEX_EFFORT_CHOICES,
+            kind: "codex".to_string(),
+            label: "Codex".to_string(),
+            models: AgentChoice::list(CODEX_MODEL_CHOICES),
+            efforts: AgentChoice::list(CODEX_EFFORT_CHOICES),
             accepts_raw_model: false,
             supports_hooks: false,
             supports_concierge: true,
+            builtin: true,
         }
     }
 
     fn create<'a>(&'a self, ctx: AgentLaunchContext<'a>) -> AgentFuture<'a> {
-        Box::pin(
-            async move { start_terminal(&ctx, self.metadata().kind, &codex_command(&ctx)).await },
-        )
+        Box::pin(async move { start_terminal(&ctx, "codex", &codex_command(&ctx)).await })
     }
 
     fn adopt<'a>(&'a self, ctx: AgentLaunchContext<'a>) -> AgentFuture<'a> {
-        Box::pin(
-            async move { start_terminal(&ctx, self.metadata().kind, &codex_command(&ctx)).await },
-        )
+        Box::pin(async move { start_terminal(&ctx, "codex", &codex_command(&ctx)).await })
     }
 }
 
-impl AgentType for ShellAgentType {
+impl AgentType for CustomAgentType {
     fn metadata(&self) -> AgentMetadata {
         AgentMetadata {
-            kind: "shell",
-            label: "Shell",
-            models: &[],
-            efforts: &[],
+            kind: self.agent.name.clone(),
+            label: self.agent.label.clone(),
+            // Custom agents don't expose model/effort pickers — the operator bakes
+            // any such flags into the stage commands themselves.
+            models: Vec::new(),
+            efforts: Vec::new(),
             accepts_raw_model: false,
-            supports_hooks: false,
+            supports_hooks: self.agent.reports_status,
             supports_concierge: false,
-        }
-    }
-
-    fn create<'a>(&'a self, ctx: AgentLaunchContext<'a>) -> AgentFuture<'a> {
-        Box::pin(
-            async move { start_terminal(&ctx, self.metadata().kind, &shell_command(&ctx)).await },
-        )
-    }
-
-    fn adopt<'a>(&'a self, ctx: AgentLaunchContext<'a>) -> AgentFuture<'a> {
-        Box::pin(
-            async move { start_terminal(&ctx, self.metadata().kind, &shell_command(&ctx)).await },
-        )
-    }
-}
-
-impl AgentType for CustomCommandAgentType {
-    fn metadata(&self) -> AgentMetadata {
-        AgentMetadata {
-            kind: "custom",
-            label: "Custom",
-            models: &[],
-            efforts: &[],
-            accepts_raw_model: false,
-            supports_hooks: false,
-            supports_concierge: false,
+            builtin: false,
         }
     }
 
     fn create<'a>(&'a self, ctx: AgentLaunchContext<'a>) -> AgentFuture<'a> {
         Box::pin(async move {
-            start_terminal(
-                &ctx,
-                self.command.as_str(),
-                &custom_command(&self.command, &ctx),
-            )
-            .await
+            let inner = custom_command(&self.agent, &ctx, LaunchMode::Fresh);
+            start_terminal(&ctx, &self.agent.name, &inner).await
         })
     }
 
     fn adopt<'a>(&'a self, ctx: AgentLaunchContext<'a>) -> AgentFuture<'a> {
         Box::pin(async move {
-            start_terminal(
-                &ctx,
-                self.command.as_str(),
-                &custom_command(&self.command, &ctx),
-            )
-            .await
+            let inner = custom_command(&self.agent, &ctx, LaunchMode::Adopt);
+            start_terminal(&ctx, &self.agent.name, &inner).await
         })
-    }
-}
-
-/// Build the shell command that launches one session's agent. `runtime` is the
-/// **resolved runtime** — the binary to actually run, which for the concierge
-/// role-kind is the `concierge.runtime` setting (claude|codex), and for every
-/// other kind is the kind itself.
-///
-/// `goal_file` is the **positional** opening prompt (catted in as the operator's
-/// first message); `primer_file` is system *context* appended via
-/// `--append-system-prompt-file`. They are mutually distinct: a normal session
-/// carries a `goal_file`, the concierge carries a `primer_file` (so it boots
-/// primed but idle, taking no turn until the operator speaks). At most one is set.
-fn inner_command(
-    runtime: &str,
-    goal_file: Option<&Path>,
-    primer_file: Option<&Path>,
-    mode: LaunchMode,
-    model: &str,
-    effort: &str,
-) -> String {
-    let ctx = AgentLaunchContext {
-        branch_id: "",
-        work_dir: Path::new("."),
-        term_session: "",
-        goal_file,
-        primer_file,
-        server_addr: "",
-        model,
-        effort,
-        extra_env: &[],
-    };
-    match runtime {
-        "claude" => claude_command(&ctx, mode),
-        "codex" => codex_command(&ctx),
-        "shell" | "none" => shell_command(&ctx),
-        other => custom_command(other, &ctx),
     }
 }
 
@@ -546,27 +508,12 @@ fn wrap_launch_script(inner: &str, env: &[(&str, &str)], weaver_dir: Option<&Pat
     script
 }
 
-pub struct LaunchScriptSpec<'a> {
-    pub runtime: &'a str,
-    pub goal_file: Option<&'a Path>,
-    pub primer_file: Option<&'a Path>,
-    pub env: &'a [(&'a str, &'a str)],
-    pub weaver_dir: Option<&'a Path>,
-    pub mode: LaunchMode,
-    pub model: &'a str,
-    pub effort: &'a str,
-}
-
-pub fn launch_script(spec: LaunchScriptSpec<'_>) -> String {
-    let inner = inner_command(
-        spec.runtime,
-        spec.goal_file,
-        spec.primer_file,
-        spec.mode,
-        spec.model,
-        spec.effort,
-    );
-    wrap_launch_script(&inner, spec.env, spec.weaver_dir)
+/// The launch script for a **bare login shell** — loom's `env` exported, then
+/// `exec` the shell, with no inner agent command. Used by the operator scratch
+/// shell and per-session debug shells ([`crate::shell`]); those are plain shells,
+/// not agents, so they don't go through [`launch`] or an [`AgentType`].
+pub fn bare_shell_script(env: &[(&str, &str)], weaver_dir: Option<&Path>) -> String {
+    wrap_launch_script("", env, weaver_dir)
 }
 
 /// Everything [`launch`] needs to bring up a session's terminal.
@@ -574,8 +521,8 @@ pub struct LaunchSpec<'a> {
     /// The branch id — the agent uses this to resolve "its" branch via
     /// `$WEAVER_BRANCH`.
     pub branch_id: &'a str,
-    /// The resolved **runtime** to launch — the agent binary (claude|codex|shell|
-    /// a bare command), already resolved from the stored kind (so a concierge
+    /// The resolved **runtime** to launch — a builtin (`claude`/`codex`) or a
+    /// custom agent's name, already resolved from the stored kind (so a concierge
     /// carries its `concierge.runtime`, not the literal `concierge`).
     pub runtime: &'a str,
     pub work_dir: &'a Path,
@@ -598,8 +545,11 @@ pub struct LaunchSpec<'a> {
     pub extra_env: &'a [(String, String)],
 }
 
-/// Bring up the session's terminal running the agent.
-pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
+/// Bring up the session's terminal running the agent. `spec.runtime` is resolved
+/// through [`resolve`] — a builtin (`claude`/`codex`) or a custom agent from the
+/// `custom_agents` table — so an unknown runtime is a hard error rather than a
+/// silently-mistyped bare command.
+pub async fn launch(db: &Db, spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
     let ctx = AgentLaunchContext {
         branch_id: spec.branch_id,
         work_dir: spec.work_dir,
@@ -611,18 +561,13 @@ pub async fn launch(spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<()> {
         effort: spec.effort,
         extra_env: spec.extra_env,
     };
-    let _instance = match agent_type(spec.runtime) {
-        Some(agent_type) => match mode {
-            LaunchMode::Fresh => agent_type.create(ctx).await,
-            LaunchMode::Adopt => agent_type.adopt(ctx).await,
-        },
-        None => {
-            let custom = CustomCommandAgentType::new(spec.runtime);
-            match mode {
-                LaunchMode::Fresh => custom.create(ctx).await,
-                LaunchMode::Adopt => custom.adopt(ctx).await,
-            }
-        }
+    let resolved = resolve(db, spec.runtime)
+        .await?
+        .ok_or_else(|| anyhow!("unknown agent '{}'", spec.runtime))?;
+    let agent_type = resolved.as_type();
+    let _instance = match mode {
+        LaunchMode::Fresh => agent_type.create(ctx).await,
+        LaunchMode::Adopt => agent_type.adopt(ctx).await,
     }?;
     Ok(())
 }
@@ -975,6 +920,29 @@ mod tests {
     use super::*;
     use std::path::Path;
 
+    fn test_ctx<'a>(
+        goal_file: Option<&'a Path>,
+        primer_file: Option<&'a Path>,
+        model: &'a str,
+        effort: &'a str,
+    ) -> AgentLaunchContext<'a> {
+        AgentLaunchContext {
+            branch_id: "",
+            work_dir: Path::new("."),
+            term_session: "",
+            goal_file,
+            primer_file,
+            server_addr: "",
+            model,
+            effort,
+            extra_env: &[],
+        }
+    }
+
+    /// Build a full launch script for a builtin runtime the way [`start_terminal`]
+    /// does — its inner command wrapped with the env exports — without spawning a
+    /// terminal, so the command strings can be asserted directly. `runtime`
+    /// `"shell"` means a bare login shell (no inner command).
     fn launch_script(
         runtime: &str,
         goal_file: Option<&Path>,
@@ -984,22 +952,77 @@ mod tests {
         model: &str,
         effort: &str,
     ) -> String {
-        super::launch_script(LaunchScriptSpec {
-            runtime,
-            goal_file,
-            primer_file,
-            env,
-            weaver_dir: None,
-            mode,
-            model,
-            effort,
-        })
+        let ctx = test_ctx(goal_file, primer_file, model, effort);
+        let inner = match runtime {
+            "claude" => claude_command(&ctx, mode),
+            "codex" => codex_command(&ctx),
+            "shell" => String::new(),
+            other => panic!("unexpected runtime in test helper: {other}"),
+        };
+        wrap_launch_script(&inner, env, None)
     }
 
     #[test]
-    fn shell_script_just_execs_a_shell() {
+    fn bare_shell_script_just_execs_a_shell() {
+        assert_eq!(bare_shell_script(&[], None), "exec \"${SHELL:-/bin/sh}\"");
+        // The `"shell"` runtime in the test helper builds the same bare shell.
         let script = launch_script("shell", None, None, &[], LaunchMode::Fresh, "", "");
         assert_eq!(script, "exec \"${SHELL:-/bin/sh}\"");
+    }
+
+    fn custom_agent(name: &str, setup: &str, launch: &str, resume: &str) -> CustomAgent {
+        CustomAgent {
+            name: name.to_string(),
+            label: name.to_string(),
+            setup: setup.to_string(),
+            launch: launch.to_string(),
+            resume: resume.to_string(),
+            reports_status: false,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn custom_agent_runs_setup_then_launch_with_the_goal() {
+        let ctx = test_ctx(Some(Path::new("/x/goal.txt")), None, "", "");
+        let a = custom_agent("aider", "printf hooks > .cfg", "aider --message", "");
+        // Fresh: setup, then the launch command with the goal content appended.
+        assert_eq!(
+            custom_command(&a, &ctx, LaunchMode::Fresh),
+            "printf hooks > .cfg; aider --message \"$(cat '/x/goal.txt')\""
+        );
+    }
+
+    #[test]
+    fn custom_agent_adopt_prefers_resume_and_drops_the_goal() {
+        let ctx = test_ctx(Some(Path::new("/x/goal.txt")), None, "", "");
+        // With a resume command, adopt runs it (setup first) and passes no goal.
+        let a = custom_agent("aider", "setup.sh", "aider --message", "aider --continue");
+        assert_eq!(
+            custom_command(&a, &ctx, LaunchMode::Adopt),
+            "setup.sh; aider --continue"
+        );
+        // Without a resume command, adopt falls back to launch-with-goal.
+        let b = custom_agent("aider", "", "aider --message", "");
+        assert_eq!(
+            custom_command(&b, &ctx, LaunchMode::Adopt),
+            "aider --message \"$(cat '/x/goal.txt')\""
+        );
+    }
+
+    #[test]
+    fn custom_agent_with_no_launch_command_execs_a_bare_shell() {
+        // A setup-only (or wholly empty) custom agent produces an empty inner
+        // command, so its session just execs the login shell — the role the old
+        // builtin "shell" agent filled, now expressible as a custom agent.
+        let ctx = test_ctx(Some(Path::new("/x/goal.txt")), None, "", "");
+        let a = custom_agent("bare", "", "", "");
+        assert_eq!(custom_command(&a, &ctx, LaunchMode::Fresh), "");
+        assert_eq!(
+            wrap_launch_script(&custom_command(&a, &ctx, LaunchMode::Fresh), &[], None),
+            "exec \"${SHELL:-/bin/sh}\""
+        );
     }
 
     #[test]
@@ -1062,10 +1085,24 @@ mod tests {
     fn concierge_kind_is_a_role_not_a_runtime() {
         // The `concierge` string marks a role; it is not a runtime, so it must be
         // resolved (to claude|codex) before launch and never reach the command
-        // builder. Hook-starting is a runtime capability, not a role property.
-        assert!(starts_from_hook("claude"));
-        assert!(!starts_from_hook(CONCIERGE_KIND));
-        assert!(!starts_from_hook("codex"));
+        // builder — it is not a builtin agent type.
+        assert!(builtin_agent_type("claude").is_some());
+        assert!(builtin_agent_type("codex").is_some());
+        assert!(builtin_agent_type(CONCIERGE_KIND).is_none());
+        // Hook-starting is a runtime capability, not a role property: only claude
+        // fires weaver's lifecycle hooks.
+        assert!(
+            builtin_agent_type("claude")
+                .unwrap()
+                .metadata()
+                .supports_hooks
+        );
+        assert!(
+            !builtin_agent_type("codex")
+                .unwrap()
+                .metadata()
+                .supports_hooks
+        );
         // The primer the concierge is seeded with is the real fleet-ops doc.
         assert!(concierge_primer().contains("fleet concierge"));
     }

--- a/crates/loom/src/chatlog.rs
+++ b/crates/loom/src/chatlog.rs
@@ -62,18 +62,33 @@ fn branch_slug(branch: &Branch) -> String {
     }
 }
 
+/// Whether `agent_kind` produces a conversation transcript worth looking for: a
+/// builtin (claude/codex) or the concierge (which runs one of them). A custom
+/// agent or bare shell has none, so its missing transcript is expected, not a
+/// problem to warn about.
+fn produces_transcript(agent_kind: &str) -> bool {
+    crate::agent::builtin_agent_type(agent_kind).is_some()
+        || agent_kind == crate::agent::CONCIERGE_KIND
+}
+
+/// Whether `agent_kind` could have a Codex transcript — the codex runtime itself
+/// or the concierge (which may run codex). Only these are worth the `~/.codex`
+/// directory walk; every other agent skips it.
+fn maybe_codex(agent_kind: &str) -> bool {
+    agent_kind == "codex" || agent_kind == crate::agent::CONCIERGE_KIND
+}
+
 /// Locate a session's live agent transcript files (oldest first). Claude's are a
 /// cheap path lookup, so always try them; Codex needs a `~/.codex` directory
-/// walk, so only fall back to it for an agent that could be Codex — never for a
-/// plain `shell`/`none` session, which has no conversation and would pay for the
-/// scan for nothing. Empty when none are found.
+/// walk, so only fall back to it for an agent that could be Codex ([`maybe_codex`]).
+/// Empty when none are found.
 fn locate(session: &Session) -> Vec<PathBuf> {
     let work_dir = PathBuf::from(&session.work_dir);
     let files = transcript::claude_transcripts_for(&work_dir);
     if !files.is_empty() {
         return files;
     }
-    if matches!(session.agent_kind.as_str(), "shell" | "none") {
+    if !maybe_codex(&session.agent_kind) {
         return Vec::new();
     }
     transcript::codex_transcripts_for(&work_dir)
@@ -117,9 +132,9 @@ pub async fn capture(
     let mut warnings = Vec::new();
     let files = locate(session);
     if files.is_empty() {
-        // Missing transcript for a real agent is worth a warning; for a shell
-        // session it's expected, so stay quiet.
-        if !matches!(session.agent_kind.as_str(), "shell" | "none") {
+        // Missing transcript for an agent that produces one is worth a warning;
+        // for a custom agent or bare shell it's expected, so stay quiet.
+        if produces_transcript(&session.agent_kind) {
             warnings.push(format!(
                 "no agent transcript found for {}",
                 session.work_dir

--- a/crates/loom/src/custom_agents.rs
+++ b/crates/loom/src/custom_agents.rs
@@ -1,0 +1,267 @@
+//! Operator-defined **custom agents**, stored in the `custom_agents` table.
+//!
+//! A custom agent lets the user wire up a coding agent loom doesn't ship — by
+//! naming the shell commands loom runs at each launch stage — so it appears in
+//! the agent list beside the builtin `claude`/`codex` without a code change. The
+//! builtin agents keep their bespoke launch logic in [`crate::agent`]; a custom
+//! agent is pure data: a name, a label, and a command per stage.
+//!
+//! Stages (each a shell fragment, exported with loom's launch env):
+//!
+//! * `setup`  — run in the worktree before the agent starts (e.g. installing the
+//!   status hooks that let weaver see the agent's working/idle state);
+//! * `launch` — the fresh-session command; the goal file is appended as a
+//!   positional `"$(cat …)"` argument, mirroring the builtin runtimes;
+//! * `resume` — the adopt/resume command (no goal). Blank falls back to `launch`.
+//!
+//! `reports_status` records whether the agent fires weaver's lifecycle hooks, so
+//! [`crate::agent`] knows whether a fresh session should wait at `launching` for
+//! the first hook or go straight to `running`.
+
+use anyhow::Result;
+use serde::Serialize;
+use sqlx::Row;
+
+use crate::db::{now_iso, Db};
+
+/// The builtin agent names a custom agent may not shadow: the two real runtimes
+/// plus the `concierge` role-kind. `shell` is deliberately *not* reserved — it is
+/// no longer a builtin, so a user may define it themselves.
+pub const RESERVED_NAMES: &[&str] = &["claude", "codex", "concierge"];
+
+/// One custom agent definition — a row of the `custom_agents` table and the shape
+/// the API returns for the editor. Every field is operator-supplied except the
+/// timestamps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CustomAgent {
+    /// The id referenced by the agent list and a session's `agent_kind`.
+    pub name: String,
+    /// The display name shown in the agent picker.
+    pub label: String,
+    /// Shell run in the worktree before launch — the "installing hooks" stage.
+    pub setup: String,
+    /// The fresh-session launch command; the goal is appended as an argument.
+    pub launch: String,
+    /// The adopt/resume command (no goal). Blank reuses [`Self::launch`].
+    pub resume: String,
+    /// Whether the agent fires weaver's lifecycle hooks (so a fresh session waits
+    /// at `launching` rather than going straight to `running`).
+    pub reports_status: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Validate a custom agent's name. It is an id — referenced by the agent list and
+/// stored as a session's `agent_kind` — so keep it to a clean, URL- and
+/// log-friendly slug: a leading letter, then letters, digits, hyphens, or
+/// underscores. The builtin names in [`RESERVED_NAMES`] are rejected so a custom
+/// agent can't shadow (or masquerade as) a real runtime. The error is a key-free
+/// reason so callers can prefix it with their own context.
+pub fn validate_name(name: &str) -> std::result::Result<(), String> {
+    if name.is_empty() {
+        return Err("name must not be empty".to_string());
+    }
+    let mut chars = name.chars();
+    let first = chars.next().unwrap();
+    if !first.is_ascii_alphabetic() {
+        return Err(format!("name must start with a letter, got '{name}'"));
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+        return Err(format!(
+            "name may contain only letters, digits, hyphens, and underscores, got '{name}'"
+        ));
+    }
+    if RESERVED_NAMES.contains(&name) {
+        return Err(format!(
+            "name '{name}' is reserved for a builtin agent — pick another name"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate the operator-supplied fields of a custom agent (everything but the
+/// name, which has its own [`validate_name`]). Returns a key-free reason on the
+/// first problem.
+pub fn validate_fields(agent: &CustomAgent) -> std::result::Result<(), String> {
+    if agent.label.trim().is_empty() {
+        return Err("label must not be empty".to_string());
+    }
+    // Every stage command is optional: an agent with no `launch` execs a bare
+    // login shell, which is a legitimate manual-terminal agent (the role the old
+    // builtin "shell" filled).
+    Ok(())
+}
+
+fn row_to_agent(r: &sqlx::sqlite::SqliteRow) -> CustomAgent {
+    CustomAgent {
+        name: r.get::<String, _>("name"),
+        label: r.get::<String, _>("label"),
+        setup: r.get::<String, _>("setup"),
+        launch: r.get::<String, _>("launch"),
+        resume: r.get::<String, _>("resume"),
+        reports_status: r.get::<i64, _>("reports_status") != 0,
+        created_at: r.get::<String, _>("created_at"),
+        updated_at: r.get::<String, _>("updated_at"),
+    }
+}
+
+const COLUMNS: &str = "name, label, setup, launch, resume, reports_status, created_at, updated_at";
+
+/// Every custom agent, ordered by name.
+pub async fn list(db: &Db) -> Result<Vec<CustomAgent>> {
+    let sql = format!("SELECT {COLUMNS} FROM custom_agents ORDER BY name");
+    let rows = sqlx::query(&sql).fetch_all(db).await?;
+    Ok(rows.iter().map(row_to_agent).collect())
+}
+
+/// One custom agent by name, or `None` when it isn't defined.
+pub async fn get(db: &Db, name: &str) -> Result<Option<CustomAgent>> {
+    let sql = format!("SELECT {COLUMNS} FROM custom_agents WHERE name = ?");
+    let row = sqlx::query(&sql).bind(name).fetch_optional(db).await?;
+    Ok(row.as_ref().map(row_to_agent))
+}
+
+/// Whether a custom agent by this name exists.
+pub async fn exists(db: &Db, name: &str) -> Result<bool> {
+    Ok(get(db, name).await?.is_some())
+}
+
+/// Upsert a custom agent. The caller is expected to [`validate_name`] /
+/// [`validate_fields`] first; this only touches the database. `created_at` is
+/// preserved on update; `updated_at` is refreshed.
+pub async fn set(db: &Db, agent: &CustomAgent) -> Result<()> {
+    let now = now_iso();
+    sqlx::query(
+        "INSERT INTO custom_agents
+             (name, label, setup, launch, resume, reports_status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(name) DO UPDATE SET
+             label = excluded.label,
+             setup = excluded.setup,
+             launch = excluded.launch,
+             resume = excluded.resume,
+             reports_status = excluded.reports_status,
+             updated_at = excluded.updated_at",
+    )
+    .bind(&agent.name)
+    .bind(agent.label.trim())
+    .bind(&agent.setup)
+    .bind(&agent.launch)
+    .bind(&agent.resume)
+    .bind(i64::from(agent.reports_status))
+    .bind(&now)
+    .bind(&now)
+    .execute(db)
+    .await?;
+    tracing::debug!(name = %agent.name, "custom_agents set");
+    Ok(())
+}
+
+/// Delete a custom agent. Removing an absent name is a no-op (returns `false`).
+pub async fn remove(db: &Db, name: &str) -> Result<bool> {
+    let res = sqlx::query("DELETE FROM custom_agents WHERE name = ?")
+        .bind(name)
+        .execute(db)
+        .await?;
+    let removed = res.rows_affected() > 0;
+    tracing::debug!(name, removed, "custom_agents remove");
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(name: &str) -> CustomAgent {
+        CustomAgent {
+            name: name.to_string(),
+            label: "Aider".to_string(),
+            setup: String::new(),
+            launch: "aider --message".to_string(),
+            resume: String::new(),
+            reports_status: false,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn validate_name_accepts_slugs() {
+        assert!(validate_name("aider").is_ok());
+        assert!(validate_name("gpt-cli").is_ok());
+        assert!(validate_name("my_agent2").is_ok());
+        // `shell` is no longer builtin, so it is a legal custom name.
+        assert!(validate_name("shell").is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_bad_shapes_and_builtins() {
+        assert!(validate_name("").is_err());
+        assert!(validate_name("2fast").is_err());
+        assert!(validate_name("has space").is_err());
+        assert!(validate_name("dots.dots").is_err());
+        // Builtin runtimes and the concierge role-kind are reserved.
+        assert!(validate_name("claude").is_err());
+        assert!(validate_name("codex").is_err());
+        assert!(validate_name("concierge").is_err());
+    }
+
+    #[test]
+    fn validate_fields_requires_only_a_label() {
+        let mut a = agent("aider");
+        assert!(validate_fields(&a).is_ok());
+        // A blank label is rejected.
+        a.label = "  ".to_string();
+        assert!(validate_fields(&a).is_err());
+        // A command-less agent (bare shell) is allowed, as long as it has a label.
+        a.label = "Bare".to_string();
+        a.launch = String::new();
+        a.setup = String::new();
+        assert!(validate_fields(&a).is_ok());
+    }
+
+    #[tokio::test]
+    async fn set_get_list_remove_round_trip() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        assert!(list(&db).await.unwrap().is_empty());
+        assert!(!exists(&db, "aider").await.unwrap());
+
+        set(&db, &agent("aider")).await.unwrap();
+        set(
+            &db,
+            &CustomAgent {
+                reports_status: true,
+                ..agent("zeta")
+            },
+        )
+        .await
+        .unwrap();
+
+        let all = list(&db).await.unwrap();
+        assert_eq!(all.len(), 2);
+        // Ordered by name.
+        assert_eq!(all[0].name, "aider");
+        assert_eq!(all[1].name, "zeta");
+        assert!(all[1].reports_status);
+        assert!(exists(&db, "aider").await.unwrap());
+
+        // Upsert replaces the mutable fields but keeps created_at.
+        let first_created = all[0].created_at.clone();
+        set(
+            &db,
+            &CustomAgent {
+                label: "Aider v2".to_string(),
+                ..agent("aider")
+            },
+        )
+        .await
+        .unwrap();
+        let updated = get(&db, "aider").await.unwrap().unwrap();
+        assert_eq!(updated.label, "Aider v2");
+        assert_eq!(updated.created_at, first_created);
+
+        assert!(remove(&db, "aider").await.unwrap());
+        assert!(!remove(&db, "aider").await.unwrap());
+        assert_eq!(list(&db).await.unwrap().len(), 1);
+    }
+}

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -192,6 +192,28 @@ CREATE TABLE IF NOT EXISTS user_github_tokens (
     token      TEXT NOT NULL,
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
+
+-- Operator-defined custom agents: a coding agent the user wires up by naming the
+-- shell commands loom runs at each launch stage, so it shows up in the agent list
+-- beside the builtin `claude`/`codex` without a code change. `name` is the id the
+-- agent list and a session's `agent_kind` reference; the builtin names are
+-- reserved (see `custom_agents::validate_name`). Each stage is a shell fragment:
+--   * `setup`  — run in the worktree before launch (e.g. installing status hooks);
+--   * `launch` — the fresh-session command, with the goal appended as an argument;
+--   * `resume` — the adopt/resume command (blank falls back to `launch`).
+-- `reports_status` records whether the agent fires weaver's lifecycle hooks (so a
+-- fresh session waits at `launching` for the first hook rather than going straight
+-- to `running`).
+CREATE TABLE IF NOT EXISTS custom_agents (
+    name           TEXT PRIMARY KEY,
+    label          TEXT NOT NULL,
+    setup          TEXT NOT NULL DEFAULT '',
+    launch         TEXT NOT NULL DEFAULT '',
+    resume         TEXT NOT NULL DEFAULT '',
+    reports_status INTEGER NOT NULL DEFAULT 0,
+    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
 "#;
 
 /// Open the shared database and apply loom's additional tables on top of the

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -12,6 +12,7 @@ pub mod backend;
 pub mod builtins;
 pub mod chatlog;
 pub mod client;
+pub mod custom_agents;
 pub mod db;
 pub mod endpoint;
 pub mod envfile;

--- a/crates/loom/src/shell.rs
+++ b/crates/loom/src/shell.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use weaver_core::branch::Branch;
 
-use crate::agent::{self, LaunchMode};
+use crate::agent;
 use crate::backend;
 use crate::session::Session;
 use crate::{agent_env, AppState};
@@ -51,8 +51,9 @@ fn shell_cwd() -> PathBuf {
 /// surface an agent session gets — `WEAVER_API` + `LOOM_TOKEN` so the in-place
 /// `weaver`/`loom` CLIs work, the operator-managed [`agent_env`] vars, and (for a
 /// per-session debug shell) the session's `WEAVER_BRANCH` — then `exec` the login
-/// shell. `agent_kind = "shell"` means no inner agent command; the empty
-/// args/`Adopt` mode are irrelevant for a bare shell.
+/// shell. This is a plain shell, not an agent, so it uses
+/// [`agent::bare_shell_script`] (no inner agent command) rather than going through
+/// the agent launch path.
 async fn shell_script(st: &AppState, branch_id: Option<&str>) -> String {
     let api_url = format!("http://{}", st.addr);
     let local_token = agent::read_local_token();
@@ -73,16 +74,7 @@ async fn shell_script(st: &AppState, branch_id: Option<&str>) -> String {
 
     let loom_exe = std::env::current_exe().ok();
     let weaver_dir = loom_exe.as_deref().and_then(Path::parent);
-    agent::launch_script(agent::LaunchScriptSpec {
-        runtime: "shell",
-        goal_file: None,
-        primer_file: None,
-        env: &env,
-        weaver_dir,
-        mode: LaunchMode::Adopt,
-        model: "",
-        effort: "",
-    })
+    agent::bare_shell_script(&env, weaver_dir)
 }
 
 /// Ensure the scratch-shell supervisor is up, spawning it if not. Idempotent: a

--- a/crates/loom/src/web/agents.rs
+++ b/crates/loom/src/web/agents.rs
@@ -1,0 +1,107 @@
+//! CRUD for **custom agents** — the operator-defined agents in the
+//! `custom_agents` table that appear in the picker beside the builtin
+//! `claude`/`codex`. The picker listing itself is `GET /api/agents`
+//! ([`super::sessions::list_agents`]); these routes add/edit/remove the custom
+//! rows it merges in.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::custom_agents::{self, CustomAgent};
+use crate::db::Db;
+
+use super::{ApiResult, AppError, AppState};
+
+/// The editable fields of a custom agent. `name` is used only by the create
+/// route (update takes it from the path); the stage commands default to empty.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct CustomAgentBody {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    label: String,
+    #[serde(default)]
+    setup: String,
+    #[serde(default)]
+    launch: String,
+    #[serde(default)]
+    resume: String,
+    #[serde(default)]
+    reports_status: bool,
+}
+
+impl CustomAgentBody {
+    /// Assemble a [`CustomAgent`] under `name`. The timestamps are filled in by
+    /// [`custom_agents::set`], so they start blank.
+    fn into_agent(self, name: &str) -> CustomAgent {
+        CustomAgent {
+            name: name.to_string(),
+            label: self.label.trim().to_string(),
+            setup: self.setup,
+            launch: self.launch,
+            resume: self.resume,
+            reports_status: self.reports_status,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+}
+
+/// The custom-agent list, returned by every mutating route so the caller can
+/// refresh in one round trip.
+async fn custom_envelope(db: &Db) -> ApiResult<Json<Value>> {
+    Ok(Json(json!({ "custom": custom_agents::list(db).await? })))
+}
+
+/// `POST /api/agents/custom` — define a new custom agent. The name must be a
+/// fresh, non-reserved slug and the definition must have a label (the stage
+/// commands are optional — a command-less agent execs a bare login shell).
+pub(super) async fn create_custom_agent(
+    State(st): State<AppState>,
+    Json(body): Json<CustomAgentBody>,
+) -> ApiResult<Json<Value>> {
+    let name = body.name.trim().to_string();
+    custom_agents::validate_name(&name).map_err(AppError::bad_request)?;
+    if custom_agents::exists(&st.db, &name).await? {
+        return Err(AppError::conflict(format!(
+            "an agent named '{name}' already exists"
+        )));
+    }
+    let agent = body.into_agent(&name);
+    custom_agents::validate_fields(&agent).map_err(AppError::bad_request)?;
+    custom_agents::set(&st.db, &agent).await?;
+    custom_envelope(&st.db).await
+}
+
+/// `PUT /api/agents/custom/{name}` — replace an existing custom agent's
+/// definition. The name (from the path) is immutable; a builtin or unknown name
+/// is a 404.
+pub(super) async fn update_custom_agent(
+    State(st): State<AppState>,
+    Path(name): Path<String>,
+    Json(body): Json<CustomAgentBody>,
+) -> ApiResult<Json<Value>> {
+    if !custom_agents::exists(&st.db, &name).await? {
+        return Err(AppError::not_found("custom agent"));
+    }
+    let agent = body.into_agent(&name);
+    custom_agents::validate_fields(&agent).map_err(AppError::bad_request)?;
+    custom_agents::set(&st.db, &agent).await?;
+    custom_envelope(&st.db).await
+}
+
+/// `DELETE /api/agents/custom/{name}` — remove a custom agent. Removing an absent
+/// name is a no-op (the desired end state already holds). Sessions already
+/// launched with the agent are unaffected; a later adopt of one would fail to
+/// resolve it, which surfaces as a clear launch error.
+pub(super) async fn delete_custom_agent(
+    State(st): State<AppState>,
+    Path(name): Path<String>,
+) -> ApiResult<Json<Value>> {
+    custom_agents::remove(&st.db, &name).await?;
+    custom_envelope(&st.db).await
+}

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -62,6 +62,7 @@
 //! through `PUT /api/sessions/{id}/tags/{key}` and cleared through `DELETE`.
 //! Absence is the calm state; there is no stored `ok` tag.
 
+mod agents;
 mod artifacts;
 mod auth;
 mod branches;
@@ -75,6 +76,7 @@ mod scratch;
 mod sessions;
 mod settings;
 
+use agents::*;
 use artifacts::*;
 use auth::*;
 use branches::*;
@@ -575,6 +577,13 @@ pub fn router(state: AppState) -> Router {
         )
         // Misc
         .route("/agents", get(list_agents))
+        // Operator-defined custom agents (create + edit/remove by name). The
+        // static `/custom` segment is registered before the `{name}` capture.
+        .route("/agents/custom", post(create_custom_agent))
+        .route(
+            "/agents/custom/{name}",
+            axum::routing::put(update_custom_agent).delete(delete_custom_agent),
+        )
         // The managed repo store + clone allowlist (register/list).
         .route("/repos", get(list_repos).post(register_repo))
         // The trusted-owner allowlist — GitHub accounts loom will act for via the

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -19,7 +19,10 @@ use crate::auth::Principal;
 use crate::db::Db;
 use crate::events::Event;
 use crate::session::{self as session_mod, NewSession, Session};
-use crate::{agent, agent_env, backend, config, db, events, git, github, repo, repo_env, setup};
+use crate::{
+    agent, agent_env, backend, config, custom_agents, db, events, git, github, repo, repo_env,
+    setup,
+};
 use weaver_api::{CreateReq, PatchSessionReq, SendReq, SessionView, TagReq};
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::Branch;
@@ -35,7 +38,10 @@ const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub token configured. Add your
 pub(super) async fn list_agents(State(st): State<AppState>) -> ApiResult<Json<Value>> {
     let default_agent = configured_agent(&st.db, "agent.default", config::DEFAULT_AGENT).await;
     Ok(Json(json!({
-        "agents": agent::agent_metadata(),
+        // The picker list (builtins + custom) and the full custom-agent
+        // definitions the editor round-trips.
+        "agents": agent::agent_metadata(&st.db).await?,
+        "custom": custom_agents::list(&st.db).await?,
         "default_agent": default_agent,
     })))
 }
@@ -145,7 +151,7 @@ async fn launch_runtime(db: &Db, agent_kind: &str) -> String {
 async fn configured_agent(db: &Db, key: &str, default: &str) -> String {
     let value = config::get_or(db, key, default).await;
     let value = value.trim();
-    if agent::agent_type(value).is_some() {
+    if agent::exists(db, value).await {
         value.to_string()
     } else {
         default.to_string()
@@ -153,19 +159,20 @@ async fn configured_agent(db: &Db, key: &str, default: &str) -> String {
 }
 
 /// Whether `value` is a valid model selector (or effort, when `model` is false)
-/// for `runtime`'s agent type. A custom/unknown runtime accepts no selector here.
-fn selector_valid(runtime: &str, value: &str, model: bool) -> bool {
-    match agent::agent_type(runtime) {
-        Some(agent_type) if model => agent_type.validate(value, "").is_ok(),
-        Some(agent_type) => agent_type.validate("", value).is_ok(),
-        None => false,
+/// for `runtime`'s agent type. A custom agent offers no selectors (empty choice
+/// lists), so any non-empty value is invalid for it — as is an unknown runtime.
+async fn selector_valid(db: &Db, runtime: &str, value: &str, model: bool) -> bool {
+    match agent::metadata_for(db, runtime).await {
+        Ok(Some(meta)) if model => agent::validate_model(&meta, value).is_ok(),
+        Ok(Some(meta)) => agent::validate_effort(&meta, value).is_ok(),
+        _ => false,
     }
 }
 
 async fn configured_selector(db: &Db, key: &str, runtime: &str, model: bool) -> String {
     let value = config::get_or(db, key, "").await;
     let value = value.trim();
-    if value.is_empty() || !selector_valid(runtime, value, model) {
+    if value.is_empty() || !selector_valid(db, runtime, value, model).await {
         return String::new();
     }
     value.to_string()
@@ -183,7 +190,7 @@ async fn repo_default_agent(db: &Db, cfg: &weaver_core::repo_config::RepoConfig)
         .map(str::trim)
         .filter(|k| !k.is_empty())
     {
-        if agent::agent_type(kind).is_some() {
+        if agent::exists(db, kind).await {
             return kind.to_string();
         }
     }
@@ -201,7 +208,7 @@ async fn repo_or_configured_selector(
     model: bool,
 ) -> String {
     if let Some(value) = repo_value.map(str::trim).filter(|v| !v.is_empty()) {
-        if selector_valid(runtime, value, model) {
+        if selector_valid(db, runtime, value, model).await {
             return value.to_string();
         }
     }
@@ -309,9 +316,12 @@ async fn ensure_github_token_available(
     created_by: Option<&str>,
     runtime: &str,
 ) -> ApiResult<()> {
-    // Shell sessions are explicitly allowed as empty/manual terminals; they do
-    // not need GitHub credentials to be useful.
-    if matches!(runtime, "shell" | "none") {
+    // Only the builtin PR-driving agents (claude/codex) need GitHub credentials to
+    // push as the user. A custom agent is operator-defined — it may be a manual
+    // terminal or never touch GitHub, and the operator supplies whatever
+    // credentials it needs via env — so it is exempt, as the old manual "shell"
+    // terminal was.
+    if agent::builtin_agent_type(runtime).is_none() {
         return Ok(());
     }
     let Some(username) = created_by else {
@@ -431,18 +441,6 @@ fn tail_chars(s: &str, max: usize) -> String {
     format!("…(truncated)\n{tail}")
 }
 
-/// A freshly launched session's lifecycle status. A Claude runtime starts
-/// `launching` because its `SessionStart`/work hook will promote it to `running`;
-/// a hookless runtime (shell, codex, a bare command) never gets that hook, so it
-/// is `running` from the start rather than stuck `launching`.
-fn initial_status(runtime: &str) -> &'static str {
-    if agent::starts_from_hook(runtime) {
-        "launching"
-    } else {
-        "running"
-    }
-}
-
 /// The session-creation core, shared by `POST /api/sessions` and the Chat
 /// surface's concierge get-or-create ([`get_chat`]). Returns the view directly so
 /// the caller can shape its own response.
@@ -560,14 +558,15 @@ pub(crate) async fn create_session_core(
             .await
         }
     };
-    if let Some(agent_type) = agent::agent_type(&runtime) {
-        agent_type
-            .validate(&model, &effort)
-            .map_err(AppError::bad_request)?;
-    } else if !model.is_empty() || !effort.is_empty() {
-        return Err(AppError::bad_request(format!(
-            "custom agent '{runtime}' does not accept model or effort selectors"
-        )));
+    match agent::metadata_for(&st.db, &runtime).await? {
+        // Blank model/effort means the agent's own default; a non-empty value must
+        // be one the agent offers. A custom agent offers none, so any explicit
+        // selector is rejected here.
+        Some(meta) => {
+            agent::validate_model(&meta, &model).map_err(AppError::bad_request)?;
+            agent::validate_effort(&meta, &effort).map_err(AppError::bad_request)?;
+        }
+        None => return Err(AppError::bad_request(format!("unknown agent '{runtime}'"))),
     }
     ensure_github_token_available(&st.db, &extra_env, created_by.as_deref(), &runtime).await?;
 
@@ -934,6 +933,7 @@ pub(crate) async fn create_session_core(
     }
 
     agent::launch(
+        &st.db,
         &agent::LaunchSpec {
             branch_id: &branch.id,
             runtime: &runtime,
@@ -951,9 +951,10 @@ pub(crate) async fn create_session_core(
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    // Only a Claude runtime emits the hook that promotes `launching` → `running`;
-    // a hookless runtime (shell, codex, a bare command) is live on launch.
-    let status = initial_status(&runtime);
+    // Only an agent that fires weaver's hooks starts `launching` (its hook
+    // promotes it to `running`); a hookless runtime (codex, most custom agents) is
+    // live on launch.
+    let status = agent::initial_status(&st.db, &runtime).await;
     let session = session_mod::insert(
         &st.db,
         &NewSession {
@@ -1548,6 +1549,7 @@ pub(crate) async fn create_warm_session(
     let extra_env = launch_env(&st.db, &repo_root, &repo_cfg).await;
     // A warm session never carries the concierge role, so its runtime is its kind.
     agent::launch(
+        &st.db,
         &agent::LaunchSpec {
             branch_id: &branch.id,
             runtime: &agent,
@@ -1566,7 +1568,7 @@ pub(crate) async fn create_warm_session(
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let status = initial_status(&agent);
+    let status = agent::initial_status(&st.db, &agent).await;
     let session = session_mod::insert(
         &st.db,
         &NewSession {
@@ -1671,6 +1673,7 @@ async fn resume_agent(
     let extra_env = launch_env(&st.db, &repo_root, &repo_cfg).await;
     let runtime = launch_runtime(&st.db, &session.agent_kind).await;
     agent::launch(
+        &st.db,
         &agent::LaunchSpec {
             branch_id: &branch.id,
             runtime: &runtime,
@@ -1687,9 +1690,9 @@ async fn resume_agent(
     )
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    // A hookless runtime (codex, a bare command) won't get the hook that would
+    // A hookless runtime (codex, most custom agents) won't get the hook that would
     // promote `launching` → `running`, so mark it live now rather than stranding it.
-    let status = initial_status(&runtime);
+    let status = agent::initial_status(&st.db, &runtime).await;
     session_mod::set_status(&st.db, &session.id, status).await?;
     events::record(
         &st.db,
@@ -2177,13 +2180,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shell_and_webhook_launches_do_not_require_user_github_token() {
+    async fn custom_and_webhook_launches_do_not_require_user_github_token() {
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
 
-        ensure_github_token_available(&db, &[], Some("alice"), "shell")
+        // A custom (non-builtin) agent is exempt — it may never touch GitHub, and
+        // the operator supplies any credentials it needs via env.
+        ensure_github_token_available(&db, &[], Some("alice"), "my-custom-agent")
             .await
             .unwrap();
+        // A webhook launch carries an attribution string, not an approved user.
         ensure_github_token_available(&db, &[], Some("github-webhook (octo)"), "codex")
             .await
             .unwrap();

--- a/crates/loom/src/web/settings.rs
+++ b/crates/loom/src/web/settings.rs
@@ -143,14 +143,16 @@ async fn validate_agent_settings_group(
     }
 
     let agent_kind = setting_after(db, changes, group.agent_key, group.agent_default).await;
-    let Some(agent_type) = agent::agent_type(&agent_kind) else {
-        errors.insert(
-            group.agent_key.to_string(),
-            json!(format!("unknown agent '{agent_kind}'")),
-        );
-        return;
+    let metadata = match agent::metadata_for(db, &agent_kind).await {
+        Ok(Some(m)) => m,
+        _ => {
+            errors.insert(
+                group.agent_key.to_string(),
+                json!(format!("unknown agent '{agent_kind}'")),
+            );
+            return;
+        }
     };
-    let metadata = agent_type.metadata();
     if group.require_concierge && !metadata.supports_concierge {
         errors.insert(
             group.agent_key.to_string(),
@@ -166,7 +168,7 @@ async fn validate_agent_settings_group(
         group.agent_key,
         group.model_key,
         &model,
-        || agent_type.validate(&model, ""),
+        || agent::validate_model(&metadata, &model),
     );
 
     let effort = setting_after(db, changes, group.effort_key, "").await;
@@ -176,7 +178,7 @@ async fn validate_agent_settings_group(
         group.agent_key,
         group.effort_key,
         &effort,
-        || agent_type.validate("", &effort),
+        || agent::validate_effort(&metadata, &effort),
     );
 }
 

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -85,6 +85,24 @@ async fn hook_event_drives_session_status() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let pool = db::connect(&db::default_db_path()).await.unwrap();
+    // The session below launches with `"agent": "shell"`; `shell` is no longer a
+    // builtin, so seed it as a command-less custom agent (execs a bare login
+    // shell, hookless).
+    loom::custom_agents::set(
+        &pool,
+        &loom::custom_agents::CustomAgent {
+            name: "shell".to_string(),
+            label: "Shell".to_string(),
+            setup: String::new(),
+            launch: String::new(),
+            resume: String::new(),
+            reports_status: false,
+            created_at: String::new(),
+            updated_at: String::new(),
+        },
+    )
+    .await
+    .unwrap();
     let state = AppState {
         db: pool.clone(),
         bus: EventBus::new(),

--- a/crates/loom/tests/integration/custom_agents.rs
+++ b/crates/loom/tests/integration/custom_agents.rs
@@ -1,0 +1,203 @@
+//! Custom agents over HTTP: the `/api/agents/custom` CRUD surface, how the
+//! definitions merge into `/api/agents`, and launching a session with one.
+
+use serde_json::json;
+use serial_test::serial;
+
+use crate::fixtures::TestServer;
+
+/// Find an agent by kind in the `/api/agents` picker list.
+fn find<'a>(agents: &'a serde_json::Value, kind: &str) -> Option<&'a serde_json::Value> {
+    agents
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["kind"] == kind)
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agents_list_merges_builtins_and_custom() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let res = client.get("/api/agents").await.unwrap();
+    let agents = &res["agents"];
+    // Builtins are present and flagged as such.
+    let claude = find(agents, "claude").expect("claude is builtin");
+    assert_eq!(claude["builtin"], true);
+    assert!(find(agents, "codex").is_some(), "codex is builtin");
+    // The old builtin "shell" agent is gone; the test fixture seeds it as a
+    // custom agent instead, so it shows up as non-builtin.
+    let shell = find(agents, "shell").expect("fixture seeds a custom shell agent");
+    assert_eq!(shell["builtin"], false);
+    // The full custom definitions ride alongside the picker list.
+    let custom = res["custom"].as_array().unwrap();
+    assert!(custom.iter().any(|a| a["name"] == "shell"));
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_agent_crud_and_validation() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    // Create one. The reply is the refreshed custom list.
+    let res = client
+        .post(
+            "/api/agents/custom",
+            json!({
+                "name": "aider",
+                "label": "Aider",
+                "setup": "echo hooks",
+                "launch": "aider --message",
+                "resume": "aider --continue",
+                "reports_status": false,
+            }),
+        )
+        .await
+        .unwrap();
+    let custom = res["custom"].as_array().unwrap();
+    let aider = custom.iter().find(|a| a["name"] == "aider").unwrap();
+    assert_eq!(aider["label"], "Aider");
+    assert_eq!(aider["launch"], "aider --message");
+
+    // It now appears in the merged picker list as a non-builtin.
+    let list = client.get("/api/agents").await.unwrap();
+    let picked = find(&list["agents"], "aider").expect("custom agent in picker");
+    assert_eq!(picked["builtin"], false);
+    assert_eq!(picked["label"], "Aider");
+
+    // A reserved builtin name is rejected.
+    assert!(
+        client
+            .post(
+                "/api/agents/custom",
+                json!({ "name": "claude", "label": "X", "launch": "x" })
+            )
+            .await
+            .is_err(),
+        "a builtin name must be rejected"
+    );
+    // A malformed slug is rejected.
+    assert!(
+        client
+            .post(
+                "/api/agents/custom",
+                json!({ "name": "has space", "label": "X", "launch": "x" })
+            )
+            .await
+            .is_err(),
+        "a non-slug name must be rejected"
+    );
+    // A missing label is rejected (a command-less agent is fine — it's a bare
+    // shell — but it still needs a label).
+    assert!(
+        client
+            .post("/api/agents/custom", json!({ "name": "empty" }))
+            .await
+            .is_err(),
+        "a label-less agent must be rejected"
+    );
+    // A duplicate name is a conflict.
+    assert!(
+        client
+            .post(
+                "/api/agents/custom",
+                json!({ "name": "aider", "label": "Dup", "launch": "x" })
+            )
+            .await
+            .is_err(),
+        "a duplicate name must be rejected"
+    );
+
+    // Update it in place (the name is immutable, taken from the path).
+    let res = client
+        .put(
+            "/api/agents/custom/aider",
+            json!({
+                "label": "Aider v2",
+                "setup": "",
+                "launch": "aider",
+                "resume": "",
+                "reports_status": true,
+            }),
+        )
+        .await
+        .unwrap();
+    let aider = res["custom"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["name"] == "aider")
+        .unwrap();
+    assert_eq!(aider["label"], "Aider v2");
+    assert_eq!(aider["reports_status"], true);
+
+    // Updating an unknown (or builtin) name is a 404.
+    assert!(
+        client
+            .put(
+                "/api/agents/custom/claude",
+                json!({ "label": "X", "launch": "x" })
+            )
+            .await
+            .is_err(),
+        "updating a builtin name must fail"
+    );
+
+    // Delete it; it leaves the list. Deleting again is a no-op.
+    let res = client.delete("/api/agents/custom/aider").await.unwrap();
+    assert!(
+        !res["custom"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|a| a["name"] == "aider"),
+        "aider is gone after delete"
+    );
+    assert!(
+        client.delete("/api/agents/custom/aider").await.is_ok(),
+        "deleting an absent agent is a no-op"
+    );
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn launch_a_session_with_a_custom_agent() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    // A custom agent whose launch command is a real, harmless binary, so the
+    // launch script runs cleanly and the session comes up.
+    client
+        .post(
+            "/api/agents/custom",
+            json!({ "name": "noop", "label": "Noop", "launch": "true", "reports_status": false }),
+        )
+        .await
+        .unwrap();
+
+    let session = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "hi", "cwd": ts.cwd(), "agent": "noop" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(session["agent_kind"], "noop");
+    // A hookless custom agent is live on launch, not stuck at `launching`.
+    assert_eq!(session["status"], "running");
+
+    // A session requesting an unknown agent is rejected.
+    assert!(
+        client
+            .post(
+                "/api/sessions",
+                json!({ "goal": "hi", "cwd": ts.cwd(), "agent": "ghost" }),
+            )
+            .await
+            .is_err(),
+        "an unknown agent must be rejected at create time"
+    );
+}

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -75,6 +75,28 @@ fn kill_supervisors_in(sock_dir: &Path) {
     }
 }
 
+/// Seed the command-less `shell` custom agent the suites launch no-op sessions
+/// with. `shell` is no longer a builtin; a custom agent with no `launch` command
+/// execs a bare login shell (hookless → `running` at once), which is exactly the
+/// cheap session the tests want.
+pub async fn seed_shell_agent(db: &loom::db::Db) {
+    loom::custom_agents::set(
+        db,
+        &loom::custom_agents::CustomAgent {
+            name: "shell".to_string(),
+            label: "Shell".to_string(),
+            setup: String::new(),
+            launch: String::new(),
+            resume: String::new(),
+            reports_status: false,
+            created_at: String::new(),
+            updated_at: String::new(),
+        },
+    )
+    .await
+    .unwrap();
+}
+
 /// Build a throwaway git repo with a single commit on `main`.
 fn init_repo(dir: &Path) {
     sh(dir, "git", &["init", "-b", "main"]);
@@ -162,6 +184,11 @@ impl TestServer {
         )
         .await
         .unwrap();
+        // The suites launch cheap no-op sessions with `"agent": "shell"`. `shell`
+        // is no longer a builtin, so seed it as a command-less custom agent: it
+        // execs a bare login shell and is hookless (so it comes up `running`
+        // immediately, never stuck `launching`).
+        seed_shell_agent(&state.db).await;
         // Keep a handle to the editor manager before `state` moves into serve, so
         // a test can register a stub upstream on the same instance.
         let ide = state.ide.clone();

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod archive;
 mod auth;
 mod branches;
 mod conversation;
+mod custom_agents;
 mod env;
 mod ide;
 mod overlookers;

--- a/crates/loom/tests/repo_setup.rs
+++ b/crates/loom/tests/repo_setup.rs
@@ -93,6 +93,24 @@ async fn start_server() -> (TestHome, loom::client::Client, db::Db, String) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let pool = db::connect(&db::default_db_path()).await.unwrap();
+    // `create_shell_session` below launches with `"agent": "shell"`; `shell` is no
+    // longer a builtin, so seed it as a command-less custom agent (execs a bare
+    // login shell, hookless → `running` immediately).
+    loom::custom_agents::set(
+        &pool,
+        &loom::custom_agents::CustomAgent {
+            name: "shell".to_string(),
+            label: "Shell".to_string(),
+            setup: String::new(),
+            launch: String::new(),
+            resume: String::new(),
+            reports_status: false,
+            created_at: String::new(),
+            updated_at: String::new(),
+        },
+    )
+    .await
+    .unwrap();
     let state = AppState {
         db: pool.clone(),
         bus: EventBus::new(),

--- a/crates/weaver-core/src/repo_config.rs
+++ b/crates/weaver-core/src/repo_config.rs
@@ -89,7 +89,7 @@ impl Setup {
 /// accepts; an empty/absent value defers to the operator's global default.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 pub struct AgentDefaults {
-    /// Default agent kind (`claude`, `codex`, `shell`, …).
+    /// Default agent kind (`claude`, `codex`, or a custom agent's name).
     #[serde(default)]
     pub default: Option<String>,
     /// Default model selector for the chosen agent.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,8 +114,9 @@ Knobs: `WEAVER_SKIP_AGENT_LINT=1` to skip a run, `WEAVER_LINT_MIN_CONFIDENCE`
 The `e2e/` suite drives the real UI against a real server. It boots **one**
 `loom server run` per Playwright *worker* (not per test) on a random port, each with
 its own `WEAVER_HOME` / sqlite db (which also scopes the `tapestry` terminal
-sockets) and a throwaway git repo (see `e2e/fixtures/weaver.ts`),
-using the deterministic `shell` agent. The per-test `weaver` fixture wipes every
+sockets) and a throwaway git repo (see `e2e/fixtures/weaver.ts`). Sessions launch
+under a deterministic, command-less custom agent (a bare login shell) the fixture
+seeds as `shell`, so tests never spawn a real agent CLI. The per-test `weaver` fixture wipes every
 session (branch + worktree) between tests, so each starts from a clean slate and
 count-based assertions hold regardless of order. Workers are fully isolated, so
 the suite runs in parallel (`fullyParallel`, `workers > 1`) and — because every
@@ -339,8 +340,8 @@ tracking.
 **Lifecycle** is driven by the selected agent protocol. Claude Code currently
 provides lifecycle hooks, so its protocol merges a `hooks` block into the
 worktree's `.claude/settings.local.json` (see `loom::agent::install_hooks` and
-`weaver_core::agent::hooks_json`); hookless protocols such as Codex and `shell`
-start `running` immediately:
+`weaver_core::agent::hooks_json`); hookless agents — Codex, and any custom agent
+whose `reports_status` is off — start `running` immediately:
 
 | Claude hook event | shells out to |
 |---|---|

--- a/docs/browser-terminal.md
+++ b/docs/browser-terminal.md
@@ -371,7 +371,7 @@ exact tech debt we're removing.
 
 - **Rust unit:** `same_origin()` cases (missing Origin → allow; matching → allow;
   cross → reject).
-- **Rust integration:** the WebSocket round-trip described in §10 (shell agent
+- **Rust integration:** the WebSocket round-trip described in §10 (a shell session
   echoes the marker; session survives disconnect).
 - **e2e (Playwright):** terminal renders; (optional) typed command echoes.
 - **Manual smoke:** launch a claude session, open the detail view, confirm the

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -383,6 +383,22 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
       }
       if (!healthy) throw new Error(`loom /api/health never returned ok:\n${serverLog}`);
 
+      // Pin the `weaver`/`loom` CLI subprocesses (setStatus, seedConversation, the
+      // artifact helpers) at THIS server. `childEnv` spreads `process.env`, so
+      // without this override they inherit any ambient `WEAVER_API` — e.g. when the
+      // suite runs from inside a weaver session — and hit the wrong loom, 404ing on
+      // this server's branches.
+      childEnv.WEAVER_API = baseUrl;
+
+      // `shell` is no longer a builtin agent: define it as a command-less custom
+      // agent (execs a bare login shell, hookless → `running` immediately). This
+      // gives every test its cheap, deterministic no-op agent and must exist
+      // before the `agent.default` patch below validates against it.
+      await fetchJson(`${baseUrl}/api/agents/custom`, {
+        method: 'POST',
+        body: JSON.stringify({ name: 'shell', label: 'Shell' }),
+      });
+
       // UI-created sessions should use a plain shell, never the real claude CLI.
       await fetchJson(`${baseUrl}/api/settings`, {
         method: 'PATCH',

--- a/e2e/tests/custom-agents.spec.ts
+++ b/e2e/tests/custom-agents.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '../fixtures/weaver';
+
+test.describe('settings · custom agents', () => {
+  test('add a custom agent, see it in the picker, then delete it', async ({ page, weaver }) => {
+    await page.goto(`${weaver.baseUrl}/settings`);
+
+    const panel = page.locator('section').filter({
+      has: page.getByRole('heading', { name: 'Custom agents' }),
+    });
+    await expect(panel).toBeVisible();
+    // The e2e fixture defines a command-less `shell` custom agent, so the list is
+    // non-empty and shows it as a bare shell.
+    const shellRow = panel.locator('li').filter({ hasText: 'shell' });
+    await expect(shellRow).toBeVisible();
+    await expect(shellRow).toContainText('(bare shell)');
+
+    // Add a new custom agent through the form.
+    await panel.getByTestId('custom-agent-add').click();
+    await panel.getByTestId('custom-agent-name').fill('aider');
+    await panel.getByTestId('custom-agent-label').fill('Aider');
+    await panel.getByTestId('custom-agent-launch').fill('aider --message');
+
+    // Capture the Agents settings pane with the add form open, both themes.
+    await page.screenshot({ path: '/tmp/custom-agents-dark.png', fullPage: true });
+    await page.evaluate(() => {
+      localStorage.setItem('loom-theme', 'light');
+      document.documentElement.classList.remove('dark');
+    });
+    await page.screenshot({ path: '/tmp/custom-agents-light.png', fullPage: true });
+    await page.evaluate(() => {
+      localStorage.setItem('loom-theme', 'dark');
+      document.documentElement.classList.add('dark');
+    });
+
+    await panel.getByTestId('custom-agent-save').click();
+
+    // It lands in the custom list...
+    await expect(panel.locator('li').filter({ hasText: 'Aider' })).toBeVisible();
+    // ...and becomes selectable as the session default runtime.
+    const session = page.locator('section').filter({
+      has: page.getByRole('heading', { name: 'Session default runtime' }),
+    });
+    await expect(session.getByRole('radio', { name: /Aider/ })).toBeVisible();
+
+    // Delete it (accept the confirm dialog); it leaves the list and the picker.
+    page.on('dialog', (d) => d.accept());
+    await panel.locator('li').filter({ hasText: 'Aider' }).getByRole('button', { name: 'Delete' }).click();
+    await expect(panel.locator('li').filter({ hasText: 'Aider' })).toHaveCount(0);
+    await expect(session.getByRole('radio', { name: /Aider/ })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## What

Replaces the hardcoded agent list with a **custom agents table**. Agents are now
either the two builtins (`claude`, `codex`) or operator-defined **custom agents**
stored in a new `custom_agents` table. A custom agent names the shell commands
loom runs at each launch stage — setup / install-hooks, launch, resume — plus
whether it fires weaver's lifecycle hooks, and then shows up in the agent picker
beside the builtins with no code change. The old builtin `shell` agent is removed.

Addresses the ask: *"all agents should be stored in a configuration that indicates
the commands to use for various stages… add a new 'custom' agent by specifying the
commands and scripts… it should then show up in the agent list under its name… remove
the old shell agent cruft, it's unused, no backwards compat needed."*

## How

- **Storage:** new `custom_agents` table (name, label, setup/launch/resume stage
  commands, `reports_status`, timestamps), migrated via loom's schema; a
  `custom_agents` model with validation + CRUD.
- **API:** `POST/PUT/DELETE /api/agents/custom`; `GET /api/agents` merges builtin +
  custom metadata (each flagged `builtin`) and carries the full custom definitions
  for the editor.
- **Resolution:** agent resolution is DB-aware (`resolve` / `agent_metadata` /
  `metadata_for`). Launching a custom agent assembles its stage script — setup, then
  launch with the goal appended as a positional `"$(cat …)"` (resume reused when
  blank). A hookless custom agent goes straight to `running`; one that reports status
  waits at `launching` for its first hook.
- **UI:** Settings → Agents gains a "Custom agents" editor (add / edit / delete); the
  runtime picker lists custom agents alongside the builtins.
- **Shell cruft removed:** the builtin `shell` agent and its bespoke launch path are
  gone. Scratch/debug terminals keep their bare-shell launch via
  `agent::bare_shell_script`. A command-less custom agent execs a bare login shell,
  filling the old shell agent's role — tests seed one named `shell`.

## Testing

- `./scripts/pre-commit.sh` (fmt + clippy + vue-tsc) — clean
- `cargo test --workspace` — green (incl. new `custom_agents` integration tests:
  merge, CRUD/validation, launch)
- Playwright `e2e/` — all 72 pass, incl. a new `custom-agents.spec.ts` (add → picker →
  delete) validated in both themes
- Also fixes a pre-existing e2e fixture footgun: the `weaver` CLI subprocesses
  inherited an ambient `WEAVER_API`; the fixture now pins it to the per-worker server.
