### PR TITLE
feat(loom,weaver): `loom session url`; GitHub-issue etiquette in WEAVER.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ loom session wait <session>           # block until it finishes or needs you
 loom session send <session> "try the curl again"   # type a message + Enter (trigger an agent round)
 loom session break <session>          # send Escape — interrupt the current turn
 loom session preview <session>        # print the recent terminal screen
+loom session url [<session>]          # its dashboard URL (yours by default) — the link to share
 loom ps                               # list active sessions
 loom session show <branch>                    # session detail
 loom attach <branch>                  # attach your terminal to the session (or use the browser terminal)
@@ -143,6 +144,11 @@ attention, `loom session send` types a message into the agent's terminal (and
 submits it to trigger a round), `loom session break` sends Escape to interrupt
 the current turn, and `loom session preview` prints the recent terminal screen.
 Each takes a session key — an id, branch id, branch name, or `repo:branch`.
+
+`loom session url` prints a session's dashboard URL — the link to hand a person,
+resolved against loom's externally-visible address (the `auth.base_url` setting,
+else the address you reached it on). With no key it is the session you are
+running inside, which is how an agent links a PR back to the work behind it.
 
 Three flags seed the task from existing work instead of a fresh description:
 `loom session launch --issue 123` takes the branch's title / goal / description

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -212,6 +212,22 @@ enum SessionCmd {
     /// with `--name`. To pick up existing work instead of describing a new
     /// task, use `--claim <id>`, `--issue <n>`, or `--branch <name>`.
     Launch(LaunchOpts),
+    /// Print a session's dashboard URL — the link to hand a human.
+    ///
+    /// With no argument this is *your own* session (resolved from
+    /// `$WEAVER_BRANCH`), so an agent opening a PR can link back to the session
+    /// that produced it:
+    ///
+    ///     gh pr create --body "$(printf 'Fixes #12\n\nloom: %s\n' "$(loom session url)")"
+    ///
+    /// The URL is resolved by the server, which is the only thing that knows
+    /// loom's externally-visible address — building it from `$WEAVER_API` inside
+    /// a session would yield a loopback link nobody else can open.
+    Url {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        /// Defaults to the current session.
+        session: Option<String>,
+    },
     /// Poll a session's status: lifecycle + the agent's attention and message.
     Poll {
         /// Session key: id, branch id, branch name, or `repo:branch`.
@@ -668,6 +684,7 @@ async fn run_issue(cmd: IssueCmd) -> Result<()> {
 async fn run_session(cmd: SessionCmd) -> Result<()> {
     match cmd {
         SessionCmd::Launch(opts) => cmd_launch(opts.into()).await,
+        SessionCmd::Url { session } => cmd_session_url(session).await,
         SessionCmd::Poll { session } => cmd_session_poll(session).await,
         SessionCmd::Wait {
             session,
@@ -2118,6 +2135,37 @@ fn attention_summary(ws: &Value) -> String {
     } else {
         format!("{attention} — {message}")
     }
+}
+
+/// `loom session url` — print a session's dashboard URL, defaulting to the
+/// session we are running inside. The server resolves the URL (only it knows
+/// loom's public origin); this just prints it bare, so it composes into a
+/// `gh pr create --body "$(…)"` without any trimming.
+async fn cmd_session_url(key: Option<String>) -> Result<()> {
+    let key = match key {
+        Some(k) => k,
+        // `$WEAVER_BRANCH` is the branch id loom exports into every session it
+        // launches, and the API resolves a branch id as a session key.
+        None => std::env::var("WEAVER_BRANCH")
+            .ok()
+            .map(|k| k.trim().to_string())
+            .filter(|k| !k.is_empty())
+            .context(
+                "not inside a loom session ($WEAVER_BRANCH is not set) — \
+                 pass a session key explicitly: loom session url <session>",
+            )?,
+    };
+    let client = client::default();
+    let res: Value = client
+        .get(&format!("/api/sessions/{key}/url"))
+        .await
+        .with_context(|| format!("no live session for '{key}'"))?;
+    let url = res
+        .get("url")
+        .and_then(Value::as_str)
+        .context("server returned no url")?;
+    println!("{url}");
+    Ok(())
 }
 
 /// `loom session poll` — a one-shot status read: lifecycle + attention.

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -540,7 +540,10 @@ async fn maybe_post_backlink(
     if base.is_empty() {
         return; // no public URL configured → a link wouldn't resolve
     }
-    let body = format!("Working on this in loom: {base}/s/{}", session.id);
+    let body = format!(
+        "Working on this in loom: {}",
+        crate::web::session_url(&base, &session.id)
+    );
     if let Err(e) = state
         .trigger
         .gh()

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -152,6 +152,16 @@ async fn cookie_secure(st: &AppState) -> bool {
     config::get_bool(&st.db, "auth.cookie_secure", config::DEFAULT_COOKIE_SECURE).await
 }
 
+/// [`external_base`], falling back to the address we are bound to when the
+/// request carries no Host — for building a link to hand out (a webhook reply, a
+/// PR back-link, `loom session url`), where there is no "no origin" answer and
+/// the bound address is the best guess available.
+pub(crate) async fn public_base(st: &AppState, headers: &HeaderMap) -> String {
+    external_base(st, headers)
+        .await
+        .unwrap_or_else(|| format!("http://{}", st.addr))
+}
+
 /// The externally-visible base URL, for the OAuth callback. Prefers the
 /// `auth.base_url` setting; otherwise derives `{proto}://{host}` from the request
 /// (honouring `X-Forwarded-Proto` from a TLS-terminating proxy).

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -310,6 +310,13 @@ pub(crate) async fn require_session(db: &Db, key: &str) -> ApiResult<(Session, B
     Err(AppError::not_found("session"))
 }
 
+/// The dashboard URL for a session — the page a person opens to watch it.
+/// `base` is an origin (with or without a trailing slash); pair it with
+/// [`auth::public_base`] to build a link that resolves off-box.
+pub(crate) fn session_url(base: &str, session_id: &str) -> String {
+    format!("{}/s/{session_id}", base.trim_end_matches('/'))
+}
+
 pub(crate) async fn require_branch(db: &Db, key: &str) -> ApiResult<Branch> {
     if let Some(branch) = branch_mod::resolve_key(db, key).await? {
         return Ok(branch);
@@ -498,6 +505,8 @@ pub fn router(state: AppState) -> Router {
             "/sessions/{id}",
             get(get_session).patch(patch_session).delete(delete_session),
         )
+        // The session's own dashboard URL — the link an agent hands a human.
+        .route("/sessions/{id}/url", get(session_url_route))
         .route("/sessions/{id}/archive", post(archive_session))
         .route("/sessions/{id}/adopt", post(adopt_session))
         .route("/sessions/{id}/recover", post(recover_session))

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -17,7 +17,7 @@ use crate::repo;
 use crate::session::{self as session_mod, Session};
 use weaver_core::branch as branch_mod;
 
-use super::auth::external_base;
+use super::auth::public_base;
 use super::sessions::create_session_core;
 use super::{ApiResult, AppError, AppState};
 
@@ -356,12 +356,10 @@ async fn handle_trigger(
                     )
                     .await
                     .ok();
-                    let base = external_base(&st, &headers)
-                        .await
-                        .unwrap_or_else(|| format!("http://{}", st.addr));
+                    let base = public_base(&st, &headers).await;
                     let reply = format!(
-                        "Passed your note to the session already on this thread — {base}/s/{}",
-                        sess.id
+                        "Passed your note to the session already on this thread — {}",
+                        super::session_url(&base, &sess.id)
                     );
                     if let Err(e) = st
                         .trigger
@@ -407,10 +405,8 @@ async fn handle_trigger(
     };
 
     // 11. Reply on the thread with the live session URL.
-    let base = external_base(&st, &headers)
-        .await
-        .unwrap_or_else(|| format!("http://{}", st.addr));
-    let reply = format!("On it — {base}/s/{}", view.id);
+    let base = public_base(&st, &headers).await;
+    let reply = format!("On it — {}", super::session_url(&base, &view.id));
     if let Err(e) = st
         .trigger
         .gh()

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -122,6 +122,25 @@ pub(super) async fn get_session(
     Ok(Json(session_view(&st.db, &session, &branch).await?))
 }
 
+/// `GET /api/sessions/{id}/url` — the dashboard URL for a session.
+///
+/// The agent inside a session can't build this itself: it only knows the
+/// loopback `$WEAVER_API` it was handed, and a `http://127.0.0.1:7878/…` link
+/// pasted into a PR is useless to whoever reads it. Only the server knows the
+/// externally-visible origin (the operator's `auth.base_url`, else the request's
+/// own Host), so resolving it is the server's job — see `loom session url`.
+pub(super) async fn session_url_route(
+    State(st): State<AppState>,
+    headers: header::HeaderMap,
+    Path(key): Path<String>,
+) -> ApiResult<Json<Value>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    let base = super::auth::public_base(&st, &headers).await;
+    Ok(Json(
+        json!({ "url": super::session_url(&base, &session.id) }),
+    ))
+}
+
 pub(super) async fn create_session(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -1,6 +1,8 @@
 //! Session lifecycle over the REST API: create → list → recent-repos → delete,
 //! plus adoption of an externally-killed session and the no-goal create path.
 
+use std::process::Command;
+
 use serde_json::json;
 use serial_test::serial;
 
@@ -696,4 +698,107 @@ async fn session_records_its_launcher_as_tree_parent() {
         .delete(&format!("/api/sessions/{parent_id}"))
         .await
         .unwrap();
+}
+
+/// `GET /api/sessions/{key}/url` — the link an agent hands a human. It resolves
+/// by any session key (id or branch id, the `$WEAVER_BRANCH` the agent carries),
+/// and honours the operator's public origin so the URL works off-box.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_url_resolves_by_key_and_honours_the_public_base() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "link me", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+    let branch_id = ws["branch"]["id"].as_str().unwrap().to_string();
+
+    // With no `auth.base_url`, the origin is derived from the request's Host —
+    // for a loopback CLI that is the server it just talked to. Honest, and right
+    // for a single-machine loom where the browser is on that same box.
+    let derived = client
+        .get(&format!("/api/sessions/{id}/url"))
+        .await
+        .unwrap();
+    assert_eq!(
+        derived["url"].as_str().unwrap(),
+        format!("http://{}/s/{id}", ts.addr),
+        "derived from the request origin"
+    );
+
+    // The branch id is a session key too — that is what `$WEAVER_BRANCH` holds,
+    // so `loom session url` inside a session resolves to the same link.
+    let by_branch = client
+        .get(&format!("/api/sessions/{branch_id}/url"))
+        .await
+        .unwrap();
+    assert_eq!(
+        by_branch["url"], derived["url"],
+        "branch id and session id name the same session"
+    );
+
+    // Once the operator declares a public origin, the URL is one an off-box
+    // reader (of a PR, say) can actually open. The trailing slash is absorbed.
+    client
+        .patch(
+            "/api/settings",
+            json!({ "auth.base_url": "https://loom.example.com/" }),
+        )
+        .await
+        .unwrap();
+    let public = client
+        .get(&format!("/api/sessions/{id}/url"))
+        .await
+        .unwrap();
+    assert_eq!(
+        public["url"].as_str().unwrap(),
+        format!("https://loom.example.com/s/{id}"),
+        "the configured public origin wins, with no doubled slash"
+    );
+
+    // And the CLI an agent actually runs: no argument, `$WEAVER_BRANCH` as loom
+    // exports it into a session. It must print the bare URL and nothing else, so
+    // `$(loom session url)` drops straight into a PR body.
+    let out = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .args(["session", "url"])
+        .env("WEAVER_API", ts.addr.to_string())
+        .env("WEAVER_BRANCH", &branch_id)
+        .output()
+        .expect("running loom session url");
+    assert!(
+        out.status.success(),
+        "loom session url failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout),
+        format!("https://loom.example.com/s/{id}\n"),
+        "the bare URL, ready to interpolate"
+    );
+
+    // Outside a session, with nothing to resolve, it says so rather than
+    // printing a URL for some arbitrary session.
+    let out = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .args(["session", "url"])
+        .env("WEAVER_API", ts.addr.to_string())
+        .env_remove("WEAVER_BRANCH")
+        .output()
+        .expect("running loom session url");
+    assert!(
+        !out.status.success(),
+        "no session key ⇒ an error, not a guess"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("not inside a loom session"),
+        "names the cause: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
 }

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -100,6 +100,8 @@ session's terminal directly, so you can nudge it without attaching:
 - `loom session preview <session>` — print its recent terminal screen, to see what
   it's doing right now. A session key is an id, branch id, branch name, or
   `repo:branch`.
+- `loom session url [<session>]` — the dashboard URL for a session, defaulting to
+  your own. The link to hand a human (see "Finishing work").
 
 This duplicates some of a coding agent's builtin sub-agents, but a weaver
 sub-session is fully decoupled: it survives independently, has its own git
@@ -177,6 +179,26 @@ has moved on since it was set (its timestamp predates your last activity).
   set `weaver status attention "<the question>"`, then continue with your
   best assumption.
 
+## Working a GitHub issue
+
+A session often comes from a GitHub thread — someone `@loom`-mentioned an issue
+or a PR, or your goal names one. That thread is where the people who care about
+the work are: they don't read this terminal, and may not read the dashboard.
+Anything they need to know goes there.
+
+- **Read the whole thread first** — `gh issue view <n> --comments` (`gh pr view
+  <n> --comments`). Your goal is a paraphrase of it; the constraint that decides
+  the design is usually three comments down.
+- **Reply where you were asked** — a question for the issue's author is a
+  `gh issue comment <n>`. Post it, raise `weaver status attention "<question>"`
+  so the dashboard shows what you're waiting on, then continue on your best
+  assumption rather than idling.
+- **Close the issue through the PR** — write `Fixes #<n>` in the body and let the
+  merge close it. Don't `gh issue close` by hand.
+- **Say which board a number belongs to.** Weaver issues and GitHub issues number
+  separately and will collide. On a GitHub thread `#12` is theirs — a weaver
+  issue number tells a reader there nothing, so describe the work instead.
+
 ## Designing before you build
 
 When the task turns on research or a tradeoff — an architecture choice, a
@@ -223,6 +245,17 @@ the work is ready:
   unless the user has told you otherwise. Most teams gate integration on review
   and CI; respect that. Use the project's normal PR workflow (e.g. `gh pr
   create`).
+- **Link the PR back to this session** — `loom session url` prints the dashboard
+  URL for the session you are in. Put it in the PR body, so a reviewer looking at
+  the diff can reach the context behind it: the goal, your status trail, the
+  designs and reports you wrote. Build the body in one go:
+
+      loom session url                        # https://loom.example.com/s/ab12cd34
+      gh pr create --title "…" --body "$(printf 'What this does…\n\nloom: %s\n' "$(loom session url)")"
+
+  Only the server knows loom's public address, which is why this is a command and
+  not something you assemble yourself — the `$WEAVER_API` you were handed is a
+  loopback address that resolves to nothing on the reviewer's machine.
 - **Drive the PR to green — opening it is the start of integration, not the
   end.** Do not walk away the moment it's open. Watch CI to completion
   (`gh pr checks <N> --watch`) and fetch review feedback — both the top-level

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,6 +192,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]` and `parent_branch`; opens a tracking issue and returns its id as `tracking_issue`) |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear a branch tag — the well-known `attention` and `triage` keys plus any free-form key |
+| `GET /api/sessions/{id}/url` | the session's dashboard URL as `{url}`, built from the externally-visible origin (`auth.base_url`, else the request's own Host) — what `loom session url` prints, so an agent can link a PR back to its session without inventing a loopback link |
 | `POST /api/sessions/{id}/{archive,adopt}` | actions |
 | `POST /api/sessions/{id}/github` | re-poll the branch's GitHub PR now and return the updated session |
 | `GET POST DELETE /api/sessions/{id}/scratch` | list / drop / remove worktree `scratch/` reference files |


### PR DESCRIPTION
An agent finishing a task opens a PR, and the reviewer reading that PR has no way
back to the work behind it — the goal, the status trail, the designs it wrote.
The agent can't link it either: the `$WEAVER_API` it was handed is a loopback
address that resolves to nothing on anyone else's machine.

## The helper

Resolve the link server-side, where the externally-visible origin is actually
known (`auth.base_url`, else the request's own Host):

- `GET /api/sessions/{id}/url` → `{url}`, by any session key.
- `loom session url [<session>]` prints it, defaulting to the session it runs in
  (`$WEAVER_BRANCH`). It prints the URL bare, so `$(loom session url)` drops
  straight into a PR body.

```
$ loom session url
https://loom.rjp.io/s/6p9t9ch7
```

The webhook reply and the PR back-link already built this URL by hand; all three
now share `session_url` + a new `public_base` (the `external_base` →
bound-address fallback that was copied twice).

## The docs

`WEAVER.md` gains a **Working a GitHub issue** section: read the whole thread
before starting, reply where you were asked, close through `Fixes #<n>`, and
don't paste weaver issue numbers onto a GitHub thread where `#12` means
something else entirely. **Finishing work** now says to link the PR back to the
session, with the `gh pr create` incantation.

## Verification

`cargo test --workspace` + `./scripts/pre-commit.sh` green; agent lint review
clean. The new integration test drives the real CLI binary against a live server
and covers both origins (derived Host, configured `auth.base_url`) and the
no-session error path.

Two pre-existing failures in `crates/weaver/tests/agent_cli.rs` (`database is
locked`) reproduce identically on the unmodified base commit — unrelated to this
change, filed separately.

Note the link above can't be dogfooded until this is deployed: the running loom
predates the route.

loom: https://loom.rjp.io/s/6p9t9ch7