### PR TITLE
fix(deploy): default the loom VM to e2-highmem-4

### DIFF
--- a/deploy/gcp/bootstrap.py
+++ b/deploy/gcp/bootstrap.py
@@ -569,7 +569,7 @@ def wait_for_https(domain: str, timeout: int = 300) -> bool:
 @click.option("--region", envvar="REGION", default="us-central1", show_default=True)
 @click.option("--zone", envvar="ZONE", default=None, help="Default: <region>-a")
 @click.option(
-    "--machine-type", envvar="MACHINE_TYPE", default="e2-standard-4", show_default=True
+    "--machine-type", envvar="MACHINE_TYPE", default="e2-highmem-4", show_default=True
 )
 @click.option(
     "--disk-size",


### PR DESCRIPTION
16 GB on e2-standard-4 proved too tight for several concurrent agent sessions: on 2026-07-03 a runaway session drove the VM into an OOM storm that made loom unreachable. The live VM was resized to e2-highmem-4 — 32 GB for ~$97/mo, the cheapest 32 GB shape (e2-standard-8 is ~$134/mo for the same RAM). Make fresh deploys match. Complements #130, which caps each session's memory so one runaway can't consume the whole box.