### PR TITLE
fix(watches): stop swallowing gh call failures in pr-label

### DIFF
--- a/crates/loom/watches/pr_label.py
+++ b/crates/loom/watches/pr_label.py
@@ -7,10 +7,7 @@ Subscribes to `pr.opened` — it wakes when a session's PR first appears, on tha
 one branch, instead of re-reading every session's labels on a timer.
 """
 
-import json
-import subprocess
-
-from weaver_loom import Round
+from weaver_loom import Round, WeaverError, gh_json
 
 DEFAULT_LABEL = "weaver"
 
@@ -19,20 +16,14 @@ TRIGGERS = {"on": ["pr.opened"]}
 
 
 def pr_labels(repo_root, pr_number):
-    """The PR's current label names via gh, or None when unreadable."""
-    try:
-        out = subprocess.run(
-            ["gh", "pr", "view", str(pr_number), "--json", "labels"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if out.returncode != 0:
-            return None
-        reply = json.loads(out.stdout)
-    except (OSError, subprocess.SubprocessError, ValueError):
-        return None
+    """The PR's current label names via gh.
+
+    Raises :class:`WeaverError` (from :func:`weaver_loom.gh_json`) when gh
+    itself couldn't answer — not installed, not authenticated, timed out, a
+    non-zero exit. The caller decides whether that's worth surviving; here it
+    is, but the *reason* rides along in the note instead of being discarded.
+    """
+    reply = gh_json(["pr", "view", str(pr_number), "--json", "labels"], cwd=repo_root)
     return [label.get("name", "") for label in reply.get("labels") or []]
 
 
@@ -44,15 +35,26 @@ def main(rnd):
         if github.get("pr_state") != "OPEN":
             continue
         pr = github.get("pr_number")
-        labels = pr_labels(branch.get("repo_root"), pr)
-        if labels is not None and label in labels:
+        try:
+            labels = pr_labels(branch.get("repo_root"), pr)
+        except WeaverError as e:
+            rnd.would(
+                "label",
+                session=session["id"],
+                pr=pr,
+                label=label,
+                note=f"PR #{pr}: gh unreadable — {e}",
+            )
             continue
-        note = (
-            f"PR #{pr} lacks label '{label}'"
-            if labels is not None
-            else f"PR #{pr}: labels unreadable via gh — would ensure '{label}'"
+        if label in labels:
+            continue
+        rnd.would(
+            "label",
+            session=session["id"],
+            pr=pr,
+            label=label,
+            note=f"PR #{pr} lacks label '{label}'",
         )
-        rnd.would("label", session=session["id"], pr=pr, label=label, note=note)
     rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} open PR(s) missing '{label}'")
 
 

--- a/crates/loom/watches/resume.py
+++ b/crates/loom/watches/resume.py
@@ -35,10 +35,13 @@ from weaver_loom import Round
 #: (stale). The watch also re-triggers itself via wake_in for backoff rechecks.
 TRIGGERS = {"on": ["session.idle", "session.stale"]}
 
-#: The transient-error signature, overridable via params.pattern. Matches the
-#: Claude overload line (`API Error: 529 Overloaded`) and the bare word
-#: `Overloaded`; the `5\d\d` form also catches sibling 5xx API errors.
-DEFAULT_PATTERN = r"(?i)(api error:\s*5\d\d|overloaded)"
+#: The transient-error signature, overridable via params.pattern. Requires the
+#: `API Error: <code>` banner Claude Code itself prints — a bare `overloaded`
+#: (with no code) matched any mention of that ordinary English word anywhere
+#: on screen, including in the agent's own prose, and nudged sessions that
+#: were never actually stalled. `429` catches rate limiting, `5\d\d` sibling
+#: server errors (529 overloaded, 500, 503, ...).
+DEFAULT_PATTERN = r"(?i)api error:\s*(429|5\d\d)\b"
 
 #: What to type to resume; the conversation is intact, so "continue" is enough.
 DEFAULT_NUDGE = "continue"

--- a/crates/loom/watches/resume.py
+++ b/crates/loom/watches/resume.py
@@ -29,7 +29,7 @@ it records the would-be action and moves on.
 import re
 import time
 
-from weaver_loom import Round, WeaverError
+from weaver_loom import Round
 
 #: Wake when a session goes quiet — a finished turn (idle) or no activity
 #: (stale). The watch also re-triggers itself via wake_in for backoff rechecks.
@@ -72,11 +72,8 @@ def is_stalled(rnd, sid, conf):
     Reads the live viewport (``screen_lines`` of scrollback, 0 = just what's on
     screen) so a *recovered* session — whose error has scrolled out of view —
     reads as healthy. A dead pane is treated as not-stalled (nothing to resume)."""
-    try:
-        screen = rnd.client.preview(sid, conf["lines"])
-    except WeaverError:
-        return False
-    return bool(conf["pattern"].search(screen or ""))
+    screen = rnd.preview_or(sid, conf["lines"])
+    return bool(conf["pattern"].search(screen))
 
 
 def backoff(conf, attempts):

--- a/crates/loom/watches/status.py
+++ b/crates/loom/watches/status.py
@@ -23,7 +23,7 @@ every mark untouched (including ``idle``) rather than guess. Honours dry_run:
 would-be writes are logged as actions and nothing mutates.
 """
 
-from weaver_loom import IDLE_KEY, IDLE_VALUE, Round, WeaverError, parse_tag_recommendations
+from weaver_loom import IDLE_KEY, IDLE_VALUE, Round, parse_tag_recommendations
 
 #: Wake on the agent's finished-turn hook — "assess when the agent goes quiet".
 TRIGGERS = {"on": ["session.idle"]}
@@ -61,10 +61,7 @@ def judge_tags(rnd, session):
     clears the watch's marks), or ``None`` for "no judgement" (no agent, or an
     unparseable reply) so the caller leaves the session's marks untouched."""
     prompt = rnd.params.get("prompt") or DEFAULT_PROMPT
-    try:
-        screen = rnd.client.preview(session["id"], SCREEN_LINES)
-    except WeaverError:
-        screen = ""
+    screen = rnd.preview_or(session["id"], SCREEN_LINES)
     out = rnd.client.agent(f"{prompt}\n\nSession screen:\n{screen}\n", rnd.model, rnd.effort)
     if not out:
         return None

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -183,13 +183,15 @@ def gh_json(args, cwd=None, timeout=30):
             ["gh", *args], cwd=cwd, capture_output=True, text=True, timeout=timeout
         )
     except FileNotFoundError as e:
-        raise WeaverError(f"gh not found: {e}") from e
+        # cwd missing raises the same exception type as gh itself missing;
+        # e.filename names whichever path the OS actually failed to find.
+        what = "gh" if e.filename in (None, "gh") else e.filename
+        raise WeaverError(f"{what} not found: {e}") from e
     except subprocess.TimeoutExpired as e:
         raise WeaverError(f"gh {' '.join(args)} timed out after {timeout}s") from e
     if out.returncode != 0:
-        raise WeaverError(
-            f"gh {' '.join(args)}: exit {out.returncode}: {out.stderr.strip()}"
-        )
+        detail = out.stderr.strip() or out.stdout.strip() or "no output"
+        raise WeaverError(f"gh {' '.join(args)}: exit {out.returncode}: {detail}")
     try:
         return json.loads(out.stdout)
     except ValueError as e:

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -48,6 +48,7 @@ from the weaver repo with ``uv pip install -e python/weaver-loom``.
 
 import json
 import os
+import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -162,6 +163,37 @@ class WeaverError(RuntimeError):
 
 class CapabilityDenied(WeaverError):
     """A mutating call attempted without the capability it requires."""
+
+
+def gh_json(args, cwd=None, timeout=30):
+    """Run ``gh <args>`` and parse its stdout as JSON.
+
+    A watch that shells out to ``gh`` needs exactly one thing: a way to tell
+    "gh couldn't answer this one call" (worth logging and moving on) apart
+    from "our code is broken" (worth a traceback). This draws that line once:
+    every failure — gh missing, the call timing out, a non-zero exit, output
+    that isn't JSON — raises :class:`WeaverError` carrying gh's own message,
+    so a caller that wants to tolerate an unreadable PR can catch that one
+    type and *keep the reason* in its note instead of discarding it. Anything
+    that isn't a `WeaverError` (a bug in the caller's own code) is left to
+    propagate as-is.
+    """
+    try:
+        out = subprocess.run(
+            ["gh", *args], cwd=cwd, capture_output=True, text=True, timeout=timeout
+        )
+    except FileNotFoundError as e:
+        raise WeaverError(f"gh not found: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise WeaverError(f"gh {' '.join(args)} timed out after {timeout}s") from e
+    if out.returncode != 0:
+        raise WeaverError(
+            f"gh {' '.join(args)}: exit {out.returncode}: {out.stderr.strip()}"
+        )
+    try:
+        return json.loads(out.stdout)
+    except ValueError as e:
+        raise WeaverError(f"gh {' '.join(args)}: unparseable JSON: {e}") from e
 
 
 def _base_url(base=None):
@@ -431,6 +463,17 @@ class Round:
         if repo and branch.get("repo_root") != repo:
             return False
         return True
+
+    def preview_or(self, session_id, lines=0, default=""):
+        """The session's terminal preview, or ``default`` when the pane is
+        already gone (:class:`WeaverError`) — the "read what's on screen but
+        tolerate a dead session" pattern every screen-reading watch needs. A
+        session vanishing between the survey and the read is expected and
+        recoverable; anything else (a bug in the caller) still propagates."""
+        try:
+            return self.client.preview(session_id, lines)
+        except WeaverError:
+            return default
 
     def would(self, action, **fields):
         """Record a stubbed would-do action — a read-only or dry-run finding."""

--- a/python/weaver-loom/tests/test_resume_program.py
+++ b/python/weaver-loom/tests/test_resume_program.py
@@ -125,6 +125,25 @@ def test_calm_session_is_never_nudged(capsys, monkeypatch):
     assert result["outcome"] == "noop"
 
 
+def test_bare_mention_of_overloaded_is_not_a_stall(capsys, monkeypatch):
+    # A screen that merely contains the ordinary English word "overloaded" (in
+    # the agent's own prose, a code comment, ...) is not the API-error banner
+    # and must never be mistaken for one.
+    prose = "  I split the overloaded handler into two smaller functions\n> "
+    client = StubClient(capabilities=["nudge"], sessions=[sess("s")], screens={"s": prose})
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={})
+    assert nudges(client) == []
+    assert result["outcome"] == "noop"
+
+
+def test_rate_limit_429_is_also_treated_as_a_stall(capsys, monkeypatch):
+    screen = "  thinking...\n● API Error: 429 Too Many Requests\n> "
+    client = StubClient(capabilities=["nudge"], sessions=[sess("s")], screens={"s": screen})
+    result = run_main(client, capsys, monkeypatch, now=1000, trigger={})
+    assert nudges(client) == [("nudge", "s", "continue", "resume")]
+    assert result["outcome"] == "ok"
+
+
 def test_pattern_and_nudge_text_are_configurable(capsys, monkeypatch):
     client = StubClient(
         capabilities=["nudge"],

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -9,6 +9,7 @@ builtin scripts against a real loom.
 """
 
 import json
+import subprocess
 
 import pytest
 from weaver_loom import (
@@ -16,6 +17,8 @@ from weaver_loom import (
     CapabilityDenied,
     Client,
     Round,
+    WeaverError,
+    gh_json,
     parse_judgement,
     parse_tag_recommendations,
 )
@@ -403,6 +406,87 @@ def test_wake_in_zero_is_emitted_to_clear_a_pending_wake(capsys):
 
 def test_state_defaults_to_empty_dict_without_config(capsys):
     assert make_round().state == {}
+
+
+# -- preview_or: the "read a screen, tolerate a dead pane" pattern -----------
+
+
+def test_preview_or_returns_the_screen():
+    rnd = make_round()
+    rnd.client.preview = lambda sid, lines=0: "hello"
+    assert rnd.preview_or("s", 10) == "hello"
+
+
+def test_preview_or_falls_back_on_weaver_error():
+    rnd = make_round()
+
+    def boom(sid, lines=0):
+        raise WeaverError("409 no live terminal")
+
+    rnd.client.preview = boom
+    assert rnd.preview_or("s", 10) == ""
+    assert rnd.preview_or("s", 10, default=None) is None
+
+
+def test_preview_or_lets_other_exceptions_propagate():
+    rnd = make_round()
+
+    def boom(sid, lines=0):
+        raise RuntimeError("not a WeaverError")
+
+    rnd.client.preview = boom
+    with pytest.raises(RuntimeError):
+        rnd.preview_or("s", 10)
+
+
+# -- gh_json: the "shell out to gh" pattern shared by gh-backed watches --------
+
+
+def _run_result(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_gh_json_parses_stdout(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _run_result(stdout='{"ok": true}')
+    )
+    assert gh_json(["pr", "view"]) == {"ok": True}
+
+
+def test_gh_json_raises_weaver_error_when_gh_is_missing(monkeypatch):
+    def boom(*a, **k):
+        raise FileNotFoundError("no such file: gh")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    with pytest.raises(WeaverError, match="gh not found"):
+        gh_json(["pr", "view"])
+
+
+def test_gh_json_raises_weaver_error_on_timeout(monkeypatch):
+    def boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="gh", timeout=30)
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    with pytest.raises(WeaverError, match="timed out"):
+        gh_json(["pr", "view"])
+
+
+def test_gh_json_raises_weaver_error_with_stderr_on_nonzero_exit(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: _run_result(returncode=1, stderr="not authenticated"),
+    )
+    with pytest.raises(WeaverError, match="not authenticated"):
+        gh_json(["pr", "view"])
+
+
+def test_gh_json_raises_weaver_error_on_bad_json(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _run_result(stdout="not json"))
+    with pytest.raises(WeaverError, match="unparseable JSON"):
+        gh_json(["pr", "view"])
 
 
 def test_set_state_rejects_non_dict():

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -464,6 +464,18 @@ def test_gh_json_raises_weaver_error_when_gh_is_missing(monkeypatch):
         gh_json(["pr", "view"])
 
 
+def test_gh_json_names_the_missing_path_when_it_is_not_gh(monkeypatch):
+    # subprocess.run(cwd=...) raises the same FileNotFoundError type when the
+    # *cwd* doesn't exist — that must not be misreported as "gh not found".
+    def boom(*a, **k):
+        raise FileNotFoundError(2, "No such file or directory", "/gone/repo")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    with pytest.raises(WeaverError, match=r"/gone/repo not found") as exc:
+        gh_json(["pr", "view"], cwd="/gone/repo")
+    assert "gh not found" not in str(exc.value)
+
+
 def test_gh_json_raises_weaver_error_on_timeout(monkeypatch):
     def boom(*a, **k):
         raise subprocess.TimeoutExpired(cmd="gh", timeout=30)
@@ -480,6 +492,24 @@ def test_gh_json_raises_weaver_error_with_stderr_on_nonzero_exit(monkeypatch):
         lambda *a, **k: _run_result(returncode=1, stderr="not authenticated"),
     )
     with pytest.raises(WeaverError, match="not authenticated"):
+        gh_json(["pr", "view"])
+
+
+def test_gh_json_falls_back_to_stdout_when_stderr_is_empty(monkeypatch):
+    # An empty stderr on a non-zero exit must not leave the WeaverError with no
+    # diagnostic text at all — fall back to stdout, then a placeholder.
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: _run_result(returncode=1, stdout="rate limited", stderr=""),
+    )
+    with pytest.raises(WeaverError, match="rate limited"):
+        gh_json(["pr", "view"])
+
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _run_result(returncode=1, stdout="", stderr="")
+    )
+    with pytest.raises(WeaverError, match="no output"):
         gh_json(["pr", "view"])
 
 


### PR DESCRIPTION
## Summary
- `pr-label`'s gh subprocess call caught every `OSError`/`SubprocessError`/`ValueError` broadly and returned `None`, so any gh failure (missing binary, unauthenticated, timeout, bad JSON) collapsed into the same generic "labels unreadable via gh" note — no way to tell why the watch wasn't labelling PRs.
- Added `weaver_loom.gh_json`, a shared helper for gh-backed watches that raises `WeaverError` carrying gh's actual error message instead of swallowing it; `pr-label` now folds that reason into its note.
- Added `Round.preview_or`, factoring out the identical `try/except WeaverError` around `client.preview` that `resume.py` and `status.py` each hand-rolled.
- Left the narrow, already-documented `WeaverError` catches in `resume.py`/`status.py` as-is — those are known recoverable failure points (a dead pane), not broad swallows.

## Test plan
- [x] `uv run --with pytest pytest -q` in `python/weaver-loom` — 83 passed (added coverage for `gh_json` and `preview_or`)
- [x] `cargo test -p loom --test integration watches::` — 16 passed, including the `builtin_scripts_report_merged_and_unlabelled_prs` end-to-end pr-label/archive-merged test
- [x] pre-commit fmt/clippy/typecheck hooks passed