### PR TITLE
fix(loom): stop parking conversations the instant they idle

### DIFF
--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -137,11 +137,13 @@ export function effectiveAttention(s: Session): EffectiveAttention {
   return { ...markOf(s, top), stale };
 }
 
-// Whether a session is *parked*: calm (no loud signal) yet carrying a tag whose
-// value is on the PARKED ladder — work waiting on an external actor (a human PR
-// reviewer, …) that needs nothing from the user. A loud signal always wins: a
-// session that needs a human is never parked, however else it's tagged. Archived
-// sessions are never parked (they read through their own terminal badge).
+// Whether a session sits on the PARKED sort ladder: calm (no loud signal) yet
+// carrying a tag whose value parks — work waiting on an external actor (a human
+// PR reviewer, …) that needs nothing from the user. This only *sinks* the row
+// below the calm default in the fleet sort (`priorityRank`); it does not shelve
+// it (see `parkReason`). A loud signal always wins: a session that needs a human
+// never sinks, however else it's tagged. Archived sessions never sink (they read
+// through their own terminal badge).
 export function isParked(s: Session): boolean {
   if (s.status === 'archived') return false;
   if (loudTags(s).length > 0) return false;
@@ -164,11 +166,14 @@ export function priorityRank(s: Session): number {
 // The resting shelf ("Parked") + manual order
 // ---------------------------------------------------------------------------
 
-// How long an agent may rest before the fleet list quietly shelves its row. The
-// list is a projection of REST state (docs/loom-ui.md): this threshold is a pure
-// view concern, applied client-side over the row's `last_activity_at`, never a
-// stored flag — only the *manual* park override (`park`) is persisted.
-export const IDLE_PARK_DAYS = 3;
+// How long an agent may rest before the fleet list quietly shelves its row —
+// long enough that a finished turn (idle in minutes) never parks a conversation,
+// only a genuinely abandoned one does. The list is a projection of REST state
+// (docs/loom-ui.md): this threshold is a pure view concern, applied client-side
+// over the row's `last_activity_at`, never a stored flag — only the *manual*
+// park override (`park`) is persisted.
+export const IDLE_PARK_HOURS = 8;
+const HOUR_MS = 3_600_000;
 const DAY_MS = 86_400_000;
 
 // Milliseconds since the agent last did anything (its `last_activity_at`, or the
@@ -180,13 +185,16 @@ export function idleMs(s: Session): number {
   return Math.max(0, Date.now() - last);
 }
 
-export type ParkReason = 'manual' | 'review' | 'idle';
+export type ParkReason = 'manual' | 'idle';
 
 // Why a session rests on the shelf, or `null` if it belongs in the live list.
-// A session is shelved when it needs nothing from you *and* one of:
-//   • you parked it by hand              → 'manual'  (park === 'parked')
-//   • it's waiting on an external review  → 'review'  (the PARKED tag, isParked)
-//   • the agent has rested past the idle threshold → 'idle'
+// The shelf hides only what genuinely needs nothing from you *and* one of:
+//   • you parked it by hand                        → 'manual'  (park === 'parked')
+//   • the agent has rested past the idle threshold → 'idle'    (IDLE_PARK_HOURS)
+// A review-wait mark deliberately does NOT shelve: an open PR awaiting an
+// external reviewer is still yours to glance at, so it stays in the live list —
+// sunk below the calm rows by `priorityRank` and labelled with its quiet
+// `awaiting: review` pill — rather than hidden away the instant a turn ends.
 // A loud signal always keeps a row live (you need to see it), and an explicit
 // 'active' override pins a row live even when idle.
 export function parkReason(s: Session): ParkReason | null {
@@ -194,8 +202,7 @@ export function parkReason(s: Session): ParkReason | null {
   if (effectiveAttention(s).level !== 'ok') return null; // needs a human → live
   if (s.park === 'active') return null; // kept live by hand
   if (s.park === 'parked') return 'manual';
-  if (isParked(s)) return 'review';
-  if (idleMs(s) >= IDLE_PARK_DAYS * DAY_MS) return 'idle';
+  if (idleMs(s) >= IDLE_PARK_HOURS * HOUR_MS) return 'idle';
   return null;
 }
 
@@ -206,10 +213,12 @@ export function shelved(s: Session): boolean {
 // A short mono label for the shelf badge — what kind of rest this is.
 export function parkLabel(s: Session): string {
   const reason = parkReason(s);
-  if (reason === 'review') return 'in review';
   if (reason === 'idle') {
-    const days = Math.floor(idleMs(s) / DAY_MS);
-    return days >= 1 ? `idle ${days}d` : 'idle';
+    const ms = idleMs(s);
+    // Shelved rows have rested at least IDLE_PARK_HOURS, so hours reads first;
+    // multi-day rests round up to days ("idle 6d").
+    if (ms >= DAY_MS) return `idle ${Math.floor(ms / DAY_MS)}d`;
+    return `idle ${Math.floor(ms / HOUR_MS)}h`;
   }
   return 'parked';
 }

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -119,8 +119,8 @@ interface TreeRow {
 // out of the visible set (or was never tracked) drops its orphaned children up.
 // The shared tree build. Groups visible sessions into threads, ranks each
 // thread by its loudest member, then splits the top-level threads two ways: the
-// live list, and the resting "Parked" shelf (long-idle / in-review / hand-parked
-// threads that need nothing from you). Live threads carry the manual drag order;
+// live list, and the resting "Parked" shelf (long-idle or hand-parked threads
+// that need nothing from you). Live threads carry the manual drag order;
 // the shelf sorts by most-recent activity. Exposes the ordered live roots so the
 // drop math can find a dragged row's new neighbours.
 const partitioned = computed(() => {
@@ -666,8 +666,8 @@ async function handleCreated() {
       </li>
     </ul>
 
-    <!-- The Parked shelf — resting threads (long idle, in review, or parked by
-         hand) collapsed out of the live list so a stale fleet doesn't drag the
+    <!-- The Parked shelf — resting threads (long idle or parked by hand)
+         collapsed out of the live list so a stale fleet doesn't drag the
          eye. Also a drop target: drag a live row here to rest it; the "Keep live"
          verb (and dragging a row back out) returns it. Shown while empty only
          mid-drag, so there's always somewhere to drop. -->

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -127,13 +127,17 @@ The fleet list is where a long day's fatigue accumulates, so two controls keep i
 from becoming a wall of stale rows:
 
 - **The resting shelf ("Parked").** Below the live list sits a collapsed shelf
-  for threads that need nothing from you right now — hand-parked, waiting on an
-  external reviewer, or simply long idle (the agent has rested past
-  `IDLE_PARK_DAYS`). Shelf rows are dimmed, labelled with *why* they rest (`in
-  review` / `idle 6d` / `parked`), and one click (or a drag) away from live. A
-  loud signal always keeps a thread live — a session that needs a human never
-  hides. The idle threshold is a pure client view over `last_activity_at`; only
-  the manual override (`park`: `'parked'` / `'active'`) is persisted.
+  for threads that need nothing from you right now — hand-parked, or simply long
+  idle (the agent has rested past `IDLE_PARK_HOURS` — hours, not minutes, so a
+  finished turn never parks a conversation, only an abandoned one). Shelf rows
+  are dimmed, labelled with *why* they rest (`idle 12h` / `idle 6d` / `parked`),
+  and one click (or a drag) away from live. A loud signal always keeps a thread
+  live — a session that needs a human never hides. A session merely *awaiting an
+  external reviewer* is **not** shelved: its `awaiting: review` mark sinks it
+  below the calm rows in the live list (it's still yours to glance at) but never
+  hides it away. The idle threshold is a pure client view over
+  `last_activity_at`; only the manual override (`park`: `'parked'` / `'active'`)
+  is persisted.
 - **Manual order.** A hover-revealed grip (`⠿`) drags a top-level thread to
   reorder it, or onto the shelf to rest it (drag back out, or "Keep live", to
   return it). A drag persists one midpoint `sort_order`; placed and untouched

--- a/e2e/tests/list.spec.ts
+++ b/e2e/tests/list.spec.ts
@@ -136,17 +136,18 @@ test.describe('session list view', () => {
     expect(updated.branch.tags.find((t) => t.key === 'priority')).toBeUndefined();
   });
 
-  test('a session awaiting external review rests on the Parked shelf', async ({
+  test('a session awaiting external review sinks in the live list, not the shelf', async ({
     page,
     weaver,
   }) => {
-    // Three sessions, created oldest→newest: a parked one (its PR awaits an
-    // external reviewer), a plainly-calm one, and one the agent raised. The
-    // review watch parks the first by stamping the quiet `awaiting: review` mark.
-    const parked = await weaver.seedSession({ goal: 'Awaiting review', name: 'parked-low' });
+    // Three sessions, created oldest→newest: one whose PR awaits an external
+    // reviewer, a plainly-calm one, and one the agent raised. The review-wait
+    // mark sinks the first below the calm rows but must NOT hide it on the shelf —
+    // an open PR awaiting review is still yours to glance at.
+    const review = await weaver.seedSession({ goal: 'Awaiting review', name: 'review-low' });
     const calm = await weaver.seedSession({ goal: 'Quietly working', name: 'calm-mid' });
     const attn = await weaver.seedSession({ goal: 'Needs a decision', name: 'top-attn' });
-    await weaver.setTag(parked, 'awaiting', 'review', {
+    await weaver.setTag(review, 'awaiting', 'review', {
       note: 'PR #7 review required — waiting on an external reviewer',
       by: 'review-wait',
     });
@@ -154,22 +155,20 @@ test.describe('session list view', () => {
 
     await page.goto(weaver.baseUrl);
 
-    // The live list holds only what a scanning user should look at: the raised row
-    // floats up, then the calm one. The "nothing to do, waiting on a reviewer" row
-    // is collapsed onto the resting shelf, out of the flow.
+    // All three stay live: the raised row floats to the top, the calm one next,
+    // and the review-waiting row sinks to the bottom — sunk, but never hidden.
     const liveIds = await page
       .getByTestId('session-list')
       .getByTestId('session-card')
       .evaluateAll((els) => els.map((e) => e.getAttribute('data-session-id')));
-    expect(liveIds).toEqual([attn.id, calm.id]);
+    expect(liveIds).toEqual([attn.id, calm.id, review.id]);
 
-    // The parked row rests on the shelf, labelled why it's resting, and still does
+    // The review-waiting row carries no loud signal (its mark is quiet) and does
     // not count toward "needs attention" — the user has no action there.
-    await page.getByTestId('parked-toggle').click();
-    const shelfCard = page.getByTestId('parked-shelf').locator(`[data-session-id="${parked.id}"]`);
-    await expect(shelfCard).toBeVisible();
-    await expect(shelfCard).toContainText('in review');
-    await expect(shelfCard.getByTestId('signal-chip')).toHaveCount(0);
+    const reviewCard = page
+      .getByTestId('session-list')
+      .locator(`[data-session-id="${review.id}"]`);
+    await expect(reviewCard.getByTestId('signal-chip')).toHaveCount(0);
     await expect(page.getByTestId('filter-attention')).toContainText('1');
   });
 

--- a/e2e/tests/park.spec.ts
+++ b/e2e/tests/park.spec.ts
@@ -35,18 +35,23 @@ test.describe('parking sessions', () => {
     await expect.poll(async () => (await parkView(weaver.baseUrl, s.id)).park).toBe('active');
   });
 
-  test('a session awaiting external review rests on the shelf, labelled', async ({ page, weaver }) => {
+  test('a session awaiting external review stays live (sunk, not shelved)', async ({ page, weaver }) => {
+    // A review-wait mark sinks a row below the calm default but must NOT hide it
+    // on the shelf — an open PR awaiting review is still yours to glance at.
     const live = await weaver.seedSession({ goal: 'Add a health endpoint', name: 'health' });
     const review = await weaver.seedSession({ goal: 'Wire the readiness probe', name: 'probe' });
-    await weaver.setTag(review, 'review', 'review'); // PARKED ladder value → shelf
+    await weaver.setTag(review, 'awaiting', 'review'); // PARKED sort ladder value
 
     await page.goto(weaver.baseUrl);
-    await page.getByTestId('parked-toggle').click();
 
-    const onShelf = page.getByTestId('parked-shelf').locator(`[data-session-id="${review.id}"]`);
-    await expect(onShelf).toBeVisible();
-    await expect(onShelf).toContainText('in review');
-    // The live one stays live.
+    // The review row stays in the live list — never banished to the shelf.
+    await expect(
+      page.getByTestId('session-list').locator(`[data-session-id="${review.id}"]`),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('parked-shelf').locator(`[data-session-id="${review.id}"]`),
+    ).toHaveCount(0);
+    // The calm one stays live too.
     await expect(
       page.getByTestId('session-list').locator(`[data-session-id="${live.id}"]`),
     ).toBeVisible();


### PR DESCRIPTION
## Problem

Conversations dropped onto the **Parked** resting shelf almost the instant they
went idle — nothing to do with idle *time*. Raising the idle threshold (this
branch first tried 3d → 8h) did nothing, because the shelf was never triggering
on idle time in the first place.

## Root cause

The `review-wait` watch stamps `awaiting: review` (value `review`, a
PARKED-ladder value) the moment a session's PR is open, non-draft, and needs a
review. `parkReason()` then shelved any such session via `isParked()`:

```ts
if (isParked(s)) return 'review';   // ← shelved on the review tag, not idle time
```

Since most weaver sessions open a PR right as they finish their turn, "turn
ended" ≈ "PR awaiting review" ≈ **shelved immediately**. (The live DB showed 48
`awaiting: review` tags — by far the most common tag — confirming this is the
common path, not a corner case.)

## Fix

The resting shelf now hides a thread only when it genuinely needs nothing from
you:

- you **hand-parked** it (`park === 'parked'`), or
- the agent has been **idle past `IDLE_PARK_HOURS`** (8h; was `IDLE_PARK_DAYS = 3`).

A `review-wait` mark **no longer shelves**. An open PR awaiting an external
reviewer is still yours to glance at, so the row stays in the live list — it
still *sinks* below the calm rows (via `priorityRank`, unchanged) and still shows
its quiet `awaiting: review` pill, but it is never hidden away.

The shelf label also gains hour granularity (`idle 12h`) for sub-day rests.

## Scope note

I kept the review-wait **sort-sink** (rows drop below the calm default in the
live list) — it's gentle and non-hiding, and it's the documented purpose of the
watch. Only the *hiding* (shelf) behavior is removed. Easy to drop the sink too
if you'd rather review-wait had no ordering effect at all.

## Testing

- `crates/loom/frontend` — `vue-tsc --noEmit` clean; production build clean.
- `e2e/tests/park.spec.ts` — 4/4 pass, including the rewritten case asserting a
  review-awaiting session **stays live (sunk, not shelved)**.

Closes #494.
