### PR TITLE
fix(loom): post the PR back-link once on open, not every poll

### DIFF
--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -458,10 +458,13 @@ async fn apply_snapshot(
         }
     }
 
-    // Back-link the PR to its loom session — a one-time comment on the open PR, so
-    // someone reading the GitHub thread can jump to the live session. Skipped once
-    // the branch is tagged linked (here or by the trigger reply).
-    if snap.pr_state == "OPEN" {
+    // Back-link the PR to its loom session — a one-time comment posted when loom
+    // first sees the PR open, so someone reading the GitHub thread can jump to the
+    // live session. Gated on the open *transition* (not every poll while OPEN): a
+    // repo where loom can't comment then fails once, rather than re-posting — and
+    // logging a failure — on every 30s poll. Skipped once the branch is tagged
+    // linked (here or by the `@loom` reply).
+    if pr_just_opened(prev_state, snap) {
         maybe_post_backlink(state, session, branch, snap).await;
     }
 
@@ -506,10 +509,11 @@ fn slug_from_repo_root(repo_root: &str) -> Option<String> {
 }
 
 /// Post a one-time comment on the branch's open PR linking back to its loom
-/// session, unless the branch is already linked (the `@loom` reply tagged it, or a
-/// prior poll posted it). Managed repos only — the App gateway needs the slug —
-/// and only when a public base URL is configured, so the link resolves.
-/// Best-effort: every failure logs and returns, leaving the tag unset to retry.
+/// session, unless the branch is already linked (the `@loom` reply tagged it).
+/// Managed repos only — the App gateway needs the slug — and only when a public
+/// base URL is configured, so the link resolves. Best-effort: a failure logs and
+/// returns without setting the tag; the caller fires this only on the PR-open
+/// transition, so a failure is not retried on every poll.
 async fn maybe_post_backlink(
     state: &AppState,
     session: &Session,


### PR DESCRIPTION
## Summary

Once the [PR-poll auth fix](https://github.com/rjpower/weaver/pull/126) landed and loom could actually read PRs, the poll-loop back-link poster started firing — and surfaced that it retries forever on a permanent failure.

On `marin-community/marin`, posting the back-link comment returns **403 "Resource not accessible by integration"** (the GitHub App there lacks Issues / Pull-requests *write*). `maybe_post_backlink` only sets the `github.linked` tag on **success**, and the caller ran it on **every poll while `pr_state == "OPEN"`** — so loom re-posted and re-logged the 403 every ~30s, per open PR:

```
loom::github: back-link: posting comment failed repo=marin-community/marin pr=6853
   error=... 403 Forbidden: "Resource not accessible by integration"
```

## Fix

Gate the back-link on the `pr.opened` **transition** (`pr_just_opened`) instead of `pr_state == "OPEN"` — which is what the function's own "post a one-time comment" contract already implied. loom now attempts the back-link **once**, when it first sees the PR open:

- A repo it can't comment on fails once and stays quiet, instead of a 30s log loop.
- Covers agent-opened PRs (first sighting is `None → OPEN`, which is a transition) exactly as before.
- The `@loom` reply's own `github.linked` tag still suppresses a duplicate when loom created the PR.

Reuses the already-unit-tested `pr_just_opened` predicate; no behavior change for the happy path.

## Not in this PR

The underlying 403 is a **permission** matter, not a code bug: the App on that repo can't post comments (which also blocks the `@loom` "On it" replies). That's tracked separately — either grant the App Issues/PR write, or route loom's comments through the operator `GH_TOKEN`.

## Testing

- `cargo clippy -p loom --all-targets` — clean
- `cargo test -p loom --lib github::` — 16 passed (incl. the `pr_just_opened` transition cases this now relies on)
