### PR TITLE
fix(weaver): resolve artifact-write URLs to a link people can open

### DIFF
--- a/crates/loom/src/web/artifacts.rs
+++ b/crates/loom/src/web/artifacts.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use axum::{
     extract::{Path, Query, State},
+    http::header,
     Json,
 };
 use serde::Deserialize;
@@ -355,6 +356,30 @@ pub(super) async fn write_branch_artifact(
     .ok();
     Ok(Json(
         artifact_view(&st.db, &branch.repo_root, &a, None).await?,
+    ))
+}
+
+/// `GET /api/branches/{key}/artifacts/{name}/url` — the dashboard deep-link for
+/// an artifact.
+///
+/// The twin of `session_url_route`: the agent that just wrote the artifact holds
+/// only the loopback (or wildcard) `$WEAVER_API` it was handed, and a
+/// `http://0.0.0.0:7878/…` link printed after a write is useless to whoever
+/// reads it. Only the server knows the externally-visible origin (the operator's
+/// `auth.base_url`, else the request's own Host), so resolving it is the
+/// server's job — see `weaver artifact write`.
+pub(super) async fn branch_artifact_url_route(
+    State(st): State<AppState>,
+    headers: header::HeaderMap,
+    Path((key, name)): Path<(String, String)>,
+) -> ApiResult<Json<Value>> {
+    // Resolve the branch so a bad key 404s rather than minting a link to
+    // nothing; the URL itself keys off the caller's `key` (the `$WEAVER_BRANCH`
+    // the SPA router resolves), exactly as the write output always has.
+    require_branch(&st.db, &key).await?;
+    let base = super::auth::public_base(&st, &headers).await;
+    Ok(Json(
+        json!({ "url": super::artifact_url(&base, &key, &name) }),
     ))
 }
 

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -154,12 +154,25 @@ async fn cookie_secure(st: &AppState) -> bool {
 
 /// [`external_base`], falling back to the address we are bound to when the
 /// request carries no Host — for building a link to hand out (a webhook reply, a
-/// PR back-link, `loom session url`), where there is no "no origin" answer and
-/// the bound address is the best guess available.
+/// PR back-link, `loom session url`, an artifact URL), where there is no "no
+/// origin" answer and the bound address is the best guess available. A wildcard
+/// host is mapped to loopback (see [`dialable_host`]) so the link resolves.
 pub(crate) async fn public_base(st: &AppState, headers: &HeaderMap) -> String {
-    external_base(st, headers)
+    let base = external_base(st, headers)
         .await
-        .unwrap_or_else(|| format!("http://{}", st.addr))
+        .unwrap_or_else(|| format!("http://{}", st.addr));
+    dialable_host(&base)
+}
+
+/// Map a wildcard host (`0.0.0.0` / `[::]`, "every interface" — not a dialable
+/// address) in a base URL to loopback, so a link we hand out actually resolves.
+/// A configured `auth.base_url` or a real browser's Host never carries a
+/// wildcard, so this only rewrites the degenerate case: a wildcard-bound server
+/// with no public origin declared, asked for a link by a caller (the `weaver`
+/// CLI) that dialed that same wildcard address.
+fn dialable_host(base: &str) -> String {
+    base.replace("://0.0.0.0", "://127.0.0.1")
+        .replace("://[::]", "://127.0.0.1")
 }
 
 /// The externally-visible base URL, for the OAuth callback. Prefers the
@@ -564,4 +577,39 @@ pub(super) async fn put_github_config(
     config::apply(&st.db, &changes).await?;
     tracing::info!(secret_provided, "github oauth config updated");
     Ok(Json(github_config_view(&st).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dialable_host;
+
+    #[test]
+    fn wildcard_hosts_map_to_loopback() {
+        // A wildcard bind is "every interface", not a dialable address — the
+        // link we hand out must point somewhere a browser can actually open.
+        assert_eq!(
+            dialable_host("http://0.0.0.0:7878"),
+            "http://127.0.0.1:7878"
+        );
+        assert_eq!(dialable_host("http://[::]:7878"), "http://127.0.0.1:7878");
+    }
+
+    #[test]
+    fn real_origins_pass_through_untouched() {
+        // A configured `auth.base_url` or a real browser's Host never carries a
+        // wildcard, so the common cases are left exactly as-is.
+        assert_eq!(
+            dialable_host("https://loom.example.com"),
+            "https://loom.example.com"
+        );
+        assert_eq!(
+            dialable_host("http://127.0.0.1:7878"),
+            "http://127.0.0.1:7878"
+        );
+        // `0.0.0.0` only elsewhere in the string (not as the host) is left alone.
+        assert_eq!(
+            dialable_host("https://host/p/0.0.0.0"),
+            "https://host/p/0.0.0.0"
+        );
+    }
 }

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -319,6 +319,14 @@ pub(crate) fn session_url(base: &str, session_id: &str) -> String {
     format!("{}/s/{session_id}", base.trim_end_matches('/'))
 }
 
+/// The dashboard deep-link for an artifact — the page a person opens to read it
+/// (`/s/:id/artifacts/:name` in the SPA router). `key` is any session key (the
+/// `$WEAVER_BRANCH` an agent carries resolves fine); pair `base` with
+/// [`auth::public_base`] so the link resolves off-box.
+pub(crate) fn artifact_url(base: &str, key: &str, name: &str) -> String {
+    format!("{}/s/{key}/artifacts/{name}", base.trim_end_matches('/'))
+}
+
 pub(crate) async fn require_branch(db: &Db, key: &str) -> ApiResult<Branch> {
     if let Some(branch) = branch_mod::resolve_key(db, key).await? {
         return Ok(branch);
@@ -597,6 +605,10 @@ pub fn router(state: AppState) -> Router {
             get(get_branch_artifact)
                 .put(write_branch_artifact)
                 .delete(delete_branch_artifact),
+        )
+        .route(
+            "/branches/{id}/artifacts/{name}/url",
+            get(branch_artifact_url_route),
         )
         .route(
             "/branches/{id}/artifacts/{name}/threads",

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -445,6 +445,25 @@ impl Client {
         .await
     }
 
+    /// The dashboard deep-link for a branch artifact, resolved server-side
+    /// (`GET /api/branches/{key}/artifacts/{name}/url`) so it carries the
+    /// externally-visible origin (`auth.base_url`, else the request Host) rather
+    /// than the loopback/wildcard address the agent dials — a `0.0.0.0` link is
+    /// useless to whoever reads it. See `loom session url` for the same pattern.
+    pub async fn branch_artifact_url(&self, key: &str, name: &str) -> Result<String> {
+        let v = self
+            .get(&format!(
+                "/api/branches/{}/artifacts/{}/url",
+                Self::seg(key),
+                Self::seg(name)
+            ))
+            .await?;
+        v.get("url")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("server returned no url"))
+    }
+
     /// Delete an artifact and its whole revision history. `repo: true` targets
     /// the repo-shared row of this name rather than the branch-scoped one
     /// (`DELETE /api/branches/{key}/artifacts/{name}`).

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -1345,14 +1345,20 @@ async fn cmd_artifact(cmd: ArtifactCmd) -> Result<()> {
             // The write already succeeded — loom is definitionally reachable at
             // this point, so the dashboard link is always known now (unlike the
             // direct-db days, when it depended on `$WEAVER_API`/`loom.json`
-            // happening to be present).
+            // happening to be present). The server resolves the link so it
+            // carries its externally-visible origin (`auth.base_url`, else the
+            // request Host) — the loopback/wildcard `$WEAVER_API` we dialed
+            // (often `http://0.0.0.0:7878`) is not a URL anyone can open. If that
+            // resolution fails, fall back to the dialed base rather than lose the
+            // rev line entirely.
+            let url = client
+                .branch_artifact_url(&key, &view.meta.name)
+                .await
+                .unwrap_or_else(|_| {
+                    format!("{}/s/{key}/artifacts/{}", client.base(), view.meta.name)
+                });
             let scope = if repo { "repo-shared" } else { "this branch" };
-            println!(
-                "{}/s/{key}/artifacts/{}  (rev {}, {scope})",
-                client.base(),
-                view.meta.name,
-                view.meta.rev
-            );
+            println!("{url}  (rev {}, {scope})", view.meta.rev);
         }
         ArtifactCmd::Ls { repo } => {
             let artifacts = client.list_branch_artifacts(&key, repo).await?;

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -534,6 +534,51 @@ async fn artifact_write_show_ls_and_revisions() {
     assert!(!ls.contains("plan"), "rm should remove it: {ls}");
 }
 
+/// The URL printed after a write is resolved server-side, so it carries the
+/// operator's externally-visible origin — not the loopback/wildcard address the
+/// agent dialed (`http://0.0.0.0:7878`), which is useless to whoever reads it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn artifact_write_url_honours_the_public_base() {
+    let env = Env::start().await;
+
+    // With no `auth.base_url`, the origin is derived from the request's Host —
+    // here the loopback address the CLI dialed, right for a single-machine loom.
+    let derived = env.run_with_stdin(&["artifact", "write", "plan"], "# Plan\n");
+    assert!(
+        derived.contains(&format!(
+            "http://{}/s/{}/artifacts/plan",
+            env.addr, env.branch_id
+        )),
+        "derived from the request origin, keyed off $WEAVER_BRANCH: {derived}"
+    );
+
+    // Once the operator declares a public origin, the printed link is one an
+    // off-box reader (of a PR, say) can actually open — and the dialed address
+    // no longer leaks into it.
+    loom::config::apply(
+        &env.db,
+        &[(
+            "auth.base_url".to_string(),
+            Some("https://loom.example.com".to_string()),
+        )],
+    )
+    .await
+    .unwrap();
+    let public = env.run_with_stdin(&["artifact", "write", "plan"], "# Plan v2\n");
+    assert!(
+        public.contains(&format!(
+            "https://loom.example.com/s/{}/artifacts/plan  (rev 2, this branch)",
+            env.branch_id
+        )),
+        "the configured public origin wins: {public}"
+    );
+    assert!(
+        !public.contains(&env.addr.to_string()),
+        "the dialed address is not leaked into the link: {public}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn artifact_comment_thread_and_resolve_roundtrip() {

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -132,11 +132,15 @@ the survey above:
 - **URL-addressable.** `weaver artifact write` prints the dashboard URL
   (`/s/<session>/artifacts/<name>`) so the agent can hand it to the user in
   a status message or PR comment — the Amp-thread lesson: the URL is the
-  collaboration feature. The write is a REST call (`weaver-api::Client`,
-  resolving the server the same way every loom client does: `$WEAVER_API`,
-  then the recorded `server.json` address), so a reachable loom is required —
-  without one the command fails with a friendly error rather than falling
-  back to a local write.
+  collaboration feature. The server resolves that link from its
+  externally-visible origin (`auth.base_url`, else the request's own Host):
+  the loopback/wildcard `$WEAVER_API` an agent dials (often
+  `http://0.0.0.0:7878`) is not an address anyone else can open, the same
+  reason `loom session url` resolves server-side. The write itself is a REST
+  call (`weaver-api::Client`, resolving the server the same way every loom
+  client does: `$WEAVER_API`, then the recorded `server.json` address), so a
+  reachable loom is required — without one the command fails with a friendly
+  error rather than falling back to a local write.
 - **It survives archive.** Artifacts live in weaver.db next to the goal,
   events, and issues, so tearing down the worktree no longer deletes the
   design doc. This fixes the worst current asymmetry for free.


### PR DESCRIPTION
## Problem

`weaver artifact write` printed its dashboard link straight from `client.base()` — the `$WEAVER_API` the agent was handed, which loom sets to its own bound address (`http://{addr}`). When loom binds a wildcard interface that is `http://0.0.0.0:7878/s/…/artifacts/…`. A wildcard host is "every interface", not a dialable address, so the printed link was useless to whoever read it in a status update or PR comment.

```
$ weaver artifact write logstore-design design.md
http://0.0.0.0:7878/s/gnd3f510/artifacts/logstore-design  (rev 1, this branch)
```

## Fix

Resolve the link **server-side**, exactly the way `loom session url` already does: only the server knows its externally-visible origin (`auth.base_url`, else the request's own `Host`). The agent can't build it — it only holds the loopback/wildcard address it dialed.

- New route `GET /api/branches/{key}/artifacts/{name}/url` → `{ "url": … }`, built from `public_base` (the twin of the existing `session_url_route`).
- `weaver artifact write` calls it and prints the resolved link, **falling back** to the dialed base if the call fails, so the `(rev N, scope)` line is never lost (older server / transient error).
- `public_base` now also maps a wildcard host (`0.0.0.0` / `[::]`) to loopback, so the degenerate case — wildcard bind with no `auth.base_url` declared — still resolves. This also hardens `loom session url`, PR back-links, and the repo links that already go through `public_base`.

With `auth.base_url` set (as on a shared deployment) the printed link is one an off-box reader can actually open; without it, it falls back to loopback rather than a wildcard — the same behaviour and the same operator requirement as `loom session url`.

## Tests

- `dialable_host` unit test (wildcard → loopback; real origins untouched).
- End-to-end CLI test (`artifact_write_url_honours_the_public_base`): asserts the printed link is derived from the request origin by default, uses a configured `auth.base_url` once set, and never leaks the dialed address.

## Notes

- Pre-existing, unrelated: the `agent_cli` suite is flaky on a heavily-loaded box with an intermittent SQLite `database is locked` on writes (an unrelated test that touches none of this code fails identically). Not introduced here; the new test passes cleanly when the lock doesn't fire.
