### PR TITLE
feat(deploy,loom): install the Codex CLI + bubblewrap, thread OPENAI_API_KEY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,28 +70,47 @@ RUN set -eux; \
     apt-get update; \
     # Base runtime + the repo tools loom's agents shell out to. gh/gcloud/docker
     # come from the signed repos configured above; the rest are stock bookworm.
-    # The last group is the everyday dev CLIs an agent reaches for in a checkout —
+    # The last groups are the everyday dev CLIs an agent reaches for in a checkout —
     # jq/ripgrep/fd for search, build-essential/pkg-config for native builds, a
     # system python3, and the usual archive/editor/pager tools. (cargo, rustc and
     # cc already ship in the rust base image, so they are not repeated here.)
+    #
+    # bubblewrap + socat are the sandbox the agent runtimes reach for on Linux:
+    # Claude Code's sandboxed Bash runs commands under `bwrap` (with `socat`
+    # relaying network) and otherwise degrades to unsandboxed with a warning;
+    # Codex prefers a system `bwrap` over the one it bundles. Both need the
+    # unprivileged user namespaces this container already permits (the
+    # SYS_ADMIN + apparmor=unconfined grant in docker-compose.yml).
+    #
+    # The remaining tools round out what a general coding agent expects to find:
+    # sqlite3 (loom's own store is sqlite; agents inspect/seed .db files),
+    # openssh-client (git-over-SSH to non-GitHub remotes; see compose), patch +
+    # diffutils (applying diffs when a native edit won't fit), procps (ps/pkill
+    # to manage servers an agent spawns), rsync, file, gettext-base (envsubst in
+    # CI/templating), and shellcheck (agents lint the shell they write).
     apt-get install -y --no-install-recommends \
       nodejs git ca-certificates gh google-cloud-cli tini \
       docker-ce-cli docker-buildx-plugin docker-compose-plugin sudo \
       jq ripgrep fd-find build-essential pkg-config \
       python3 python3-pip python3-venv \
-      unzip zip less wget vim tree; \
+      unzip zip less wget vim tree \
+      bubblewrap socat \
+      sqlite3 openssh-client patch diffutils procps rsync file \
+      gettext-base shellcheck; \
     rm -rf /var/lib/apt/lists/*; \
     # Debian ships fd as `fdfind` to avoid a name clash; expose the conventional
     # `fd` name agents (and fd-aware tools) expect.
     ln -s "$(command -v fdfind)" /usr/local/bin/fd
 
-# Claude Code — the agent runtime loom's sessions launch — is deliberately NOT
-# baked into the image. The container runs as a non-root user, so a Claude
-# installed into the read-only system dirs (what `npm i -g` does) can't
-# auto-update and reports it's "installed in a read-only location". Instead
-# loom-entrypoint (below) runs Claude's own installer at first boot into the app
-# user's $HOME/.local — on the persisted loom_home volume, so it is writable,
-# auto-updates itself in place, and the updates survive container recreates.
+# The agent runtimes loom's sessions launch — Claude Code (`claude`) and the
+# OpenAI Codex CLI (`codex`) — are deliberately NOT baked into the image. The
+# container runs as a non-root user, so a runtime installed into the read-only
+# system dirs (what a build-time `npm i -g` lands in) can neither self-update
+# (Claude reports it's "installed in a read-only location") nor be bumped live.
+# Instead loom-entrypoint (below) installs both at first boot into the app user's
+# $HOME on the persisted loom_home volume, where they are writable, update in
+# place (`claude` auto-updates; `codex update` on demand), and survive container
+# recreates. Pin either with CLAUDE_CODE_VERSION / CODEX_VERSION (see compose).
 
 # code-server — the per-session embedded VS Code that `crate::ide` spawns and
 # reverse-proxies (one rooted at each worktree, behind loom's auth). The `.deb`
@@ -211,8 +230,8 @@ echo 'app ALL=(root) NOPASSWD: /usr/local/bin/loom-cgroup-init' > /etc/sudoers.d
 chmod 440 /etc/sudoers.d/loom-cgroup-init
 EOF
 
-# Container entrypoint: before the daemon starts, make sure the writable,
-# self-updating Claude install exists on the persisted $HOME volume and the
+# Container entrypoint: before the daemon starts, make sure the agent runtimes
+# (`claude` + `codex`) are installed on the persisted $HOME volume and the
 # delegated session-cgroup subtree is prepared, then hand off to the CMD. Both
 # run only for `loom server …` — one-shot admin commands (`loom config set`,
 # `loom setup`, the compose init service) skip them.
@@ -232,6 +251,19 @@ if [ "${1:-}" = loom ] && [ "${2:-}" = server ]; then
     curl -fsSL https://claude.ai/install.sh | bash -s -- "${CLAUDE_CODE_VERSION:-stable}" || true
     [ -x "$HOME/.local/bin/claude" ] \
       || echo "loom: WARNING: Claude install failed (offline?); agents lack 'claude' until a later boot installs it" >&2
+  fi
+  if ! command -v codex >/dev/null 2>&1; then
+    echo "loom: installing Codex CLI into $HOME/.npm-global ..." >&2
+    # The Codex runtime installs the same way client packages do: `npm i -g`
+    # lands `codex` in $HOME/.npm-global/bin (NPM_CONFIG_PREFIX, on the volume,
+    # early on PATH), so it persists across recreates and can be bumped live with
+    # `codex update`. Pin with CODEX_VERSION (an npm dist-tag or exact version;
+    # default `latest`). Non-fatal — like Claude, loom still boots and agents can
+    # add it on a later networked boot. Codex is useless without OpenAI auth
+    # (OPENAI_API_KEY, or `codex login`); installing the CLI needs neither.
+    npm install -g "@openai/codex@${CODEX_VERSION:-latest}" || true
+    command -v codex >/dev/null 2>&1 \
+      || echo "loom: WARNING: Codex install failed (offline?); the codex runtime is unavailable until a later boot installs it" >&2
   fi
   # Delegate the per-session cgroup subtree (see loom-cgroup-init above).
   # Non-fatal: without it sessions run with no memory limit.

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1415,9 +1415,10 @@ async fn cmd_setup_secrets(opts: SecretsOpts) -> Result<()> {
         "ANTHROPIC_API_KEY",
         existing_names.contains("ANTHROPIC_API_KEY"),
     )?;
+    let openai = prompt_secret("OPENAI_API_KEY", existing_names.contains("OPENAI_API_KEY"))?;
     let gh_token = prompt_secret("GH_TOKEN", existing_names.contains("GH_TOKEN"))?;
 
-    if anthropic.is_none() && gh_token.is_none() {
+    if anthropic.is_none() && openai.is_none() && gh_token.is_none() {
         println!("nothing entered — existing values kept unchanged");
         return Ok(());
     }
@@ -1426,6 +1427,10 @@ async fn cmd_setup_secrets(opts: SecretsOpts) -> Result<()> {
     if let Some(v) = &anthropic {
         loom::agent_env::set(&db, "ANTHROPIC_API_KEY", v).await?;
         stored.push("ANTHROPIC_API_KEY");
+    }
+    if let Some(v) = &openai {
+        loom::agent_env::set(&db, "OPENAI_API_KEY", v).await?;
+        stored.push("OPENAI_API_KEY");
     }
     if let Some(v) = &gh_token {
         loom::agent_env::set(&db, "GH_TOKEN", v).await?;

--- a/crates/loom/src/loom_config.rs
+++ b/crates/loom/src/loom_config.rs
@@ -59,6 +59,8 @@ pub struct LoomConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anthropic_api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openai_api_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gh_token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_email: Option<String>,
@@ -146,6 +148,12 @@ pub static FIELDS: &[FieldSpec] = &[
         secret: true,
         get_fn: |c| c.anthropic_api_key.as_deref(),
         set_fn: |c, v| c.anthropic_api_key = Some(v),
+    },
+    FieldSpec {
+        env_name: "OPENAI_API_KEY",
+        secret: true,
+        get_fn: |c| c.openai_api_key.as_deref(),
+        set_fn: |c, v| c.openai_api_key = Some(v),
     },
     FieldSpec {
         env_name: "GH_TOKEN",
@@ -401,6 +409,7 @@ mod tests {
                 "LOOM_GITHUB_WEBHOOK_SECRET",
                 "LOOM_GITHUB_CLIENT_SECRET",
                 "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
                 "GH_TOKEN",
             ]
         );

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,8 +30,8 @@ services:
   network only. It is never published to the host; the only way in is through
   Caddy.
 
-loom drives the agents your sessions run (`gh`, `git`, `claude`, `uv`, an
-embedded VS Code), so the image is large and self-contained.
+loom drives the agents your sessions run (`gh`, `git`, `claude`, `codex`, `uv`,
+an embedded VS Code), so the image is large and self-contained.
 
 ## Prerequisites
 
@@ -102,7 +102,8 @@ and why; you don't hand-edit `.env` itself.
 | `LOOM_OWNER_GITHUB` | **yes** | GitHub login seeded as the first approved user on a fresh database — the only account that can sign in until it approves others. Approved users are also who may drive the `@loom` trigger; add more in **Settings → Approved users**. |
 | `GH_TOKEN` | **yes** | GitHub token loom uses to clone private repos, push branches, and reply to `@loom` comments. |
 | `LOOM_GITHUB_WEBHOOK_SECRET` | for `@loom` | Shared secret for the inbound webhook; must match the secret on the GitHub webhook. Until set, the webhook rejects every delivery. |
-| `ANTHROPIC_API_KEY` | for Claude | API key for the Claude agents. Alternatively log in interactively (see [first-run](#claude-authentication)). |
+| `ANTHROPIC_API_KEY` | for Claude | API key for the Claude agents. Alternatively log in interactively (see [first-run](#agent-authentication)). |
+| `OPENAI_API_KEY` | for Codex | API key for the Codex agents; only needed if you launch the `codex` runtime. Alternatively log in interactively (see [first-run](#agent-authentication)). |
 | `LOOM_GITHUB_CLIENT_ID` / `_SECRET` | for login | GitHub OAuth app — the owner's only way to sign in on a fresh DB (see [first-run](#first-run-login)). Callback: `https://<LOOM_DOMAIN>/api/auth/github/callback`. |
 | `LOOM_TLS_EMAIL` | no | ACME contact for cert-expiry notices; only used if you uncomment the global block in the Caddyfile. |
 | `HOST_UID` / `HOST_GID` | no (1000) | uid:gid the image runs as — matters only if you bind-mount a host dir. |
@@ -120,10 +121,11 @@ environment, with the environment winning (see `loom_config`'s module docs).
 (cloning private repos; the Claude launch-gate). Every *session* loom launches
 also needs them — `loom setup secrets --config /home/app/loom.toml` (run via
 `docker compose exec loom` against the running deploy, or as part of the
-[Quick start](#quick-start) sequence before first start) prompts for both and
-stores them as operator environment variables, live for every session from
-then on, no restart. Run it in addition to (not instead of) rendering them
-into `.env` above.
+[Quick start](#quick-start) sequence before first start) prompts for the agent
+keys (`ANTHROPIC_API_KEY` for Claude, `OPENAI_API_KEY` for Codex) and `GH_TOKEN`,
+and stores them as operator environment variables, live for every session from
+then on, no restart. Leave a key blank to skip it. Run it in addition to (not
+instead of) rendering them into `.env` above.
 
 ## Security posture
 
@@ -259,13 +261,20 @@ For automation, the `loom` CLI inside the container is already authenticated as
 the owner (via the machine-local token loom injects), so it works without a
 login — e.g. `docker compose exec loom loom token add ci`.
 
-### Claude authentication
+### Agent authentication
 
 If you did not set `ANTHROPIC_API_KEY`, log in to Claude once interactively; the
 credentials persist in `~/.claude.json` on the `loom_home` volume:
 
 ```sh
 docker compose exec loom claude    # follow the prompts, then exit
+```
+
+The Codex runtime authenticates the same way — set `OPENAI_API_KEY`, or log in
+once interactively (persisted under `~/.codex` on the same volume):
+
+```sh
+docker compose exec loom codex login    # follow the prompts, then exit
 ```
 
 ## Wire the `@loom` GitHub trigger
@@ -322,18 +331,36 @@ volume would mount root-owned. To put repos on their own disk, point
 
 The agent tooling the image ships splits by how it updates:
 
-- **Claude Code updates itself, no image rebuild.** The container runs as a
-  non-root user, so a Claude installed into the read-only system dirs could not
-  auto-update ("installed in a read-only location"). Instead, the first time the
-  daemon starts it runs Claude's native installer into the persisted `loom_home`
-  volume (`~/.local/bin/claude`), and Claude auto-updates itself in place from
-  then on — updates land without a rebuild and survive `up`/`down`/recreate. That
-  first install needs network (the deploy needs it anyway); if it fails loom
-  still comes up and installs on a later boot. Pin the tracked build with
-  `CLAUDE_CODE_VERSION` (`stable` — the default — `latest`, or an exact version
-  like `2.1.198`) in the `loom` service's `environment:` in
-  [`docker-compose.yml`](standalone/docker-compose.yml); force one live with
-  `docker compose exec loom claude install <version> --force`.
+- **The agent runtimes install at first boot, no image rebuild.** The container
+  runs as a non-root user, so a runtime installed into the read-only system dirs
+  could neither self-update (Claude reports "installed in a read-only location")
+  nor be bumped live. Instead, the first time the daemon starts it installs both
+  `claude` and `codex` into the persisted `loom_home` volume (`~/.local/bin` and
+  the home npm prefix `~/.npm-global/bin`), where updates land without a rebuild
+  and survive `up`/`down`/recreate. That first install needs network (the deploy
+  needs it anyway); if it fails loom still comes up and installs on a later boot.
+  - **Claude Code** auto-updates itself in place. Pin the tracked build with
+    `CLAUDE_CODE_VERSION` (`stable` — the default — `latest`, or an exact version
+    like `2.1.198`); force one live with
+    `docker compose exec loom claude install <version> --force`.
+  - **Codex CLI** updates on demand rather than automatically. Pin with
+    `CODEX_VERSION` (an npm dist-tag or exact version; default `latest`); bump one
+    live with `docker compose exec loom codex update` (or reinstall with
+    `docker compose exec loom npm i -g @openai/codex@<version>`).
+
+  Set either pin in the `loom` service's `environment:` in
+  [`docker-compose.yml`](standalone/docker-compose.yml).
+
+- **Command sandboxing.** The image ships `bubblewrap` + `socat`, the sandbox
+  the runtimes reach for on Linux: Claude Code's sandboxed Bash runs commands
+  under `bwrap` (falling back to unsandboxed with a warning if it can't), and
+  Codex prefers a system `bwrap` over the one it bundles. Both rely on the
+  unprivileged user namespaces this container already permits via its
+  `SYS_ADMIN` + `apparmor=unconfined` grant (see
+  [Security posture](#security-posture)); a fresh `/proc` mount can still fail
+  in this nested setting, so a runtime may need its weaker-nested-sandbox escape
+  hatch (Codex `--no-proc`; Claude `enableWeakerNestedSandbox`) to sandbox at
+  all. The container is itself the trust boundary either way.
 
 - **Adding more client packages at runtime.** `~/.local/bin` and a home npm
   prefix (`~/.npm-global/bin`) are on `PATH` and on the `loom_home` volume, so

--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -49,6 +49,12 @@ LOOM_GITHUB_WEBHOOK_SECRET=replace-with-a-long-random-string
 #   docker compose exec loom claude
 ANTHROPIC_API_KEY=sk-ant-your-key
 
+# OpenAI API key for the Codex agents. Only needed if you launch the `codex`
+# runtime; leave it blank to use Claude alone, or run a one-time interactive
+# login that persists on the loom_home volume:
+#   docker compose exec loom codex login
+# OPENAI_API_KEY=sk-proj-your-key
+
 # ── GitHub sign-in ────────────────────────────────────────────────────────────
 # The owner's only way to log in on a fresh database (loopback trust is off for
 # this internet-facing deploy). Register an OAuth app with callback

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -32,8 +32,11 @@ owner_github = "your-github-login"
 # github_client_secret = ""
 
 # Paste-once agent secrets — `loom setup secrets` prompts for these (hidden
-# input) instead of you typing them in cleartext here.
+# input) instead of you typing them in cleartext here. anthropic_api_key feeds
+# the Claude runtime, openai_api_key the Codex runtime; set only the ones you
+# use (either can also be an interactive `claude` / `codex login` instead).
 # anthropic_api_key = ""
+# openai_api_key = ""
 # gh_token = ""
 
 # Deploy-mechanism knobs — every one has a sensible compose-level default, so


### PR DESCRIPTION
## What

The Docker install now supports the `codex` runtime end-to-end, adds the sandbox tooling both agent runtimes want on Linux, and rounds out the everyday dev CLIs a coding agent reaches for.

loom already shipped a `codex` runtime (`CodexAgentType`), but the image installed neither the Codex CLI nor a sandbox for it, and there was no path for an OpenAI key — so picking Codex in the UI launched a `codex` that wasn't on `PATH`.

## Changes

**Image (`Dockerfile`)**
- **Codex CLI installed at first boot**, alongside Claude, into the persisted `$HOME` volume (`npm i -g @openai/codex`, on `PATH` via `NPM_CONFIG_PREFIX`) — survives recreates, bumps live with `codex update`, pinnable with `CODEX_VERSION`. Non-fatal, mirroring the Claude install.
- **`bubblewrap` + `socat`** — Claude Code's sandboxed Bash runs commands under `bwrap` (with `socat` relaying network) and otherwise degrades to unsandboxed with a warning; Codex prefers a system `bwrap` over the one it bundles. The container already permits the unprivileged user namespaces they need (`SYS_ADMIN` + `apparmor=unconfined`).
- **Common dev CLIs**: `sqlite3`, `openssh-client`, `patch`, `diffutils`, `procps`, `rsync`, `file`, `gettext-base`, `shellcheck`.

**Auth (`loom`)**
- Added `openai_api_key` to the loom config contract (`FIELDS`), so `render-env` / `push-secrets` carry `OPENAI_API_KEY` through and `loom setup secrets` prompts for it.
- Documented in `deploy/README.md`, `.env.example`, and `loom.toml.example`. Codex authenticates like Claude: `OPENAI_API_KEY`, or an interactive `codex login` persisted on the `loom_home` volume.

## Notes
- A fresh `/proc` mount can still fail in this nested-container setting, so a runtime may need its weaker-nested-sandbox escape hatch (Codex `--no-proc`; Claude `enableWeakerNestedSandbox`) to sandbox at all — the container is itself the trust boundary either way. Noted in the deploy docs.
- CI does not build the image; verified locally: `cargo test -p loom --lib loom_config` (8 passing, incl. the secret-markers contract), `cargo build -p loom`, and the pre-commit fmt/clippy/typecheck hook are all green. apt package names are stock bookworm.