### PR TITLE
fix(loom): submit forwarded @loom comments via bracketed paste

### DIFF
--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -112,6 +112,44 @@ pub async fn send_literal(name: &str, text: &str) -> Result<()> {
     c.send(text.as_bytes()).await
 }
 
+/// Bracketed-paste framing (DECSET 2004), exactly what a terminal emulator emits
+/// around a paste. The markers tell the TUI "this block is content, not
+/// keystrokes", so a following [`send_enter`] is read as a distinct submit.
+const PASTE_START: &[u8] = b"\x1b[200~";
+const PASTE_END: &[u8] = b"\x1b[201~";
+
+/// Deliver `text` as a single bracketed-paste block, then pair with [`send_enter`]
+/// to submit — the reliable way to hand an agent a multi-line message.
+///
+/// Typing multi-line text verbatim ([`send_literal`]) and following it with a bare
+/// `Enter` does not submit: an agent TUI (Claude Code) treats the burst as a paste
+/// and folds the trailing `\r` into the composer as one more newline, so the whole
+/// message lands in the entry box unsent. Wrapping the text in bracketed-paste
+/// markers is how the interactive terminal avoids this — xterm.js frames every
+/// paste the same way — and the closing marker ends the paste so the subsequent
+/// `Enter` counts as a submit. Newlines are normalized to `\r`, matching xterm.js.
+///
+/// Loom only drives agents that enable bracketed paste; where 2004 mode is off the
+/// markers would land as literal text, so this is not a general typing primitive.
+pub async fn paste(name: &str, text: &str) -> Result<()> {
+    let framed = frame_paste(text);
+    tracing::debug!(session = %name, bytes = framed.len(), "pasting input to terminal");
+    let mut c = tapestry::Client::connect(name).await?;
+    c.send(&framed).await
+}
+
+/// Wrap `text` in bracketed-paste markers, normalizing newlines to `\r` first
+/// (what xterm.js does on paste). Split out from [`paste`] so the framing is
+/// unit-testable without a live terminal.
+fn frame_paste(text: &str) -> Vec<u8> {
+    let normalized = text.replace("\r\n", "\r").replace('\n', "\r");
+    let mut framed = Vec::with_capacity(PASTE_START.len() + normalized.len() + PASTE_END.len());
+    framed.extend_from_slice(PASTE_START);
+    framed.extend_from_slice(normalized.as_bytes());
+    framed.extend_from_slice(PASTE_END);
+    framed
+}
+
 /// Send a single named key (e.g. `Enter`, `Escape`) to the session.
 pub async fn send_key(name: &str, key: &str) -> Result<()> {
     let bytes = key_bytes(key);
@@ -176,6 +214,29 @@ fn key_bytes(key: &str) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn frame_paste_wraps_in_bracketed_markers_and_normalizes_newlines() {
+        let framed = frame_paste("line one\nline two\r\nline three");
+        let s = String::from_utf8(framed).unwrap();
+        // The block is delimited so the TUI reads it as content and the following
+        // Enter as a distinct submit — the whole point of the fix.
+        assert!(
+            s.starts_with("\x1b[200~"),
+            "missing paste-start marker: {s:?}"
+        );
+        assert!(s.ends_with("\x1b[201~"), "missing paste-end marker: {s:?}");
+        // Every newline (both LF and CRLF) collapses to a single CR, matching xterm.js,
+        // and no stray LF survives inside the block.
+        assert_eq!(
+            s, "\x1b[200~line one\rline two\rline three\x1b[201~",
+            "newlines should normalize to a single CR"
+        );
+        assert!(
+            !s.contains('\n'),
+            "no LF should remain inside the paste block"
+        );
+    }
 
     #[test]
     fn memory_prelude_confines_the_session_to_its_named_cgroup() {

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -551,7 +551,7 @@ async fn forward_comment_to_session(
          (Reply on the thread with `gh {cmd} comment {number} --body \"…\"` if a response is warranted.)",
         comment.trim(),
     );
-    if let Err(e) = backend::send_literal(&session.term_session, &note).await {
+    if let Err(e) = backend::paste(&session.term_session, &note).await {
         tracing::warn!(session = %session.id, error = %e, "github webhook: forwarding comment to session failed");
         return false;
     }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2086,7 +2086,7 @@ pub(super) async fn send_session(
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
     require_live_terminal(&session).await?;
-    backend::send_literal(&session.term_session, &req.text)
+    backend::paste(&session.term_session, &req.text)
         .await
         .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     if req.submit {

--- a/crates/loom/tests/integration/terminal.rs
+++ b/crates/loom/tests/integration/terminal.rs
@@ -111,3 +111,69 @@ async fn terminal_websocket_roundtrip() {
 
     client.delete(&format!("/api/sessions/{id}")).await.unwrap();
 }
+
+/// The HTTP `send` endpoint (the composer / webhook-forward path) must actually
+/// submit: it types via a bracketed-paste block and then presses Enter, and the
+/// command has to run. This is the regression guard for the "text lands in the
+/// entry box but never sends" bug — an agent TUI folds a bare trailing Enter into
+/// a raw multi-line burst as one more newline, so the send path frames the text
+/// as a paste (exactly as xterm.js does) to keep the Enter a distinct submit.
+/// Against a real PTY it also proves the paste markers are consumed by readline
+/// rather than corrupting the command.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_send_submits_via_bracketed_paste() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let session = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "send test", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = session["id"].as_str().unwrap().to_string();
+
+    // Wait for the shell to be executing (not just echoing) before sending, using
+    // the same arithmetic marker the roundtrip test uses.
+    let mut term = connect_terminal(&ts.addr, &id).await;
+    let mut ready = false;
+    for _ in 0..15 {
+        send_input(&mut term, "echo RDY$((6 * 7))\n").await;
+        if drain_until(&mut term, "RDY42", Duration::from_secs(1))
+            .await
+            .contains("RDY42")
+        {
+            ready = true;
+            break;
+        }
+    }
+    assert!(ready, "shell never came up");
+
+    // Drive the endpoint under test. `submit` defaults to true, so this types the
+    // command as a paste and follows it with Enter. `SEND$((21 * 2))` is the typed
+    // text; `SEND42` appears only in the OUTPUT, so draining for it confirms the
+    // shell executed the line rather than merely echoing the keystrokes.
+    let resp = client
+        .post(
+            &format!("/api/sessions/{id}/send"),
+            json!({ "text": "echo SEND$((21 * 2))" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp["submitted"],
+        json!(true),
+        "send should report a submit"
+    );
+
+    let out = drain_until(&mut term, "SEND42", Duration::from_secs(8)).await;
+    assert!(
+        out.contains("SEND42"),
+        "the paste + Enter never submitted the command; got:\n{out}"
+    );
+
+    term.send(Message::Close(None)).await.ok();
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}


### PR DESCRIPTION
## Problem

When a follow-up `@loom` comment is forwarded into a running session, the note showed up in the agent's entry box but never sent — the agent never woke to process it.

`forward_comment_to_session` typed the note verbatim as a raw multi-line burst (`send_literal`) and followed it with a bare `Enter` (`send_enter`). An agent TUI (Claude Code) reads that burst as a paste and folds the trailing `\r` into the composer as one more newline, so the whole note sits unsubmitted. The interactive terminal escapes this only because xterm.js wraps every paste in bracketed-paste markers — the programmatic path did not.

## Fix

Add `backend::paste`, which delivers the text as a single **bracketed-paste block** (`ESC[200~ … ESC[201~`) — the exact framing xterm.js emits — and normalizes newlines to `\r`. The closing marker ends the paste, so the following `Enter` counts as a distinct submit.

- `forward_comment_to_session` (the reported webhook path) now uses `paste`.
- `send_session` (the composer's HTTP send) shared the identical latent multi-line bug, so it routes through the same helper.

`send_enter` is unchanged and still follows the paste to submit.

## Tests

- **Unit** (`backend.rs`): pins the framing bytes — markers present, `\n`/`\r\n` collapse to a single `\r`, no stray `\n`.
- **End-to-end** (`terminal.rs`): drives the real `POST /sessions/{id}/send` endpoint against a live PTY shell and asserts the submitted command actually executes — proving the paste markers reach the PTY, are consumed by readline, and the trailing Enter submits.

Existing webhook forward tests still pass.