### PR TITLE
fix(loom): default ACP sessions to `auto` permission mode

### DIFF
--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -227,8 +227,9 @@ async function stopTurn() {
 // The well-known claude/codex ACP modes, used when the session doesn't expose an
 // explicit `available_modes` list (SessionView carries only `current_mode`
 // today). Wire the chip to `session.available_modes` the moment the server adds it.
-const KNOWN_MODES = ['default', 'acceptEdits', 'plan', 'bypassPermissions'];
+const KNOWN_MODES = ['auto', 'default', 'acceptEdits', 'plan', 'bypassPermissions'];
 const MODE_LABEL: Record<string, string> = {
+  auto: 'auto',
   default: 'default',
   acceptEdits: 'accept edits',
   plan: 'plan',

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -110,8 +110,9 @@ export interface Session {
   protocol: 'terminal' | 'acp';
   /** The agent's own on-disk ACP session id for an `acp` session, or null. */
   acp_session_id: string | null;
-  /** The current ACP mode id (gating posture: `bypassPermissions`, `acceptEdits`,
-   *  `default`, `plan`), or null for a terminal session / before one is set. */
+  /** The current ACP mode id (gating posture: `bypassPermissions`, `auto`,
+   *  `acceptEdits`, `default`, `plan`), or null for a terminal session / before
+   *  one is set. */
   current_mode: string | null;
   /** The latest context-window usage an ACP agent reported, or null. */
   usage: AcpUsage | null;

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -704,9 +704,16 @@ fn weaver_bin_path() -> String {
 // then brings up. See docs/plans/acp.md "Launch mapping".
 // ---------------------------------------------------------------------------
 
-/// The permission posture an ACP session boots in when the create request names
-/// none — the moral equivalent of the retired pre-seeded launch gates.
-pub const DEFAULT_ACP_MODE: &str = "bypassPermissions";
+/// The permission posture every ACP session boots in — the concierge and
+/// detached workstreams alike — when the create request names none. `auto` is
+/// Claude Code's background-classifier posture: a safety model vets each tool
+/// call, executing routine work on its own and escalating only genuinely risky
+/// actions as an interactive permission card (surfaced in the conversation with a
+/// loud `attention` tag, answerable from the dashboard). An explicit request
+/// `mode` / `--mode` still overrides — e.g. `bypassPermissions` for a fully
+/// unattended run. (For a codex session this maps to codex's `agent` mode; see
+/// [`codex_acp_mode`].)
+pub const DEFAULT_ACP_MODE: &str = "auto";
 
 /// Resolve the execution backend for a launch: the agent's declared `protocol`
 /// unless the create request overrides it. A blank/absent override keeps the
@@ -992,7 +999,9 @@ fn codex_acp_config(model: &str, effort: &str) -> Option<String> {
 fn codex_acp_mode(mode: &str) -> String {
     match mode.trim() {
         "bypassPermissions" => "agent-full-access".to_string(),
-        "acceptEdits" | "default" | "" => "agent".to_string(),
+        // `auto` (claude's background-classifier posture) has no codex equivalent;
+        // the closest is `agent` — workspace-write that escalates on risk.
+        "acceptEdits" | "default" | "auto" | "" => "agent".to_string(),
         "plan" => "read-only".to_string(),
         other => other.to_string(),
     }
@@ -1821,10 +1830,21 @@ mod tests {
     }
 
     #[test]
+    fn sessions_boot_in_auto_by_default() {
+        // Every ACP session (concierge and detached workstream alike) boots in
+        // Claude Code's background-classifier `auto` posture unless overridden;
+        // for a codex session that maps to codex's workspace-write `agent` mode.
+        assert_eq!(DEFAULT_ACP_MODE, "auto");
+        assert_eq!(codex_acp_mode(DEFAULT_ACP_MODE), "agent");
+    }
+
+    #[test]
     fn codex_acp_mode_maps_the_claude_vocabulary_and_passes_codex_ids_through() {
         assert_eq!(codex_acp_mode("bypassPermissions"), "agent-full-access");
         assert_eq!(codex_acp_mode("acceptEdits"), "agent");
         assert_eq!(codex_acp_mode("default"), "agent");
+        // `auto` has no codex analogue → the workspace-write `agent` mode.
+        assert_eq!(codex_acp_mode("auto"), "agent");
         assert_eq!(codex_acp_mode(""), "agent");
         assert_eq!(codex_acp_mode("plan"), "read-only");
         // Codex's own ids are honoured verbatim.

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -636,7 +636,7 @@ struct LaunchOpts {
     /// builtins).
     #[arg(long)]
     protocol: Option<String>,
-    /// ACP launch permission posture: `bypassPermissions` (the default),
+    /// ACP launch permission posture: `auto` (the default), `bypassPermissions`,
     /// `acceptEdits`, `default`, or `plan`. Ignored for a terminal launch.
     #[arg(long)]
     mode: Option<String>,

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -645,7 +645,8 @@ pub(crate) async fn create_session_core(
         None => return Err(AppError::bad_request(format!("unknown agent '{runtime}'"))),
     };
     // The ACP launch permission posture (ignored for a terminal launch): the
-    // request's mode, else the bypass default (the retired pre-seeded gates).
+    // request's mode, else the `auto` default — a background classifier vets each
+    // tool call and escalates only risky actions as a permission card.
     let mode = req
         .mode
         .as_deref()
@@ -1963,8 +1964,7 @@ async fn adopt_terminal_into_acp(
             goal_file: goal_file.as_deref(),
             primer_file: primer_file.as_deref(),
             extra_env: &extra_env,
-            // Terminal rows carry no mode; the seeded-gates posture they ran
-            // under matches the acp default.
+            // Terminal rows carry no mode; on adoption they take the acp default.
             mode: agent::DEFAULT_ACP_MODE,
             custom: None,
         },

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -152,8 +152,9 @@ pub struct SessionView {
     /// The agent's own on-disk ACP session id for an `acp` session, or `null`.
     #[serde(default)]
     pub acp_session_id: Option<String>,
-    /// The current ACP mode id (gating posture: `bypassPermissions`, `acceptEdits`,
-    /// `default`, `plan`), or `null` for a terminal session / before one is set.
+    /// The current ACP mode id (gating posture: `bypassPermissions`, `auto`,
+    /// `acceptEdits`, `default`, `plan`), or `null` for a terminal session /
+    /// before one is set.
     #[serde(default)]
     pub current_mode: Option<String>,
     /// The latest context-window usage (`{used, size}`) reported by an ACP agent,
@@ -583,9 +584,10 @@ pub struct CreateReq {
     /// support the requested backend.
     #[serde(default)]
     pub protocol: Option<String>,
-    /// The ACP launch permission posture (`bypassPermissions` | `acceptEdits` |
-    /// `default` | `plan`). Blank/absent defaults to `bypassPermissions` (the
-    /// detached autonomous posture). Ignored for a terminal launch.
+    /// The ACP launch permission posture (`auto` | `bypassPermissions` |
+    /// `acceptEdits` | `default` | `plan`). Blank/absent defaults to `auto` — a
+    /// background classifier vets each tool call, escalating only risky actions as
+    /// a permission card. Ignored for a terminal launch.
     #[serde(default)]
     pub mode: Option<String>,
 }

--- a/docs/plans/acp.md
+++ b/docs/plans/acp.md
@@ -332,10 +332,12 @@ HTTP, orthogonal to the execution backend).
 ### Permissions & modes
 
 The launch posture is a per-session choice, not a hard-coded constant: the
-create form (and `loom session launch --mode`) picks **autonomous**
-(`bypassPermissions` — the shipped default for detached sessions, the moral
-equivalent of today's pre-seeded gates, which retire) or a supervised mode
-(`acceptEdits`, `default`, `plan`). The mode is live thereafter — the
+create form (and `loom session launch --mode`) picks the **`auto`** default
+(Claude Code's background-classifier posture — a safety model vets each tool
+call, running routine work on its own and escalating only genuinely risky
+actions) or an explicit posture — **autonomous** (`bypassPermissions`) for a
+fully unattended run, or a supervised mode (`acceptEdits`, `default`, `plan`).
+The mode is live thereafter — the
 composer's mode chip drives `session/set_mode`. In any gated mode a
 `session/request_permission` surfaces as an interactive card in the
 conversation plus a loud `attention` tag, so the fleet list raises the


### PR DESCRIPTION
## What

Every ACP session — the **Chat concierge** *and* detached workstream **session
chats** — booted in `bypassPermissions`, inherited from the generic
`DEFAULT_ACP_MODE`. Under bypass, loom auto-answers every permission request, so
agents ran with **no gating at all**. That's the "it seems to default to
something else" in #522.

This moves the default to Claude Code's **`auto`** mode: a background classifier
vets each tool call, executing routine work on its own and **escalating only
genuinely risky actions** as an interactive permission card (surfaced with a loud
`attention` tag, answerable from the dashboard). `bypassPermissions` stays
available as an explicit request `mode` / `loom launch --mode` override for a
fully unattended run.

`auto` is a real, current Claude Code / ACP / Agent-SDK mode (string id `"auto"`,
shared across `--permission-mode`, `defaultMode`, ACP `availableModes` /
`session/set_mode`, and the SDK `permissionMode`).

## Changes

- **`agent.rs`** — `DEFAULT_ACP_MODE` → `"auto"`; map `auto` → codex's `agent`
  mode (codex has no classifier) so a codex session degrades gracefully.
- **Vocabulary** — `auto` is the documented default across the DTO/type docs,
  `loom launch --mode` help, the ACP design doc, and the conversation **mode
  chip** (`AcpConversation.vue`, which now leads with it).

The create-launch mode resolution and both adopt-path fallbacks already read
`DEFAULT_ACP_MODE`, so they follow the flip automatically.

## Why this is safe with loom's existing plumbing

loom already **surfaces** (rather than auto-answers) every non-`bypassPermissions`
permission request (`acp/mod.rs`), and `auto`'s classifier runs adapter-side —
so only the actions it escalates reach the conversation as cards. No change to
the answer-policy was needed.

## Behavior change to weigh

A **detached** session in `auto` now **pauses** on an escalated action until
someone answers the card from the dashboard — `bypassPermissions` never paused.
That's the intended safety net (autonomous on the safe majority, gated on the
dangerous minority), but it does change unattended runs; `bypassPermissions`
remains the explicit escape hatch for run-and-forget.

## Verify before relying on it

`auto` requires a current `claude-agent-acp` adapter (≈ v2.1.207+) and a capable
model (Opus 4.6+ / Sonnet 4.6+ / Fable 5). Worth a smoke test that the deployed
adapter accepts `permissionMode: "auto"` in `session/new` — an older adapter that
rejects the unknown mode would fail launches fleet-wide.

## Tests

- `sessions_boot_in_auto_by_default`: `DEFAULT_ACP_MODE == "auto"` and its codex
  mapping → `agent`.
- Full loom lib suite (241) + frontend typecheck green.

Closes #522.
