### PR TITLE
feat(tapestry,loom): relay mode — durable frame spool for ACP agents

### DIFF
--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -88,6 +88,8 @@ pub async fn new_session(
         env,
         cols: 80,
         rows: 24,
+        mode: tapestry::Mode::Pty,
+        segment_max_bytes: None,
         supervisor_bin: tapestry_bin().as_deref(),
     })
     .await;
@@ -96,6 +98,66 @@ pub async fn new_session(
         Err(e) => tracing::warn!(session = %name, error = %e, "failed to spawn terminal session"),
     }
     result
+}
+
+/// Create a detached **relay** session: the supervisor spawns `script` via
+/// `sh -c` in `cwd` over plain pipes (no PTY), spooling the child's stdout as
+/// newline-delimited frames for a subscriber to replay/stream. The seam for ACP
+/// agents; PTY sessions keep [`new_session`].
+///
+/// `env` is delivered out of band exactly as [`new_session`] does it, so secret
+/// values never touch argv. [`has_session`]/[`kill_session`] work unchanged for
+/// relay sessions (the control socket is the same).
+pub async fn new_relay_session(
+    name: &str,
+    script: &str,
+    env: &[(&str, &str)],
+    cwd: &std::path::Path,
+) -> Result<()> {
+    tracing::info!(session = %name, cwd = %cwd.display(), "spawning relay session");
+    let result = tapestry::spawn_detached(&tapestry::LaunchOptions {
+        name,
+        cwd,
+        script,
+        env,
+        cols: 80,
+        rows: 24,
+        mode: tapestry::Mode::Relay,
+        segment_max_bytes: None,
+        supervisor_bin: tapestry_bin().as_deref(),
+    })
+    .await;
+    match &result {
+        Ok(()) => tracing::info!(session = %name, "relay session spawned"),
+        Err(e) => tracing::warn!(session = %name, error = %e, "failed to spawn relay session"),
+    }
+    result
+}
+
+/// Subscribe to a relay session's frame stream from `cursor`: the returned
+/// [`tapestry::RelayStream`] replays every spooled frame with `seq > cursor`,
+/// then streams live frames, then a terminal `Exit`. Only one subscriber exists
+/// at a time — this evicts any previous one.
+pub async fn subscribe_relay(name: &str, cursor: u64) -> Result<tapestry::RelayStream> {
+    tapestry::Client::connect(name)
+        .await?
+        .subscribe(cursor)
+        .await
+}
+
+/// Append raw bytes to a relay session's child stdin (complete newline-terminated
+/// frames; the relay writes them through untouched).
+pub async fn relay_write(name: &str, bytes: &[u8]) -> Result<()> {
+    let mut c = tapestry::Client::connect(name).await?;
+    c.relay_write(bytes).await
+}
+
+/// Advance a relay session's retention watermark to `seq` — everything up to and
+/// including it has been durably processed, so fully-acked spool segments can be
+/// dropped.
+pub async fn relay_ack(name: &str, seq: u64) -> Result<()> {
+    let mut c = tapestry::Client::connect(name).await?;
+    c.relay_ack(seq).await
 }
 
 /// Render the session's screen to text; `history` extra scrollback lines.

--- a/crates/tapestry/src/bin/tapestry.rs
+++ b/crates/tapestry/src/bin/tapestry.rs
@@ -116,6 +116,8 @@ async fn main() -> Result<()> {
                 env: &[],
                 cols: 80,
                 rows: 24,
+                mode: tapestry::Mode::Pty,
+                segment_max_bytes: None,
                 supervisor_bin: None, // current_exe is the tapestry binary
             })
             .await?;

--- a/crates/tapestry/src/client.rs
+++ b/crates/tapestry/src/client.rs
@@ -86,6 +86,68 @@ impl Client {
         self.expect_ok().await
     }
 
+    /// (Relay) Append raw bytes to the child's stdin — a one-shot `WRITE` outside
+    /// a subscribe (the streaming equivalent is [`RelayStream::write`]). The
+    /// caller sends complete newline-terminated frames; the relay writes bytes
+    /// through untouched.
+    pub async fn relay_write(&mut self, bytes: &[u8]) -> Result<()> {
+        protocol::write_frame(&mut self.stream, &req::write(bytes.to_vec())).await?;
+        self.expect_ok().await
+    }
+
+    /// (Relay) Advance the retention watermark — everything up to and including
+    /// `seq` has been durably processed. A one-shot `ACK` outside a subscribe (the
+    /// streaming equivalent is [`RelayStream::ack`]).
+    pub async fn relay_ack(&mut self, seq: u64) -> Result<()> {
+        protocol::write_frame(&mut self.stream, &req::ack(seq)).await?;
+        self.expect_ok().await
+    }
+
+    /// (Relay) Switch this connection into a subscribe: the returned
+    /// [`RelayStream`] first replays every spooled frame with `seq > cursor`, then
+    /// streams live frames, and finally an [`RelayEvent::Exit`] once the child has
+    /// exited. Only one subscriber exists at a time — this evicts any previous one.
+    pub async fn subscribe(self, cursor: u64) -> Result<RelayStream> {
+        let mut stream = self.stream;
+        protocol::write_frame(&mut stream, &req::subscribe(cursor)).await?;
+        let (rd, wr) = stream.into_split();
+
+        // A background reader decodes FRAME/EXIT frames into a bounded channel;
+        // `send().await` back-pressures the socket (and thus the supervisor) when
+        // the consumer is slow, mirroring the attach path.
+        let (ev_tx, ev_rx) = mpsc::channel::<RelayEvent>(ATTACH_BUFFER);
+        tokio::spawn(async move {
+            let mut rd = rd;
+            loop {
+                match protocol::read_frame(&mut rd).await {
+                    Ok(Some(frame)) if frame.op == op::FRAME => {
+                        let Some((seq, body)) = frame.as_relay_frame() else {
+                            continue;
+                        };
+                        let ev = RelayEvent::Frame {
+                            seq,
+                            payload: body.to_vec(),
+                        };
+                        if ev_tx.send(ev).await.is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Some(frame)) if frame.op == op::EXIT => {
+                        let status =
+                            serde_json::from_slice::<Option<i32>>(&frame.payload).unwrap_or(None);
+                        let _ = ev_tx.send(RelayEvent::Exit { status }).await;
+                        // EXIT is terminal for the stream; nothing follows it.
+                        break;
+                    }
+                    Ok(Some(_)) => {} // ignore stray frames
+                    Ok(None) | Err(_) => break,
+                }
+            }
+        });
+
+        Ok(RelayStream { wr, ev_rx })
+    }
+
     /// Switch this connection into an interactive attach at the given size. The
     /// returned [`Attach`] streams PTY output and accepts input/resize; the
     /// first output chunk is a full repaint of the current screen.
@@ -198,5 +260,45 @@ impl AttachOutput {
     /// The next chunk of PTY output, or `None` once the stream ends.
     pub async fn recv(&mut self) -> Option<Vec<u8>> {
         self.out_rx.recv().await
+    }
+}
+
+/// One event from a relay [`RelayStream`]: a relayed child-stdout frame, or the
+/// child's exit. `Exit` is terminal — no event follows it.
+#[derive(Debug, Clone)]
+pub enum RelayEvent {
+    /// A relayed child-stdout frame with its spool sequence number.
+    Frame { seq: u64, payload: Vec<u8> },
+    /// The child exited. `status` is its code (a signal death is `128 + signal`),
+    /// or `None` if unknown.
+    Exit { status: Option<i32> },
+}
+
+/// A live relay subscription: receive [`RelayEvent`]s (replayed then live frames,
+/// then a terminal `Exit`), and send `ACK`/`WRITE` back to the supervisor.
+/// Dropping it closes the connection, which the supervisor sees as an
+/// unsubscribe (the child keeps running).
+pub struct RelayStream {
+    wr: OwnedWriteHalf,
+    ev_rx: mpsc::Receiver<RelayEvent>,
+}
+
+impl RelayStream {
+    /// The next relay event, or `None` once the stream ends (the socket closed).
+    pub async fn recv(&mut self) -> Option<RelayEvent> {
+        self.ev_rx.recv().await
+    }
+
+    /// Advance the retention watermark: everything up to and including `seq` has
+    /// been durably processed, so the supervisor may drop fully-acked spool
+    /// segments.
+    pub async fn ack(&mut self, seq: u64) -> Result<()> {
+        protocol::write_frame(&mut self.wr, &req::ack(seq)).await
+    }
+
+    /// Append raw bytes to the child's stdin (send complete newline-terminated
+    /// frames; the relay writes them through untouched).
+    pub async fn write(&mut self, bytes: &[u8]) -> Result<()> {
+        protocol::write_frame(&mut self.wr, &req::write(bytes.to_vec())).await
     }
 }

--- a/crates/tapestry/src/lib.rs
+++ b/crates/tapestry/src/lib.rs
@@ -25,13 +25,28 @@ pub mod paths;
 pub mod protocol;
 pub mod supervisor;
 
-pub use client::{Attach, AttachInput, AttachOutput, Client};
+pub use client::{Attach, AttachInput, AttachOutput, Client, RelayEvent, RelayStream};
 pub use supervisor::{run as supervise, SupervisorConfig};
 
 use anyhow::{Context, Result};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Stdio;
+
+/// Which backend a supervisor runs. `Pty` is the historical terminal supervisor
+/// (a PTY + vt100 screen, raw-byte attach); `Relay` is the ACP frame relay
+/// (piped stdio, a durable on-disk frame spool, subscribe/ack/write). The two
+/// share the process scaffolding — detached spawn, spec over stdin, control
+/// socket, process-group kill — and differ only in what the core task owns.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Mode {
+    /// PTY + vt100 screen (the default; what an omitted `mode` in the spec means).
+    #[default]
+    Pty,
+    /// Piped stdio + frame spool (ACP agents).
+    Relay,
+}
 
 /// Options for launching a session. Mirrors what loom passes to
 /// `backend::new_session` plus the agent environment.
@@ -48,6 +63,13 @@ pub struct LaunchOptions<'a> {
     pub env: &'a [(&'a str, &'a str)],
     pub cols: u16,
     pub rows: u16,
+    /// Which backend to run. [`Mode::Pty`] (the default) keeps the historical
+    /// terminal supervisor; [`Mode::Relay`] runs the ACP frame relay.
+    pub mode: Mode,
+    /// (Relay) Roll to a fresh spool segment once the active one exceeds this
+    /// many bytes. `None` uses the supervisor default (a few MiB). Exposed mainly
+    /// so tests can force rotation with a tiny value; ignored in PTY mode.
+    pub segment_max_bytes: Option<u64>,
     /// The supervisor binary to re-exec as `<bin> supervise <spec>`. `None` uses
     /// the current executable — correct when the caller *is* the `tapestry`
     /// binary (the standalone CLI). A host like loom, whose `current_exe` is
@@ -81,6 +103,8 @@ pub async fn spawn_detached(opts: &LaunchOptions<'_>) -> Result<()> {
         "env": opts.env,
         "cols": opts.cols,
         "rows": opts.rows,
+        "mode": opts.mode,
+        "segment_max_bytes": opts.segment_max_bytes,
     });
 
     let mut cmd = std::process::Command::new(&exe);
@@ -145,6 +169,14 @@ pub struct LaunchSpec {
     pub env: Vec<(String, String)>,
     pub cols: u16,
     pub rows: u16,
+    /// Backend mode. Absent in specs written before relay mode existed, so it
+    /// defaults to [`Mode::Pty`] — the historical behaviour, preserved for
+    /// back-compat.
+    #[serde(default)]
+    pub mode: Mode,
+    /// (Relay) Spool segment-rotation threshold in bytes; `None` = default.
+    #[serde(default)]
+    pub segment_max_bytes: Option<u64>,
 }
 
 impl From<LaunchSpec> for SupervisorConfig {
@@ -156,6 +188,8 @@ impl From<LaunchSpec> for SupervisorConfig {
             env: s.env,
             cols: s.cols,
             rows: s.rows,
+            mode: s.mode,
+            segment_max_bytes: s.segment_max_bytes,
         }
     }
 }

--- a/crates/tapestry/src/paths.rs
+++ b/crates/tapestry/src/paths.rs
@@ -27,6 +27,20 @@ pub fn socket_path(name: &str) -> PathBuf {
     run_dir().join(format!("{}.sock", sanitize(name)))
 }
 
+/// The relay frame-spool directory for a session — a directory of segment files
+/// (`<first-seq>.seg`) living beside the control socket. Only relay-mode
+/// supervisors create it; it outlives *client* restarts (not supervisor
+/// restarts), so the frames a dead subscriber missed can be replayed.
+pub fn spool_dir(name: &str) -> PathBuf {
+    run_dir().join(format!("{}.spool", sanitize(name)))
+}
+
+/// The relay stderr log for a session — the child's stderr, appended verbatim,
+/// beside the control socket.
+pub fn stderr_log_path(name: &str) -> PathBuf {
+    run_dir().join(format!("{}.stderr.log", sanitize(name)))
+}
+
 /// Reduce a session name to a single safe filename component: ASCII
 /// alphanumerics plus `-`/`_` survive, everything else (path separators, `.`,
 /// NUL, …) becomes `_`. This forecloses `../` traversal and absolute-path

--- a/crates/tapestry/src/protocol.rs
+++ b/crates/tapestry/src/protocol.rs
@@ -17,9 +17,16 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 /// Opcodes. Client→server requests are the low range; server→client replies are
 /// the high range; the two attach-stream opcodes (`INPUT`/`RESIZE`) are shared
 /// with the terminal.rs bridge shape (`0x00`/`0x01`).
+///
+/// The relay-mode opcodes ([`SUBSCRIBE`](op::SUBSCRIBE)/[`FRAME`](op::FRAME)/
+/// [`ACK`](op::ACK)/[`WRITE`](op::WRITE)/[`EXIT`](op::EXIT)) are purely additive:
+/// they sit beside the PTY set (`SUBSCRIBE` next to `ATTACH`, `FRAME`/`EXIT` next
+/// to `OUTPUT`), so an older peer that never sends them is unaffected, and a PTY
+/// session never emits them.
 pub mod op {
     // Client → server, one-shot requests.
     /// Render the current screen to text. Payload: `u32` scrollback rows.
+    /// (Relay mode: returns a short UTF-8 status summary instead of a screen.)
     pub const CAPTURE: u8 = 0x10;
     /// Write bytes to the PTY verbatim (the `send-keys -l` analogue). Payload: raw bytes.
     pub const SEND: u8 = 0x11;
@@ -32,16 +39,28 @@ pub mod op {
     /// Switch this connection to the live terminal stream. Payload: `u16` cols,
     /// `u16` rows (the attaching client's initial size).
     pub const ATTACH: u8 = 0x20;
+    /// (Relay) Switch this connection to the live frame stream, replaying every
+    /// spooled frame with `seq > cursor` first. Payload: `u64` cursor.
+    pub const SUBSCRIBE: u8 = 0x21;
+    /// (Relay) Advance the retention watermark — the client has durably processed
+    /// everything up to and including this seq. Payload: `u64` seq. Valid both
+    /// one-shot and in-stream (after a [`SUBSCRIBE`]).
+    pub const ACK: u8 = 0x22;
+    /// (Relay) Append raw bytes to the child's stdin. Payload: raw bytes. Valid
+    /// both one-shot and in-stream (after a [`SUBSCRIBE`]).
+    pub const WRITE: u8 = 0x23;
 
     // During an attach, client → server.
     /// Keystrokes to forward to the PTY. Payload: raw bytes.
     pub const INPUT: u8 = 0x00;
     // RESIZE (0x12) is reused for in-stream resizes.
+    // ACK (0x22) / WRITE (0x23) double as the in-stream client→server ops for a
+    // relay subscribe (the INPUT/RESIZE analogues).
 
     // Server → client.
     /// Reply to [`CAPTURE`]. Payload: UTF-8 screen text.
     pub const CAPTURE_RESP: u8 = 0x80;
-    /// Generic success for [`SEND`]/[`RESIZE`]/[`KILL`]. No payload.
+    /// Generic success for [`SEND`]/[`RESIZE`]/[`KILL`]/[`ACK`]/[`WRITE`]. No payload.
     pub const OK: u8 = 0x81;
     /// Reply to [`PING`]. Payload: JSON [`PongInfo`].
     pub const PONG: u8 = 0x82;
@@ -49,16 +68,44 @@ pub mod op {
     pub const ERR: u8 = 0x83;
     /// A chunk of PTY output during an attach. Payload: raw bytes.
     pub const OUTPUT: u8 = 0x90;
+    /// (Relay) One relayed child-stdout frame. Payload: `u64` seq + frame bytes.
+    pub const FRAME: u8 = 0x91;
+    /// (Relay) The child exited. Payload: JSON `Option<i32>` exit code (a
+    /// signal death maps to `128 + signal`). Sent once to the live subscriber.
+    pub const EXIT: u8 = 0x92;
 }
 
 /// Reply to a [`PING`](op::PING): whether the child is alive plus a little info.
+///
+/// The relay-mode fields (`relay`, `exited`, `spooled`, `acked`) all carry
+/// `#[serde(default)]`, so a PONG from an older PTY-only supervisor still decodes
+/// and a PTY session simply reports the defaults (`relay = false`, no `exited`,
+/// zero seqs).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PongInfo {
+    /// Whether the *supervisor* is serving. For a PTY session this always means
+    /// the child runs too (the supervisor tears down on child exit); a relay
+    /// supervisor outlives its child, so `alive` stays true after exit — read
+    /// [`Self::exited`] for the child's state.
     pub alive: bool,
     pub pid: Option<u32>,
     pub cols: u16,
     pub rows: u16,
     pub alternate_screen: bool,
+    /// Relay mode (piped stdio + frame spool) rather than a PTY.
+    #[serde(default)]
+    pub relay: bool,
+    /// (Relay) The child's exit code once it has exited, else `None` while it
+    /// still runs. A signal death is reported as `128 + signal`.
+    #[serde(default)]
+    pub exited: Option<i32>,
+    /// (Relay) The highest sequence number assigned to a spooled frame (0 before
+    /// the first frame).
+    #[serde(default)]
+    pub spooled: u64,
+    /// (Relay) The retention watermark — the highest acked seq.
+    #[serde(default)]
+    pub acked: u64,
 }
 
 /// Cap on a single inbound frame body (16 MiB). Bounds a hostile or buggy peer's
@@ -108,6 +155,42 @@ impl Frame {
         } else {
             0
         }
+    }
+
+    /// A frame whose whole payload is a single big-endian `u64` (subscribe
+    /// cursor / ack seq).
+    pub fn u64(op: u8, v: u64) -> Self {
+        Self::new(op, v.to_be_bytes().to_vec())
+    }
+
+    /// Decode a leading big-endian `u64` from the payload, defaulting to 0.
+    pub fn as_u64(&self) -> u64 {
+        if self.payload.len() >= 8 {
+            let mut b = [0u8; 8];
+            b.copy_from_slice(&self.payload[..8]);
+            u64::from_be_bytes(b)
+        } else {
+            0
+        }
+    }
+
+    /// A [`FRAME`](op::FRAME): an 8-byte big-endian seq followed by the frame bytes.
+    pub fn relay_frame(seq: u64, body: &[u8]) -> Self {
+        let mut p = Vec::with_capacity(8 + body.len());
+        p.extend_from_slice(&seq.to_be_bytes());
+        p.extend_from_slice(body);
+        Self::new(op::FRAME, p)
+    }
+
+    /// Decode a [`FRAME`](op::FRAME) payload into `(seq, body)`, or `None` if it
+    /// is too short to carry a seq.
+    pub fn as_relay_frame(&self) -> Option<(u64, &[u8])> {
+        if self.payload.len() < 8 {
+            return None;
+        }
+        let mut b = [0u8; 8];
+        b.copy_from_slice(&self.payload[..8]);
+        Some((u64::from_be_bytes(b), &self.payload[8..]))
     }
 }
 
@@ -169,5 +252,14 @@ pub mod req {
     }
     pub fn input(data: Vec<u8>) -> Frame {
         Frame::new(op::INPUT, data)
+    }
+    pub fn subscribe(cursor: u64) -> Frame {
+        Frame::u64(op::SUBSCRIBE, cursor)
+    }
+    pub fn ack(seq: u64) -> Frame {
+        Frame::u64(op::ACK, seq)
+    }
+    pub fn write(data: Vec<u8>) -> Frame {
+        Frame::new(op::WRITE, data)
     }
 }

--- a/crates/tapestry/src/supervisor.rs
+++ b/crates/tapestry/src/supervisor.rs
@@ -68,9 +68,42 @@ pub struct SupervisorConfig {
     pub script: String,
     /// Extra environment for the child, on top of the inherited environment.
     pub env: Vec<(String, String)>,
-    /// Initial PTY size.
+    /// Initial PTY size (relay mode ignores it — there is no PTY).
     pub cols: u16,
     pub rows: u16,
+    /// Which backend to run: PTY + vt100 screen, or the ACP frame relay.
+    pub mode: crate::Mode,
+    /// (Relay) Spool segment-rotation threshold in bytes; `None` = default.
+    pub segment_max_bytes: Option<u64>,
+}
+
+/// Create the run directory and clear a stale socket for `name`, returning the
+/// control-socket path to bind. Shared by both backends. A *live* supervisor
+/// already listening is refused rather than clobbered.
+async fn prepare_socket(name: &str) -> Result<PathBuf> {
+    let socket = crate::paths::socket_path(name);
+    if let Some(parent) = socket.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating run dir {}", parent.display()))?;
+    }
+    // A stale socket from a prior crash would make bind() fail with EADDRINUSE.
+    // A successful connect proves a live supervisor is already listening for this
+    // name — refuse rather than clobber it; otherwise the file is stale, remove it.
+    if socket.exists() {
+        if tokio::net::UnixStream::connect(&socket).await.is_ok() {
+            anyhow::bail!("session {name} already has a live supervisor");
+        }
+        let _ = std::fs::remove_file(&socket);
+    }
+    Ok(socket)
+}
+
+/// Run the supervisor to completion, dispatching on the backend mode.
+pub async fn run(cfg: SupervisorConfig) -> Result<()> {
+    match cfg.mode {
+        crate::Mode::Pty => run_pty(cfg).await,
+        crate::Mode::Relay => relay::run(cfg).await,
+    }
 }
 
 /// Control messages to the core task. The single owner of screen + client state.
@@ -104,24 +137,11 @@ enum Cmd {
     ChildExited,
 }
 
-/// Run the supervisor to completion: bring up the PTY + child, serve the control
-/// socket, and return once the child exits or a [`Kill`](Cmd::Kill) arrives. The
-/// socket file is removed on the way out.
-pub async fn run(cfg: SupervisorConfig) -> Result<()> {
-    let socket = crate::paths::socket_path(&cfg.name);
-    if let Some(parent) = socket.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating run dir {}", parent.display()))?;
-    }
-    // A stale socket from a prior crash would make bind() fail with EADDRINUSE.
-    // A successful connect proves a live supervisor is already listening for this
-    // name — refuse rather than clobber it; otherwise the file is stale, remove it.
-    if socket.exists() {
-        if tokio::net::UnixStream::connect(&socket).await.is_ok() {
-            anyhow::bail!("session {} already has a live supervisor", cfg.name);
-        }
-        let _ = std::fs::remove_file(&socket);
-    }
+/// Run a PTY supervisor to completion: bring up the PTY + child, serve the
+/// control socket, and return once the child exits or a [`Kill`](Cmd::Kill)
+/// arrives. The socket file is removed on the way out.
+async fn run_pty(cfg: SupervisorConfig) -> Result<()> {
+    let socket = prepare_socket(&cfg.name).await?;
 
     // --- PTY + child -------------------------------------------------------
     let pty_system = native_pty_system();
@@ -274,6 +294,12 @@ pub async fn run(cfg: SupervisorConfig) -> Result<()> {
                             cols,
                             rows,
                             alternate_screen: parser.screen().alternate_screen(),
+                            // PTY sessions are not relays; the relay-only fields
+                            // stay at their defaults.
+                            relay: false,
+                            exited: None,
+                            spooled: 0,
+                            acked: 0,
                         });
                     }
                     Cmd::Attach { cols, rows, out_tx, resp } => {
@@ -534,4 +560,724 @@ async fn handle_attach(
     }
     let _ = cmd_tx.send(Cmd::Detach(sub_id));
     Ok(())
+}
+
+/// The **relay** backend: pipe the child's stdio (no PTY, no vt100) and act as a
+/// durable frame relay between it and a possibly-absent, possibly-reconnecting
+/// subscriber.
+///
+/// Shape mirrors the PTY supervisor — a single core task owns the mutable state
+/// (the on-disk [`Spool`] and the one subscriber), fed by helper threads:
+///
+/// * a **reader thread** splits child stdout into newline-delimited frames (no
+///   JSON parsing — framing only) and `blocking_send`s them into a bounded
+///   channel, so a slow subscriber back-pressures the child;
+/// * a **stderr thread** appends child stderr to a per-session log file;
+/// * a **writer thread** drains client `WRITE`s into the child's stdin;
+/// * a **wait thread** reaps the child and reports its exit code.
+///
+/// Unlike the PTY supervisor, the core does **not** shut down when the child
+/// exits: it records the status, tells the live subscriber (after the last
+/// frame), and keeps serving so the spool and stderr log stay queryable and a
+/// late client can still subscribe/replay. Only an explicit `KILL` (or SIGTERM)
+/// tears it down.
+mod relay {
+    use super::*;
+    use std::io::{BufRead, Read, Write};
+    use std::os::unix::process::CommandExt;
+    use std::path::Path;
+    use std::process::Stdio;
+
+    /// Default spool segment-rotation threshold (4 MiB): enough headroom that
+    /// rotation is rare, small enough that a fully-acked segment frees promptly.
+    const DEFAULT_SEGMENT_BYTES: u64 = 4 * 1024 * 1024;
+    /// Frame backlog buffered from the reader thread before its `blocking_send`
+    /// parks and back-pressures the child — the relay analogue of `OUTPUT_BOUND`.
+    const FRAME_BOUND: usize = 256;
+    /// stderr read-chunk size.
+    const STDERR_BUF: usize = 32 * 1024;
+
+    /// A server→client message bound for the live subscriber.
+    enum Out {
+        Frame { seq: u64, body: Vec<u8> },
+        Exit { code: i32 },
+    }
+
+    /// Control messages to the relay core (the single owner of the spool +
+    /// subscriber). Spooled frames travel on their own bounded channel (so the
+    /// reader thread can park under back-pressure), not through here.
+    enum Cmd {
+        /// Append bytes to the child's stdin.
+        Write(Vec<u8>),
+        /// Advance the retention watermark.
+        Ack(u64),
+        /// Begin streaming: replay every spooled frame with `seq > cursor`, then
+        /// register as the live subscriber (evicting any previous one). Replies
+        /// with the subscriber id once replay + registration finish.
+        Subscribe {
+            cursor: u64,
+            out_tx: mpsc::Sender<Out>,
+            resp: oneshot::Sender<u64>,
+        },
+        /// A subscriber's connection ended; clear it if still current.
+        Unsubscribe(u64),
+        /// A short textual status summary (the relay's `CAPTURE` answer).
+        Capture { resp: oneshot::Sender<String> },
+        /// Liveness + info.
+        Ping { resp: oneshot::Sender<PongInfo> },
+        /// Kill the child's process group and shut the supervisor down.
+        Kill,
+        /// The child exited with this code (a signal death is `128 + signal`).
+        ChildExited(i32),
+    }
+
+    /// Run a relay supervisor to completion. Returns on `KILL`/SIGTERM (an
+    /// on-its-own child exit does *not* return — see the type docs).
+    pub async fn run(cfg: SupervisorConfig) -> Result<()> {
+        let socket = super::prepare_socket(&cfg.name).await?;
+        let segment_max = cfg
+            .segment_max_bytes
+            .unwrap_or(DEFAULT_SEGMENT_BYTES)
+            .max(1);
+
+        // --- child over pipes ---------------------------------------------
+        let mut cmd = std::process::Command::new("sh");
+        cmd.arg("-c")
+            .arg(&cfg.script)
+            .current_dir(&cfg.cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for (k, v) in &cfg.env {
+            cmd.env(k, v);
+        }
+        // Lead a new session so the child is its own process-group leader — then
+        // `KILL` can SIGKILL the whole group (the adapter and anything it spawns),
+        // exactly as the PTY path relies on portable_pty's setsid.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = cmd.spawn().context("spawning relay child")?;
+        let child_pid: Option<u32> = Some(child.id());
+        let mut stdin = child.stdin.take().context("relay child stdin missing")?;
+        let stdout = child.stdout.take().context("relay child stdout missing")?;
+        let stderr = child.stderr.take().context("relay child stderr missing")?;
+
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<Cmd>();
+
+        // Reader: child stdout → newline frames → bounded channel.
+        let (frame_tx, mut frame_rx) = mpsc::channel::<Vec<u8>>(FRAME_BOUND);
+        std::thread::spawn(move || {
+            let mut reader = std::io::BufReader::new(stdout);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_until(b'\n', &mut buf) {
+                    Ok(0) | Err(_) => break, // EOF or read error
+                    Ok(_) => {
+                        // Strip the delimiter; forward any non-empty line verbatim
+                        // (the relay never parses the JSON — framing only).
+                        let line = buf.strip_suffix(b"\n").unwrap_or(&buf);
+                        if line.is_empty() {
+                            continue;
+                        }
+                        if frame_tx.blocking_send(line.to_vec()).is_err() {
+                            break; // core gone
+                        }
+                    }
+                }
+            }
+        });
+
+        // stderr: child stderr → per-session log, created fresh on spawn.
+        let stderr_path = crate::paths::stderr_log_path(&cfg.name);
+        let stderr_file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&stderr_path)
+            .with_context(|| format!("creating stderr log {}", stderr_path.display()))?;
+        std::thread::spawn(move || {
+            let mut reader = stderr;
+            let mut file = stderr_file;
+            let mut buf = [0u8; STDERR_BUF];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        if file.write_all(&buf[..n]).is_err() {
+                            break;
+                        }
+                        let _ = file.flush();
+                    }
+                }
+            }
+        });
+
+        // Writer: mpsc → child stdin.
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let writer_thread = std::thread::spawn(move || {
+            while let Some(bytes) = write_rx.blocking_recv() {
+                if stdin.write_all(&bytes).is_err() {
+                    break;
+                }
+                let _ = stdin.flush();
+            }
+        });
+
+        // Wait: reap the child → Cmd::ChildExited(code).
+        {
+            let cmd_tx = cmd_tx.clone();
+            std::thread::spawn(move || {
+                let code = child.wait().map(exit_code).unwrap_or(-1);
+                let _ = cmd_tx.send(Cmd::ChildExited(code));
+            });
+        }
+
+        // --- socket listener ----------------------------------------------
+        let listener = UnixListener::bind(&socket)
+            .with_context(|| format!("binding control socket {}", socket.display()))?;
+        {
+            let cmd_tx = cmd_tx.clone();
+            tokio::spawn(async move {
+                loop {
+                    match listener.accept().await {
+                        Ok((stream, _)) => {
+                            let cmd_tx = cmd_tx.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = handle_conn(stream, cmd_tx).await {
+                                    tracing::debug!(error = %e, "relay control connection ended");
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            tracing::debug!(error = %e, "relay accept failed");
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+
+        // SIGTERM tears down (kills the child) like the PTY path.
+        {
+            let cmd_tx = cmd_tx.clone();
+            tokio::spawn(async move {
+                if let Ok(mut sig) =
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                {
+                    sig.recv().await;
+                    let _ = cmd_tx.send(Cmd::Kill);
+                }
+            });
+        }
+
+        // --- core task ----------------------------------------------------
+        let mut spool = Spool::create(crate::paths::spool_dir(&cfg.name), segment_max)
+            .context("creating frame spool")?;
+        let mut subscriber: Option<(u64, mpsc::Sender<Out>)> = None;
+        let mut next_sub_id: u64 = 0;
+        let mut exited: Option<i32> = None;
+        let mut frame_open = true;
+        // Set once the child has exited *and* its stdout has fully drained into
+        // the spool — the point after which `EXIT` may be delivered (so it always
+        // trails the child's last frame, live or replayed).
+        let mut finished = false;
+
+        loop {
+            tokio::select! {
+                // Poll control ahead of frames so ping/kill stay responsive.
+                biased;
+                cmd = cmd_rx.recv() => {
+                    let Some(cmd) = cmd else { break };
+                    match cmd {
+                        Cmd::Write(bytes) => {
+                            let _ = write_tx.send(bytes);
+                        }
+                        Cmd::Ack(seq) => {
+                            spool.set_ack(seq);
+                        }
+                        Cmd::Subscribe { cursor, out_tx, resp } => {
+                            // A new subscriber evicts the previous one.
+                            subscriber = None;
+                            let mut wedged = false;
+                            // Replay spooled frames strictly after the cursor,
+                            // segment by segment (bounding memory to one segment).
+                            'replay: for path in spool.replay_segments(cursor) {
+                                for (seq, body) in read_records(&path) {
+                                    if seq > cursor
+                                        && !deliver(&out_tx, Out::Frame { seq, body }).await
+                                    {
+                                        wedged = true;
+                                        break 'replay;
+                                    }
+                                }
+                            }
+                            // If the child is already fully done, the late
+                            // subscriber still learns the terminal state.
+                            if !wedged && finished {
+                                if let Some(code) = exited {
+                                    if !deliver(&out_tx, Out::Exit { code }).await {
+                                        wedged = true;
+                                    }
+                                }
+                            }
+                            let id = next_sub_id;
+                            next_sub_id += 1;
+                            if !wedged {
+                                subscriber = Some((id, out_tx));
+                            }
+                            let _ = resp.send(id);
+                        }
+                        Cmd::Unsubscribe(id) => {
+                            if matches!(&subscriber, Some((cur, _)) if *cur == id) {
+                                subscriber = None;
+                            }
+                        }
+                        Cmd::Capture { resp } => {
+                            let _ = resp.send(spool.summary(&cfg.name, child_pid, exited));
+                        }
+                        Cmd::Ping { resp } => {
+                            let _ = resp.send(PongInfo {
+                                // The relay supervisor answers even after the
+                                // child exits, so `alive` reports *supervisor*
+                                // liveness; `exited` carries the child's state.
+                                alive: true,
+                                pid: child_pid,
+                                cols: 0,
+                                rows: 0,
+                                alternate_screen: false,
+                                relay: true,
+                                exited,
+                                spooled: spool.spooled(),
+                                acked: spool.acked(),
+                            });
+                        }
+                        Cmd::Kill => {
+                            kill_group(child_pid);
+                            break;
+                        }
+                        Cmd::ChildExited(code) => {
+                            if exited.is_none() {
+                                exited = Some(code);
+                            }
+                            maybe_finish(&mut subscriber, &mut finished, exited, frame_open).await;
+                        }
+                    }
+                }
+                frame = frame_rx.recv(), if frame_open => {
+                    match frame {
+                        Some(bytes) => match spool.append(&bytes) {
+                            Ok(seq) => {
+                                if let Some((_, tx)) = subscriber.as_ref() {
+                                    if !deliver(tx, Out::Frame { seq, body: bytes }).await {
+                                        subscriber = None;
+                                    }
+                                }
+                            }
+                            Err(e) => tracing::error!(error = %e, "spool append failed"),
+                        },
+                        None => {
+                            // Child stdout closed: every frame is now spooled.
+                            frame_open = false;
+                            maybe_finish(&mut subscriber, &mut finished, exited, frame_open).await;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Teardown: drop the subscriber, stop the writer, and remove this
+        // session's artifacts (socket, spool, stderr log) — reached only on an
+        // explicit kill, which destroys the session.
+        drop(subscriber);
+        drop(write_tx);
+        let _ = writer_thread.join();
+        let _ = std::fs::remove_file(&socket);
+        let _ = std::fs::remove_dir_all(spool.dir());
+        let _ = std::fs::remove_file(&stderr_path);
+        tracing::info!(session = %cfg.name, "relay supervisor exited");
+        Ok(())
+    }
+
+    /// Deliver one message to the subscriber with back-pressure: `await` its
+    /// bounded channel, but treat a wedged (no capacity within [`EVICT_AFTER`]) or
+    /// closed channel as gone. Returns `false` if the subscriber should be dropped.
+    async fn deliver(tx: &mpsc::Sender<Out>, msg: Out) -> bool {
+        matches!(
+            tokio::time::timeout(EVICT_AFTER, tx.send(msg)).await,
+            Ok(Ok(()))
+        )
+    }
+
+    /// Once the child has exited *and* its stdout has drained (`!frame_open`),
+    /// deliver the one-time `EXIT` to the live subscriber and latch `finished`.
+    /// Idempotent — the latch means it fires exactly once.
+    async fn maybe_finish(
+        subscriber: &mut Option<(u64, mpsc::Sender<Out>)>,
+        finished: &mut bool,
+        exited: Option<i32>,
+        frame_open: bool,
+    ) {
+        if *finished || frame_open {
+            return;
+        }
+        let Some(code) = exited else { return };
+        *finished = true;
+        if let Some((_, tx)) = subscriber.as_ref() {
+            if !deliver(tx, Out::Exit { code }).await {
+                *subscriber = None;
+            }
+        }
+    }
+
+    /// SIGKILL the child's whole process group (see the PTY `Cmd::Kill` note for
+    /// why the group, not just the leader). ESRCH (group already gone) is success.
+    fn kill_group(pid: Option<u32>) {
+        if let Some(pid) = pid.filter(|&p| p != 0) {
+            if unsafe { libc::kill(-(pid as i32), libc::SIGKILL) } != 0 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() != Some(libc::ESRCH) {
+                    tracing::warn!(pid, error = %err, "relay process-group kill failed");
+                }
+            }
+        }
+    }
+
+    /// Map a child exit to a single code: the exit status, or `128 + signal` for
+    /// a signal death (the shell convention), so it is always `Some` for
+    /// [`PongInfo::exited`].
+    fn exit_code(status: std::process::ExitStatus) -> i32 {
+        use std::os::unix::process::ExitStatusExt;
+        status
+            .code()
+            .unwrap_or_else(|| 128 + status.signal().unwrap_or(0))
+    }
+
+    /// One relay control connection: a loop of request frames. `PING`/`CAPTURE`/
+    /// `KILL`/`WRITE`/`ACK` reply on the same stream and continue; `SUBSCRIBE`
+    /// consumes the connection and switches it to the live frame stream.
+    async fn handle_conn(
+        stream: tokio::net::UnixStream,
+        cmd_tx: mpsc::UnboundedSender<Cmd>,
+    ) -> Result<()> {
+        let mut stream = stream;
+        loop {
+            let Some(frame) = protocol::read_frame(&mut stream).await? else {
+                return Ok(());
+            };
+            match frame.op {
+                op::PING => {
+                    let (resp_tx, resp_rx) = oneshot::channel();
+                    if cmd_tx.send(Cmd::Ping { resp: resp_tx }).is_err() {
+                        return Ok(());
+                    }
+                    let info = resp_rx.await.ok();
+                    let payload = serde_json::to_vec(&info).unwrap_or_default();
+                    protocol::write_frame(&mut stream, &Frame::new(op::PONG, payload)).await?;
+                }
+                op::CAPTURE => {
+                    let (resp_tx, resp_rx) = oneshot::channel();
+                    if cmd_tx.send(Cmd::Capture { resp: resp_tx }).is_err() {
+                        return Ok(());
+                    }
+                    let text = resp_rx.await.unwrap_or_default();
+                    protocol::write_frame(
+                        &mut stream,
+                        &Frame::new(op::CAPTURE_RESP, text.into_bytes()),
+                    )
+                    .await?;
+                }
+                op::WRITE => {
+                    let _ = cmd_tx.send(Cmd::Write(frame.payload));
+                    protocol::write_frame(&mut stream, &Frame::new(op::OK, Vec::new())).await?;
+                }
+                op::ACK => {
+                    let _ = cmd_tx.send(Cmd::Ack(frame.as_u64()));
+                    protocol::write_frame(&mut stream, &Frame::new(op::OK, Vec::new())).await?;
+                }
+                op::KILL => {
+                    let _ = cmd_tx.send(Cmd::Kill);
+                    protocol::write_frame(&mut stream, &Frame::new(op::OK, Vec::new())).await?;
+                    return Ok(());
+                }
+                op::SUBSCRIBE => {
+                    return handle_subscribe(stream, cmd_tx, frame.as_u64()).await;
+                }
+                other => {
+                    protocol::write_frame(
+                        &mut stream,
+                        &Frame::new(op::ERR, format!("unknown opcode {other:#x}").into_bytes()),
+                    )
+                    .await?;
+                }
+            }
+        }
+    }
+
+    /// Drive a live subscribe: stream `FRAME`/`EXIT` to the client and forward its
+    /// `ACK`/`WRITE` back, until either side closes. The output pump is spawned
+    /// *before* registration so the core's replay sends have a consumer.
+    async fn handle_subscribe(
+        stream: tokio::net::UnixStream,
+        cmd_tx: mpsc::UnboundedSender<Cmd>,
+        cursor: u64,
+    ) -> Result<()> {
+        let (rd, wr) = stream.into_split();
+        let (out_tx, mut out_rx) = mpsc::channel::<Out>(SUBSCRIBER_BOUND);
+
+        // Output pump: core → client FRAME/EXIT frames.
+        let mut out_task = tokio::spawn(async move {
+            let mut wr = wr;
+            while let Some(msg) = out_rx.recv().await {
+                let frame = match msg {
+                    Out::Frame { seq, body } => Frame::relay_frame(seq, &body),
+                    Out::Exit { code } => Frame::new(
+                        op::EXIT,
+                        serde_json::to_vec(&Some(code)).unwrap_or_default(),
+                    ),
+                };
+                if protocol::write_frame(&mut wr, &frame).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Register; replay runs inside the core before it replies with our id.
+        let (id_tx, id_rx) = oneshot::channel();
+        cmd_tx
+            .send(Cmd::Subscribe {
+                cursor,
+                out_tx,
+                resp: id_tx,
+            })
+            .map_err(|_| anyhow::anyhow!("supervisor gone"))?;
+        let sub_id = id_rx.await.context("subscribe registration dropped")?;
+
+        // Input pump: client ACK/WRITE frames → core.
+        let in_cmd_tx = cmd_tx.clone();
+        let mut in_task = tokio::spawn(async move {
+            let mut rd = rd;
+            while let Ok(Some(frame)) = protocol::read_frame(&mut rd).await {
+                let cmd = match frame.op {
+                    op::ACK => Cmd::Ack(frame.as_u64()),
+                    op::WRITE => Cmd::Write(frame.payload),
+                    _ => continue, // ignore stray ops mid-stream
+                };
+                if in_cmd_tx.send(cmd).is_err() {
+                    break;
+                }
+            }
+        });
+
+        tokio::select! {
+            _ = &mut out_task => in_task.abort(),
+            _ = &mut in_task => out_task.abort(),
+        }
+        let _ = cmd_tx.send(Cmd::Unsubscribe(sub_id));
+        Ok(())
+    }
+
+    /// The zero-padded segment filename for a segment whose first frame is `seq`.
+    fn segment_name(first_seq: u64) -> String {
+        format!("{first_seq:08}.seg")
+    }
+
+    /// Parse a segment file into its `(seq, frame)` records. One record per line,
+    /// `seq\tframe`; the split is on the *first* tab so a frame containing tabs is
+    /// preserved. A missing/short file yields no records.
+    fn read_records(path: &Path) -> Vec<(u64, Vec<u8>)> {
+        let Ok(data) = std::fs::read(path) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for line in data.split(|&b| b == b'\n') {
+            if line.is_empty() {
+                continue;
+            }
+            let Some(tab) = line.iter().position(|&b| b == b'\t') else {
+                continue;
+            };
+            let Ok(seq) = std::str::from_utf8(&line[..tab])
+                .unwrap_or("")
+                .parse::<u64>()
+            else {
+                continue;
+            };
+            out.push((seq, line[tab + 1..].to_vec()));
+        }
+        out
+    }
+
+    /// One rotated-out or active segment's metadata. The first seq is encoded in
+    /// the file name (`<first-seq>.seg`), so only the moving `last_seq` is tracked.
+    struct Segment {
+        /// Highest seq written; the segment's first-seq minus one while empty.
+        last_seq: u64,
+        path: PathBuf,
+    }
+
+    /// The on-disk frame spool: an append-only directory of segment files, one
+    /// `seq\tframe\n` record per line, rotated by size. Crash-tolerant on the
+    /// writer side (append-only); it need only outlive *client* restarts, so the
+    /// index (segment list, next seq, watermark) is kept in memory rather than
+    /// recovered — a supervisor restart is out of scope.
+    struct Spool {
+        dir: PathBuf,
+        segment_max_bytes: u64,
+        /// Seq the next appended frame will get (starts at 1).
+        next_seq: u64,
+        /// Retention watermark — the highest acked seq.
+        ack: u64,
+        /// Rotated-out (sealed) segments, oldest first.
+        sealed: Vec<Segment>,
+        /// The segment currently being appended to.
+        active: Segment,
+        active_file: std::fs::File,
+        active_bytes: u64,
+    }
+
+    impl Spool {
+        /// Create a fresh spool directory (clearing any stale one from a prior
+        /// session of the same name) with an empty first segment at seq 1.
+        fn create(dir: PathBuf, segment_max_bytes: u64) -> Result<Self> {
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir)
+                .with_context(|| format!("creating spool dir {}", dir.display()))?;
+            let first_seq = 1;
+            let path = dir.join(segment_name(first_seq));
+            let active_file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .with_context(|| format!("opening spool segment {}", path.display()))?;
+            Ok(Self {
+                dir,
+                segment_max_bytes,
+                next_seq: 1,
+                ack: 0,
+                sealed: Vec::new(),
+                active: Segment {
+                    last_seq: first_seq - 1,
+                    path,
+                },
+                active_file,
+                active_bytes: 0,
+            })
+        }
+
+        /// Append one frame, returning its seq. Rotates to a fresh segment once
+        /// the active one crosses the size threshold.
+        fn append(&mut self, body: &[u8]) -> Result<u64> {
+            let seq = self.next_seq;
+            let mut rec = Vec::with_capacity(20 + body.len());
+            rec.extend_from_slice(seq.to_string().as_bytes());
+            rec.push(b'\t');
+            rec.extend_from_slice(body);
+            rec.push(b'\n');
+            self.active_file.write_all(&rec)?;
+            self.active.last_seq = seq;
+            self.active_bytes += rec.len() as u64;
+            self.next_seq += 1;
+            if self.active_bytes >= self.segment_max_bytes {
+                self.rotate()?;
+            }
+            Ok(seq)
+        }
+
+        /// Seal the active segment and open a fresh one starting at `next_seq`.
+        fn rotate(&mut self) -> Result<()> {
+            let first_seq = self.next_seq;
+            let path = self.dir.join(segment_name(first_seq));
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .with_context(|| format!("opening spool segment {}", path.display()))?;
+            let sealed = std::mem::replace(
+                &mut self.active,
+                Segment {
+                    last_seq: first_seq - 1,
+                    path,
+                },
+            );
+            self.sealed.push(sealed);
+            self.active_file = file;
+            self.active_bytes = 0;
+            Ok(())
+        }
+
+        /// Advance the watermark and delete every sealed segment fully covered by
+        /// it (highest seq ≤ ack). The active segment is never deleted. An
+        /// over-ack (beyond what's spooled) clamps to the last spooled seq.
+        fn set_ack(&mut self, seq: u64) {
+            let seq = seq.min(self.next_seq.saturating_sub(1));
+            if seq <= self.ack {
+                return;
+            }
+            self.ack = seq;
+            let ack = self.ack;
+            self.sealed.retain(|seg| {
+                if seg.last_seq <= ack {
+                    let _ = std::fs::remove_file(&seg.path);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+
+        /// Segment file paths (in seq order) that may hold a frame with
+        /// `seq > cursor` — every segment whose highest seq exceeds the cursor.
+        fn replay_segments(&self, cursor: u64) -> Vec<PathBuf> {
+            let mut paths = Vec::new();
+            for seg in &self.sealed {
+                if seg.last_seq > cursor {
+                    paths.push(seg.path.clone());
+                }
+            }
+            if self.active.last_seq > cursor {
+                paths.push(self.active.path.clone());
+            }
+            paths
+        }
+
+        /// The highest spooled seq (0 before the first frame).
+        fn spooled(&self) -> u64 {
+            self.next_seq.saturating_sub(1)
+        }
+
+        /// The retention watermark.
+        fn acked(&self) -> u64 {
+            self.ack
+        }
+
+        fn dir(&self) -> &Path {
+            &self.dir
+        }
+
+        /// A short human-readable status line — the relay's `CAPTURE` answer.
+        fn summary(&self, name: &str, pid: Option<u32>, exited: Option<i32>) -> String {
+            let child = match exited {
+                Some(code) => format!("exited (code {code})"),
+                None => match pid {
+                    Some(p) => format!("running (pid {p})"),
+                    None => "running".to_string(),
+                },
+            };
+            let spooled = self.spooled();
+            let retained = spooled.saturating_sub(self.ack);
+            format!(
+                "relay session {name}: child {child}; spooled seq 1..{spooled} \
+                 ({retained} retained past ack {}), {} segment(s)\n",
+                self.ack,
+                self.sealed.len() + 1,
+            )
+        }
+    }
 }

--- a/crates/tapestry/tests/lifecycle.rs
+++ b/crates/tapestry/tests/lifecycle.rs
@@ -30,6 +30,8 @@ impl Harness {
             env: vec![],
             cols: 80,
             rows: 24,
+            mode: tapestry::Mode::Pty,
+            segment_max_bytes: None,
         };
         tokio::spawn(async move {
             let _ = tapestry::supervise(cfg).await;

--- a/crates/tapestry/tests/relay.rs
+++ b/crates/tapestry/tests/relay.rs
@@ -1,0 +1,287 @@
+//! Integration tests for the **relay** backend: a piped-stdio supervisor with a
+//! durable frame spool, subscribe/replay/ack/write, stderr capture, and exit
+//! reporting. Mirrors `lifecycle.rs` — each test runs an in-process supervisor
+//! against a private temp `WEAVER_HOME`, so sockets and spools never collide.
+//!
+//! The child in most tests is `while read l; do echo "got:$l"; done` — an echo
+//! loop over stdin, exactly the shape the relay is built for (write a line in,
+//! get a framed line out). dash flushes each `echo` promptly even when stdout is
+//! a pipe, so no `stdbuf` dance is needed.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serial_test::serial;
+use tapestry::{Client, Mode, RelayEvent, RelayStream, SupervisorConfig};
+use tempfile::TempDir;
+
+/// An echo loop: read a line, emit `got:<line>`.
+const ECHO: &str = "while read l; do echo \"got:$l\"; done";
+
+/// A running in-process relay supervisor pinned to a private temp home.
+struct Relay {
+    _home: TempDir,
+    name: String,
+}
+
+impl Relay {
+    async fn start(tag: &str, script: &str, segment_max_bytes: Option<u64>) -> Relay {
+        let home = TempDir::new().unwrap();
+        std::env::set_var("WEAVER_HOME", home.path());
+        let name = format!("tap-relay-{}-{tag}", std::process::id());
+        let cfg = SupervisorConfig {
+            name: name.clone(),
+            cwd: std::env::temp_dir(),
+            script: script.to_string(),
+            env: vec![],
+            cols: 80,
+            rows: 24,
+            mode: Mode::Relay,
+            segment_max_bytes,
+        };
+        tokio::spawn(async move {
+            let _ = tapestry::supervise(cfg).await;
+        });
+        for _ in 0..200 {
+            if Client::connect(&name).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        Relay { _home: home, name }
+    }
+
+    /// Append a newline-terminated line to the child's stdin.
+    async fn write_line(&self, line: &str) {
+        Client::connect(&self.name)
+            .await
+            .unwrap()
+            .relay_write(format!("{line}\n").as_bytes())
+            .await
+            .unwrap();
+    }
+
+    async fn subscribe(&self, cursor: u64) -> RelayStream {
+        Client::connect(&self.name)
+            .await
+            .unwrap()
+            .subscribe(cursor)
+            .await
+            .unwrap()
+    }
+
+    async fn ping(&self) -> tapestry::protocol::PongInfo {
+        Client::connect(&self.name)
+            .await
+            .unwrap()
+            .ping()
+            .await
+            .unwrap()
+    }
+
+    /// Block until the spool has assigned at least `n` sequence numbers.
+    async fn wait_spooled(&self, n: u64) {
+        for _ in 0..400 {
+            if self.ping().await.spooled >= n {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("spool never reached seq {n}");
+    }
+
+    async fn kill(&self) {
+        if let Ok(mut c) = Client::connect(&self.name).await {
+            let _ = c.kill().await;
+        }
+    }
+}
+
+/// The next event, expected to be a `Frame`; panics on anything else.
+async fn next_frame(sub: &mut RelayStream) -> (u64, Vec<u8>) {
+    match tokio::time::timeout(Duration::from_secs(5), sub.recv()).await {
+        Ok(Some(RelayEvent::Frame { seq, payload })) => (seq, payload),
+        other => panic!("expected a frame, got {other:?}"),
+    }
+}
+
+/// The next event, expected to be `Exit`; panics on anything else.
+async fn next_exit(sub: &mut RelayStream) -> Option<i32> {
+    match tokio::time::timeout(Duration::from_secs(5), sub.recv()).await {
+        Ok(Some(RelayEvent::Exit { status })) => status,
+        other => panic!("expected exit, got {other:?}"),
+    }
+}
+
+/// Segment files in a spool dir, sorted (so `[0]` is the earliest).
+fn segment_files(dir: &Path) -> Vec<PathBuf> {
+    let mut v: Vec<PathBuf> = std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "seg"))
+        .collect();
+    v.sort();
+    v
+}
+
+/// The highest seq recorded in a segment file (records are `seq\tframe`).
+fn segment_max_seq(path: &Path) -> u64 {
+    std::fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .filter_map(|l| l.split('\t').next().and_then(|s| s.parse::<u64>().ok()))
+        .max()
+        .unwrap()
+}
+
+/// A WRITE reaches the child, whose echoed line comes back as FRAME seq 1.
+#[tokio::test]
+#[serial]
+async fn write_then_subscribe_yields_the_frame() {
+    let r = Relay::start("basics", ECHO, None).await;
+    r.write_line("hello").await;
+
+    let mut sub = r.subscribe(0).await;
+    assert_eq!(next_frame(&mut sub).await, (1, b"got:hello".to_vec()));
+
+    r.kill().await;
+}
+
+/// Frames written with no subscriber are spooled and replay in order on a later
+/// subscribe; a cursored subscribe replays only what follows the cursor.
+#[tokio::test]
+#[serial]
+async fn replay_survives_client_death_and_respects_the_cursor() {
+    let r = Relay::start("replay", ECHO, None).await;
+
+    // Two lines with nobody listening.
+    r.write_line("a").await;
+    r.write_line("b").await;
+    r.wait_spooled(2).await;
+
+    {
+        let mut sub = r.subscribe(0).await;
+        assert_eq!(next_frame(&mut sub).await, (1, b"got:a".to_vec()));
+        assert_eq!(next_frame(&mut sub).await, (2, b"got:b".to_vec()));
+        // Dropping `sub` here unsubscribes — the "client died" case.
+    }
+
+    // A third line, then a subscribe past the first two: only frame 3 replays.
+    r.write_line("c").await;
+    r.wait_spooled(3).await;
+    let mut sub = r.subscribe(2).await;
+    assert_eq!(next_frame(&mut sub).await, (3, b"got:c".to_vec()));
+
+    r.kill().await;
+}
+
+/// Acking past a sealed segment deletes its file; a subscribe from the watermark
+/// still yields every frame after it.
+#[tokio::test]
+#[serial]
+async fn ack_truncates_fully_acked_segments() {
+    // A tiny segment size forces frequent rotation.
+    let r = Relay::start("ack", ECHO, Some(20)).await;
+
+    let total = 12u64;
+    for i in 1..=total {
+        r.write_line(&format!("l{i}")).await;
+    }
+    r.wait_spooled(total).await;
+
+    let dir = tapestry::paths::spool_dir(&r.name);
+    let segs = segment_files(&dir);
+    assert!(
+        segs.len() >= 2,
+        "expected the spool to roll into multiple segments, got {segs:?}"
+    );
+
+    // Ack the whole first (sealed) segment, then watch its file disappear.
+    let first = dir.join("00000001.seg");
+    assert!(first.exists(), "first segment missing before ack");
+    let ack_to = segment_max_seq(&first);
+    Client::connect(&r.name)
+        .await
+        .unwrap()
+        .relay_ack(ack_to)
+        .await
+        .unwrap();
+
+    let mut deleted = false;
+    for _ in 0..200 {
+        if !first.exists() {
+            deleted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        deleted,
+        "first segment not deleted after acking seq {ack_to}"
+    );
+
+    // The ping watermark reflects the ack, and a subscribe from it replays the
+    // whole tail — nothing lost to truncation.
+    assert_eq!(r.ping().await.acked, ack_to);
+    let mut sub = r.subscribe(ack_to).await;
+    for seq in (ack_to + 1)..=total {
+        assert_eq!(
+            next_frame(&mut sub).await,
+            (seq, format!("got:l{seq}").into_bytes())
+        );
+    }
+
+    r.kill().await;
+}
+
+/// The child's stderr lands in the per-session log file.
+#[tokio::test]
+#[serial]
+async fn stderr_is_captured_to_the_log() {
+    let r = Relay::start("stderr", "echo OOPS_ON_STDERR >&2; exec sleep 30", None).await;
+    let log = tapestry::paths::stderr_log_path(&r.name);
+
+    let mut contents = String::new();
+    for _ in 0..200 {
+        if let Ok(s) = std::fs::read_to_string(&log) {
+            if s.contains("OOPS_ON_STDERR") {
+                contents = s;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        contents.contains("OOPS_ON_STDERR"),
+        "stderr log missing content; got {contents:?}"
+    );
+
+    r.kill().await;
+}
+
+/// When the child exits, the live subscriber gets an `Exit`, PING reports the
+/// status while the supervisor stays alive, and the spool still replays.
+#[tokio::test]
+#[serial]
+async fn exit_is_reported_and_the_spool_outlives_the_child() {
+    let r = Relay::start("exit", "echo bye; exit 7", None).await;
+
+    // Frame then exit (whether the frame streams live or replays from the spool).
+    let mut sub = r.subscribe(0).await;
+    assert_eq!(next_frame(&mut sub).await, (1, b"bye".to_vec()));
+    assert_eq!(next_exit(&mut sub).await, Some(7));
+
+    // The supervisor answers after the child is gone: alive (supervisor), relay,
+    // exit code recorded.
+    let info = r.ping().await;
+    assert!(info.alive, "relay supervisor should outlive its child");
+    assert!(info.relay);
+    assert_eq!(info.exited, Some(7));
+
+    // The spool remains queryable: a fresh subscribe replays the frame + exit.
+    let mut sub2 = r.subscribe(0).await;
+    assert_eq!(next_frame(&mut sub2).await, (1, b"bye".to_vec()));
+    assert_eq!(next_exit(&mut sub2).await, Some(7));
+
+    r.kill().await;
+}


### PR DESCRIPTION
Phase 2 of the ACP migration (design: docs/plans/acp.md on PR #150): a second tapestry backend beside the PTY one. Relay mode spawns its child over plain pipes and acts as a durable frame relay between the child stdio and a possibly-absent, possibly-reconnecting client — the survives-loom-restart scaffolding a headless ACP adapter needs.

- Launch spec gains a `mode` discriminator (`pty` default, back-compat via serde defaults).
- Child stdout → newline frames → an on-disk segment spool (`seq\tframe` records, size-rotated); truncation is ack-driven (`SUBSCRIBE(cursor)`/`FRAME(seq)`/`ACK(seq)`/`WRITE` opcodes, all additive). A reconnecting client replays from its cursor, so a frame is retired only once the client has durably processed it.
- stderr streams to a per-session log; on child exit the supervisor stays alive (spool/log queryable, EXIT strictly trails the last frame), KILL semantics unchanged.
- Loom seam: `new_relay_session` / `subscribe_relay` / `relay_write` / `relay_ack`; has_session/kill unchanged.
- Integration tests: write→subscribe, replay-after-client-death with cursoring, ack truncation, stderr capture, exit reporting; PTY suites untouched and green.

No consumer yet — the loom ACP client lands next (weaver #506 closes here; #507 builds on this seam).

loom: https://loom.rjp.io/s/drkl7h2z