### PR TITLE
fix(weaver): stop nested `claude -p` from firing the parent branch's hooks

### DIFF
--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -864,6 +864,16 @@ fn apply_launch_gates(root: &mut Value, seed: &GateSeed) -> bool {
 /// subprocess so it runs fresh and isolated (the lint-review precedent).
 /// Mirrors `scripts/lint-review.py`'s `STRIPPED_ENV`. Shared by the one-shot
 /// agent here and the watch script executor.
+///
+/// `WEAVER_BRANCH` is stripped for a subtler reason than the rest. A nested
+/// `claude -p` still reads the worktree's `.claude/settings.local.json` and
+/// fires the weaver lifecycle hooks (`SessionStart`/`Stop`/…) — verified against
+/// a real `claude`; `--settings '{"hooks":{}}'` does *not* suppress them. Left in
+/// the child's env, `$WEAVER_BRANCH` makes each hook write an `idle`/`working`
+/// event attributed to the *parent* branch, mid-turn, corrupting the very signal
+/// the dashboard and `loom session wait` key on. Stripping it makes `weaver hook`
+/// a no-op (it has no branch to key on). These agents are pipe-in/pipe-out — they
+/// never call the `weaver` CLI — so they lose nothing by not carrying it.
 pub const STRIPPED_ENV: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "CLAUDECODE",
@@ -871,6 +881,7 @@ pub const STRIPPED_ENV: &[&str] = &[
     "CLAUDE_CODE_EXECPATH",
     "CLAUDE_CODE_SESSION_ID",
     "CLAUDE_CODE_SSE_PORT",
+    "WEAVER_BRANCH",
 ];
 
 /// Spawn a one-shot headless agent: write `prompt` to its stdin, capture
@@ -981,6 +992,17 @@ mod tests {
         // The `"shell"` runtime in the test helper builds the same bare shell.
         let script = launch_script("shell", None, None, LaunchMode::Fresh, "", "");
         assert_eq!(script, "exec \"${SHELL:-/bin/sh}\"");
+    }
+
+    /// A nested headless agent must not carry `$WEAVER_BRANCH`, or it fires the
+    /// worktree's weaver lifecycle hooks against the parent branch (see the
+    /// constant's own docs). Guard the strip so it can't silently regress.
+    #[test]
+    fn stripped_env_drops_the_branch_marker() {
+        assert!(
+            STRIPPED_ENV.contains(&"WEAVER_BRANCH"),
+            "nested agents must not inherit $WEAVER_BRANCH: {STRIPPED_ENV:?}"
+        );
     }
 
     fn custom_agent(name: &str, setup: &str, launch: &str, resume: &str) -> CustomAgent {

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -218,12 +218,17 @@ review comment, an issue reply: no tradeoff, no review, just write the code.
    ask="Peer-review the design on stdin against this repo. What is wrong, missing,
    or over-built? Be concrete and blunt — no praise, no summary."
    weaver artifact show design | codex exec -s read-only "$ask"
-   weaver artifact show design | claude -p --model fable "$ask"
+   weaver artifact show design | env -u WEAVER_BRANCH claude -p --model fable "$ask"
    ```
 
    If you are `codex`: one of your own sub-agents, plus `claude -p --model fable`.
    Run both in the background and in parallel — each takes minutes. If a reviewer
    isn't on `PATH`, note it and go with one.
+
+   The `env -u WEAVER_BRANCH` is load-bearing: a nested `claude -p` reads this
+   worktree's `.claude/settings.local.json` and fires weaver's lifecycle hooks.
+   Carrying `$WEAVER_BRANCH` into it would stamp a spurious `idle` on your branch
+   mid-turn. Strip it from any `claude -p` you launch from inside the worktree.
 3. Incorporate the findings and rev the artifact. The reviews will be partly
    wrong; use judgment, not a patch queue. Fix what lands, record what you
    rejected and why. `weaver artifact write design` appends the revision. Only

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -1653,6 +1653,22 @@ fn compact_replay(b: &BranchView, summary: &str) -> String {
 }
 
 async fn cmd_hook(event: String) -> Result<()> {
+    // A nested, isolated agent — a headless `claude -p` review, lint, or one-shot
+    // spawned from inside a session — carries no `$WEAVER_BRANCH` (the spawner
+    // strips it precisely so the child doesn't impersonate the parent). It reads
+    // the worktree's `.claude/settings.local.json` all the same and fires these
+    // lifecycle hooks; with no branch to key on, the hook is intentionally inert.
+    // Return quietly — writing nothing, printing nothing — rather than surfacing
+    // the "not in a loom session" error `branch_key` would raise for a real
+    // command. This is the server-side half of the fix: even a nested agent that
+    // still fires the hook cannot stamp the parent branch's lifecycle.
+    if std::env::var("WEAVER_BRANCH")
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
+        return Ok(());
+    }
     // Hooks must never break the agent: best-effort, swallow errors.
     let result: Result<()> = (async {
         let client = client();

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -664,6 +664,38 @@ async fn hook_writes_an_event_row() {
     );
 }
 
+/// A nested, isolated agent (a headless `claude -p` review/lint/one-shot) still
+/// fires the worktree's weaver lifecycle hooks, but the spawner strips
+/// `$WEAVER_BRANCH` so the child cannot impersonate the parent. With no branch to
+/// key on, `weaver hook` must be a silent no-op: exit 0, print nothing, and — the
+/// load-bearing part — write no event that would stamp the parent branch's
+/// lifecycle mid-turn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn hook_without_weaver_branch_is_a_silent_no_op() {
+    let env = Env::start().await;
+    let out = std::process::Command::new(weaver_bin())
+        .args(["hook", "--event", "idle"])
+        .env("WEAVER_API", format!("http://{}", env.addr))
+        .env_remove("WEAVER_BRANCH")
+        .env_remove("LOOM_TOKEN")
+        .output()
+        .expect("failed to spawn weaver");
+    assert!(out.status.success(), "the hook must never fail the agent");
+    assert!(
+        out.stdout.is_empty() && out.stderr.is_empty(),
+        "a branchless hook must be silent: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    // And it recorded nothing against the seeded branch — the whole point.
+    let log = env.run(&["log"]);
+    assert!(
+        !log.contains("idle") && !log.contains("hook"),
+        "a branchless hook must not write an event: {log}"
+    );
+}
+
 /// `weaver readme` prints the full weaver workflow guide so an agent can pull
 /// the rules back on demand (e.g. after a compaction replayed only the catch-up).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/scripts/lint-review.py
+++ b/scripts/lint-review.py
@@ -60,6 +60,13 @@ INSTRUCTIONS = (
 # Markers of the *calling* Claude Code session. Stripped before exec so the
 # sub-agent runs as a fresh, isolated session on subscription auth — not nested
 # in our transcript, not billed via the metered API key.
+#
+# WEAVER_BRANCH is stripped for a different reason: the sub-agent still reads the
+# worktree's .claude/settings.local.json and fires weaver's lifecycle hooks. Left
+# in its env, $WEAVER_BRANCH would make each hook stamp an idle/working event on
+# the *parent* branch mid-review, corrupting the dashboard and `loom session wait`
+# signal. Stripping it makes `weaver hook` a no-op. (Mirrors the Rust STRIPPED_ENV
+# in crates/loom/src/agent.rs.)
 STRIPPED_ENV = (
     "ANTHROPIC_API_KEY",
     "CLAUDECODE",
@@ -67,6 +74,7 @@ STRIPPED_ENV = (
     "CLAUDE_CODE_EXECPATH",
     "CLAUDE_CODE_SESSION_ID",
     "CLAUDE_CODE_SSE_PORT",
+    "WEAVER_BRANCH",
 )
 
 # Catalog "Output format":  <path>:<line>: <code> (<confidence>) <message>


### PR DESCRIPTION
## Problem

A worktree's `.claude/settings.local.json` installs `SessionStart`/`UserPromptSubmit`/`Notification`/`Stop` hooks that run `weaver hook`, which resolves the branch it reports against from `$WEAVER_BRANCH`. Any nested headless `claude -p` launched from inside the worktree — the WEAVER.md peer-review loop, `scripts/lint-review.py`, `run_oneshot`, the watch executor — reads that **same project settings file** and fires those lifecycle hooks. With `$WEAVER_BRANCH` inherited, each firing stamps an `idle`/`working` event on the **parent** branch, mid-turn, corrupting the exact signal the dashboard and `loom session wait` key on (`monitor.rs::apply_hook` → `IDLE_KEY`).

## Verified against a real `claude`

Reproduced with an isolated stub-hook project:

| Invocation | Hooks fired on parent? |
|---|---|
| baseline nested `claude -p` | **yes** — `session-start`, `working`, **`idle`** |
| `--settings '{"hooks":{}}'` (inline / file / empty per-event arrays) | **yes, still fired** — `--settings` does *not* override project hooks; they union across scopes |
| `--bare` | no, but breaks auth (`Not logged in`) and drops CLAUDE.md/skills |
| strip `WEAVER_BRANCH` | fire but **no-op** (`weaver hook` has no branch to key on) |

So the `--settings` override is a dead end here; stripping the env the hook keys on is the one clean lever.

## Fix

- Add `WEAVER_BRANCH` to `STRIPPED_ENV` (Rust — shared by `run_oneshot` + the watch executor) and to `scripts/lint-review.py`'s mirror. These agents are pipe-in/pipe-out and never call the `weaver` CLI, so they lose nothing.
- WEAVER.md's hand-run peer-review `claude -p` gets `env -u WEAVER_BRANCH`, with a note explaining why.
- `weaver hook` returns a silent no-op when `WEAVER_BRANCH` is absent — the server-side half, so a nested agent that still fires the hook writes nothing and prints nothing.

## Tests

- `hook_without_weaver_branch_is_a_silent_no_op` (agent_cli): the real `weaver hook` binary with no `WEAVER_BRANCH` exits 0, is silent, and records no event.
- `stripped_env_drops_the_branch_marker` (loom): regression guard on the strip.

Closes #457.