### PR TITLE
feat(loom): set the browser tab title to the open session name

### DIFF
--- a/crates/loom/frontend/src/App.vue
+++ b/crates/loom/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue';
+import { useRoute } from 'vue-router';
 import AppRail from './components/AppRail.vue';
 import StatusBar from './components/StatusBar.vue';
 import { me } from './auth';
@@ -21,8 +22,26 @@ const authed = computed(() => me.authenticated);
 // view paints from cache the instant it mounts (no empty-state flash, no
 // refetch round-trip) and there is exactly one request per tick. Start it once
 // authenticated; stop on sign-out so the login screen never polls.
-const { startFleetPoll, stopFleetPoll } = useFleet();
+const { startFleetPoll, stopFleetPoll, sessionById } = useFleet();
 watch(authed, (ok) => (ok ? startFleetPoll() : stopFleetPoll()), { immediate: true });
+
+// The browser tab title tracks what you're looking at: on a session page it's
+// the session's title (falling back to its branch name), so several open loom
+// tabs are tellable apart at a glance; everywhere else it's the bare app name.
+// Derived from the shared fleet snapshot — the same source the page header reads
+// — so a rename reflects here on the next poll, and a deep link shows the base
+// title only until that row arrives (no wrong-name flash, just a late refine).
+const route = useRoute();
+const BASE_TITLE = 'weaver';
+const docTitle = computed(() => {
+  const id = route.params.id;
+  if (typeof id === 'string' && route.path.startsWith(`/s/${id}`)) {
+    const name = sessionById(id)?.branch.title || sessionById(id)?.branch.name;
+    if (name) return `${name} · ${BASE_TITLE}`;
+  }
+  return BASE_TITLE;
+});
+watch(docTitle, (t) => (document.title = t), { immediate: true });
 
 // Views kept alive across navigation so returning is instant — no remount, no
 // refetch flash, no entrance-animation replay. The list views return exactly as

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -28,6 +28,22 @@ test.describe('session detail view', () => {
     await expect(details.getByText(`base ${s.branch.base_branch}`)).toBeVisible();
   });
 
+  test('sets the browser tab title to the open session', async ({ page, weaver }) => {
+    const s = await weaver.seedSession({ goal: 'Name my tab', name: 'tab-task' });
+
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
+
+    // The tab title tracks the open session (its title, falling back to the
+    // branch name) so several loom tabs are tellable apart. It's derived from
+    // the shared fleet snapshot, which the deep link fills a beat after landing,
+    // so toHaveTitle auto-retries until the row arrives.
+    await expect(page).toHaveTitle('tab-task · weaver');
+
+    // Leaving the session for the fleet list drops back to the bare app name.
+    await page.goto(`${weaver.baseUrl}/`);
+    await expect(page).toHaveTitle('weaver');
+  });
+
   test('clearing the attention chip marks the agent’s attention calm', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Acknowledge me', name: 'ack-task' });
     // The agent raises its attention; the human's only write here is to clear it.


### PR DESCRIPTION
## What

The browser tab title was always the bare app name **weaver**, so several open loom tabs were indistinguishable. Now, on a session page the tab title becomes the session's **title** (falling back to its **branch name**) — e.g. `fix-login-flow · weaver` — and stays `weaver` everywhere else.

## How

Derived reactively in the shell (`App.vue`) from the current route + the shared fleet snapshot (`sessionsStore`) — the same source the page header reads:

- On any `/s/:id…` route, look up the session in the fleet snapshot and use `branch.title || branch.name`.
- Anywhere else (list, settings, issues, watches, chat), the base title `weaver`.

Reading the fleet store rather than the detail page's own state keeps this centralized (no keep-alive lifecycle juggling) and means a rename reflects on the next poll. A deep link shows the base title only until the fleet row arrives — no wrong-name flash, just a late refine to the real name.

## Testing

- Added an e2e test in `detail.spec.ts`: deep-linking to a session sets the tab title to `<name> · weaver`, and navigating back to the fleet list resets it to `weaver`.
- Full `detail.spec.ts` suite green; frontend `vue-tsc` typecheck clean.