### PR TITLE
feat(deploy): install common dev CLIs in the loom image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,22 @@ RUN set -eux; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
       > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends nodejs git ca-certificates gh google-cloud-cli tini \
-      docker-ce-cli docker-buildx-plugin docker-compose-plugin sudo; \
-    rm -rf /var/lib/apt/lists/*
+    # Base runtime + the repo tools loom's agents shell out to. gh/gcloud/docker
+    # come from the signed repos configured above; the rest are stock bookworm.
+    # The last group is the everyday dev CLIs an agent reaches for in a checkout —
+    # jq/ripgrep/fd for search, build-essential/pkg-config for native builds, a
+    # system python3, and the usual archive/editor/pager tools. (cargo, rustc and
+    # cc already ship in the rust base image, so they are not repeated here.)
+    apt-get install -y --no-install-recommends \
+      nodejs git ca-certificates gh google-cloud-cli tini \
+      docker-ce-cli docker-buildx-plugin docker-compose-plugin sudo \
+      jq ripgrep fd-find build-essential pkg-config \
+      python3 python3-pip python3-venv \
+      unzip zip less wget vim tree; \
+    rm -rf /var/lib/apt/lists/*; \
+    # Debian ships fd as `fdfind` to avoid a name clash; expose the conventional
+    # `fd` name agents (and fd-aware tools) expect.
+    ln -s "$(command -v fdfind)" /usr/local/bin/fd
 
 # Claude Code — the agent runtime loom's sessions launch — is deliberately NOT
 # baked into the image. The container runs as a non-root user, so a Claude


### PR DESCRIPTION
## What

Adds the everyday dev command-line tools to the loom runtime image so agents have them in their checkout.

The runtime stage (`FROM rust:1-bookworm`) previously carried only the deploy-specific toolchain — `gh`, `gcloud`, the Docker CLI, node, git. But that image is *also* where loom's agents do their actual work, and they routinely shell out to standard dev utilities that weren't installed.

Added to the runtime apt layer:

- **search:** `jq`, `ripgrep`, `fd-find` (symlinked to the conventional `fd` — Debian ships it as `fdfind`)
- **native builds:** `build-essential`, `pkg-config`
- **python:** a system `python3` (+ `pip`, `venv`)
- **archive/editor/pager staples:** `unzip`, `zip`, `less`, `wget`, `vim`, `tree`

`cargo`, `rustc`, and `cc` already ship in the `rust:1-bookworm` base image, so they're not repeated (the requested `cargo` is already available).

## Verification

Installed all added packages in a throwaway `rust:1-bookworm` container — every package name resolves on bookworm, and confirmed the tools run:

```
jq-1.6 · ripgrep 13.0.0 · fd (fdfind) 8.6.0 · GNU Make 4.3 · pkg-config 1.8.1
Python 3.11.2 · unzip 6.00 · wget 1.21.3 · tree 2.1.0 · cargo 1.96.1 (base image)
```

Closes weaver #393.