### PR TITLE
feat(loom): request-context logging (method+path on every line) + 500 cause chains

### DIFF
--- a/crates/loom/src/logs.rs
+++ b/crates/loom/src/logs.rs
@@ -18,6 +18,7 @@ use tokio::sync::broadcast;
 use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
 /// How many recent lines the snapshot buffer retains. A few thousand is plenty to
@@ -115,11 +116,46 @@ pub fn layer() -> CaptureLayer {
 /// The layer type returned by [`layer`].
 pub struct CaptureLayer;
 
-impl<S: Subscriber> Layer<S> for CaptureLayer {
-    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+/// A span's rendered fields (e.g. `" method=GET path=/api/tasks"`), stashed in the
+/// span's extensions by [`CaptureLayer::on_new_span`] and folded into every event
+/// logged within that span — so a line carries the request it belongs to even when
+/// the event itself never named it.
+struct SpanFields(String);
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        let mut visitor = MessageVisitor::default();
+        attrs.record(&mut visitor);
+        if !visitor.fields.is_empty() {
+            if let Some(span) = ctx.span(id) {
+                span.extensions_mut().insert(SpanFields(visitor.fields));
+            }
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
         let meta = event.metadata();
         let mut visitor = MessageVisitor::default();
         event.record(&mut visitor);
+        // Fold in the enclosing span scope's fields (root → leaf), so a line logged
+        // while handling a request carries its `method`/`path` even though the event
+        // never named them — e.g. `authentication required status=401 method=GET
+        // path=/api/tasks` instead of a context-free `status=401`.
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope.from_root() {
+                if let Some(fields) = span.extensions().get::<SpanFields>() {
+                    visitor.fields.push_str(&fields.0);
+                }
+            }
+        }
         buffer().push(LogLine {
             seq: 0, // assigned in push()
             ts: chrono::Utc::now().to_rfc3339(),
@@ -225,6 +261,38 @@ mod tests {
         let snap = buf.snapshot(3);
         let msgs: Vec<&str> = snap.iter().map(|l| l.message.as_str()).collect();
         assert_eq!(msgs, ["7", "8", "9"]);
+    }
+
+    #[test]
+    fn folds_enclosing_span_fields_into_event() {
+        use tracing_subscriber::prelude::*;
+
+        // Install a registry + our capture layer for this thread, emit a warn
+        // inside a `method`/`path` span, then find our line in the global buffer by
+        // a unique marker (other tests may share the buffer).
+        let subscriber = tracing_subscriber::registry().with(layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("http", method = "GET", path = "/api/tasks");
+            let _g = span.enter();
+            tracing::warn!("mark-9f3c authentication required");
+        });
+
+        let snap = buffer().snapshot(2000);
+        let line = snap
+            .iter()
+            .rev()
+            .find(|l| l.message.contains("mark-9f3c"))
+            .expect("the event was captured");
+        assert!(
+            line.message.contains("method=GET"),
+            "line carries the span's method: {}",
+            line.message
+        );
+        assert!(
+            line.message.contains("path=/api/tasks"),
+            "line carries the span's path: {}",
+            line.message
+        );
     }
 
     #[test]

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -114,6 +114,7 @@ use serde_json::{json, Value};
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::services::{ServeDir, ServeFile};
+use tracing::Instrument;
 
 use crate::db::Db;
 use crate::events::EventBus;
@@ -151,6 +152,10 @@ pub struct AppError {
     /// nested under `details`) — for callers whose wire contract is a flat
     /// object, e.g. the artifact write-conflict `{ "error", "latest" }`.
     fields: Option<Value>,
+    /// For an internal error built from an `anyhow::Error`: the full cause chain
+    /// (and backtrace, when `RUST_BACKTRACE` is set), logged server-side so an
+    /// operator sees *why* — the client still gets only the concise `message`.
+    source_chain: Option<String>,
 }
 
 impl AppError {
@@ -160,6 +165,7 @@ impl AppError {
             message: message.into(),
             details: None,
             fields: None,
+            source_chain: None,
         }
     }
     fn bad_request(message: impl Into<String>) -> Self {
@@ -193,7 +199,13 @@ impl AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         if self.status.is_server_error() {
-            tracing::error!(status = %self.status.as_u16(), message = %self.message, "request failed");
+            // Log the full cause chain (and backtrace when captured), not just the
+            // top-level message, so the log says *why* the request 500'd.
+            tracing::error!(
+                status = %self.status.as_u16(),
+                error = %self.source_chain.as_deref().unwrap_or(&self.message),
+                "request failed"
+            );
         } else {
             tracing::warn!(status = %self.status.as_u16(), message = %self.message, "request rejected");
         }
@@ -212,7 +224,17 @@ impl IntoResponse for AppError {
 
 impl<E: Into<anyhow::Error>> From<E> for AppError {
     fn from(err: E) -> Self {
-        Self::new(StatusCode::INTERNAL_SERVER_ERROR, err.into().to_string())
+        let err = err.into();
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: err.to_string(),
+            details: None,
+            fields: None,
+            // `{err:?}` renders anyhow's full cause chain plus the backtrace when
+            // one was captured (`RUST_BACKTRACE=1`); `to_string()` above is just
+            // the top-level message the client sees.
+            source_chain: Some(format!("{err:?}")),
+        }
     }
 }
 
@@ -419,6 +441,21 @@ fn is_immutable_asset(path: &str) -> bool {
     filename
         .split('.')
         .any(|seg| seg.len() == 8 && seg.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
+/// Outermost middleware: open a per-request tracing span carrying the method and
+/// path, so *every* log line emitted while the request is handled — an auth
+/// rejection, a validation `warn`, an internal `error` — is tagged with which
+/// request produced it. Without it a bare `authentication required status=401`
+/// tells an operator nothing about *what* was being accessed. The span's fields
+/// are folded into each line by [`crate::logs::CaptureLayer`].
+async fn request_context_span(request: Request<axum::body::Body>, next: Next) -> Response {
+    let span = tracing::info_span!(
+        "http",
+        method = %request.method(),
+        path = %request.uri().path(),
+    );
+    next.run(request).instrument(span).await
 }
 
 // ---------------------------------------------------------------------------
@@ -672,6 +709,9 @@ pub fn router(state: AppState) -> Router {
         .layer(axum::middleware::from_fn(static_cache_middleware))
         .layer(CompressionLayer::new())
         .layer(CorsLayer::permissive())
+        // Outermost, so it wraps auth and every other layer: tag each request's log
+        // lines with its method + path (see `request_context_span`).
+        .layer(axum::middleware::from_fn(request_context_span))
 }
 
 #[cfg(test)]

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -47,6 +47,13 @@ services:
     # (below), so the image exists by the time this service starts.
     restart: unless-stopped
     env_file: .env
+    # RUST_BACKTRACE feeds anyhow's backtrace capture, so an internal (500) error's
+    # server log carries the stack where the error arose, not just its message.
+    # Cheap here — loom is low-traffic and errors are rare. A backtrace at a
+    # *warning* would only show tokio executor frames (the async stack isn't the
+    # request path), so warnings rely on the per-request span (method/path) instead.
+    environment:
+      RUST_BACKTRACE: "1"
     depends_on:
       loom-init:
         condition: service_completed_successfully


### PR DESCRIPTION
## Summary

Reading the live Debug log, a line like `authentication required status=401` (or `… has no live terminal to drive status=409`) told you *nothing* about which request produced it. This adds request context to every log line, and the error cause-chain to 500s.

### Every log line carries its request's method + path
- A new outermost middleware, `request_context_span`, opens an `info_span!("http", method, path)` around every request (wrapping auth and everything else).
- `CaptureLayer` (the tee into the in-browser log viewer) now walks the event's **span scope** and folds each enclosing span's fields into the line. Previously it only recorded the event's own fields, so span context never reached the browser viewer (stdout's `fmt` layer already rendered spans).
- Result: that 401 now reads `authentication required status=401 method=GET path=/api/tasks`. The context lands on *every* line emitted while handling the request — auth rejections, validation warnings, internal errors, and ordinary handler `info` logs alike.

### Internal errors log *why*, not just the top message
- `AppError` gains a `source_chain`: for an error built from an `anyhow::Error`, it captures `{err:?}` — the full cause chain plus a backtrace when one was captured. The 5xx branch logs that instead of the bare `.to_string()`. The client response body is unchanged (still the concise `message`).
- `RUST_BACKTRACE=1` in the standalone compose so those chains carry a stack from where the error arose.

### Why not a backtrace on warnings?
In async Rust the synchronous stack at a log point is tokio executor frames (`poll → task → worker`), not the `route → auth → handler` path — so a raw backtrace on a 401/409 is noise. The tracing **span** is the async-correct "where am I" context, which is what this PR adds. A backtrace only pays off for a genuine 500 (unknown code path), where anyhow captures it at error creation — hence enabling it there.

## Testing

- `cargo clippy -p loom --all-targets` — clean
- Full loom suite green: **201 (lib) + 86 (integration)**, 0 failures
- New unit test `logs::folds_enclosing_span_fields_into_event` — asserts a warn emitted inside a `method`/`path` span is captured with `method=… path=…` folded in
- Existing error-body assertions still pass (the client-facing `message` is unchanged)
