### PR TITLE
docs(weaver): default the design → peer review → rev loop

### DIFF
--- a/.agents/skills/smartdoc.md
+++ b/.agents/skills/smartdoc.md
@@ -22,6 +22,8 @@ hand-rolled data URI. `weaver artifact rm <name>` removes one and its history.
   for an artifact only when there's a document worth reading.
 - A committed design doc is still a normal repo file on a normal PR. weaver just
   isn't its manager.
+- A design that turns on research or a tradeoff goes out for peer review before
+  it is built — the loop is in `weaver readme` ("Designing before you build").
 
 ## The division of labor
 

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -177,6 +177,38 @@ has moved on since it was set (its timestamp predates your last activity).
   set `weaver status attention "<the question>"`, then continue with your
   best assumption.
 
+## Designing before you build
+
+When the task turns on research or a tradeoff — an architecture choice, a
+migration strategy, an API contract, a storage model, anything expensive to
+reverse — write the design down and have it reviewed before you build it. Skip
+this for a quick fix, a bug with an obvious cause, a rename, a doc tweak, a
+review comment, an issue reply: no tradeoff, no review, just write the code.
+
+1. Write it as an artifact — `weaver artifact write design <file>`: the
+   reasoning, the alternatives you rejected and why, the open questions. Name it
+   `design`; `plan` means the issue-referencing task list above. Stay `ok` — a
+   draft awaiting review is not something the user needs to look at.
+2. Send it to two reviewers, each checking it against the code. If you are
+   `claude`:
+
+   ```sh
+   ask="Peer-review the design on stdin against this repo. What is wrong, missing,
+   or over-built? Be concrete and blunt — no praise, no summary."
+   weaver artifact show design | codex exec -s read-only "$ask"
+   weaver artifact show design | claude -p --model fable "$ask"
+   ```
+
+   If you are `codex`: one of your own sub-agents, plus `claude -p --model fable`.
+   Run both in the background and in parallel — each takes minutes. If a reviewer
+   isn't on `PATH`, note it and go with one.
+3. Incorporate the findings and rev the artifact. The reviews will be partly
+   wrong; use judgment, not a patch queue. Fix what lands, record what you
+   rejected and why. `weaver artifact write design` appends the revision. Only
+   now surface it: raise `attention` with the URL, and if the session came from a
+   GitHub issue or PR, paste the design on that thread (`gh issue comment <n>` /
+   `gh pr comment <n>`) — a reader there can't open a loopback dashboard URL.
+
 ## Finishing work
 
 You are on a dedicated branch in your own worktree. There is no "merge" button —


### PR DESCRIPTION
Research and tradeoff work — an architecture choice, a migration strategy, an API contract — gets a written design reviewed before it is built. Sessions had no default for this, so the round only happened when a user asked for it by hand in the goal.

Adds a **Designing before you build** section to `WEAVER.md` (the primer every session sees, and what `weaver readme` prints):

1. Write the design as a `design` artifact.
2. Send it to two reviewers — `codex` + `claude -p --model fable` if you are claude; a sub-agent + fable if you are codex.
3. Incorporate, rev, and only *then* surface it — status `attention` plus the GitHub thread.

Scoped explicitly: a quick fix, an obvious bug, a rename, a doc tweak, a review comment, or an issue reply has no tradeoff to review.

The artifact is named `design`, not `plan` — `plan` already means the smartdoc task list that references issues, defined 140 lines earlier in the same file.

## Dogfooded

The section was written by running its own loop: the design went out to `codex` and `claude --model fable`, and both reviews are incorporated. What they changed: the `plan`→`design` rename, dropping an `attention` raise on a draft the workflow itself revises, deleting an over-firing trigger test, dropping a read-only claim true only of codex, and moving the GitHub paste after revision so the thread copy isn't stale at rev 1.

The commands are smoke-tested rather than assumed — `codex exec -s read-only` genuinely reads the repo under its sandbox, and both reviews cite real `file:line`.

## Follow-ups filed

- #455 — `codex` is not installed in the deployed loom image, so deployed sessions fall back to one reviewer (the section handles this with an on-PATH fallback).
- #456 — `weaver artifact write` prints a loopback URL rather than `auth.base_url`; the section documents around it for now.
- #457 — a nested headless `claude -p` inherits the worktree's hooks and fires `weaver hook` lifecycle events against the parent branch (pre-existing; `scripts/lint-review.py` does the same).