### PR TITLE
fix(loom): trigger on a @loom mention anywhere in a comment

### DIFF
--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -10,7 +10,8 @@
 //! 2. **Dedupe** on the `X-GitHub-Delivery` GUID ([`record_delivery`]) so a
 //!    replayed or GitHub-retried delivery never launches a second session.
 //! 3. **Filter** to `issue_comment`/`created`, ignoring the bot's own comments.
-//! 4. **Parse** a fixed command prefix ([`is_trigger`]) — no free-text in v1.
+//! 4. **Match** the trigger phrase ([`is_trigger`]) — a standalone mention
+//!    anywhere in the comment's prose, quotes and code excluded.
 //! 5. **Authorize the commenter** ([`authorize`]): a known loom operator, or
 //!    someone with write/admin on the repo (checked via the GitHub API). Anyone
 //!    else is silently ignored; a per-repo rate limit blunts spam.
@@ -52,7 +53,7 @@ pub async fn webhook_secret(db: &Db) -> String {
     env_or_setting(db, "LOOM_GITHUB_WEBHOOK_SECRET", WEBHOOK_SECRET_KEY).await
 }
 
-/// The trigger phrase a comment must begin with, from the
+/// The phrase that tags loom into a comment ([`is_trigger`]), from the
 /// `github.trigger_phrase` setting (default `@loom`).
 pub async fn trigger_phrase(db: &Db) -> String {
     let phrase = config::get_or(
@@ -72,8 +73,13 @@ pub async fn trigger_phrase(db: &Db) -> String {
 
 /// The bot's own GitHub login, whose comments are ignored to prevent a
 /// self-trigger loop. `LOOM_GITHUB_BOT_LOGIN`, else the `github.bot_login`
-/// setting; `None` when unset (the command-prefix filter is the real guard, so
-/// this is defence in depth and optional).
+/// setting; `None` when unset.
+///
+/// Optional, but worth setting: loom's own replies never carry the phrase, and
+/// [`is_trigger`] ignores quoted text, so the common loops are already closed —
+/// but a session that replies on its thread and *mentions* the phrase in prose
+/// would tag itself. [`authorize`] is the backstop (the bot identity is not
+/// normally an approved user); this closes it a step earlier.
 pub async fn bot_login(db: &Db) -> Option<String> {
     let login = env_or_setting(db, "LOOM_GITHUB_BOT_LOGIN", BOT_LOGIN_KEY).await;
     let login = login.trim();
@@ -130,13 +136,130 @@ pub fn verify_signature(secret: &str, body: &[u8], header: Option<&str>) -> bool
 // Command + payload parsing.
 // ---------------------------------------------------------------------------
 
-/// Whether `body` begins with the trigger `phrase`, ignoring leading whitespace
-/// and case. The match is anchored to the **start** so a quote of an earlier
-/// comment, or the phrase buried mid-text, does not trigger.
+/// Whether `body` mentions the trigger `phrase` — matched case-insensitively
+/// **anywhere** in the comment's prose, so `please @loom rebase this` fires just
+/// as `@loom rebase this` does. People tag a bot mid-sentence; anchoring to the
+/// start only taught them the trigger was broken.
+///
+/// *Prose* is the load-bearing word. Two narrow exclusions keep "anywhere" from
+/// meaning "in text that isn't addressing the bot":
+///
+/// - **Quotes** ([`mentionable_text`] drops `>` lines). GitHub's quote-reply
+///   pastes the comment being answered verbatim, so a plain substring match
+///   would re-fire on every round of a thread.
+/// - **Code**, fenced or inline. Talking *about* the trigger — ``the phrase is
+///   `@loom` `` — is not using it.
+///
+/// The mention must also stand alone ([`mentions`]): `@loomer`, `me@loom.dev`,
+/// and `@loom-bot` do not tag `@loom`.
+///
+/// An empty phrase never matches, guarding a misconfigured setting.
 pub fn is_trigger(body: &str, phrase: &str) -> bool {
-    let body = body.trim_start().to_lowercase();
     let phrase = phrase.trim().to_lowercase();
-    !phrase.is_empty() && body.starts_with(&phrase)
+    if phrase.is_empty() {
+        return false;
+    }
+    mentions(&mentionable_text(body).to_lowercase(), &phrase)
+}
+
+/// Whether `text` contains `phrase` bounded by non-word characters on both
+/// sides. Both arguments must already be lowercased.
+///
+/// `-` counts as a word character because a GitHub login is `[A-Za-z0-9-]`:
+/// `@loom-bot` names a *different* account, not `@loom` with punctuation after
+/// it. Ordinary trailing punctuation (`@loom!`) is not a word character, so it
+/// still tags.
+fn mentions(text: &str, phrase: &str) -> bool {
+    let is_word = |c: char| c.is_alphanumeric() || c == '_' || c == '-';
+    let mut from = 0;
+    while let Some(rel) = text[from..].find(phrase) {
+        let start = from + rel;
+        let end = start + phrase.len();
+        if !text[..start].chars().next_back().is_some_and(is_word)
+            && !text[end..].chars().next().is_some_and(is_word)
+        {
+            return true;
+        }
+        // This hit was glued to a word; a later one may still stand alone.
+        from = start + text[start..].chars().next().map_or(1, char::len_utf8);
+    }
+    false
+}
+
+/// `body` reduced to the text a mention can live in: blockquote lines and code
+/// (fenced or inline) removed. Each removal leaves whitespace behind, so cutting
+/// a span never fuses its neighbours into one word.
+fn mentionable_text(body: &str) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut fence: Option<(char, usize)> = None;
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        match (fence, fence_marker(trimmed)) {
+            // Per CommonMark a block closes only on its own character, at least
+            // as long as the fence that opened it — so a ```` block can hold a
+            // ``` one (and a ``` block a ~~~ one) without ending early.
+            (Some((open, len)), Some((c, run))) if c == open && run >= len => fence = None,
+            (Some(_), _) => {}
+            (None, Some(marker)) => fence = Some(marker),
+            (None, None) if trimmed.starts_with('>') => {}
+            (None, None) => {
+                push_without_inline_code(line, &mut out);
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+/// The character and length of a ```` ``` ````/`~~~` code-fence line (three or
+/// more of either), else `None`.
+fn fence_marker(trimmed: &str) -> Option<(char, usize)> {
+    let mut chars = trimmed.chars();
+    let c = chars.next().filter(|&c| c == '`' || c == '~')?;
+    let run = 1 + chars.take_while(|&x| x == c).count();
+    (run >= 3).then_some((c, run))
+}
+
+/// Append `line` to `out` with its inline-code spans blanked. A span opens on a
+/// run of backticks and closes on the next run of the *same* length, per
+/// CommonMark — so ``` ``@loom`` ``` is code, not a mention. An unclosed run is
+/// literal text: only the backticks go, and the rest of the line stays prose.
+fn push_without_inline_code(line: &str, out: &mut String) {
+    let chars: Vec<char> = line.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '`' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        let run = backtick_run(&chars, i);
+        out.push(' ');
+        i = closing_run(&chars, i + run, run).unwrap_or(i + run);
+    }
+}
+
+/// How many backticks run consecutively from `i`.
+fn backtick_run(chars: &[char], i: usize) -> usize {
+    chars[i..].iter().take_while(|&&c| c == '`').count()
+}
+
+/// The index just past the first run of *exactly* `run` backticks at or after
+/// `from`, or `None` when the span is never closed.
+fn closing_run(chars: &[char], from: usize, run: usize) -> Option<usize> {
+    let mut i = from;
+    while i < chars.len() {
+        if chars[i] != '`' {
+            i += 1;
+            continue;
+        }
+        let r = backtick_run(chars, i);
+        if r == run {
+            return Some(i + r);
+        }
+        i += r;
+    }
+    None
 }
 
 /// The `issue_comment` webhook payload, narrowed to the fields the trigger uses.
@@ -479,17 +602,70 @@ mod tests {
     }
 
     #[test]
-    fn is_trigger_anchors_to_the_start_ignoring_case_and_lead_space() {
-        let phrase = "@loom work on this";
-        assert!(is_trigger("@loom work on this issue please", phrase));
-        assert!(is_trigger("  @LOOM Work On This", phrase));
-        assert!(is_trigger("@loom work on this", phrase));
-        // Not at the start → ignored (e.g. quoting someone else).
-        assert!(!is_trigger("> @loom work on this", phrase));
-        assert!(!is_trigger("please @loom work on this", phrase));
+    fn is_trigger_matches_a_mention_anywhere_ignoring_case() {
+        let phrase = "@loom";
+        assert!(is_trigger("@loom rebase onto main", phrase));
+        assert!(is_trigger("  @LOOM Rebase Onto Main", phrase));
+        // The point of the substring match: people tag mid-sentence.
+        assert!(is_trigger("please @loom rebase this", phrase));
+        assert!(is_trigger("nice catch!\n\ncc @loom", phrase));
+        assert!(is_trigger("**@loom** — over to you", phrase));
         assert!(!is_trigger("just a normal comment", phrase));
         // An empty phrase never matches (guards a misconfigured setting).
         assert!(!is_trigger("anything", ""));
+        // A multi-word phrase behaves the same way.
+        let phrase = "@loom work on this";
+        assert!(is_trigger("ok — @loom work on this, please", phrase));
+        assert!(is_trigger("@loom work on this", phrase));
+        assert!(!is_trigger("@loom work on something else", phrase));
+    }
+
+    #[test]
+    fn is_trigger_ignores_quoted_and_code_text() {
+        let phrase = "@loom";
+        // GitHub's quote-reply pastes the comment being answered — matching it
+        // would re-fire the bot on every round of a thread.
+        assert!(!is_trigger(
+            "> @loom rebase onto main\n\ndone, thanks",
+            phrase
+        ));
+        // Talking *about* the trigger is not using it.
+        assert!(!is_trigger("does `@loom` still work?", phrase));
+        assert!(!is_trigger("does ``@loom`` still work?", phrase));
+        assert!(!is_trigger(
+            "```\n@loom rebase\n```\nthat's the syntax",
+            phrase
+        ));
+        assert!(!is_trigger("~~~\n@loom rebase\n~~~", phrase));
+        // A shorter inner fence doesn't close the block, so this is all code.
+        assert!(!is_trigger("````\n```\n@loom rebase\n```\n````", phrase));
+        // ...but a real mention alongside quoted or code text still fires.
+        assert!(is_trigger(
+            "> an earlier comment\n\n@loom take another pass",
+            phrase
+        ));
+        assert!(is_trigger(
+            "run `git rebase` first, then @loom verify",
+            phrase
+        ));
+        assert!(is_trigger("```\ncode\n```\n\n@loom review this", phrase));
+        // An unclosed backtick is literal text, not an open code span that
+        // swallows the rest of the comment.
+        assert!(is_trigger("weird ` backtick, @loom look", phrase));
+    }
+
+    #[test]
+    fn is_trigger_requires_a_standalone_mention() {
+        let phrase = "@loom";
+        assert!(!is_trigger("ping @loomer about it", phrase));
+        assert!(!is_trigger("mail me@loom.dev", phrase));
+        // A different account, not @loom with a hyphen after it.
+        assert!(!is_trigger("that's @loom-bot's job", phrase));
+        // Ordinary punctuation is not part of the mention.
+        assert!(is_trigger("over to you, @loom!", phrase));
+        assert!(is_trigger("(@loom)", phrase));
+        // A glued hit does not mask a real one later on.
+        assert!(is_trigger("me@loom.dev — and @loom, take a look", phrase));
     }
 
     #[test]

--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -137,9 +137,9 @@ pub fn verify_signature(secret: &str, body: &[u8], header: Option<&str>) -> bool
 // ---------------------------------------------------------------------------
 
 /// Whether `body` mentions the trigger `phrase` — matched case-insensitively
-/// **anywhere** in the comment's prose, so `please @loom rebase this` fires just
-/// as `@loom rebase this` does. People tag a bot mid-sentence; anchoring to the
-/// start only taught them the trigger was broken.
+/// **anywhere** in the comment's prose, because people tag a bot mid-sentence as
+/// readily as they open with it: `please @loom rebase this` tags as surely as
+/// `@loom rebase this`.
 ///
 /// *Prose* is the load-bearing word. Two narrow exclusions keep "anywhere" from
 /// meaning "in text that isn't addressing the bot":

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -239,7 +239,7 @@ pub(super) async fn github_webhook(
         &format!("{}#{number} (@{author})", slug.slug()),
     );
     tokio::spawn(async move {
-        match handle_trigger(st, headers, slug, event, author).await {
+        match handle_trigger(st, headers, slug, event, author, phrase).await {
             Ok(Some(id)) => {
                 crate::tasks::registry().finish(task_id, "done", &format!("session {id}"))
             }
@@ -264,6 +264,7 @@ async fn handle_trigger(
     slug: repo::RepoSlug,
     event: github_trigger::IssueCommentEvent,
     author: String,
+    phrase: String,
 ) -> Result<Option<String>, String> {
     // Honor the App's installation as the repo grant: auto-register any repo the
     // App is installed on into the managed allowlist, so the clone path below
@@ -336,8 +337,15 @@ async fn handle_trigger(
     if let Some(branch) = target_branch.as_deref() {
         if let Ok(Some(b)) = branch_mod::find_by_repo_branch(&st.db, &repo_root_str, branch).await {
             if let Ok(Some(sess)) = session_mod::active_for_branch(&st.db, &b.id).await {
-                if forward_comment_to_session(&sess, &author, is_pr, number, &event.comment.body)
-                    .await
+                if forward_comment_to_session(
+                    &sess,
+                    &author,
+                    is_pr,
+                    number,
+                    &event.comment.body,
+                    &phrase,
+                )
+                .await
                 {
                     crate::events::record(
                         &st.db,
@@ -499,6 +507,7 @@ async fn forward_comment_to_session(
     is_pr: bool,
     number: i64,
     comment: &str,
+    phrase: &str,
 ) -> bool {
     let (thread, cmd) = if is_pr {
         ("PR", "pr")
@@ -506,7 +515,7 @@ async fn forward_comment_to_session(
         ("issue", "issue")
     };
     let note = format!(
-        "New @loom comment from @{author} on {thread} #{number}:\n\n{}\n\n\
+        "New {phrase} comment from @{author} on {thread} #{number}:\n\n{}\n\n\
          (Reply on the thread with `gh {cmd} comment {number} --body \"…\"` if a response is warranted.)",
         comment.trim(),
     );

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -264,6 +264,35 @@ async fn non_trigger_comment_is_ignored() {
     assert!(fake.comments.lock().unwrap().is_empty());
 }
 
+/// The trigger is a **mention**, not a prefix: tagging the phrase mid-sentence
+/// launches, while a mention that only appears inside a quote does not. (The
+/// unit tests in `github_trigger` pin the matcher itself; this is the same
+/// distinction through the real handler.)
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_mid_comment_mention_triggers_and_a_quoted_one_does_not() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+
+    // A quote-reply pastes the comment being answered; that is not a new trigger.
+    let quoted = trigger_body("rjpower", 8, "> @loom work on this\n\nagreed — nice one");
+    let resp = post(&ts, "d-quoted", Some(sign(SECRET, &quoted)), &quoted).await;
+    assert_eq!(resp.status(), 200, "a quoted mention is acknowledged");
+    assert_eq!(
+        session_count(&ts).await,
+        0,
+        "no session from a mention that only appears in a quote"
+    );
+    assert!(fake.comments.lock().unwrap().is_empty());
+
+    // ...but tagging it part-way through a comment does launch.
+    let body = trigger_body("rjpower", 8, "nice catch — @loom take it from here please");
+    let resp = post(&ts, "d-midtext", Some(sign(SECRET, &body)), &body).await;
+    assert_eq!(resp.status(), 200);
+    wait_for_sessions(&ts, 1).await;
+    wait_for_comments(&fake, 1).await;
+}
+
 /// A commenter who is not an approved loom user launches nothing — but instead of
 /// a silent drop, loom replies once with a friendly "request access" note so they
 /// know how to proceed. (Repo write access is not itself a grant — only the

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -215,11 +215,12 @@ pub const REGISTRY: &[SettingSpec] = &[
     SettingSpec {
         key: "github.trigger_phrase",
         label: "GitHub trigger phrase",
-        description: "The phrase an issue comment must begin with for the GitHub \
-            webhook to launch a session against that repo (default `@loom`). \
-            Matched case-insensitively against the start of the comment; kept a \
-            fixed prefix rather than free-text to limit the abuse surface. The \
-            webhook is only active once `LOOM_GITHUB_WEBHOOK_SECRET` is configured.",
+        description: "The phrase that tags loom into an issue or PR comment and \
+            launches a session against that repo (default `@loom`). Matched \
+            case-insensitively anywhere in the comment, as a standalone mention: \
+            quoted lines and code are ignored, and `@loom-bot` is a different \
+            name. The webhook is only active once `LOOM_GITHUB_WEBHOOK_SECRET` \
+            is configured.",
         kind: SettingKind::String,
         default: DEFAULT_GITHUB_TRIGGER_PHRASE,
         group: "GitHub",

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -25,9 +25,15 @@ receiver, in order:
    no-op, so a repeat never launches a second session.
 3. **Filters** to `issue_comment` / `action == created`. Edits, deletions, other
    events, and the bot's own comments (set `github.bot_login`) are ignored.
-4. **Matches the command.** The comment must *begin* with the trigger phrase
-   (`github.trigger_phrase`, default `@loom`), matched case-insensitively. Fixed
-   prefix only — no free-text.
+4. **Matches the trigger.** The comment must tag the trigger phrase
+   (`github.trigger_phrase`, default `@loom`), matched case-insensitively
+   **anywhere** in the comment's prose — `please @loom rebase this` fires just as
+   `@loom rebase this` does. Two kinds of text don't count as tagging, because
+   they quote or discuss the phrase rather than address the bot with it: quoted
+   lines (`>`), so a quote-reply pasting an earlier `@loom` never re-fires the
+   thread; and code, fenced or inline, so a comment asking whether `` `@loom` ``
+   still works launches nothing. The mention must stand alone — `@loom-bot` and
+   `me@loom.dev` are not `@loom`.
 5. **Authorizes the commenter.** Their GitHub login must be an
    [approved loom user](#who-can-trigger) — the *same* allowlist that gates
    signing in to the app. Repo write access is **not** by itself a grant. An
@@ -146,9 +152,10 @@ launches nothing.
 
 ### Optional settings
 
-- `github.trigger_phrase` — the phrase a comment must begin with (default
-  `@loom`). Matched as a case-insensitive prefix, so `@loom rebase onto main`
-  triggers. Settable in **Settings → GitHub** or
+- `github.trigger_phrase` — the phrase that tags loom (default `@loom`). Matched
+  case-insensitively anywhere in a comment's prose, as a standalone mention
+  ([step 4](#how-it-works)) — both `@loom rebase onto main` and `can you rebase
+  this, @loom?` trigger. Settable in **Settings → GitHub** or
   `weaver config set github.trigger_phrase "…"`.
 - `github.bot_login` (or `LOOM_GITHUB_BOT_LOGIN`) — a GitHub login whose own
   comments are ignored, so a bot account can post without re-triggering itself.
@@ -247,9 +254,11 @@ picks a comment up later, so debugging is one question: *did the delivery arrive
 and which gate did it hit?* Work through it in order:
 
 1. **Was the comment the right shape?** It must be a PR/issue **conversation**
-   comment (an `issue_comment`) that *begins* with the trigger phrase. An inline
-   code-review comment and a review summary are different events loom does not
-   subscribe to, so `@loom` in those never fires.
+   comment (an `issue_comment`) that tags the trigger phrase in its prose — a
+   mention that sits only inside a quote or a code span is ignored by design
+   ([step 4](#how-it-works)). An inline code-review comment and a review summary
+   are different events loom does not subscribe to, so `@loom` in those never
+   fires.
 
 2. **Did GitHub deliver it, and what did loom answer?** The GitHub App's
    **Settings → Advanced → Recent Deliveries** (or the repo/org webhook's) shows


### PR DESCRIPTION
The GitHub webhook only fired when the trigger phrase opened the comment, so tagging it mid-sentence — "please @loom rebase this", the common way people address a bot — silently did nothing.

`is_trigger` now matches the phrase anywhere in a comment's prose. Two exclusions keep "anywhere" from meaning "in text that isn't addressing the bot":

- Quoted lines (`>`). GitHub's quote-reply pastes the comment being answered verbatim, so a plain substring match would re-fire on every round of a thread.
- Code, fenced or inline. A comment discussing `` `@loom` `` talks about the trigger rather than using it.

The mention must also stand alone, so `@loom-bot` and `me@loom.dev` don't tag `@loom`.

Alongside: the note forwarded into an already-running session hardcoded "@loom" regardless of `github.trigger_phrase`, so an instance configured with another phrase announced the wrong one. It now uses the configured phrase.

Fixes #453