### PR TITLE
feat(deploy): run docker builds in loom sessions via the host daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,19 @@ RUN set -eux; \
     chmod a+r /etc/apt/keyrings/cloud.google.asc; \
     echo "deb [signed-by=/etc/apt/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt cloud-sdk main" \
       > /etc/apt/sources.list.d/google-cloud-sdk.list; \
+    # Docker CLI — client only, NO daemon. loom sessions run `docker build`; the
+    # container reaches the *host's* Docker daemon over the bind-mounted
+    # /var/run/docker.sock (see docker-compose.yml), so only the CLI + the buildx
+    # and compose plugins ship here, not docker-ce/containerd. Same signed-repo
+    # keyring idiom as gh/gcloud above.
+    curl -fsSL https://download.docker.com/linux/debian/gpg \
+      -o /etc/apt/keyrings/docker.asc; \
+    chmod a+r /etc/apt/keyrings/docker.asc; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+      > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends nodejs git ca-certificates gh google-cloud-cli tini; \
+    apt-get install -y --no-install-recommends nodejs git ca-certificates gh google-cloud-cli tini \
+      docker-ce-cli docker-buildx-plugin docker-compose-plugin; \
     rm -rf /var/lib/apt/lists/*
 
 # Claude Code — the agent runtime loom's sessions launch — is deliberately NOT

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -107,6 +107,7 @@ and why; you don't hand-edit `.env` itself.
 | `LOOM_TLS_EMAIL` | no | ACME contact for cert-expiry notices; only used if you uncomment the global block in the Caddyfile. |
 | `HOST_UID` / `HOST_GID` | no (1000) | uid:gid the image runs as — matters only if you bind-mount a host dir. |
 | `LOOM_IMAGE` | no | Override the image tag (defaults to the locally-built `loom:latest`). |
+| `DOCKER_GID` | no (999) | Host `docker` group gid the loom container joins to reach the bind-mounted Docker socket for in-session `docker build` (see [Agent runtime](#agent-runtime--client-packages)). `run.py` and the GCP startup-script derive it from the host automatically; set it by hand only for a manual `docker compose up` on a host whose docker gid isn't the 999 default. |
 
 Every one of these is an ordinary `loom.toml` field (`tls_email`, `host_uid`,
 `host_gid`, `image`, alongside the credential fields above) — there's no
@@ -141,6 +142,15 @@ you can forget to apply:
 - **`auth.base_url = https://<LOOM_DOMAIN>`** — the canonical public origin, used
   for the GitHub OAuth callback and trusted by the terminal's WebSocket
   origin check.
+
+Separately, the `loom` container is given access to the **host's Docker socket**
+so sessions can `docker build` (see
+[Agent runtime](#agent-runtime--client-packages)). Socket access is
+root-equivalent on the host, and it is the *same* daemon that runs this stack —
+so a session's `docker` commands can reach loom's own containers and volumes (the
+database included). This is deliberate for a single-tenant host running the
+owner's own agents; do not carry it into a deploy that runs code you do not
+trust.
 
 Background on these knobs is in the repo
 [README "Authentication"](../README.md#authentication) and
@@ -328,6 +338,19 @@ The agent tooling the image ships splits by how it updates:
   Only OS/system packages (`apt-get`) still need an image rebuild — the system
   dirs are read-only to the non-root user. Add those to the
   [`Dockerfile`](../Dockerfile) and rerun `docker compose up -d --build`.
+
+- **`docker build` in sessions.** The image ships the Docker CLI (client only,
+  plus the buildx/compose plugins), and the `loom` container bind-mounts the
+  host's `/var/run/docker.sock` — so a session's `docker build`/`docker compose`
+  runs against the *host* daemon, reusing its layer cache and writing images to
+  the host data-root (the persistent data disk on the GCP deploy), not into the
+  container. The non-root app user reaches the socket by joining the host
+  `docker` group via `DOCKER_GID`, which `run.py` and the GCP startup-script
+  derive from the host for you. Note the socket-share tradeoff in
+  [Security posture](#security-posture): it is the same daemon that runs this
+  stack. `docker build` and `docker run` with in-container paths work; a
+  `docker run -v <worktree-path>:…` bind mount does **not**, because that path
+  exists in the loom container, not on the host the daemon resolves it against.
 
 ## Operations
 

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -152,10 +152,14 @@ re-issue a certificate (subject to Let's Encrypt's rate limits).
 `bootstrap.py` mitigates this by default: it creates a separate persistent
 disk (`DATA_DISK_SIZE`, default 500GB) and `startup-script.sh` points Docker's
 entire data-root at it (`/etc/docker/daemon.json`), so every named volume
-lands on that disk without any change to `docker-compose.yml`. That disk
-still gets deleted if you delete the VM *and* the disk together — it is
-durability against VM recreation, not against `terraform destroy`-style
-teardown. To keep state across a full teardown, detach the disk first
+lands on that disk without any change to `docker-compose.yml`. The images and
+layers agents build with in-session `docker build` land there too — the loom
+container shares this host daemon over its socket (see
+[`../README.md` "Agent runtime"](../README.md#agent-runtime--client-packages)),
+so `docker system df` on the VM and the 500GB default both cover your build
+footprint. That disk still gets deleted if you delete the VM *and* the disk
+together — it is durability against VM recreation, not against
+`terraform destroy`-style teardown. To keep state across a full teardown, detach the disk first
 (`gcloud compute instances detach-disk`) or snapshot it
 (`gcloud compute disks snapshot`) before deleting the instance.
 

--- a/deploy/gcp/startup-script.sh
+++ b/deploy/gcp/startup-script.sh
@@ -141,6 +141,15 @@ gcloud secrets versions access latest --project="$PROJECT" --secret=LOOM_DOTENV 
 if [ "$IMAGE_MODE" = "pull" ] && [ -n "$AR_IMAGE" ]; then
   echo "LOOM_IMAGE=${AR_IMAGE}" >>"$ENV_FILE"
 fi
+# Docker-out-of-Docker: the loom container mounts this host's Docker socket (see
+# ../standalone/docker-compose.yml) so sessions can `docker build`. The non-root
+# app user reaches the root-owned socket by joining the host `docker` group, so
+# pass its numeric gid through .env — also deploy-placement, not a config field.
+# Docker is installed above, so the group exists by now.
+DOCKER_GID="$(getent group docker | cut -d: -f3)"
+if [ -n "$DOCKER_GID" ]; then
+  echo "DOCKER_GID=${DOCKER_GID}" >>"$ENV_FILE"
+fi
 chmod 600 "$ENV_FILE"
 
 # ---- bring up the stack -----------------------------------------------------

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -59,7 +59,23 @@ services:
         condition: service_completed_successfully
     expose:
       - "7878" # internal to the compose network only — never published
+    # Docker-out-of-Docker: a session's `docker build`/`docker compose` talks to
+    # the HOST's Docker daemon over its bind-mounted socket (volumes, below), so
+    # builds run on the host — reusing its layer cache and writing images/layers
+    # to the host data-root (the persistent data disk on the GCP deploy), not into
+    # the container. The non-root app user reaches the root-owned socket by joining
+    # the host `docker` group via its numeric gid: startup-script.sh derives it on
+    # the GCP VM and run.py on a standalone host (both append DOCKER_GID to .env);
+    # the 999 fallback is the usual Debian docker gid for a hand-run `compose up`.
+    # SECURITY: this is the SAME daemon that runs this stack, so a session's docker
+    # commands can see and mutate loom's own containers/volumes (the DB included) —
+    # and socket access is root-equivalent on the host. Acceptable only because
+    # this is a single-tenant box running the owner's own agents (see ../README.md
+    # "Security posture").
+    group_add:
+      - "${DOCKER_GID:-999}"
     volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
       # Persisted HOME for the container user. Everything stateful lives here and
       # is owned by the `app` user the image runs as:
       #   * the weaver sqlite db + the 0600 machine-local loom token (~/.weaver),

--- a/deploy/standalone/run.py
+++ b/deploy/standalone/run.py
@@ -62,6 +62,20 @@ def find_loom() -> str:
     die("`loom` not found — build it (`cargo build -p loom`) or put it on PATH.")
 
 
+def docker_gid() -> str | None:
+    """The host's `docker` group gid, so the loom container's app user can join
+    it (compose `group_add`) and reach the bind-mounted Docker socket for
+    `docker build`. None when there's no such group (e.g. Docker Desktop on
+    macOS, where the socket isn't group-owned anyway) — the compose file's 999
+    fallback then applies. Keep in sync with gcp/startup-script.sh's derivation."""
+    try:
+        import grp
+
+        return str(grp.getgrnam("docker").gr_gid)
+    except (ImportError, KeyError):
+        return None
+
+
 def owner_configured(env_text: str) -> bool:
     """Whether the rendered env names a non-empty LOOM_OWNER_GITHUB. Without one
     the daemon refuses to boot (it would come up locked out), so we fail early
@@ -114,6 +128,11 @@ def main(local_: bool, config: str | None, no_build: bool) -> None:
     # arch deploy doesn't need a multi-arch container builder. Respects an
     # explicit BUILDX_BUILDER if you've set one.
     env.setdefault("BUILDX_BUILDER", "default")
+    # Pass the host docker gid through for the loom service's `group_add`, so
+    # sessions can reach the bind-mounted Docker socket (see docker-compose.yml).
+    gid = docker_gid()
+    if gid:
+        env.setdefault("DOCKER_GID", gid)
     if local_:
         env["LOOM_DOMAIN"] = "localhost"
     run(render, env=env)


### PR DESCRIPTION
## What

Sessions frequently run `docker build`, but the loom runtime image shipped **no docker at all** — so in-session builds had nothing to talk to. This enables it via **Docker-out-of-Docker**: the loom container gets the Docker *client* and talks to the **host's** Docker daemon over its socket.

Chosen over a privileged `docker:dind` sidecar because loom runs on a single-tenant host where builds should share the host's layer cache and land on the persistent data disk — no separate daemon, cache, or `--privileged` container to manage.

## Changes

- **`Dockerfile`** — install the Docker CLI + buildx/compose plugins (client only, no daemon/containerd) in the runtime stage, via Docker's signed apt repo (same keyring idiom as `gh`/`gcloud`).
- **`deploy/standalone/docker-compose.yml`** — bind-mount `/var/run/docker.sock` into the `loom` service and join the host `docker` group by gid (`group_add: ${DOCKER_GID:-999}`) so the non-root `app` user can reach the root-owned socket.
- **`deploy/gcp/startup-script.sh`** + **`deploy/standalone/run.py`** — derive the host's docker gid and pass it through `.env` as `DOCKER_GID` (deploy-placement, like `LOOM_IMAGE`).
- **docs** (`deploy/README.md`, `deploy/gcp/README.md`) — the socket-share, its security tradeoff, and that in-session builds consume the data disk.

Builds run on the host daemon, reusing its layer cache and writing images to the host data-root — the persistent 500GB data disk on the GCP deploy.

## Security tradeoff (documented)

The container gets access to the **same** daemon that runs the loom stack, and Docker socket access is **root-equivalent on the host**. A session's `docker` commands can therefore see and mutate loom's own containers/volumes (the DB included). This is acceptable *only* because the box is single-tenant and runs the owner's own agents — it's called out in `deploy/README.md` "Security posture".

## Validation

- ✅ Built the runtime apt layer for real — `docker-ce-cli` / buildx / compose install and run on bookworm.
- ✅ `docker compose config` renders the socket mount + `group_add`, with the `999` fallback when `DOCKER_GID` is unset (and only on the `loom` service, not `loom-init`).
- ✅ **Mechanism proof**: a non-root uid-1000 container joined to the host docker group via `group_add`, with the socket mounted and a writable `HOME` (as `app` has at `/home/app`), successfully ran `docker build` **and** `docker run` against the host daemon.
- ✅ `bash -n` + `py_compile` on the changed scripts.

## Rollout

Re-run `bootstrap.py` (build mode) — it re-clones, rewrites `.env` with `DOCKER_GID`, and `docker compose up -d --build` rebuilds the image and recreates the `loom` container with the socket mount. In pull mode, `push-image.py` first, then re-deploy.

Closes #383.