### PR TITLE
feat(loom,weaver): mirror session status onto its GitHub thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
+ "chrono",
  "clap",
  "clap_complete",
  "loom",

--- a/crates/loom/frontend/src/components/SessionOverview.vue
+++ b/crates/loom/frontend/src/components/SessionOverview.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
 import { computed, ref, watch, onMounted } from 'vue';
-import type { Session, WeaverEvent, Issue, IssueRefStatus, ArtifactView } from '../types';
-import { getArtifact } from '../api';
+import type { Session, WeaverEvent, Issue, IssueRefStatus, ArtifactView, ArtifactMeta } from '../types';
+import { getArtifact, getArtifacts } from '../api';
+import { timeAgo } from '../lib/time';
+import { effectiveAttention, lifecycleDot, messageOf } from '../lib/sessionState';
 import SessionActivity from './SessionActivity.vue';
 import SessionIssues from './SessionIssues.vue';
 import MarkdownView from './MarkdownView.vue';
 
-// The Overview tab: the read-only context for a session — the goal (rendered as
-// projected markdown), the pinned `plan` artifact, claimed work + repo backlog,
-// and the de-noised activity feed. The PR snapshot lives as a small link in the
-// session header rather than as a section here.
-// Everything here is authored by the AGENT (the goal, `weaver status`,
-// `weaver issue`, `weaver artifact write plan`); the page's writes (acknowledge
+// The Overview tab is the session BRIEF — the pane for coming back to a session
+// after time away. It leads with the current state (the agent's `weaver status`
+// synopsis), then what there is to read (documents, the links the agent
+// surfaced), then the standing context: goal, plan, issues, activity. The PR
+// snapshot lives as a small link in the session header rather than as a section
+// here. Everything is authored by the AGENT (the goal, `weaver status`,
+// `weaver issue`, `weaver artifact write`); the page's writes (acknowledge
 // attention, rename, lifecycle) all live in the header, and the live working
 // surface (terminal + scratch) is the Terminal tab.
 const props = defineProps<{
@@ -21,6 +24,79 @@ const props = defineProps<{
   issues: Issue[];
   backlog: Issue[];
 }>();
+
+// -- State — the synopsis line ----------------------------------------------
+
+const attention = computed(() => effectiveAttention(props.ws));
+const stateMessage = computed(() => messageOf(props.ws) || attention.value.note);
+// When the agent last spoke: the attention tag's set_at (stamped on every
+// `weaver status`, loud or calm) — else the branch's own updated_at.
+const stateWhen = computed(() => {
+  const tag = props.ws.branch.tags.find((t) => t.key === 'attention');
+  return tag?.set_at || props.ws.branch.updated_at;
+});
+
+// -- Docs — every artifact the session published -----------------------------
+
+const docs = ref<ArtifactMeta[]>([]);
+
+async function loadDocs() {
+  try {
+    // The goal is the charter — it has its own section below, not a list row.
+    docs.value = (await getArtifacts(props.ws.id)).filter((a) => a.name !== 'goal');
+  } catch {
+    docs.value = [];
+  }
+}
+
+// -- Links — URLs the agent surfaced, plus the canonical GitHub anchors ------
+
+interface BriefLink {
+  href: string;
+  label: string;
+  /** Where it came from — the quiet suffix the row shows. */
+  source: string;
+}
+
+const URL_RE = /https?:\/\/[^\s)\]>"'`]+/g;
+
+// Strings inside event payloads that can carry prose with URLs in it.
+const TEXT_KEYS = ['note', 'text', 'message'] as const;
+
+const links = computed<BriefLink[]>(() => {
+  const out: BriefLink[] = [];
+  const seen = new Set<string>();
+  const push = (href: string, label: string, source: string) => {
+    const key = href.replace(/\/+$/, '');
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({ href, label, source });
+  };
+
+  // The canonical anchors first: the wired GitHub thread, then the PR.
+  const wiring = props.ws.branch.tags.find((t) => t.key === 'github')?.value;
+  const wired = wiring?.match(/^([\w.-]+\/[\w.-]+)#(\d+)$/);
+  if (wired) {
+    push(`https://github.com/${wired[1]}/issues/${wired[2]}`, wiring!, 'wired thread');
+  }
+  const pr = props.ws.branch.github;
+  if (pr?.pr_url) {
+    push(pr.pr_url, `PR #${pr.pr_number}`, pr.pr_title || 'pull request');
+  }
+
+  // Then anything the agent said in its status trail / notes, newest first.
+  for (const ev of [...props.events].reverse()) {
+    for (const k of TEXT_KEYS) {
+      const text = ev.data[k];
+      if (typeof text !== 'string') continue;
+      for (const raw of text.match(URL_RE) ?? []) {
+        const href = raw.replace(/[.,;:]+$/, '');
+        push(href, href.replace(/^https?:\/\//, ''), timeAgo(ev.created_at));
+      }
+    }
+  }
+  return out.slice(0, 12);
+});
 
 // The goal's `#N` refs aren't projected by the backend (it has no artifact to
 // hang a ref map on), so build one client-side from the session's issues — the
@@ -57,17 +133,93 @@ async function loadPlan() {
 
 const planIsMarkdown = computed(() => (plan.value?.meta.kind ?? 'markdown') === 'markdown');
 
-onMounted(loadPlan);
-// SSE drives `events`; an `artifact_written` for `plan` means re-fetch. Cheap to
-// just reload whenever any artifact_written arrives.
+onMounted(() => {
+  loadPlan();
+  loadDocs();
+});
+// SSE drives `events`; an `artifact_written` means the plan or the doc list may
+// have moved. Cheap to just reload both whenever one arrives.
 watch(
   () => props.events.filter((e) => e.kind === 'artifact_written').length,
-  () => loadPlan(),
+  () => {
+    loadPlan();
+    loadDocs();
+  },
 );
 </script>
 
 <template>
   <div class="space-y-5">
+    <!-- State — the synopsis: what the agent last said, when, at what level.
+         The one line to read when coming back to a session. -->
+    <section
+      class="rounded border border-line bg-surface px-4 py-3"
+      data-testid="session-state"
+    >
+      <div class="flex items-baseline gap-2">
+        <span
+          class="h-2 w-2 shrink-0 self-center rounded-full"
+          :class="lifecycleDot(ws)"
+          aria-hidden="true"
+        ></span>
+        <p class="min-w-0 font-serif text-[15px] leading-snug text-fg">
+          {{ stateMessage || 'No status reported yet.' }}
+        </p>
+      </div>
+      <div class="mt-1 pl-4 text-2xs text-muted">
+        <span v-if="attention.level !== 'ok'" class="font-semibold">{{ attention.level }} · </span>
+        <span>{{ timeAgo(stateWhen) }}</span>
+      </div>
+    </section>
+
+    <!-- Docs — every artifact the session published (the goal stays below as
+         the charter). Names link into the artifact viewer. -->
+    <section
+      v-if="docs.length"
+      class="rounded border border-line bg-surface"
+      data-testid="session-docs"
+    >
+      <header class="border-b border-line px-4 py-2.5">
+        <div class="text-2xs font-semibold uppercase tracking-wider text-muted">Documents</div>
+      </header>
+      <ul class="divide-y divide-line">
+        <li v-for="d in docs" :key="d.name">
+          <router-link
+            :to="`/s/${ws.id}/artifacts/${d.name}`"
+            class="flex items-baseline gap-2 px-4 py-2 hover:bg-subtle"
+          >
+            <span class="font-mono text-xs text-accent">{{ d.name }}</span>
+            <span class="min-w-0 truncate font-serif text-sm text-fg">{{ d.title }}</span>
+            <span class="ml-auto shrink-0 font-mono text-2xs text-faint">v{{ d.rev }}</span>
+            <span class="shrink-0 text-2xs text-faint">{{ timeAgo(d.updated_at) }}</span>
+          </router-link>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Links — the wired GitHub thread, the PR, and any URL the agent surfaced
+         in its status trail, newest first. -->
+    <section
+      v-if="links.length"
+      class="rounded border border-line bg-surface"
+      data-testid="session-links"
+    >
+      <header class="border-b border-line px-4 py-2.5">
+        <div class="text-2xs font-semibold uppercase tracking-wider text-muted">Links</div>
+      </header>
+      <ul class="divide-y divide-line">
+        <li v-for="l in links" :key="l.href" class="flex items-baseline gap-2 px-4 py-2">
+          <a
+            :href="l.href"
+            target="_blank"
+            rel="noopener"
+            class="min-w-0 truncate text-sm text-accent hover:underline"
+          >{{ l.label }}</a>
+          <span class="ml-auto shrink-0 text-2xs text-faint">{{ l.source }}</span>
+        </li>
+      </ul>
+    </section>
+
     <!-- Goal — the branch charter, rendered as projected markdown (its `#N`
          issue refs become live status chips from the session's issues). Carries
          `session-goal` for the detail/list specs. -->

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -31,6 +31,11 @@ function parkOf(value: string | undefined): number {
 // loud status. Mirrors weaver-core's `IDLE_KEY`.
 export const IDLE_KEY = 'idle';
 
+// Loom's machine bookkeeping for its GitHub side-effects (the PR back-link
+// mark, the status-card comment id). Not user-meaningful, so the pill row
+// hides them; the `github` wiring tag itself stays visible.
+const BOOKKEEPING_KEYS = ['github.linked', 'github.status_comment'];
+
 // Severity of a tag value: 0 is quiet (a pill), >0 is loud (a badge).
 function severityOf(value: string | undefined): number {
   return (value && SEVERITY[value]) || 0;
@@ -278,7 +283,10 @@ export function signalChips(s: Session): SignalChip[] {
 export function quietTags(s: Session): Tag[] {
   if (s.status === 'archived') return [];
   return (s.branch.tags ?? []).filter(
-    (t) => severityOf(t.value) === 0 && t.key !== IDLE_KEY,
+    (t) =>
+      severityOf(t.value) === 0 &&
+      t.key !== IDLE_KEY &&
+      !BOOKKEEPING_KEYS.includes(t.key),
   );
 }
 

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -225,7 +225,14 @@ function eventLine(ev: WeaverEvent): string {
   if (ev.kind === 'status') return `status → ${d.status ?? '?'}`;
   if (ev.kind === 'tag') {
     // `{ key, value, note, by }`; an empty value means the tag was cleared.
+    // The agent's own `attention` events carry the status message as `note` —
+    // rendered message-first, they make the feed the session's progress log
+    // (an empty attention value is the calm `ok`, not a bare "cleared").
     const key = (d.key as string) ?? 'tag';
+    if (key === 'attention' && d.by === 'agent') {
+      const level = (d.value as string) || 'ok';
+      return d.note ? `${level} — ${d.note}` : `status → ${level}`;
+    }
     const note = d.note ? ` (${d.note})` : '';
     return d.value ? `${key} → ${d.value}${note}` : `${key} cleared`;
   }

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -651,6 +651,16 @@ async function handleCreated() {
           <span v-if="s.last_activity_at" class="mt-0.5 block font-mono text-2xs text-faint">
             {{ timeAgo(s.last_activity_at) }}
           </span>
+          <!-- The session brief: catch up without opening the terminal. The
+               row's stretched link stays the shell — this is the side door. -->
+          <router-link
+            :to="`/s/${s.id}?tab=overview`"
+            data-testid="row-overview"
+            class="relative z-10 mt-0.5 block font-mono text-2xs text-faint hover:text-accent"
+            @click.stop
+          >
+            overview →
+          </router-link>
         </div>
 
         <!-- The row's ⋯ menu: park, then every lifecycle verb (Adopt/Recover,
@@ -744,6 +754,16 @@ async function handleCreated() {
             <span v-if="s.last_activity_at" class="mt-0.5 block font-mono text-2xs text-faint">
               {{ timeAgo(s.last_activity_at) }}
             </span>
+            <!-- A resting session is exactly the one you catch up on via the
+                 brief rather than by waking its terminal. -->
+            <router-link
+              :to="`/s/${s.id}?tab=overview`"
+              data-testid="row-overview"
+              class="relative z-10 mt-0.5 block font-mono text-2xs text-faint hover:text-accent"
+              @click.stop
+            >
+              overview →
+            </router-link>
           </div>
 
           <button

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -126,6 +126,291 @@ const POLL_TICK: Duration = Duration::from_secs(30);
 /// Shared with [`crate::web`] (the trigger reply path).
 pub const LINKED_TAG: &str = "github.linked";
 
+// ---------------------------------------------------------------------------
+// The status card
+//
+// A branch wired to a GitHub thread mirrors its `weaver status` trail onto one
+// comment there — the trigger's "On it" reply, edited in place — so the people
+// watching the issue or PR see the agent's progress without opening the
+// dashboard. Edits notify no one: the card is the quiet channel; the agent
+// still posts real comments when it needs a human.
+// ---------------------------------------------------------------------------
+
+/// Branch tag wiring a session to a GitHub thread — see
+/// [`tags::GITHUB_KEY`] (the registry entry) for the contract.
+pub const WIRED_TAG: &str = tags::GITHUB_KEY;
+
+/// Branch tag holding the GitHub comment id of the status card — loom's
+/// bookkeeping, the same shape as [`LINKED_TAG`] (the value is the handle).
+/// See [`tags::GITHUB_COMMENT_KEY`].
+pub const STATUS_COMMENT_TAG: &str = tags::GITHUB_COMMENT_KEY;
+
+/// How many trail bullets the status card shows; older entries collapse into a
+/// count line so a long session never turns the comment into a scroll.
+const STATUS_CARD_CAP: usize = 15;
+
+/// Keys loom stamps mechanically to track its own GitHub side-effects. The
+/// generic tag routes refuse to *set* them — a forged comment id would aim
+/// loom's edits at someone else's comment. Clearing stays allowed (harmless:
+/// loom re-creates its bookkeeping on the next pass).
+pub fn is_reserved_tag(key: &str) -> bool {
+    key == LINKED_TAG || key == STATUS_COMMENT_TAG
+}
+
+/// Parse a [`WIRED_TAG`] value — `owner/name#number` — into its slug and
+/// thread number. `None` for anything else (the tag is free-form user input).
+pub fn parse_wiring(value: &str) -> Option<(String, i64)> {
+    let (slug, number) = value.trim().split_once('#')?;
+    let number: i64 = number.trim().parse().ok().filter(|n| *n > 0)?;
+    let slug = slug.trim();
+    let mut parts = slug.split('/');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(o), Some(n), None) if !o.is_empty() && !n.is_empty() => {
+            Some((slug.to_string(), number))
+        }
+        _ => None,
+    }
+}
+
+/// One rendered bullet of the status trail: the level's dot, the time, the
+/// level name when loud, and the message. Events with nothing to say (a bare
+/// `weaver status ok`) render `None`.
+fn status_bullet(event: &weaver_core::events::Event) -> Option<String> {
+    let value = event.data["value"].as_str().unwrap_or_default();
+    let note = event.data["note"].as_str().unwrap_or_default().trim();
+    let loud = !value.is_empty();
+    if note.is_empty() && !loud {
+        return None;
+    }
+    let icon = match value {
+        "blocked" => "\u{1f534}",   // red circle
+        "attention" => "\u{1f7e0}", // orange circle
+        _ => "\u{1f7e2}",           // green circle
+    };
+    let when = chrono::DateTime::parse_from_rfc3339(&event.created_at)
+        .map(|t| t.format("%b %e %H:%M").to_string())
+        .unwrap_or_default();
+    let mut line = format!("- {icon} `{when}Z`");
+    if loud {
+        line.push_str(&format!(" **{value}**"));
+        if !note.is_empty() {
+            line.push_str(" —");
+        }
+    }
+    if !note.is_empty() {
+        line.push_str(&format!(" {note}"));
+    }
+    Some(line)
+}
+
+/// Render the status card: the "On it" header linking the session, the
+/// documents the agent has published (linked into the dashboard's artifact
+/// viewer), then the trail of `weaver status` reports (oldest first, capped at
+/// [`STATUS_CARD_CAP`]). Pure, so the format is unit-testable; `events` is the
+/// branch's history oldest-first, filtered here to the agent's own attention
+/// reports.
+pub fn render_status_card(
+    session_url: &str,
+    artifacts: &[String],
+    events: &[weaver_core::events::Event],
+) -> String {
+    let bullets: Vec<String> = events
+        .iter()
+        // The agent's own reports only: a manual tag edit in the UI records the
+        // same event shape but must never read as agent progress on GitHub.
+        .filter(|e| {
+            e.kind == "tag" && e.data["key"] == tags::ATTENTION_KEY && e.data["by"] == "agent"
+        })
+        .filter_map(status_bullet)
+        .collect();
+    let mut body = format!("On it — {session_url}");
+    if !artifacts.is_empty() {
+        let links: Vec<String> = artifacts
+            .iter()
+            .map(|name| format!("[{name}]({session_url}/artifacts/{name})"))
+            .collect();
+        body.push_str(&format!("\nDocs: {}", links.join(" · ")));
+    }
+    if bullets.is_empty() {
+        return body;
+    }
+    body.push_str("\n\n");
+    if bullets.len() > STATUS_CARD_CAP {
+        let hidden = bullets.len() - STATUS_CARD_CAP;
+        body.push_str(&format!("…{hidden} earlier updates\n"));
+    }
+    let shown = &bullets[bullets.len().saturating_sub(STATUS_CARD_CAP)..];
+    body.push_str(&shown.join("\n"));
+    body
+}
+
+/// One card sync at a time, process-wide: two racing status writes must never
+/// both see "no tracked comment" and double-post. Coarse — every branch shares
+/// it — which costs nothing at this fleet's write rate; each sync re-reads the
+/// event history inside the lock, so whichever runs last renders the full
+/// trail and stale renders can't stick.
+static SYNC_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Mirror a wired branch's status trail onto its GitHub thread: render the
+/// card and edit the tracked comment in place — posting a fresh one the first
+/// time, or again when someone deleted it. A no-op for unwired branches, and
+/// best-effort everywhere: a GitHub hiccup logs and never surfaces to the
+/// status write that spawned this. Transient failures retry — a terminal
+/// status ("ready for review", a final `blocked`) has no later write to
+/// self-heal through, so it must not be lost to one flaky call.
+pub async fn sync_status_comment(state: AppState, branch_id: String) {
+    for attempt in 0..3u32 {
+        if attempt > 0 {
+            tokio::time::sleep(Duration::from_secs(5 * 4u64.pow(attempt - 1))).await;
+        }
+        if sync_status_comment_once(&state, &branch_id).await {
+            return;
+        }
+    }
+    tracing::warn!(branch = %branch_id, "status card: giving up after retries");
+}
+
+/// One sync attempt. `true` means done — synced, or nothing to do (unwired, no
+/// live session, no public base); `false` is a transient GitHub failure worth
+/// retrying.
+async fn sync_status_comment_once(state: &AppState, branch_id: &str) -> bool {
+    let wired = match tags::get(&state.db, branch_id, WIRED_TAG).await {
+        Ok(Some(tag)) => tag,
+        Ok(None) => return true,
+        Err(e) => {
+            tracing::warn!(branch = %branch_id, error = %e, "status card: reading wiring tag failed");
+            return true;
+        }
+    };
+    let Some((slug, number)) = parse_wiring(&wired.value) else {
+        tracing::warn!(branch = %branch_id, value = %wired.value, "status card: unparsable `github` tag; expected owner/name#number");
+        return true;
+    };
+    // Only a public base yields a link a GitHub reader can follow — same guard
+    // as the PR back-link. Without one the card would advertise a loopback URL.
+    let base = config::get(&state.db, "auth.base_url")
+        .await
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    if base.is_empty() {
+        tracing::debug!(branch = %branch_id, "status card: no auth.base_url; skipping");
+        return true;
+    }
+    let session = match session_mod::active_for_branch(&state.db, branch_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return true, // no live session — nothing is reporting status
+        Err(e) => {
+            tracing::warn!(branch = %branch_id, error = %e, "status card: session lookup failed");
+            return true;
+        }
+    };
+
+    let _guard = SYNC_LOCK.lock().await;
+    let mut events = match events::history(&state.db, branch_id, 500).await {
+        Ok(ev) => ev,
+        Err(e) => {
+            tracing::warn!(branch = %branch_id, error = %e, "status card: reading event history failed");
+            return true;
+        }
+    };
+    // The trail starts when the wiring did: statuses written before the agent
+    // was told they'd be public stay private (hand-wiring an old session must
+    // not retroactively publish its history).
+    events.retain(|e| e.created_at >= wired.set_at);
+    // The card links the agent's published documents (`goal` excluded — it
+    // paraphrases the thread itself). Names only: full contents stay a
+    // deliberate `gh` comment, posting one is the "please read this" act.
+    let artifacts: Vec<String> = match branch_mod::get(&state.db, branch_id).await {
+        Ok(Some(branch)) => {
+            weaver_core::artifact::list_for_session(&state.db, &branch.repo_root, branch_id)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|a| a.name)
+                .filter(|n| n != "goal")
+                .collect()
+        }
+        _ => Vec::new(),
+    };
+    let body = render_status_card(
+        &crate::web::session_url(&base, &session.id),
+        &artifacts,
+        &events,
+    );
+
+    // The tracked comment counts only while its note still names the current
+    // wiring: a re-pointed `github` tag must get a fresh comment on the new
+    // thread, never a PATCH of the old one.
+    let wired_to = format!("{slug}#{number}");
+    let tracked: Option<i64> = match tags::get(&state.db, branch_id, STATUS_COMMENT_TAG).await {
+        Ok(tag) => tag
+            .filter(|t| t.note == wired_to)
+            .and_then(|t| t.value.parse().ok()),
+        Err(e) => {
+            tracing::warn!(branch = %branch_id, error = %e, "status card: reading comment tag failed");
+            return true;
+        }
+    };
+    if let Some(comment_id) = tracked {
+        match state
+            .trigger
+            .gh()
+            .update_issue_comment(&slug, comment_id, &body)
+            .await
+        {
+            Ok(true) => return true,
+            Ok(false) => {
+                tracing::info!(repo = %slug, comment = comment_id, "status card: comment gone; posting a fresh one");
+            }
+            Err(e) => {
+                tracing::warn!(repo = %slug, comment = comment_id, error = %e, "status card: comment update failed");
+                return false;
+            }
+        }
+    }
+    match state
+        .trigger
+        .gh()
+        .post_issue_comment(&slug, number, &body)
+        .await
+    {
+        Ok(comment_id) => {
+            record_status_comment(&state.db, branch_id, &slug, number, comment_id).await;
+            true
+        }
+        Err(e) => {
+            tracing::warn!(repo = %slug, number, error = %e, "status card: posting comment failed");
+            false
+        }
+    }
+}
+
+/// Stamp the [`STATUS_COMMENT_TAG`] bookkeeping tag after a card lands. The
+/// note records the wiring the comment belongs to — [`sync_status_comment`]
+/// trusts the comment id only while that note matches the current `github`
+/// tag. Shared with the trigger reply path, which posts the card's first
+/// revision.
+pub async fn record_status_comment(
+    db: &Db,
+    branch_id: &str,
+    slug: &str,
+    number: i64,
+    comment_id: i64,
+) {
+    tags::set(
+        db,
+        branch_id,
+        STATUS_COMMENT_TAG,
+        &comment_id.to_string(),
+        &format!("{slug}#{number}"),
+        "loom",
+    )
+    .await
+    .ok();
+}
+
 /// The fields requested from `gh pr view --json`. Kept in one place so the parse
 /// struct and the query can't drift.
 const PR_FIELDS: &str =
@@ -1069,5 +1354,102 @@ mod tests {
             .unwrap();
         assert_eq!(session.status, "running");
         assert!(f.work_dir.exists());
+    }
+
+    // -- the status card ----------------------------------------------------
+
+    #[test]
+    fn parse_wiring_accepts_a_thread_and_rejects_noise() {
+        assert_eq!(
+            parse_wiring("acme/widgets#87"),
+            Some(("acme/widgets".to_string(), 87))
+        );
+        assert_eq!(
+            parse_wiring("  acme/widgets#87  "),
+            Some(("acme/widgets".to_string(), 87))
+        );
+        for bad in [
+            "",
+            "acme/widgets",
+            "#87",
+            "acme#87",
+            "acme/widgets#0",
+            "acme/widgets#-3",
+            "acme/widgets#seven",
+            "a/b/c#7",
+        ] {
+            assert_eq!(parse_wiring(bad), None, "{bad:?} must not parse");
+        }
+    }
+
+    fn status_event(value: &str, note: &str, by: &str) -> weaver_core::events::Event {
+        weaver_core::events::Event {
+            id: 0,
+            branch_id: "b".to_string(),
+            kind: "tag".to_string(),
+            data: json!({ "key": "attention", "value": value, "note": note, "by": by }),
+            created_at: "2026-07-18T21:04:05.000Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn status_card_renders_the_trail_oldest_first() {
+        let events = vec![
+            status_event("", "mapping the code", "agent"),
+            // A manual UI edit must never read as agent progress.
+            status_event("attention", "operator note", "manual"),
+            // An unrelated tag event is not part of the trail.
+            weaver_core::events::Event {
+                id: 0,
+                branch_id: "b".to_string(),
+                kind: "tag".to_string(),
+                data: json!({ "key": "idle", "value": "idle", "note": "", "by": "loom" }),
+                created_at: "2026-07-18T21:05:00.000Z".to_string(),
+            },
+            // A bare `weaver status ok` (no message) says nothing new.
+            status_event("", "", "agent"),
+            status_event("blocked", "build broken", "agent"),
+        ];
+        let card = render_status_card("http://loom/s/abc", &[], &events);
+        let lines: Vec<&str> = card.lines().collect();
+        assert_eq!(lines[0], "On it — http://loom/s/abc");
+        assert_eq!(lines[1], "");
+        assert!(lines[2].contains("mapping the code") && lines[2].contains("\u{1f7e2}"));
+        assert!(lines[3].contains("**blocked** — build broken") && lines[3].contains("\u{1f534}"));
+        assert_eq!(lines.len(), 4, "manual/idle/silent events render nothing");
+    }
+
+    #[test]
+    fn status_card_with_no_trail_is_just_the_header() {
+        assert_eq!(
+            render_status_card("http://loom/s/abc", &[], &[]),
+            "On it — http://loom/s/abc"
+        );
+    }
+
+    #[test]
+    fn status_card_links_published_artifacts() {
+        let card = render_status_card(
+            "http://loom/s/abc",
+            &["design".to_string(), "plan".to_string()],
+            &[status_event("", "drafted the design", "agent")],
+        );
+        let lines: Vec<&str> = card.lines().collect();
+        assert_eq!(
+            lines[1],
+            "Docs: [design](http://loom/s/abc/artifacts/design) · [plan](http://loom/s/abc/artifacts/plan)"
+        );
+        assert!(lines[3].contains("drafted the design"));
+    }
+
+    #[test]
+    fn status_card_collapses_a_long_trail() {
+        let events: Vec<_> = (0..20)
+            .map(|i| status_event("", &format!("step {i}"), "agent"))
+            .collect();
+        let card = render_status_card("http://loom/s/abc", &[], &events);
+        assert!(card.contains("…5 earlier updates"));
+        assert!(!card.contains("step 4"), "collapsed entries are dropped");
+        assert!(card.contains("step 5") && card.contains("step 19"));
     }
 }

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -158,18 +158,18 @@ pub fn is_reserved_tag(key: &str) -> bool {
 }
 
 /// Parse a [`WIRED_TAG`] value — `owner/name#number` — into its slug and
-/// thread number. `None` for anything else (the tag is free-form user input).
+/// thread number. `None` for anything else (the tag is free-form user input,
+/// and the slug ends up in GitHub API paths): both segments must pass the same
+/// charset gate as [`crate::repo::parse_slug`], and only the bare documented
+/// form is accepted — a URL form parse_slug would reduce is rejected here so
+/// the stored tag, the sync's API paths, and the comment bookkeeping note all
+/// agree on one spelling.
 pub fn parse_wiring(value: &str) -> Option<(String, i64)> {
     let (slug, number) = value.trim().split_once('#')?;
     let number: i64 = number.trim().parse().ok().filter(|n| *n > 0)?;
     let slug = slug.trim();
-    let mut parts = slug.split('/');
-    match (parts.next(), parts.next(), parts.next()) {
-        (Some(o), Some(n), None) if !o.is_empty() && !n.is_empty() => {
-            Some((slug.to_string(), number))
-        }
-        _ => None,
-    }
+    let parsed = crate::repo::parse_slug(slug).ok()?;
+    (parsed.slug() == slug).then(|| (parsed.slug(), number))
 }
 
 /// One rendered bullet of the status trail: the level's dot, the time, the
@@ -225,9 +225,35 @@ pub fn render_status_card(
         .collect();
     let mut body = format!("On it — {session_url}");
     if !artifacts.is_empty() {
+        // Artifact names are agent-chosen free text: escape the Markdown label
+        // and percent-encode the URL path segment, or a bracket/paren in a name
+        // silently breaks the card's link syntax.
+        use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+        const SEG: &AsciiSet = &CONTROLS
+            .add(b' ')
+            .add(b'"')
+            .add(b'#')
+            .add(b'%')
+            .add(b'/')
+            .add(b'?')
+            .add(b'(')
+            .add(b')')
+            .add(b'<')
+            .add(b'>')
+            .add(b'[')
+            .add(b']')
+            .add(b'\\')
+            .add(b'`');
         let links: Vec<String> = artifacts
             .iter()
-            .map(|name| format!("[{name}]({session_url}/artifacts/{name})"))
+            .map(|name| {
+                let label = name
+                    .replace('\\', "\\\\")
+                    .replace('[', "\\[")
+                    .replace(']', "\\]");
+                let path = utf8_percent_encode(name, SEG);
+                format!("[{label}]({session_url}/artifacts/{path})")
+            })
             .collect();
         body.push_str(&format!("\nDocs: {}", links.join(" · ")));
     }
@@ -1377,6 +1403,13 @@ mod tests {
             "acme/widgets#-3",
             "acme/widgets#seven",
             "a/b/c#7",
+            // The slug feeds GitHub API paths: the repo charset gate applies,
+            // and only the bare documented form is a wiring (no URL forms).
+            "../evil#7",
+            "acme/..#7",
+            "acme/wid gets#7",
+            "acme/wid%2Fgets#7",
+            "https://github.com/acme/widgets#7",
         ] {
             assert_eq!(parse_wiring(bad), None, "{bad:?} must not parse");
         }
@@ -1440,6 +1473,17 @@ mod tests {
             "Docs: [design](http://loom/s/abc/artifacts/design) · [plan](http://loom/s/abc/artifacts/plan)"
         );
         assert!(lines[3].contains("drafted the design"));
+    }
+
+    #[test]
+    fn status_card_escapes_hostile_artifact_names() {
+        // Names are agent-chosen free text; brackets must not break the link
+        // Markdown and the URL segment must be percent-encoded.
+        let card = render_status_card("http://loom/s/abc", &["a](x) [b".to_string()], &[]);
+        assert_eq!(
+            card.lines().nth(1).unwrap(),
+            "Docs: [a\\](x) \\[b](http://loom/s/abc/artifacts/a%5D%28x%29%20%5Bb)"
+        );
     }
 
     #[test]

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -462,6 +462,76 @@ impl GithubApi for GithubApp {
         Ok(true)
     }
 
+    async fn react_to_comment(&self, repo: &str, comment_id: i64, content: &str) -> Result<()> {
+        if !self.is_configured().await {
+            tracing::debug!(
+                repo,
+                comment_id,
+                "app not configured; reacting via gh fallback"
+            );
+            return self
+                .fallback
+                .react_to_comment(repo, comment_id, content)
+                .await;
+        }
+        let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
+        let token = self.token_for_repo(&slug.owner, &slug.name).await?;
+        let url = format!(
+            "{}/repos/{}/{}/issues/comments/{comment_id}/reactions",
+            self.api_base, slug.owner, slug.name
+        );
+        let resp = self
+            .http
+            .post(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "content": content }))
+            .send()
+            .await
+            .context("reacting to the comment")?;
+        check_status(resp, "reacting to the comment").await?;
+        tracing::info!(repo, comment = comment_id, content, "reacted to comment");
+        Ok(())
+    }
+
+    async fn issue_state(
+        &self,
+        repo: &str,
+        number: i64,
+    ) -> Result<crate::github_trigger::IssueState> {
+        if !self.is_configured().await {
+            tracing::debug!(
+                repo,
+                number,
+                "app not configured; fetching issue state via gh fallback"
+            );
+            return self.fallback.issue_state(repo, number).await;
+        }
+        let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
+        let token = self.token_for_repo(&slug.owner, &slug.name).await?;
+        let url = format!(
+            "{}/repos/{}/{}/issues/{number}",
+            self.api_base, slug.owner, slug.name
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("fetching the issue")?;
+        let resp = check_status(resp, "fetching the issue").await?;
+        let v: serde_json::Value = resp.json().await.context("parsing issue json")?;
+        Ok(crate::github_trigger::IssueState {
+            state: v["state"].as_str().unwrap_or_default().to_string(),
+            title: v["title"].as_str().unwrap_or_default().to_string(),
+            updated_at: v["updated_at"].as_str().unwrap_or_default().to_string(),
+        })
+    }
+
     async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
         if !self.is_configured().await {
             tracing::debug!(
@@ -667,6 +737,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         expiry_offset_secs: i64,
         comments: Mutex<Vec<Value>>,
         updates: Mutex<Vec<Value>>,
+        reactions: Mutex<Vec<Value>>,
         last_comment_auth: Mutex<Option<String>>,
     }
 
@@ -677,6 +748,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
                 expiry_offset_secs,
                 comments: Mutex::new(Vec::new()),
                 updates: Mutex::new(Vec::new()),
+                reactions: Mutex::new(Vec::new()),
                 last_comment_auth: Mutex::new(None),
             })
         }
@@ -743,6 +815,27 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         StatusCode::OK
     }
 
+    async fn mock_react(
+        State(s): State<Arc<MockState>>,
+        Path((owner, name, comment_id)): Path<(String, String, i64)>,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, Json<Value>) {
+        s.reactions.lock().unwrap().push(json!({
+            "repo": format!("{owner}/{name}"),
+            "comment": comment_id,
+            "content": body["content"],
+        }));
+        (StatusCode::CREATED, Json(json!({ "id": 1 })))
+    }
+
+    async fn mock_issue(Path((owner, name, number)): Path<(String, String, i64)>) -> Json<Value> {
+        Json(json!({
+            "state": "closed",
+            "title": format!("issue {number} of {owner}/{name}"),
+            "updated_at": "2026-07-18T12:00:00Z",
+        }))
+    }
+
     /// Spawn the mock GitHub REST server on a random port; returns its base URL.
     async fn spawn_mock(state: Arc<MockState>) -> String {
         let app = Router::new()
@@ -755,9 +848,14 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
                 "/repos/{owner}/{name}/issues/{issue}/comments",
                 post(mock_comments),
             )
+            .route("/repos/{owner}/{name}/issues/{number}", get(mock_issue))
             .route(
                 "/repos/{owner}/{name}/issues/comments/{comment_id}",
                 patch(mock_update_comment),
+            )
+            .route(
+                "/repos/{owner}/{name}/issues/comments/{comment_id}/reactions",
+                post(mock_react),
             )
             .with_state(state);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -798,6 +896,27 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             Ok(PrHead {
                 head_ref: "fallback-head".to_string(),
                 cross_repo: false,
+            })
+        }
+
+        async fn react_to_comment(
+            &self,
+            _repo: &str,
+            _comment_id: i64,
+            _content: &str,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn issue_state(
+            &self,
+            _repo: &str,
+            _number: i64,
+        ) -> Result<crate::github_trigger::IssueState> {
+            Ok(crate::github_trigger::IssueState {
+                state: "open".to_string(),
+                title: "fallback".to_string(),
+                updated_at: "2026-07-18T00:00:00Z".to_string(),
             })
         }
     }

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -391,7 +391,7 @@ impl GithubApp {
 
 #[async_trait::async_trait]
 impl GithubApi for GithubApp {
-    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
+    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64> {
         if !self.is_configured().await {
             tracing::debug!(
                 repo,
@@ -416,9 +416,50 @@ impl GithubApi for GithubApp {
             .send()
             .await
             .context("posting the issue comment")?;
-        check_status(resp, "posting the issue comment").await?;
-        tracing::info!(repo, issue, "posted issue comment");
-        Ok(())
+        let resp = check_status(resp, "posting the issue comment").await?;
+        let created: serde_json::Value =
+            resp.json().await.context("parsing created-comment json")?;
+        let id = created["id"]
+            .as_i64()
+            .ok_or_else(|| anyhow!("created-comment json carries no id"))?;
+        tracing::info!(repo, issue, comment = id, "posted issue comment");
+        Ok(id)
+    }
+
+    async fn update_issue_comment(&self, repo: &str, comment_id: i64, body: &str) -> Result<bool> {
+        if !self.is_configured().await {
+            tracing::debug!(
+                repo,
+                comment_id,
+                "app not configured; updating comment via gh fallback"
+            );
+            return self
+                .fallback
+                .update_issue_comment(repo, comment_id, body)
+                .await;
+        }
+        let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
+        let token = self.token_for_repo(&slug.owner, &slug.name).await?;
+        let url = format!(
+            "{}/repos/{}/{}/issues/comments/{comment_id}",
+            self.api_base, slug.owner, slug.name
+        );
+        let resp = self
+            .http
+            .patch(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "body": body }))
+            .send()
+            .await
+            .context("updating the issue comment")?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+        check_status(resp, "updating the issue comment").await?;
+        tracing::info!(repo, comment = comment_id, "updated issue comment");
+        Ok(true)
     }
 
     async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
@@ -520,7 +561,7 @@ mod tests {
 
     use axum::extract::{Json, Path, State};
     use axum::http::{HeaderMap, StatusCode};
-    use axum::routing::{get, post};
+    use axum::routing::{get, patch, post};
     use axum::Router;
     use jsonwebtoken::{decode, DecodingKey, Validation};
     use serde_json::{json, Value};
@@ -625,6 +666,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         /// → already expired, to exercise refresh.
         expiry_offset_secs: i64,
         comments: Mutex<Vec<Value>>,
+        updates: Mutex<Vec<Value>>,
         last_comment_auth: Mutex<Option<String>>,
     }
 
@@ -634,10 +676,17 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
                 token_mints: AtomicUsize::new(0),
                 expiry_offset_secs,
                 comments: Mutex::new(Vec::new()),
+                updates: Mutex::new(Vec::new()),
                 last_comment_auth: Mutex::new(None),
             })
         }
     }
+
+    /// The id the mock stamps on every created comment.
+    const MOCK_COMMENT_ID: i64 = 4242;
+    /// A comment id the mock's PATCH route answers with 404, standing in for a
+    /// comment a human deleted.
+    const MOCK_DELETED_COMMENT_ID: i64 = 404_404;
 
     async fn mock_access_tokens(State(s): State<Arc<MockState>>) -> Json<Value> {
         s.token_mints.fetch_add(1, Ordering::SeqCst);
@@ -660,7 +709,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         Path((owner, name, issue)): Path<(String, String, i64)>,
         headers: HeaderMap,
         Json(body): Json<Value>,
-    ) -> StatusCode {
+    ) -> (StatusCode, Json<Value>) {
         *s.last_comment_auth.lock().unwrap() = headers
             .get("authorization")
             .and_then(|v| v.to_str().ok())
@@ -670,7 +719,28 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             "issue": issue,
             "body": body["body"],
         }));
-        StatusCode::CREATED
+        (StatusCode::CREATED, Json(json!({ "id": MOCK_COMMENT_ID })))
+    }
+
+    async fn mock_update_comment(
+        State(s): State<Arc<MockState>>,
+        Path((owner, name, comment_id)): Path<(String, String, i64)>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> StatusCode {
+        if comment_id == MOCK_DELETED_COMMENT_ID {
+            return StatusCode::NOT_FOUND;
+        }
+        *s.last_comment_auth.lock().unwrap() = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        s.updates.lock().unwrap().push(json!({
+            "repo": format!("{owner}/{name}"),
+            "comment": comment_id,
+            "body": body["body"],
+        }));
+        StatusCode::OK
     }
 
     /// Spawn the mock GitHub REST server on a random port; returns its base URL.
@@ -684,6 +754,10 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             .route(
                 "/repos/{owner}/{name}/issues/{issue}/comments",
                 post(mock_comments),
+            )
+            .route(
+                "/repos/{owner}/{name}/issues/comments/{comment_id}",
+                patch(mock_update_comment),
             )
             .with_state(state);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -703,12 +777,21 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
 
     #[async_trait::async_trait]
     impl GithubApi for RecordingFallback {
-        async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
+        async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64> {
             self.comment_calls
                 .lock()
                 .unwrap()
                 .push((repo.to_string(), issue, body.to_string()));
-            Ok(())
+            Ok(7)
+        }
+
+        async fn update_issue_comment(
+            &self,
+            _repo: &str,
+            _comment_id: i64,
+            _body: &str,
+        ) -> Result<bool> {
+            Ok(true)
         }
 
         async fn pr_head(&self, _repo: &str, _number: i64) -> Result<PrHead> {
@@ -786,9 +869,11 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         let base = spawn_mock(mock.clone()).await;
         let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
 
-        app.post_issue_comment("acme/widgets", 7, "On it — http://loom/s/abc")
+        let id = app
+            .post_issue_comment("acme/widgets", 7, "On it — http://loom/s/abc")
             .await
             .unwrap();
+        assert_eq!(id, MOCK_COMMENT_ID, "the created comment's id comes back");
 
         let comments = mock.comments.lock().unwrap().clone();
         assert_eq!(comments.len(), 1);
@@ -800,6 +885,35 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             mock.last_comment_auth.lock().unwrap().clone(),
             Some("Bearer ghs_installation_token".to_string()),
         );
+    }
+
+    #[tokio::test]
+    async fn update_issue_comment_edits_in_place_and_flags_a_deleted_comment() {
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock.clone()).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+
+        let updated = app
+            .update_issue_comment("acme/widgets", MOCK_COMMENT_ID, "On it — now with a trail")
+            .await
+            .unwrap();
+        assert!(updated);
+        let updates = mock.updates.lock().unwrap().clone();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0]["comment"], MOCK_COMMENT_ID);
+        assert_eq!(updates[0]["body"], "On it — now with a trail");
+        assert_eq!(
+            mock.last_comment_auth.lock().unwrap().clone(),
+            Some("Bearer ghs_installation_token".to_string()),
+        );
+
+        // A 404 (the comment was deleted) is a clean `false`, not an error —
+        // the caller reposts instead of retry-spamming.
+        let updated = app
+            .update_issue_comment("acme/widgets", MOCK_DELETED_COMMENT_ID, "orphaned edit")
+            .await
+            .unwrap();
+        assert!(!updated);
     }
 
     // -- installation as the allowlist (§6.3) -------------------------------

--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -298,6 +298,10 @@ impl IssuePayload {
 
 #[derive(Debug, Deserialize)]
 pub struct CommentPayload {
+    /// The comment's REST id — the handle a reaction acknowledges it by.
+    /// Defaults to 0 (treated as "unknown") if GitHub ever omits it.
+    #[serde(default)]
+    pub id: i64,
     #[serde(default)]
     pub body: String,
     pub user: UserPayload,
@@ -437,6 +441,25 @@ pub trait GithubApi: Send + Sync {
 
     /// Resolve pull request `number` of `repo` (`owner/name`) to its head branch.
     async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead>;
+
+    /// React to comment `comment_id` of `repo` with `content` (a GitHub
+    /// reaction name, e.g. `"eyes"`). The quiet acknowledgment: visible on the
+    /// comment itself, no thread noise, no notification.
+    async fn react_to_comment(&self, repo: &str, comment_id: i64, content: &str) -> Result<()>;
+
+    /// Fetch the live state of issue-or-PR `number` of `repo` — the minimal
+    /// snapshot `weaver issue show` renders beside the weaver ledger.
+    async fn issue_state(&self, repo: &str, number: i64) -> Result<IssueState>;
+}
+
+/// A thread's live state as GitHub reports it: `open`/`closed`, its title, and
+/// the ISO time of its last touch. Deliberately minimal — an agent that needs
+/// the discussion itself reads it with `gh`.
+#[derive(Debug, Clone)]
+pub struct IssueState {
+    pub state: String,
+    pub title: String,
+    pub updated_at: String,
 }
 
 /// The production [`GithubApi`]: shells out to the `gh` CLI with the ambient
@@ -473,6 +496,27 @@ impl GithubApi for GhCli {
             Err(e) if e.to_string().contains("HTTP 404") => Ok(false),
             Err(e) => Err(e),
         }
+    }
+
+    async fn react_to_comment(&self, repo: &str, comment_id: i64, content: &str) -> Result<()> {
+        let path = format!("repos/{repo}/issues/comments/{comment_id}/reactions");
+        let field = format!("content={content}");
+        gh_capture(&["api", "-X", "POST", &path, "-f", &field]).await?;
+        tracing::info!(repo, comment = comment_id, content, "reacted to comment");
+        Ok(())
+    }
+
+    async fn issue_state(&self, repo: &str, number: i64) -> Result<IssueState> {
+        // The `issues` route serves PR threads too (state/title/updated_at are
+        // thread-level), so one call covers both kinds of tracking link.
+        let path = format!("repos/{repo}/issues/{number}");
+        let out = gh_capture(&["api", &path]).await?;
+        let v: serde_json::Value = serde_json::from_str(&out).context("parsing issue json")?;
+        Ok(IssueState {
+            state: v["state"].as_str().unwrap_or_default().to_string(),
+            title: v["title"].as_str().unwrap_or_default().to_string(),
+            updated_at: v["updated_at"].as_str().unwrap_or_default().to_string(),
+        })
     }
 
     async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
@@ -781,6 +825,23 @@ mod tests {
             Ok(PrHead {
                 head_ref: "feature".to_string(),
                 cross_repo: false,
+            })
+        }
+
+        async fn react_to_comment(
+            &self,
+            _repo: &str,
+            _comment_id: i64,
+            _content: &str,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn issue_state(&self, _repo: &str, _number: i64) -> Result<IssueState> {
+            Ok(IssueState {
+                state: "open".to_string(),
+                title: "t".to_string(),
+                updated_at: "2026-07-18T00:00:00Z".to_string(),
             })
         }
     }

--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -416,15 +416,24 @@ pub struct PrHead {
     pub cross_repo: bool,
 }
 
-/// The GitHub operations the trigger performs — posting a reply and resolving a
-/// PR's head branch — behind a trait so the `gh`-backed implementation
-/// ([`GhCli`]) and a test fake are interchangeable. The production impl is the
-/// GitHub **App** (short-lived installation tokens); the [`GhCli`] fallback uses
-/// the ambient `GH_TOKEN`.
+/// The GitHub operations loom performs against a thread — posting and editing
+/// comments, resolving a PR's head branch — behind a trait so the `gh`-backed
+/// implementation ([`GhCli`]) and a test fake are interchangeable. The
+/// production impl is the GitHub **App** (short-lived installation tokens); the
+/// [`GhCli`] fallback uses the ambient `GH_TOKEN`.
 #[async_trait::async_trait]
 pub trait GithubApi: Send + Sync {
-    /// Post a comment on `issue` of `repo` (`owner/name`).
-    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()>;
+    /// Post a comment on `issue` of `repo` (`owner/name`), returning the new
+    /// comment's id — the handle
+    /// [`update_issue_comment`](Self::update_issue_comment) edits it by.
+    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64>;
+
+    /// Replace the body of comment `comment_id` of `repo` (an id
+    /// [`post_issue_comment`](Self::post_issue_comment) returned). `Ok(false)`
+    /// means the comment no longer exists (someone deleted it) — the caller may
+    /// post a fresh one; transient failures stay `Err` so they are never
+    /// answered by a duplicate comment.
+    async fn update_issue_comment(&self, repo: &str, comment_id: i64, body: &str) -> Result<bool>;
 
     /// Resolve pull request `number` of `repo` (`owner/name`) to its head branch.
     async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead>;
@@ -436,11 +445,34 @@ pub struct GhCli;
 
 #[async_trait::async_trait]
 impl GithubApi for GhCli {
-    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
-        let number = issue.to_string();
-        gh_capture(&["issue", "comment", &number, "--repo", repo, "--body", body]).await?;
-        tracing::info!(repo, issue, "posted issue comment");
-        Ok(())
+    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64> {
+        // `gh api` rather than the `gh issue comment` porcelain: the raw REST
+        // response carries the comment id (porcelain prints only an HTML URL),
+        // and the same route serves issues and pull requests alike.
+        let path = format!("repos/{repo}/issues/{issue}/comments");
+        let field = format!("body={body}");
+        let out = gh_capture(&["api", &path, "-f", &field]).await?;
+        let v: serde_json::Value =
+            serde_json::from_str(&out).context("parsing created-comment json")?;
+        let id = v["id"]
+            .as_i64()
+            .context("created-comment json carries no id")?;
+        tracing::info!(repo, issue, comment = id, "posted issue comment");
+        Ok(id)
+    }
+
+    async fn update_issue_comment(&self, repo: &str, comment_id: i64, body: &str) -> Result<bool> {
+        let path = format!("repos/{repo}/issues/comments/{comment_id}");
+        let field = format!("body={body}");
+        match gh_capture(&["api", "-X", "PATCH", &path, "-f", &field]).await {
+            Ok(_) => {
+                tracing::info!(repo, comment = comment_id, "updated issue comment");
+                Ok(true)
+            }
+            // `gh api` reports "gh: Not Found (HTTP 404)" on stderr.
+            Err(e) if e.to_string().contains("HTTP 404") => Ok(false),
+            Err(e) => Err(e),
+        }
     }
 
     async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
@@ -730,12 +762,19 @@ mod tests {
 
     #[async_trait::async_trait]
     impl GithubApi for FakeGh {
-        async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<()> {
-            self.comments
-                .lock()
-                .unwrap()
-                .push((repo.to_string(), issue, body.to_string()));
-            Ok(())
+        async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64> {
+            let mut comments = self.comments.lock().unwrap();
+            comments.push((repo.to_string(), issue, body.to_string()));
+            Ok(comments.len() as i64)
+        }
+
+        async fn update_issue_comment(
+            &self,
+            _repo: &str,
+            _comment_id: i64,
+            _body: &str,
+        ) -> Result<bool> {
+            Ok(true)
         }
 
         async fn pr_head(&self, _repo: &str, _number: i64) -> Result<PrHead> {

--- a/crates/loom/src/web/artifacts.rs
+++ b/crates/loom/src/web/artifacts.rs
@@ -205,6 +205,12 @@ pub(super) async fn write_artifact(
     )
     .await
     .ok();
+    // A wired GitHub thread's status card links the session's documents —
+    // refresh it so a new doc appears there without waiting for a status write.
+    tokio::spawn(crate::github::sync_status_comment(
+        st.clone(),
+        branch.id.clone(),
+    ));
     Ok(Json(
         artifact_view(&st.db, &branch.repo_root, &a, None).await?,
     ))
@@ -353,6 +359,11 @@ pub(super) async fn write_branch_artifact(
     )
     .await
     .ok();
+    // Same card refresh as the session-scoped write route above.
+    tokio::spawn(crate::github::sync_status_comment(
+        st.clone(),
+        branch.id.clone(),
+    ));
     Ok(Json(
         artifact_view(&st.db, &branch.repo_root, &a, None).await?,
     ))

--- a/crates/loom/src/web/branches.rs
+++ b/crates/loom/src/web/branches.rs
@@ -112,15 +112,32 @@ pub(super) async fn set_branch_status(
         level.clone()
     };
     tracing::info!(branch = %branch.id, level = %level, "branch status set");
+    // The message rides the event as its note, so the event log carries the
+    // full trail of status reports — the progress log the activity feed and a
+    // wired GitHub thread render — not just the level transitions.
+    // Propagated, not swallowed: the event log is the source of truth for the
+    // status trail (the activity feed and a wired GitHub card render from it),
+    // so a dropped insert must fail the write loudly enough to be retried.
     events::record(
         &st.db,
         &st.bus,
         &branch.id,
         "tag",
-        json!({ "key": tags::ATTENTION_KEY, "value": value, "note": "", "by": "agent" }),
+        json!({
+            "key": tags::ATTENTION_KEY,
+            "value": value,
+            "note": message.unwrap_or_default(),
+            "by": "agent",
+        }),
     )
-    .await
-    .ok();
+    .await?;
+    // Mirror the trail onto the branch's wired GitHub thread (a no-op when the
+    // `github` tag is absent) — detached, so a GitHub hiccup never slows or
+    // fails the status write.
+    tokio::spawn(crate::github::sync_status_comment(
+        st.clone(),
+        branch.id.clone(),
+    ));
     let branch = branch_mod::get(&st.db, &branch.id)
         .await?
         .ok_or_else(|| AppError::not_found("branch"))?;
@@ -157,6 +174,19 @@ pub(super) async fn set_branch_tag(
 ) -> ApiResult<Json<BranchView>> {
     let branch = require_branch(&st.db, &key).await?;
     let value = req.value.trim();
+    if crate::github::is_reserved_tag(&tag_key) {
+        return Err(AppError::bad_request(format!(
+            "'{tag_key}' is loom-internal bookkeeping — it can be cleared, not set by hand"
+        )));
+    }
+    // The `github` wiring is consumed by the status-card mirror; a typo'd
+    // value would silently mirror nothing, so it fails here where the setter
+    // can see it.
+    if tag_key == tags::GITHUB_KEY && crate::github::parse_wiring(value).is_none() {
+        return Err(AppError::bad_request(format!(
+            "invalid value '{value}' for '{tag_key}' — expected owner/name#number"
+        )));
+    }
     if !tags::is_valid_value(&tag_key, value) {
         return Err(AppError::bad_request(if tags::is_loud(&tag_key) {
             format!(

--- a/crates/loom/src/web/issues.rs
+++ b/crates/loom/src/web/issues.rs
@@ -121,7 +121,29 @@ pub(super) async fn get_issue(
     let issue = weaver_core::issue::get(&st.db, id)
         .await?
         .ok_or_else(|| AppError::not_found("issue"))?;
-    Ok(Json(issue_view(&st.db, issue).await?))
+    let mut view = issue_view(&st.db, issue).await?;
+    // Best-effort live snapshot of the linked GitHub thread, so `weaver issue
+    // show` surfaces "closed / re-titled while you worked". Single-issue reads
+    // only (lists would fan out), bounded so a slow GitHub can't hang the CLI,
+    // and a failure just leaves the field absent — the ledger still stands.
+    if let (Some(repo), Some(number)) = (view.github_repo.clone(), view.github_issue) {
+        view.github_state = tokio::time::timeout(
+            std::time::Duration::from_secs(4),
+            st.trigger.gh().issue_state(&repo, number),
+        )
+        .await
+        .ok()
+        .and_then(|r| {
+            r.map_err(|e| tracing::debug!(repo, number, error = %e, "live issue state unavailable"))
+                .ok()
+        })
+        .map(|s| weaver_api::GithubThreadState {
+            state: s.state,
+            title: s.title,
+            updated_at: s.updated_at,
+        });
+    }
+    Ok(Json(view))
 }
 
 pub(super) async fn patch_issue(

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -358,18 +358,37 @@ async fn handle_trigger(
                     )
                     .await
                     .ok();
-                    let base = public_base(&st, &headers).await;
-                    let reply = format!(
-                        "Passed your note to the session already on this thread — {}",
-                        super::session_url(&base, &sess.id)
-                    );
-                    if let Err(e) = st
-                        .trigger
-                        .gh()
-                        .post_issue_comment(&slug.slug(), number, &reply)
-                        .await
-                    {
-                        tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: posting forward-ack failed");
+                    // Acknowledge quietly: a 👀 reaction on the triggering
+                    // comment says "seen, forwarded" right where it was typed,
+                    // without an ack comment per mention piling up on the
+                    // thread. Fall back to the old ack comment if the reaction
+                    // can't land (no comment id, or an App installation that
+                    // predates the reactions permission grant) — feedback that
+                    // the note reached the session matters more than quiet.
+                    let reacted = event.comment.id > 0
+                        && st
+                            .trigger
+                            .gh()
+                            .react_to_comment(&slug.slug(), event.comment.id, "eyes")
+                            .await
+                            .map_err(|e| {
+                                tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: reacting to forwarded comment failed");
+                            })
+                            .is_ok();
+                    if !reacted {
+                        let base = public_base(&st, &headers).await;
+                        let reply = format!(
+                            "Passed your note to the session already on this thread — {}",
+                            super::session_url(&base, &sess.id)
+                        );
+                        if let Err(e) = st
+                            .trigger
+                            .gh()
+                            .post_issue_comment(&slug.slug(), number, &reply)
+                            .await
+                        {
+                            tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: posting forward-ack failed");
+                        }
                     }
                     tracing::info!(session = %sess.id, repo = %slug.slug(), number, "github webhook: forwarded comment to active session");
                     return Ok(None);

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -423,6 +423,10 @@ async fn handle_trigger(
         repo: Some(slug.slug()),
         title: Some(event.issue.title.clone()),
         goal: Some(trigger_goal(&slug.slug(), is_pr, number, &event, &author)),
+        // Record the thread on the tracking issue too (issues only — a PR
+        // number in the issue link would read as the wrong thing), so the
+        // weaver ledger and the `github` wiring tag agree from birth.
+        github_issue: (!is_pr).then_some(number),
         ..Default::default()
     };
     if let Some(branch) = target_branch {
@@ -440,16 +444,87 @@ async fn handle_trigger(
         }
     };
 
-    // 11. Reply on the thread with the live session URL.
+    // 11. Wire the branch to the thread: the `github` tag is what
+    //     `github::sync_status_comment` reads to mirror every `weaver status`
+    //     write back here. Stamped before the reply so a failed reply still
+    //     wires — the first status write then posts the card instead. Left
+    //     untouched when already wired to this thread (a relaunch): the tag's
+    //     `set_at` scopes the mirrored trail, and re-stamping would truncate it.
+    let wired_to = format!("{}#{number}", slug.slug());
+    let already_wired = matches!(
+        weaver_core::tags::get(&st.db, &view.branch.id, crate::github::WIRED_TAG).await,
+        Ok(Some(ref t)) if t.value == wired_to
+    );
+    if !already_wired {
+        weaver_core::tags::set(
+            &st.db,
+            &view.branch.id,
+            crate::github::WIRED_TAG,
+            &wired_to,
+            "wired by the @loom trigger",
+            "loom",
+        )
+        .await
+        .ok();
+    }
+
+    // 12. Reply on the thread with the live session URL. The reply is the
+    //     session's **status card**: its comment id is recorded so later status
+    //     writes edit it in place into the live trail.
     let base = public_base(&st, &headers).await;
     let reply = format!("On it — {}", super::session_url(&base, &view.id));
-    if let Err(e) = st
+    match st
         .trigger
         .gh()
         .post_issue_comment(&slug.slug(), number, &reply)
         .await
     {
-        tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: posting reply failed");
+        Ok(comment_id) => {
+            // A relaunch on an already-wired thread leaves the previous card
+            // frozen mid-arc — point its readers at the live one. The full
+            // trail re-renders onto the new card (the wiring's `set_at`
+            // predates it), so nothing is lost.
+            if let Ok(Some(prev)) =
+                weaver_core::tags::get(&st.db, &view.branch.id, crate::github::STATUS_COMMENT_TAG)
+                    .await
+            {
+                if prev.note == wired_to {
+                    if let Ok(prev_id) = prev.value.parse::<i64>() {
+                        if prev_id != comment_id {
+                            st.trigger
+                                .gh()
+                                .update_issue_comment(
+                                    &slug.slug(),
+                                    prev_id,
+                                    "~~On it~~ — this session was relaunched; the live status card is below.",
+                                )
+                                .await
+                                .ok();
+                        }
+                    }
+                }
+            }
+            crate::github::record_status_comment(
+                &st.db,
+                &view.branch.id,
+                &slug.slug(),
+                number,
+                comment_id,
+            )
+            .await;
+            // On a relaunch, render the card now (it re-reads the trail), so
+            // the new card doesn't sit bare until the next status write. A
+            // fresh launch has no trail yet — the reply already is the card.
+            if already_wired {
+                tokio::spawn(crate::github::sync_status_comment(
+                    st.clone(),
+                    view.branch.id.clone(),
+                ));
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, repo = %slug.slug(), "github webhook: posting reply failed");
+        }
     }
     tracing::info!(
         session = %view.id,
@@ -508,17 +583,17 @@ fn trigger_goal(
         .map(str::trim)
         .filter(|b| !b.is_empty())
         .unwrap_or("(no description)");
-    let respond = if is_pr {
-        format!(
-            "- This worktree is checked out on the PR's own branch — commit and `git push` here to update pull request #{number} directly.\n\
-             - Reply on the thread when you have something to report: `gh pr comment {number} --repo {repo} --body \"…\"`."
-        )
+    let work = if is_pr {
+        format!("- This worktree is checked out on the PR's own branch — commit and `git push` here to update pull request #{number} directly.")
     } else {
-        format!(
-            "- Do the work on this branch and open a pull request against the default branch when it's ready.\n\
-             - Reply on the thread when you have something to report: `gh issue comment {number} --repo {repo} --body \"…\"`."
-        )
+        "- Do the work on this branch and open a pull request against the default branch when it's ready.".to_string()
     };
+    let comment_cmd = if is_pr { "pr" } else { "issue" };
+    let respond = format!(
+        "{work}\n\
+         - Your `weaver status` messages are mirrored onto this thread (loom edits its \"On it\" comment into a live status trail), so progress reporting is automatic — write status messages for that audience.\n\
+         - Comment on the thread only when you need a person there — a question, a design to review, the finished result: `gh {comment_cmd} comment {number} --repo {repo} --body \"…\"`."
+    );
     format!(
         "You've been tagged into GitHub {kind} #{number} of {repo} ({url}) via a comment.\n\n\
          ## {title_kind}\n{}\n\n{body}\n\n\

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -670,6 +670,15 @@ pub(crate) async fn create_session_core(
         github_issue = Some(number);
         github_repo = github::repo_slug(&repo_root).await.ok();
         tracing::debug!(issue = number, github_repo = ?github_repo, "seeded session fields from github issue");
+    } else if let Some(number) = req.github_issue {
+        // The caller already holds the thread (the `@loom` trigger): record the
+        // GitHub link on the tracking issue without the fetch-and-seed above.
+        github_issue = Some(number);
+        github_repo = req
+            .repo
+            .as_deref()
+            .and_then(|r| crate::repo::parse_slug(r).ok())
+            .map(|s| s.slug());
     }
 
     // Claiming an existing weaver issue seeds the same three fields from it.
@@ -889,13 +898,22 @@ pub(crate) async fn create_session_core(
     } else {
         let mut prompt_parts: Vec<String> = Vec::new();
         if !goal.is_empty() {
-            prompt_parts.push(goal.clone());
+            // A hookless runtime (Codex, custom) never receives the WEAVER.md
+            // primer, so the launch prompt is its entire orientation — those
+            // still get the goal pasted. Hook-capable agents get a pointer
+            // instead: the goal lives once, as the `goal` artifact.
+            let hookless = !agent::metadata_for(&st.db, &runtime)
+                .await
+                .ok()
+                .flatten()
+                .is_some_and(|m| m.supports_hooks);
+            if hookless {
+                prompt_parts.push(goal.clone());
+            }
+            prompt_parts.push(entrance_note(&title, tracking_issue));
         }
         if let Some(note) = scratch_note(&scratch_names) {
             prompt_parts.push(note);
-        }
-        if let Some(id) = tracking_issue {
-            prompt_parts.push(tracking_note(id));
         }
         let launch_prompt = prompt_parts.join("\n\n");
         let goal_file = if launch_prompt.is_empty() {
@@ -1208,17 +1226,29 @@ pub(super) async fn reset_chat(State(st): State<AppState>) -> ApiResult<Json<Ses
     Ok(Json(create_concierge(st).await?))
 }
 
-/// A line appended to a session's launch prompt telling the agent which weaver
-/// issue tracks its task, so it keeps the issue up to date and closes it when
-/// done. Mirrors [`scratch_note`]: it rides on the prompt only, never the
-/// stored goal.
-fn tracking_note(issue_id: i64) -> String {
-    format!(
-        "This session is tracked as weaver issue #{issue_id}. Keep your status \
-         current with `weaver status <level> \"<message>\"` as you work, and \
-         run `weaver issue close {issue_id}` once the task is complete (e.g. the \
-         PR is open) so whoever launched you knows you are done."
-    )
+/// The session's launch prompt: a pointer to the goal rather than a copy of
+/// it. The goal lives once, as the `goal` artifact (`weaver summary` opens
+/// with it) — pasting it here made a second copy that drifted the moment the
+/// agent revved the artifact. The pointer routes through the `weaver` CLI so
+/// it orients hookless agents (Codex, custom) too, which never receive the
+/// WEAVER.md primer. Mirrors [`scratch_note`]: it rides on the prompt only
+/// (goal.txt), never the stored goal.
+fn entrance_note(title: &str, tracking_issue: Option<i64>) -> String {
+    let mut note = format!(
+        "Your task: {title}.\n\n\
+         Run `weaver summary` first — it prints the full goal, your current \
+         status, and the open tasks. `weaver readme` prints the complete \
+         workflow guide when it is not already in your context."
+    );
+    if let Some(id) = tracking_issue {
+        note.push_str(&format!(
+            " This session is tracked as weaver issue #{id}: keep `weaver \
+             status <level> \"<message>\"` honest as you work, and run `weaver \
+             issue close {id}` once the task is complete (e.g. the PR is open) \
+             so whoever launched you knows you are done."
+        ));
+    }
+    note
 }
 
 /// Open (or adopt) the tracking issue for a freshly-launched session: the one
@@ -1335,6 +1365,18 @@ pub(super) async fn set_session_tag(
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
     let value = req.value.trim();
+    if crate::github::is_reserved_tag(&tag_key) {
+        return Err(AppError::bad_request(format!(
+            "'{tag_key}' is loom-internal bookkeeping — it can be cleared, not set by hand"
+        )));
+    }
+    // Same wiring-format gate as the branch-scoped route: the status-card
+    // mirror consumes this value, so a typo must fail loudly at set time.
+    if tag_key == tags::GITHUB_KEY && crate::github::parse_wiring(value).is_none() {
+        return Err(AppError::bad_request(format!(
+            "invalid value '{value}' for '{tag_key}' — expected owner/name#number"
+        )));
+    }
     if !tags::is_valid_value(&tag_key, value) {
         return Err(AppError::bad_request(if tags::is_loud(&tag_key) {
             format!(
@@ -2438,11 +2480,18 @@ mod tests {
     }
 
     #[test]
-    fn tracking_note_names_the_issue_and_how_to_close_it() {
-        let note = tracking_note(42);
-        assert!(note.contains("weaver issue #42"));
+    fn entrance_note_points_at_the_goal_instead_of_pasting_it() {
+        let note = entrance_note("Wire the flux capacitor", Some(42));
+        assert!(note.contains("Wire the flux capacitor"));
+        // The orientation is a pointer, not a copy: the goal is fetched.
+        assert!(note.contains("weaver summary"));
         // It tells the agent exactly how to signal "done".
+        assert!(note.contains("weaver issue #42"));
         assert!(note.contains("weaver issue close 42"));
         assert!(note.contains("weaver status"));
+        // Untracked sessions get the orientation with no issue contract.
+        let untracked = entrance_note("Poke around", None);
+        assert!(untracked.contains("weaver summary"));
+        assert!(!untracked.contains("issue"));
     }
 }

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -40,6 +40,11 @@ struct FakeGithub {
     /// What `pr_head` returns; a PR-flow test sets this to a branch it created in
     /// the fixture remote. `None` → a plain same-repo head named `feature`.
     pr_head: Mutex<Option<loom::github_trigger::PrHead>>,
+    /// Every `react_to_comment` call as `(repo, comment_id, content)`.
+    reactions: Mutex<Vec<(String, i64, String)>>,
+    /// When set, `react_to_comment` fails — an installation without the
+    /// reactions permission — so a test can watch the ack-comment fallback.
+    fail_reactions: Mutex<bool>,
 }
 
 #[async_trait::async_trait]
@@ -77,6 +82,34 @@ impl loom::github_trigger::GithubApi for FakeGithub {
                 head_ref: "feature".to_string(),
                 cross_repo: false,
             }))
+    }
+
+    async fn react_to_comment(
+        &self,
+        repo: &str,
+        comment_id: i64,
+        content: &str,
+    ) -> anyhow::Result<()> {
+        if *self.fail_reactions.lock().unwrap() {
+            anyhow::bail!("Resource not accessible by integration (HTTP 403)");
+        }
+        self.reactions
+            .lock()
+            .unwrap()
+            .push((repo.to_string(), comment_id, content.to_string()));
+        Ok(())
+    }
+
+    async fn issue_state(
+        &self,
+        _repo: &str,
+        _number: i64,
+    ) -> anyhow::Result<loom::github_trigger::IssueState> {
+        Ok(loom::github_trigger::IssueState {
+            state: "open".to_string(),
+            title: "fixture issue".to_string(),
+            updated_at: "2026-07-18T00:00:00Z".to_string(),
+        })
     }
 }
 
@@ -142,10 +175,16 @@ async fn prepare_repo(ts: &TestServer) -> tempfile::TempDir {
 /// The raw JSON body of an `issue_comment.created` carrying `comment` from
 /// `login` on issue `number` of `acme/widgets`.
 fn trigger_body(login: &str, number: i64, comment: &str) -> Vec<u8> {
+    trigger_body_with_id(login, number, comment, 1001)
+}
+
+/// Like [`trigger_body`], with an explicit comment id — for tests that follow a
+/// reaction back to the comment it acknowledges.
+fn trigger_body_with_id(login: &str, number: i64, comment: &str, comment_id: i64) -> Vec<u8> {
     json!({
         "action": "created",
         "issue": {"number": number, "title": "Make it faster", "body": "perf please"},
-        "comment": {"body": comment, "user": {"login": login}},
+        "comment": {"id": comment_id, "body": comment, "user": {"login": login}},
         "repository": {"full_name": "acme/widgets"}
     })
     .to_string()
@@ -225,6 +264,18 @@ async fn wait_for_comments(fake: &FakeGithub, n: usize) {
     }
     let have = fake.comments.lock().unwrap().len();
     panic!("expected >= {n} replies, saw {have}");
+}
+
+/// Poll until the fake gateway has recorded at least `n` reactions.
+async fn wait_for_reactions(fake: &FakeGithub, n: usize) {
+    for _ in 0..200 {
+        if fake.reactions.lock().unwrap().len() >= n {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    let have = fake.reactions.lock().unwrap().len();
+    panic!("expected >= {n} reactions, saw {have}");
 }
 
 /// A missing signature, and one computed with the wrong secret, are both
@@ -551,7 +602,8 @@ async fn replayed_delivery_is_a_noop() {
 }
 
 /// A second @loom comment on a thread that already has a live session forwards the
-/// comment into that session (an ack, no duplicate) instead of spawning a new one.
+/// comment into that session and acknowledges it with a 👀 reaction on that
+/// comment — no ack comment, no duplicate session. The thread stays quiet.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn repeat_trigger_forwards_to_active_session() {
@@ -566,13 +618,69 @@ async fn repeat_trigger_forwards_to_active_session() {
         200
     );
     // Wait for the first session to exist *and* its reply to land, so the second
-    // delivery deterministically finds an active session to forward into (and its
-    // ack is the second comment, not a race with the first).
+    // delivery deterministically finds an active session to forward into.
     wait_for_sessions(&ts, 1).await;
     wait_for_comments(&fake, 1).await;
 
     // A second @loom on the same issue (new delivery) is forwarded, not forked.
-    let body2 = trigger_body("rjpower", 42, "@loom also handle the edge case");
+    let body2 = trigger_body_with_id("rjpower", 42, "@loom also handle the edge case", 2002);
+    assert_eq!(
+        post(&ts, "d-second", Some(sign(SECRET, &body2)), &body2)
+            .await
+            .status(),
+        200
+    );
+    wait_for_reactions(&fake, 1).await;
+    assert_eq!(
+        session_count(&ts).await,
+        1,
+        "the repeat trigger spawns no duplicate session"
+    );
+
+    // The forward is acknowledged where it was typed, not with a new comment.
+    let reactions = fake.reactions.lock().unwrap().clone();
+    assert_eq!(
+        reactions,
+        vec![("acme/widgets".to_string(), 2002, "eyes".to_string())],
+        "the triggering comment gets the 👀"
+    );
+    assert_eq!(
+        fake.comments.lock().unwrap().len(),
+        1,
+        "the forward posts no ack comment"
+    );
+
+    let id = ts.client.get("/api/sessions").await.unwrap()[0]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+/// When the reaction can't land (an App installation that predates the
+/// reactions permission), the forward falls back to the old ack comment —
+/// feedback that the note reached the session beats staying quiet.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn forward_ack_falls_back_to_a_comment_when_the_reaction_fails() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+
+    let body = trigger_body("rjpower", 42, "@loom start");
+    assert_eq!(
+        post(&ts, "d-first", Some(sign(SECRET, &body)), &body)
+            .await
+            .status(),
+        200
+    );
+    wait_for_sessions(&ts, 1).await;
+    wait_for_comments(&fake, 1).await;
+
+    *fake.fail_reactions.lock().unwrap() = true;
+    let body2 = trigger_body("rjpower", 42, "@loom one more thing");
     assert_eq!(
         post(&ts, "d-second", Some(sign(SECRET, &body2)), &body2)
             .await
@@ -580,17 +688,11 @@ async fn repeat_trigger_forwards_to_active_session() {
         200
     );
     wait_for_comments(&fake, 2).await;
-    assert_eq!(
-        session_count(&ts).await,
-        1,
-        "the repeat trigger spawns no duplicate session"
-    );
 
     let comments = fake.comments.lock().unwrap().clone();
-    assert_eq!(comments.len(), 2, "one ack per trigger");
     assert!(
         comments[1].2.contains("Passed your note"),
-        "the repeat trigger is acked as a forward: {}",
+        "the forward is acked as a comment when the reaction fails: {}",
         comments[1].2
     );
 

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -28,11 +28,15 @@ fn sign(secret: &str, body: &[u8]) -> String {
     format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
 }
 
-/// A recording GitHub gateway standing in for `gh`: it captures every reply
-/// posted and answers `pr_head` with a value a PR-flow test can pin.
+/// A recording GitHub gateway standing in for `gh`: it captures every comment
+/// posted or edited and answers `pr_head` with a value a PR-flow test can pin.
+/// Posted comments get ids 1, 2, … in order, so a test can follow an edit back
+/// to the post it targets.
 #[derive(Default)]
 struct FakeGithub {
     comments: Mutex<Vec<(String, i64, String)>>,
+    /// Every `update_issue_comment` call as `(repo, comment_id, body)`.
+    updates: Mutex<Vec<(String, i64, String)>>,
     /// What `pr_head` returns; a PR-flow test sets this to a branch it created in
     /// the fixture remote. `None` → a plain same-repo head named `feature`.
     pr_head: Mutex<Option<loom::github_trigger::PrHead>>,
@@ -40,12 +44,23 @@ struct FakeGithub {
 
 #[async_trait::async_trait]
 impl loom::github_trigger::GithubApi for FakeGithub {
-    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> anyhow::Result<()> {
-        self.comments
+    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> anyhow::Result<i64> {
+        let mut comments = self.comments.lock().unwrap();
+        comments.push((repo.to_string(), issue, body.to_string()));
+        Ok(comments.len() as i64)
+    }
+
+    async fn update_issue_comment(
+        &self,
+        repo: &str,
+        comment_id: i64,
+        body: &str,
+    ) -> anyhow::Result<bool> {
+        self.updates
             .lock()
             .unwrap()
-            .push((repo.to_string(), issue, body.to_string()));
-        Ok(())
+            .push((repo.to_string(), comment_id, body.to_string()));
+        Ok(true)
     }
 
     async fn pr_head(
@@ -386,6 +401,110 @@ async fn happy_path_creates_session_and_replies() {
 
     ts.client
         .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+/// An issue trigger wires the branch to the thread (the `github` tag) and
+/// records the "On it" reply's comment id; a `weaver status` write then edits
+/// that same comment into the status card, and a later write re-renders it
+/// with the whole trail.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn status_writes_mirror_onto_the_on_it_comment() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+    // The card links sessions through the configured public base; without one
+    // the mirror deliberately stays quiet.
+    ts.client
+        .patch(
+            "/api/settings",
+            json!({ "auth.base_url": "http://loom.test" }),
+        )
+        .await
+        .unwrap();
+
+    let body = trigger_body("rjpower", 42, "@loom work on this please");
+    let resp = post(&ts, "d-mirror", Some(sign(SECRET, &body)), &body).await;
+    assert_eq!(resp.status(), 200);
+    wait_for_sessions(&ts, 1).await;
+    wait_for_comments(&fake, 1).await;
+
+    let sessions = ts.client.get("/api/sessions").await.unwrap();
+    let session = &sessions.as_array().unwrap()[0];
+    let session_id = session["id"].as_str().unwrap().to_string();
+    let branch_id = session["branch"]["id"].as_str().unwrap().to_string();
+    let tags = session["branch"]["tags"].as_array().unwrap();
+    let tag = |key: &str| {
+        tags.iter()
+            .find(|t| t["key"] == key)
+            .unwrap_or_else(|| panic!("missing tag {key} in {tags:?}"))
+    };
+    assert_eq!(
+        tag("github")["value"].as_str(),
+        Some("acme/widgets#42"),
+        "the trigger wires the branch to the thread"
+    );
+    assert_eq!(
+        tag("github.status_comment")["value"].as_str(),
+        Some("1"),
+        "the On-it reply's comment id is recorded"
+    );
+
+    // First status report → the reply is edited in place into the card.
+    ts.client
+        .post(
+            &format!("/api/branches/{branch_id}/status"),
+            json!({ "level": "ok", "message": "wired the gateway" }),
+        )
+        .await
+        .unwrap();
+    for _ in 0..200 {
+        if !fake.updates.lock().unwrap().is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    let updates = fake.updates.lock().unwrap().clone();
+    assert_eq!(updates.len(), 1, "one edit per status write: {updates:?}");
+    let (repo, comment_id, card) = &updates[0];
+    assert_eq!(repo, "acme/widgets");
+    assert_eq!(*comment_id, 1, "the edit targets the On-it reply");
+    assert!(
+        card.starts_with(&format!("On it — http://loom.test/s/{session_id}")),
+        "the card keeps the session link: {card}"
+    );
+    assert!(card.contains("wired the gateway"), "trail bullet: {card}");
+
+    // A second report re-renders the card with the whole trail.
+    ts.client
+        .post(
+            &format!("/api/branches/{branch_id}/status"),
+            json!({ "level": "attention", "message": "ready for review" }),
+        )
+        .await
+        .unwrap();
+    for _ in 0..200 {
+        if fake.updates.lock().unwrap().len() >= 2 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    let updates = fake.updates.lock().unwrap().clone();
+    assert_eq!(updates.len(), 2, "a second edit landed: {updates:?}");
+    let card = &updates[1].2;
+    assert!(
+        card.contains("wired the gateway") && card.contains("**attention** — ready for review"),
+        "the whole trail renders: {card}"
+    );
+    assert_eq!(
+        fake.comments.lock().unwrap().len(),
+        1,
+        "status mirroring edits the one comment, never posts new ones"
+    );
+
+    ts.client
+        .delete(&format!("/api/sessions/{session_id}"))
         .await
         .unwrap();
 }

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -168,6 +168,24 @@ pub struct IssueView {
     /// Empty when the issue carries none. Unlike branch tags these never carry
     /// the loud `attention`/`triage` ladder.
     pub tags: Vec<TagView>,
+    /// Live state of the linked GitHub thread, fetched at read time by the
+    /// single-issue endpoint when the issue carries a `github_repo` +
+    /// `github_issue` link. Absent on list endpoints (no fan-out of GitHub
+    /// calls) and when the fetch fails — the ledger fields above still stand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_state: Option<GithubThreadState>,
+}
+
+/// The minimal live snapshot of a GitHub thread `weaver issue show` renders
+/// beside the weaver ledger: enough to notice "this was closed / re-titled
+/// while I worked". An agent that needs the discussion reads it with `gh`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GithubThreadState {
+    /// `open` | `closed`.
+    pub state: String,
+    pub title: String,
+    /// ISO time of the thread's last touch, as GitHub reports it.
+    pub updated_at: String,
 }
 
 impl IssueView {
@@ -187,6 +205,7 @@ impl IssueView {
             updated_at: i.updated_at,
             closed_at: i.closed_at,
             tags: tags.iter().map(TagView::from).collect(),
+            github_state: None,
         }
     }
 }

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -508,6 +508,12 @@ pub struct CreateReq {
     pub name: Option<String>,
     #[serde(default)]
     pub issue: Option<i64>,
+    /// A GitHub issue number the caller already holds the content of (the
+    /// `@loom` trigger, whose webhook payload carries the thread): recorded on
+    /// the tracking issue as its GitHub link, with none of `issue`'s
+    /// fetch-and-seed. Ignored when `issue` is set.
+    #[serde(default)]
+    pub github_issue: Option<i64>,
     /// A pre-existing weaver issue id to claim for this session (fan-out
     /// pickup). Seeds title/goal/description and stamps `claimed_branch`.
     #[serde(default)]

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -5,6 +5,13 @@ review progress asynchronously through the loom dashboard.
 This document describes how to work *with weaver*. It is distinct from any
 `AGENTS.md` in the repo, which describes the project itself — read that too.
 
+Two CLIs share the loom server, split by subject. **`weaver` manages your
+current state and the work ledger** — status, tags, artifacts, issues, the
+event log — every command implicitly scoped to this branch or its repo.
+**`loom` manages sessions as objects** — launching, inspecting, and driving
+detached sessions, yours or a sub-tree's (see "Launching and tracking
+sub-sessions"). Report yourself with `weaver`; drive sessions with `loom`.
+
 ## The `weaver` CLI
 
 On your `PATH`; every command talks to the loom server, which is already
@@ -52,7 +59,8 @@ watches your progress without reading this terminal:
 ## Launching and tracking sub-sessions
 
 Fan work out into its own detached session — a parallel sub-tree on its own
-branch and worktree — and track it the way someone tracks you:
+branch and worktree — and track it the way someone tracks you. The session
+itself is `loom`'s to manage; the ledger that tracks it stays in `weaver`:
 
 - `loom session launch "<task>"` — spawn a sub-session; prints its branch and
   **tracking issue number**, your handle on the sub-tree. Forks from a

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -7,210 +7,157 @@ This document describes how to work *with weaver*. It is distinct from any
 
 ## The `weaver` CLI
 
-It is on your `PATH`. From anywhere in the worktree you can run:
+On your `PATH`; every command talks to the loom server, which is already
+running. Start with `weaver summary`, and re-run it whenever you lose the
+thread — after a context compaction weaver replays it for you automatically.
 
-- `weaver artifact show goal` — print the task this branch was created for. The
-  goal lives as an artifact named `goal`; update it with `weaver artifact write
-  goal <file|->` as your understanding evolves.
-- `weaver summary` — a quick catch-up on the branch: the goal, your current
-  status, the outstanding tasks, and a hint or two for what to do next. Run it
-  when you pick up or resume a branch. After a context compaction weaver replays
-  this catch-up for you automatically, so you don't lose track of where you are.
-- `weaver readme` — print this guide (the full weaver workflow). Re-read it when
-  you need the rules back — e.g. after a compaction, when only the concise
-  catch-up was replayed.
-- `weaver status <level> "<message>"` — tell the dashboard how you are
-  doing. `level` is one of `ok`, `attention`, or `blocked`; the message is a
-  short current-state note ("Wired up routes; tests pass"). This is your single
-  channel for reporting status — both the level and the message in one call —
-  and the trail of these messages is your progress log: record a decision or
-  where you left off by setting the status, not in a separate note.
+- `weaver summary` — the catch-up: goal, status, artifacts, open discussion,
+  outstanding tasks, and what to do next.
+- `weaver artifact show goal` — the task this branch was created for. Update it
+  with `weaver artifact write goal <file|->` as your understanding evolves.
+- `weaver status <level> "<message>"` — your single status channel; see
+  "Signalling your status".
 - `weaver issue add "<title>"` — add a task claimed by this branch (`--repo`
-  files it in the shared repo backlog instead).
-- `weaver issue ls` — this branch's tasks plus the unclaimed repo backlog
-  (`--mine` for just yours, `--repo` for the whole repo). `weaver issue close N`.
-- `weaver issue show N` — an issue plus the live status of the branch working
-  it; `weaver issue wait N` blocks until it closes or that branch needs you
-  (see "Launching and tracking sub-sessions" below).
-- `weaver artifact write <name> [<file>]` — write a versioned document to
-  weaver (a design, a report, a diagram, a plan) for the user to read. Prints a
-  dashboard URL to hand them. Reads stdin with `-`; `--repo` makes it
-  repo-shared so a fan-out of child sessions sees one copy. An image file
-  (`.png`, `.svg`, …) is embedded as a base64 data-URI markdown doc, so it
-  renders inline — just `weaver artifact write shot screenshot.png`. `weaver
-  artifact ls` lists this branch's plus the shared ones; `weaver artifact show
-  <name> [--rev N]` prints content; `weaver artifact rm <name>` removes it and
-  its history (`--repo` targets the shared one).
-- Division of labor: **the `goal` artifact = the charter (what to do); issues = the only task
-  ledger; artifacts = documents for the user to read.** A "plan" is just *an
-  artifact named `plan`* following smartdoc conventions: prose, a mermaid
-  diagram, and a task list whose items **reference issues** (`- #41 Index
-  layer`) instead of declaring them. The doc never states status — the dashboard
-  projects live issue state at render time. There is no sync engine: **you are
-  the reconciler.** File the issues with `weaver issue add`, reference them in
-  the doc, and keep the two aligned as work moves. See the smartdoc skill
-  (`.agents/skills/smartdoc.md`).
-- `weaver status` — with no argument, show the goal, status, and open-issue
-  count.
+  files it in the shared repo backlog instead). `weaver issue ls` — this
+  branch's tasks plus the unclaimed backlog (`--mine`, `--repo` to rescope).
+  `weaver issue show N` / `close N` / `wait N` — inspect, finish, or block on
+  one (see "Launching and tracking sub-sessions").
+- `weaver artifact write <name> [<file>]` — write a versioned document (a
+  design, report, diagram, plan) for the user to read; prints a dashboard URL
+  to hand them. Reads stdin with `-`; `--repo` shares it repo-wide; an image
+  file is embedded so it renders inline. `weaver artifact ls` / `show <name>
+  [--rev N]` / `rm <name>` round it out.
+- `weaver tag set|rm|ls` — free-form quiet tags on the branch; `weaver log` —
+  the event trail; `weaver readme` — this guide, back on demand.
 
-These talk directly to the weaver database — no daemon required.
+Division of labor: **the `goal` artifact is the charter; issues are the only
+task ledger; artifacts are documents for the user.** A "plan" is just an
+artifact named `plan` following smartdoc conventions: prose, a mermaid diagram,
+and a task list that **references issues** (`- #41 Index layer`) instead of
+declaring them — the dashboard projects live issue state at render time. There
+is no sync engine: **you are the reconciler.** See the smartdoc skill
+(`.agents/skills/smartdoc.md`).
 
 ## Your tracking issue
 
-This branch has a **tracking issue** — a weaver issue claimed by your branch
-that represents the task you were launched for. `weaver issue ls --mine` shows
-it. It is how the agent (or human) that launched you watches your progress
-without reading this terminal:
+This branch has a **tracking issue** — the weaver issue for the task you were
+launched with (`weaver issue ls --mine`). It is how whoever launched you
+watches your progress without reading this terminal:
 
-- Keep your status honest with `weaver status` as you work — that is the
-  live signal whoever launched you polls.
-- When the task is genuinely complete (the PR is open, the work is done), run
-  `weaver issue close <id>` on the tracking issue. Closing it is the
-  unambiguous "this sub-tree is finished" signal; leaving it open means "still
-  in flight". Do not close it early.
+- Keep `weaver status` honest — that is the live signal they poll.
+- When the task is genuinely complete (the PR is open, the work is done),
+  `weaver issue close <id>`. Closing is the unambiguous "finished" signal; do
+  not close early.
 
 ## Launching and tracking sub-sessions
 
-You can fan work out into its own detached session — a parallel sub-tree on its
-own branch and worktree — and track it the same way someone tracks you:
+Fan work out into its own detached session — a parallel sub-tree on its own
+branch and worktree — and track it the way someone tracks you:
 
-- `loom session launch "<what the sub-agent should do>"` — spawn a sub-session.
-  It prints the new branch and a **tracking issue number** for the task; that
-  issue is your handle on the sub-tree. The new branch forks from a
-  freshly-fetched `origin/<default branch>` unless you pass `--base <branch>`.
-- `weaver issue show <id>` — poll the sub-tree: its tracking issue's
-  open/closed state plus the sub-agent's live `weaver status` (attention +
-  current-state message).
-- `weaver issue wait <id>` — block until the sub-tree finishes (its tracking
-  issue closes) or needs you (the sub-agent raises its attention to
-  `attention`/`blocked`). Takes `--timeout <secs>`; prints why it woke.
-- `weaver issue ls` lists the sub-tasks you have delegated under
-  "Delegated by this branch", each with its sub-agent's current status.
-
-The tracking issue is the high-level handle; `loom session` also drives a child
-session's terminal directly, so you can nudge it without attaching:
-
-- `loom session poll <session>` — one-shot status (lifecycle + attention).
-- `loom session wait <session>` — block on the session itself (not its issue)
-  until it finishes, is lost, or raises attention. `--timeout <secs>`.
-- `loom session send <session> "<message>"` — type a message into the
-  sub-agent's pane and submit it, triggering an agent round (e.g. to answer a
-  question it asked or redirect it).
-- `loom session break <session>` — send Escape to interrupt its current turn.
-- `loom session preview <session>` — print its recent terminal screen, to see what
-  it's doing right now. A session key is an id, branch id, branch name, or
+- `loom session launch "<task>"` — spawn a sub-session; prints its branch and
+  **tracking issue number**, your handle on the sub-tree. Forks from a
+  freshly-fetched `origin/<default branch>` unless `--base <branch>`.
+- `weaver issue show <id>` — the sub-tree's tracking issue plus the sub-agent's
+  live status. `weaver issue wait <id>` blocks until it closes or the sub-agent
+  raises `attention`/`blocked` (`--timeout <secs>`; prints why it woke).
+  `weaver issue ls` lists your delegations under "Delegated by this branch".
+- Drive the child's terminal directly when you need to nudge it:
+  `loom session poll|wait|send|break|preview <session>` (one-shot status /
+  block on the session itself / type a message into its pane / send Escape /
+  read its screen). A session key is an id, branch id, branch name, or
   `repo:branch`.
-- `loom session url [<session>]` — the dashboard URL for a session, defaulting to
-  your own. The link to hand a human (see "Finishing work").
+- `loom session url [<session>]` — the dashboard URL, defaulting to your own;
+  the link to hand a human (see "Finishing work").
 
-This duplicates some of a coding agent's builtin sub-agents, but a weaver
-sub-session is fully decoupled: it survives independently, has its own git
-history, and you can hand it off or revisit it later.
+Unlike a coding agent's builtin sub-agents, a weaver sub-session is fully
+decoupled: it survives independently, has its own git history, and can be
+handed off or revisited later.
 
-## Launching sessions in the right workspace
-
-`loom session launch` cuts the new worktree from the mainline of *one* repo,
-defaulting to whatever checkout you run it in. Say which repo explicitly: pass
-`--repo <path>` pointing at (any directory inside) the target checkout, or `cd`
-into it first (`--base` only pins the branch, not the repo). The repos live
-under `/home/power/code/<repo>/` — e.g. `marin`, `tunix`, `marin-experiments`.
-So for marin work:
-
-    loom session launch --repo /home/power/code/marin "<task>"
-
-The branch is always namespaced `weaver/<slug>` regardless of repo, so the
-branch name won't tell you where it landed. After launching, check the printed
-`dir:` line sits under the intended repo's `.worktrees/` — if you wanted marin
-but it reads `/home/power/code/weaver/.worktrees/...`, it went to the wrong repo.
-
-`iris` and `grug` are subsystems inside the marin monorepo, not separate repos —
-launch their work into the marin checkout.
+`loom session launch` cuts the worktree from *one* repo — whatever checkout you
+run it in, unless you pass `--repo <path>` (`--base` pins only the branch, not
+the repo). Repos live under `/home/power/code/<repo>/`; `iris` and `grug` are
+subsystems of the marin monorepo, so launch their work with `--repo
+/home/power/code/marin`. Branches are always named `weaver/<slug>` regardless
+of repo — after launching, check the printed `dir:` line sits under the
+intended repo's `.worktrees/`.
 
 ## Signalling your status
 
-The user scans the dashboard for sessions that need them. Keep your status
-honest with `weaver status <level> "<message>"`. The level is the
-"does this need me?" signal; the message says what's going on:
+The user scans the dashboard for sessions that need them. Report with
+`weaver status <level> "<message>"` — the level is the "does this need me?"
+signal, the message the current state:
 
-- `ok` — progressing normally, **or** blocked on something external that is not
-  the user (a CI run, a PR review, a long workflow). No action needed.
-  Example: `weaver status ok "waiting on PR review feedback"`.
-- `attention` — you want the user to look: a question, a decision to confirm, or
-  "done — ready for review". Example: `weaver status attention "ready for review"`.
-- `blocked` — you are stuck or hit an error and need help to proceed.
-  Example: `weaver status blocked "build broken, can't reproduce locally"`.
+- `ok` — progressing normally, **or** waiting on something external that is
+  not the user (CI, a PR review, a long workflow). No action needed.
+- `attention` — you want the user: a question, a decision, "ready for review".
+- `blocked` — stuck; you need help to proceed.
 
-Set it as your situation changes — especially raise it to `attention` before you
-finish a turn expecting the user, and drop back to `ok` once you are moving
-again. A bare `weaver status ok` lowers the level and keeps your last
-message. This replaces the old guessed working/waiting/idle indicator, which was
-often wrong (e.g. it read "idle" while you were really waiting on a workflow).
+Set it as your situation changes — raise it before finishing a turn expecting
+the user, drop back to `ok` once you are moving. A bare `weaver status ok`
+lowers the level and keeps the last message. The trail of these messages is
+your progress log: record decisions and hand-off points by setting status, not
+in separate notes — the dashboard's activity feed renders the trail, and on a
+session wired to GitHub it is mirrored publicly (see "Working a GitHub
+issue").
 
-Under the hood, status is stored as **tags** on your branch. A tag is a single
-`(key, value)` annotation with a note, an author, and a timestamp. Three keys are
-well known:
+Under the hood, status is a **tag** on your branch — a single `(key, value)`
+annotation with a note, an author, and a timestamp:
 
-- `attention` — your self-report, the value being `attention` or `blocked`. This
-  is what `weaver status` writes; `ok` is the absence of the tag, so
-  `weaver status ok` clears it. Absence is the calm state — a calm branch carries no
-  attention tag, only its `description` message.
-- `triage` — a watch's outside assessment of your branch, the same
-  `attention`/`blocked` ladder but authored by a watch (or `manual`), never
-  by you. It is independent of your `attention` tag and carries its own reason
-  and attribution.
-- `idle` — a soothing, *quiet* mark stamped mechanically when your agent goes
-  quiet (a finished turn or a lull): the calm "resting, no one needed" state. It
-  is **not** loud — an idle agent does not read as needing the user — and you
-  never set it yourself. The status watch may replace it with a real `attention`
-  status once it judges the session genuinely needs a human.
+- `attention` — your self-report, `attention` or `blocked`. `ok` clears it:
+  absence is the calm state; your prose `description` still shows.
+- `triage` — a watch's outside assessment, never yours.
+- `idle` — a quiet mark stamped mechanically when your agent goes quiet; never
+  set it yourself.
 
-Your prose `description` is separate from the tags and is shown even when you are
-calm. Any other key is a free-form, quiet tag. A tag is stale once your session
-has moved on since it was set (its timestamp predates your last activity).
+Any other key is a free-form quiet tag. A tag is stale once your session has
+moved on since it was set.
 
 ## How to work here
 
-- Prefer to make a well-reasoned decision, record it with `weaver status`,
-  and keep going. Default to recording and continuing rather than stopping.
-- You may still ask the user for feedback in plain prose when a choice genuinely
-  matters. But **never block on an interactive TUI prompt** — multiple-choice
-  menus, plan-approval dialogs, and the like cannot be answered from the
-  dashboard. State the question as plain text and
-  set `weaver status attention "<the question>"`, then continue with your
-  best assumption.
+- Make a well-reasoned decision, record it with `weaver status`, and keep
+  going. Default to recording and continuing rather than stopping.
+- Ask the user in plain prose when a choice genuinely matters — but **never
+  block on an interactive TUI prompt**; those cannot be answered from the
+  dashboard. State the question as text, set `weaver status attention
+  "<the question>"`, and continue on your best assumption.
 
 ## Working a GitHub issue
 
-A session often comes from a GitHub thread — someone `@loom`-mentioned an issue
-or a PR, or your goal names one. That thread is where the people who care about
-the work are: they don't read this terminal, and may not read the dashboard.
-Anything they need to know goes there.
+A session often comes from a GitHub thread — an `@loom` mention on an issue or
+PR, or a goal that names one. The people who care about the work are on that
+thread; they don't read this terminal.
 
-- **Read the whole thread first** — `gh issue view <n> --comments` (`gh pr view
-  <n> --comments`). Your goal is a paraphrase of it; the constraint that decides
-  the design is usually three comments down.
-- **Reply where you were asked** — a question for the issue's author is a
-  `gh issue comment <n>`. Post it, raise `weaver status attention "<question>"`
-  so the dashboard shows what you're waiting on, then continue on your best
-  assumption rather than idling.
-- **Close the issue through the PR** — write `Fixes #<n>` in the body and let the
-  merge close it. Don't `gh issue close` by hand.
-- **Say which board a number belongs to.** Weaver issues and GitHub issues number
-  separately and will collide. On a GitHub thread `#12` is theirs — a weaver
-  issue number tells a reader there nothing, so describe the work instead.
+- **Your status is public there.** A session wired to a thread (the `github`
+  tag — `weaver summary` shows the wiring) has its `weaver status` trail
+  mirrored onto loom's "On it" comment, edited in place as a live status card.
+  Progress reporting is therefore automatic: write status messages for that
+  audience, and don't hand-post progress comments. To wire a session yourself:
+  `weaver tag set github owner/name#123`; `weaver tag rm github` stops it.
+- **Comment when you need a person.** A question, a design to review, the
+  finished result — post it with `gh issue comment <n>` / `gh pr comment <n>`
+  (comment edits notify no one; a real comment does), and raise
+  `weaver status attention "<question>"` so the dashboard agrees. Then
+  continue on your best assumption rather than idling.
+- **Read the whole thread first** — `gh issue view <n> --comments`. Your goal
+  is a paraphrase of it; the deciding constraint is usually three comments
+  down.
+- **Close the issue through the PR** — `Fixes #<n>` in the body; don't
+  `gh issue close` by hand.
+- **Say which board a number belongs to.** Weaver issues and GitHub issues
+  number separately; on a GitHub thread `#12` is theirs, so describe weaver
+  work rather than citing its number.
 
 ## Designing before you build
 
 When the task turns on research or a tradeoff — an architecture choice, a
-migration strategy, an API contract, a storage model, anything expensive to
-reverse — write the design down and have it reviewed before you build it. Skip
-this for a quick fix, a bug with an obvious cause, a rename, a doc tweak, a
-review comment, an issue reply: no tradeoff, no review, just write the code.
+migration, an API contract, anything expensive to reverse — write the design
+down and have it reviewed before building. Skip this for quick fixes, renames,
+doc tweaks, review comments: no tradeoff, no review, just write the code.
 
-1. Write it as an artifact — `weaver artifact write design <file>`: the
-   reasoning, the alternatives you rejected and why, the open questions. Name it
-   `design`; `plan` means the issue-referencing task list above. Stay `ok` — a
-   draft awaiting review is not something the user needs to look at.
+1. `weaver artifact write design <file>` — the reasoning, the rejected
+   alternatives, the open questions. Name it `design` (`plan` means the
+   issue-referencing task list). Stay `ok` — a draft awaiting review is not
+   something the user needs to see.
 2. Send it to two reviewers, each checking it against the code. If you are
    `claude`:
 
@@ -221,55 +168,40 @@ review comment, an issue reply: no tradeoff, no review, just write the code.
    weaver artifact show design | claude -p --model fable "$ask"
    ```
 
-   If you are `codex`: one of your own sub-agents, plus `claude -p --model fable`.
-   Run both in the background and in parallel — each takes minutes. If a reviewer
-   isn't on `PATH`, note it and go with one.
-3. Incorporate the findings and rev the artifact. The reviews will be partly
-   wrong; use judgment, not a patch queue. Fix what lands, record what you
-   rejected and why. `weaver artifact write design` appends the revision. Only
-   now surface it: raise `attention` with the URL, and if the session came from a
-   GitHub issue or PR, paste the design on that thread (`gh issue comment <n>` /
-   `gh pr comment <n>`) — a reader there can't open a loopback dashboard URL.
+   If you are `codex`: one of your own sub-agents, plus `claude -p --model
+   fable`. Run both in the background, in parallel. If a reviewer isn't on
+   `PATH`, note it and go with one.
+3. Incorporate findings with judgment — reviews are partly wrong; fix what
+   lands, record what you rejected and why, and rev the artifact. Only now
+   surface it: raise `attention` with the URL, and if the session came from a
+   GitHub thread, paste the design there (`gh issue comment` / `gh pr
+   comment`) — a reader there can't open a loopback dashboard URL.
 
 ## Finishing work
 
-You are on a dedicated branch in your own worktree. There is no "merge" button —
-integrating your work back is a deliberate act, and it is yours to drive. When
-the work is ready:
+You are on a dedicated branch in your own worktree; integrating it back is
+yours to drive.
 
-- **Commit** your changes with a clear message and keep the worktree clean.
-- **Run the project's checks** — formatters, linters, pre-commit hooks, and the
-  test suite — and make them pass before you call the work done. If the repo
-  documents specific commands (often in `AGENTS.md`), use those.
-- **Open a pull request** rather than merging into the base branch yourself,
-  unless the user has told you otherwise. Most teams gate integration on review
-  and CI; respect that. Use the project's normal PR workflow (e.g. `gh pr
-  create`).
-- **Link the PR back to this session** — `loom session url` prints the dashboard
-  URL for the session you are in. Put it in the PR body, so a reviewer looking at
-  the diff can reach the context behind it: the goal, your status trail, the
-  designs and reports you wrote. Build the body in one go:
+- **Commit** with a clear message; keep the worktree clean.
+- **Run the project's checks** — formatters, linters, tests (see the repo's
+  `AGENTS.md`) — and make them pass first.
+- **Open a pull request** (`gh pr create`) rather than merging yourself,
+  unless told otherwise.
+- **Link the PR to this session** — put `$(loom session url)` in the body so a
+  reviewer can reach the goal, status trail, and designs behind the diff. Only
+  the server knows loom's public address — `$WEAVER_API` is a loopback URL
+  that resolves to nothing on a reviewer's machine.
+- **Drive the PR to green — opening it starts integration, it doesn't finish
+  it.** Watch CI (`gh pr checks <N> --watch`), fetch reviews (`gh pr view <N>
+  --json reviews,comments`) and inline comments (`gh api
+  repos/{owner}/{repo}/pulls/<N>/comments`), fix and push on the same branch,
+  re-watch. Local green is not CI green. Keep status honest while you wait
+  (`weaver status ok "waiting on CI"`).
+- Once CI is green and review addressed: `weaver status attention "ready for
+  review"` (the message doubles as your summary), and file follow-ups with
+  `weaver issue add`.
 
-      loom session url                        # https://loom.example.com/s/ab12cd34
-      gh pr create --title "…" --body "$(printf 'What this does…\n\nloom: %s\n' "$(loom session url)")"
-
-  Only the server knows loom's public address, which is why this is a command and
-  not something you assemble yourself — the `$WEAVER_API` you were handed is a
-  loopback address that resolves to nothing on the reviewer's machine.
-- **Drive the PR to green — opening it is the start of integration, not the
-  end.** Do not walk away the moment it's open. Watch CI to completion
-  (`gh pr checks <N> --watch`) and fetch review feedback — both the top-level
-  reviews (`gh pr view <N> --json reviews,comments`) and inline code comments
-  (`gh api repos/{owner}/{repo}/pulls/<N>/comments`). Local green is not CI
-  green: fix any failing check and address every review comment with follow-up
-  commits on the same branch, then re-watch. Keep `weaver status` honest while
-  you wait (`weaver status ok "waiting on CI"`).
-- Once CI is green and review is addressed, raise `weaver status attention
-  "ready for review"` (the message doubles as your concise summary, and file any
-  follow-ups as issues with `weaver issue add`) so the user knows to look.
-
-When a session is finished with, the user may **archive** it from the dashboard:
-that tears down this terminal session and removes the worktree, but preserves the
-branch and the weaver history (goal, status, events) for future reference. So
-make sure anything worth keeping is committed to the branch or filed as an issue
-before you consider the task complete.
+When a session is finished with, the user may **archive** it from the
+dashboard: the terminal and worktree go, the branch and weaver history stay.
+Commit anything worth keeping — or file it as an issue — before you call the
+task complete.

--- a/crates/weaver-core/src/artifact.rs
+++ b/crates/weaver-core/src/artifact.rs
@@ -89,7 +89,7 @@ pub async fn write(db: &Db, new: &NewRevision<'_>) -> Result<Artifact> {
         author,
     } = *new;
     let now = now_iso();
-    let mut tx = db.begin().await?;
+    let mut tx = crate::db::begin_immediate(db).await?;
 
     // Find (or create) the envelope. The lookup is exact on (repo, branch, name)
     // — a write targets one specific scope, it never resolves shared-vs-scoped.
@@ -303,7 +303,7 @@ pub async fn list_for_repo(db: &Db, repo_root: &str) -> Result<Vec<Artifact>> {
 /// Foreign keys aren't enabled on the pool, so the `artifact_versions` cascade
 /// won't fire — clear the versions explicitly before dropping the envelope.
 pub async fn delete(db: &Db, id: i64) -> Result<()> {
-    let mut tx = db.begin().await?;
+    let mut tx = crate::db::begin_immediate(db).await?;
     sqlx::query("DELETE FROM artifact_versions WHERE artifact_id = ?")
         .bind(id)
         .execute(&mut *tx)

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -568,7 +568,7 @@ pub type Change = (String, Option<String>);
 /// Callers are expected to [`validate`] each value first; `apply` itself only
 /// touches the database.
 pub async fn apply(db: &Db, changes: &[Change]) -> Result<()> {
-    let mut tx = db.begin().await?;
+    let mut tx = crate::db::begin_immediate(db).await?;
     let now = now_iso();
     for (key, value) in changes {
         match value {

--- a/crates/weaver-core/src/db.rs
+++ b/crates/weaver-core/src/db.rs
@@ -77,7 +77,11 @@ pub async fn connect(path: &Path) -> Result<Db> {
     let options = SqliteConnectOptions::from_str(&format!("sqlite:{}", path.display()))
         .with_context(|| format!("invalid database path {}", path.display()))?
         .create_if_missing(true)
-        .journal_mode(SqliteJournalMode::Wal);
+        .journal_mode(SqliteJournalMode::Wal)
+        // A writer that loses the lock race waits its turn instead of failing
+        // with SQLITE_BUSY "database is locked". Only effective for writes that
+        // take the lock up front — see [`begin_immediate`].
+        .busy_timeout(std::time::Duration::from_secs(5));
 
     // Apply migrations on a dedicated single connection, then close it, *before*
     // the shared read/write pool opens. A column-adding migration (`ALTER TABLE
@@ -110,13 +114,23 @@ pub async fn connect_in_memory() -> Result<Db> {
     tracing::info!("opening in-memory database");
     let options = SqliteConnectOptions::new()
         .in_memory(true)
-        .journal_mode(SqliteJournalMode::Wal);
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(std::time::Duration::from_secs(5));
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         .connect_with(options)
         .await?;
     migrate(&pool).await?;
     Ok(pool)
+}
+
+/// Open a write transaction that takes SQLite's write lock up front
+/// (`BEGIN IMMEDIATE`). A default deferred transaction starts as a reader and
+/// upgrades on its first write — and an upgrade that loses the race fails with
+/// SQLITE_BUSY *immediately*, bypassing the connection's `busy_timeout`. Every
+/// multi-statement write path begins here so it waits its turn instead.
+pub async fn begin_immediate(db: &Db) -> sqlx::Result<sqlx::Transaction<'_, sqlx::Sqlite>> {
+    db.begin_with("BEGIN IMMEDIATE").await
 }
 
 /// Apply pending schema migrations. The migration framework (ordered SQL files

--- a/crates/weaver-core/src/discussion.rs
+++ b/crates/weaver-core/src/discussion.rs
@@ -114,7 +114,7 @@ pub async fn create_thread(db: &Db, new: &NewThread<'_>) -> Result<Thread> {
         body,
     } = *new;
     let now = now_iso();
-    let mut tx = db.begin().await?;
+    let mut tx = crate::db::begin_immediate(db).await?;
 
     let (thread_id,): (i64,) = sqlx::query_as(
         "INSERT INTO artifact_threads
@@ -152,7 +152,7 @@ pub async fn create_thread(db: &Db, new: &NewThread<'_>) -> Result<Thread> {
 /// (unexpectedly) empty thread). Returns the new comment.
 pub async fn add_comment(db: &Db, thread_id: i64, author: &str, body: &str) -> Result<Comment> {
     let now = now_iso();
-    let mut tx = db.begin().await?;
+    let mut tx = crate::db::begin_immediate(db).await?;
 
     let next_seq: i64 = {
         let max: Option<i64> =
@@ -282,7 +282,7 @@ pub async fn list_for_artifact(
 /// artifact. Foreign keys aren't enabled on the pool, so the `ON DELETE
 /// CASCADE` in the schema won't fire — clear comments before threads.
 pub async fn delete_for_artifact(db: &Db, artifact_id: i64) -> Result<()> {
-    let mut tx = db.begin().await?;
+    let mut tx = crate::db::begin_immediate(db).await?;
     sqlx::query(
         "DELETE FROM artifact_comments WHERE thread_id IN
             (SELECT id FROM artifact_threads WHERE artifact_id = ?)",

--- a/crates/weaver-core/src/tags.rs
+++ b/crates/weaver-core/src/tags.rs
@@ -72,6 +72,20 @@ pub const RECOVERED_KEY: &str = "recovered";
 /// The fixed value the [`RECOVERED_KEY`] tag carries.
 pub const RECOVERED_VALUE: &str = "true";
 
+/// Branch tag wiring a session to a GitHub thread; the value is
+/// `owner/name#number` (an issue or a PR — GitHub comments treat them alike).
+/// Quiet. While present, loom mirrors every `weaver status` write onto one
+/// comment on that thread — the "On it" status card, edited in place. The
+/// `@loom` trigger stamps it at launch; `weaver tag set github owner/name#123`
+/// wires a session by hand; clearing it stops the mirroring.
+pub const GITHUB_KEY: &str = "github";
+
+/// Loom's bookkeeping for the status card: the GitHub comment id it edits,
+/// with the wiring it belongs to in the note. Machine-owned — the tag routes
+/// refuse to set it by hand (a forged id would aim loom's edits at someone
+/// else's comment); clearing it just makes the next status write post afresh.
+pub const GITHUB_COMMENT_KEY: &str = "github.status_comment";
+
 /// The loud keys: those that raise an attention signal on the dashboard. Any
 /// other key is quiet (a deletable pill) — including the soothing [`IDLE_KEY`].
 pub const LOUD_KEYS: &[&str] = &[ATTENTION_KEY, TRIAGE_KEY];

--- a/crates/weaver/Cargo.toml
+++ b/crates/weaver/Cargo.toml
@@ -12,6 +12,7 @@ weaver-core = { path = "../weaver-core" }
 weaver-api = { path = "../weaver-api" }
 anyhow = "1"
 base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 serde = { version = "1", features = ["derive"] }

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -867,6 +867,22 @@ async fn cmd_status(level: Option<String>, message: String) -> Result<()> {
     Ok(())
 }
 
+/// A compact "how long ago" for an ISO-8601 timestamp: `3m ago`, `2h ago`,
+/// `5d ago`. Unparseable input (or the future, from clock skew) renders as
+/// `just now` — this is orientation, not arithmetic anyone acts on.
+fn age_of(iso: &str) -> String {
+    let Ok(t) = chrono::DateTime::parse_from_rfc3339(iso) else {
+        return "just now".to_string();
+    };
+    let mins = (chrono::Utc::now() - t.with_timezone(&chrono::Utc)).num_minutes();
+    match mins {
+        i64::MIN..=1 => "just now".to_string(),
+        2..=119 => format!("{mins}m ago"),
+        120..=2879 => format!("{}h ago", mins / 60),
+        _ => format!("{}d ago", mins / 1440),
+    }
+}
+
 /// The branch's GitHub wiring — the `github` tag's `owner/name#number` — when
 /// the session mirrors its status trail onto a GitHub thread.
 fn github_wiring_of(b: &BranchView) -> Option<&str> {
@@ -1071,7 +1087,25 @@ async fn cmd_issue(cmd: IssueCmd) -> Result<()> {
                 println!("  from:    {src}");
             }
             if let Some(n) = i.github_issue {
-                println!("  github:  #{n}");
+                let slug = i.github_repo.as_deref().unwrap_or_default();
+                match &i.github_state {
+                    // The live thread, as GitHub reports it right now — catches
+                    // "closed / re-titled while you worked". `gh` has the rest.
+                    Some(gh) => {
+                        let renamed = if gh.title != i.title && !gh.title.is_empty() {
+                            format!(" — {:?}", gh.title)
+                        } else {
+                            String::new()
+                        };
+                        println!(
+                            "  github:  {slug}#{n} {}{renamed} (updated {})",
+                            gh.state,
+                            age_of(&gh.updated_at)
+                        );
+                    }
+                    None if slug.is_empty() => println!("  github:  #{n}"),
+                    None => println!("  github:  {slug}#{n}"),
+                }
             }
             if !i.tags.is_empty() {
                 let rendered = i

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -564,6 +564,12 @@ async fn render_summary(client: &Client, b: &BranchView) -> Result<String> {
         format!("{attention} — {}", b.description)
     };
     let _ = writeln!(out, "Status:  {status}  (weaver status)");
+    if let Some(wiring) = github_wiring_of(b) {
+        let _ = writeln!(
+            out,
+            "GitHub:  status messages mirror publicly to {wiring}  (weaver tag rm github stops it)"
+        );
+    }
 
     // Artifacts visible from this branch (its own + repo-shared) — the documents
     // the agent has written to weaver (designs, reports, the `plan`).
@@ -791,6 +797,23 @@ async fn cmd_log(limit: i64) -> Result<()> {
             s.to_string()
         } else if let Some(s) = ev.data.get("status").and_then(Value::as_str) {
             s.to_string()
+        } else if let Some(key) = ev.data.get("key").and_then(Value::as_str) {
+            // A tag event. For the agent's own `attention` reports this is the
+            // status trail: `level — message`; an empty value is the calm `ok`
+            // (any other key cleared reads as "cleared").
+            let value = ev.data.get("value").and_then(Value::as_str).unwrap_or("");
+            let note = ev.data.get("note").and_then(Value::as_str).unwrap_or("");
+            let shown = match (key, value) {
+                (k, "") if k == tags::ATTENTION_KEY => "ok".to_string(),
+                (k, "") => format!("{k} cleared"),
+                (k, v) if k == tags::ATTENTION_KEY => v.to_string(),
+                (k, v) => format!("{k}: {v}"),
+            };
+            if note.is_empty() {
+                shown
+            } else {
+                format!("{shown} — {note}")
+            }
         } else if let Some(level) = ev.data.get("level").and_then(Value::as_str) {
             match ev.data.get("note").and_then(Value::as_str) {
                 Some(n) if !n.is_empty() => format!("{level} — {n}"),
@@ -837,8 +860,21 @@ async fn cmd_status(level: Option<String>, message: String) -> Result<()> {
         format!("{attention} — {}", b.description)
     };
     println!("status:      {status}");
+    if let Some(wiring) = github_wiring_of(&b) {
+        println!("github:      status messages mirror publicly to {wiring}");
+    }
     println!("open issues: {}", b.open_issue_count);
     Ok(())
+}
+
+/// The branch's GitHub wiring — the `github` tag's `owner/name#number` — when
+/// the session mirrors its status trail onto a GitHub thread.
+fn github_wiring_of(b: &BranchView) -> Option<&str> {
+    b.tags
+        .iter()
+        .find(|t| t.key == tags::GITHUB_KEY)
+        .map(|t| t.value.as_str())
+        .filter(|v| !v.is_empty())
 }
 
 /// Report the agent's status: set the attention level and, when a message is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,7 +384,11 @@ The **`attention` tag** is otherwise the agent's own call, set via `weaver
 status <level> ["<message>"]`. That calls `POST /api/branches/{key}/status`,
 which writes the tag (and, when a message is given, the `description`) and
 records a `tag` event the monitor re-broadcasts over SSE, atomically in one
-request — `ok` clears the tag, the two loud levels upsert it. A bare `weaver
+request — `ok` clears the tag, the two loud levels upsert it. The message rides
+the event as its `note`, so the event log carries the full **status trail** —
+the progress log the dashboard's activity feed renders, `weaver log` prints,
+and a GitHub-wired session mirrors publicly (see [GitHub
+integration](#github-integration)). A bare `weaver
 status <level>` changes only the level and keeps the last message. Last write
 wins, so an explicit declaration overrides the hook-inferred default. The
 general `weaver tag set|rm|ls` group writes any key the same way, over the
@@ -465,6 +469,23 @@ JSON parse + check rollup), `refresh` (fetch → store → announce → maybe
 archive, behind both the poller and the refresh endpoint), and `poll` (the
 loop). The merge-archive decision is split into `apply_snapshot` so it is
 testable without invoking `gh`.
+
+**The status card.** A branch carrying the quiet `github` tag
+(`owner/name#number` — stamped by the `@loom` trigger, or set by hand with
+`weaver tag set github …`, format-validated at set time) mirrors its status
+trail onto that GitHub thread: `github::sync_status_comment`, spawned detached
+by the status endpoint and by artifact writes, renders one comment — the
+session link, links to the branch's artifacts, and the trail of the agent's
+own `attention` events since wiring — and edits it in place through the
+trigger's `GithubApi` gateway (`post_issue_comment` returns the comment id;
+`update_issue_comment` PATCHes it, reporting a deleted comment as `Ok(false)`
+so the card is reposted, while transient errors retry). A process-wide lock
+serializes syncs so racing writes can't double-post. The comment id lives in
+the machine-owned `github.status_comment` tag (note = the wiring it belongs
+to, so re-pointing the `github` tag posts fresh instead of editing the old
+thread); it and `github.linked` are refused by the tag-set routes and hidden
+from the dashboard's pill row. See
+[github-trigger.md "The status card"](github-trigger.md#the-status-card).
 
 ## Authentication
 

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -53,8 +53,11 @@ receiver, in order:
    duplicate. Otherwise loom creates the session, seeded with the issue/PR title,
    body, and the triggering comment, plus a primer on how to respond — push to the
    PR branch (or open a PR for an issue) and reply on the thread with `gh`.
-8. **Replies** on the thread with the session URL (or, for a forwarded comment,
-   that it was passed to the running session).
+8. **Replies** on the thread with the session URL. A forwarded comment is
+   acknowledged with a 👀 **reaction** on the triggering comment instead — seen,
+   passed along, no ack comment accumulating on an active thread. When the
+   reaction can't land (no comment id in the delivery, or a token that can't
+   react), loom falls back to the ack comment so the feedback isn't lost.
 
 Steps 6–8 (clone, create-or-forward, reply) run in a **detached task**: the
 handler returns `200` as soon as the gates pass. Cloning a large repo can outlast

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -4,9 +4,11 @@ loom turns an issue or PR comment into a session. Comment **`@loom`** on a GitHu
 issue or pull request and loom launches a session against that repo — attached to
 the PR's own branch (so the agent's commits land on the PR) or, for an issue, a
 stable `weaver/issue-<n>` branch — seeded with the thread's context, and replies
-with a link to the live session (`On it — {base}/s/{id}`). A follow-up `@loom` on
-a thread that already has a running session is handed to that session instead of
-starting a second one.
+with a link to the live session (`On it — {base}/s/{id}`). That reply is the
+session's **status card**: as the agent reports progress with `weaver status`,
+loom edits the comment in place into a live trail (see [The status
+card](#the-status-card)). A follow-up `@loom` on a thread that already has a
+running session is handed to that session instead of starting a second one.
 
 This is an internet-exposed, untrusted-input endpoint. Two gates protect it:
 every delivery is verified cryptographically (HMAC), and the commenter is
@@ -68,6 +70,41 @@ falling back to the ambient `GH_TOKEN` when they have none — so its pushes and
 `gh` replies are attributed to them. Separately, the poll loop posts a one-time
 back-link comment (`Working on this in loom: {base}/s/{id}`) on a session's open
 PR when one isn't already linked, so a reader of the PR can jump to the session.
+
+## The status card
+
+The "On it" reply doubles as the thread's live view of the session. At launch
+the trigger **wires** the branch to the thread — a quiet `github` tag whose
+value is `owner/name#number` — and records the reply's comment id. From then
+on, every `weaver status <level> "<message>"` the agent writes re-renders that
+comment:
+
+> On it — {base}/s/{id}
+> Docs: [design]({base}/s/{id}/artifacts/design)
+>
+> - 🟢 `Jul 18 21:04Z` reading the thread; mapping the code
+> - 🟠 `Jul 18 22:15Z` **attention** — ready for review
+
+One comment, edited in place — comment edits notify no one, so subscribers are
+never spammed; a reader opening the thread sees the whole arc, plus links to
+the documents the agent has published (the dashboard's artifact viewer). The
+agent still posts real comments when it needs a person — a question, a design
+review, the result — and those do notify.
+
+The mirroring works on any session, not just triggered ones: `weaver tag set
+github owner/name#123` wires a session by hand (the card appears on its next
+status report), and `weaver tag rm github` stops the mirroring, freezing the
+comment. The card requires a configured `auth.base_url` (the session link must
+resolve for a GitHub reader) and posts through the same App-token/`gh`
+credential ladder as the reply. Two loom-internal tags do the bookkeeping —
+`github.status_comment` (the comment id the card lives in) and `github.linked`
+(the PR back-link dedupe); both are machine-owned, hidden from the dashboard's
+pill row, and refused by the tag-set routes (clearing one is harmless: loom
+re-creates its state).
+
+If a follow-up `@loom` lands on a thread whose session's terminal is gone, the
+relaunch posts a fresh "On it" card, marks the old one *superseded*, and — the
+wiring survives the relaunch — the new card carries the full trail.
 
 Everything past the signature check returns **200** whether or not it launched a
 session (a non-trigger comment, a replay, an unregistered or rate-limited repo,

--- a/e2e/tests/brief.spec.ts
+++ b/e2e/tests/brief.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '../fixtures/weaver';
+
+// The Overview tab is the session BRIEF — the catch-up pane. These cover the
+// three sections this rework added (state synopsis, document list, surfaced
+// links) and the list row's side-door link that lands on it.
+
+test.describe('session brief', () => {
+  test('the fleet row offers an overview side door that lands on the brief', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await weaver.seedSession({ name: 'brief-door', goal: 'Ship the brief' });
+    await weaver.setStatus(s, 'ok', 'mapping the code');
+
+    await page.goto(weaver.baseUrl);
+    const row = page.getByTestId('session-card').filter({ hasText: 'brief-door' });
+    await row.getByTestId('row-overview').click();
+
+    await expect(page).toHaveURL(new RegExp(`/s/${s.id}\\?tab=overview`));
+    // The brief leads with the state synopsis — the agent's last message.
+    await expect(page.getByTestId('session-state')).toContainText('mapping the code');
+  });
+
+  test('the brief shows state, documents, and surfaced links', async ({ page, weaver }) => {
+    const s = await weaver.seedSession({ name: 'brief-full', goal: 'Ship the brief' });
+    await weaver.writeArtifact(s, 'design', '# The design\n', { title: 'The design' });
+    await weaver.setTag(s, 'github', 'acme/widgets#87');
+    await weaver.setStatus(s, 'attention', 'draft at https://example.test/doc ready for eyes');
+
+    await page.goto(`${weaver.baseUrl}/s/${s.id}?tab=overview`);
+
+    // State: the message, and the loud level called out beneath it.
+    const state = page.getByTestId('session-state');
+    await expect(state).toContainText('draft at https://example.test/doc ready for eyes');
+    await expect(state).toContainText('attention');
+
+    // Documents: the artifact by name + title, linking into the viewer.
+    const docs = page.getByTestId('session-docs');
+    await expect(docs).toContainText('design');
+    await expect(docs).toContainText('The design');
+    await expect(docs.getByRole('link', { name: /design/ })).toHaveAttribute(
+      'href',
+      `/s/${s.id}/artifacts/design`,
+    );
+
+    // Links: the wired GitHub thread first, then the URL harvested from the
+    // status trail.
+    const links = page.getByTestId('session-links');
+    await expect(links).toContainText('acme/widgets#87');
+    await expect(links.getByRole('link', { name: 'acme/widgets#87' })).toHaveAttribute(
+      'href',
+      'https://github.com/acme/widgets/issues/87',
+    );
+    await expect(links).toContainText('example.test/doc');
+  });
+
+  test('a calm session with nothing published shows the quiet empty brief', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await weaver.seedSession({ name: 'brief-empty', goal: 'Quiet start' });
+
+    await page.goto(`${weaver.baseUrl}/s/${s.id}?tab=overview`);
+
+    await expect(page.getByTestId('session-state')).toContainText('No status reported yet.');
+    // No documents, no links — the sections stay absent, not empty husks.
+    await expect(page.getByTestId('session-docs')).toHaveCount(0);
+    await expect(page.getByTestId('session-links')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Wires a session to a GitHub issue/PR thread and keeps the trigger's "On it" comment current: one status card, edited in place as the agent reports, so the thread shows the whole arc without notification spam.

## What changed

**The status card** (`loom::github`)
- The `@loom` trigger's "On it — {url}" reply becomes the session's status card: each `weaver status` report appends a bullet (🟢/🟠/🔴, UTC timestamp, message), edited in place via a new `update_issue_comment` on the `GithubApi` gateway (`post_issue_comment` now returns the comment id; a deleted comment reports `Ok(false)` → repost + re-stamp).
- The card links published artifacts (design/plan/report) into the dashboard viewer — names as links, not contents; posting content to the thread stays a deliberate act.
- Sync is spawned detached from the status endpoint and artifact-write routes; a process-wide mutex prevents double-posts, 3 attempts with backoff cover transient GitHub failures, and each attempt re-reads the trail so the final render is complete. Requires `auth.base_url` (same guard as the PR back-link).
- Relaunch (follow-up `@loom` on a dead session's thread) posts a fresh card, marks the old one superseded, and preserves the wiring's `set_at` so the trail survives.

**Wiring = tags**
- `github` tag (`owner/name#number`, format-validated at set time) wires any session by hand: `weaver tag set github acme/widgets#87`; `weaver tag rm github` stops mirroring.
- `github.status_comment` / `github.linked` are machine-owned bookkeeping: refused by the tag-set routes, hidden from the dashboard pill row. The comment id is trusted only while its note matches the current wiring, so re-pointing posts fresh instead of editing a stranger's thread.

**The trail is now real**
- `POST /api/branches/{key}/status` records the message as the tag event's note (previously only the latest message survived on `branches.description`) and propagates the event insert. The activity feed, `weaver log`, and the card all render the same progress log.
- `weaver summary` and bare `weaver status` print the wiring so the fact survives compaction.

**Entrance message + WEAVER.md**
- The launch prompt no longer pastes the goal: "Your task: {title}. Run `weaver summary` first…". Hookless runtimes (no WEAVER.md primer) still get the goal pasted — the prompt is their entire orientation.
- WEAVER.md tightened ~25%; "Working a GitHub issue" leads with the status-is-public contract; fixed the stale "talk directly to the weaver database" claim.

**Fix: pre-existing "database is locked" failures** (#503)
- weaver-core's multi-statement write transactions began deferred; the read→write upgrade under load returns SQLITE_BUSY immediately, bypassing `busy_timeout`. All such sites now use `db::begin_immediate` (`BEGIN IMMEDIATE`) and connections carry a 5s busy timeout — agent_cli goes 28/28 under load (reproduced failing on clean main).

## Testing
- loom + weaver-core + agent_cli suites green (incl. new webhook integration test asserting two status posts → two in-place edits of comment 1, one comment total)
- e2e Playwright 85/85 locally (CI does not run e2e)
- `cargo test --workspace`: 19 suites, all ok

Follow-ups filed: #499 (Overview → session brief), #500 (`weaver session` CLI mirror), #501 (live GH state in `weaver issue show`), #502 (forward-ack spam).

Design doc: https://loom.rjp.io/s/fi0jkawy/artifacts/design
Session: https://loom.rjp.io/s/fi0jkawy