### PR TITLE
fix(loom): authenticate the PR poll loop + watch scripts with GH_TOKEN

### DIFF
--- a/crates/loom/src/agent_env.rs
+++ b/crates/loom/src/agent_env.rs
@@ -4,8 +4,11 @@
 //! alongside loom's own `WEAVER_*` / `LOOM_TOKEN` — so the operator can add a
 //! registry token, a `GH_HOST`, an `ANTHROPIC_BASE_URL`, etc. at runtime from
 //! the settings pane, without rebuilding the image or editing the deploy env
-//! file. They are NOT applied to the env-stripped one-shot judgement agent
-//! (see [`crate::agent`]).
+//! file. The one-shot judgement agent runs env-stripped and gets none of them
+//! (see [`crate::agent`]); watch scripts are likewise stripped but do receive
+//! `GH_TOKEN` (via [`get`]), since loom's *own* GitHub reads — the PR poll loop
+//! and github watches' `gh` calls — run in the server process, which has no
+//! ambient GitHub auth of its own.
 //!
 //! This is a flat name/value store: unlike [`crate::config`] there is no
 //! registry of known keys, because the whole point is arbitrary,
@@ -80,6 +83,20 @@ pub async fn list(db: &Db) -> Result<Vec<EnvVar>> {
             updated_at: r.get::<String, _>("updated_at"),
         })
         .collect())
+}
+
+/// One variable's value, or `None` when unset (or on a DB error — callers use
+/// this for best-effort credential lookup, where a miss and an error are the same
+/// "no value" outcome). Used by loom's *own* GitHub operations — the PR poll loop
+/// and watch scripts — which run in the server process and so don't inherit the
+/// per-session agent environment.
+pub async fn get(db: &Db, name: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM agent_env WHERE name = ?")
+        .bind(name)
+        .fetch_optional(db)
+        .await
+        .ok()
+        .flatten()
 }
 
 /// The variables as a plain `(name, value)` list — what [`crate::agent::launch`]
@@ -180,9 +197,17 @@ mod tests {
             ]
         );
 
+        // `get` reads a single value; a missing key is `None`.
+        assert_eq!(
+            get(&db, "GH_HOST").await.as_deref(),
+            Some("github.internal")
+        );
+        assert_eq!(get(&db, "MISSING").await, None);
+
         assert!(remove(&db, "API_TOKEN").await.unwrap());
         // Removing again is a no-op.
         assert!(!remove(&db, "API_TOKEN").await.unwrap());
         assert_eq!(list(&db).await.unwrap().len(), 1);
+        assert_eq!(get(&db, "API_TOKEN").await, None, "gone after remove");
     }
 }

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -284,10 +284,22 @@ pub async fn gh_available() -> bool {
 /// Fetch the pull request for `branch` (its remote head ref) from `repo_root`.
 /// `Ok(None)` means there is simply no PR for the branch yet; `Err` is a real
 /// failure (no GitHub remote, auth, `gh` missing) the caller logs and skips.
-pub async fn fetch_pr(repo_root: &Path, branch: &str) -> Result<Option<GithubStatus>> {
-    let out = Command::new("gh")
-        .args(["pr", "view", branch, "--json", PR_FIELDS])
-        .current_dir(repo_root)
+pub async fn fetch_pr(
+    repo_root: &Path,
+    branch: &str,
+    token: Option<&str>,
+) -> Result<Option<GithubStatus>> {
+    let mut cmd = Command::new("gh");
+    cmd.args(["pr", "view", branch, "--json", PR_FIELDS])
+        .current_dir(repo_root);
+    // The poll loop runs in the loom process, which carries no ambient `gh` auth
+    // (the operator's `GH_TOKEN` is session-scoped, not the server's). Without a
+    // token `gh pr view` fails and every branch's PR status stays blank — starving
+    // the pr-label / review-wait / archive-merged watches, which key off it.
+    if let Some(token) = token {
+        cmd.env("GH_TOKEN", token);
+    }
+    let out = cmd
         .output()
         .await
         .context("failed to spawn gh (is the GitHub CLI installed?)")?;
@@ -360,7 +372,16 @@ pub async fn refresh(
     branch: &Branch,
     archive_on_merge: bool,
 ) -> Result<Option<GithubStatus>> {
-    let snap = match fetch_pr(&PathBuf::from(&branch.repo_root), &branch.branch).await? {
+    // loom's own token for `gh` — the operator's `GH_TOKEN` from Settings →
+    // Environment (the server process has no ambient GitHub auth of its own).
+    let token = crate::agent_env::get(&state.db, "GH_TOKEN").await;
+    let snap = match fetch_pr(
+        &PathBuf::from(&branch.repo_root),
+        &branch.branch,
+        token.as_deref(),
+    )
+    .await?
+    {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/crates/loom/src/watch.rs
+++ b/crates/loom/src/watch.rs
@@ -1001,6 +1001,14 @@ async fn spawn_script(
     for key in crate::agent::STRIPPED_ENV {
         command.env_remove(key);
     }
+    // github watches shell out to `gh` (reading PR labels/state) from this
+    // otherwise env-stripped process; hand them the operator's `GH_TOKEN`
+    // (Settings → Environment) so those reads authenticate. Set after the strip so
+    // it wins. Nothing else from the agent env leaks in — a watch still reaches the
+    // fleet only through the REST API.
+    if let Some(token) = crate::agent_env::get(&state.db, "GH_TOKEN").await {
+        command.env("GH_TOKEN", token);
+    }
 
     let started = std::time::Instant::now();
     let out = command.output().await.map_err(|e| {

--- a/crates/loom/tests/integration/programs/echo_env.py
+++ b/crates/loom/tests/integration/programs/echo_env.py
@@ -1,0 +1,15 @@
+"""Test fixture: echo the GH_TOKEN this watch subprocess received.
+
+Watches run env-stripped; loom injects the operator's GH_TOKEN (Settings →
+Environment) into the subprocess so github watches (pr-label, review-wait,
+archive-merged) can shell out to `gh`. This program echoes the value it was
+handed into its round summary, so an integration test can assert that injection
+end-to-end.
+"""
+
+import os
+
+from weaver_loom import Round
+
+rnd = Round()
+rnd.finish("token[" + (os.environ.get("GH_TOKEN") or "") + "]")

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -90,6 +90,17 @@ fn survey_program() -> String {
     .to_string()
 }
 
+/// Fixture that echoes the `GH_TOKEN` it was handed into its summary, so a test
+/// can assert loom injects the operator's token into the (otherwise env-stripped)
+/// watch subprocess — what github watches need for their own `gh` calls.
+fn echo_env_program() -> String {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/integration/programs/echo_env.py"
+    )
+    .to_string()
+}
+
 /// A reactive fixture that declares a `pr.merged` subscription and surveys only
 /// the triggering session (via `triggered_sessions`).
 fn survey_triggered_program() -> String {
@@ -885,6 +896,52 @@ async fn rest_watch_lifecycle_and_validation() {
 // ---------------------------------------------------------------------------
 
 use loom::builtins::python3_available;
+
+/// A github watch shells out to `gh` (reading PR labels/state); loom must inject
+/// the operator's `GH_TOKEN` (Settings → Environment) into the otherwise
+/// env-stripped watch subprocess, or every github watch (pr-label, review-wait,
+/// archive-merged) is blind. The explicit inject wins over any ambient value, so
+/// the exact token reaches the process.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn watch_subprocess_receives_operator_gh_token() {
+    if !python3_available() {
+        eprintln!("skipping: python3 not on PATH");
+        return;
+    }
+    let ts = TestServer::start().await;
+    let state = engine_state(&ts).await;
+
+    let o = enabled_watch(
+        &state,
+        watch_store::NewWatch {
+            name: "echo-env".to_string(),
+            trigger_spec: json!({ "on": ["session.idle"] }).to_string(),
+            scope: json!({}).to_string(),
+            program: echo_env_program(),
+            capabilities: vec!["observe".to_string()],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Set the operator token (Settings → Environment) and fire a manual round.
+    loom::agent_env::set(&state.db, "GH_TOKEN", "ghtok-marker-xyz")
+        .await
+        .unwrap();
+    let run_id = watch::fire_now(&state, &o.name, false, "manual")
+        .await
+        .unwrap();
+
+    let runs = watch_store::recent_runs(&state.db, &o.id, 10)
+        .await
+        .unwrap();
+    let run = runs.iter().find(|r| r.id == run_id).unwrap();
+    assert_eq!(
+        run.summary, "token[ghtok-marker-xyz]",
+        "the operator's GH_TOKEN reaches the env-stripped watch subprocess"
+    );
+}
 
 /// A stored PR snapshot for a branch, as the GitHub poll loop would write it.
 fn pr_snapshot(state: &str, number: i64) -> weaver_core::github::GithubStatus {


### PR DESCRIPTION
## Summary

Debugging why the **pr-label** watch reported `surveyed 3, 0 open PR(s) missing 'weaver'` while an open loom PR (`marin-community/marin#6853`, head `weaver/issue-6823`) genuinely lacked the label, the root cause turned out to be an auth gap in loom's *own* GitHub reads.

### Root cause
- The pr-label watch (and review-wait, archive-merged) key off `branch.github.pr_state == "OPEN"`, which the **PR poll loop** populates by running `gh pr view`.
- That `gh` — and a watch script's own `gh` calls — inherit the **loom server process** environment. On the deploy that env has **no GitHub auth**: `GH_TOKEN` is absent and `gh` is logged out (the operator's `GH_TOKEN` from Settings → Environment is layered only into agent *work-sessions*, not the server process). Verified on the VM: `NO_GH_TOKEN`, `gh auth status` → "not logged into any GitHub hosts".
- So `fetch_pr` failed for every branch, `branch.github` stayed blank, and the watches surveyed the fleet but saw no open PRs → permanent no-op. Clones/replies/back-links were fine — they go through the App gateway; PR polling was the one path still on raw `gh`.

### Fix
- **Poll loop:** `fetch_pr` accepts a token and sets it as `GH_TOKEN` on the `gh` child; `refresh` supplies the operator's `GH_TOKEN` (`agent_env::get`). The poll now authenticates and fills in `branch.github` — which unblocks every github-dependent watch *and* the fleet PR badges.
- **Watch scripts:** the subprocess now also receives the operator's `GH_TOKEN` (set *after* the env strip, so it wins), so a github watch's own `gh` reads (PR labels/state) authenticate. Nothing else from the agent env leaks in — a watch still reaches the fleet only through the REST API.
- Adds `agent_env::get(db, name) -> Option<String>` for the single-value credential lookup.

This is why setting `GH_TOKEN` in Settings → Environment didn't help: that value only reaches agent sessions. After this change loom's own PR polling and watch `gh` calls use it too.

## Testing

- `cargo clippy -p loom --all-targets` — clean
- Full loom suite green: **201 (lib) + 87 (integration)**, 0 failures
- New unit test: `agent_env::get` round-trip (present / missing / after-remove)
- New integration test `watch_subprocess_receives_operator_gh_token` — sets `GH_TOKEN` via `agent_env`, fires a watch, and asserts the exact token reaches the (otherwise env-stripped) subprocess

## Note

This uses the operator's PAT (Settings → Environment) for loom's own reads. A future refinement could mint a per-repo **App installation token** for the poll (as clones already do), removing the shared-PAT dependency for repos the App is installed on.
