### PR TITLE
feat(loom): @loom works on the PR branch; drop the launching status

### DIFF
--- a/crates/loom/frontend/src/components/StatusBadge.vue
+++ b/crates/loom/frontend/src/components/StatusBadge.vue
@@ -5,11 +5,10 @@ const props = defineProps<{ status: string }>();
 
 // Lifecycle (mechanical) status — a calm, scannable hue per state, kept softer
 // than the loud attention axis (SignalChip) so a raised signal still wins the
-// eye. `running`/`done` read healthy green, `launching` a starting cyan, `error`
-// the soft block red, and detached/archived states recede to neutral.
+// eye. `running`/`done` read healthy green, `error` the soft block red, and
+// detached/archived states recede to neutral.
 const palette: Record<string, string> = {
   created: 'bg-subtle text-muted',
-  launching: 'bg-info-soft text-info ring-1 ring-inset ring-info-line/30',
   running: 'bg-ok-soft text-ok ring-1 ring-inset ring-ok-line/30',
   orphaned: 'bg-subtle text-muted',
   done: 'bg-ok-soft text-ok ring-1 ring-inset ring-ok-line/30',

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -220,13 +220,13 @@ export function quietTags(s: Session): Tag[] {
 // `set_at` — so the mark would be born stale and a finished turn would never read
 // "Idle"; and (2) sub-agent or shell pane activity under an idle mark is, by
 // design, still "resting" (see monitor `apply_hook`), not a reason to retract it.
-const LIVE_STATUSES = new Set(['launching', 'running']);
+const LIVE_STATUSES = new Set(['running']);
 
 // Whether the session still has a live agent pane to type into — the gate for
 // the conversation composer. `POST /sessions/{id}/send` 409s once the terminal
 // is gone (orphaned / done / error / archived), so the composer only shows while
-// the agent is launching or running. Reuses LIVE_STATUSES: the same "the agent
-// is here" notion as the idle mark.
+// the agent is running. Reuses LIVE_STATUSES: the same "the agent is here" notion
+// as the idle mark.
 export function canSend(s: Session): boolean {
   return LIVE_STATUSES.has(s.status);
 }
@@ -266,7 +266,7 @@ export function conversationState(s: Session): ConvState {
   // cyan — quiet hues well below the loud amber/red, which stays the sole signal
   // that something needs a human.
   if (idleTag(s)) return { glyph: '✓', label: 'Idle', tone: 'info' };
-  if (s.status === 'running' || s.status === 'launching') return { glyph: '▶', label: 'Working', tone: 'ok' };
+  if (s.status === 'running') return { glyph: '▶', label: 'Working', tone: 'ok' };
   return { glyph: '✓', label: 'Idle', tone: 'info' };
 }
 
@@ -294,6 +294,6 @@ export function lifecycleDot(s: Session): string {
   if (level === 'blocked') return 'bg-block-line';
   if (level === 'attention') return 'bg-attn-line';
   if (idleTag(s)) return 'bg-info-line';
-  if (s.status === 'running' || s.status === 'launching') return 'bg-ok-line';
+  if (s.status === 'running') return 'bg-ok-line';
   return 'bg-faint/50';
 }

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -184,18 +184,12 @@ pub async fn exists(db: &Db, kind: &str) -> bool {
     matches!(metadata_for(db, kind).await, Ok(Some(_)))
 }
 
-/// The lifecycle status a freshly launched session of `runtime` starts in. An
-/// agent that fires weaver's hooks starts `launching` (its SessionStart/work hook
-/// promotes it to `running`); a hookless agent (codex, most custom agents) never
-/// gets that hook, so it is `running` from the start rather than stuck
-/// `launching`. An unknown runtime is treated as hookless.
-pub async fn initial_status(db: &Db, runtime: &str) -> &'static str {
-    let hooked = matches!(metadata_for(db, runtime).await, Ok(Some(m)) if m.supports_hooks);
-    if hooked {
-        "launching"
-    } else {
-        "running"
-    }
+/// The lifecycle status a freshly launched or resumed session starts in. Every
+/// runtime is live the moment its terminal spawns, so this is always `running` —
+/// there is no separate `launching` state to wait out. Kept as the single place
+/// that names a new session's initial status.
+pub async fn initial_status(_db: &Db, _runtime: &str) -> &'static str {
+    "running"
 }
 
 /// Check that `model` is one of `metadata`'s offered choices (blank is always

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -3003,7 +3003,7 @@ mod tests {
         for s in ["done", "error", "archived"] {
             assert!(is_terminal_status(s), "{s} should be terminal");
         }
-        for s in ["created", "launching", "running", "orphaned"] {
+        for s in ["created", "running", "orphaned"] {
             assert!(!is_terminal_status(s), "{s} should not be terminal");
         }
     }

--- a/crates/loom/src/custom_agents.rs
+++ b/crates/loom/src/custom_agents.rs
@@ -14,9 +14,9 @@
 //!   positional `"$(cat …)"` argument, mirroring the builtin runtimes;
 //! * `resume` — the adopt/resume command (no goal). Blank falls back to `launch`.
 //!
-//! `reports_status` records whether the agent fires weaver's lifecycle hooks, so
-//! [`crate::agent`] knows whether a fresh session should wait at `launching` for
-//! the first hook or go straight to `running`.
+//! `reports_status` records whether the agent fires weaver's lifecycle hooks —
+//! the working / idle / attention signals — surfaced to the UI as the runtime's
+//! `supports_hooks` capability.
 
 use anyhow::Result;
 use serde::Serialize;
@@ -44,8 +44,8 @@ pub struct CustomAgent {
     pub launch: String,
     /// The adopt/resume command (no goal). Blank reuses [`Self::launch`].
     pub resume: String,
-    /// Whether the agent fires weaver's lifecycle hooks (so a fresh session waits
-    /// at `launching` rather than going straight to `running`).
+    /// Whether the agent fires weaver's lifecycle hooks — the working / idle /
+    /// attention signals, surfaced as the runtime's `supports_hooks` capability.
     pub reports_status: bool,
     pub created_at: String,
     pub updated_at: String,

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -188,9 +188,8 @@ CREATE TABLE IF NOT EXISTS user_github_tokens (
 --   * `setup`  — run in the worktree before launch (e.g. installing status hooks);
 --   * `launch` — the fresh-session command, with the goal appended as an argument;
 --   * `resume` — the adopt/resume command (blank falls back to `launch`).
--- `reports_status` records whether the agent fires weaver's lifecycle hooks (so a
--- fresh session waits at `launching` for the first hook rather than going straight
--- to `running`).
+-- `reports_status` records whether the agent fires weaver's lifecycle hooks, which
+-- drive the idle/attention signals (a fresh session is `running` immediately).
 CREATE TABLE IF NOT EXISTS custom_agents (
     name           TEXT PRIMARY KEY,
     label          TEXT NOT NULL,

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -32,7 +32,7 @@ use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
 
-use crate::github_trigger::{GhCli, GithubApi};
+use crate::github_trigger::{GhCli, GithubApi, PrHead};
 use crate::repo::RepoSlug;
 use weaver_core::db::Db;
 
@@ -407,6 +407,44 @@ impl GithubApi for GithubApp {
         tracing::info!(repo, issue, "posted issue comment");
         Ok(())
     }
+
+    async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
+        if !self.is_configured().await {
+            return self.fallback.pr_head(repo, number).await;
+        }
+        let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
+        let token = self.token_for_repo(&slug.owner, &slug.name).await?;
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{number}",
+            self.api_base, slug.owner, slug.name
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("fetching the pull request")?;
+        let resp = check_status(resp, "fetching the pull request").await?;
+        let body: serde_json::Value = resp.json().await.context("parsing pull request json")?;
+        let head_ref = body["head"]["ref"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| anyhow!("pull request #{number} has no head ref"))?
+            .to_string();
+        // A cross-repo PR's head lives in a fork (`head.repo.full_name` differs
+        // from `base.repo.full_name`); GitHub also sets `head.repo` to null when
+        // the fork was deleted, which we likewise treat as unpushable.
+        let head_repo = body["head"]["repo"]["full_name"].as_str();
+        let base_repo = body["base"]["repo"]["full_name"].as_str();
+        let cross_repo = head_repo.is_none() || head_repo != base_repo;
+        Ok(PrHead {
+            head_ref,
+            cross_repo,
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -645,6 +683,13 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
                 .unwrap()
                 .push((repo.to_string(), issue, body.to_string()));
             Ok(())
+        }
+
+        async fn pr_head(&self, _repo: &str, _number: i64) -> Result<PrHead> {
+            Ok(PrHead {
+                head_ref: "fallback-head".to_string(),
+                cross_repo: false,
+            })
         }
     }
 

--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -159,6 +159,18 @@ pub struct IssuePayload {
     /// GitHub sends `null` for an empty issue body, so this is an `Option`.
     #[serde(default)]
     pub body: Option<String>,
+    /// Present (a `{ url, … }` object) only when the comment is on a **pull
+    /// request** — GitHub reuses the `issue_comment` event for both. Its mere
+    /// presence is the PR/issue discriminant; the fields inside are unused.
+    #[serde(default)]
+    pub pull_request: Option<serde_json::Value>,
+}
+
+impl IssuePayload {
+    /// Whether this comment is on a pull request (vs a plain issue).
+    pub fn is_pr(&self) -> bool {
+        self.pull_request.is_some()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -271,14 +283,28 @@ const RATE_MAX: usize = 20;
 // The GitHub gateway — the two external operations the trigger performs.
 // ---------------------------------------------------------------------------
 
-/// The one GitHub operation the trigger performs — posting the reply — behind a
-/// trait so the `gh`-backed implementation ([`GhCli`]) and a test fake are
-/// interchangeable. The production impl is the GitHub **App** (short-lived
-/// installation tokens); the [`GhCli`] fallback uses the ambient `GH_TOKEN`.
+/// A pull request's head branch — where its commits live — plus whether that
+/// branch is in a fork (`cross_repo`). loom attaches a session's worktree to the
+/// head branch so the agent's commits land on the PR directly; a cross-repo PR's
+/// head lives in a fork loom can't push to, so those fall back to a fresh branch.
+#[derive(Debug, Clone)]
+pub struct PrHead {
+    pub head_ref: String,
+    pub cross_repo: bool,
+}
+
+/// The GitHub operations the trigger performs — posting a reply and resolving a
+/// PR's head branch — behind a trait so the `gh`-backed implementation
+/// ([`GhCli`]) and a test fake are interchangeable. The production impl is the
+/// GitHub **App** (short-lived installation tokens); the [`GhCli`] fallback uses
+/// the ambient `GH_TOKEN`.
 #[async_trait::async_trait]
 pub trait GithubApi: Send + Sync {
     /// Post a comment on `issue` of `repo` (`owner/name`).
     async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()>;
+
+    /// Resolve pull request `number` of `repo` (`owner/name`) to its head branch.
+    async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead>;
 }
 
 /// The production [`GithubApi`]: shells out to the `gh` CLI with the ambient
@@ -292,6 +318,32 @@ impl GithubApi for GhCli {
         gh_capture(&["issue", "comment", &number, "--repo", repo, "--body", body]).await?;
         tracing::info!(repo, issue, "posted issue comment");
         Ok(())
+    }
+
+    async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
+        let n = number.to_string();
+        let out = gh_capture(&[
+            "pr",
+            "view",
+            &n,
+            "--repo",
+            repo,
+            "--json",
+            "headRefName,isCrossRepository",
+        ])
+        .await?;
+        #[derive(Deserialize)]
+        struct View {
+            #[serde(rename = "headRefName")]
+            head_ref: String,
+            #[serde(rename = "isCrossRepository")]
+            cross_repo: bool,
+        }
+        let view: View = serde_json::from_str(&out).context("parsing `gh pr view` json")?;
+        Ok(PrHead {
+            head_ref: view.head_ref,
+            cross_repo: view.cross_repo,
+        })
     }
 }
 
@@ -508,6 +560,13 @@ mod tests {
                 .unwrap()
                 .push((repo.to_string(), issue, body.to_string()));
             Ok(())
+        }
+
+        async fn pr_head(&self, _repo: &str, _number: i64) -> Result<PrHead> {
+            Ok(PrHead {
+                head_ref: "feature".to_string(),
+                cross_repo: false,
+            })
         }
     }
 

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -240,7 +240,8 @@ fn parse_iso(ts: &str) -> Option<DateTime<Utc>> {
 ///
 /// Mapping rationale: the work hooks drive only liveness and a soothing idle
 /// signal. A `working` / `waiting` / `idle` hook means the agent process is
-/// alive → `running` (this also promotes a freshly-`launching` session).
+/// alive → `running` (this also lifts a recovered `orphaned` session back to
+/// `running`).
 /// `session-start` is returned early below — it is recorded for the primer
 /// injection (in the `weaver hook` CLI) but the launch path owns the initial
 /// status, so it carries no liveness or tag signal here. Beyond liveness:

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -55,13 +55,7 @@ pub struct Session {
 /// "idle"). Liveness is all the orchestrator can know for sure; the agent
 /// reports the rest via `weaver status`.
 pub const STATUSES: &[&str] = &[
-    "created",
-    "launching",
-    "running",
-    "orphaned",
-    "done",
-    "error",
-    "archived",
+    "created", "running", "orphaned", "done", "error", "archived",
 ];
 
 pub fn is_terminal(status: &str) -> bool {

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -10,9 +10,12 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use weaver_api::CreateReq;
 
+use crate::backend;
 use crate::git;
 use crate::github_trigger;
 use crate::repo;
+use crate::session::{self as session_mod, Session};
+use weaver_core::branch as branch_mod;
 
 use super::auth::external_base;
 use super::sessions::create_session_core;
@@ -194,20 +197,123 @@ pub(super) async fn github_webhook(
         app.ensure_installed_repo_registered(&slug).await;
     }
 
-    // 7. Acquire the repo (it must be in the managed allowlist — `resolve_clone`
-    //    rejects others) and create the session, seeded from the issue carried in
-    //    the trusted payload. Seeding title/goal from the payload (not a `gh`
-    //    re-fetch) means the managed clone needs no reachable GitHub remote.
-    //    Attribute the launch to the webhook bot, annotated with the triggering
-    //    GitHub login (`created_by`, from PR #94) — tracking, not a boundary.
-    let req = CreateReq {
+    // 7. Resolve the commenter to their loom user (proven to exist by `authorize`
+    //    above). Attributing the launch to them makes their personal GitHub token
+    //    the session's `GH_TOKEN` — so its push / `gh` act as them — with the
+    //    ambient token as the fallback (see `apply_user_github_token`).
+    let username = match crate::auth::user_by_github(&st.db, &author).await {
+        Ok(Some(u)) => u.username,
+        _ => {
+            tracing::warn!(login = %author, "github webhook: approved user vanished before launch");
+            return ok();
+        }
+    };
+
+    // 8. Acquire the managed clone (allowlist-gated; `resolve_clone` also fetches
+    //    `--all`, so a PR's head lands as `origin/<ref>`), then resolve the branch
+    //    this trigger targets: a PR works on its own head branch so the agent's
+    //    commits land on the PR; an issue gets a stable `weaver/issue-<n>`.
+    let repo_root = match repo::resolve_clone(&st.db, &slug.slug(), st.trigger.app()).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(repo = %slug.slug(), error = ?e, "github webhook: clone/allowlist rejected");
+            return ok();
+        }
+    };
+    let repo_root_str = repo_root.to_string_lossy().to_string();
+    let number = event.issue.number;
+    let is_pr = event.issue.is_pr();
+
+    let mut target_branch = if is_pr {
+        match st.trigger.gh().pr_head(&slug.slug(), number).await {
+            // A fork PR's head is unreachable/unpushable — fall through to a fresh
+            // auto-named branch rather than pretend to attach to it.
+            Ok(h) if h.cross_repo => {
+                tracing::info!(repo = %slug.slug(), pr = number, "cross-repo PR; using a fresh branch");
+                None
+            }
+            Ok(h) => Some(h.head_ref),
+            Err(e) => {
+                tracing::warn!(repo = %slug.slug(), pr = number, error = %e, "github webhook: PR head lookup failed");
+                None
+            }
+        }
+    } else {
+        Some(format!("weaver/issue-{number}"))
+    };
+
+    // Materialize a PR head branch locally — bare names resolve only local heads,
+    // so `existing_branch` needs a real `refs/heads/<ref>`. On failure, drop to a
+    // fresh branch.
+    if is_pr {
+        if let Some(branch) = target_branch.clone() {
+            if let Err(e) = git::create_local_branch_from_origin(&repo_root, &branch).await {
+                tracing::warn!(repo = %slug.slug(), %branch, error = %e, "github webhook: could not materialize PR branch");
+                target_branch = None;
+            }
+        }
+    }
+
+    // 9. If an active session already owns the target branch, forward the new
+    //    comment into it rather than spawning a duplicate.
+    if let Some(branch) = target_branch.as_deref() {
+        if let Ok(Some(b)) = branch_mod::find_by_repo_branch(&st.db, &repo_root_str, branch).await {
+            if let Ok(Some(sess)) = session_mod::active_for_branch(&st.db, &b.id).await {
+                if forward_comment_to_session(&sess, &author, is_pr, number, &event.comment.body)
+                    .await
+                {
+                    crate::events::record(
+                        &st.db,
+                        &st.bus,
+                        &b.id,
+                        "nudge",
+                        serde_json::json!({ "by": format!("github ({author})"), "text": event.comment.body }),
+                    )
+                    .await
+                    .ok();
+                    let base = external_base(&st, &headers)
+                        .await
+                        .unwrap_or_else(|| format!("http://{}", st.addr));
+                    let reply = format!(
+                        "Passed your note to the session already on this thread — {base}/s/{}",
+                        sess.id
+                    );
+                    if let Err(e) = st
+                        .trigger
+                        .gh()
+                        .post_issue_comment(&slug.slug(), number, &reply)
+                        .await
+                    {
+                        tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: posting forward-ack failed");
+                    }
+                    tracing::info!(session = %sess.id, repo = %slug.slug(), number, "github webhook: forwarded comment to active session");
+                }
+                return ok();
+            }
+        }
+    }
+
+    // 10. Otherwise create a new session. A PR (or a dormant issue branch that
+    //     already exists) attaches to that branch so work lands on it; a first-time
+    //     issue creates `weaver/issue-<n>`; a fork PR / lookup failure auto-names.
+    let branch_exists_locally = match target_branch.as_deref() {
+        Some(b) => git::branch_exists(&repo_root, b).await,
+        None => false,
+    };
+    let mut req = CreateReq {
         repo: Some(slug.slug()),
         title: Some(event.issue.title.clone()),
-        goal: Some(event.goal_seed()),
+        goal: Some(trigger_goal(&slug.slug(), is_pr, number, &event, &author)),
         ..Default::default()
     };
-    let created_by = format!("github-webhook ({author})");
-    let view = match create_session_core(st.clone(), req, Some(created_by)).await {
+    if let Some(branch) = target_branch {
+        if is_pr || branch_exists_locally {
+            req.existing_branch = Some(branch);
+        } else {
+            req.name = Some(format!("issue-{number}"));
+        }
+    }
+    let view = match create_session_core(st.clone(), req, Some(username)).await {
         Ok(v) => v,
         Err(e) => {
             // A non-allowlisted repo lands here (a BadRequest from resolve_clone),
@@ -217,7 +323,7 @@ pub(super) async fn github_webhook(
         }
     };
 
-    // 8. Reply on the issue with the live session URL.
+    // 11. Reply on the thread with the live session URL.
     let base = external_base(&st, &headers)
         .await
         .unwrap_or_else(|| format!("http://{}", st.addr));
@@ -225,7 +331,7 @@ pub(super) async fn github_webhook(
     if let Err(e) = st
         .trigger
         .gh()
-        .post_issue_comment(&slug.slug(), event.issue.number, &reply)
+        .post_issue_comment(&slug.slug(), number, &reply)
         .await
     {
         tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: posting reply failed");
@@ -233,11 +339,94 @@ pub(super) async fn github_webhook(
     tracing::info!(
         session = %view.id,
         repo = %slug.slug(),
-        issue = event.issue.number,
+        number,
+        is_pr,
         login = %author,
         "github webhook: launched session"
     );
     ok()
+}
+
+/// Build the opening goal for a trigger-launched session: the issue/PR title and
+/// body, the triggering comment, and how to respond — push to the PR branch (or
+/// open a PR) and reply on the thread with `gh`.
+fn trigger_goal(
+    repo: &str,
+    is_pr: bool,
+    number: i64,
+    event: &github_trigger::IssueCommentEvent,
+    author: &str,
+) -> String {
+    let (kind, title_kind, url) = if is_pr {
+        (
+            "pull request",
+            "Pull request",
+            format!("https://github.com/{repo}/pull/{number}"),
+        )
+    } else {
+        (
+            "issue",
+            "Issue",
+            format!("https://github.com/{repo}/issues/{number}"),
+        )
+    };
+    let body = event
+        .issue
+        .body
+        .as_deref()
+        .map(str::trim)
+        .filter(|b| !b.is_empty())
+        .unwrap_or("(no description)");
+    let respond = if is_pr {
+        format!(
+            "- This worktree is checked out on the PR's own branch — commit and `git push` here to update pull request #{number} directly.\n\
+             - Reply on the thread when you have something to report: `gh pr comment {number} --repo {repo} --body \"…\"`."
+        )
+    } else {
+        format!(
+            "- Do the work on this branch and open a pull request against the default branch when it's ready.\n\
+             - Reply on the thread when you have something to report: `gh issue comment {number} --repo {repo} --body \"…\"`."
+        )
+    };
+    format!(
+        "You've been tagged into GitHub {kind} #{number} of {repo} ({url}) via a comment.\n\n\
+         ## {title_kind}\n{}\n\n{body}\n\n\
+         ## Triggering comment (from @{author})\n{}\n\n\
+         ## How to respond\n{respond}",
+        event.issue.title.trim(),
+        event.comment.body.trim(),
+    )
+}
+
+/// Inject a "new comment" note into an already-running session's terminal so a
+/// follow-up @loom comment continues the existing thread instead of forking a new
+/// session. Returns whether the note was delivered (best-effort: a dead terminal
+/// — e.g. an orphaned session — logs and returns `false`).
+async fn forward_comment_to_session(
+    session: &Session,
+    author: &str,
+    is_pr: bool,
+    number: i64,
+    comment: &str,
+) -> bool {
+    let (thread, cmd) = if is_pr {
+        ("PR", "pr")
+    } else {
+        ("issue", "issue")
+    };
+    let note = format!(
+        "New @loom comment from @{author} on {thread} #{number}:\n\n{}\n\n\
+         (Reply on the thread with `gh {cmd} comment {number} --body \"…\"` if a response is warranted.)",
+        comment.trim(),
+    );
+    if let Err(e) = backend::send_literal(&session.term_session, &note).await {
+        tracing::warn!(session = %session.id, error = %e, "github webhook: forwarding comment to session failed");
+        return false;
+    }
+    if let Err(e) = backend::send_enter(&session.term_session).await {
+        tracing::warn!(session = %session.id, error = %e, "github webhook: submitting forwarded comment failed");
+    }
+    true
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -274,25 +274,31 @@ async fn launch_env(
 /// Overlay the launching user's personal GitHub token onto `env` as `GH_TOKEN`,
 /// so the session's `git push` / `gh` act as that user (their pushes and PRs are
 /// attributed to them, matching the per-user commit identity loom already sets).
-/// Precedence mirrors the commit-identity handling: only for a launch that
-/// carries a `created_by` principal (webhook/warm/adopt keep the shared ambient
-/// token), and only if no higher env layer (`repo_env` / `agent_env` / the repo
-/// file) already set a non-empty `GH_TOKEN` — an explicit usable value wins.
-/// Best-effort: a lookup failure is logged, never fatal, so a token-store hiccup
-/// can't block a launch.
+/// The user's registered token takes precedence over any ambient `GH_TOKEN`; when
+/// they have none, whatever a lower env layer set (the ambient Settings →
+/// Environment value, `repo_env`, or the repo file) stands as the fallback. Only
+/// for a launch that carries a `created_by` username. Best-effort: a lookup
+/// failure is logged, never fatal, so a token-store hiccup can't block a launch.
 async fn apply_user_github_token(
     db: &Db,
     env: &mut Vec<(String, String)>,
     created_by: Option<&str>,
 ) {
     let Some(username) = created_by else { return };
-    if env_has_nonempty(env, "GH_TOKEN") {
-        return;
-    }
     match crate::user_token::get(db, username).await {
-        Ok(Some(token)) => env.push(("GH_TOKEN".to_string(), token)),
-        Ok(None) => {}
+        Ok(Some(token)) if !token.trim().is_empty() => set_env(env, "GH_TOKEN", token),
+        Ok(_) => {}
         Err(e) => tracing::warn!(%username, "failed to load user github token: {e}"),
+    }
+}
+
+/// Set `name` in `env`, replacing an existing entry in place (so a user token
+/// overrides an ambient value) or appending it when absent.
+fn set_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
+    if let Some(slot) = env.iter_mut().find(|(k, _)| k == name) {
+        slot.1 = value;
+    } else {
+        env.push((name.to_string(), value));
     }
 }
 
@@ -958,9 +964,7 @@ pub(crate) async fn create_session_core(
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    // Only an agent that fires weaver's hooks starts `launching` (its hook
-    // promotes it to `running`); a hookless runtime (codex, most custom agents) is
-    // live on launch.
+    // Live the moment the terminal spawns — there is no `launching` state.
     let status = agent::initial_status(&st.db, &runtime).await;
     let session = session_mod::insert(
         &st.db,
@@ -1696,8 +1700,7 @@ async fn resume_agent(
     )
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    // A hookless runtime (codex, most custom agents) won't get the hook that would
-    // promote `launching` → `running`, so mark it live now rather than stranding it.
+    // A resumed agent is already established and live — mark it `running`.
     let status = agent::initial_status(&st.db, &runtime).await;
     session_mod::set_status(&st.db, &session.id, status).await?;
     events::record(
@@ -2066,41 +2069,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_gh_token_layer_wins_over_user_token() {
+    async fn user_token_overrides_ambient_gh_token_layer() {
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
         crate::user_token::set(&db, "alice", "ghp_alice")
             .await
             .unwrap();
 
-        // A repo/operator env layer already set GH_TOKEN: it must survive untouched
-        // and stay the single GH_TOKEN entry (no duplicate appended).
-        let mut env = vec![("GH_TOKEN".to_string(), "repo-token".to_string())];
+        // A lower env layer (the ambient Settings → Environment value, repo_env, …)
+        // already set GH_TOKEN: the user's own token overrides it *in place* — so
+        // their push/comment act as them — with no duplicate entry appended.
+        let mut env = vec![("GH_TOKEN".to_string(), "ambient-token".to_string())];
         apply_user_github_token(&db, &mut env, Some("alice")).await;
         let gh: Vec<&(String, String)> = env.iter().filter(|(k, _)| k == "GH_TOKEN").collect();
         assert_eq!(gh.len(), 1, "no duplicate GH_TOKEN is appended");
-        assert_eq!(gh[0].1, "repo-token", "the explicit layer wins");
+        assert_eq!(
+            gh[0].1, "ghp_alice",
+            "the user's own token wins over the ambient layer"
+        );
     }
 
     #[tokio::test]
-    async fn empty_gh_token_layer_does_not_block_user_token() {
+    async fn ambient_gh_token_is_the_fallback_without_a_user_token() {
         let db = crate::db::connect_in_memory().await.unwrap();
-        seed_user(&db, "alice").await;
-        crate::user_token::set(&db, "alice", "ghp_alice")
-            .await
-            .unwrap();
+        seed_user(&db, "bob").await; // bob has no stored token
 
-        let mut env = vec![("GH_TOKEN".to_string(), "  ".to_string())];
-        apply_user_github_token(&db, &mut env, Some("alice")).await;
+        // With no user token, whatever a lower layer set stands as the fallback.
+        let mut env = vec![("GH_TOKEN".to_string(), "ambient-token".to_string())];
+        apply_user_github_token(&db, &mut env, Some("bob")).await;
         let gh: Vec<&(String, String)> = env.iter().filter(|(k, _)| k == "GH_TOKEN").collect();
+        assert_eq!(gh.len(), 1, "the ambient layer is left untouched");
         assert_eq!(
-            gh.len(),
-            2,
-            "the user token is appended after the empty layer"
-        );
-        assert_eq!(
-            gh[1].1, "ghp_alice",
-            "the appended token wins at export time"
+            gh[0].1, "ambient-token",
+            "with no user token, the ambient value is the fallback"
         );
     }
 

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -218,8 +218,8 @@ async fn chat_get_or_creates_a_hidden_singleton_concierge() {
     let chat_id = chat["id"].as_str().unwrap().to_string();
     assert_eq!(chat["agent_kind"], "concierge");
     assert_eq!(
-        chat["status"], "launching",
-        "the default (claude) concierge waits for its first hook to go running"
+        chat["status"], "running",
+        "every runtime is live on launch — there is no `launching` state"
     );
     // It boots primed-but-idle (no positional prompt ⇒ no turn ⇒ no `Stop` hook),
     // so creation seeds the soothing `idle` mark itself — otherwise the chat would

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -62,7 +62,15 @@ async fn make_session(ts: &TestServer, goal: &str) -> (String, String, String) {
 
 /// Register an enabled watch and return it.
 async fn enabled_watch(state: &AppState, new: watch_store::NewWatch) -> watch_store::Watch {
-    let o = watch_store::create(&state.db, &new).await.unwrap();
+    // Builtins are seeded (enabled) at engine start, so a watch with a builtin's
+    // name may already exist — reuse it rather than colliding on UNIQUE(name).
+    let o = match watch_store::get_by_name(&state.db, &new.name)
+        .await
+        .unwrap()
+    {
+        Some(existing) => existing,
+        None => watch_store::create(&state.db, &new).await.unwrap(),
+    };
     watch_store::set_enabled(&state.db, &o.id, true)
         .await
         .unwrap();

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -29,10 +29,13 @@ fn sign(secret: &str, body: &[u8]) -> String {
 }
 
 /// A recording GitHub gateway standing in for `gh`: it captures every reply
-/// posted (the one outbound call the trigger makes).
+/// posted and answers `pr_head` with a value a PR-flow test can pin.
 #[derive(Default)]
 struct FakeGithub {
     comments: Mutex<Vec<(String, i64, String)>>,
+    /// What `pr_head` returns; a PR-flow test sets this to a branch it created in
+    /// the fixture remote. `None` → a plain same-repo head named `feature`.
+    pr_head: Mutex<Option<loom::github_trigger::PrHead>>,
 }
 
 #[async_trait::async_trait]
@@ -43,6 +46,22 @@ impl loom::github_trigger::GithubApi for FakeGithub {
             .unwrap()
             .push((repo.to_string(), issue, body.to_string()));
         Ok(())
+    }
+
+    async fn pr_head(
+        &self,
+        _repo: &str,
+        _number: i64,
+    ) -> anyhow::Result<loom::github_trigger::PrHead> {
+        Ok(self
+            .pr_head
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or(loom::github_trigger::PrHead {
+                head_ref: "feature".to_string(),
+                cross_repo: false,
+            }))
     }
 }
 
@@ -67,6 +86,8 @@ fn make_bare_remote(root: &Path) -> String {
     std::fs::write(work.join("README.md"), "hello\n").unwrap();
     sh(&work, "git", &["add", "."]);
     sh(&work, "git", &["commit", "-q", "-m", "init"]);
+    // A second branch so a PR-head-attach test has an `origin/feature` to fetch.
+    sh(&work, "git", &["branch", "feature"]);
 
     let bare = root.join("acme").join("widgets");
     std::fs::create_dir_all(bare.parent().unwrap()).unwrap();
@@ -109,6 +130,24 @@ fn trigger_body(login: &str, number: i64, comment: &str) -> Vec<u8> {
     json!({
         "action": "created",
         "issue": {"number": number, "title": "Make it faster", "body": "perf please"},
+        "comment": {"body": comment, "user": {"login": login}},
+        "repository": {"full_name": "acme/widgets"}
+    })
+    .to_string()
+    .into_bytes()
+}
+
+/// Like [`trigger_body`], but the issue carries a `pull_request` link, so the
+/// handler treats it as a PR comment (attaching to the PR's head branch).
+fn trigger_body_pr(login: &str, number: i64, comment: &str) -> Vec<u8> {
+    json!({
+        "action": "created",
+        "issue": {
+            "number": number,
+            "title": "Fix the tests",
+            "body": "they are red",
+            "pull_request": {"url": "https://api.github.com/repos/acme/widgets/pulls/7"}
+        },
         "comment": {"body": comment, "user": {"login": login}},
         "repository": {"full_name": "acme/widgets"}
     })
@@ -258,8 +297,8 @@ async fn happy_path_creates_session_and_replies() {
     );
     assert_eq!(
         session["created_by"].as_str(),
-        Some("github-webhook (rjpower)"),
-        "the session is attributed to the webhook bot, annotated with the triggering login"
+        Some("rjpower"),
+        "the session is attributed to the commenting user, so its GH_TOKEN is theirs"
     );
 
     // loom replied on the triggering issue with the session URL.
@@ -320,6 +359,96 @@ async fn replayed_delivery_is_a_noop() {
         .as_str()
         .unwrap()
         .to_string();
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+/// A second @loom comment on a thread that already has a live session forwards the
+/// comment into that session (an ack, no duplicate) instead of spawning a new one.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repeat_trigger_forwards_to_active_session() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+
+    let body = trigger_body("rjpower", 42, "@loom start");
+    assert_eq!(
+        post(&ts, "d-first", Some(sign(SECRET, &body)), &body)
+            .await
+            .status(),
+        200
+    );
+    assert_eq!(
+        session_count(&ts).await,
+        1,
+        "the first trigger creates a session"
+    );
+
+    // A second @loom on the same issue (new delivery) is forwarded, not forked.
+    let body2 = trigger_body("rjpower", 42, "@loom also handle the edge case");
+    assert_eq!(
+        post(&ts, "d-second", Some(sign(SECRET, &body2)), &body2)
+            .await
+            .status(),
+        200
+    );
+    assert_eq!(
+        session_count(&ts).await,
+        1,
+        "the repeat trigger spawns no duplicate session"
+    );
+
+    let comments = fake.comments.lock().unwrap().clone();
+    assert_eq!(comments.len(), 2, "one ack per trigger");
+    assert!(
+        comments[1].2.contains("Passed your note"),
+        "the repeat trigger is acked as a forward: {}",
+        comments[1].2
+    );
+
+    let id = ts.client.get("/api/sessions").await.unwrap()[0]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+/// A comment on a **pull request** attaches the session's worktree to the PR's own
+/// head branch, so the agent's commits land on the PR.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pr_trigger_attaches_to_pr_head_branch() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+    // The mock resolves PR #7's head to the `feature` branch the fixture created.
+    *fake.pr_head.lock().unwrap() = Some(loom::github_trigger::PrHead {
+        head_ref: "feature".to_string(),
+        cross_repo: false,
+    });
+
+    let body = trigger_body_pr("rjpower", 7, "@loom fix the failing tests");
+    assert_eq!(
+        post(&ts, "d-pr", Some(sign(SECRET, &body)), &body)
+            .await
+            .status(),
+        200
+    );
+
+    let sessions = ts.client.get("/api/sessions").await.unwrap();
+    let sessions = sessions.as_array().unwrap();
+    assert_eq!(sessions.len(), 1, "the PR trigger launched one session");
+    assert_eq!(
+        sessions[0]["branch"]["branch"].as_str(),
+        Some("feature"),
+        "the session is attached to the PR's head branch, not a fresh one"
+    );
+
+    let id = sessions[0]["id"].as_str().unwrap().to_string();
     ts.client
         .delete(&format!("/api/sessions/{id}"))
         .await

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -273,6 +273,20 @@ pub async fn worktree_add_existing(repo_root: &Path, path: &Path, branch: &str) 
     Ok(())
 }
 
+/// Materialize a local `branch` from `origin/<branch>` — used to check out a PR's
+/// head branch after a fetch, since a bare branch name resolves only local heads.
+/// A no-op when the local branch already exists; errors if `origin/<branch>` was
+/// never fetched. Creating from a remote-tracking ref sets upstream, so a later
+/// `git push` targets the same branch (updating the PR).
+pub async fn create_local_branch_from_origin(repo_root: &Path, branch: &str) -> Result<()> {
+    if branch_exists(repo_root, branch).await {
+        return Ok(());
+    }
+    git(repo_root, &["branch", branch, &format!("origin/{branch}")]).await?;
+    tracing::info!(%branch, "created local branch from origin");
+    Ok(())
+}
+
 /// List local branch names (`refs/heads/*`).
 pub async fn list_branches(repo_root: &Path) -> Result<Vec<String>> {
     let out = git(

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -1,9 +1,12 @@
 # GitHub trigger (`@loom`)
 
-loom turns an issue comment into a session. Comment **`@loom`** on a GitHub
-issue or PR and loom launches a session against that repo — seeded from the
-issue — and replies on the issue with a link to the live session
-(`On it — {base}/s/{id}`).
+loom turns an issue or PR comment into a session. Comment **`@loom`** on a GitHub
+issue or pull request and loom launches a session against that repo — attached to
+the PR's own branch (so the agent's commits land on the PR) or, for an issue, a
+stable `weaver/issue-<n>` branch — seeded with the thread's context, and replies
+with a link to the live session (`On it — {base}/s/{id}`). A follow-up `@loom` on
+a thread that already has a running session is handed to that session instead of
+starting a second one.
 
 This is an internet-exposed, untrusted-input endpoint. Two gates protect it:
 every delivery is verified cryptographically (HMAC), and the commenter is
@@ -31,12 +34,24 @@ receiver, in order:
    else is silently ignored. A per-repo rate limit blunts comment spam.
 6. **Resolves the repo** through the [managed repo store](#which-repos) — an
    approved user's trigger on any repo the App is installed on registers it — and
-   creates the session, seeded with the issue title and body.
-7. **Replies** on the issue with the session URL.
+   picks the branch to work on: a **pull request** comment attaches the session's
+   worktree to the PR's head branch, so the agent's commits push straight to the
+   PR; an **issue** comment gets a stable `weaver/issue-<n>` branch. (A PR from a
+   fork, whose head loom can't push to, falls back to a fresh branch.)
+7. **Reuses or creates.** If an active session already owns that branch, the new
+   comment is forwarded into it (a nudge in its terminal) rather than launching a
+   duplicate. Otherwise loom creates the session, seeded with the issue/PR title,
+   body, and the triggering comment, plus a primer on how to respond — push to the
+   PR branch (or open a PR for an issue) and reply on the thread with `gh`.
+8. **Replies** on the thread with the session URL (or, for a forwarded comment,
+   that it was passed to the running session).
 
-The reply (step 7) reaches GitHub through the [GitHub App](#the-github-app) when
+The reply (step 8) reaches GitHub through the [GitHub App](#the-github-app) when
 one is configured — with a short-lived, per-installation token — and otherwise
-through the `gh` CLI's ambient `GH_TOKEN`.
+through the `gh` CLI's ambient `GH_TOKEN`. The **session itself** acts as the
+commenter: its `GH_TOKEN` is that user's personal token (**Settings → Account**),
+falling back to the ambient `GH_TOKEN` when they have none — so its pushes and
+`gh` replies are attributed to them.
 
 Everything past the signature check returns **200** whether or not it launched a
 session (a non-trigger comment, a replay, an unauthorized commenter, an


### PR DESCRIPTION
## Summary

Two changes in `loom`, plus one incidental test fix.

### 1. `@loom` works on the PR branch (the main change)

Reworks the GitHub `@loom` trigger so a triggered session lands where the work belongs:

- **PR comment → the PR's own head branch.** The session's worktree attaches to the PR head branch (materialized locally from `origin/<ref>`), so the agent's commits push straight to the PR. A fork PR (unpushable head) falls back to a fresh branch.
- **Issue comment → a stable `weaver/issue-<n>` branch.**
- **Reuse over duplicate.** A follow-up `@loom` on a thread that already has an active session forwards the comment into that session (a terminal nudge) instead of spawning a second one.
- **Richer context.** The goal is seeded with the issue/PR title, body, and the triggering comment, plus a primer on how to respond — push to the branch (or open a PR), and reply on the thread with `gh`.
- **Acts as the commenter.** The session is attributed to the commenting user, so its `GH_TOKEN` is *their* personal token, with the ambient `GH_TOKEN` as the fallback (user-token-first — a flip from the previous ambient-wins precedence). Adds a `pr_head` method to the `GithubApi` gateway (App REST + `gh` CLI).

A triggered session is still a normal session (identical `create_session_core` path), so it gets the full standard bootstrap — the WEAVER.md primer, the repo's CLAUDE.md/AGENTS.md, the `[setup]` script, per-user commit identity; the trigger context is layered on top as the opening goal.

### 2. Drop the `launching` lifecycle status

Every runtime is live the moment its terminal spawns, so `initial_status` is always `running`. The bug this fixes: a resumed-then-idle claude fires only `session-start` (not a promotion hook), so a recovered session stranded at `launching`. With the status gone there is nothing to strand.

### Incidental: `enabled_watch` test-helper fix

Rebasing onto #122 (builtins now seed enabled) surfaced a pre-existing failure — the `review-wait` test collided on `UNIQUE(watches.name)`. Confirmed it fails on pristine `main` too; fixed the helper to reuse a seeded builtin by name rather than always creating.

## Testing

- `cargo clippy -p loom -p weaver-core --all-targets` — clean
- Full loom suite + weaver-core git tests — **281 passing, 0 failures** (re-run on the rebased tree, not just trusting the auto-merge)
- New integration coverage: `pr_trigger_attaches_to_pr_head_branch`, `repeat_trigger_forwards_to_active_session`
- Frontend `vue-tsc` typecheck — clean
