### PR TITLE
fix(loom): relaunch when a follow-up @loom comment can't reach an orphaned session

### DIFF
--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -333,7 +333,9 @@ async fn handle_trigger(
     }
 
     // 9. If an active session already owns the target branch, forward the new
-    //    comment into it rather than spawning a duplicate.
+    //    comment into it rather than spawning a duplicate — unless its terminal is
+    //    unreachable, in which case retire it and fall through to a fresh launch
+    //    (below) so the comment isn't dropped.
     if let Some(branch) = target_branch.as_deref() {
         if let Ok(Some(b)) = branch_mod::find_by_repo_branch(&st.db, &repo_root_str, branch).await {
             if let Ok(Some(sess)) = session_mod::active_for_branch(&st.db, &b.id).await {
@@ -370,8 +372,42 @@ async fn handle_trigger(
                         tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: posting forward-ack failed");
                     }
                     tracing::info!(session = %sess.id, repo = %slug.slug(), number, "github webhook: forwarded comment to active session");
+                    return Ok(None);
                 }
-                return Ok(None);
+                // The session is active in the DB but its terminal is unreachable —
+                // an orphaned session that outlived its terminal (e.g. a crash the
+                // monitor hasn't marked yet). Retire it with a terminal status so the
+                // branch is free — `error`, not `archived`, because `active_for_branch`
+                // still counts `archived` as active and `create_session_core` would
+                // then reject the branch as busy. Then fall through to launch a fresh
+                // session: the trigger goal already carries this comment and the dead
+                // session's commits are on the branch, so nothing is dropped. The
+                // fresh launch reuses the existing worktree (see `existing_branch`).
+                tracing::warn!(
+                    session = %sess.id,
+                    branch = %b.id,
+                    repo = %slug.slug(),
+                    "github webhook: session terminal unreachable; retiring it and launching a fresh session"
+                );
+                if let Err(e) = session_mod::set_status(&st.db, &sess.id, "error").await {
+                    tracing::warn!(session = %sess.id, error = %e, "github webhook: retiring unreachable session failed");
+                    return Err(format!(
+                        "retiring unreachable session {} failed: {e}",
+                        sess.id
+                    ));
+                }
+                crate::events::record(
+                    &st.db,
+                    &st.bus,
+                    &b.id,
+                    "status",
+                    serde_json::json!({
+                        "status": "error",
+                        "reason": "terminal unreachable when forwarding a new @loom comment; relaunching",
+                    }),
+                )
+                .await
+                .ok();
             }
         }
     }

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -485,6 +485,103 @@ async fn repeat_trigger_forwards_to_active_session() {
         .unwrap();
 }
 
+/// A follow-up @loom comment on a thread whose session is orphaned — its terminal
+/// died but the DB row still counts as active — must not be dropped. loom fails to
+/// forward into the dead terminal, retires the orphaned session, and launches a
+/// fresh one on the same branch (the trigger goal carries the comment), replying
+/// with the launch cue rather than a forward ack.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn orphaned_session_terminal_relaunches_instead_of_dropping() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+
+    // First trigger → one session with a live terminal.
+    let body = trigger_body("rjpower", 42, "@loom start");
+    assert_eq!(
+        post(&ts, "d-orphan-1", Some(sign(SECRET, &body)), &body)
+            .await
+            .status(),
+        200
+    );
+    wait_for_sessions(&ts, 1).await;
+    wait_for_comments(&fake, 1).await;
+
+    let first_id = ts.client.get("/api/sessions").await.unwrap()[0]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Orphan it: kill the terminal but leave the DB row active, then wait until the
+    // terminal is genuinely gone so the next forward attempt deterministically fails.
+    let term = format!("weaver-{first_id}");
+    loom::backend::kill_session(&term).await.unwrap();
+    for _ in 0..200 {
+        if !loom::backend::has_session(&term).await {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    assert!(
+        !loom::backend::has_session(&term).await,
+        "the first session's terminal is dead before the second trigger"
+    );
+
+    // A second @loom comment on the same issue: forwarding into the dead terminal
+    // fails, so loom retires the orphaned session and launches a fresh one.
+    let body2 = trigger_body("rjpower", 42, "@loom pick this back up");
+    assert_eq!(
+        post(&ts, "d-orphan-2", Some(sign(SECRET, &body2)), &body2)
+            .await
+            .status(),
+        200
+    );
+
+    // A fresh session appears (two rows now: the retired one + the new one) and a
+    // second reply lands.
+    wait_for_sessions(&ts, 2).await;
+    wait_for_comments(&fake, 2).await;
+
+    let sessions = ts.client.get("/api/sessions").await.unwrap();
+    let sessions = sessions.as_array().unwrap().clone();
+    let retired = sessions
+        .iter()
+        .find(|s| s["id"].as_str() == Some(first_id.as_str()))
+        .expect("the orphaned session is still recorded");
+    assert_eq!(
+        retired["status"].as_str(),
+        Some("error"),
+        "the unreachable session was retired to a terminal status so the branch is free"
+    );
+    let fresh_id = sessions
+        .iter()
+        .find(|s| s["id"].as_str() != Some(first_id.as_str()))
+        .expect("a fresh session was launched")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // The reply is the launch cue, not a forward ack — proving a relaunch happened
+    // rather than the comment being silently swallowed by the dead terminal.
+    let comments = fake.comments.lock().unwrap().clone();
+    assert_eq!(comments.len(), 2, "one reply per trigger");
+    assert!(
+        comments[1].2.starts_with("On it — "),
+        "the follow-up trigger replies with the launch cue: {}",
+        comments[1].2
+    );
+    assert!(
+        comments[1].2.contains(&format!("/s/{fresh_id}")),
+        "the reply links the fresh session: {}",
+        comments[1].2
+    );
+
+    ts.client
+        .delete(&format!("/api/sessions/{fresh_id}"))
+        .await
+        .unwrap();
+}
+
 /// A comment on a **pull request** attaches the session's worktree to the PR's own
 /// head branch, so the agent's commits land on the PR.
 #[serial]


### PR DESCRIPTION
## Problem

A `@loom` trigger on a thread whose branch had an **orphaned session** — active in the DB but with a dead/unreachable terminal — silently dropped the comment. `handle_trigger` tried to forward the comment into the dead terminal, `forward_comment_to_session` returned `false`, and control fell to an unconditional `return Ok(None)`: no session revived, no reply posted, nothing.

Observed in a production loom log:

```
INFO  loom::web::repos  github webhook: trigger accepted, launching in background repo=marin-community/marin number=7323 is_pr=false
INFO  loom::repo        managed repo clone ready
WARN  loom::web::repos  github webhook: forwarding comment to session failed session=hubf628i error=connecting to session weaver-hubf628i
```

## Fix

On a failed forward, retire the unreachable session and fall through to the existing create path, which launches a fresh session on the same branch. Two details make it correct:

- **Retire with `error`, not `archived`.** `session::active_for_branch` only excludes `done`/`error`, so an `archived` session still reads as active and `create_session_core`'s branch-busy guard would reject the relaunch.
- **Delivery is reliable.** The fresh launch reuses the existing worktree (via `existing_branch`) and `trigger_goal` already bakes the triggering comment into the opening goal — so the comment lands without a boot-race against a resuming terminal, and the dead session's commits are still on the branch.

The forward-to-a-live-session path is unchanged.

## Test

Adds `orphaned_session_terminal_relaunches_instead_of_dropping`: launches a session, kills its terminal to orphan it, fires a second trigger, and asserts the orphaned session is retired to `error` and a fresh session launches — replying with the `On it —` launch cue rather than the `Passed your note` forward ack.

All 9 webhook integration tests pass; fmt + clippy + typecheck clean.

Closes weaver issue #484.