### PR TITLE
feat(loom): async @loom trigger, Debug task list, PR back-links, richer logs

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -352,3 +352,7 @@ export const getLogs = (limit = 500) =>
 
 /** Build version, pid, and start time of the running server. */
 export const getServerStatus = () => get('/status') as Promise<import('./types').ServerStatus>;
+
+/** Recent detached background tasks (the `@loom` webhook launches that run off the
+ *  request), newest first. Operator-only, like the log endpoints. */
+export const getTasks = () => get('/tasks') as Promise<import('./types').TaskRecord[]>;

--- a/crates/loom/frontend/src/components/LogsPanel.vue
+++ b/crates/loom/frontend/src/components/LogsPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue';
 import * as api from '../api';
-import type { LogLine, ServerStatus } from '../types';
+import type { LogLine, ServerStatus, TaskRecord } from '../types';
 
 // Live server logs, straight from the process's tracing output — the same lines
 // that go to stdout / `docker compose logs`, but readable from the browser so an
@@ -185,35 +185,104 @@ const uptime = computed(() => {
   return h ? `${h}h ${m}m` : m ? `${m}m ${s}s` : `${s}s`;
 });
 
+// --- Background tasks ------------------------------------------------------
+// The detached `@loom` webhook launches (clone → create → reply) that run off the
+// webhook request. Polled — low-frequency, so a few-second refresh is plenty; no
+// SSE like the logs.
+const tasks = ref<TaskRecord[]>([]);
+async function loadTasks() {
+  try {
+    tasks.value = await api.getTasks();
+  } catch {
+    /* keep the last snapshot; the log pane surfaces server-side errors */
+  }
+}
+const taskStateClass = (s: string): string =>
+  s === 'done' ? 'text-ok' : s === 'error' ? 'text-block' : 'text-info';
+let taskTimer: ReturnType<typeof setInterval> | null = null;
+
+// Refresh both the log snapshot and the task list (the toolbar Refresh button).
+function refresh() {
+  loadSnapshot();
+  loadTasks();
+}
+
 onMounted(() => {
   loadSnapshot().then(() => {
     if (live.value) openStream();
   });
+  loadTasks();
+  taskTimer = setInterval(loadTasks, 5000);
 });
-onUnmounted(closeStream);
+onUnmounted(() => {
+  closeStream();
+  if (taskTimer) clearInterval(taskTimer);
+});
 </script>
 
 <template>
   <div>
-    <h2 class="mb-1.5 text-2xs font-semibold uppercase tracking-wider text-muted">Server logs</h2>
-    <p class="mb-3 text-xs text-faint">
-      The running server's log stream, live. The same lines go to
-      <code>docker compose logs</code>; this is a read-only mirror so you can debug from the browser.
-      May contain secrets — visible to approved operators only.
-    </p>
-
     <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
 
-    <!-- Status line -->
+    <!-- Status line: server identity, so a redeploy is visible (pid/start change). -->
     <div
       v-if="status"
-      class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border border-line bg-surface px-3 py-2 font-mono text-2xs text-muted"
+      class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border border-line bg-surface px-3 py-2 font-mono text-2xs text-muted"
     >
       <span>v<span class="text-accent">{{ status.version }}</span></span>
       <span>pid <span class="text-accent">{{ status.pid }}</span></span>
       <span>up <span class="text-accent">{{ uptime }}</span></span>
       <span :title="status.started_at">started {{ shortTime(status.started_at) }}</span>
     </div>
+
+    <!-- Background tasks: the detached @loom webhook launches. -->
+    <section class="mb-5">
+      <h2 class="mb-1.5 text-2xs font-semibold uppercase tracking-wider text-muted">
+        Background tasks
+      </h2>
+      <p class="mb-2 text-xs text-faint">
+        Detached <code>@loom</code> webhook launches — the clone, session create, and reply that run
+        after the webhook returns its <code>200</code>. Newest first.
+      </p>
+      <div class="overflow-x-auto rounded-md border border-line">
+        <table class="w-full border-collapse font-mono text-2xs">
+          <thead>
+            <tr class="bg-surface text-left text-faint">
+              <th class="px-2 py-1 font-medium">State</th>
+              <th class="px-2 py-1 font-medium">Kind</th>
+              <th class="px-2 py-1 font-medium">Task</th>
+              <th class="px-2 py-1 font-medium">Detail</th>
+              <th class="whitespace-nowrap px-2 py-1 font-medium">Started</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="!tasks.length">
+              <td colspan="5" class="px-2 py-2 text-muted">No background tasks yet.</td>
+            </tr>
+            <tr v-for="t in tasks" :key="t.id" class="border-t border-line/40 align-top">
+              <td class="px-2 py-1 font-semibold" :class="taskStateClass(t.state)">{{ t.state }}</td>
+              <td class="whitespace-nowrap px-2 py-1 text-muted">{{ t.kind }}</td>
+              <td class="px-2 py-1 break-all">{{ t.label }}</td>
+              <td class="px-2 py-1 break-all text-muted">{{ t.detail || '—' }}</td>
+              <td
+                class="whitespace-nowrap px-2 py-1 text-faint"
+                :title="t.started_at"
+              >
+                {{ shortTime(t.started_at) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Server logs -->
+    <h2 class="mb-1.5 text-2xs font-semibold uppercase tracking-wider text-muted">Server logs</h2>
+    <p class="mb-3 text-xs text-faint">
+      The running server's log stream, live. The same lines go to
+      <code>docker compose logs</code>; this is a read-only mirror so you can debug from the browser.
+      May contain secrets — visible to approved operators only.
+    </p>
 
     <!-- Controls -->
     <div class="mb-2 flex flex-wrap items-center gap-2">
@@ -242,7 +311,7 @@ onUnmounted(closeStream);
         class="min-w-0 flex-1 rounded bg-input px-2 py-1 font-mono text-xs outline-none focus:ring-1 ring-accent"
       />
 
-      <button class="btn-secondary px-2.5 py-1 text-xs" @click="loadSnapshot">Refresh</button>
+      <button class="btn-secondary px-2.5 py-1 text-xs" @click="refresh">Refresh</button>
       <button class="btn-secondary px-2.5 py-1 text-xs" @click="copyLogs">
         {{ copied ? 'Copied' : 'Copy' }}
       </button>

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -615,3 +615,19 @@ export interface ServerStatus {
   pid: number;
   started_at: string;
 }
+
+/** One detached background task (a `@loom` webhook launch). Mirrors
+ *  `loom::tasks::TaskRecord`. */
+export interface TaskRecord {
+  id: number;
+  /** Coarse category, e.g. `github-trigger` or `github-unauthorized`. */
+  kind: string;
+  /** Human label, e.g. `owner/repo#123 (@user)`. */
+  label: string;
+  /** `running` | `done` | `error`. */
+  state: string;
+  /** Outcome detail: a session id, `forwarded…`, or an error message. */
+  detail: string;
+  started_at: string;
+  finished_at: string | null;
+}

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -100,8 +100,8 @@ const categories: CategoryItem[] = [
   },
   {
     id: 'logs',
-    label: 'Logs',
-    summary: 'Live server logs and build status for debugging this loom deployment.',
+    label: 'Debug',
+    summary: 'Background tasks, live server logs, and build status for debugging this loom deployment.',
   },
 ];
 

--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -21,7 +21,8 @@ pub async fn has_session(name: &str) -> bool {
 
 /// Create a detached session running `script` via `sh -c` in `cwd`.
 pub async fn new_session(name: &str, cwd: &std::path::Path, script: &str) -> Result<()> {
-    tapestry::spawn_detached(&tapestry::LaunchOptions {
+    tracing::info!(session = %name, cwd = %cwd.display(), "spawning terminal session");
+    let result = tapestry::spawn_detached(&tapestry::LaunchOptions {
         name,
         cwd,
         script,
@@ -32,7 +33,12 @@ pub async fn new_session(name: &str, cwd: &std::path::Path, script: &str) -> Res
         rows: 24,
         supervisor_bin: tapestry_bin().as_deref(),
     })
-    .await
+    .await;
+    match &result {
+        Ok(()) => tracing::info!(session = %name, "terminal session spawned"),
+        Err(e) => tracing::warn!(session = %name, error = %e, "failed to spawn terminal session"),
+    }
+    result
 }
 
 /// Render the session's screen to text; `history` extra scrollback lines.
@@ -44,18 +50,22 @@ pub async fn capture(name: &str, history: usize) -> Result<String> {
 /// Type `text` into the session verbatim (the `send-keys -l` analogue). No
 /// trailing newline; pair with [`send_enter`] to submit.
 pub async fn send_literal(name: &str, text: &str) -> Result<()> {
+    tracing::debug!(session = %name, bytes = text.len(), "sending literal input to terminal");
     let mut c = tapestry::Client::connect(name).await?;
     c.send(text.as_bytes()).await
 }
 
 /// Send a single named key (e.g. `Enter`, `Escape`) to the session.
 pub async fn send_key(name: &str, key: &str) -> Result<()> {
+    let bytes = key_bytes(key);
+    tracing::debug!(session = %name, bytes = bytes.len(), "sending key to terminal");
     let mut c = tapestry::Client::connect(name).await?;
-    c.send(key_bytes(key)).await
+    c.send(bytes).await
 }
 
 /// Submit the current input — a bare `Enter`.
 pub async fn send_enter(name: &str) -> Result<()> {
+    tracing::debug!(session = %name, "submitting terminal input");
     send_key(name, "Enter").await
 }
 

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -120,6 +120,12 @@ pub async fn create_pr(work_dir: &Path, base: &str, title: &str, body: &str) -> 
 
 const POLL_TICK: Duration = Duration::from_secs(30);
 
+/// Branch tag marking that loom has back-linked this branch's PR to its session
+/// (posted the `…/s/{id}` comment). Set by the poll loop's back-link poster or,
+/// for a `@loom`-triggered PR, by the trigger reply — so exactly one link lands.
+/// Shared with [`crate::web`] (the trigger reply path).
+pub const LINKED_TAG: &str = "github.linked";
+
 /// The fields requested from `gh pr view --json`. Kept in one place so the parse
 /// struct and the query can't drift.
 const PR_FIELDS: &str =
@@ -431,6 +437,13 @@ async fn apply_snapshot(
         }
     }
 
+    // Back-link the PR to its loom session — a one-time comment on the open PR, so
+    // someone reading the GitHub thread can jump to the live session. Skipped once
+    // the branch is tagged linked (here or by the trigger reply).
+    if snap.pr_state == "OPEN" {
+        maybe_post_backlink(state, session, branch, snap).await;
+    }
+
     let recovered = tags::get(&state.db, &branch.id, tags::RECOVERED_KEY)
         .await?
         .is_some_and(|tag| tag.value == tags::RECOVERED_VALUE);
@@ -458,6 +471,71 @@ async fn apply_snapshot(
         }
     }
     Ok(())
+}
+
+/// Derive the `owner/name` slug for a managed clone from its on-disk root
+/// (`<repos_dir>/owner/name`). `None` for a local-path repo (forked from `cwd`),
+/// which has no managed slug — and may have no GitHub remote — so it's skipped.
+fn slug_from_repo_root(repo_root: &str) -> Option<String> {
+    let rest = Path::new(repo_root)
+        .strip_prefix(crate::repo::repos_dir())
+        .ok()?;
+    let s = rest.to_string_lossy().replace('\\', "/");
+    (s.matches('/').count() == 1 && !s.is_empty()).then_some(s)
+}
+
+/// Post a one-time comment on the branch's open PR linking back to its loom
+/// session, unless the branch is already linked (the `@loom` reply tagged it, or a
+/// prior poll posted it). Managed repos only — the App gateway needs the slug —
+/// and only when a public base URL is configured, so the link resolves.
+/// Best-effort: every failure logs and returns, leaving the tag unset to retry.
+async fn maybe_post_backlink(
+    state: &AppState,
+    session: &Session,
+    branch: &Branch,
+    snap: &GithubStatus,
+) {
+    match tags::get(&state.db, &branch.id, LINKED_TAG).await {
+        Ok(Some(_)) => return, // already linked
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(branch = %branch.branch, error = %e, "back-link: reading link tag failed");
+            return;
+        }
+    }
+    let Some(slug) = slug_from_repo_root(&branch.repo_root) else {
+        return; // local-path repo: no managed slug
+    };
+    let base = crate::config::get(&state.db, "auth.base_url")
+        .await
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    if base.is_empty() {
+        return; // no public URL configured → a link wouldn't resolve
+    }
+    let body = format!("Working on this in loom: {base}/s/{}", session.id);
+    if let Err(e) = state
+        .trigger
+        .gh()
+        .post_issue_comment(&slug, snap.pr_number, &body)
+        .await
+    {
+        tracing::warn!(repo = %slug, pr = snap.pr_number, error = %e, "back-link: posting comment failed");
+        return;
+    }
+    tags::set(
+        &state.db,
+        &branch.id,
+        LINKED_TAG,
+        &session.id,
+        "loom back-link comment posted",
+        "loom",
+    )
+    .await
+    .ok();
+    tracing::info!(session = %session.id, repo = %slug, pr = snap.pr_number, "posted loom back-link comment on PR");
 }
 
 /// Close every open weaver issue the merged branch was working and log each
@@ -553,6 +631,28 @@ mod tests {
     #[test]
     fn rollup_none_when_empty() {
         assert_eq!(rollup_checks(&[]), None);
+    }
+
+    #[test]
+    fn slug_from_managed_clone_root() {
+        // A managed clone lives at `<repos_dir>/owner/name`.
+        let root = crate::repo::repos_dir().join("acme").join("widgets");
+        assert_eq!(
+            slug_from_repo_root(&root.to_string_lossy()),
+            Some("acme/widgets".to_string())
+        );
+    }
+
+    #[test]
+    fn slug_none_for_local_path_repo() {
+        // A repo forked from an arbitrary local checkout has no managed slug — the
+        // back-link poster must skip it rather than invent an `owner/name`.
+        assert_eq!(slug_from_repo_root("/home/someone/projects/thing"), None);
+        // The repos_dir root itself (no owner/name tail) is not a slug either.
+        assert_eq!(
+            slug_from_repo_root(&crate::repo::repos_dir().to_string_lossy()),
+            None
+        );
     }
 
     #[test]

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -223,6 +223,7 @@ impl GithubApp {
             .private_key()
             .await
             .ok_or_else(|| anyhow!("GitHub App private key is not configured"))?;
+        tracing::debug!(app_id, "minting app jwt");
         build_app_jwt(app_id, &pem, Utc::now().timestamp())
     }
 
@@ -233,6 +234,7 @@ impl GithubApp {
     /// that the App is installed on — and so authorized for — the repo. Errors
     /// (e.g. a 404 when the App is not installed) propagate so callers fail closed.
     pub async fn installation_id(&self, owner: &str, name: &str) -> Result<i64> {
+        tracing::debug!(owner, name, "resolving repo installation");
         let jwt = self.current_jwt().await?;
         let url = format!("{}/repos/{owner}/{name}/installation", self.api_base);
         let resp = self
@@ -249,6 +251,12 @@ impl GithubApp {
             .json()
             .await
             .context("parsing the installation response")?;
+        tracing::debug!(
+            owner,
+            name,
+            installation = body.id,
+            "resolved repo installation"
+        );
         Ok(body.id)
     }
 
@@ -385,6 +393,11 @@ impl GithubApp {
 impl GithubApi for GithubApp {
     async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
         if !self.is_configured().await {
+            tracing::debug!(
+                repo,
+                issue,
+                "app not configured; posting comment via gh fallback"
+            );
             return self.fallback.post_issue_comment(repo, issue, body).await;
         }
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
@@ -410,6 +423,11 @@ impl GithubApi for GithubApp {
 
     async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
         if !self.is_configured().await {
+            tracing::debug!(
+                repo,
+                number,
+                "app not configured; fetching pr head via gh fallback"
+            );
             return self.fallback.pr_head(repo, number).await;
         }
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
@@ -440,6 +458,13 @@ impl GithubApi for GithubApp {
         let head_repo = body["head"]["repo"]["full_name"].as_str();
         let base_repo = body["base"]["repo"]["full_name"].as_str();
         let cross_repo = head_repo.is_none() || head_repo != base_repo;
+        tracing::info!(
+            repo,
+            number,
+            head_ref = %head_ref,
+            cross_repo,
+            "resolved pull request head"
+        );
         Ok(PrHead {
             head_ref,
             cross_repo,
@@ -484,6 +509,7 @@ async fn check_status(resp: reqwest::Response, what: &str) -> Result<reqwest::Re
         return Ok(resp);
     }
     let body = resp.text().await.unwrap_or_default();
+    tracing::warn!(what, %status, "github rest call failed");
     bail!("{what}: GitHub returned {status}: {}", body.trim())
 }
 

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -30,6 +30,7 @@ pub mod server;
 pub mod session;
 pub mod setup;
 pub mod shell;
+pub mod tasks;
 pub mod terminal;
 pub mod user_token;
 pub mod watch;

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -81,6 +81,7 @@ pub async fn run(state: AppState) {
             }
         };
         let mut alive: HashSet<String> = HashSet::new();
+        tracing::debug!(sessions = sessions.len(), "monitor tick: session walk");
 
         // Edge-detect no-activity staleness once per walk, gated on the
         // watch master switch (no consumer ⇒ no point emitting). The
@@ -145,6 +146,7 @@ pub async fn run(state: AppState) {
             let h = hash(&normalize_screen(&screen));
             if screen_hash.get(&session.id) != Some(&h) {
                 screen_hash.insert(session.id.clone(), h);
+                tracing::debug!(id = %session.id, "activity detected; touching session");
                 let _ = session_mod::touch(&state.db, &session.id).await;
             }
         }
@@ -199,6 +201,7 @@ pub async fn detect_stale(
     if is_stale(session, after, now) {
         if seen.insert(session.id.clone()) {
             let idle_secs = idle_secs(session, now);
+            tracing::info!(id = %session.id, idle_secs, "session marked stale");
             if events::record(
                 &state.db,
                 &state.bus,
@@ -214,7 +217,9 @@ pub async fn detect_stale(
         }
     } else {
         // Activity resumed (or never crossed): re-arm the edge.
-        seen.remove(&session.id);
+        if seen.remove(&session.id) {
+            tracing::info!(id = %session.id, "session activity resumed; no longer stale");
+        }
     }
     last_event
 }
@@ -280,6 +285,16 @@ async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64
     // terminal state.
     let status_changed = session.status != "running" && !session_mod::is_terminal(&session.status);
     if status_changed {
+        if session.status == "orphaned" {
+            tracing::info!(id = %session.id, branch = %branch_id, "lifting orphaned session back to running");
+        } else {
+            tracing::debug!(
+                id = %session.id,
+                branch = %branch_id,
+                previous_status = %session.status,
+                "session transitioning to running via hook"
+            );
+        }
         let _ = session_mod::set_status(&state.db, &session.id, "running").await;
     }
     let _ = session_mod::touch(&state.db, &session.id).await;
@@ -309,6 +324,7 @@ async fn apply_hook(state: &AppState, branch_id: &str, kind: &str) -> Option<i64
         if current == value {
             continue;
         }
+        tracing::debug!(branch = %branch_id, key, value, "hook applied tag mutation");
         if value.is_empty() {
             let _ = tags::clear(&state.db, branch_id, key).await;
         } else {

--- a/crates/loom/src/repo.rs
+++ b/crates/loom/src/repo.rs
@@ -180,6 +180,7 @@ pub struct ManagedRepo {
 
 /// Register (or update the remote/path of) a managed repo, returning the row.
 pub async fn register(db: &Db, slug: &str, remote_url: &str, path: &str) -> Result<ManagedRepo> {
+    tracing::info!(slug, path, "registering managed repo");
     sqlx::query(
         "INSERT INTO repos (slug, remote_url, path) VALUES (?, ?, ?)
          ON CONFLICT(slug) DO UPDATE SET
@@ -216,6 +217,7 @@ pub async fn get_registered(db: &Db, slug: &str) -> Result<Option<ManagedRepo>> 
     .bind(slug)
     .fetch_optional(db)
     .await?;
+    tracing::debug!(slug, found = row.is_some(), "looked up registered repo");
     Ok(row)
 }
 
@@ -231,10 +233,12 @@ pub async fn is_allowlisted(db: &Db, repo_root: &Path) -> Result<bool> {
     let target = repo_root
         .canonicalize()
         .unwrap_or_else(|_| repo_root.to_path_buf());
-    Ok(list_registered(db).await?.into_iter().any(|registered| {
+    let allowed = list_registered(db).await?.into_iter().any(|registered| {
         let path = PathBuf::from(&registered.path);
         path.canonicalize().unwrap_or(path) == target
-    }))
+    });
+    tracing::debug!(repo = %repo_root.display(), allowed, "checked repo allowlist");
+    Ok(allowed)
 }
 
 /// How a managed-repo resolution can fail, so the web layer maps each cause to
@@ -262,12 +266,14 @@ pub async fn resolve_clone(
     input: &str,
     app: Option<&crate::github_app::GithubApp>,
 ) -> std::result::Result<PathBuf, ResolveError> {
+    tracing::debug!(input, "resolving managed repo clone");
     let slug = parse_slug(input).map_err(ResolveError::BadRequest)?;
     let slug_str = slug.slug();
     let registered = get_registered(db, &slug_str)
         .await
         .map_err(|e| ResolveError::Clone(e.to_string()))?
         .ok_or_else(|| {
+            tracing::info!(repo = %slug_str, "repo not registered; refusing clone");
             ResolveError::BadRequest(format!(
                 "repo '{slug_str}' is not registered — register it via POST /api/repos first"
             ))
@@ -275,7 +281,10 @@ pub async fn resolve_clone(
     let dest = PathBuf::from(&registered.path);
     let token = match app {
         Some(app) => match app.token_for_repo(&slug.owner, &slug.name).await {
-            Ok(token) => Some(token),
+            Ok(token) => {
+                tracing::debug!(repo = %slug_str, "minted GitHub App installation token for repo");
+                Some(token)
+            }
             Err(e) => {
                 tracing::debug!(
                     repo = %slug_str,
@@ -288,9 +297,14 @@ pub async fn resolve_clone(
         },
         None => None,
     };
+    tracing::info!(repo = %slug_str, dest = %dest.display(), authenticated = token.is_some(), "acquiring managed repo clone");
     git::clone(&registered.remote_url, &dest, token.as_deref())
         .await
-        .map_err(|e| ResolveError::Clone(format!("cloning {slug_str}: {e}")))?;
+        .map_err(|e| {
+            tracing::warn!(repo = %slug_str, dest = %dest.display(), error = %e, "managed repo clone/fetch failed");
+            ResolveError::Clone(format!("cloning {slug_str}: {e}"))
+        })?;
+    tracing::info!(repo = %slug_str, dest = %dest.display(), "managed repo clone ready");
     Ok(dest)
 }
 

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -107,6 +107,15 @@ pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
     .bind(&now)
     .execute(db)
     .await?;
+    tracing::info!(
+        session = %s.id,
+        branch = %s.branch_id,
+        agent_kind = %s.agent_kind,
+        status = %s.status,
+        managed_by = s.managed_by.as_deref().unwrap_or("-"),
+        parent_branch = s.parent_branch_id.as_deref().unwrap_or("-"),
+        "session created"
+    );
     get(db, &s.id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("session vanished after insert"))
@@ -245,6 +254,7 @@ pub async fn touch(db: &Db, id: &str) -> Result<()> {
         .bind(id)
         .execute(db)
         .await?;
+    tracing::debug!(session = %id, "session activity touched");
     Ok(())
 }
 
@@ -253,6 +263,7 @@ pub async fn delete(db: &Db, id: &str) -> Result<()> {
         .bind(id)
         .execute(db)
         .await?;
+    tracing::info!(session = %id, "session row deleted");
     Ok(())
 }
 

--- a/crates/loom/src/tasks.rs
+++ b/crates/loom/src/tasks.rs
@@ -1,0 +1,136 @@
+//! An in-memory registry of detached background tasks — currently the GitHub
+//! `@loom` trigger launches, which run off the webhook request so a slow clone
+//! can't blow GitHub's ~10s delivery timeout. Surfaced on the Debug page so an
+//! operator can watch a webhook being handled *after* its `200` was returned —
+//! the work that used to vanish into a spawned future with no trace.
+//!
+//! A capped ring (newest kept), lost on restart, exactly like the log buffer
+//! ([`crate::logs`]). Not persisted — it is an observability aid, not a job
+//! queue.
+
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
+use serde::Serialize;
+
+/// Most task records retained; older ones are evicted.
+const CAP: usize = 100;
+
+/// One background task's lifecycle, as shown on the Debug page.
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskRecord {
+    pub id: u64,
+    /// A coarse category, e.g. `github-trigger`.
+    pub kind: String,
+    /// A human label, e.g. `marin-community/marin#6823 (@rjpower)`.
+    pub label: String,
+    /// `running` | `done` | `error`.
+    pub state: String,
+    /// Outcome detail: a session id, `forwarded`, or an error message.
+    pub detail: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+}
+
+#[derive(Default)]
+struct Inner {
+    seq: u64,
+    tasks: VecDeque<TaskRecord>,
+}
+
+/// The process-wide registry of background tasks.
+pub struct Registry {
+    inner: Mutex<Inner>,
+}
+
+impl Registry {
+    fn new() -> Self {
+        Registry {
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    /// Record a task starting; returns its id for a later [`Self::finish`].
+    pub fn start(&self, kind: &str, label: &str) -> u64 {
+        let mut inner = self.inner.lock().unwrap();
+        inner.seq += 1;
+        let id = inner.seq;
+        inner.tasks.push_back(TaskRecord {
+            id,
+            kind: kind.to_string(),
+            label: label.to_string(),
+            state: "running".to_string(),
+            detail: String::new(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+            finished_at: None,
+        });
+        while inner.tasks.len() > CAP {
+            inner.tasks.pop_front();
+        }
+        id
+    }
+
+    /// Mark task `id` finished with `state` (`done` | `error`) and a `detail`.
+    /// A no-op if the record was already evicted.
+    pub fn finish(&self, id: u64, state: &str, detail: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(t) = inner.tasks.iter_mut().find(|t| t.id == id) {
+            t.state = state.to_string();
+            t.detail = detail.to_string();
+            t.finished_at = Some(chrono::Utc::now().to_rfc3339());
+        }
+    }
+
+    /// All records, newest first.
+    pub fn snapshot(&self) -> Vec<TaskRecord> {
+        let inner = self.inner.lock().unwrap();
+        inner.tasks.iter().rev().cloned().collect()
+    }
+}
+
+/// The process-wide task registry.
+pub fn registry() -> &'static Registry {
+    static REGISTRY: OnceLock<Registry> = OnceLock::new();
+    REGISTRY.get_or_init(Registry::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_finish_and_snapshot_newest_first() {
+        let r = Registry::new();
+        let a = r.start("github-trigger", "acme/widgets#1");
+        let b = r.start("github-trigger", "acme/widgets#2");
+        r.finish(a, "done", "session abc");
+
+        let snap = r.snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].id, b, "newest first");
+        assert_eq!(snap[0].state, "running");
+        assert_eq!(snap[1].id, a);
+        assert_eq!(snap[1].state, "done");
+        assert_eq!(snap[1].detail, "session abc");
+        assert!(snap[1].finished_at.is_some());
+    }
+
+    #[test]
+    fn evicts_oldest_beyond_cap() {
+        let r = Registry::new();
+        for i in 0..(CAP + 10) {
+            r.start("t", &format!("job-{i}"));
+        }
+        let snap = r.snapshot();
+        assert_eq!(snap.len(), CAP, "capped at CAP");
+        assert_eq!(snap[0].label, format!("job-{}", CAP + 9), "newest kept");
+    }
+
+    #[test]
+    fn finish_on_evicted_id_is_a_noop() {
+        let r = Registry::new();
+        // id 0 never existed.
+        r.finish(0, "done", "nothing");
+        assert!(r.snapshot().is_empty());
+    }
+}

--- a/crates/loom/src/watch.rs
+++ b/crates/loom/src/watch.rs
@@ -208,6 +208,7 @@ pub async fn tick_timer(state: &AppState) {
         // this same (awaited) pass, before the round runs, so it stays one-shot.
         if let Some(wake) = o.wake_at.as_deref().and_then(parse_iso) {
             if wake <= now {
+                tracing::debug!(watch = %o.id, name = %o.name, "watch timer: wake due; emitting tick");
                 match events::record_system(
                     &state.db,
                     &state.bus,
@@ -253,6 +254,7 @@ pub async fn tick_timer(state: &AppState) {
             continue;
         }
         // Due: emit the cron tick (the dispatcher fires the round) and advance.
+        tracing::debug!(watch = %o.id, name = %o.name, "watch timer: cron due; emitting tick");
         if let Err(e) =
             events::record_system(&state.db, &state.bus, "cron", json!({ "watch": o.id })).await
         {
@@ -343,6 +345,7 @@ pub async fn dispatch(state: &AppState, in_flight: &InFlight, ev: &events::Event
                 } else {
                     "cron"
                 };
+                tracing::debug!(watch = %o.id, name = %o.name, reason, "dispatching cron tick to watch");
                 let _ = fire(
                     state,
                     in_flight,
@@ -366,6 +369,7 @@ pub async fn dispatch(state: &AppState, in_flight: &InFlight, ev: &events::Event
                     .get("reason")
                     .and_then(Value::as_str)
                     .unwrap_or("manual");
+                tracing::info!(watch = %o.id, name = %o.name, reason, dry_run, "dispatching manual run to watch");
                 let _ = fire(state, in_flight, &o, reason, dry_run, &TriggerCtx::manual()).await;
             }
         }
@@ -381,6 +385,14 @@ pub async fn dispatch(state: &AppState, in_flight: &InFlight, ev: &events::Event
             };
             let repo = event_repo(state, ev).await;
             let session = triggering_session(state, ev).await;
+            tracing::debug!(
+                event = %event,
+                level = ?level,
+                branch = %ev.branch_id,
+                session = ?session,
+                repo = ?repo,
+                "watch dispatch: normalized reactive event"
+            );
             let watches = match watch_store::list_enabled(&state.db).await {
                 Ok(o) => o,
                 Err(e) => {
@@ -399,6 +411,14 @@ pub async fn dispatch(state: &AppState, in_flight: &InFlight, ev: &events::Event
                         branch: (!events::is_system(&ev.branch_id)).then(|| ev.branch_id.clone()),
                         repo: repo.clone(),
                     };
+                    tracing::debug!(
+                        watch = %o.id,
+                        name = %o.name,
+                        event = %event,
+                        branch = ?ctx.branch,
+                        session = ?ctx.session,
+                        "watch trigger matched; dispatching round"
+                    );
                     let _ =
                         fire(state, in_flight, &o, &format!("event:{event}"), false, &ctx).await;
                 }
@@ -631,6 +651,7 @@ async fn record_skipped(
     let run_id = watch_store::start_run(&state.db, &o.id, trigger_reason, trigger_event)
         .await
         .ok()?;
+    tracing::info!(watch = %o.id, name = %o.name, run = run_id, summary, "watch round skipped");
     let _ = watch_store::finish_run(
         &state.db,
         run_id,
@@ -1165,6 +1186,7 @@ pub async fn fire_now(
     // no-overlap domain (the engine loop guards its own concurrent fires).
     let in_flight = new_in_flight();
     let reason = if reason.is_empty() { "manual" } else { reason };
+    tracing::info!(watch = %o.id, name = %o.name, reason, dry_run, "operator fired watch now");
     fire(
         state,
         &in_flight,
@@ -1206,7 +1228,10 @@ pub async fn ensure_warm_session(state: &AppState, o: &Watch) -> anyhow::Result<
     // id and (cheaply) repair the watch linkage if it drifted.
     if let Some(existing) = session_mod::active_managed_by(&state.db, &o.id).await? {
         if o.warm_session_id.as_deref() != Some(existing.id.as_str()) {
+            tracing::info!(watch = %o.id, session = %existing.id, "repairing drifted warm session linkage");
             watch_store::set_warm_session(&state.db, &o.id, Some(&existing.id)).await?;
+        } else {
+            tracing::debug!(watch = %o.id, session = %existing.id, "reusing existing warm session");
         }
         return Ok(Some(existing.id));
     }

--- a/crates/loom/src/web/logview.rs
+++ b/crates/loom/src/web/logview.rs
@@ -14,6 +14,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
 
 use crate::logs::{self, LogLine};
+use crate::tasks::{self, TaskRecord};
 
 #[derive(Debug, Deserialize)]
 pub(super) struct LogsQuery {
@@ -60,4 +61,11 @@ pub(super) async fn server_status() -> Json<ServerStatus> {
         pid: std::process::id(),
         started_at: logs::buffer().started_at().to_string(),
     })
+}
+
+/// `GET /api/tasks` — recent detached background tasks (the GitHub-trigger
+/// launches that run off the webhook request), newest first. Operator-only, same
+/// as the log endpoints — a task label names a repo/issue an operator can act on.
+pub(super) async fn tasks_snapshot() -> Json<Vec<TaskRecord>> {
+    Json(tasks::registry().snapshot())
 }

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -611,11 +611,13 @@ pub fn router(state: AppState) -> Router {
         // container, for one-time setup like `gcloud auth login`.
         .route("/shell/terminal", get(crate::terminal::shell_ws))
         .route("/shell/restart", post(restart_shell))
-        // Server logs (Settings → Logs) — snapshot + live SSE tail + build status.
-        // Operator-only: server logs can carry tokens injected into agents.
+        // Server logs + background tasks (Settings → Debug) — snapshot + live SSE
+        // tail + build status + the detached trigger-task list. Operator-only:
+        // server logs can carry tokens injected into agents.
         .route("/logs", get(logs_snapshot))
         .route("/logs/stream", get(logs_stream))
         .route("/status", get(server_status))
+        .route("/tasks", get(tasks_snapshot))
         // Watches — periodic / triggered watch programs over the fleet.
         .route("/watches", get(list_watches).post(create_watch))
         // The static segment wins over the `{id}` capture below, so a program

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -180,44 +180,121 @@ pub(super) async fn github_webhook(
 
     // 6. Authorize the commenter (the untrusted boundary): they must be an
     //    approved loom user — the same allowlist that gates signing in to the app.
-    //    Repo write access is *not* itself a grant. Unauthorized → silent no-op;
-    //    replying would amplify spam across a flood of comments.
+    //    Repo write access is *not* itself a grant. Unauthorized → reply once with
+    //    a friendly "request access" note instead of a silent drop, so a would-be
+    //    user knows to ask rather than assume loom is broken. The per-repo rate
+    //    limit above bounds this against a comment flood; the reply is spawned (a
+    //    comment post is a round-trip) and tracked so the attempt shows on Debug.
     if !github_trigger::authorize(&st.db, &author).await {
-        tracing::info!(login = %author, repo = %slug.slug(), "github webhook: commenter not authorized");
+        tracing::info!(login = %author, repo = %slug.slug(), "github webhook: commenter not authorized; replying with access info");
+        let number = event.issue.number;
+        let slug_str = slug.slug();
+        let task_id = crate::tasks::registry().start(
+            "github-unauthorized",
+            &format!("{slug_str}#{number} (@{author})"),
+        );
+        tokio::spawn(async move {
+            let body = format!(
+                "Hi @{author} — thanks for the ping. You're not on this loom instance's \
+                 access list yet, so I can't pick this up. Ask an operator to grant you \
+                 access, then tag me again and I'll jump in."
+            );
+            match st
+                .trigger
+                .gh()
+                .post_issue_comment(&slug_str, number, &body)
+                .await
+            {
+                Ok(_) => crate::tasks::registry().finish(task_id, "done", "replied: needs access"),
+                Err(e) => {
+                    tracing::warn!(repo = %slug_str, error = %e, "github webhook: posting access-info reply failed");
+                    crate::tasks::registry().finish(
+                        task_id,
+                        "error",
+                        &format!("reply failed: {e}"),
+                    );
+                }
+            }
+        });
         return ok();
     }
 
-    // 6a. An approved user has been authorized above, so honor the App's
-    //     installation as the repo grant: auto-register any repo the App is
-    //     installed on into the managed allowlist, so the clone path below accepts
-    //     it, *complementing* explicitly registered repos. A no-op when the App is
-    //     unconfigured, the repo is already registered, or the App is not installed
-    //     on it (leaving the repos-table allowlist to govern).
+    // 6b. Accept the trigger and hand the heavy work — clone, branch resolution,
+    //     session create, reply — to a detached task. That work can take far
+    //     longer than GitHub's ~10s webhook timeout on a large repo; doing it
+    //     inline lets GitHub drop the connection and cancel the handler mid-clone
+    //     (and, since the delivery is already recorded, never retry). So log the
+    //     receipt (the Debug stream shows the hook firing), return `200` now, and
+    //     run it in the background, tracked in the task registry for the Debug page.
+    let number = event.issue.number;
+    tracing::info!(
+        repo = %slug.slug(),
+        number,
+        login = %author,
+        is_pr = event.issue.is_pr(),
+        "github webhook: trigger accepted, launching in background"
+    );
+    let task_id = crate::tasks::registry().start(
+        "github-trigger",
+        &format!("{}#{number} (@{author})", slug.slug()),
+    );
+    tokio::spawn(async move {
+        match handle_trigger(st, headers, slug, event, author).await {
+            Ok(Some(id)) => {
+                crate::tasks::registry().finish(task_id, "done", &format!("session {id}"))
+            }
+            Ok(None) => {
+                crate::tasks::registry().finish(task_id, "done", "forwarded to existing session")
+            }
+            Err(e) => crate::tasks::registry().finish(task_id, "error", &e),
+        }
+    });
+    ok()
+}
+
+/// The heavy half of a `@loom` trigger, run detached from the webhook request so
+/// a slow clone can't blow the delivery timeout: acquire the clone, resolve the
+/// target branch, forward-or-create the session, and reply on the thread. Returns
+/// the new session id (`Some`), `None` when the comment was forwarded to an
+/// existing session, or an `Err` describing why nothing launched — the string is
+/// surfaced on the Debug page's task list.
+async fn handle_trigger(
+    st: AppState,
+    headers: HeaderMap,
+    slug: repo::RepoSlug,
+    event: github_trigger::IssueCommentEvent,
+    author: String,
+) -> Result<Option<String>, String> {
+    // Honor the App's installation as the repo grant: auto-register any repo the
+    // App is installed on into the managed allowlist, so the clone path below
+    // accepts it, *complementing* explicitly registered repos. A no-op when the
+    // App is unconfigured, the repo is already registered, or the App is not
+    // installed on it (leaving the repos-table allowlist to govern).
     if let Some(app) = st.trigger.app() {
         app.ensure_installed_repo_registered(&slug).await;
     }
 
-    // 7. Resolve the commenter to their loom user (proven to exist by `authorize`
-    //    above). Attributing the launch to them makes their personal GitHub token
-    //    the session's `GH_TOKEN` — so its push / `gh` act as them — with the
-    //    ambient token as the fallback (see `apply_user_github_token`).
+    // Resolve the commenter to their loom user (proven to exist by `authorize`).
+    // Attributing the launch to them makes their personal GitHub token the
+    // session's `GH_TOKEN` — so its push / `gh` act as them — with the ambient
+    // token as the fallback (see `apply_user_github_token`).
     let username = match crate::auth::user_by_github(&st.db, &author).await {
         Ok(Some(u)) => u.username,
         _ => {
             tracing::warn!(login = %author, "github webhook: approved user vanished before launch");
-            return ok();
+            return Err("approved user vanished before launch".to_string());
         }
     };
 
-    // 8. Acquire the managed clone (allowlist-gated; `resolve_clone` also fetches
-    //    `--all`, so a PR's head lands as `origin/<ref>`), then resolve the branch
-    //    this trigger targets: a PR works on its own head branch so the agent's
-    //    commits land on the PR; an issue gets a stable `weaver/issue-<n>`.
+    // Acquire the managed clone (allowlist-gated; `resolve_clone` also fetches
+    // `--all`, so a PR's head lands as `origin/<ref>`), then resolve the branch
+    // this trigger targets: a PR works on its own head branch so the agent's
+    // commits land on the PR; an issue gets a stable `weaver/issue-<n>`.
     let repo_root = match repo::resolve_clone(&st.db, &slug.slug(), st.trigger.app()).await {
         Ok(p) => p,
         Err(e) => {
             tracing::warn!(repo = %slug.slug(), error = ?e, "github webhook: clone/allowlist rejected");
-            return ok();
+            return Err(format!("clone/allowlist rejected: {e:?}"));
         }
     };
     let repo_root_str = repo_root.to_string_lossy().to_string();
@@ -288,7 +365,7 @@ pub(super) async fn github_webhook(
                     }
                     tracing::info!(session = %sess.id, repo = %slug.slug(), number, "github webhook: forwarded comment to active session");
                 }
-                return ok();
+                return Ok(None);
             }
         }
     }
@@ -316,10 +393,8 @@ pub(super) async fn github_webhook(
     let view = match create_session_core(st.clone(), req, Some(username)).await {
         Ok(v) => v,
         Err(e) => {
-            // A non-allowlisted repo lands here (a BadRequest from resolve_clone),
-            // as does a clone/launch failure. Acknowledge; don't make GitHub retry.
             tracing::warn!(repo = %slug.slug(), error = ?e, "github webhook: session create failed");
-            return ok();
+            return Err(format!("session create failed: {e:?}"));
         }
     };
 
@@ -344,7 +419,23 @@ pub(super) async fn github_webhook(
         login = %author,
         "github webhook: launched session"
     );
-    ok()
+    // A PR's `On it` comment already carries the session's loom URL, so mark the
+    // branch linked and the poll loop's back-link poster leaves it alone. An
+    // issue's `On it` sits on the issue, not the eventual PR, so it doesn't count
+    // — the poster links the PR when it opens.
+    if is_pr {
+        weaver_core::tags::set(
+            &st.db,
+            &view.branch.id,
+            crate::github::LINKED_TAG,
+            &view.id,
+            "loom back-link posted with the trigger reply",
+            "loom",
+        )
+        .await
+        .ok();
+    }
+    Ok(Some(view.id))
 }
 
 /// Build the opening goal for a trigger-launched session: the issue/PR title and

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -268,6 +268,7 @@ async fn launch_env(
             .unwrap_or_default(),
     );
     repo_env::layer(&mut env, config_env_pairs(cfg));
+    tracing::debug!(repo = %repo_root_str, env_vars = env.len(), "layered launch environment");
     env
 }
 
@@ -286,8 +287,13 @@ async fn apply_user_github_token(
 ) {
     let Some(username) = created_by else { return };
     match crate::user_token::get(db, username).await {
-        Ok(Some(token)) if !token.trim().is_empty() => set_env(env, "GH_TOKEN", token),
-        Ok(_) => {}
+        Ok(Some(token)) if !token.trim().is_empty() => {
+            set_env(env, "GH_TOKEN", token);
+            tracing::info!(%username, "applied user github token as GH_TOKEN");
+        }
+        Ok(_) => {
+            tracing::debug!(%username, "no personal github token on file, leaving ambient GH_TOKEN")
+        }
         Err(e) => tracing::warn!(%username, "failed to load user github token: {e}"),
     }
 }
@@ -351,6 +357,7 @@ async fn ensure_github_token_available(
     {
         return Ok(());
     }
+    tracing::warn!(created_by = ?created_by, runtime = %runtime, "launch blocked: no github token available");
     Err(AppError::new(
         StatusCode::PRECONDITION_REQUIRED,
         MISSING_GITHUB_TOKEN_MESSAGE,
@@ -381,6 +388,7 @@ async fn run_repo_setup(
     env: &[(String, String)],
 ) -> setup::SetupOutcome {
     let timeout = setup_timeout(&st.db).await;
+    tracing::info!(branch = branch_id, work_dir = %work_dir.display(), timeout_secs = timeout.as_secs(), "running repo [setup] script");
     events::record(
         &st.db,
         &st.bus,
@@ -458,6 +466,12 @@ pub(crate) async fn create_session_core(
     req: CreateReq,
     created_by: Option<String>,
 ) -> ApiResult<SessionView> {
+    tracing::info!(
+        repo = ?req.repo,
+        agent = ?req.agent,
+        created_by = ?created_by,
+        "create_session_core: starting session creation"
+    );
     // Resolve the repo root. An explicit managed `repo` (a slug/URL) is
     // allowlist-checked and cloned-if-absent into the managed store, then used
     // directly; otherwise fork from `cwd`'s repo (the default). The traversal /
@@ -479,6 +493,7 @@ pub(crate) async fn create_session_core(
     // Canonicalize so repo identity matches the `weaver` CLI's resolver — issues
     // are keyed on this path and the two binaries must agree on it.
     let repo_root = repo_root.canonicalize().unwrap_or(repo_root);
+    tracing::debug!(repo_root = %repo_root.display(), "resolved repo root");
 
     // The repo's committed `.weaver/config.toml`, read from its primary checkout.
     // It supplies agent/model/effort defaults (below an explicit request, above
@@ -503,6 +518,7 @@ pub(crate) async fn create_session_core(
             weaver_core::repo_config::RepoConfig::default()
         }
     };
+    tracing::debug!(repo_root = %repo_root.display(), "loaded repo config");
 
     let agent = match req.agent {
         Some(a) => a.trim().to_string(),
@@ -513,6 +529,7 @@ pub(crate) async fn create_session_core(
     // deliverable to track), and is hidden from the fleet list by its kind.
     let is_concierge = agent == agent::CONCIERGE_KIND;
     let runtime = launch_runtime(&st.db, &agent).await;
+    tracing::debug!(agent = %agent, runtime = %runtime, is_concierge, "resolved agent runtime");
     // The resolved launch environment: global agent_env < per-repo repo_env < the
     // repo file's [env]. It is needed before provisioning so a real agent launch
     // can stop cleanly when neither the user nor the deployment provides GH_TOKEN.
@@ -574,7 +591,9 @@ pub(crate) async fn create_session_core(
         }
         None => return Err(AppError::bad_request(format!("unknown agent '{runtime}'"))),
     }
+    tracing::debug!(model = %model, effort = %effort, "resolved and validated model/effort");
     ensure_github_token_available(&st.db, &extra_env, created_by.as_deref(), &runtime).await?;
+    tracing::debug!(runtime = %runtime, "github token availability check passed");
 
     // Build title/goal/description; an optional GitHub issue seeds all three.
     let mut goal = req.goal.unwrap_or_default().trim().to_string();
@@ -586,6 +605,7 @@ pub(crate) async fn create_session_core(
     let mut github_repo = None;
     let mut github_issue: Option<i64> = None;
     if let Some(number) = req.issue {
+        tracing::info!(issue = number, repo = %repo_root.display(), "fetching github issue to seed session");
         let issue = github::fetch_issue(&repo_root, number)
             .await
             .map_err(|e| AppError::bad_request(format!("issue #{number}: {e}")))?;
@@ -602,12 +622,14 @@ pub(crate) async fn create_session_core(
         description = issue.body.clone();
         github_issue = Some(number);
         github_repo = github::repo_slug(&repo_root).await.ok();
+        tracing::debug!(issue = number, github_repo = ?github_repo, "seeded session fields from github issue");
     }
 
     // Claiming an existing weaver issue seeds the same three fields from it.
     let repo_root_str = repo_root.display().to_string();
     let mut claimed_issue_id: Option<i64> = None;
     if let Some(issue_id) = req.claim_issue {
+        tracing::debug!(issue_id, "claiming existing weaver issue for new session");
         let issue = weaver_core::issue::get(&st.db, issue_id)
             .await?
             .ok_or_else(|| AppError::not_found("issue"))?;
@@ -664,8 +686,10 @@ pub(crate) async fn create_session_core(
         Some(b) => b,
         None => git::default_base(&repo_root).await?,
     };
+    tracing::debug!(base = %base, "resolved base branch");
 
     let (branch_name, work_dir) = if let Some(existing_branch) = existing {
+        tracing::info!(branch = %existing_branch, "reusing existing branch for session");
         if !git::branch_exists(&repo_root, existing_branch).await {
             return Err(AppError::bad_request(format!(
                 "branch '{existing_branch}' does not exist in this repo"
@@ -688,12 +712,16 @@ pub(crate) async fn create_session_core(
             .await
             .map_err(|e| AppError::bad_request(e.to_string()))?
         {
-            Some(p) => p,
+            Some(p) => {
+                tracing::debug!(branch = %existing_branch, work_dir = %p.display(), "found existing worktree for branch");
+                p
+            }
             None => {
                 let slug = branch_mod::slugify(existing_branch);
                 let dir = repo_root.join(".worktrees").join(&slug);
                 tokio::fs::create_dir_all(repo_root.join(".worktrees")).await?;
                 git::ensure_excluded(&repo_root, ".worktrees/").await.ok();
+                tracing::info!(branch = %existing_branch, work_dir = %dir.display(), "provisioning worktree for existing branch");
                 git::worktree_add_existing(&repo_root, &dir, existing_branch)
                     .await
                     .map_err(|e| AppError::bad_request(e.to_string()))?;
@@ -705,6 +733,7 @@ pub(crate) async fn create_session_core(
         // Create `weaver/<slug>` with a unique suffix.
         let explicit = req.name.as_deref().map(str::trim).filter(|n| !n.is_empty());
         let base_slug = branch_mod::slugify(explicit.unwrap_or(title.as_str()));
+        tracing::debug!(base_slug = %base_slug, base = %base, "creating new branch for session");
         let mut slug = base_slug.clone();
         let mut suffix = 2;
         loop {
@@ -725,6 +754,7 @@ pub(crate) async fn create_session_core(
         let work_dir = repo_root.join(".worktrees").join(&slug);
         tokio::fs::create_dir_all(repo_root.join(".worktrees")).await?;
         git::ensure_excluded(&repo_root, ".worktrees/").await.ok();
+        tracing::info!(branch = %branch_name, work_dir = %work_dir.display(), base = %base, "provisioning worktree for new branch");
         git::worktree_add(&repo_root, &work_dir, &branch_name, &base)
             .await
             .map_err(|e| AppError::bad_request(e.to_string()))?;
@@ -733,6 +763,7 @@ pub(crate) async fn create_session_core(
 
     // Get-or-create the branch row, then stamp its title/goal/description.
     let branch = branch_mod::upsert(&st.db, &repo_root_str, &branch_name, &base).await?;
+    tracing::debug!(branch = %branch.id, branch_name = %branch_name, "upserted branch row");
     branch_mod::set_title(&st.db, &branch.id, &title).await?;
     if !goal.is_empty() {
         branch_mod::set_goal(&st.db, &branch.id, &goal, "user").await?;
@@ -744,6 +775,7 @@ pub(crate) async fn create_session_core(
     let branch = branch_mod::get(&st.db, &branch.id)
         .await?
         .ok_or_else(|| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, "branch vanished"))?;
+    tracing::debug!(branch = %branch.id, title = %title, "stamped branch title/goal/description");
 
     // Resolve the launching parent once: it names the tracking issue's
     // `source_branch` *and* the session's tree parent (`parent_branch_id`).
@@ -769,6 +801,7 @@ pub(crate) async fn create_session_core(
     let tracking_issue = if is_concierge {
         None
     } else {
+        tracing::debug!(branch = %branch.id, "opening tracking issue for session");
         create_tracking_issue(
             &st,
             &branch,
@@ -782,10 +815,12 @@ pub(crate) async fn create_session_core(
         )
         .await?
     };
+    tracing::debug!(branch = %branch.id, tracking_issue = ?tracking_issue, "tracking issue resolved");
 
     let session_id = branch_mod::new_id();
     let run_dir = db::run_dir(&session_id);
     tokio::fs::create_dir_all(&run_dir).await?;
+    tracing::info!(session = %session_id, branch = %branch.id, run_dir = %run_dir.display(), "allocated session id and run dir");
 
     // Drop any attached reference files into the worktree before the agent
     // launches, then tell the agent they are there. The branch goal stays the
@@ -793,6 +828,7 @@ pub(crate) async fn create_session_core(
     // launch prompt (goal.txt) only, so they reach the agent without cluttering
     // the dashboard.
     let scratch_names = write_initial_scratch(&work_dir, &req.scratch).await?;
+    tracing::debug!(session = %session_id, scratch_files = scratch_names.len(), "wrote initial scratch files");
     // The concierge boots primed-but-idle: its fleet-ops primer is injected as
     // system *context* (primer.txt → `--append-system-prompt-file`), not as a
     // positional opening prompt, so it takes no turn until the operator sends the
@@ -801,6 +837,7 @@ pub(crate) async fn create_session_core(
     let (goal_file, primer_file) = if is_concierge {
         let f = run_dir.join("primer.txt");
         tokio::fs::write(&f, agent::concierge_primer()).await?;
+        tracing::debug!(session = %session_id, "wrote concierge primer file");
         (None, Some(f))
     } else {
         let mut prompt_parts: Vec<String> = Vec::new();
@@ -819,12 +856,14 @@ pub(crate) async fn create_session_core(
         } else {
             let f = run_dir.join("goal.txt");
             tokio::fs::write(&f, &launch_prompt).await?;
+            tracing::debug!(session = %session_id, "wrote goal file for launch prompt");
             Some(f)
         };
         (goal_file, None)
     };
 
     let term_session = format!("weaver-{session_id}");
+    tracing::debug!(session = %session_id, term_session = %term_session, "derived terminal session name");
 
     // Attribute the agent's commits to the launching user (design §6.3, Level A):
     // export their GitHub identity as the git author/committer. Inserted only if
@@ -845,8 +884,11 @@ pub(crate) async fn create_session_core(
                         extra_env.push((k.to_string(), v.clone()));
                     }
                 }
+                tracing::debug!(%username, "attributed commits to launching user");
             }
-            Ok(None) => {}
+            Ok(None) => {
+                tracing::debug!(%username, "no commit identity registered, using shared identity")
+            }
             Err(e) => tracing::warn!(%username, "failed to resolve commit identity: {e}"),
         }
     }
@@ -859,6 +901,7 @@ pub(crate) async fn create_session_core(
     // session in a visible error state instead of launching a half-provisioned
     // worktree.
     if let Some(script) = repo_cfg.setup.script() {
+        tracing::debug!(branch = %branch.id, repo = %repo_root.display(), "repo declares a [setup] script");
         if repo::is_allowlisted(&st.db, &repo_root)
             .await
             .unwrap_or(false)
@@ -866,6 +909,7 @@ pub(crate) async fn create_session_core(
             let outcome =
                 run_repo_setup(&st, &branch.id, &work_dir, &run_dir, &script, &extra_env).await;
             if !outcome.success {
+                tracing::warn!(branch = %branch.id, "repo setup failed, aborting launch before agent start");
                 // Surface the failure as a loud, visible session state rather than
                 // launching the agent into a half-provisioned worktree. The
                 // worktree is left intact for inspection; full output is in the
@@ -945,6 +989,14 @@ pub(crate) async fn create_session_core(
         }
     }
 
+    tracing::info!(
+        session = %session_id,
+        branch = %branch.id,
+        runtime = %runtime,
+        work_dir = %work_dir.display(),
+        env_vars = extra_env.len(),
+        "launching agent terminal"
+    );
     agent::launch(
         &st.db,
         &agent::LaunchSpec {
@@ -963,6 +1015,7 @@ pub(crate) async fn create_session_core(
     )
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    tracing::info!(session = %session_id, branch = %branch.id, "agent terminal launched");
 
     // Live the moment the terminal spawns — there is no `launching` state.
     let status = agent::initial_status(&st.db, &runtime).await;
@@ -984,6 +1037,7 @@ pub(crate) async fn create_session_core(
         },
     )
     .await?;
+    tracing::debug!(session = %session.id, status = %status, "inserted session row");
 
     if let Err(e) = repo::record_use(&st.db, &branch.repo_root).await {
         tracing::warn!(branch = %branch.id, error = %e, "failed to record recent repo");
@@ -1008,6 +1062,7 @@ pub(crate) async fn create_session_core(
     // normal session seeds a positional prompt and runs a turn on launch, so its
     // own hooks drive this mark — only the idle-booting concierge needs the seed.
     if is_concierge {
+        tracing::debug!(branch = %branch.id, "stamping concierge idle mark");
         if let Err(e) = tags::set(
             &st.db,
             &branch.id,
@@ -1075,6 +1130,7 @@ async fn create_concierge(st: AppState) -> ApiResult<SessionView> {
                 "the concierge needs a repo to live in — open a session in a repo first",
             )
         })?;
+    tracing::info!(repo = %home.repo_root, "launching fleet concierge session");
     let req = CreateReq {
         cwd: home.repo_root,
         agent: Some(agent::CONCIERGE_KIND.to_string()),
@@ -1092,6 +1148,7 @@ async fn create_concierge(st: AppState) -> ApiResult<SessionView> {
 /// place, so the operator gets a fresh agent with none of the prior context.
 /// Returns the new session view, exactly as [`get_chat`] would.
 pub(super) async fn reset_chat(State(st): State<AppState>) -> ApiResult<Json<SessionView>> {
+    tracing::info!("resetting fleet concierge chat");
     if let Some(session) = session_mod::active_concierge(&st.db).await? {
         if let Some(branch) = branch_mod::get(&st.db, &session.branch_id).await? {
             // Best-effort teardown of the old concierge; a warning here must not
@@ -1139,6 +1196,7 @@ async fn create_tracking_issue(
     claim_issue: Option<i64>,
 ) -> ApiResult<Option<i64>> {
     let source = parent_branch.unwrap_or(&branch.branch).to_string();
+    tracing::debug!(branch = %branch.id, source = %source, "resolving tracking issue for session");
 
     // Claiming an existing weaver issue: that issue *is* the tracker, so the
     // claim must actually land — otherwise we'd hand back a tracking id for an
@@ -1326,6 +1384,7 @@ pub(super) async fn delete_session(
     Query(q): Query<DeleteQuery>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
+    tracing::info!(session = %session.id, branch = %branch.id, keep_branch = q.keep_branch, "deleting session");
     let mut warnings: Vec<String> = Vec::new();
 
     backend::kill_session(&session.term_session).await.ok();
@@ -1333,11 +1392,13 @@ pub(super) async fn delete_session(
     st.ide.kill(&session.id);
     let repo_root = PathBuf::from(&branch.repo_root);
     let work_dir = PathBuf::from(&session.work_dir);
+    tracing::debug!(session = %session.id, "killed terminal, debug shells, and ide sessions");
     if let Err(e) = git::worktree_remove(&repo_root, &work_dir).await {
         warnings.push(format!("worktree remove: {e}"));
         tokio::fs::remove_dir_all(&work_dir).await.ok();
     }
     if !q.keep_branch {
+        tracing::debug!(session = %session.id, branch_name = %branch.branch, "deleting git branch");
         if let Err(e) = git::delete_branch(&repo_root, &branch.branch).await {
             warnings.push(format!("delete branch: {e}"));
         }
@@ -1379,6 +1440,7 @@ pub(crate) async fn archive(
     session: &Session,
     branch: &Branch,
 ) -> Result<Vec<String>, AppError> {
+    tracing::info!(session = %session.id, branch = %branch.id, "archiving session");
     let mut warnings: Vec<String> = Vec::new();
 
     // Capture the agent's conversation log before teardown. The transcript lives
@@ -1386,13 +1448,16 @@ pub(crate) async fn archive(
     // it whole regardless. Best-effort: failures are warnings, never fatal.
     let (_, log_warnings) = crate::chatlog::capture(&st.db, session, branch).await;
     warnings.extend(log_warnings);
+    tracing::debug!(session = %session.id, "captured conversation transcript before teardown");
 
     backend::kill_session(&session.term_session).await.ok();
     crate::shell::kill_debug_all(&session.id).await;
     st.ide.kill(&session.id);
     let repo_root = PathBuf::from(&branch.repo_root);
     let work_dir = PathBuf::from(&session.work_dir);
+    tracing::debug!(session = %session.id, "killed terminal, debug shells, and ide sessions");
     if work_dir.exists() {
+        tracing::debug!(session = %session.id, work_dir = %work_dir.display(), "removing worktree");
         if let Err(e) = git::worktree_remove(&repo_root, &work_dir).await {
             warnings.push(format!("worktree remove: {e}"));
             tokio::fs::remove_dir_all(&work_dir).await.ok();
@@ -1436,6 +1501,7 @@ pub(super) async fn archive_session(
     Path(key): Path<String>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
+    tracing::debug!(key = %key, session = %session.id, "handling archive session request");
     let warnings = archive(&st, &session, &branch).await?;
     Ok(Json(
         json!({ "archived": true, "branch": branch.branch, "warnings": warnings }),
@@ -1501,6 +1567,7 @@ pub(crate) async fn create_warm_session(
     watch: &Watch,
     repo_root: &std::path::Path,
 ) -> Result<Session, AppError> {
+    tracing::info!(watch = %watch.id, repo = %repo_root.display(), "creating warm session for watch");
     let repo_root = repo_root
         .canonicalize()
         .unwrap_or_else(|_| repo_root.to_path_buf());
@@ -1525,16 +1592,19 @@ pub(crate) async fn create_warm_session(
     let work_dir = repo_root.join(".worktrees").join(&slug);
     tokio::fs::create_dir_all(repo_root.join(".worktrees")).await?;
     git::ensure_excluded(&repo_root, ".worktrees/").await.ok();
+    tracing::info!(watch = %watch.id, branch = %branch_name, work_dir = %work_dir.display(), "provisioning worktree for warm session");
     git::worktree_add(&repo_root, &work_dir, &branch_name, &base)
         .await
         .map_err(|e| AppError::bad_request(e.to_string()))?;
 
     let branch = branch_mod::upsert(&st.db, &repo_root_str, &branch_name, &base).await?;
     branch_mod::set_title(&st.db, &branch.id, &format!("watch {}", watch.name)).await?;
+    tracing::debug!(watch = %watch.id, branch = %branch.id, "upserted warm session branch row");
 
     let session_id = branch_mod::new_id();
     let run_dir = db::run_dir(&session_id);
     tokio::fs::create_dir_all(&run_dir).await?;
+    tracing::debug!(watch = %watch.id, session = %session_id, "allocated warm session id and run dir");
 
     // The warm session runs the configured default agent (the watch's
     // judging agent, normally `claude`); its `prompt` param, when set, seeds the
@@ -1558,6 +1628,7 @@ pub(crate) async fn create_warm_session(
     let repo_cfg = repo_cfg_or_default(&repo_root);
     let extra_env = launch_env(&st.db, &repo_root, &repo_cfg).await;
     // A warm session never carries the concierge role, so its runtime is its kind.
+    tracing::info!(watch = %watch.id, session = %session_id, agent = %agent, work_dir = %work_dir.display(), "launching warm session agent terminal");
     agent::launch(
         &st.db,
         &agent::LaunchSpec {
@@ -1577,6 +1648,7 @@ pub(crate) async fn create_warm_session(
     )
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    tracing::info!(watch = %watch.id, session = %session_id, "warm session agent terminal launched");
 
     let status = agent::initial_status(&st.db, &agent).await;
     let session = session_mod::insert(
@@ -1617,6 +1689,7 @@ pub(crate) async fn adopt(
     session: &Session,
     branch: &Branch,
 ) -> Result<(), AppError> {
+    tracing::info!(session = %session.id, branch = %branch.id, "adopting orphaned session");
     if backend::has_session(&session.term_session).await {
         return Err(AppError::conflict(
             "session already has a running terminal process",
@@ -1629,6 +1702,7 @@ pub(crate) async fn adopt(
             session.work_dir
         )));
     }
+    tracing::debug!(session = %session.id, work_dir = %work_dir.display(), "adopt preflight checks passed");
     resume_agent(st, session, branch, "session adopted").await
 }
 
@@ -1644,6 +1718,7 @@ async fn resume_agent(
     branch: &Branch,
     reason: &str,
 ) -> Result<(), AppError> {
+    tracing::info!(session = %session.id, branch = %branch.id, reason = %reason, "resuming agent");
     let work_dir = PathBuf::from(&session.work_dir);
     // A normal session persists its positional prompt in goal.txt; the concierge
     // persists its primer in primer.txt instead (re-appended as system context so
@@ -1669,6 +1744,7 @@ async fn resume_agent(
                 }
                 Err(e) => tracing::warn!(error = %e, "failed to read goal for adopt refresh"),
             }
+            tracing::debug!(session = %session.id, "refreshed goal file for resume");
             Some(f)
         } else {
             None
@@ -1682,6 +1758,7 @@ async fn resume_agent(
     let repo_cfg = repo_cfg_or_default(&repo_root);
     let extra_env = launch_env(&st.db, &repo_root, &repo_cfg).await;
     let runtime = launch_runtime(&st.db, &session.agent_kind).await;
+    tracing::info!(session = %session.id, branch = %branch.id, runtime = %runtime, work_dir = %work_dir.display(), "relaunching agent terminal for resume");
     agent::launch(
         &st.db,
         &agent::LaunchSpec {
@@ -1700,6 +1777,7 @@ async fn resume_agent(
     )
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    tracing::debug!(session = %session.id, "agent terminal relaunched, resuming conversation");
     // A resumed agent is already established and live — mark it `running`.
     let status = agent::initial_status(&st.db, &runtime).await;
     session_mod::set_status(&st.db, &session.id, status).await?;
@@ -1721,6 +1799,7 @@ pub(super) async fn adopt_session(
     Path(key): Path<String>,
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
+    tracing::debug!(key = %key, session = %session.id, "handling adopt session request");
     adopt(&st, &session, &branch).await?;
     let (session, branch) = require_session(&st.db, &session.id).await?;
     Ok(Json(session_view(&st.db, &session, &branch).await?))
@@ -1733,6 +1812,7 @@ pub(super) async fn adopt_session(
 /// the agent (resuming the prior Claude conversation with `--continue`, exactly as
 /// [`adopt`] does). The session rejoins the active fleet.
 async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<(), AppError> {
+    tracing::info!(session = %session.id, branch = %branch.id, "recovering archived session");
     if backend::has_session(&session.term_session).await {
         return Err(AppError::conflict(
             "session already has a running terminal process",
@@ -1757,9 +1837,12 @@ async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<()
         git::worktree_prune(&repo_root).await.ok();
         tokio::fs::create_dir_all(repo_root.join(".worktrees")).await?;
         git::ensure_excluded(&repo_root, ".worktrees/").await.ok();
+        tracing::info!(session = %session.id, branch = %branch.id, work_dir = %work_dir.display(), "rebuilding worktree for recovered session");
         git::worktree_add_existing(&repo_root, &work_dir, &branch.branch)
             .await
             .map_err(|e| AppError::bad_request(e.to_string()))?;
+    } else {
+        tracing::debug!(session = %session.id, "worktree still present, skipping rebuild");
     }
 
     tags::set(
@@ -1782,6 +1865,7 @@ async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<()
     )
     .await
     .ok();
+    tracing::debug!(session = %session.id, branch = %branch.id, "marked session recovered, resuming agent");
     resume_agent(st, session, branch, "session recovered").await?;
     Ok(())
 }
@@ -1791,6 +1875,7 @@ pub(super) async fn recover_session(
     Path(key): Path<String>,
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
+    tracing::debug!(key = %key, session = %session.id, "handling recover session request");
     recover(&st, &session, &branch).await?;
     let (session, branch) = require_session(&st.db, &session.id).await?;
     Ok(Json(session_view(&st.db, &session, &branch).await?))

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -187,6 +187,31 @@ async fn session_count(ts: &TestServer) -> usize {
         .len()
 }
 
+/// The trigger's real work — clone, session create, reply — now runs in a detached
+/// task *after* the webhook's `200`, so tests wait for the effect rather than
+/// reading it synchronously. Poll until the fleet shows at least `n` sessions.
+async fn wait_for_sessions(ts: &TestServer, n: usize) {
+    for _ in 0..200 {
+        if session_count(ts).await >= n {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("expected >= {n} sessions, saw {}", session_count(ts).await);
+}
+
+/// Poll until the fake gateway has recorded at least `n` replies.
+async fn wait_for_comments(fake: &FakeGithub, n: usize) {
+    for _ in 0..200 {
+        if fake.comments.lock().unwrap().len() >= n {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    let have = fake.comments.lock().unwrap().len();
+    panic!("expected >= {n} replies, saw {have}");
+}
+
 /// A missing signature, and one computed with the wrong secret, are both
 /// rejected with 401 — and nothing is launched.
 #[serial]
@@ -239,12 +264,13 @@ async fn non_trigger_comment_is_ignored() {
     assert!(fake.comments.lock().unwrap().is_empty());
 }
 
-/// A commenter who is not an approved loom user is refused: nothing launches
-/// and, to avoid amplifying spam, no reply is posted. (Repo write access is not
-/// itself a grant — only the approved-user allowlist is.)
+/// A commenter who is not an approved loom user launches nothing — but instead of
+/// a silent drop, loom replies once with a friendly "request access" note so they
+/// know how to proceed. (Repo write access is not itself a grant — only the
+/// approved-user allowlist is; the per-repo rate limit bounds the reply.)
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn unauthorized_commenter_is_rejected() {
+async fn unauthorized_commenter_gets_access_reply() {
     let (ts, fake) = boot().await;
     let _remotes = prepare_repo(&ts).await;
 
@@ -255,14 +281,23 @@ async fn unauthorized_commenter_is_rejected() {
         200,
         "an unauthorized trigger is acknowledged, not errored"
     );
+
+    // The reply is posted from a detached task; wait for it.
+    wait_for_comments(&fake, 1).await;
+    let comments = fake.comments.lock().unwrap().clone();
+    assert_eq!(comments.len(), 1, "exactly one access-info reply");
+    let (repo, issue, reply) = &comments[0];
+    assert_eq!(repo, "acme/widgets");
+    assert_eq!(*issue, 5);
+    assert!(
+        reply.contains("access"),
+        "the reply tells them they need access: {reply}"
+    );
+
     assert_eq!(
         session_count(&ts).await,
         0,
         "an unauthorized commenter launches nothing"
-    );
-    assert!(
-        fake.comments.lock().unwrap().is_empty(),
-        "no reply to an unauthorized commenter"
     );
 }
 
@@ -279,6 +314,9 @@ async fn happy_path_creates_session_and_replies() {
     let body = trigger_body("rjpower", 42, "@loom work on this please");
     let resp = post(&ts, "d-happy", Some(sign(SECRET, &body)), &body).await;
     assert_eq!(resp.status(), 200);
+
+    // The launch runs in a detached task after the 200; wait for it to land.
+    wait_for_sessions(&ts, 1).await;
 
     // A session now exists, seeded from the issue title.
     let sessions = ts.client.get("/api/sessions").await.unwrap();
@@ -302,6 +340,7 @@ async fn happy_path_creates_session_and_replies() {
     );
 
     // loom replied on the triggering issue with the session URL.
+    wait_for_comments(&fake, 1).await;
     let comments = fake.comments.lock().unwrap().clone();
     assert_eq!(comments.len(), 1, "exactly one reply");
     let (repo, issue, reply) = &comments[0];
@@ -335,13 +374,11 @@ async fn replayed_delivery_is_a_noop() {
 
     let resp = post(&ts, "d-replay", Some(sig.clone()), &body).await;
     assert_eq!(resp.status(), 200);
-    assert_eq!(
-        session_count(&ts).await,
-        1,
-        "first delivery launches a session"
-    );
+    wait_for_sessions(&ts, 1).await;
+    wait_for_comments(&fake, 1).await;
 
-    // The exact same delivery again — same GUID, body, signature.
+    // The exact same delivery again — same GUID, body, signature. The GUID dedupe
+    // rejects it synchronously (before any spawn), so nothing new can appear.
     let resp = post(&ts, "d-replay", Some(sig), &body).await;
     assert_eq!(resp.status(), 200);
     assert_eq!(
@@ -380,11 +417,11 @@ async fn repeat_trigger_forwards_to_active_session() {
             .status(),
         200
     );
-    assert_eq!(
-        session_count(&ts).await,
-        1,
-        "the first trigger creates a session"
-    );
+    // Wait for the first session to exist *and* its reply to land, so the second
+    // delivery deterministically finds an active session to forward into (and its
+    // ack is the second comment, not a race with the first).
+    wait_for_sessions(&ts, 1).await;
+    wait_for_comments(&fake, 1).await;
 
     // A second @loom on the same issue (new delivery) is forwarded, not forked.
     let body2 = trigger_body("rjpower", 42, "@loom also handle the edge case");
@@ -394,6 +431,7 @@ async fn repeat_trigger_forwards_to_active_session() {
             .status(),
         200
     );
+    wait_for_comments(&fake, 2).await;
     assert_eq!(
         session_count(&ts).await,
         1,
@@ -438,6 +476,7 @@ async fn pr_trigger_attaches_to_pr_head_branch() {
             .status(),
         200
     );
+    wait_for_sessions(&ts, 1).await;
 
     let sessions = ts.client.get("/api/sessions").await.unwrap();
     let sessions = sessions.as_array().unwrap();

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -105,11 +105,13 @@ pub async fn clone(url: &str, dest: &Path, token: Option<&str>) -> Result<()> {
     let envs = token.map(token_auth_envs).unwrap_or_default();
     // An existing clone (its `.git` is present) is refreshed, not re-cloned.
     if dest.join(".git").exists() {
+        tracing::info!(dest = %dest.display(), authenticated = token.is_some(), "fetching existing clone");
         git_with_envs(dest, &["fetch", "--all", "--prune"], &envs).await?;
         tracing::info!(dest = %dest.display(), "fetched existing clone");
         return Ok(());
     }
     if let Some(parent) = dest.parent() {
+        tracing::debug!(parent = %parent.display(), "ensuring repo parent dir exists");
         tokio::fs::create_dir_all(parent)
             .await
             .with_context(|| format!("creating repo parent {}", parent.display()))?;
@@ -117,6 +119,7 @@ pub async fn clone(url: &str, dest: &Path, token: Option<&str>) -> Result<()> {
     // `git clone` has no working tree to `-C` into yet, so it is spawned directly
     // rather than through the `git()` helper.
     let dest_str = dest.to_string_lossy();
+    tracing::info!(dest = %dest.display(), authenticated = token.is_some(), "cloning repository");
     let out = Command::new("git")
         .args(["clone", url, &dest_str])
         .envs(envs.iter().map(|(k, v)| (*k, v.as_str())))
@@ -141,6 +144,7 @@ pub async fn clone(url: &str, dest: &Path, token: Option<&str>) -> Result<()> {
 /// that (for example) the in-repo `.worktrees/` directory is not reported as
 /// untracked content. This is local-only and never touches a tracked file.
 pub async fn ensure_excluded(repo_root: &Path, pattern: &str) -> Result<()> {
+    tracing::debug!(repo = %repo_root.display(), pattern, "ensuring exclude pattern present");
     let common = git(
         repo_root,
         &["rev-parse", "--path-format=absolute", "--git-common-dir"],
@@ -153,6 +157,7 @@ pub async fn ensure_excluded(repo_root: &Path, pattern: &str) -> Result<()> {
         .await
         .unwrap_or_default();
     if current.lines().any(|l| l.trim() == pattern) {
+        tracing::debug!(repo = %repo_root.display(), pattern, "exclude pattern already present");
         return Ok(());
     }
     let mut next = current;
@@ -186,7 +191,9 @@ pub async fn branch_exists(dir: &Path, branch: &str) -> bool {
 
 /// Whether a remote named `name` is configured (`git remote get-url`).
 async fn has_remote(dir: &Path, name: &str) -> bool {
-    git(dir, &["remote", "get-url", name]).await.is_ok()
+    let present = git(dir, &["remote", "get-url", name]).await.is_ok();
+    tracing::debug!(dir = %dir.display(), remote = name, present, "checked remote presence");
+    present
 }
 
 /// Whether `rev` resolves to a commit in this repo.
@@ -217,15 +224,18 @@ async fn origin_default_branch(dir: &Path) -> Option<String> {
     {
         if let Some(name) = out.strip_prefix("origin/") {
             if !name.is_empty() {
+                tracing::debug!(dir = %dir.display(), default_branch = name, "resolved origin default branch from origin/HEAD");
                 return Some(name.to_string());
             }
         }
     }
     for cand in ["main", "master"] {
         if commit_exists(dir, &format!("origin/{cand}")).await {
+            tracing::debug!(dir = %dir.display(), default_branch = cand, "resolved origin default branch by probing candidates");
             return Some(cand.to_string());
         }
     }
+    tracing::debug!(dir = %dir.display(), "could not resolve an origin default branch");
     None
 }
 
@@ -243,14 +253,18 @@ async fn origin_default_branch(dir: &Path) -> Option<String> {
 /// fall back to the current branch.
 pub async fn default_base(dir: &Path) -> Result<String> {
     if !has_remote(dir, "origin").await {
+        tracing::debug!(dir = %dir.display(), "no origin remote; falling back to current branch");
         return current_branch(dir).await;
     }
     if let Some(default) = origin_default_branch(dir).await {
         // Best-effort: refresh the tracking ref so the fork point is current.
         // Ignore network failures — a stale ref still beats the local branch.
-        let _ = git(dir, &["fetch", "origin", &default]).await;
+        tracing::info!(dir = %dir.display(), branch = %default, "fetching origin to refresh default base");
+        let fetch_result = git(dir, &["fetch", "origin", &default]).await;
+        tracing::debug!(dir = %dir.display(), branch = %default, ok = fetch_result.is_ok(), "fetch of default branch completed");
         let remote_ref = format!("origin/{default}");
         if commit_exists(dir, &remote_ref).await {
+            tracing::debug!(dir = %dir.display(), base = %remote_ref, "using fresh origin default as launch base");
             return Ok(remote_ref);
         }
     }
@@ -260,6 +274,7 @@ pub async fn default_base(dir: &Path) -> Result<String> {
 /// Create a new worktree at `path` on a new `branch` forked from `base`.
 pub async fn worktree_add(repo_root: &Path, path: &Path, branch: &str, base: &str) -> Result<()> {
     let path = path.to_string_lossy();
+    tracing::info!(repo = %repo_root.display(), %branch, base, path = %path, "creating worktree with new branch");
     git(repo_root, &["worktree", "add", "-b", branch, &path, base]).await?;
     tracing::info!(%branch, base, path = %path, "worktree created");
     Ok(())
@@ -268,6 +283,7 @@ pub async fn worktree_add(repo_root: &Path, path: &Path, branch: &str, base: &st
 /// Check out an existing `branch` into a new worktree at `path` (no `-b`).
 pub async fn worktree_add_existing(repo_root: &Path, path: &Path, branch: &str) -> Result<()> {
     let path = path.to_string_lossy();
+    tracing::info!(repo = %repo_root.display(), %branch, path = %path, "creating worktree for existing branch");
     git(repo_root, &["worktree", "add", &path, branch]).await?;
     tracing::info!(%branch, path = %path, "worktree created for existing branch");
     Ok(())
@@ -280,8 +296,10 @@ pub async fn worktree_add_existing(repo_root: &Path, path: &Path, branch: &str) 
 /// `git push` targets the same branch (updating the PR).
 pub async fn create_local_branch_from_origin(repo_root: &Path, branch: &str) -> Result<()> {
     if branch_exists(repo_root, branch).await {
+        tracing::debug!(repo = %repo_root.display(), %branch, "local branch already exists; skipping create");
         return Ok(());
     }
+    tracing::info!(repo = %repo_root.display(), %branch, "creating local branch from origin");
     git(repo_root, &["branch", branch, &format!("origin/{branch}")]).await?;
     tracing::info!(%branch, "created local branch from origin");
     Ok(())
@@ -294,11 +312,13 @@ pub async fn list_branches(repo_root: &Path) -> Result<Vec<String>> {
         &["for-each-ref", "--format=%(refname:short)", "refs/heads"],
     )
     .await?;
-    Ok(out
+    let branches: Vec<String> = out
         .lines()
         .map(|l| l.trim().to_string())
         .filter(|l| !l.is_empty())
-        .collect())
+        .collect();
+    tracing::debug!(repo = %repo_root.display(), count = branches.len(), "listed local branches");
+    Ok(branches)
 }
 
 /// Path of the worktree that currently has `branch` checked out, if any.
@@ -314,17 +334,20 @@ pub async fn worktree_for_branch(repo_root: &Path, branch: &str) -> Result<Optio
             current = Some(PathBuf::from(rest));
         } else if let Some(rest) = line.strip_prefix("branch ") {
             if rest == target {
+                tracing::debug!(repo = %repo_root.display(), %branch, path = ?current, "found worktree for branch");
                 return Ok(current);
             }
         } else if line.is_empty() {
             current = None;
         }
     }
+    tracing::debug!(repo = %repo_root.display(), %branch, "no worktree checked out for branch");
     Ok(None)
 }
 
 pub async fn worktree_remove(repo_root: &Path, path: &Path) -> Result<()> {
     let path = path.to_string_lossy();
+    tracing::info!(repo = %repo_root.display(), path = %path, "removing worktree");
     git(repo_root, &["worktree", "remove", "--force", &path]).await?;
     tracing::info!(path = %path, "worktree removed");
     Ok(())
@@ -336,12 +359,14 @@ pub async fn worktree_remove(repo_root: &Path, path: &Path) -> Result<()> {
 /// when nothing is stale. Used when re-checking out a branch whose worktree was
 /// torn down (e.g. recovering an archived session).
 pub async fn worktree_prune(repo_root: &Path) -> Result<()> {
+    tracing::debug!(repo = %repo_root.display(), "pruning stale worktree entries");
     git(repo_root, &["worktree", "prune"]).await?;
     tracing::info!(repo = %repo_root.display(), "worktree pruned");
     Ok(())
 }
 
 pub async fn delete_branch(repo_root: &Path, branch: &str) -> Result<()> {
+    tracing::info!(repo = %repo_root.display(), %branch, "deleting branch");
     git(repo_root, &["branch", "-D", branch]).await?;
     tracing::info!(%branch, "branch deleted");
     Ok(())

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -30,8 +30,10 @@ receiver, in order:
    prefix only — no free-text.
 5. **Authorizes the commenter.** Their GitHub login must be an
    [approved loom user](#who-can-trigger) — the *same* allowlist that gates
-   signing in to the app. Repo write access is **not** by itself a grant. Anyone
-   else is silently ignored. A per-repo rate limit blunts comment spam.
+   signing in to the app. Repo write access is **not** by itself a grant. An
+   unapproved commenter gets a one-line "request access" reply — rather than a
+   silent drop, so they know to ask instead of assuming loom is broken. A per-repo
+   rate limit bounds both the launch and that reply against comment spam.
 6. **Resolves the repo** through the [managed repo store](#which-repos) — an
    approved user's trigger on any repo the App is installed on registers it — and
    picks the branch to work on: a **pull request** comment attaches the session's
@@ -46,17 +48,25 @@ receiver, in order:
 8. **Replies** on the thread with the session URL (or, for a forwarded comment,
    that it was passed to the running session).
 
+Steps 6–8 (clone, create-or-forward, reply) run in a **detached task**: the
+handler returns `200` as soon as the gates pass. Cloning a large repo can outlast
+GitHub's ~10s delivery timeout, and a timed-out delivery would cancel an inline
+handler mid-clone. Each launch is tracked on **Settings → Debug** (running / done
+/ error, with the outcome), so you can follow it after the `200`.
+
 The reply (step 8) reaches GitHub through the [GitHub App](#the-github-app) when
 one is configured — with a short-lived, per-installation token — and otherwise
 through the `gh` CLI's ambient `GH_TOKEN`. The **session itself** acts as the
 commenter: its `GH_TOKEN` is that user's personal token (**Settings → Account**),
 falling back to the ambient `GH_TOKEN` when they have none — so its pushes and
-`gh` replies are attributed to them.
+`gh` replies are attributed to them. Separately, the poll loop posts a one-time
+back-link comment (`Working on this in loom: {base}/s/{id}`) on a session's open
+PR when one isn't already linked, so a reader of the PR can jump to the session.
 
 Everything past the signature check returns **200** whether or not it launched a
-session (a non-trigger comment, a replay, an unauthorized commenter, an
-unregistered repo, a rate-limited repo), so GitHub does not retry a delivery loom
-deliberately ignored.
+session (a non-trigger comment, a replay, an unregistered or rate-limited repo,
+or an unauthorized commenter — who gets the access-request reply), so GitHub does
+not retry a delivery loom handled without launching.
 
 ## Who can trigger
 
@@ -248,14 +258,17 @@ and which gate did it hit?* Work through it in order:
      `issue_comment`;
    - *401* — the webhook secret loom holds does not match the one GitHub signs
      with;
-   - *200 but nothing launched* — it hit a silent gate (below); read the logs.
+   - *200 but nothing launched* — it hit a gate (below), or the launch is still
+     running / failed in the background; read the logs and the **Debug** page's
+     background-task list, which shows each launch's outcome.
 
    `scripts/gh_app_deliveries.py` prints the same delivery log from the command
    line (it mints an App JWT from the key in `loom.toml`).
 
-3. **Read the server logs.** The quickest path is **Settings → Logs** in the web
-   UI — a live, filterable mirror of the server's log stream, so you can watch a
-   delivery land without shelling into the box (handy on the Docker deploy). The
+3. **Read the server logs.** The quickest path is **Settings → Debug** in the web
+   UI — a live, filterable mirror of the server's log stream (plus the
+   background-task list), so you can watch a delivery land without shelling into
+   the box (handy on the Docker deploy). The
    same lines go to the process stdout, so `docker compose logs -f loom` (or
    `RUST_LOG=loom=debug` for the outbound `gh`/REST calls) works too. Each gate
    logs a distinct line — look for: `signature verification failed` (401, secret


### PR DESCRIPTION
## Summary

Five related changes to the `@loom` GitHub trigger and its observability, plus a broad logging sweep. Motivated by a real failure: tagging `@loom` on a large repo (`marin-community/marin`, ~760 MB) did nothing — the webhook arrived and passed every gate, but the inline clone outlived GitHub's ~10s delivery timeout, so GitHub dropped the connection, axum cancelled the handler mid-clone, and (the delivery GUID already recorded) retries deduped to nothing.

### 1. The trigger runs in a detached task
`github_webhook` now returns `200` as soon as the security gates pass; the heavy work — clone, branch resolution, forward-or-create, reply — runs in `handle_trigger` off the request. A slow clone can no longer blow the delivery timeout or get cancelled. Everything before the spawn (HMAC verify, GUID dedupe, event/phrase filter, rate limit, authorize) still runs inline, so the security boundary is unchanged.

### 2. Background-task registry + Debug page
A capped in-memory registry (`loom::tasks`, mirrors the log ring buffer) records each detached launch — `running` / `done` / `error` with the outcome (session id, "forwarded", or the error). `GET /api/tasks` serves it (operator-only, next to `/logs`). **Settings → Logs** is renamed **Debug** and lists the tasks above the live log stream.

### 3. PR back-links
The poll loop posts a one-time comment — `Working on this in loom: {base}/s/{id}` — on a session's open PR when the branch isn't already linked, tagging it `github.linked` so exactly one lands. A `@loom`-triggered PR's "On it" reply already carries the link, so it sets the tag itself. Managed repos only (the App gateway needs the slug), and only when `auth.base_url` is set so the link resolves.

### 4. Unauthorized commenters get a friendly reply
Instead of a silent drop, an un-approved user who tags `@loom` gets a one-line "you're not on the access list — ask an operator" note. Bounded by the same per-repo rate limit, spawned + tracked on the Debug page. (Repo write access is still not a grant; only the approved-user allowlist is.)

### 5. Broad observability logging
Generous `tracing` across the imperative paths so an operator can watch work happen in the Debug stream: git clone/fetch/worktree/branch (`weaver-core::git`), session create/launch/archive/delete and terminal I/O (`session`, `backend`, `web::sessions`), repo resolve (`repo`), App installation-token mint (`github_app`), watches, and the monitor loop. Purely additive; no secret values logged (tokens/JWTs/keystrokes → ids, names, counts, lengths only).

## Testing

- `cargo clippy -p loom -p weaver-core --all-targets` — clean
- Full suites green: **weaver-core 87**, **loom 200 (lib) + 86 (integration)**, 0 failures
- Webhook integration tests updated for the async timing (poll for the effect after the `200`); new/rewritten: `unauthorized_commenter_gets_access_reply`, plus `wait_for_sessions` / `wait_for_comments` helpers threaded through `happy_path`, `replayed_delivery`, `repeat_trigger`, `pr_trigger`
- New unit tests: `loom::tasks` registry (start/finish/snapshot, cap eviction, evicted-id no-op); `slug_from_repo_root` (managed-clone slug vs. local-path `None`)
- Frontend `vue-tsc` typecheck — clean
