### PR TITLE
feat(loom): launch into any GitHub repo; surface adopt/archive in the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules/
 .weaver/
 .bot/
 e2e/test-results/
+test-results/
 *.pyc
 python/weaver-loom/dist/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ loom server run                            # run the daemon (REST + UI + termina
 loom session launch "Add a /health endpoint"               # new worktree + terminal + agent, seeded with the task
 loom session launch "Refactor the parser" --name parser-refactor   # override the branch slug
 loom session launch "Big refactor" --model opus --effort high      # pick model tier + reasoning effort
+loom session launch "Fix the flaky test" --repo ~/code/other       # a local checkout other than the cwd
+loom session launch "How do I run this?" --repo acme/widgets       # a GitHub repo — cloned on first use
 loom session poll <session>           # one-shot status (lifecycle + attention)
 loom session wait <session>           # block until it finishes or needs you
 loom session send <session> "try the curl again"   # type a message + Enter (trigger an agent round)

--- a/crates/loom/CONCIERGE.md
+++ b/crates/loom/CONCIERGE.md
@@ -63,11 +63,14 @@ operator confirm in their next message.
 
 `loom session launch` cuts the new worktree from the mainline of *one* repo,
 defaulting to whatever checkout you run it in. Say which repo explicitly: pass
-`--repo <path>` pointing at (any directory inside) the target checkout, or `cd`
-into it first. The repos live under `/home/power/code/<repo>/` — e.g. `marin`,
-`tunix`, `marin-experiments`. So for marin work:
+`--repo`, or `cd` into it first. `--repo` takes either a path to (any directory
+inside) a local checkout, or a GitHub `owner/name` slug — a repo loom doesn't
+have yet is cloned on first use, so you can launch into one that was never
+checked out here. The local repos live under `/home/power/code/<repo>/` — e.g.
+`marin`, `tunix`, `marin-experiments`. So for marin work:
 
     loom session launch --repo /home/power/code/marin "<task>"
+    loom session launch --repo marin-community/vllm "<task>"   # never cloned here
 
 The branch is always namespaced `weaver/<slug>` regardless of repo, so the
 branch name won't tell you where it landed. After launching, check the printed

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -210,11 +210,10 @@ async function create() {
       model: model.value || undefined,
       effort: effort.value || undefined,
     };
+    // A remote reference travels as `repo`: the server registers it if it is new
+    // and clones it on the way, so an unknown `owner/name` needs no separate
+    // "add the repo" step here. A path travels as `cwd`.
     if (looksLikeRemoteRepo(repoInput)) {
-      if (!managedRepos.value.some((r) => r.slug === repoInput || r.remote_url === repoInput)) {
-        await registerRepo(repoInput);
-        await loadManagedRepos();
-      }
       body.repo = repoInput;
     } else {
       body.cwd = repoInput;

--- a/crates/loom/frontend/src/components/SessionDetailsPopover.vue
+++ b/crates/loom/frontend/src/components/SessionDetailsPopover.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import type { Session } from '../types';
 
-// The "⌄ details" menu for the page header. Holds everything low-frequency so
-// it stays out of the always-visible header run, yet reachable from any scroll
+// The "⋯ manage" menu for the page header. Holds everything low-frequency so it
+// stays out of the always-visible header run, yet reachable from any scroll
 // position (the lifecycle actions used to sit at the bottom of a long Overview,
 // where they scrolled out of sight). Two stacked sections:
-//   • identity / machine metadata (id, branch, base, terminal, worktree, github)
 //   • lifecycle actions, injected by the header via the #actions slot
-// Read-only metadata; the page owns open-state.
+//   • identity / machine metadata (id, branch, base, terminal, worktree, github)
+//
+// Actions come first, under a heading: they are the reason a human opens this,
+// and burying them under a scrolling metadata list is what made adopt/archive so
+// hard to find. The metadata is reference material — it can take second place
+// and scroll.
 defineProps<{ ws: Session; open: boolean }>();
 const emit = defineEmits<{ 'update:open': [boolean] }>();
 
@@ -28,7 +32,21 @@ function close() {
       data-testid="details-popover"
       class="absolute right-0 z-20 mt-1 flex max-h-[calc(100vh-7rem)] w-80 flex-col rounded border border-line bg-surface p-3 shadow-lg"
     >
-      <dl class="min-h-0 space-y-2 overflow-y-auto text-xs">
+      <!-- Lifecycle actions (Adopt / Recover / Archive / Remove), supplied by the
+           header — first, because they are what this menu is for. -->
+      <div class="shrink-0">
+        <h3 class="mb-1 px-2 text-2xs font-semibold uppercase tracking-wider text-muted">
+          Actions
+        </h3>
+        <slot name="actions" />
+      </div>
+
+      <h3
+        class="mb-1 mt-3 shrink-0 border-t border-line px-2 pt-3 text-2xs font-semibold uppercase tracking-wider text-muted"
+      >
+        Details
+      </h3>
+      <dl class="min-h-0 space-y-2 overflow-y-auto px-2 text-xs">
         <div class="flex gap-2">
           <dt class="w-16 shrink-0 text-faint">id</dt>
           <dd class="min-w-0 break-all font-mono text-muted">{{ ws.id }}</dd>
@@ -58,12 +76,6 @@ function close() {
           <dd class="min-w-0 break-all font-mono text-muted">{{ ws.created_by }}</dd>
         </div>
       </dl>
-      <!-- Lifecycle actions (Adopt / Archive / Remove), supplied by the header.
-           Kept here so destructive, low-frequency operations live one click
-           away from anywhere on the page, not buried below a long Overview. -->
-      <div class="mt-3 shrink-0 border-t border-line pt-3">
-        <slot name="actions" />
-      </div>
     </div>
   </div>
 </template>

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue';
+import { useRouter } from 'vue-router';
 import type { Session } from '../types';
 import {
   messageOf,
   conversationState,
+  lifecycleActions,
   signalChips,
   quietTags,
   TONE_TEXT,
@@ -14,6 +16,7 @@ import StatusBadge from './StatusBadge.vue';
 import SignalChip from './SignalChip.vue';
 import TagPill from './TagPill.vue';
 import SessionDetailsPopover from './SessionDetailsPopover.vue';
+import SessionRemedyButton from './SessionRemedyButton.vue';
 import GithubStatus from './GithubStatus.vue';
 
 // The session page header — one compact chrome block shared by both the detail
@@ -33,11 +36,19 @@ import GithubStatus from './GithubStatus.vue';
 const props = defineProps<{ ws: Session }>();
 const emit = defineEmits<{ reload: [] }>();
 
+const router = useRouter();
+// The detail page's subject is the session itself, so a successful Remove has to
+// leave: route back to the fleet list rather than reload a page that is gone.
 const actions = useSessionActions(
   () => props.ws.id,
   () => emit('reload'),
+  () => router.push('/'),
 );
-const { busy, notice, error, rename, clearTag, adopt, archive, recover, remove } = actions;
+const { busy, notice, error, rename, clearTag, run } = actions;
+
+// The lifecycle verbs the ⋯ manage menu offers — the same policy the fleet
+// list's row menu renders, so the two surfaces can't drift.
+const lifecycle = computed(() => lifecycleActions(props.ws));
 
 const showDetails = ref(false);
 
@@ -144,50 +155,42 @@ const quiet = computed(() => quietTags(props.ws));
              default here just as on the fleet list. -->
         <StatusBadge v-if="ws.status !== 'running'" :status="ws.status" />
 
-        <!-- ⌄ details — identity metadata + the lifecycle actions. -->
+        <!-- The remedy, promoted out of the menu and parked against the badge
+             that announces the problem: an orphaned session offers Adopt, an
+             archived one Recover. Same component the fleet-list row uses, so the
+             cure looks and reads the same wherever you meet a stuck session. -->
+        <SessionRemedyButton :ws="ws" @changed="emit('reload')" @error="error = $event" />
+
+        <!-- ⋯ manage — the lifecycle actions, with the identity metadata under
+             them. Named for what a human comes here to *do*: it used to read
+             "⌄ details", which advertised only the metadata, so nobody looking
+             to archive or adopt a session ever thought to open it. -->
         <div class="relative">
           <button
             type="button"
+            :aria-expanded="showDetails"
             class="rounded px-1.5 py-1 text-xs text-muted hover:bg-subtle hover:text-fg"
             @click="showDetails = !showDetails"
           >
-            ⌄ details
+            ⋯ manage
           </button>
           <SessionDetailsPopover :ws="ws" v-model:open="showDetails">
             <template #actions>
-              <div class="flex flex-wrap items-center gap-2">
+              <div class="space-y-1">
                 <button
-                  v-if="ws.status === 'orphaned'"
-                  class="rounded bg-subtle px-3 py-1.5 text-xs text-accent ring-1 ring-inset ring-accent/30 hover:bg-subtle-hover"
-                  :disabled="busy === 'adopt'"
-                  @click="adopt"
+                  v-for="a in lifecycle"
+                  :key="a.verb"
+                  type="button"
+                  :data-testid="`action-${a.verb}`"
+                  :disabled="!!busy"
+                  class="block w-full rounded px-2 py-1.5 text-left transition-colors disabled:opacity-60"
+                  :class="a.danger ? 'text-block hover:bg-block-soft' : 'text-fg hover:bg-subtle'"
+                  @click="run(a.verb)"
                 >
-                  {{ busy === 'adopt' ? 'Adopting…' : 'Adopt' }}
-                </button>
-                <!-- Recover brings a torn-down (archived) session back: rebuild
-                     its worktree from the kept branch and resume the agent. -->
-                <button
-                  v-if="ws.status === 'archived'"
-                  class="rounded bg-subtle px-3 py-1.5 text-xs text-accent ring-1 ring-inset ring-accent/30 hover:bg-subtle-hover"
-                  :disabled="busy === 'recover'"
-                  @click="recover"
-                >
-                  {{ busy === 'recover' ? 'Recovering…' : 'Recover' }}
-                </button>
-                <button
-                  v-if="ws.status !== 'archived'"
-                  class="btn-secondary px-3 py-1.5 text-xs"
-                  :disabled="busy === 'archive'"
-                  @click="archive"
-                >
-                  {{ busy === 'archive' ? 'Archiving…' : 'Archive' }}
-                </button>
-                <button
-                  class="btn-danger ml-auto px-3 py-1.5 text-xs"
-                  :disabled="busy === 'remove'"
-                  @click="remove"
-                >
-                  Remove
+                  <span class="block text-xs font-medium">
+                    {{ busy === a.verb ? a.busyLabel : a.label }}
+                  </span>
+                  <span class="block text-2xs text-faint">{{ a.hint }}</span>
                 </button>
               </div>
             </template>

--- a/crates/loom/frontend/src/components/SessionRemedyButton.vue
+++ b/crates/loom/frontend/src/components/SessionRemedyButton.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Session } from '../types';
+import { remedyAction } from '../lib/sessionState';
+import { useSessionActions } from '../lib/sessionActions';
+
+// The one button that unsticks a stuck session: Adopt for an orphaned one
+// (terminal gone, worktree intact), Recover for an archived one (torn down,
+// branch kept). Renders nothing for a healthy session — there is nothing to fix.
+//
+// It is deliberately parked against the status badge that announces the problem,
+// on every surface that shows one (the fleet-list row and the detail header), so
+// the cure travels with the diagnosis instead of hiding behind a menu. The same
+// verbs are still in the ⋯ menu for anyone who looks there.
+const props = defineProps<{ ws: Session }>();
+const emit = defineEmits<{ changed: []; error: [string] }>();
+
+const remedy = computed(() => remedyAction(props.ws));
+
+const { busy, error, run } = useSessionActions(
+  () => props.ws.id,
+  () => emit('changed'),
+);
+
+async function invoke() {
+  if (!remedy.value) return;
+  await run(remedy.value.verb);
+  if (error.value) emit('error', error.value);
+}
+</script>
+
+<template>
+  <!-- `relative z-10` keeps it clickable above a list row's stretched-link
+       overlay; it is inert on surfaces that have no such overlay. -->
+  <button
+    v-if="remedy"
+    type="button"
+    :data-testid="`remedy-${remedy.verb}`"
+    :title="remedy.hint"
+    :disabled="!!busy"
+    class="relative z-10 shrink-0 rounded bg-subtle px-2 py-0.5 text-2xs font-medium text-accent ring-1 ring-inset ring-accent/30 transition-colors hover:bg-subtle-hover disabled:opacity-60"
+    @click="invoke"
+  >
+    {{ busy ? remedy.busyLabel : remedy.label }}
+  </button>
+</template>

--- a/crates/loom/frontend/src/components/SessionRowActions.vue
+++ b/crates/loom/frontend/src/components/SessionRowActions.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { Session } from '../types';
+import { lifecycleActions } from '../lib/sessionState';
+import { useSessionActions } from '../lib/sessionActions';
+
+// A fleet-list row's ⋯ menu: every lifecycle verb that applies to the session
+// (its remedy, Archive, Remove). Before this the fleet list — the one place you
+// actually survey and tidy a fleet — could not act on it at all: adopting or
+// archiving meant opening the session and hunting through the header's popover.
+//
+// Quiet until wanted: the ⋯ appears on row hover or keyboard focus, so a calm
+// fleet stays calm. A stuck session also carries its remedy as a plain button up
+// beside its status badge (SessionRemedyButton) — this menu is the full set.
+//
+// Which verbs apply is `lifecycleActions(s)`, shared with the detail header so
+// the two surfaces can't drift; the writes are `useSessionActions`. This
+// component is only the chrome.
+const props = defineProps<{ ws: Session }>();
+const emit = defineEmits<{ changed: []; error: [string] }>();
+
+const open = ref(false);
+const actions = computed(() => lifecycleActions(props.ws));
+
+const { busy, error, run } = useSessionActions(
+  () => props.ws.id,
+  () => emit('changed'),
+);
+
+async function invoke(verb: Parameters<typeof run>[0]) {
+  open.value = false;
+  await run(verb);
+  if (error.value) emit('error', error.value);
+}
+</script>
+
+<template>
+  <!-- `relative z-10` lifts the control above the row's stretched-link overlay,
+       so clicking ⋯ opens the menu instead of opening the session. -->
+  <div class="relative z-10 shrink-0">
+    <button
+      type="button"
+      data-testid="row-actions"
+      :aria-label="`Actions for ${ws.branch.title || ws.branch.name}`"
+      :aria-expanded="open"
+      :class="[
+        'rounded px-1.5 py-0.5 text-sm leading-none text-faint transition-colors',
+        'hover:bg-subtle hover:text-fg focus-visible:opacity-100',
+        open ? 'bg-subtle text-fg opacity-100' : 'opacity-0 group-hover:opacity-100',
+      ]"
+      @click="open = !open"
+    >
+      ⋯
+    </button>
+
+    <!-- Transparent backdrop dismisses on outside click — the same
+         dependency-free pattern as the header's manage popover. -->
+    <div v-if="open" class="fixed inset-0 z-20" @click="open = false"></div>
+    <div
+      v-if="open"
+      data-testid="row-actions-menu"
+      class="absolute right-0 top-full z-30 mt-1 w-64 overflow-hidden rounded border border-line bg-surface py-1 shadow-lg"
+    >
+      <button
+        v-for="a in actions"
+        :key="a.verb"
+        type="button"
+        :data-testid="`row-action-${a.verb}`"
+        :disabled="!!busy"
+        class="block w-full px-3 py-1.5 text-left transition-colors disabled:opacity-60"
+        :class="a.danger ? 'text-block hover:bg-block-soft' : 'text-fg hover:bg-subtle'"
+        @click="invoke(a.verb)"
+      >
+        <span class="block text-xs font-medium">
+          {{ busy === a.verb ? a.busyLabel : a.label }}
+        </span>
+        <span class="block text-2xs text-faint">{{ a.hint }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/lib/sessionActions.ts
+++ b/crates/loom/frontend/src/lib/sessionActions.ts
@@ -1,10 +1,9 @@
 import { ref } from 'vue';
-import { useRouter } from 'vue-router';
 import { post, patch, del } from '../api';
+import type { LifecycleVerb } from './sessionState';
 
-// The session's write surface for the page header (hosted by SessionDetail).
-// Kept as a composable so the header's lifecycle behaviour lives in one place
-// rather than being inlined into the view.
+// The session's write surface, shared by every place that can act on a session:
+// the detail page's header and the fleet list's per-row menu.
 //
 //   rename       — the one human-authored branch field (the workstream label)
 //   clearTag     — delete any one tag, loud or quiet (a chip's × clears it);
@@ -13,13 +12,20 @@ import { post, patch, del } from '../api';
 //   archive      — tear down terminal + worktree, keep the branch/history
 //   recover      — rebuild an archived session's worktree and resume its agent
 //                  (the inverse of archive — reuses the kept branch/history)
-//   remove        — delete the session entirely, then route back to the list
+//   remove       — delete the session entirely
+//   run(verb)    — dispatch one of the four lifecycle verbs by name, so a caller
+//                  driving a list of actions doesn't re-switch on them
 //
-// `reload` is called after any write that mutates server state the page shows,
-// so the caller can re-fetch. `busy` names the in-flight action (for per-button
-// spinners); `notice`/`error` carry the last result.
-export function useSessionActions(getId: () => string, reload: () => void | Promise<void>) {
-  const router = useRouter();
+// `reload` is called after any write that mutates server state the caller shows.
+// `removed` fires after a successful remove — the detail page routes back to the
+// list (its subject is gone), the fleet list just refreshes in place. `busy`
+// names the in-flight action (for per-button spinners); `notice`/`error` carry
+// the last result.
+export function useSessionActions(
+  getId: () => string,
+  reload: () => void | Promise<void>,
+  removed?: () => void,
+) {
   const busy = ref('');
   const notice = ref('');
   const error = ref('');
@@ -86,8 +92,12 @@ export function useSessionActions(getId: () => string, reload: () => void | Prom
     act('remove', async () => {
       if (!confirm('Remove this session, its worktree and terminal session?')) return;
       await del(`/sessions/${getId()}`);
-      router.push('/');
+      if (removed) removed();
+      else await reload();
     });
 
-  return { busy, notice, error, rename, clearTag, adopt, archive, recover, remove };
+  const run = (verb: LifecycleVerb) =>
+    ({ adopt, recover, archive, remove })[verb]();
+
+  return { busy, notice, error, rename, clearTag, adopt, archive, recover, remove, run };
 }

--- a/crates/loom/frontend/src/lib/sessionActions.ts
+++ b/crates/loom/frontend/src/lib/sessionActions.ts
@@ -13,8 +13,10 @@ import type { LifecycleVerb } from './sessionState';
 //   recover      — rebuild an archived session's worktree and resume its agent
 //                  (the inverse of archive — reuses the kept branch/history)
 //   remove       — delete the session entirely
-//   run(verb)    — dispatch one of the four lifecycle verbs by name, so a caller
-//                  driving a list of actions doesn't re-switch on them
+//
+// The four lifecycle verbs above are exposed as `run(verb)`, so a caller
+// rendering a list of `lifecycleActions()` can invoke whichever one was clicked
+// without re-switching on the verb.
 //
 // `reload` is called after any write that mutates server state the caller shows.
 // `removed` fires after a successful remove — the detail page routes back to the
@@ -96,8 +98,10 @@ export function useSessionActions(
       else await reload();
     });
 
-  const run = (verb: LifecycleVerb) =>
-    ({ adopt, recover, archive, remove })[verb]();
+  // The four lifecycle verbs are only ever reached by name — a caller renders a
+  // list of `LifecycleAction`s and invokes whichever one was clicked — so `run`
+  // is the whole surface and the individual verbs stay internal.
+  const run = (verb: LifecycleVerb) => ({ adopt, recover, archive, remove })[verb]();
 
-  return { busy, notice, error, rename, clearTag, adopt, archive, recover, remove, run };
+  return { busy, notice, error, rename, clearTag, run };
 }

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -297,3 +297,69 @@ export function lifecycleDot(s: Session): string {
   if (s.status === 'running') return 'bg-ok-line';
   return 'bg-faint/50';
 }
+
+// ---------------------------------------------------------------------------
+// Lifecycle actions — which verbs apply to a session, in one place
+// ---------------------------------------------------------------------------
+
+export type LifecycleVerb = 'adopt' | 'recover' | 'archive' | 'remove';
+
+export interface LifecycleAction {
+  verb: LifecycleVerb;
+  /** Imperative label, as it appears on the button or menu item. */
+  label: string;
+  /** Present participle shown while the action is in flight. */
+  busyLabel: string;
+  /** What it does, for the menu item's second line and the button's tooltip. */
+  hint: string;
+  /** Destructive — rendered in the block (danger) tone, last. */
+  danger?: boolean;
+}
+
+const ADOPT: LifecycleAction = {
+  verb: 'adopt',
+  label: 'Adopt',
+  busyLabel: 'Adopting…',
+  hint: 'Recreate the terminal and resume the agent',
+};
+const RECOVER: LifecycleAction = {
+  verb: 'recover',
+  label: 'Recover',
+  busyLabel: 'Recovering…',
+  hint: 'Rebuild the worktree and resume the agent',
+};
+const ARCHIVE: LifecycleAction = {
+  verb: 'archive',
+  label: 'Archive',
+  busyLabel: 'Archiving…',
+  hint: 'Tear down the terminal and worktree, keep the branch',
+};
+const REMOVE: LifecycleAction = {
+  verb: 'remove',
+  label: 'Remove',
+  busyLabel: 'Removing…',
+  hint: 'Delete the session, its worktree and terminal',
+  danger: true,
+};
+
+// The one action that gets a session unstuck, when it is stuck: an orphaned
+// session (terminal gone, worktree intact) is adopted; an archived one (torn
+// down, branch kept) is recovered. Surfaced next to the status badge that
+// announces the state, so the cure sits with the diagnosis rather than behind a
+// menu. Null for every healthy session — there is nothing to fix.
+export function remedyAction(s: Session): LifecycleAction | null {
+  if (s.status === 'orphaned') return ADOPT;
+  if (s.status === 'archived') return RECOVER;
+  return null;
+}
+
+// Every lifecycle action available on a session, in menu order: its remedy (if
+// stuck), then archive (unless it already is), then the destructive remove.
+export function lifecycleActions(s: Session): LifecycleAction[] {
+  const actions: LifecycleAction[] = [];
+  const remedy = remedyAction(s);
+  if (remedy) actions.push(remedy);
+  if (s.status !== 'archived') actions.push(ARCHIVE);
+  actions.push(REMOVE);
+  return actions;
+}

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -8,6 +8,8 @@ import IdleChip from '../components/IdleChip.vue';
 import TagPill from '../components/TagPill.vue';
 import GithubStatus from '../components/GithubStatus.vue';
 import NewSessionDrawer from '../components/NewSessionDrawer.vue';
+import SessionRowActions from '../components/SessionRowActions.vue';
+import SessionRemedyButton from '../components/SessionRemedyButton.vue';
 import { timeAgo } from '../lib/time';
 import { effectiveAttention, idleTag, lifecycleDot, messageOf, priorityRank, quietTags, signalChips } from '../lib/sessionState';
 import { useFleet } from '../lib/sessionsStore';
@@ -323,7 +325,10 @@ async function handleCreated() {
       top. The row itself stays neutral — no full-tile wash — so threading reads
       cleanly; the chip carries the signal. Stagger via --i.
     -->
-    <ul v-if="sessions.length" data-testid="session-list" class="fade-in overflow-hidden rounded-md border border-line bg-surface">
+    <!-- No `overflow-hidden` on the list: a row's ⋯ menu drops out of its row and
+         would be clipped by it. The corners the clip used to round are rounded on
+         the first/last row instead. -->
+    <ul v-if="sessions.length" data-testid="session-list" class="fade-in rounded-md border border-line bg-surface">
       <li
         v-for="{ session: s, depth, verticals, isLast } in treeRows"
         :key="s.id"
@@ -332,7 +337,7 @@ async function handleCreated() {
         :data-depth="depth"
         :class="[
           'group relative flex cursor-pointer items-start gap-2.5 border-b border-line px-3 py-2 last:border-0',
-          'min-h-11 transition-colors hover:bg-subtle',
+          'min-h-11 transition-colors hover:bg-subtle first:rounded-t-md last:rounded-b-md',
         ]"
       >
         <!-- Tree gutter: threads a child session under the one that launched it.
@@ -383,6 +388,10 @@ async function handleCreated() {
                  the running state — nearly every live row is running, so the pill
                  would just be repeated noise; only off-nominal states show one. -->
             <StatusBadge v-if="s.status !== 'running'" :status="s.status" class="shrink-0" />
+            <!-- The cure, next to the diagnosis: an ORPHANED row offers Adopt, an
+                 ARCHIVED one Recover, right where the badge announces the state.
+                 Renders nothing for a healthy session. -->
+            <SessionRemedyButton :ws="s" @changed="refresh" @error="error = $event" />
             <!-- Soothing idle mark: a calm, neutral chip when the agent is
                  resting (no loud signal). Reassures rather than alarms. -->
             <IdleChip v-if="idleTag(s)" :tag="idleTag(s)!" />
@@ -441,6 +450,16 @@ async function handleCreated() {
             {{ timeAgo(s.last_activity_at) }}
           </span>
         </div>
+
+        <!-- The row's ⋯ menu: every lifecycle verb (Adopt/Recover, Archive,
+             Remove). The fleet list is where a human surveys and tidies a fleet,
+             so it acts here rather than only from inside a session. -->
+        <SessionRowActions
+          :ws="s"
+          class="mt-0.5"
+          @changed="refresh"
+          @error="error = $event"
+        />
       </li>
     </ul>
   </div>

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -573,12 +573,14 @@ struct LaunchOpts {
     /// (see `weaver config get agent.default`).
     #[arg(long)]
     agent: Option<String>,
-    /// Repo to launch into: a path to (any directory inside) the target repo's
-    /// checkout. The new worktree is cut from this repo's mainline. Defaults to
-    /// the current directory — so without it you launch into whatever repo you
-    /// happen to be standing in, which is the wrong one when you mean another.
+    /// Repo to launch into: either a path to (any directory inside) a local
+    /// checkout, or a GitHub `owner/name` slug (or clone URL) — a repo loom
+    /// doesn't have yet is cloned into its managed repo store on first use. The
+    /// new worktree is cut from the repo's mainline. Defaults to the current
+    /// directory — so without it you launch into whatever repo you happen to be
+    /// standing in, which is the wrong one when you mean another.
     #[arg(long)]
-    repo: Option<std::path::PathBuf>,
+    repo: Option<String>,
     /// Branch to fork the new worktree from. Defaults to a freshly-fetched
     /// `origin/<default branch>` (the repo's mainline), so new work starts from
     /// the latest upstream rather than the launching checkout.
@@ -1922,7 +1924,7 @@ struct LaunchArgs {
     goal: String,
     name: Option<String>,
     agent: Option<String>,
-    repo: Option<std::path::PathBuf>,
+    repo: Option<String>,
     base: Option<String>,
     title: Option<String>,
     issue: Option<i64>,
@@ -1971,19 +1973,43 @@ const LAUNCH_HINT: &str = "nothing to do — give the agent a task or something 
   loom session launch --name <slug> --agent shell      # an empty named worktree (no task)
 See `loom session launch --help` for all options.";
 
-/// The directory a launch forks from — `--repo` if given, else the current
-/// directory. `loom session launch` has no separate repo selector beyond this:
-/// the server resolves the target repo from this path (its main worktree), so
-/// any directory inside the intended checkout works. We canonicalize, which
-/// anchors a relative `--repo` to the CLI's cwd (not the daemon's) and turns a
-/// typo into a clear error here rather than an opaque server-side failure.
-fn resolve_launch_cwd(repo: Option<&std::path::Path>) -> Result<std::path::PathBuf> {
-    match repo {
-        Some(p) => p
-            .canonicalize()
-            .with_context(|| format!("--repo path not found: {}", p.display())),
-        None => std::env::current_dir().context("could not read the current directory"),
+/// What a launch forks from, once `--repo` has been classified.
+#[derive(Debug, PartialEq, Eq)]
+enum RepoTarget {
+    /// A local checkout — any directory inside it. The server resolves the repo
+    /// from this path (its main worktree), so it travels as the request's `cwd`.
+    Local(std::path::PathBuf),
+    /// A repo loom manages for us: a GitHub `owner/name` slug or a clone URL.
+    /// Travels as the request's `repo`, which the server registers and clones
+    /// into its managed store on first use.
+    Managed(String),
+}
+
+/// Classify `--repo` (absent → the current directory). An existing path is a
+/// local checkout; anything else is a managed-repo reference if it parses as a
+/// clean `owner/name` slug or clone URL — which is what lets you launch into a
+/// repo this machine has never checked out. Neither one is a typo, and saying so
+/// here beats an opaque server-side failure.
+///
+/// A path that exists wins over a slug of the same spelling: a real directory in
+/// front of you is never a guess, so `--repo ./acme/widgets` can't be hijacked
+/// into a clone of `github.com/acme/widgets`.
+fn resolve_repo_target(repo: Option<&str>) -> Result<RepoTarget> {
+    let Some(input) = repo.map(str::trim).filter(|s| !s.is_empty()) else {
+        let cwd = std::env::current_dir().context("could not read the current directory")?;
+        return Ok(RepoTarget::Local(cwd));
+    };
+    // Canonicalizing anchors a relative path to the CLI's cwd, not the daemon's.
+    if let Ok(path) = std::path::Path::new(input).canonicalize() {
+        return Ok(RepoTarget::Local(path));
     }
+    if loom::repo::parse_slug(input).is_ok() {
+        return Ok(RepoTarget::Managed(input.to_string()));
+    }
+    bail!(
+        "--repo '{input}' is neither a local path that exists nor a repo to clone \
+         (expected `owner/name` or a clone URL)"
+    )
 }
 
 async fn cmd_launch(a: LaunchArgs) -> Result<()> {
@@ -2004,7 +2030,17 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
         effort,
     } = a;
     let client = client::default();
-    let cwd = resolve_launch_cwd(repo.as_deref())?;
+    let target = resolve_repo_target(repo.as_deref())?;
+    // A managed repo travels as `repo` (the server registers it and clones it if
+    // this is its first use); a local checkout travels as `cwd`. Exactly one is
+    // set — the server ignores `cwd` whenever `repo` is present.
+    let (cwd, managed_repo) = match &target {
+        RepoTarget::Local(path) => (path.display().to_string(), None),
+        RepoTarget::Managed(r) => (String::new(), Some(r.as_str())),
+    };
+    if let Some(r) = managed_repo {
+        println!("repo {r} — cloning it if loom doesn't have it yet...");
+    }
     // When an agent in a weaver session runs `loom session launch`,
     // `$WEAVER_BRANCH` is its own branch id — pass it so the tracking issue is
     // attributed to the launching (parent) agent. A human shell launch leaves it
@@ -2018,7 +2054,8 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
             json!({
                 "goal": goal,
                 "title": title,
-                "cwd": cwd.display().to_string(),
+                "cwd": cwd,
+                "repo": managed_repo,
                 "base": base,
                 "agent": agent,
                 "name": name,
@@ -3057,21 +3094,83 @@ mod tests {
         }
     }
 
+    // Serial: reads the process's current directory, which the precedence test
+    // below moves.
+    #[serial_test::serial]
     #[test]
-    fn resolve_launch_cwd_honors_repo_and_rejects_a_bad_path() {
+    fn resolve_repo_target_reads_a_local_checkout() {
         // No `--repo` falls back to the current directory.
         let here = std::env::current_dir().unwrap();
-        assert_eq!(resolve_launch_cwd(None).unwrap(), here);
+        assert_eq!(resolve_repo_target(None).unwrap(), RepoTarget::Local(here));
 
-        // `--repo` selects (and canonicalizes) the given checkout.
+        // A path that exists is a local checkout, canonicalized.
         let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
         assert_eq!(
-            resolve_launch_cwd(Some(dir.path())).unwrap(),
-            dir.path().canonicalize().unwrap()
+            resolve_repo_target(Some(&path)).unwrap(),
+            RepoTarget::Local(dir.path().canonicalize().unwrap())
         );
+    }
 
-        // A typo'd `--repo` fails here, not as an opaque server error.
-        assert!(resolve_launch_cwd(Some(&dir.path().join("nope"))).is_err());
+    #[test]
+    fn resolve_repo_target_reads_a_repo_to_clone() {
+        // A repo this machine has never checked out: the whole point — it is
+        // handed to the server as a managed repo rather than failing as a path.
+        for input in [
+            "marin-community/vllm",
+            "https://github.com/acme/widgets.git",
+            "git@github.com:acme/widgets.git",
+        ] {
+            assert_eq!(
+                resolve_repo_target(Some(input)).unwrap(),
+                RepoTarget::Managed(input.to_string()),
+                "input: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_repo_target_rejects_what_is_neither() {
+        // A typo'd path that can't be a repo reference either fails here, not as
+        // an opaque server error.
+        let dir = tempfile::tempdir().unwrap();
+        for bad in [
+            dir.path().join("nope").to_string_lossy().to_string(),
+            "../not-a-checkout".to_string(),
+            "one-segment".to_string(),
+        ] {
+            assert!(resolve_repo_target(Some(&bad)).is_err(), "bad: {bad}");
+        }
+    }
+
+    /// A real directory in front of you is never a guess: `acme/widgets` is a
+    /// perfectly good slug, but when it also *exists* as a relative path it stays
+    /// local rather than being hijacked into a clone of the GitHub repo that
+    /// happens to share its spelling. Only a relative path can collide with a
+    /// slug like this, so the test has to work from a real cwd (hence `serial` —
+    /// it moves the process's current directory).
+    #[serial_test::serial]
+    #[test]
+    fn resolve_repo_target_prefers_an_existing_path_over_a_slug() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("acme").join("widgets");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let restore = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let resolved = resolve_repo_target(Some("acme/widgets"));
+        std::env::set_current_dir(restore).unwrap();
+
+        // Same spelling as the slug — and it resolves to the directory, not a clone.
+        assert_eq!(
+            resolved.unwrap(),
+            RepoTarget::Local(nested.canonicalize().unwrap())
+        );
+        // With no such directory around, the very same string is a repo to clone.
+        assert_eq!(
+            resolve_repo_target(Some("acme/widgets")).unwrap(),
+            RepoTarget::Managed("acme/widgets".to_string())
+        );
     }
 
     #[test]

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -127,6 +127,15 @@ pub(super) async fn create_session(
     Extension(principal): Extension<Principal>,
     Json(req): Json<CreateReq>,
 ) -> ApiResult<Json<SessionView>> {
+    // Naming a managed repo here registers it: a signed-in principal asking to
+    // launch into `owner/name` is the grant, so a repo loom has never seen just
+    // works (it is cloned on the way through `create_session_core`). The `repos`
+    // allowlist exists to gate the *unauthenticated* GitHub webhook, which
+    // resolves its own clone against it before it ever reaches the shared core —
+    // so admitting a repo on an authenticated launch leaves that boundary intact.
+    if let Some(input) = req.repo.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        ensure_repo_registered(&st.db, input).await?;
+    }
     // Attribute the session to whoever the auth middleware resolved: a human
     // (cookie/token) → their username; a loopback/local-token call → the owner;
     // a future webhook → its bot principal. Read from the `Principal`, never
@@ -134,6 +143,25 @@ pub(super) async fn create_session(
     Ok(Json(
         create_session_core(st, req, Some(principal.username)).await?,
     ))
+}
+
+/// Add a managed-repo reference to the registry if it isn't there yet — the same
+/// slug → (remote, managed path) mapping `POST /api/repos` writes. Idempotent: a
+/// repo already registered keeps the remote it was registered with.
+async fn ensure_repo_registered(db: &Db, input: &str) -> ApiResult<()> {
+    let slug = repo::parse_slug(input).map_err(AppError::bad_request)?;
+    if repo::get_registered(db, &slug.slug()).await?.is_some() {
+        return Ok(());
+    }
+    let path = slug.path(&repo::repos_dir());
+    repo::register(
+        db,
+        &slug.slug(),
+        &repo::remote_url_for(input, &slug),
+        &path.to_string_lossy(),
+    )
+    .await?;
+    Ok(())
 }
 
 /// Resolve the **runtime** a session of `agent_kind` launches with. Every kind is

--- a/crates/loom/tests/integration/repos.rs
+++ b/crates/loom/tests/integration/repos.rs
@@ -1,10 +1,13 @@
-//! The managed repo store over the REST API: register a repo into the allowlist,
-//! then launch a session with `{repo: "owner/name"}` so loom clones it into the
-//! managed store and forks the worktree from the clone — no `cwd`. Plus the
-//! security gates: traversal identifiers and non-allowlisted repos are rejected.
+//! The managed repo store over the REST API: launch a session with
+//! `{repo: "owner/name"}` and loom clones the repo into the managed store and
+//! forks the worktree from that clone — no `cwd`. It works whether the repo was
+//! registered up front (`POST /api/repos`) or is being named for the first time,
+//! which is what lets `loom launch --repo owner/name` reach a repo this machine
+//! has never checked out. Plus the security gate that survives: traversal
+//! identifiers are rejected.
 //!
-//! The clone source is a *local bare repo* (registered via a `file://` URL), so
-//! these tests never touch the network.
+//! The clone source is a *local bare repo* (named by a `file://` URL), so these
+//! tests never touch the network.
 
 use serde_json::json;
 use serial_test::serial;
@@ -117,11 +120,73 @@ async fn register_then_launch_clones_into_managed_store() {
         .unwrap();
 }
 
-/// Security: a traversal identifier and a non-allowlisted repo are both rejected
-/// with a 400 before any clone is attempted.
+/// Launching into a repo loom has never seen needs no separate "add the repo"
+/// step: naming it on an authenticated create registers it and clones it. This is
+/// what `loom launch --repo owner/name` and the new-session drawer both rely on.
+///
+/// (The repo is named by its `file://` URL rather than a bare slug, so the clone
+/// stays local — a bare slug would resolve to its canonical github.com remote.)
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn create_rejects_traversal_and_unregistered_repos() {
+async fn launching_into_an_unregistered_repo_registers_and_clones_it() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let remotes = tempfile::tempdir().unwrap();
+    let remote_url = make_bare_remote(remotes.path());
+
+    // Nothing is registered yet.
+    assert!(client
+        .get("/api/repos")
+        .await
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    // Launch straight at it — no POST /api/repos first.
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "first sight", "repo": remote_url, "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+    let work_dir = ws["work_dir"].as_str().unwrap().to_string();
+
+    // It was cloned into the managed store and forked from there.
+    assert!(
+        work_dir.contains("/acme/widgets/.worktrees/"),
+        "worktree should live in the managed clone, got {work_dir}"
+    );
+    assert!(loom::repo::repos_dir()
+        .join("acme")
+        .join("widgets")
+        .join(".git")
+        .exists());
+
+    // And the launch registered it, so it is a known repo from now on.
+    let list = client.get("/api/repos").await.unwrap();
+    let list = list.as_array().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["slug"], "acme/widgets");
+    assert_eq!(list[0]["remote_url"], remote_url);
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// Security: a traversal identifier is rejected with a 400 before any clone is
+/// attempted, on both the create and the register path.
+///
+/// Note what is *not* asserted here: an unregistered repo. Naming a repo on an
+/// authenticated create is the grant that registers it (see the test above) — the
+/// `repos` allowlist gates the *unauthenticated* GitHub webhook, which resolves
+/// its own clone through `repo::resolve_clone` before it reaches the shared
+/// create path. That gate is proven in `repo::tests::resolve_clone_enforces_allowlist_then_clones`.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_rejects_traversal_identifiers() {
     let ts = TestServer::start().await;
     let client = &ts.client;
 
@@ -137,20 +202,6 @@ async fn create_rejects_traversal_and_unregistered_repos() {
             "traversal id {bad:?} should be a 400, got {err}"
         );
     }
-
-    // A clean slug that is not registered — refused by the allowlist boundary.
-    let err = client
-        .post(
-            "/api/sessions",
-            json!({ "repo": "ghost/repo", "agent": "shell" }),
-        )
-        .await
-        .unwrap_err()
-        .to_string();
-    assert!(
-        err.contains("400") && err.contains("not registered"),
-        "unregistered repo should be a 400, got {err}"
-    );
 
     // Registration itself rejects a traversal identifier.
     let err = client

--- a/crates/smartdoc/src/lib.rs
+++ b/crates/smartdoc/src/lib.rs
@@ -214,15 +214,15 @@ fn checklist_item(trimmed: &str) -> Option<ChecklistItem> {
         .or_else(|| trimmed.strip_prefix("* "))
         .or_else(|| trimmed.strip_prefix("+ "))?;
     let rest = after_bullet.trim_start();
-    let (checked, body) = if let Some(b) = rest.strip_prefix("[ ]") {
-        (false, b)
-    } else if let Some(b) = rest
-        .strip_prefix("[x]")
-        .or_else(|| rest.strip_prefix("[X]"))
-    {
-        (true, b)
-    } else {
-        return None;
+    let (checked, body) = match rest.strip_prefix("[ ]") {
+        Some(b) => (false, b),
+        // Not an empty box, so the only other checklist item is a ticked one —
+        // anything else is not a checklist line at all.
+        None => (
+            true,
+            rest.strip_prefix("[x]")
+                .or_else(|| rest.strip_prefix("[X]"))?,
+        ),
     };
     let text = body.trim().to_string();
     Some(ChecklistItem {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,6 +171,16 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
   own `WEAVER.md`.
 - **Worktrees** live under `<repo>/.worktrees/<slug>` on `weaver/<slug>`
   (unless `--branch` reused an existing branch).
+- **Which repo a session forks from** is either a local checkout (`CreateReq.cwd`
+  — the server resolves its main worktree) or a **managed repo**
+  (`CreateReq.repo`: a GitHub `owner/name` slug or clone URL). A managed repo is
+  cloned into the repo store (`$WEAVER_REPOS_DIR`, default `$WEAVER_HOME/repos`,
+  laid out `<root>/<owner>/<name>`) on first use and fetched thereafter, and the
+  worktree is cut from that clone. Naming one on an authenticated create
+  registers it in the `repos` table, so `loom launch --repo acme/widgets` works
+  against a repo this machine has never checked out. That table doubles as the
+  clone **allowlist** for the *unauthenticated* GitHub webhook, which resolves its
+  own clone through `repo::resolve_clone` and refuses a repo that is not on it.
 
 ## REST API
 

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -144,6 +144,9 @@ export interface WeaverFixture {
   getSession(id: string): Promise<Session>;
   /** GET /api/sessions. */
   listSessions(): Promise<Session[]>;
+  /** POST /api/sessions/{id}/archive — tear the session down (branch kept), so a
+   *  test can set up the archived state it wants to act on. */
+  archiveSession(id: string): Promise<void>;
   /** Flip a session's status by writing a hook event row via `weaver hook`. */
   hook(session: Session, event: 'working' | 'waiting' | 'idle'): Promise<void>;
   /** Declare the agent's status (level + message) via `weaver status`. It
@@ -549,6 +552,10 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
 
       async listSessions() {
         return (await fetchJson(`${baseUrl}/api/sessions`)) as Session[];
+      },
+
+      async archiveSession(id) {
+        await fetchJson(`${baseUrl}/api/sessions/${id}/archive`, { method: 'POST' });
       },
 
       async hook(session, event) {

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -18,10 +18,10 @@ test.describe('session detail view', () => {
     // issue's body in the issues panel, so a bare getByText is ambiguous.
     await expect(page.getByTestId('session-goal')).toHaveText('Render my details');
 
-    // Identity metadata (id, branch, base) lives behind the ⌄ details popover,
-    // not cluttering the header. Scope to the popover and match exactly so the
-    // id doesn't also match the `weaver-<id>` terminal line.
-    await page.getByRole('button', { name: 'details' }).click();
+    // Identity metadata (id, branch, base) lives behind the ⋯ manage menu, under
+    // the lifecycle actions, not cluttering the header. Scope to the popover and
+    // match exactly so the id doesn't also match the `weaver-<id>` terminal line.
+    await page.getByRole('button', { name: 'manage' }).click();
     const details = page.getByTestId('details-popover');
     await expect(details.getByText(s.id, { exact: true })).toBeVisible();
     await expect(details.getByText(s.branch.branch, { exact: true })).toBeVisible();

--- a/e2e/tests/lifecycle.spec.ts
+++ b/e2e/tests/lifecycle.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '../fixtures/weaver';
 
-// The lifecycle actions (Archive / Remove) live in the header's ⌄ details menu —
-// reachable from any surface and scroll position, not buried at the foot of the
-// Overview tab.
+// The lifecycle actions (Adopt / Recover / Archive / Remove) are reachable from
+// two places: the detail header's ⋯ manage menu, and each fleet-list row's ⋯
+// menu. A stuck session (orphaned/archived) also carries its remedy as a plain
+// button next to the status badge, on both surfaces.
 test.describe('session lifecycle actions', () => {
   test('Remove (confirmed) deletes the session and returns to the list', async ({
     page,
@@ -13,7 +14,7 @@ test.describe('session lifecycle actions', () => {
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);
     await expect(page.getByRole('heading', { name: 'remove-task' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'details' }).click();
+    await page.getByRole('button', { name: 'manage' }).click();
 
     // Remove uses a native confirm() dialog — accept it.
     page.once('dialog', (dialog) => {
@@ -36,7 +37,7 @@ test.describe('session lifecycle actions', () => {
     const s = await weaver.seedSession({ goal: 'Keep me', name: 'keep-task' });
 
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);
-    await page.getByRole('button', { name: 'details' }).click();
+    await page.getByRole('button', { name: 'manage' }).click();
 
     page.once('dialog', (dialog) => dialog.dismiss());
     await page.getByRole('button', { name: 'Remove' }).click();
@@ -54,7 +55,7 @@ test.describe('session lifecycle actions', () => {
     const s = await weaver.seedSession({ goal: 'Archive me', name: 'archive-task' });
 
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);
-    await page.getByRole('button', { name: 'details' }).click();
+    await page.getByRole('button', { name: 'manage' }).click();
 
     page.once('dialog', (dialog) => {
       expect(dialog.type()).toBe('confirm');
@@ -81,7 +82,7 @@ test.describe('session lifecycle actions', () => {
 
     await page.setViewportSize({ width: 1280, height: 300 });
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);
-    await page.getByRole('button', { name: 'details' }).click();
+    await page.getByRole('button', { name: 'manage' }).click();
 
     for (const name of ['Archive', 'Remove']) {
       const box = await page.getByRole('button', { name }).boundingBox();
@@ -95,5 +96,52 @@ test.describe('session lifecycle actions', () => {
     await page.getByRole('button', { name: 'Remove' }).click();
     await expect(page).toHaveURL(/\/$/);
     expect(await weaver.listSessions()).toHaveLength(0);
+  });
+
+  test('a fleet-list row can archive its session without opening it', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await weaver.seedSession({ goal: 'Archive from the list', name: 'row-archive' });
+
+    await page.goto(`${weaver.baseUrl}/`);
+    const row = page.locator(`[data-session-id="${s.id}"]`);
+    await expect(row).toBeVisible();
+
+    // The ⋯ menu is revealed by hovering the row, and holds the verbs.
+    await row.hover();
+    await row.getByTestId('row-actions').click();
+    await expect(row.getByTestId('row-actions-menu')).toBeVisible();
+
+    page.once('dialog', (dialog) => {
+      expect(dialog.type()).toBe('confirm');
+      dialog.accept();
+    });
+    await row.getByTestId('row-action-archive').click();
+
+    // Archived server-side — and we never left the list.
+    await expect.poll(async () => (await weaver.getSession(s.id)).status).toBe('archived');
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('an archived session offers Recover next to its badge, on both surfaces', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await weaver.seedSession({ goal: 'Recover me', name: 'recover-task' });
+    await weaver.archiveSession(s.id);
+
+    // On the fleet list (archived rows are behind the reveal chip), the row
+    // carries its own remedy — no need to open the session to find it. It is the
+    // same component the detail header renders, hence the same test id.
+    await page.goto(`${weaver.baseUrl}/`);
+    await page.getByRole('button', { name: /archived/ }).click();
+    const row = page.locator(`[data-session-id="${s.id}"]`);
+    await expect(row.getByTestId('remedy-recover')).toBeVisible();
+
+    // And on the detail page, sitting against the ARCHIVED badge.
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
+    await expect(page.getByTestId('status-badge')).toHaveText(/archived/i);
+    await expect(page.getByTestId('remedy-recover')).toBeVisible();
   });
 });


### PR DESCRIPTION
Two fixes from the fixups issue (#425).

## 1. `loom launch --repo owner/name`

`--repo` only accepted a local path, so a GitHub repo died as a missing file:

```
$ loom launch --repo marin-community/vllm --agent claude 'How do i run iris?'
error: --repo path not found: marin-community/vllm: No such file or directory (os error 2)
```

…even though loom already had the managed repo store, the clone-on-demand resolver (`repo::resolve_clone`), and a working "+ Clone new repo" box in the new-session drawer. Only the CLI couldn't reach any of it.

`--repo` now takes a path **or** an `owner/name` slug / clone URL. An unknown repo is registered and cloned into the managed store on first use, and the worktree is cut from that clone.

- **A path wins over a slug of the same spelling** — a real directory in front of you is never a guess, so a local `acme/widgets` stays local.
- **A typo fails in the CLI**, before any network call: `--repo 'one-segment' is neither a local path that exists nor a repo to clone (expected owner/name or a clone URL)`.
- **Registration moved server-side** (the authenticated create path), so the CLI and the drawer are both thin clients — the drawer no longer registers the repo itself before creating the session.

The `repos` allowlist still gates the *unauthenticated* GitHub `@loom` webhook, which resolves its own clone against it before it ever reaches the shared create path — that boundary is unchanged, and the integration test says so.

## 2. Adopt and archive were unfindable

Every lifecycle verb lived behind one button labelled `⌄ details`. It advertised metadata, so nobody opened it looking for a verb — and the actions sat *below* a scrolling metadata list once you did. The fleet list, where you actually survey and tidy a fleet, had no actions at all.

- **A stuck session carries its own cure.** Adopt (orphaned) / Recover (archived) is now a plain button against the status badge that announces the state — on the fleet row *and* the detail header, same component.
- **Fleet rows get a `⋯` menu** (Adopt/Recover, Archive, Remove), revealed on hover, so a fleet can be tidied without opening anything.
- **`⌄ details` → `⋯ manage`**, which opens on **Actions** (each verb saying what it does) with Details beneath.
- Which verbs apply lives in `lifecycleActions()` / `remedyAction()`, read by both surfaces, so they can't drift.

Before/after screenshots: https://claude.ai/code/artifact/855ae992-efaf-4169-b466-47ac5318fd10

## Verification

Driven end-to-end against an isolated loom (temp `WEAVER_HOME`): launching into a never-cloned repo really clones it and forks the worktree from the clone; a local `--repo` path is unchanged; both error cases report cleanly.

`cargo test --workspace` green · 81 Playwright tests green (2 new: archive from a list row, Recover on both surfaces) · `pytest` green · fmt + clippy + typecheck clean · agent lint review clean (it caught a weak precedence test, now rewritten to actually exercise the path-vs-slug collision).