### PR TITLE
feat(loom): confine each session to a memory-limited cgroup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN set -eux; \
       > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends nodejs git ca-certificates gh google-cloud-cli tini \
-      docker-ce-cli docker-buildx-plugin docker-compose-plugin; \
+      docker-ce-cli docker-buildx-plugin docker-compose-plugin sudo; \
     rm -rf /var/lib/apt/lists/*
 
 # Claude Code — the agent runtime loom's sessions launch — is deliberately NOT
@@ -160,25 +160,70 @@ git config --system url.https://github.com/.insteadOf git@github.com:
 git config --system url.https://github.com/.insteadOf ssh://git@github.com/
 EOF
 
+# Per-session memory limits. loom confines each terminal session to its own
+# memory-limited cgroup under /sys/fs/cgroup/agents (see backend::new_session);
+# this root-only script prepares that subtree at boot and delegates it to the
+# app user. cgroup v2's no-internal-process rule means the container-root cgroup
+# must be emptied into a leaf (init/) before controllers can be enabled on its
+# children, and migrating a session into agents/<name> additionally needs write
+# access to the source/destination *common ancestor's* cgroup.procs — hence the
+# chowns at the bottom. Needs the rw cgroupfs remount, which is why the compose
+# service runs with SYS_ADMIN + apparmor=unconfined (docker-compose.yml); where
+# that grant is absent this script fails and the entrypoint just warns — loom
+# runs fine, sessions are simply unlimited. The app user may run exactly this
+# script as root (sudoers line below), nothing else.
+RUN <<'EOF'
+cat > /usr/local/bin/loom-cgroup-init <<'SH'
+#!/bin/sh
+set -eu
+[ -f /sys/fs/cgroup/cgroup.controllers ] || { echo "cgroup v2 not mounted" >&2; exit 1; }
+if [ ! -w /sys/fs/cgroup ]; then
+  # Docker mounts the container's cgroup view read-only; replace it with a rw
+  # mount of the same (namespaced) tree.
+  umount /sys/fs/cgroup
+  mount -t cgroup2 cgroup2 /sys/fs/cgroup
+fi
+grep -qw memory /sys/fs/cgroup/cgroup.controllers || { echo "memory controller not delegated" >&2; exit 1; }
+mkdir -p /sys/fs/cgroup/init /sys/fs/cgroup/agents
+while read -r p; do
+  echo "$p" > /sys/fs/cgroup/init/cgroup.procs || true
+done < /sys/fs/cgroup/cgroup.procs
+echo +memory > /sys/fs/cgroup/cgroup.subtree_control
+echo +memory > /sys/fs/cgroup/agents/cgroup.subtree_control
+chown -R app /sys/fs/cgroup/agents
+chown app /sys/fs/cgroup/cgroup.procs /sys/fs/cgroup/init/cgroup.procs
+SH
+chmod 755 /usr/local/bin/loom-cgroup-init
+echo 'app ALL=(root) NOPASSWD: /usr/local/bin/loom-cgroup-init' > /etc/sudoers.d/loom-cgroup-init
+chmod 440 /etc/sudoers.d/loom-cgroup-init
+EOF
+
 # Container entrypoint: before the daemon starts, make sure the writable,
-# self-updating Claude install exists on the persisted $HOME volume, then hand
-# off to the CMD. Runs the install only for `loom server …` — one-shot admin
-# commands (`loom config set`, `loom setup`, the compose init service) skip it.
+# self-updating Claude install exists on the persisted $HOME volume and the
+# delegated session-cgroup subtree is prepared, then hand off to the CMD. Both
+# run only for `loom server …` — one-shot admin commands (`loom config set`,
+# `loom setup`, the compose init service) skip them.
 RUN <<'EOF'
 cat > /usr/local/bin/loom-entrypoint <<'SH'
 #!/bin/sh
 set -eu
-if [ "${1:-}" = loom ] && [ "${2:-}" = server ] && [ ! -x "$HOME/.local/bin/claude" ]; then
-  echo "loom: installing self-updating Claude Code into $HOME/.local ..." >&2
-  # The stock native installer drops claude into $HOME/.local/bin (writable, on
-  # the volume); Claude then auto-updates itself in place. Pin with
-  # CLAUDE_CODE_VERSION (stable|latest|<version>; default stable). `curl | bash`
-  # can't surface a download failure through the pipe, so check the binary landed
-  # rather than trusting the exit status. Non-fatal: loom still boots either way;
-  # agents just lack `claude` until a boot with network installs it.
-  curl -fsSL https://claude.ai/install.sh | bash -s -- "${CLAUDE_CODE_VERSION:-stable}" || true
-  [ -x "$HOME/.local/bin/claude" ] \
-    || echo "loom: WARNING: Claude install failed (offline?); agents lack 'claude' until a later boot installs it" >&2
+if [ "${1:-}" = loom ] && [ "${2:-}" = server ]; then
+  if [ ! -x "$HOME/.local/bin/claude" ]; then
+    echo "loom: installing self-updating Claude Code into $HOME/.local ..." >&2
+    # The stock native installer drops claude into $HOME/.local/bin (writable, on
+    # the volume); Claude then auto-updates itself in place. Pin with
+    # CLAUDE_CODE_VERSION (stable|latest|<version>; default stable). `curl | bash`
+    # can't surface a download failure through the pipe, so check the binary landed
+    # rather than trusting the exit status. Non-fatal: loom still boots either way;
+    # agents just lack `claude` until a boot with network installs it.
+    curl -fsSL https://claude.ai/install.sh | bash -s -- "${CLAUDE_CODE_VERSION:-stable}" || true
+    [ -x "$HOME/.local/bin/claude" ] \
+      || echo "loom: WARNING: Claude install failed (offline?); agents lack 'claude' until a later boot installs it" >&2
+  fi
+  # Delegate the per-session cgroup subtree (see loom-cgroup-init above).
+  # Non-fatal: without it sessions run with no memory limit.
+  sudo -n /usr/local/bin/loom-cgroup-init \
+    || echo "loom: WARNING: cgroup delegation failed; sessions run without memory limits" >&2
 fi
 exec "$@"
 SH

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -371,6 +371,9 @@ pub struct AgentLaunchContext<'a> {
     pub effort: &'a str,
     /// Operator-managed environment variables exported into the session.
     pub extra_env: &'a [(String, String)],
+    /// Per-session memory ceiling in GiB (0 = unlimited), resolved from the
+    /// `session.memory_max_gb` setting by [`launch`].
+    pub memory_max_gb: u64,
 }
 
 impl AgentType for ClaudeAgentType {
@@ -554,6 +557,7 @@ pub async fn launch(db: &Db, spec: &LaunchSpec<'_>, mode: LaunchMode) -> Result<
         model: spec.model,
         effort: spec.effort,
         extra_env: spec.extra_env,
+        memory_max_gb: backend::memory_max_gb(db).await,
     };
     let resolved = resolve(db, spec.runtime)
         .await?
@@ -616,7 +620,7 @@ async fn start_terminal(
         session = ctx.term_session,
         "launching agent session"
     );
-    backend::new_session(ctx.term_session, ctx.work_dir, &script)
+    backend::new_session(ctx.term_session, ctx.work_dir, &script, ctx.memory_max_gb)
         .await
         .with_context(|| format!("terminal: launching session {}", ctx.term_session))?;
     tracing::info!(
@@ -930,6 +934,7 @@ mod tests {
             model,
             effort,
             extra_env: &[],
+            memory_max_gb: 0,
         }
     }
 

--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -14,18 +14,70 @@
 
 use anyhow::Result;
 
+use crate::db::Db;
+
 /// Whether a session with this name has a live supervisor.
 pub async fn has_session(name: &str) -> bool {
     tapestry::Client::is_alive(name).await
 }
 
-/// Create a detached session running `script` via `sh -c` in `cwd`.
-pub async fn new_session(name: &str, cwd: &std::path::Path, script: &str) -> Result<()> {
-    tracing::info!(session = %name, cwd = %cwd.display(), "spawning terminal session");
+/// The delegated cgroup-v2 subtree sessions confine themselves under. Created
+/// and chowned to the loom user at container boot by `loom-cgroup-init` (see
+/// the Dockerfile); absent (the normal case outside the standalone deploy)
+/// the [`memory_prelude`] guard makes the confinement a no-op.
+const AGENT_CGROUP_DIR: &str = "/sys/fs/cgroup/agents";
+
+/// The per-session memory ceiling in GiB, from the `session.memory_max_gb`
+/// setting. 0 = unlimited.
+pub async fn memory_max_gb(db: &Db) -> u64 {
+    let default = weaver_core::config::DEFAULT_SESSION_MEMORY_MAX_GB;
+    weaver_core::config::get_or(db, "session.memory_max_gb", &default.to_string())
+        .await
+        .trim()
+        .parse()
+        .unwrap_or(default as u64)
+}
+
+/// Shell prelude that moves the session into its own memory-limited cgroup
+/// before the launch script proper runs — every process the session spawns
+/// inherits it, so a runaway agent OOMs alone inside its cgroup instead of
+/// taking the host down. Runs only where [`AGENT_CGROUP_DIR`] is writable (the
+/// delegated subtree the standalone deploy prepares at boot); elsewhere the
+/// guard falls through silently. A *failed* confinement attempt, by contrast,
+/// warns into the session terminal so an unlimited session is visible.
+fn memory_prelude(name: &str, memory_max_gb: u64) -> String {
+    let dir = format!("{AGENT_CGROUP_DIR}/{name}");
+    let bytes = memory_max_gb * 1024 * 1024 * 1024;
+    // memory.swap.max is zeroed so the ceiling can't leak into swap on a host
+    // that has any, but best-effort: the file is missing on kernels without
+    // swap accounting, and the RAM cap alone is still worth keeping.
+    format!(
+        "if [ -w {AGENT_CGROUP_DIR} ]; then \
+if mkdir -p '{dir}' 2>/dev/null && echo {bytes} > '{dir}/memory.max' 2>/dev/null \
+&& echo $$ > '{dir}/cgroup.procs' 2>/dev/null; then \
+echo 0 > '{dir}/memory.swap.max' 2>/dev/null || true; else \
+echo 'loom: warning: could not apply the {memory_max_gb}g session memory limit' >&2; fi; fi\n"
+    )
+}
+
+/// Create a detached session running `script` via `sh -c` in `cwd`. A non-zero
+/// `memory_max_gb` prepends the [`memory_prelude`] confining the session to
+/// that many GiB.
+pub async fn new_session(
+    name: &str,
+    cwd: &std::path::Path,
+    script: &str,
+    memory_max_gb: u64,
+) -> Result<()> {
+    tracing::info!(session = %name, cwd = %cwd.display(), memory_max_gb, "spawning terminal session");
+    let script = match memory_max_gb {
+        0 => script.to_string(),
+        gb => format!("{}{}", memory_prelude(name, gb), script),
+    };
     let result = tapestry::spawn_detached(&tapestry::LaunchOptions {
         name,
         cwd,
-        script,
+        script: &script,
         // The launch script already bakes the agent env in as `export`
         // statements (see agent::launch_script).
         env: &[],
@@ -113,5 +165,44 @@ fn key_bytes(key: &str) -> &[u8] {
         "Space" => b" ",
         "BSpace" => b"\x7f",
         other => other.as_bytes(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_prelude_confines_the_session_to_its_named_cgroup() {
+        let prelude = memory_prelude("weaver-abc123", 8);
+        // Guarded on the delegated subtree, so it no-ops where none exists.
+        assert!(prelude.starts_with("if [ -w /sys/fs/cgroup/agents ]; then "));
+        // The limit lands in this session's own cgroup, in bytes.
+        assert!(prelude.contains("mkdir -p '/sys/fs/cgroup/agents/weaver-abc123'"));
+        assert!(
+            prelude.contains("echo 8589934592 > '/sys/fs/cgroup/agents/weaver-abc123/memory.max'")
+        );
+        // The shell moves itself in, so everything it spawns inherits the cap.
+        assert!(prelude.contains("echo $$ > '/sys/fs/cgroup/agents/weaver-abc123/cgroup.procs'"));
+        // The cap can't leak into swap (best-effort — see memory_prelude).
+        assert!(prelude.contains("echo 0 > '/sys/fs/cgroup/agents/weaver-abc123/memory.swap.max'"));
+        // A failed attempt is loud in the session terminal.
+        assert!(prelude.contains("could not apply the 8g session memory limit"));
+        // Newline-terminated so the launch script proper starts on its own line.
+        assert!(prelude.ends_with("fi\n"));
+    }
+
+    #[tokio::test]
+    async fn memory_max_gb_reads_the_setting_and_defaults_to_8() {
+        let db = weaver_core::db::connect_in_memory().await.unwrap();
+        assert_eq!(memory_max_gb(&db).await, 8);
+        weaver_core::config::apply(&db, &[("session.memory_max_gb".into(), Some("12".into()))])
+            .await
+            .unwrap();
+        assert_eq!(memory_max_gb(&db).await, 12);
+        weaver_core::config::apply(&db, &[("session.memory_max_gb".into(), Some("0".into()))])
+            .await
+            .unwrap();
+        assert_eq!(memory_max_gb(&db).await, 0);
     }
 }

--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -28,13 +28,15 @@ pub async fn has_session(name: &str) -> bool {
 const AGENT_CGROUP_DIR: &str = "/sys/fs/cgroup/agents";
 
 /// The per-session memory ceiling in GiB, from the `session.memory_max_gb`
-/// setting. 0 = unlimited.
+/// setting. 0 = unlimited; the setting validates as a signed integer, so a
+/// stored negative clamps to 0 rather than silently reverting to the default.
 pub async fn memory_max_gb(db: &Db) -> u64 {
     let default = weaver_core::config::DEFAULT_SESSION_MEMORY_MAX_GB;
     weaver_core::config::get_or(db, "session.memory_max_gb", &default.to_string())
         .await
         .trim()
-        .parse()
+        .parse::<i64>()
+        .map(|v| v.max(0) as u64)
         .unwrap_or(default as u64)
 }
 
@@ -47,7 +49,7 @@ pub async fn memory_max_gb(db: &Db) -> u64 {
 /// warns into the session terminal so an unlimited session is visible.
 fn memory_prelude(name: &str, memory_max_gb: u64) -> String {
     let dir = format!("{AGENT_CGROUP_DIR}/{name}");
-    let bytes = memory_max_gb * 1024 * 1024 * 1024;
+    let bytes = memory_max_gb.saturating_mul(1024 * 1024 * 1024);
     // memory.swap.max is zeroed so the ceiling can't leak into swap on a host
     // that has any, but best-effort: the file is missing on kernels without
     // swap accounting, and the RAM cap alone is still worth keeping.
@@ -204,5 +206,17 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(memory_max_gb(&db).await, 0);
+        // A stored negative (the setting validates as a signed int) clamps to
+        // unlimited rather than reverting to the default.
+        weaver_core::config::apply(&db, &[("session.memory_max_gb".into(), Some("-1".into()))])
+            .await
+            .unwrap();
+        assert_eq!(memory_max_gb(&db).await, 0);
+    }
+
+    #[test]
+    fn memory_prelude_saturates_an_absurd_limit_instead_of_wrapping() {
+        let prelude = memory_prelude("s", u64::MAX / 2);
+        assert!(prelude.contains(&format!("echo {} > ", u64::MAX)));
     }
 }

--- a/crates/loom/src/shell.rs
+++ b/crates/loom/src/shell.rs
@@ -87,7 +87,13 @@ pub async fn ensure(st: &AppState) -> Result<()> {
     let script = shell_script(st, None).await;
     let cwd = shell_cwd();
     tracing::info!(session = SHELL_SESSION, cwd = %cwd.display(), "spawning operator scratch shell");
-    backend::new_session(SHELL_SESSION, &cwd, &script).await
+    backend::new_session(
+        SHELL_SESSION,
+        &cwd,
+        &script,
+        backend::memory_max_gb(&st.db).await,
+    )
+    .await
 }
 
 /// Reset the scratch shell: kill the current supervisor (best-effort) and bring
@@ -141,7 +147,7 @@ pub async fn ensure_debug(
     let script = shell_script(st, Some(&branch.id)).await;
     let cwd = PathBuf::from(&session.work_dir);
     tracing::info!(session = %name, cwd = %cwd.display(), "spawning session debug shell");
-    backend::new_session(&name, &cwd, &script).await?;
+    backend::new_session(&name, &cwd, &script, backend::memory_max_gb(&st.db).await).await?;
     Ok(name)
 }
 

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -51,6 +51,11 @@ pub const DEFAULT_COOKIE_SECURE: bool = false;
 /// killed and the session is left in a visible error state. 600s mirrors the
 /// watch/lint-review precedent.
 pub const DEFAULT_SETUP_TIMEOUT_SECS: i64 = 600;
+/// Memory ceiling (GiB) applied to each terminal session via a per-session
+/// cgroup, where the runtime provides a delegated subtree (see
+/// `backend::new_session` in the `loom` crate). One runaway agent process then
+/// OOMs alone instead of taking the whole host down. 0 disables the limit.
+pub const DEFAULT_SESSION_MEMORY_MAX_GB: i64 = 8;
 
 // ---------------------------------------------------------------------------
 // Setting registry
@@ -369,6 +374,22 @@ pub const REGISTRY: &[SettingSpec] = &[
             arbitrary code from an unknown repo.",
         kind: SettingKind::Int,
         default: "600",
+        group: "Sessions",
+        options: &[],
+    },
+    SettingSpec {
+        key: "session.memory_max_gb",
+        label: "Session memory limit (GiB)",
+        description: "Memory ceiling for each terminal session — the agent and \
+            everything it spawns — enforced through a per-session cgroup. When a \
+            session crosses it, the kernel OOM-kills the biggest process inside \
+            that session only; the host and the other sessions are untouched. \
+            Applies where loom runs with a delegated cgroup subtree (the \
+            standalone Docker deploy prepares one at boot); elsewhere sessions \
+            run unlimited. 0 disables the limit. Takes effect for sessions \
+            launched after the change.",
+        kind: SettingKind::Int,
+        default: "8",
         group: "Sessions",
         options: &[],
     },

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -152,6 +152,16 @@ database included). This is deliberate for a single-tenant host running the
 owner's own agents; do not carry it into a deploy that runs code you do not
 trust.
 
+The `loom` container also runs with `SYS_ADMIN` and an unconfined AppArmor
+profile. These exist for one purpose: at boot, `loom-cgroup-init` (root-only,
+via a single sudoers line) remounts the container's own cgroup-v2 tree
+read-write and delegates an `agents/` subtree to the app user, which is what
+lets loom confine **each session to its own memory cgroup** (the
+`session.memory_max_gb` setting, default 8 GiB). A runaway agent process is
+then OOM-killed inside its session instead of stalling the whole VM. Next to
+the docker.sock mount these grants add no real capability on this box; remove
+them and loom still runs, with sessions simply unlimited.
+
 Background on these knobs is in the repo
 [README "Authentication"](../README.md#authentication) and
 [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md). To change one after the fact:

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -74,6 +74,23 @@ services:
     # "Security posture").
     group_add:
       - "${DOCKER_GID:-999}"
+    # Per-session memory limits (`session.memory_max_gb`): at boot the
+    # entrypoint runs loom-cgroup-init (see the Dockerfile), which remounts the
+    # container's own cgroup-v2 tree read-write and delegates an agents/
+    # subtree to the app user; each session then confines itself there and a
+    # runaway agent OOMs alone instead of taking the VM down. The remount is
+    # what needs SYS_ADMIN and an unconfined AppArmor profile — a wider grant
+    # than default, but this container already holds the root-equivalent
+    # docker.sock (above), so it adds nothing on this single-tenant box. Without
+    # these the init script fails and sessions simply run unlimited.
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor=unconfined
+    # The delegation dance assumes the container sees only its own cgroup
+    # subtree; private is the cgroup-v2 default, pinned here because the limits
+    # depend on it.
+    cgroup: private
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # Persisted HOME for the container user. Everything stateful lives here and


### PR DESCRIPTION
A runaway agent process could exhaust the whole VM: yesterday a single 13 GB python3 inside one session drove the host into an OOM storm that made loom unreachable until the box was rebooted. Each terminal session (agent, scratch shell, debug shell) now moves itself into its own cgroup under a delegated /sys/fs/cgroup/agents subtree before its launch script runs, so the kernel OOM-kills a runaway inside its own session while the host, loom, and every other session stay up. The session terminal survives and shows the kill.

The ceiling is the new session.memory_max_gb setting (Sessions group, default 8 GiB, 0 disables), read at launch by backend::new_session, which prepends a guarded shell prelude: where no delegated subtree exists (bare-metal loom, tests, CI) the prelude no-ops silently; a failed confinement attempt warns into the session terminal instead, so an unlimited session is visible. memory.swap.max is zeroed best-effort so the cap cannot leak into swap.

The standalone deploy prepares the subtree at boot. loom-cgroup-init (root, runnable by the app user via a single sudoers line) remounts the container's cgroup2 view read-write, empties the container-root cgroup into init/ (cgroup v2 forbids enabling controllers on a subtree while the parent holds processes), enables the memory controller, and delegates agents/ to the app user — including the common-ancestor cgroup.procs chowns that self-migration requires. The compose service gains cap_add SYS_ADMIN + apparmor=unconfined for the remount; next to the root-equivalent docker.sock mount the stack already holds, this adds no real capability on the single-tenant box. Where the grant is absent the init script fails, the entrypoint warns, and sessions simply run unlimited.

Verified end-to-end in a bookworm container with exactly the compose grants: the init script delegates cleanly, a non-root session enters its cgroup, an over-limit allocation is OOM-killed inside the cgroup (host untouched, session shell alive), and docker exec keeps working after the delegation dance.