### PR TITLE
fix(tapestry,loom): keep session secrets off argv

### DIFF
--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -476,11 +476,12 @@ pub fn concierge_primer() -> &'static str {
     BUILTIN_CONCIERGE_MD
 }
 
-/// Wrap a value in single quotes for safe `export NAME=…` in the launch script,
-/// escaping any embedded single quote the POSIX way (`'\''` — close the quote,
-/// an escaped literal quote, reopen). loom's own values never contain quotes,
-/// but operator-supplied env vars ([`crate::agent_env`]) are arbitrary, so a
-/// stray `'` must not break out of the assignment.
+/// Wrap a value in single quotes for safe interpolation into the launch script —
+/// e.g. a goal/primer file path in `"$(cat '…')"` — escaping any embedded single
+/// quote the POSIX way (`'\''` — close the quote, an escaped literal quote,
+/// reopen). Paths come from the operator's filesystem and are arbitrary, so a
+/// stray `'` must not break out of the quotes. (Environment values are *not*
+/// quoted here: they no longer ride in the script — see [`wrap_launch_script`].)
 fn sh_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
@@ -489,13 +490,17 @@ fn sh_single_quote_path(path: &Path) -> String {
     sh_single_quote(&path.display().to_string())
 }
 
-fn wrap_launch_script(inner: &str, env: &[(&str, &str)], weaver_dir: Option<&Path>) -> String {
+/// Build the launch script the supervisor runs as `sh -c <script>`: prepend the
+/// weaver bin dir to `$PATH`, run the (optional) inner agent command, then `exec`
+/// the login shell. The session's environment is delivered **out of band** (via
+/// the process environment — see [`start_terminal`] / [`backend::new_session`]),
+/// not `export`-ed here, so secret values never land on the child shell's argv.
+/// The `$PATH` prepend stays in the script because it needs the shell to expand
+/// the inherited `$PATH` at runtime; it carries no secret.
+fn wrap_launch_script(inner: &str, weaver_dir: Option<&Path>) -> String {
     let mut script = String::new();
     if let Some(dir) = weaver_dir {
         script.push_str(&format!("export PATH=\"{}:$PATH\"; ", dir.display()));
-    }
-    for (k, v) in env {
-        script.push_str(&format!("export {k}={}; ", sh_single_quote(v)));
     }
     if !inner.is_empty() {
         script.push_str(inner);
@@ -505,12 +510,13 @@ fn wrap_launch_script(inner: &str, env: &[(&str, &str)], weaver_dir: Option<&Pat
     script
 }
 
-/// The launch script for a **bare login shell** — loom's `env` exported, then
+/// The launch script for a **bare login shell** — the `$PATH` prepend, then
 /// `exec` the shell, with no inner agent command. Used by the operator scratch
 /// shell and per-session debug shells ([`crate::shell`]); those are plain shells,
-/// not agents, so they don't go through [`launch`] or an [`AgentType`].
-pub fn bare_shell_script(env: &[(&str, &str)], weaver_dir: Option<&Path>) -> String {
-    wrap_launch_script("", env, weaver_dir)
+/// not agents, so they don't go through [`launch`] or an [`AgentType`]. Their
+/// environment is delivered out of band alongside this script, same as an agent's.
+pub fn bare_shell_script(weaver_dir: Option<&Path>) -> String {
+    wrap_launch_script("", weaver_dir)
 }
 
 /// Everything [`launch`] needs to bring up a session's terminal.
@@ -606,23 +612,32 @@ async fn start_terminal(
     if let Some(token) = local_token.as_deref() {
         env.push(("LOOM_TOKEN", token));
     }
-    // Operator-managed vars are exported last, so for any shared name they'd win.
+    // Operator-managed vars are applied last, so for any shared name they'd win.
     // That's safe because `agent_env::validate_name` reserves loom's own
     // WEAVER_*/LOOM_ prefixes, so a stored var can never shadow the environment
     // loom needs — everything else the agent's tools read is theirs to set.
     for (k, v) in ctx.extra_env {
         env.push((k.as_str(), v.as_str()));
     }
-    let script = wrap_launch_script(inner, &env, weaver_dir);
+    // The env is delivered to the child through the process environment (see
+    // `backend::new_session` → `tapestry::spawn_detached`), not `export`-ed into
+    // the script — so tokens/keys never appear on any process's argv.
+    let script = wrap_launch_script(inner, weaver_dir);
     tracing::debug!(
         branch = ctx.branch_id,
         runtime,
         session = ctx.term_session,
         "launching agent session"
     );
-    backend::new_session(ctx.term_session, ctx.work_dir, &script, ctx.memory_max_gb)
-        .await
-        .with_context(|| format!("terminal: launching session {}", ctx.term_session))?;
+    backend::new_session(
+        ctx.term_session,
+        ctx.work_dir,
+        &script,
+        &env,
+        ctx.memory_max_gb,
+    )
+    .await
+    .with_context(|| format!("terminal: launching session {}", ctx.term_session))?;
     tracing::info!(
         branch = ctx.branch_id,
         runtime,
@@ -946,7 +961,6 @@ mod tests {
         runtime: &str,
         goal_file: Option<&Path>,
         primer_file: Option<&Path>,
-        env: &[(&str, &str)],
         mode: LaunchMode,
         model: &str,
         effort: &str,
@@ -958,14 +972,14 @@ mod tests {
             "shell" => String::new(),
             other => panic!("unexpected runtime in test helper: {other}"),
         };
-        wrap_launch_script(&inner, env, None)
+        wrap_launch_script(&inner, None)
     }
 
     #[test]
     fn bare_shell_script_just_execs_a_shell() {
-        assert_eq!(bare_shell_script(&[], None), "exec \"${SHELL:-/bin/sh}\"");
+        assert_eq!(bare_shell_script(None), "exec \"${SHELL:-/bin/sh}\"");
         // The `"shell"` runtime in the test helper builds the same bare shell.
-        let script = launch_script("shell", None, None, &[], LaunchMode::Fresh, "", "");
+        let script = launch_script("shell", None, None, LaunchMode::Fresh, "", "");
         assert_eq!(script, "exec \"${SHELL:-/bin/sh}\"");
     }
 
@@ -1019,25 +1033,30 @@ mod tests {
         let a = custom_agent("bare", "", "", "");
         assert_eq!(custom_command(&a, &ctx, LaunchMode::Fresh), "");
         assert_eq!(
-            wrap_launch_script(&custom_command(&a, &ctx, LaunchMode::Fresh), &[], None),
+            wrap_launch_script(&custom_command(&a, &ctx, LaunchMode::Fresh), None),
             "exec \"${SHELL:-/bin/sh}\""
         );
     }
 
     #[test]
-    fn claude_script_exports_env_and_runs_claude() {
+    fn claude_script_runs_claude_and_keeps_env_off_the_script() {
         let script = launch_script(
             "claude",
             Some(Path::new("/x/goal.txt")),
             None,
-            &[("WEAVER_API", "http://h:1")],
             LaunchMode::Fresh,
             "",
             "",
         );
-        assert!(script.contains("export WEAVER_API='http://h:1'; "));
         assert!(script.contains("claude \"$(cat '/x/goal.txt')\"; "));
         assert!(script.ends_with("exec \"${SHELL:-/bin/sh}\""));
+        // Regression guard: the session environment is delivered out of band via
+        // the process environment (see `start_terminal` / `backend::new_session`),
+        // so no `export` of an env var may leak into the argv-visible script.
+        assert!(
+            !script.contains("export WEAVER_API") && !script.contains("export LOOM_TOKEN"),
+            "env must not be baked into the launch script: {script}"
+        );
     }
 
     #[test]
@@ -1049,7 +1068,6 @@ mod tests {
             "claude",
             None,
             Some(Path::new("/x/primer.txt")),
-            &[],
             LaunchMode::Fresh,
             "",
             "",
@@ -1067,7 +1085,6 @@ mod tests {
             "claude",
             None,
             Some(Path::new("/x/primer.txt")),
-            &[],
             LaunchMode::Adopt,
             "",
             "",
@@ -1114,7 +1131,6 @@ mod tests {
             "codex",
             Some(Path::new("/x/goal.txt")),
             None,
-            &[],
             LaunchMode::Fresh,
             "",
             "",
@@ -1128,7 +1144,6 @@ mod tests {
             "codex",
             Some(Path::new("/x/goal.txt")),
             None,
-            &[],
             LaunchMode::Adopt,
             "",
             "",
@@ -1149,7 +1164,6 @@ mod tests {
             "codex",
             None,
             Some(Path::new("/x/primer.txt")),
-            &[],
             LaunchMode::Fresh,
             "",
             "",
@@ -1161,22 +1175,16 @@ mod tests {
     }
 
     #[test]
-    fn env_values_with_single_quotes_are_escaped() {
-        // An operator env var whose value contains a single quote must not break
-        // out of the `export NAME='…'` assignment.
-        let script = launch_script(
-            "shell",
-            None,
-            None,
-            &[("MSG", "it's \"quoted\"")],
-            LaunchMode::Fresh,
-            "",
-            "",
-        );
-        assert!(
-            script.contains(r#"export MSG='it'\''s "quoted"'; "#),
-            "got: {script}"
-        );
+    fn operator_env_never_reaches_the_launch_script() {
+        // Operator env vars used to be shell-quoted into the script as
+        // `export NAME='…'`; they are now delivered via the process environment
+        // (`CommandBuilder::env`, off argv) instead. A value with shell
+        // metacharacters therefore needs no quoting and — crucially — must not
+        // appear in the script at all, so `ps` can't read it. The script is a
+        // pure function of the inner command, independent of the env.
+        let script = launch_script("shell", None, None, LaunchMode::Fresh, "", "");
+        assert_eq!(script, "exec \"${SHELL:-/bin/sh}\"");
+        assert!(!script.contains("export MSG"), "got: {script}");
     }
 
     #[test]
@@ -1202,7 +1210,6 @@ mod tests {
             "codex",
             Some(Path::new("/x/goal.txt")),
             None,
-            &[],
             LaunchMode::Fresh,
             "gpt-5.5",
             "xhigh",
@@ -1219,7 +1226,6 @@ mod tests {
             "claude",
             Some(Path::new("/x/goal.txt")),
             None,
-            &[],
             LaunchMode::Adopt,
             "",
             "",

--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -62,13 +62,18 @@ echo 'loom: warning: could not apply the {memory_max_gb}g session memory limit' 
     )
 }
 
-/// Create a detached session running `script` via `sh -c` in `cwd`. A non-zero
-/// `memory_max_gb` prepends the [`memory_prelude`] confining the session to
-/// that many GiB.
+/// Create a detached session running `script` via `sh -c` in `cwd`, with `env`
+/// applied to the child's process environment. A non-zero `memory_max_gb`
+/// prepends the [`memory_prelude`] confining the session to that many GiB.
+///
+/// `env` is delivered out of band (over stdin to the supervisor, then via
+/// `execve`), not `export`-ed into `script`, so secret values never appear on
+/// any process's argv. See [`tapestry::spawn_detached`].
 pub async fn new_session(
     name: &str,
     cwd: &std::path::Path,
     script: &str,
+    env: &[(&str, &str)],
     memory_max_gb: u64,
 ) -> Result<()> {
     tracing::info!(session = %name, cwd = %cwd.display(), memory_max_gb, "spawning terminal session");
@@ -80,9 +85,7 @@ pub async fn new_session(
         name,
         cwd,
         script: &script,
-        // The launch script already bakes the agent env in as `export`
-        // statements (see agent::launch_script).
-        env: &[],
+        env,
         cols: 80,
         rows: 24,
         supervisor_bin: tapestry_bin().as_deref(),

--- a/crates/loom/src/shell.rs
+++ b/crates/loom/src/shell.rs
@@ -47,34 +47,40 @@ fn shell_cwd() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("/"))
 }
 
-/// Build the launch script for a scratch/debug login shell: export the operator
-/// surface an agent session gets — `WEAVER_API` + `LOOM_TOKEN` so the in-place
-/// `weaver`/`loom` CLIs work, the operator-managed [`agent_env`] vars, and (for a
-/// per-session debug shell) the session's `WEAVER_BRANCH` — then `exec` the login
-/// shell. This is a plain shell, not an agent, so it uses
-/// [`agent::bare_shell_script`] (no inner agent command) rather than going through
-/// the agent launch path.
-async fn shell_script(st: &AppState, branch_id: Option<&str>) -> String {
+/// Build the launch script **and** environment for a scratch/debug login shell.
+/// The env is the operator surface an agent session gets — `WEAVER_API` +
+/// `LOOM_TOKEN` so the in-place `weaver`/`loom` CLIs work, the operator-managed
+/// [`agent_env`] vars, and (for a per-session debug shell) the session's
+/// `WEAVER_BRANCH`. The script just `exec`s the login shell via
+/// [`agent::bare_shell_script`] (no inner agent command); the env is delivered
+/// out of band by [`backend::new_session`], not `export`-ed into the script, so
+/// secrets stay off argv. This is a plain shell, not an agent, so it does not go
+/// through the agent launch path.
+async fn shell_script(st: &AppState, branch_id: Option<&str>) -> (String, Vec<(String, String)>) {
     let api_url = format!("http://{}", st.addr);
     let local_token = agent::read_local_token();
     let extra = agent_env::pairs(&st.db).await.unwrap_or_default();
 
-    let mut env: Vec<(&str, &str)> = vec![("WEAVER_API", api_url.as_str())];
+    let mut env: Vec<(String, String)> = vec![("WEAVER_API".to_string(), api_url)];
     // A debug shell is rooted in a branch's worktree, so it gets that branch; the
     // operator scratch shell has none and is deliberately left without one.
     if let Some(branch) = branch_id {
-        env.push(("WEAVER_BRANCH", branch));
+        env.push(("WEAVER_BRANCH".to_string(), branch.to_string()));
     }
-    if let Some(token) = local_token.as_deref() {
-        env.push(("LOOM_TOKEN", token));
+    if let Some(token) = local_token {
+        env.push(("LOOM_TOKEN".to_string(), token));
     }
-    for (k, v) in &extra {
-        env.push((k.as_str(), v.as_str()));
-    }
+    env.extend(extra);
 
     let loom_exe = std::env::current_exe().ok();
     let weaver_dir = loom_exe.as_deref().and_then(Path::parent);
-    agent::bare_shell_script(&env, weaver_dir)
+    (agent::bare_shell_script(weaver_dir), env)
+}
+
+/// Borrow an owned env pair list as the `&[(&str, &str)]` slice
+/// [`backend::new_session`] takes.
+fn env_refs(env: &[(String, String)]) -> Vec<(&str, &str)> {
+    env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect()
 }
 
 /// Ensure the scratch-shell supervisor is up, spawning it if not. Idempotent: a
@@ -84,13 +90,14 @@ pub async fn ensure(st: &AppState) -> Result<()> {
     if backend::has_session(SHELL_SESSION).await {
         return Ok(());
     }
-    let script = shell_script(st, None).await;
+    let (script, env) = shell_script(st, None).await;
     let cwd = shell_cwd();
     tracing::info!(session = SHELL_SESSION, cwd = %cwd.display(), "spawning operator scratch shell");
     backend::new_session(
         SHELL_SESSION,
         &cwd,
         &script,
+        &env_refs(&env),
         backend::memory_max_gb(&st.db).await,
     )
     .await
@@ -144,10 +151,17 @@ pub async fn ensure_debug(
     if backend::has_session(&name).await {
         return Ok(name);
     }
-    let script = shell_script(st, Some(&branch.id)).await;
+    let (script, env) = shell_script(st, Some(&branch.id)).await;
     let cwd = PathBuf::from(&session.work_dir);
     tracing::info!(session = %name, cwd = %cwd.display(), "spawning session debug shell");
-    backend::new_session(&name, &cwd, &script, backend::memory_max_gb(&st.db).await).await?;
+    backend::new_session(
+        &name,
+        &cwd,
+        &script,
+        &env_refs(&env),
+        backend::memory_max_gb(&st.db).await,
+    )
+    .await?;
     Ok(name)
 }
 

--- a/crates/tapestry/src/bin/tapestry.rs
+++ b/crates/tapestry/src/bin/tapestry.rs
@@ -25,7 +25,7 @@ usage:
   tapestry resize  <name> <cols> <rows>    resize the session
   tapestry attach  <name>                  attach this terminal to the session
   tapestry kill    <name>                  kill the session
-  tapestry supervise <json-spec>           (internal) run a supervisor"
+  tapestry supervise -                     (internal) run a supervisor; reads its JSON spec from stdin"
     );
     std::process::exit(2);
 }
@@ -75,9 +75,22 @@ async fn main() -> Result<()> {
     let cmd = args.first().map(String::as_str).unwrap_or("");
     match cmd {
         "supervise" => {
-            let spec_json = args.get(1).context("supervise needs a JSON spec")?;
-            let spec: LaunchSpec =
-                serde_json::from_str(spec_json).context("parsing supervise spec")?;
+            // The spec normally arrives on **stdin** (`supervise -`), so its
+            // secret env values never land on argv (world-readable via `ps` /
+            // /proc/<pid>/cmdline). An explicit JSON arg is still accepted for
+            // manual poking. See [`tapestry::spawn_detached`].
+            let spec: LaunchSpec = match args.get(1).map(String::as_str) {
+                Some("-") | None => {
+                    let mut buf = String::new();
+                    std::io::stdin()
+                        .read_to_string(&mut buf)
+                        .context("reading supervise spec from stdin")?;
+                    serde_json::from_str(&buf).context("parsing supervise spec (stdin)")?
+                }
+                Some(json) => {
+                    serde_json::from_str(json).context("parsing supervise spec (argv)")?
+                }
+            };
             // This process supervises exactly one session, so make it the
             // session's subreaper: anything the agent orphans (it backgrounds
             // gh, sleep, MCP servers, … which then detach) reparents here

--- a/crates/tapestry/src/lib.rs
+++ b/crates/tapestry/src/lib.rs
@@ -40,6 +40,11 @@ pub struct LaunchOptions<'a> {
     pub cwd: &'a Path,
     /// The shell command the supervisor runs as `sh -c <script>`.
     pub script: &'a str,
+    /// Environment for the child, applied via the process environment (execve),
+    /// **not** by `export`-ing into [`Self::script`]. Delivered to the supervisor
+    /// over stdin (see [`spawn_detached`]) and injected with `CommandBuilder::env`,
+    /// so secret values never touch any process's argv. Inherited by the exec'd
+    /// login shell and everything it spawns, exactly as `export` would.
     pub env: &'a [(&'a str, &'a str)],
     pub cols: u16,
     pub rows: u16,
@@ -58,9 +63,12 @@ pub struct LaunchOptions<'a> {
 /// to init — so the supervisor, and the agent under it, survive a loom restart.
 /// Returns once the supervisor is accepting on its socket.
 ///
-/// The supervisor is this very binary re-executed as `tapestry supervise`; the
-/// launch parameters travel as a single JSON argument so a script with spaces or
-/// quotes needs no shell-escaping.
+/// The supervisor is this very binary re-executed as `tapestry supervise -`; the
+/// launch parameters travel as a single JSON blob **over stdin**, not on argv.
+/// That keeps the spec's secret env values (tokens, API keys) out of the
+/// supervisor's `/proc/<pid>/cmdline`, which is world-readable via `ps` for the
+/// whole life of the long-running supervisor. It also means a script with spaces
+/// or quotes needs no shell-escaping.
 pub async fn spawn_detached(opts: &LaunchOptions<'_>) -> Result<()> {
     let exe = match opts.supervisor_bin {
         Some(p) => p.to_path_buf(),
@@ -76,9 +84,11 @@ pub async fn spawn_detached(opts: &LaunchOptions<'_>) -> Result<()> {
     });
 
     let mut cmd = std::process::Command::new(&exe);
+    // `-` tells the supervisor to read its JSON spec from stdin (see below); the
+    // spec never appears on argv.
     cmd.arg("supervise")
-        .arg(spec.to_string())
-        .stdin(Stdio::null())
+        .arg("-")
+        .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     // setsid in the child so it leads a new session with no controlling
@@ -95,7 +105,23 @@ pub async fn spawn_detached(opts: &LaunchOptions<'_>) -> Result<()> {
             Ok(())
         });
     }
-    cmd.spawn().context("spawning detached supervisor")?;
+    let mut child = cmd.spawn().context("spawning detached supervisor")?;
+
+    // Deliver the spec over the stdin pipe, then close it so the supervisor's
+    // read hits EOF. The supervisor reads stdin to completion before any PTY
+    // setup, so this small (<64 KiB) write never blocks. The child handle is
+    // dropped without waiting — the supervisor is detached (setsid) and outlives
+    // us on purpose.
+    {
+        use std::io::Write as _;
+        let mut stdin = child
+            .stdin
+            .take()
+            .context("detached supervisor stdin pipe missing")?;
+        stdin
+            .write_all(spec.to_string().as_bytes())
+            .context("writing launch spec to supervisor stdin")?;
+    }
 
     // Wait (bounded) for the socket to come up so callers can drive the session
     // as soon as this returns.


### PR DESCRIPTION
## Problem

A session's environment — `WEAVER_*`, `LOOM_TOKEN`, and operator-managed secrets like `GH_TOKEN` / `WANDB_API_KEY` — was exposed in plaintext on process command lines, readable by any local process via `ps` / `/proc/<pid>/cmdline` for the **entire life of the session**.

Two argv hops leaked it:

1. `loom` baked the env into the launch **script** as `export NAME='…'` statements (`agent::wrap_launch_script`), so the `sh -c <script>` child carried every secret on its argv.
2. `tapestry::spawn_detached` passed the whole launch spec (script included) as a single **JSON argv argument** to `tapestry supervise <json>`, so the long-lived supervisor process carried them too.

Both processes persist for the whole session, so `ps aux` showed tokens the entire time.

## Fix

Deliver the environment **out of band** so it never touches argv:

- `tapestry::spawn_detached` now execs `tapestry supervise -` with a piped stdin and **writes the JSON spec to stdin**, not argv.
- `tapestry supervise` reads its spec from **stdin** on `-` (an explicit JSON arg is still accepted for manual/dev use).
- `loom` stops `export`-ing env into the script. `start_terminal` and the scratch/debug shells pass the env vec through `backend::new_session` → `LaunchOptions.env`, which the supervisor applies via `CommandBuilder::env` (the `execve` environment). The child inherits it exactly as `export` did, so nested shells/subprocesses are unaffected.
- Only `export PATH="…:$PATH"` stays script-side — it needs runtime `$PATH` expansion and carries no secret.

## Verification

- `cargo test -p tapestry` — the detached-supervisor tests drive `spawn_detached`, exercising the new stdin transport end-to-end. ✅
- `cargo test -p loom --lib` — 204 pass, including two rewritten regression tests asserting env never lands in the launch script. ✅
- `fmt` + `clippy -D warnings` + `vue-tsc` typecheck clean (pre-commit hook). ✅
- **Live `/proc` check** with a runtime-random marker in a session's env:
  - supervisor argv → `tapestry supervise -`
  - child argv → `sleep 300`
  - marker on **any** process's argv → **NONE**
  - marker in child's **`environ`** → **present** (delivery intact)

  Before this change the same marker appeared on both the `tapestry supervise …` and `sh -c …` cmdlines.

## Note

This stops *future* leakage. Any secrets currently exposed on running sessions (e.g. `GH_TOKEN`, `LOOM_TOKEN`, `WANDB_API_KEY`) were world-readable via `ps` and should be **rotated**; the fix only takes effect for sessions spawned after loom/tapestry are redeployed with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)