### PR TITLE
feat(loom): terminal appearance settings — theme, font, size

### DIFF
--- a/crates/loom/frontend/package-lock.json
+++ b/crates/loom/frontend/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
@@ -184,6 +185,15 @@
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
       "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/crates/loom/frontend/package.json
+++ b/crates/loom/frontend/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",

--- a/crates/loom/frontend/src/components/AgentTerminal.vue
+++ b/crates/loom/frontend/src/components/AgentTerminal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, nextTick } from 'vue';
-import { Terminal, type ITheme } from '@xterm/xterm';
+import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebglAddon } from '@xterm/addon-webgl';
@@ -9,8 +9,12 @@ import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { SearchAddon, type ISearchOptions } from '@xterm/addon-search';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import '@xterm/xterm/css/xterm.css';
-import { get } from '../api';
-import type { SettingView } from '../types';
+import {
+  type TerminalConfig,
+  defaultTerminalConfig,
+  fetchTerminalConfig,
+  ensureFontLoaded,
+} from '../lib/terminalConfig';
 
 // A real terminal in the browser: xterm.js bridged over a WebSocket to the
 // session's terminal supervisor, which streams the raw PTY. The supervisor is
@@ -93,42 +97,6 @@ function clearStatusReveal() {
 const OP_INPUT = 0x00;
 const OP_RESIZE = 0x01;
 
-// Terminal palettes, selected by the `terminal.theme` server setting. The dark
-// palette keeps xterm's own ANSI colours (they already assume a dark terminal)
-// but sits on the UI's recessed-panel tone (--code dark) rather than pure
-// black, so the pane reads as part of the workbench instead of a hole in it.
-// The light palette (Solarized Light) must supply its own foreground, cursor,
-// and full 16-colour set, because xterm's defaults are unreadable on a light
-// background.
-const DARK_THEME: ITheme = { background: '#181818' };
-const LIGHT_THEME: ITheme = {
-  background: '#fdf6e3',
-  foreground: '#586e75',
-  cursor: '#586e75',
-  cursorAccent: '#fdf6e3',
-  selectionBackground: '#eee8d5',
-  black: '#073642',
-  red: '#dc322f',
-  green: '#859900',
-  yellow: '#b58900',
-  blue: '#268bd2',
-  magenta: '#d33682',
-  cyan: '#2aa198',
-  white: '#eee8d5',
-  brightBlack: '#002b36',
-  brightRed: '#cb4b16',
-  brightGreen: '#586e75',
-  brightYellow: '#657b83',
-  brightBlue: '#839496',
-  brightMagenta: '#6c71c4',
-  brightCyan: '#93a1a1',
-  brightWhite: '#fdf6e3',
-};
-
-function themeFor(name: string | undefined): ITheme {
-  return name === 'light' ? LIGHT_THEME : DARK_THEME;
-}
-
 // Open a URL only if it is http(s); reject javascript:/data:/file: which an
 // untrusted agent could otherwise emit. Shared by the OSC 8 linkHandler (for
 // explicit hyperlinks) and the web-links addon (which linkifies bare URLs that
@@ -189,25 +157,11 @@ async function copyOutput() {
   }
 }
 
-// How long to wait for the theme fetch before opening the terminal with the
-// dark default anyway. Same-origin localhost answers in single-digit ms; this
-// ceiling only matters if the request stalls, so the terminal never hangs
-// closed waiting on it.
-const THEME_FETCH_TIMEOUT_MS = 1000;
-
-// Best-effort fetch of the configured terminal theme. Any failure (offline,
-// stale server without the setting) falls back to the dark default. The caller
-// races this against a timeout so a *slow* (not just failed) request can't hold
-// the terminal closed either.
-async function loadTheme(): Promise<ITheme> {
-  try {
-    const res = (await get('/settings')) as { settings?: SettingView[] };
-    const s = res?.settings?.find((x) => x.key === 'terminal.theme');
-    return themeFor(s?.value);
-  } catch {
-    return DARK_THEME;
-  }
-}
+// How long to wait for the appearance fetch before opening the terminal with
+// the dark, default-font config anyway. Same-origin localhost answers in
+// single-digit ms; this ceiling only matters if the request stalls, so the
+// terminal never hangs closed waiting on it.
+const CONFIG_FETCH_TIMEOUT_MS = 1000;
 
 function wsUrl(): string {
   // http→ws / https→wss on the page origin.
@@ -314,32 +268,30 @@ function onVisible() {
 
 onMounted(async () => {
   if (!host.value) return;
-  // Resolve the configured palette before constructing the terminal so it
-  // paints in the right theme from the first frame (no dark→light flash on the
-  // common fast path). But never let a slow/stalled request hold the terminal
-  // closed: race the fetch against a short timeout, open with the dark default
-  // if it loses, and upgrade to the configured palette once it lands.
-  const themePromise = loadTheme();
-  const initialTheme = await Promise.race([
-    themePromise,
-    new Promise<ITheme>((resolve) => setTimeout(() => resolve(DARK_THEME), THEME_FETCH_TIMEOUT_MS)),
+  // Resolve the configured appearance (palette, font, size) before constructing
+  // the terminal so it paints right from the first frame (no dark→light or
+  // font-swap flash on the common fast path). But never let a slow/stalled
+  // request hold the terminal closed: race the fetch against a short timeout,
+  // open with the dark defaults if it loses, and upgrade once it lands.
+  const configPromise = fetchTerminalConfig();
+  const initial = await Promise.race<TerminalConfig>([
+    configPromise,
+    new Promise<TerminalConfig>((resolve) =>
+      setTimeout(() => resolve(defaultTerminalConfig()), CONFIG_FETCH_TIMEOUT_MS),
+    ),
   ]);
   if (disposed || !host.value) return; // unmounted while the fetch was in flight
-  // Make sure the bundled mono face is ready before xterm measures its cell
+  // Make sure the chosen mono face is ready before xterm measures its cell
   // grid — a fallback-metrics first paint would misalign the whole pane.
-  // fonts.load resolves quickly (and harmlessly) even if the face is missing;
-  // skip it where the FontFaceSet API itself is absent.
-  if (document.fonts?.load) {
-    await document.fonts.load('13px "IBM Plex Mono"').catch(() => {});
-    if (disposed || !host.value) return;
-  }
+  await ensureFontLoaded(initial.fontFamily, initial.fontSize);
+  if (disposed || !host.value) return;
   term = new Terminal({
     convertEol: false,
-    fontFamily: '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-    fontSize: 13,
+    fontFamily: initial.fontFamily,
+    fontSize: initial.fontSize,
     scrollback: 5000,
     allowProposedApi: true, // required to activate the unicode11 addon
-    theme: initialTheme,
+    theme: initial.theme,
     // Constrain agent-supplied OSC 8 hyperlinks to http(s); reject
     // javascript:/data:/file: which an untrusted agent could otherwise emit.
     linkHandler: {
@@ -350,12 +302,20 @@ onMounted(async () => {
   });
   term.open(host.value);
 
-  // If the timeout won the race above, apply the real palette once the fetch
-  // resolves. Reference equality holds because the palettes are module-level
-  // singletons, so a no-op (configured theme === fallback) doesn't churn the
-  // renderer.
-  themePromise.then((t) => {
-    if (!disposed && term && t !== initialTheme) term.options.theme = t;
+  // If the timeout won the race above, apply the real config once the fetch
+  // resolves. Only touch options that actually differ so a no-op (configured ===
+  // fallback) doesn't churn the renderer; a font change reloads its face first,
+  // then a fit() re-measures the cell grid for the new metrics.
+  configPromise.then(async (cfg) => {
+    if (disposed || !term) return;
+    if (cfg.theme !== initial.theme) term.options.theme = cfg.theme;
+    if (cfg.fontFamily !== initial.fontFamily || cfg.fontSize !== initial.fontSize) {
+      await ensureFontLoaded(cfg.fontFamily, cfg.fontSize);
+      if (disposed || !term) return;
+      term.options.fontFamily = cfg.fontFamily;
+      term.options.fontSize = cfg.fontSize;
+      scheduleFit();
+    }
   });
 
   fit = new FitAddon();

--- a/crates/loom/frontend/src/components/AppearancePanel.vue
+++ b/crates/loom/frontend/src/components/AppearancePanel.vue
@@ -261,7 +261,7 @@ onUnmounted(() => {
       <div class="grid gap-3 border-t border-line pt-4 md:grid-cols-[10rem_minmax(0,1fr)]">
         <div class="min-w-0">
           <div class="text-sm font-medium">Size</div>
-          <p class="mt-0.5 text-xs text-muted">Point size, {{ MIN_FONT_SIZE }}–{{ MAX_FONT_SIZE }}.</p>
+          <p class="mt-0.5 text-xs text-muted">Pixel size, {{ MIN_FONT_SIZE }}–{{ MAX_FONT_SIZE }}.</p>
         </div>
         <div class="flex flex-wrap items-center gap-2">
           <button
@@ -321,7 +321,7 @@ onUnmounted(() => {
         </button>
         <button
           class="btn-secondary px-3 py-1.5 text-xs disabled:opacity-50"
-          :disabled="busy || allDefault"
+          :disabled="busy || allDefault || !loaded"
           title="Reset theme, font, and size to their defaults"
           @click="resetDefaults"
         >

--- a/crates/loom/frontend/src/components/AppearancePanel.vue
+++ b/crates/loom/frontend/src/components/AppearancePanel.vue
@@ -1,0 +1,334 @@
+<script setup lang="ts">
+import { ref, computed, reactive, onMounted, onUnmounted, watch, nextTick } from 'vue';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+import { get, patch } from '../api';
+import type { SettingView } from '../types';
+import {
+  FONT_CHOICES,
+  fontStack,
+  themeFor,
+  ensureFontLoaded,
+  clampFontSize,
+  MIN_FONT_SIZE,
+  MAX_FONT_SIZE,
+  DEFAULT_FONT_SIZE,
+} from '../lib/terminalConfig';
+
+// The terminal Appearance pane: theme, font, and size for the in-browser
+// terminal, with a live xterm preview that renders exactly what a real terminal
+// will. Self-contained like the other settings panels — it fetches and patches
+// `/settings` directly rather than routing through the parent's drafts.
+
+const THEME_KEY = 'terminal.theme';
+const FONT_KEY = 'terminal.font';
+const SIZE_KEY = 'terminal.font_size';
+const KEYS = [THEME_KEY, FONT_KEY, SIZE_KEY];
+
+const THEMES = [
+  { token: 'dark', label: 'Dark', bg: '#181818', fg: '#d0d0d0' },
+  { token: 'light', label: 'Light', bg: '#fdf6e3', fg: '#586e75' },
+];
+
+const SIZE_PRESETS = [12, 13, 14, 16];
+
+// Sample session shown in the preview. Uses only the base-16 SGR colours (plus
+// bold/underline) so the swatches and text track whichever palette the theme
+// supplies — that's what makes the dark↔light difference legible at a glance.
+const SAMPLE = [
+  '\x1b[1;32m➜\x1b[0m \x1b[1;36m~/weaver\x1b[0m \x1b[1;30mgit:(\x1b[33mmain\x1b[1;30m)\x1b[0m cargo run',
+  '\x1b[32m   Compiling\x1b[0m loom \x1b[90mv0.1.0\x1b[0m',
+  '\x1b[1;34mINFO\x1b[0m server listening on \x1b[4;36mhttp://127.0.0.1:8080\x1b[0m',
+  '\x1b[31merror\x1b[0m: \x1b[1mconnection reset\x1b[0m — retrying',
+  '',
+  '  \x1b[30;40m 0 \x1b[31;41m 1 \x1b[32;42m 2 \x1b[33;43m 3 \x1b[34;44m 4 \x1b[35;45m 5 \x1b[36;46m 6 \x1b[37;47m 7 \x1b[0m',
+  '  \x1b[90;100m 8 \x1b[91;101m 9 \x1b[92;102m10 \x1b[93;103m11 \x1b[94;104m12 \x1b[95;105m13 \x1b[96;106m14 \x1b[97;107m15 \x1b[0m',
+  '\x1b[1;32m➜\x1b[0m \x1b[1;36m~/weaver\x1b[0m ',
+].join('\r\n');
+
+const stored = ref<Record<string, SettingView>>({});
+const draft = reactive<Record<string, string>>({
+  [THEME_KEY]: 'dark',
+  [FONT_KEY]: 'plex',
+  [SIZE_KEY]: String(DEFAULT_FONT_SIZE),
+});
+const busy = ref(false);
+const error = ref('');
+const notice = ref('');
+const loaded = ref(false);
+
+const host = ref<HTMLElement | null>(null);
+let term: Terminal | null = null;
+let fit: FitAddon | null = null;
+let observer: ResizeObserver | null = null;
+let disposed = false;
+
+const sizeNumber = computed(() => clampFontSize(Number(draft[SIZE_KEY])));
+
+const dirty = computed(() => KEYS.some((k) => draft[k] !== stored.value[k]?.value));
+const allDefault = computed(() => KEYS.every((k) => stored.value[k]?.is_default));
+
+function adopt(settings: SettingView[]) {
+  const byKey: Record<string, SettingView> = {};
+  for (const s of settings) if (KEYS.includes(s.key)) byKey[s.key] = s;
+  stored.value = byKey;
+  for (const k of KEYS) if (byKey[k]) draft[k] = byKey[k].value;
+}
+
+async function load() {
+  try {
+    const res = (await get('/settings')) as { settings?: SettingView[] };
+    adopt(res?.settings ?? []);
+    error.value = '';
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    loaded.value = true;
+  }
+}
+
+function patchBody(reset: boolean): Record<string, string | null> {
+  return Object.fromEntries(KEYS.map((k) => [k, reset ? null : draft[k]]));
+}
+
+async function commit(body: Record<string, string | null>, done: string) {
+  busy.value = true;
+  error.value = '';
+  notice.value = '';
+  try {
+    const res = (await patch('/settings', body)) as { settings?: SettingView[] };
+    adopt(res?.settings ?? []);
+    notice.value = done;
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function save() {
+  if (!dirty.value) return;
+  // Normalise the size to the clamped value we actually apply before saving.
+  draft[SIZE_KEY] = String(sizeNumber.value);
+  await commit(patchBody(false), 'Saved terminal appearance.');
+}
+
+async function resetDefaults() {
+  await commit(patchBody(true), 'Reset terminal appearance to defaults.');
+}
+
+function nudgeSize(delta: number) {
+  draft[SIZE_KEY] = String(clampFontSize(sizeNumber.value + delta));
+}
+
+// --- Live preview ----------------------------------------------------------
+
+async function applyPreview() {
+  if (!term) return;
+  const family = fontStack(draft[FONT_KEY]);
+  await ensureFontLoaded(family, sizeNumber.value);
+  if (disposed || !term) return;
+  term.options.theme = themeFor(draft[THEME_KEY]);
+  term.options.fontFamily = family;
+  term.options.fontSize = sizeNumber.value;
+  fit?.fit();
+}
+
+async function buildPreview() {
+  if (!host.value || term) return;
+  const family = fontStack(draft[FONT_KEY]);
+  await ensureFontLoaded(family, sizeNumber.value);
+  if (disposed || !host.value) return;
+  term = new Terminal({
+    convertEol: false,
+    disableStdin: true,
+    cursorBlink: true,
+    fontFamily: family,
+    fontSize: sizeNumber.value,
+    scrollback: 0,
+    theme: themeFor(draft[THEME_KEY]),
+  });
+  fit = new FitAddon();
+  term.loadAddon(fit);
+  term.open(host.value);
+  fit.fit();
+  term.write(SAMPLE);
+  observer = new ResizeObserver(() => fit?.fit());
+  observer.observe(host.value);
+}
+
+// Re-render the preview whenever a control changes (before the user saves), so
+// the preview is always the pending selection, not the persisted one.
+watch(
+  () => [draft[THEME_KEY], draft[FONT_KEY], sizeNumber.value],
+  () => applyPreview(),
+);
+
+onMounted(async () => {
+  await load();
+  await nextTick();
+  await buildPreview();
+});
+
+onUnmounted(() => {
+  disposed = true;
+  observer?.disconnect();
+  term?.dispose();
+});
+</script>
+
+<template>
+  <div class="space-y-4">
+    <p v-if="notice" class="text-xs text-accent">{{ notice }}</p>
+    <p v-if="error" class="text-xs text-block">{{ error }}</p>
+
+    <!-- Live preview: a real xterm instance, so what shows here is exactly what
+         a session terminal renders with these settings. -->
+    <section class="overflow-hidden rounded-md border border-line bg-surface">
+      <div class="flex items-center justify-between border-b border-line px-3 py-2">
+        <h3 class="text-sm font-medium">Preview</h3>
+        <span class="rounded bg-input px-1.5 py-0.5 font-mono text-2xs text-faint">live</span>
+      </div>
+      <div class="p-3">
+        <div class="overflow-hidden rounded ring-1 ring-line">
+          <div ref="host" class="h-44 w-full" data-testid="appearance-preview"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Controls -->
+    <section class="space-y-4 rounded-md border border-line bg-surface p-4">
+      <!-- Theme -->
+      <div class="grid gap-3 md:grid-cols-[10rem_minmax(0,1fr)]">
+        <div class="min-w-0">
+          <div class="text-sm font-medium">Theme</div>
+          <p class="mt-0.5 text-xs text-muted">Colour palette for the terminal.</p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="t in THEMES"
+            :key="t.token"
+            type="button"
+            :data-testid="`theme-${t.token}`"
+            :aria-pressed="draft[THEME_KEY] === t.token"
+            class="flex items-center gap-2 rounded border px-3 py-1.5 text-sm"
+            :class="
+              draft[THEME_KEY] === t.token
+                ? 'border-accent bg-accent text-accent-fg'
+                : 'border-line bg-input text-muted hover:bg-subtle hover:text-fg'
+            "
+            @click="draft[THEME_KEY] = t.token"
+          >
+            <span
+              class="h-4 w-4 rounded-full ring-1 ring-line"
+              :style="{ background: t.bg, color: t.fg }"
+              aria-hidden="true"
+            ></span>
+            {{ t.label }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Font -->
+      <div class="grid gap-3 border-t border-line pt-4 md:grid-cols-[10rem_minmax(0,1fr)]">
+        <div class="min-w-0">
+          <div class="text-sm font-medium">Font</div>
+          <p class="mt-0.5 text-xs text-muted">Typeface, previewed in its own face.</p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="f in FONT_CHOICES"
+            :key="f.token"
+            type="button"
+            :data-testid="`font-${f.token}`"
+            :aria-pressed="draft[FONT_KEY] === f.token"
+            class="rounded border px-3 py-1.5 text-sm"
+            :class="
+              draft[FONT_KEY] === f.token
+                ? 'border-accent bg-accent text-accent-fg'
+                : 'border-line bg-input text-muted hover:bg-subtle hover:text-fg'
+            "
+            :style="{ fontFamily: fontStack(f.token) }"
+            @click="draft[FONT_KEY] = f.token"
+          >
+            {{ f.label }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Size -->
+      <div class="grid gap-3 border-t border-line pt-4 md:grid-cols-[10rem_minmax(0,1fr)]">
+        <div class="min-w-0">
+          <div class="text-sm font-medium">Size</div>
+          <p class="mt-0.5 text-xs text-muted">Point size, {{ MIN_FONT_SIZE }}–{{ MAX_FONT_SIZE }}.</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <button
+            v-for="p in SIZE_PRESETS"
+            :key="p"
+            type="button"
+            :aria-pressed="sizeNumber === p"
+            class="rounded border px-2.5 py-1 text-xs tabular-nums"
+            :class="
+              sizeNumber === p
+                ? 'border-accent bg-accent text-accent-fg'
+                : 'border-line bg-input text-muted hover:bg-subtle hover:text-fg'
+            "
+            @click="draft[SIZE_KEY] = String(p)"
+          >
+            {{ p }}
+          </button>
+          <div class="flex items-center overflow-hidden rounded border border-line">
+            <button
+              type="button"
+              class="px-2 py-1 text-sm text-muted hover:bg-subtle hover:text-fg"
+              title="Smaller"
+              @click="nudgeSize(-1)"
+            >
+              −
+            </button>
+            <input
+              :value="draft[SIZE_KEY]"
+              type="number"
+              :min="MIN_FONT_SIZE"
+              :max="MAX_FONT_SIZE"
+              data-testid="font-size-input"
+              class="w-14 bg-input px-2 py-1 text-center text-sm tabular-nums outline-none"
+              @input="draft[SIZE_KEY] = ($event.target as HTMLInputElement).value"
+            />
+            <button
+              type="button"
+              class="px-2 py-1 text-sm text-muted hover:bg-subtle hover:text-fg"
+              title="Larger"
+              @click="nudgeSize(1)"
+            >
+              +
+            </button>
+          </div>
+          <span class="text-2xs text-faint">px</span>
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex items-center gap-2 border-t border-line pt-4">
+        <button
+          class="btn-primary px-3 py-1.5 text-xs disabled:opacity-50"
+          :disabled="busy || !dirty || !loaded"
+          @click="save"
+        >
+          Save
+        </button>
+        <button
+          class="btn-secondary px-3 py-1.5 text-xs disabled:opacity-50"
+          :disabled="busy || allDefault"
+          title="Reset theme, font, and size to their defaults"
+          @click="resetDefaults"
+        >
+          Reset to defaults
+        </button>
+        <span v-if="dirty" class="text-2xs text-faint">Unsaved changes — applies to terminals opened after saving.</span>
+      </div>
+    </section>
+  </div>
+</template>

--- a/crates/loom/frontend/src/lib/terminalConfig.ts
+++ b/crates/loom/frontend/src/lib/terminalConfig.ts
@@ -1,0 +1,139 @@
+// Terminal appearance: the single place that turns the `terminal.*` server
+// settings into concrete xterm.js options (palette, font stack, size). Both the
+// live terminal (`AgentTerminal.vue`) and the settings preview
+// (`AppearancePanel.vue`) resolve through here, so what the preview shows is
+// exactly what a real terminal renders.
+
+import type { ITheme } from '@xterm/xterm';
+import { get } from '../api';
+import type { SettingView } from '../types';
+
+// Terminal palettes, selected by the `terminal.theme` setting. The dark palette
+// keeps xterm's own ANSI colours (they already assume a dark terminal) but sits
+// on the UI's recessed-panel tone rather than pure black, so the pane reads as
+// part of the workbench instead of a hole in it. The light palette (Solarized
+// Light) must supply its own foreground, cursor, and full 16-colour set,
+// because xterm's defaults are unreadable on a light background.
+export const DARK_THEME: ITheme = { background: '#181818' };
+export const LIGHT_THEME: ITheme = {
+  background: '#fdf6e3',
+  foreground: '#586e75',
+  cursor: '#586e75',
+  cursorAccent: '#fdf6e3',
+  selectionBackground: '#eee8d5',
+  black: '#073642',
+  red: '#dc322f',
+  green: '#859900',
+  yellow: '#b58900',
+  blue: '#268bd2',
+  magenta: '#d33682',
+  cyan: '#2aa198',
+  white: '#eee8d5',
+  brightBlack: '#002b36',
+  brightRed: '#cb4b16',
+  brightGreen: '#586e75',
+  brightYellow: '#657b83',
+  brightBlue: '#839496',
+  brightMagenta: '#6c71c4',
+  brightCyan: '#93a1a1',
+  brightWhite: '#fdf6e3',
+};
+
+export type ThemeToken = 'dark' | 'light';
+export const DEFAULT_THEME: ThemeToken = 'dark';
+
+export function themeFor(name: string | undefined): ITheme {
+  return name === 'light' ? LIGHT_THEME : DARK_THEME;
+}
+
+// Font tokens the `terminal.font` setting stores, mapped to concrete stacks. The
+// bundled faces (imported in main.ts) lead their stack; the platform monospace
+// stack is the last-resort fallback and the whole of the `system` choice.
+export type FontToken = 'plex' | 'jetbrains' | 'system';
+export const DEFAULT_FONT: FontToken = 'plex';
+
+const SYSTEM_STACK = 'ui-monospace, SFMono-Regular, Menlo, Consolas, "DejaVu Sans Mono", monospace';
+
+export const FONT_STACKS: Record<FontToken, string> = {
+  plex: `"IBM Plex Mono", ${SYSTEM_STACK}`,
+  jetbrains: `"JetBrains Mono", ${SYSTEM_STACK}`,
+  system: SYSTEM_STACK,
+};
+
+// Human labels + a representative face to load before measuring, keyed by token.
+// Consumed by the Appearance picker so each option previews in its own font.
+export const FONT_CHOICES: { token: FontToken; label: string; face: string | null }[] = [
+  { token: 'plex', label: 'IBM Plex Mono', face: 'IBM Plex Mono' },
+  { token: 'jetbrains', label: 'JetBrains Mono', face: 'JetBrains Mono' },
+  { token: 'system', label: 'System monospace', face: null },
+];
+
+export function fontStack(token: string | undefined): string {
+  return FONT_STACKS[(token as FontToken) ?? DEFAULT_FONT] ?? FONT_STACKS[DEFAULT_FONT];
+}
+
+// Font size, in points. Clamp what we apply to a legible range so a stray edit
+// (or a stale value) can't render the terminal unusable.
+export const DEFAULT_FONT_SIZE = 13;
+export const MIN_FONT_SIZE = 8;
+export const MAX_FONT_SIZE = 24;
+
+export function clampFontSize(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_FONT_SIZE;
+  return Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, Math.round(n)));
+}
+
+export interface TerminalConfig {
+  themeToken: string;
+  theme: ITheme;
+  fontToken: string;
+  fontFamily: string;
+  fontSize: number;
+}
+
+function valueOf(settings: SettingView[], key: string, fallback: string): string {
+  return settings.find((s) => s.key === key)?.value?.trim() || fallback;
+}
+
+// Turn a settings snapshot into resolved xterm options. Pure — pass live
+// `/settings` values or in-flight drafts; the preview uses the same path.
+export function resolveTerminalConfig(settings: SettingView[]): TerminalConfig {
+  const themeToken = valueOf(settings, 'terminal.theme', DEFAULT_THEME);
+  const fontToken = valueOf(settings, 'terminal.font', DEFAULT_FONT);
+  const fontSize = clampFontSize(Number(valueOf(settings, 'terminal.font_size', String(DEFAULT_FONT_SIZE))));
+  return {
+    themeToken,
+    theme: themeFor(themeToken),
+    fontToken,
+    fontFamily: fontStack(fontToken),
+    fontSize,
+  };
+}
+
+// The dark, default-everything config — the safe fallback when `/settings` is
+// slow or unreachable, and the base a live terminal opens with before the fetch
+// lands.
+export function defaultTerminalConfig(): TerminalConfig {
+  return resolveTerminalConfig([]);
+}
+
+// Best-effort fetch + resolve of the configured terminal appearance. Any
+// failure (offline, a stale server missing the keys) falls back to the dark
+// defaults.
+export async function fetchTerminalConfig(): Promise<TerminalConfig> {
+  try {
+    const res = (await get('/settings')) as { settings?: SettingView[] };
+    return resolveTerminalConfig(res?.settings ?? []);
+  } catch {
+    return defaultTerminalConfig();
+  }
+}
+
+// Preload a bundled face so xterm measures real (not fallback) cell metrics
+// before it paints — avoids a reflow/misalign on first render or a font switch.
+// A missing face or absent FontFaceSet API resolves harmlessly.
+export async function ensureFontLoaded(fontFamily: string, size: number): Promise<void> {
+  const face = fontFamily.match(/"([^"]+)"/)?.[1];
+  if (!face || !document.fonts?.load) return;
+  await document.fonts.load(`${size}px "${face}"`).catch(() => {});
+}

--- a/crates/loom/frontend/src/lib/terminalConfig.ts
+++ b/crates/loom/frontend/src/lib/terminalConfig.ts
@@ -72,8 +72,9 @@ export function fontStack(token: string | undefined): string {
   return FONT_STACKS[(token as FontToken) ?? DEFAULT_FONT] ?? FONT_STACKS[DEFAULT_FONT];
 }
 
-// Font size, in points. Clamp what we apply to a legible range so a stray edit
-// (or a stale value) can't render the terminal unusable.
+// Font size, in CSS pixels (xterm's `fontSize`). Clamp what we apply to a
+// legible range so a stray edit (or a stale value) can't render the terminal
+// unusable.
 export const DEFAULT_FONT_SIZE = 13;
 export const MIN_FONT_SIZE = 8;
 export const MAX_FONT_SIZE = 24;

--- a/crates/loom/frontend/src/main.ts
+++ b/crates/loom/frontend/src/main.ts
@@ -6,6 +6,10 @@ import '@fontsource-variable/ibm-plex-sans/wght-italic.css';
 import '@fontsource/ibm-plex-mono/400.css';
 import '@fontsource/ibm-plex-mono/500.css';
 import '@fontsource/ibm-plex-mono/600.css';
+// A second bundled mono, offered as a terminal typeface in Appearance settings
+// (the platform stack is the third choice, needing no bundled face).
+import '@fontsource/jetbrains-mono/400.css';
+import '@fontsource/jetbrains-mono/500.css';
 import { createApp } from 'vue';
 import { createRouter, createWebHistory } from 'vue-router';
 import App from './App.vue';

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -10,6 +10,7 @@ import EnvPanel from '../components/EnvPanel.vue';
 import LogsPanel from '../components/LogsPanel.vue';
 import AgentProfileEditor from '../components/AgentProfileEditor.vue';
 import CustomAgentsPanel from '../components/CustomAgentsPanel.vue';
+import AppearancePanel from '../components/AppearancePanel.vue';
 import SettingFieldRow from '../components/SettingFieldRow.vue';
 
 const route = useRoute();
@@ -81,7 +82,7 @@ const categories: CategoryItem[] = [
     id: 'appearance',
     label: 'Appearance',
     group: 'Appearance',
-    summary: 'Visual preferences for the workbench and terminal.',
+    summary: 'Theme, font, and size for the in-browser terminal, with a live preview.',
   },
   {
     id: 'env',
@@ -435,6 +436,7 @@ onMounted(load);
         <TokensPanel v-else-if="category === 'tokens'" />
         <AccountPanel v-else-if="category === 'account'" />
         <LogsPanel v-else-if="category === 'logs'" />
+        <AppearancePanel v-else-if="category === 'appearance'" />
 
         <div v-else-if="category === 'agents'" class="space-y-4">
           <AgentProfileEditor

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -36,6 +36,16 @@ pub const DEFAULT_GITHUB_TRIGGER_PHRASE: &str = "@loom";
 /// The palette the browser terminal (xterm.js) renders with. `dark` keeps the
 /// classic black background; `light` swaps in a light, readable palette.
 pub const DEFAULT_TERMINAL_THEME: &str = "dark";
+/// The typeface the browser terminal renders with. A token, not a raw font
+/// stack: the frontend maps it to a concrete `font-family` (`plex` → the
+/// bundled IBM Plex Mono, `jetbrains` → the bundled JetBrains Mono, `system` →
+/// the platform monospace stack). Keeping it a token keeps the stored value
+/// stable and the CSS the frontend's concern.
+pub const DEFAULT_TERMINAL_FONT: &str = "plex";
+/// Point size the browser terminal renders at. The frontend clamps the applied
+/// value to a legible range (8–24) so a stray edit can't make the terminal
+/// unusable.
+pub const DEFAULT_TERMINAL_FONT_SIZE: i64 = 13;
 /// Whether requests from the loopback interface are trusted as the machine owner
 /// without a token or login. On by default: it keeps the local CLI, the agent,
 /// and watch scripts working with no configuration. Turn it off behind a
@@ -265,6 +275,29 @@ pub const REGISTRY: &[SettingSpec] = &[
         default: DEFAULT_TERMINAL_THEME,
         group: "Appearance",
         options: &["dark", "light"],
+    },
+    SettingSpec {
+        key: "terminal.font",
+        label: "Terminal font",
+        description: "Typeface for the in-browser terminal. `plex` is the \
+            bundled IBM Plex Mono; `jetbrains` is the bundled JetBrains Mono; \
+            `system` uses the platform's own monospace font. Takes effect the \
+            next time a terminal is opened.",
+        kind: SettingKind::Enum,
+        default: DEFAULT_TERMINAL_FONT,
+        group: "Appearance",
+        options: &["plex", "jetbrains", "system"],
+    },
+    SettingSpec {
+        key: "terminal.font_size",
+        label: "Terminal font size",
+        description: "Point size for the in-browser terminal. Clamped to a \
+            legible 8–24 range when applied. Takes effect the next time a \
+            terminal is opened.",
+        kind: SettingKind::Int,
+        default: "13",
+        group: "Appearance",
+        options: &[],
     },
     SettingSpec {
         key: "watch.enabled",
@@ -652,6 +685,19 @@ mod tests {
         assert_eq!(json["options"], serde_json::json!(["dark", "light"]));
         assert_eq!(json["value"], "dark");
         assert_eq!(json["is_default"], true);
+    }
+
+    #[test]
+    fn terminal_appearance_settings_validate() {
+        // Font is an enum: only the three declared tokens pass.
+        assert!(validate("terminal.font", "plex").is_ok());
+        assert!(validate("terminal.font", "jetbrains").is_ok());
+        assert!(validate("terminal.font", "system").is_ok());
+        assert!(validate("terminal.font", "comic-sans").is_err());
+        // Font size is an int: numbers pass, prose does not. (Range clamping is
+        // the frontend's job — the registry only guards the kind.)
+        assert!(validate("terminal.font_size", "14").is_ok());
+        assert!(validate("terminal.font_size", "large").is_err());
     }
 
     #[tokio::test]

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -42,9 +42,9 @@ pub const DEFAULT_TERMINAL_THEME: &str = "dark";
 /// the platform monospace stack). Keeping it a token keeps the stored value
 /// stable and the CSS the frontend's concern.
 pub const DEFAULT_TERMINAL_FONT: &str = "plex";
-/// Point size the browser terminal renders at. The frontend clamps the applied
-/// value to a legible range (8–24) so a stray edit can't make the terminal
-/// unusable.
+/// Pixel size the browser terminal renders at (xterm's `fontSize`, in CSS px).
+/// The frontend clamps the applied value to a legible range (8–24) so a stray
+/// edit can't make the terminal unusable.
 pub const DEFAULT_TERMINAL_FONT_SIZE: i64 = 13;
 /// Whether requests from the loopback interface are trusted as the machine owner
 /// without a token or login. On by default: it keeps the local CLI, the agent,
@@ -291,8 +291,8 @@ pub const REGISTRY: &[SettingSpec] = &[
     SettingSpec {
         key: "terminal.font_size",
         label: "Terminal font size",
-        description: "Point size for the in-browser terminal. Clamped to a \
-            legible 8–24 range when applied. Takes effect the next time a \
+        description: "Pixel size for the in-browser terminal (CSS px). Clamped \
+            to a legible 8–24 range when applied. Takes effect the next time a \
             terminal is opened.",
         kind: SettingKind::Int,
         default: "13",

--- a/e2e/tests/appearance.spec.ts
+++ b/e2e/tests/appearance.spec.ts
@@ -9,7 +9,7 @@ test.describe('settings · terminal appearance', () => {
     const preview = page.getByTestId('appearance-preview');
     await expect(preview.locator('.xterm')).toBeVisible();
 
-    // Defaults: dark theme, IBM Plex Mono, 13pt.
+    // Defaults: dark theme, IBM Plex Mono, 13px.
     await expect(page.getByTestId('theme-dark')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-plex')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-size-input')).toHaveValue('13');

--- a/e2e/tests/appearance.spec.ts
+++ b/e2e/tests/appearance.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '../fixtures/weaver';
+
+test.describe('settings · terminal appearance', () => {
+  test('live preview, save, persist, and reset', async ({ page, weaver }) => {
+    await page.goto(`${weaver.baseUrl}/settings?tab=appearance`);
+
+    // The live preview is a real xterm instance — the same renderer a session
+    // terminal uses — so it proves the config resolves end to end.
+    const preview = page.getByTestId('appearance-preview');
+    await expect(preview.locator('.xterm')).toBeVisible();
+
+    // Defaults: dark theme, IBM Plex Mono, 13pt.
+    await expect(page.getByTestId('theme-dark')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('font-plex')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('font-size-input')).toHaveValue('13');
+
+    // Change every knob and save.
+    await page.getByTestId('theme-light').click();
+    await page.getByTestId('font-jetbrains').click();
+    await page.getByTestId('font-size-input').fill('16');
+    await expect(page.getByTestId('theme-light')).toHaveAttribute('aria-pressed', 'true');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Saved terminal appearance.')).toBeVisible();
+
+    // The server is the source of truth — the API reflects the new values.
+    const settings = (await page.evaluate(async () => {
+      const r = await fetch('/api/settings');
+      return (await r.json()).settings as { key: string; value: string }[];
+    })) as { key: string; value: string }[];
+    const value = (k: string) => settings.find((s) => s.key === k)?.value;
+    expect(value('terminal.theme')).toBe('light');
+    expect(value('terminal.font')).toBe('jetbrains');
+    expect(value('terminal.font_size')).toBe('16');
+
+    // …and the selection survives a reload (the panel reads back from /settings).
+    await page.reload();
+    await expect(page.getByTestId('theme-light')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('font-jetbrains')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('font-size-input')).toHaveValue('16');
+
+    // Reset returns all three to their registry defaults.
+    await page.getByRole('button', { name: 'Reset to defaults' }).click();
+    await expect(page.getByText('Reset terminal appearance to defaults.')).toBeVisible();
+    await expect(page.getByTestId('theme-dark')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('font-plex')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('font-size-input')).toHaveValue('13');
+  });
+});


### PR DESCRIPTION
The Appearance settings pane now configures the in-browser terminal's theme, font, and size, with a live preview.

## What
- Two new registry settings alongside `terminal.theme`: `terminal.font` (`plex` → the bundled IBM Plex Mono, `jetbrains` → the bundled JetBrains Mono, `system` → the platform monospace stack) and `terminal.font_size` (points, clamped to 8–24 when applied).
- A dedicated `AppearancePanel` replaces the generic setting rows for the Appearance category. It renders a real xterm instance as a live preview, so theme, typeface, and size are shown exactly as a session terminal will render them before you save. Each font option previews in its own face.
- A shared `lib/terminalConfig` module resolves the three settings into xterm options. `AgentTerminal` consumes it, so the live terminal now applies font family and size, not just the palette — and the preview and the real terminal stay in lockstep.

## Why
The terminal previously hardcoded IBM Plex Mono at 13px; only the palette was configurable. This makes the terminal's appearance a first-class, API-backed preference like the rest of settings — set from the UI (or the CLI, via the registry) and consumed by the thin client.

Settings are validated and persisted through the existing `GET`/`PATCH /api/settings` contract. Covered by a weaver-core validation test and an `appearance` e2e that exercises the preview, save, persistence, and reset; verified visually in both workbench themes.

Part of #394