### PR TITLE
fix(loom): open conversations pinned to the foot and tighten chat rhythm

### DIFF
--- a/crates/loom/frontend/.prettierrc.json
+++ b/crates/loom/frontend/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/crates/loom/frontend/package-lock.json
+++ b/crates/loom/frontend/package-lock.json
@@ -35,6 +35,7 @@
         "@types/markdown-it": "^14.1.2",
         "postcss": "^8.5.15",
         "postcss-loader": "^8.2.1",
+        "prettier": "^3.9.5",
         "rspack-vue-loader": "^17.5.0",
         "tailwindcss": "^4.2.1",
         "typescript": "^5.9.3",
@@ -2857,6 +2858,22 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode.js": {

--- a/crates/loom/frontend/package.json
+++ b/crates/loom/frontend/package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "build": "rspack build --mode production",
     "dev": "rspack serve --mode development",
-    "typecheck": "vue-tsc --noEmit"
+    "typecheck": "vue-tsc --noEmit",
+    "format": "prettier --write src",
+    "format:check": "prettier --check src"
   },
   "dependencies": {
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
@@ -36,6 +38,7 @@
     "@types/markdown-it": "^14.1.2",
     "postcss": "^8.5.15",
     "postcss-loader": "^8.2.1",
+    "prettier": "^3.9.5",
     "rspack-vue-loader": "^17.5.0",
     "tailwindcss": "^4.2.1",
     "typescript": "^5.9.3",

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -86,8 +86,7 @@ export const listRepos = () => get('/repos') as Promise<ManagedRepo[]>;
 
 /** Register a repo (a GitHub `owner/name` slug or clone URL) in the managed
  *  store / allowlist (`POST /api/repos`). Returns the stored mapping. */
-export const registerRepo = (repo: string) =>
-  post('/repos', { repo }) as Promise<ManagedRepo>;
+export const registerRepo = (repo: string) => post('/repos', { repo }) as Promise<ManagedRepo>;
 
 // --- Your GitHub token (per-user) ------------------------------------------
 
@@ -99,8 +98,7 @@ export interface GithubTokenStatus {
 }
 
 /** Whether you've set a personal GitHub token (`GET /api/auth/github-token`). */
-export const getMyGithubToken = () =>
-  get('/auth/github-token') as Promise<GithubTokenStatus>;
+export const getMyGithubToken = () => get('/auth/github-token') as Promise<GithubTokenStatus>;
 
 /** Set/replace your personal GitHub token, injected as GH_TOKEN into the
  *  sessions you launch so your agents act as you (`PUT /api/auth/github-token`).
@@ -247,7 +245,10 @@ export const addComment = (id: string, name: string, tid: number, body: NewComme
 
 /** Mark a thread resolved. */
 export const resolveThread = (id: string, name: string, tid: number) =>
-  post(`/sessions/${id}/artifacts/${encodeURIComponent(name)}/threads/${tid}/resolve`, {}) as Promise<Thread>;
+  post(
+    `/sessions/${id}/artifacts/${encodeURIComponent(name)}/threads/${tid}/resolve`,
+    {},
+  ) as Promise<Thread>;
 
 /** Type a message into the session's agent pane and, by default, submit it with
  *  Enter to trigger a round (the same primitive the `loom` CLI's `send` wraps).
@@ -262,8 +263,7 @@ import type { ChatSnapshot, PromptAck } from './types';
 /** The journaled conversation snapshot for an ACP session — the transcript a
  *  client paints before tailing `/chat/stream` (`GET /sessions/{id}/chat`). A
  *  terminal session 409s (it has no chat journal). */
-export const getSessionChat = (id: string) =>
-  get(`/sessions/${id}/chat`) as Promise<ChatSnapshot>;
+export const getSessionChat = (id: string) => get(`/sessions/${id}/chat`) as Promise<ChatSnapshot>;
 
 /** Send a user message to an ACP session (`session/prompt`). Returns 202 with
  *  `{ queued, turn }` — `queued` when a turn was already in flight (the message

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -204,7 +204,9 @@ onMounted(() => {
     <!-- Identity -->
     <section>
       <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">Signed in</h2>
-      <div class="flex items-center justify-between rounded-md border border-line bg-surface px-3 py-2.5">
+      <div
+        class="flex items-center justify-between rounded-md border border-line bg-surface px-3 py-2.5"
+      >
         <div>
           <p class="text-sm font-medium">{{ me.username }}</p>
           <p class="text-2xs text-faint">
@@ -259,7 +261,8 @@ onMounted(() => {
           A fine-grained token your sessions use for <code class="font-mono">git push</code> and
           <code class="font-mono">gh</code>, so your agents act as you.
           <a class="text-accent underline" :href="PAT_CREATE_URL" target="_blank" rel="noopener">
-            Create one</a>
+            Create one</a
+          >
           with <span class="font-medium">Contents</span> and
           <span class="font-medium">Pull requests</span> read/write on the repos you work in.
           <span :class="ghTokenStatus?.set ? 'text-accent' : 'text-faint'">
@@ -296,9 +299,7 @@ onMounted(() => {
 
     <!-- GitHub App -->
     <section>
-      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
-        GitHub App
-      </h2>
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">GitHub App</h2>
       <div class="rounded-md border border-line bg-surface px-3 py-2.5">
         <!-- App identity: one App powers both sign-in and the @loom trigger. -->
         <div v-if="gh?.app_configured" class="mb-2">
@@ -316,8 +317,8 @@ onMounted(() => {
             <span class="text-faint"> · App ID {{ gh.app_id }}</span>
           </p>
           <p class="text-xs text-muted mt-0.5">
-            One GitHub App powers both sign-in and the <code class="font-mono">@loom</code>
-            trigger. Manage it with <code class="font-mono">loom setup github-app</code>.
+            One GitHub App powers both sign-in and the <code class="font-mono">@loom</code> trigger.
+            Manage it with <code class="font-mono">loom setup github-app</code>.
           </p>
         </div>
         <p v-else class="text-xs text-muted mb-2">
@@ -336,7 +337,8 @@ onMounted(() => {
           <template v-if="gh?.app_configured">The same App's</template>
           <template v-else>The</template>
           OAuth client, with callback
-          <code class="font-mono">{{ gh?.callback_path }}</code>. Powers "Continue with GitHub".
+          <code class="font-mono">{{ gh?.callback_path }}</code
+          >. Powers "Continue with GitHub".
           <span :class="gh?.configured ? 'text-accent' : 'text-faint'">
             {{ gh?.configured ? 'Configured.' : 'Not configured.' }}
           </span>
@@ -370,8 +372,8 @@ onMounted(() => {
         Approved users
       </h2>
       <p class="text-2xs text-faint mb-1.5">
-        Everyone allowed near loom. An approved user can sign in here, and — if their
-        GitHub login is on file — trigger a session by commenting
+        Everyone allowed near loom. An approved user can sign in here, and — if their GitHub login
+        is on file — trigger a session by commenting
         <code class="font-mono">@loom</code> on a GitHub PR or issue.
       </p>
       <div class="overflow-hidden rounded-md border border-line bg-surface">

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -959,8 +959,8 @@ function goTo(anchor: string) {
 <style scoped>
 /* Flatten MarkdownView's card into tight, left-aligned serif prose on the
    canvas — the transcript reads as printed dialogue, not stacked cards. The
-   document defaults (1.7 leading, 1em block gaps, deep list indents) are cut
-   for a printed page; a conversation reads denser, so they tighten here. */
+   denser chat rhythm (leading, block gaps, list indents) is the shared
+   `chat-prose` layer in markdown.css; only this surface's geometry lives here. */
 .acp-scroll :deep(div:has(> .markdown-body)) {
   background: transparent;
   overflow: visible;
@@ -969,29 +969,6 @@ function goTo(anchor: string) {
   max-width: 46rem;
   margin: 0;
   padding: 0.125rem 0;
-  line-height: 1.55;
-}
-.acp-scroll :deep(.markdown-body p),
-.acp-scroll :deep(.markdown-body blockquote),
-.acp-scroll :deep(.markdown-body ul),
-.acp-scroll :deep(.markdown-body ol),
-.acp-scroll :deep(.markdown-body dl),
-.acp-scroll :deep(.markdown-body table),
-.acp-scroll :deep(.markdown-body pre),
-.acp-scroll :deep(.markdown-body details) {
-  margin-bottom: 0.6em;
-}
-.acp-scroll :deep(.markdown-body h1),
-.acp-scroll :deep(.markdown-body h2),
-.acp-scroll :deep(.markdown-body h3),
-.acp-scroll :deep(.markdown-body h4),
-.acp-scroll :deep(.markdown-body h5),
-.acp-scroll :deep(.markdown-body h6) {
-  margin: 1em 0 0.4em;
-}
-.acp-scroll :deep(.markdown-body ul),
-.acp-scroll :deep(.markdown-body ol) {
-  padding-left: 1.5em;
 }
 
 /* Speaker block: a hairline rule + micro-caps label + mono time, serif beneath. */

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -35,6 +35,7 @@ import type {
   TurnEndPayload,
 } from '../types';
 import { canSend } from '../lib/sessionState';
+import { useFollowFoot } from '../lib/followFoot';
 import MarkdownView from './MarkdownView.vue';
 
 // The Conversation surface for an *ACP* session (`protocol='acp'`): typeset
@@ -581,45 +582,14 @@ const elapsedLabel = computed(() => {
   return `${m}:${String(s).padStart(2, '0')}`;
 });
 
-// ── Follow-the-foot scroll ───────────────────────────────────────────────────
-// A chat opens at its newest exchange and stays *pinned* there while content
-// grows; scrolling up releases the pin, scrolling back to the foot re-arms it.
-// Growth lands asynchronously — markdown parses off-tick, images load, the pane
-// un-hides from a v-show tab — so a ResizeObserver on the transcript body does
-// the following; a one-shot scroll after nextTick would race the paint and
-// strand the view mid-history.
+// ── Follow-the-foot scroll (lib/followFoot.ts): pinned-at-the-newest-exchange. ──
 const convScroll = ref<HTMLElement | null>(null);
 const convBody = ref<HTMLElement | null>(null);
-const pinned = ref(true);
-function nearBottom(): boolean {
-  const el = convScroll.value;
-  if (!el) return true;
-  return el.scrollHeight - el.scrollTop - el.clientHeight < 120;
-}
-function scrollToBottom() {
-  const el = convScroll.value;
-  if (el) el.scrollTop = el.scrollHeight;
-}
-function autoFollow() {
-  if (pinned.value) nextTick(scrollToBottom);
-}
+const { pinned, scrollToBottom, autoFollow, trackPin } = useFollowFoot(convScroll, convBody);
 function onScroll() {
-  pinned.value = nearBottom();
+  trackPin();
   updateActive();
 }
-let bodyRO: ResizeObserver | null = null;
-watch(convBody, (el) => {
-  bodyRO?.disconnect();
-  if (!el) return;
-  bodyRO ??= new ResizeObserver(() => {
-    if (pinned.value) scrollToBottom();
-  });
-  bodyRO.observe(el);
-});
-onUnmounted(() => {
-  bodyRO?.disconnect();
-  bodyRO = null;
-});
 
 // ── Jump-list scroll-spy ─────────────────────────────────────────────────────
 const activeAnchor = ref('');

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -82,8 +82,12 @@ const errorMsg = ref('');
 let loadSeq = 0;
 async function load({ preserve = false }: { preserve?: boolean } = {}) {
   const seq = ++loadSeq;
-  if (!preserve) state.value = 'loading';
-  const stick = preserve && nearBottom();
+  // A fresh load (mount / session switch) re-pins the view to the foot — a chat
+  // opens at its newest exchange; a preserved refresh keeps the reader's pin.
+  if (!preserve) {
+    state.value = 'loading';
+    pinned.value = true;
+  }
   try {
     const snap = await getSessionChat(id.value);
     if (seq !== loadSeq) return;
@@ -104,7 +108,7 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
   }
   await nextTick();
   if (seq !== loadSeq) return;
-  if (stick || !preserve) scrollToBottom();
+  if (pinned.value) scrollToBottom();
   updateActive();
 }
 
@@ -537,9 +541,16 @@ const elapsedLabel = computed(() => {
   return `${m}:${String(s).padStart(2, '0')}`;
 });
 
-// ── Jump-list scroll-spy ─────────────────────────────────────────────────────
+// ── Follow-the-foot scroll ───────────────────────────────────────────────────
+// A chat opens at its newest exchange and stays *pinned* there while content
+// grows; scrolling up releases the pin, scrolling back to the foot re-arms it.
+// Growth lands asynchronously — markdown parses off-tick, images load, the pane
+// un-hides from a v-show tab — so a ResizeObserver on the transcript body does
+// the following; a one-shot scroll after nextTick would race the paint and
+// strand the view mid-history.
 const convScroll = ref<HTMLElement | null>(null);
-const activeAnchor = ref('');
+const convBody = ref<HTMLElement | null>(null);
+const pinned = ref(true);
 function nearBottom(): boolean {
   const el = convScroll.value;
   if (!el) return true;
@@ -550,8 +561,28 @@ function scrollToBottom() {
   if (el) el.scrollTop = el.scrollHeight;
 }
 function autoFollow() {
-  if (nearBottom()) nextTick(scrollToBottom);
+  if (pinned.value) nextTick(scrollToBottom);
 }
+function onScroll() {
+  pinned.value = nearBottom();
+  updateActive();
+}
+let bodyRO: ResizeObserver | null = null;
+watch(convBody, (el) => {
+  bodyRO?.disconnect();
+  if (!el) return;
+  bodyRO ??= new ResizeObserver(() => {
+    if (pinned.value) scrollToBottom();
+  });
+  bodyRO.observe(el);
+});
+onUnmounted(() => {
+  bodyRO?.disconnect();
+  bodyRO = null;
+});
+
+// ── Jump-list scroll-spy ─────────────────────────────────────────────────────
+const activeAnchor = ref('');
 function updateActive() {
   const root = convScroll.value;
   if (!root) return;
@@ -586,179 +617,181 @@ function goTo(anchor: string) {
       <div
         ref="convScroll"
         data-testid="acp-conversation"
-        class="acp-scroll min-h-0 flex-1 overflow-auto pb-8 pr-1"
-        @scroll.passive="updateActive"
+        class="acp-scroll min-h-0 flex-1 overflow-auto pb-6 pr-1"
+        @scroll.passive="onScroll"
       >
-        <!-- A fresh session: say so, instead of a blank canvas. -->
-        <div v-if="isEmpty" class="acp-empty" data-testid="acp-empty">
-          <p class="acp-empty-lede">No conversation yet</p>
-          <p class="acp-empty-hint">
-            {{
-              composerVisible
-                ? 'The transcript appears when the agent takes its first turn — or start one with a message below.'
-                : 'The transcript appears when the agent takes its first turn.'
-            }}
-          </p>
-        </div>
-
-        <template v-for="row in model.rows" :key="row.key">
-          <!-- Turn rule — dashed hairline between turns. -->
-          <div
-            v-if="row.type === 'turnRule'"
-            class="acp-turn-rule"
-            :class="{ loud: row.loud }"
-            data-testid="acp-turn-rule"
-          >
-            <span
-              >turn {{ row.turn + 1 }} · {{ row.stop
-              }}<template v-if="row.ctx != null"> · {{ Math.round(row.ctx / 1000) }}k ctx</template></span
-            >
+        <div ref="convBody">
+          <!-- A fresh session: say so, instead of a blank canvas. -->
+          <div v-if="isEmpty" class="acp-empty" data-testid="acp-empty">
+            <p class="acp-empty-lede">No conversation yet</p>
+            <p class="acp-empty-hint">
+              {{
+                composerVisible
+                  ? 'The transcript appears when the agent takes its first turn — or start one with a message below.'
+                  : 'The transcript appears when the agent takes its first turn.'
+              }}
+            </p>
           </div>
 
-          <!-- YOU — the human turn. -->
+          <template v-for="row in model.rows" :key="row.key">
+            <!-- Turn rule — dashed hairline between turns. -->
+            <div
+              v-if="row.type === 'turnRule'"
+              class="acp-turn-rule"
+              :class="{ loud: row.loud }"
+              data-testid="acp-turn-rule"
+            >
+              <span
+                >turn {{ row.turn + 1 }} · {{ row.stop
+                }}<template v-if="row.ctx != null"> · {{ Math.round(row.ctx / 1000) }}k ctx</template></span
+              >
+            </div>
+
+            <!-- YOU — the human turn. -->
+            <section
+              v-else-if="row.type === 'user'"
+              :id="row.anchor"
+              :data-anchor="row.anchor"
+              class="acp-speaker"
+            >
+              <header class="acp-rule">
+                <span class="acp-label text-accent">You</span>
+                <span class="acp-time">{{ row.time }}</span>
+              </header>
+              <MarkdownView :id="id" path="" :source="row.text" />
+            </section>
+
+            <!-- AGENT — the model's prose. -->
+            <section v-else-if="row.type === 'agent'" class="acp-speaker">
+              <header class="acp-rule">
+                <span class="acp-label">Agent</span>
+                <span v-if="row.time" class="acp-time">{{ row.time }}</span>
+              </header>
+              <MarkdownView :id="id" path="" :source="row.text" />
+            </section>
+
+            <!-- Thinking — streaming shows its live tail (the status line below
+                 names it); settled folds away. -->
+            <div v-else-if="row.type === 'thought'" class="acp-thought" data-testid="acp-thought">
+              <template v-if="row.streaming">
+                <div class="acp-thought-live-clip">
+                  <p class="acp-thought-body">{{ row.text }}</p>
+                </div>
+              </template>
+              <template v-else>
+                <button type="button" class="acp-fold-head" @click="toggleFold(row.key)">
+                  <span class="chev" :class="{ open: foldOpen(row.key) }">▸</span>
+                  <span>thinking</span>
+                </button>
+                <p v-if="foldOpen(row.key)" class="acp-thought-body">{{ row.text }}</p>
+              </template>
+            </div>
+
+            <!-- Apparatus: one folded activity line per run of tool calls. -->
+            <div v-else-if="row.type === 'activity'" class="acp-activity" data-testid="acp-activity">
+              <button
+                type="button"
+                class="acp-fold-head"
+                data-testid="acp-activity-head"
+                @click="toggleFold(row.key, row.failures > 0)"
+              >
+                <span class="chev" :class="{ open: foldOpen(row.key, row.failures > 0) }">▸</span>
+                <span v-if="row.items.length === 1" class="acp-activity-solo">
+                  <span class="acp-tool-glyph">{{ toolGlyph(row.items[0].tool.tool_kind) }}</span>
+                  <span class="truncate">{{ row.items[0].tool.title || row.items[0].tool.tool_kind }}</span>
+                </span>
+                <span v-else
+                  >{{ row.items.length }} steps — {{ activityBreakdown(row.items) }}</span
+                >
+                <span v-if="row.failures" class="acp-activity-failbadge" data-testid="acp-activity-failed"
+                  >{{ row.failures }} failed</span
+                >
+              </button>
+              <ul v-if="foldOpen(row.key, row.failures > 0)" class="acp-activity-list">
+                <li v-for="it in row.items" :key="it.tool.tool_call_id" data-testid="acp-activity-item">
+                  <button
+                    type="button"
+                    class="acp-activity-line"
+                    :disabled="!hasDetail(it.tool)"
+                    @click="toggleFold(`tool-${it.tool.tool_call_id}`, it.failed)"
+                  >
+                    <span class="acp-tool-glyph">{{ toolGlyph(it.tool.tool_kind) }}</span>
+                    <span class="truncate">{{ it.tool.title || it.tool.tool_kind }}</span>
+                    <span v-if="it.failed" class="acp-activity-status text-block">failed</span>
+                    <span v-else-if="hasDetail(it.tool)" class="chev sm" :class="{ open: foldOpen(`tool-${it.tool.tool_call_id}`, it.failed) }"
+                      >▸</span
+                    >
+                  </button>
+                  <div
+                    v-if="hasDetail(it.tool) && foldOpen(`tool-${it.tool.tool_call_id}`, it.failed)"
+                    class="acp-detail"
+                    data-testid="acp-detail"
+                  >
+                    <template v-for="(c, ci) in it.tool.content" :key="ci">
+                      <!-- A diff renders as real ±diff lines. -->
+                      <pre v-if="c.type === 'diff'" class="acp-diff" data-testid="acp-diff"><code
+                        v-for="(l, li) in diffLines(c)"
+                        :key="li"
+                        class="acp-diff-line"
+                        :class="l.sign === '-' ? 'acp-diff-del' : 'acp-diff-add'"
+                      >{{ l.sign }} {{ l.text }}
+  </code></pre>
+                      <!-- Text / command output on the recessed panel tone. -->
+                      <pre v-else-if="c.type === 'text' && c.text" class="acp-payload">{{ c.text }}</pre>
+                    </template>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <!-- Permission — the one interactive block. -->
+            <div v-else-if="row.type === 'permission'" class="acp-perm" data-testid="acp-permission">
+              <div class="acp-perm-label">Permission</div>
+              <p class="acp-perm-title">{{ row.perm.title }}</p>
+              <div v-if="row.perm.outcome" class="acp-perm-receipt" data-testid="acp-permission-receipt">
+                {{ row.perm.outcome.option_id }} · {{ shortTime(row.perm.outcome.at) }}
+              </div>
+              <div v-else class="acp-perm-options">
+                <button
+                  v-for="opt in row.perm.options"
+                  :key="opt.option_id"
+                  type="button"
+                  :class="isAllow(opt.kind) ? 'btn-primary' : 'btn-secondary'"
+                  class="px-2.5 py-1 text-xs"
+                  :disabled="answering.has(row.perm.request_id)"
+                  data-testid="acp-permission-option"
+                  @click="answer(row.perm, opt.option_id)"
+                >
+                  {{ opt.name }}
+                </button>
+              </div>
+            </div>
+
+            <!-- Mode change — a quiet centred marker. -->
+            <div v-else-if="row.type === 'mode'" class="acp-mode-note">mode → {{ modeLabel(row.mode) }}</div>
+          </template>
+
+          <!-- Optimistic (in-flight / queued) user messages. -->
           <section
-            v-else-if="row.type === 'user'"
-            :id="row.anchor"
-            :data-anchor="row.anchor"
+            v-for="(o, i) in optimistic"
+            :key="`opt-${i}`"
             class="acp-speaker"
+            data-testid="acp-optimistic"
           >
             <header class="acp-rule">
               <span class="acp-label text-accent">You</span>
-              <span class="acp-time">{{ row.time }}</span>
+              <span v-if="o.queued" class="acp-queued" data-testid="acp-queued">queued for next turn</span>
             </header>
-            <MarkdownView :id="id" path="" :source="row.text" />
+            <MarkdownView :id="id" path="" :source="o.text" />
           </section>
 
-          <!-- AGENT — the model's prose. -->
-          <section v-else-if="row.type === 'agent'" class="acp-speaker">
-            <header class="acp-rule">
-              <span class="acp-label">Agent</span>
-              <span v-if="row.time" class="acp-time">{{ row.time }}</span>
-            </header>
-            <MarkdownView :id="id" path="" :source="row.text" />
-          </section>
-
-          <!-- Thinking — streaming shows its live tail (the status line below
-               names it); settled folds away. -->
-          <div v-else-if="row.type === 'thought'" class="acp-thought" data-testid="acp-thought">
-            <template v-if="row.streaming">
-              <div class="acp-thought-live-clip">
-                <p class="acp-thought-body">{{ row.text }}</p>
-              </div>
-            </template>
-            <template v-else>
-              <button type="button" class="acp-fold-head" @click="toggleFold(row.key)">
-                <span class="chev" :class="{ open: foldOpen(row.key) }">▸</span>
-                <span>thinking</span>
-              </button>
-              <p v-if="foldOpen(row.key)" class="acp-thought-body">{{ row.text }}</p>
-            </template>
-          </div>
-
-          <!-- Apparatus: one folded activity line per run of tool calls. -->
-          <div v-else-if="row.type === 'activity'" class="acp-activity" data-testid="acp-activity">
-            <button
-              type="button"
-              class="acp-fold-head"
-              data-testid="acp-activity-head"
-              @click="toggleFold(row.key, row.failures > 0)"
+          <!-- Live status — what the agent is doing right now, at the tail. -->
+          <div v-if="turnLive" class="acp-status" data-testid="acp-working" role="status" aria-live="polite">
+            <span class="acp-live-label">{{ statusLabel }}…</span>
+            <span class="acp-status-meta"
+              >turn {{ (liveTurnNo ?? 0) + 1 }} · {{ elapsedLabel }}</span
             >
-              <span class="chev" :class="{ open: foldOpen(row.key, row.failures > 0) }">▸</span>
-              <span v-if="row.items.length === 1" class="acp-activity-solo">
-                <span class="acp-tool-glyph">{{ toolGlyph(row.items[0].tool.tool_kind) }}</span>
-                <span class="truncate">{{ row.items[0].tool.title || row.items[0].tool.tool_kind }}</span>
-              </span>
-              <span v-else
-                >{{ row.items.length }} steps — {{ activityBreakdown(row.items) }}</span
-              >
-              <span v-if="row.failures" class="acp-activity-failbadge" data-testid="acp-activity-failed"
-                >{{ row.failures }} failed</span
-              >
-            </button>
-            <ul v-if="foldOpen(row.key, row.failures > 0)" class="acp-activity-list">
-              <li v-for="it in row.items" :key="it.tool.tool_call_id" data-testid="acp-activity-item">
-                <button
-                  type="button"
-                  class="acp-activity-line"
-                  :disabled="!hasDetail(it.tool)"
-                  @click="toggleFold(`tool-${it.tool.tool_call_id}`, it.failed)"
-                >
-                  <span class="acp-tool-glyph">{{ toolGlyph(it.tool.tool_kind) }}</span>
-                  <span class="truncate">{{ it.tool.title || it.tool.tool_kind }}</span>
-                  <span v-if="it.failed" class="acp-activity-status text-block">failed</span>
-                  <span v-else-if="hasDetail(it.tool)" class="chev sm" :class="{ open: foldOpen(`tool-${it.tool.tool_call_id}`, it.failed) }"
-                    >▸</span
-                  >
-                </button>
-                <div
-                  v-if="hasDetail(it.tool) && foldOpen(`tool-${it.tool.tool_call_id}`, it.failed)"
-                  class="acp-detail"
-                  data-testid="acp-detail"
-                >
-                  <template v-for="(c, ci) in it.tool.content" :key="ci">
-                    <!-- A diff renders as real ±diff lines. -->
-                    <pre v-if="c.type === 'diff'" class="acp-diff" data-testid="acp-diff"><code
-                      v-for="(l, li) in diffLines(c)"
-                      :key="li"
-                      class="acp-diff-line"
-                      :class="l.sign === '-' ? 'acp-diff-del' : 'acp-diff-add'"
-                    >{{ l.sign }} {{ l.text }}
-</code></pre>
-                    <!-- Text / command output on the recessed panel tone. -->
-                    <pre v-else-if="c.type === 'text' && c.text" class="acp-payload">{{ c.text }}</pre>
-                  </template>
-                </div>
-              </li>
-            </ul>
           </div>
-
-          <!-- Permission — the one interactive block. -->
-          <div v-else-if="row.type === 'permission'" class="acp-perm" data-testid="acp-permission">
-            <div class="acp-perm-label">Permission</div>
-            <p class="acp-perm-title">{{ row.perm.title }}</p>
-            <div v-if="row.perm.outcome" class="acp-perm-receipt" data-testid="acp-permission-receipt">
-              {{ row.perm.outcome.option_id }} · {{ shortTime(row.perm.outcome.at) }}
-            </div>
-            <div v-else class="acp-perm-options">
-              <button
-                v-for="opt in row.perm.options"
-                :key="opt.option_id"
-                type="button"
-                :class="isAllow(opt.kind) ? 'btn-primary' : 'btn-secondary'"
-                class="px-2.5 py-1 text-xs"
-                :disabled="answering.has(row.perm.request_id)"
-                data-testid="acp-permission-option"
-                @click="answer(row.perm, opt.option_id)"
-              >
-                {{ opt.name }}
-              </button>
-            </div>
-          </div>
-
-          <!-- Mode change — a quiet centred marker. -->
-          <div v-else-if="row.type === 'mode'" class="acp-mode-note">mode → {{ modeLabel(row.mode) }}</div>
-        </template>
-
-        <!-- Optimistic (in-flight / queued) user messages. -->
-        <section
-          v-for="(o, i) in optimistic"
-          :key="`opt-${i}`"
-          class="acp-speaker"
-          data-testid="acp-optimistic"
-        >
-          <header class="acp-rule">
-            <span class="acp-label text-accent">You</span>
-            <span v-if="o.queued" class="acp-queued" data-testid="acp-queued">queued for next turn</span>
-          </header>
-          <MarkdownView :id="id" path="" :source="o.text" />
-        </section>
-
-        <!-- Live status — what the agent is doing right now, at the tail. -->
-        <div v-if="turnLive" class="acp-status" data-testid="acp-working" role="status" aria-live="polite">
-          <span class="acp-live-label">{{ statusLabel }}…</span>
-          <span class="acp-status-meta"
-            >turn {{ (liveTurnNo ?? 0) + 1 }} · {{ elapsedLabel }}</span
-          >
         </div>
       </div>
 
@@ -870,7 +903,9 @@ function goTo(anchor: string) {
 
 <style scoped>
 /* Flatten MarkdownView's card into tight, left-aligned serif prose on the
-   canvas — the transcript reads as printed dialogue, not stacked cards. */
+   canvas — the transcript reads as printed dialogue, not stacked cards. The
+   document defaults (1.7 leading, 1em block gaps, deep list indents) are cut
+   for a printed page; a conversation reads denser, so they tighten here. */
 .acp-scroll :deep(div:has(> .markdown-body)) {
   background: transparent;
   overflow: visible;
@@ -879,12 +914,35 @@ function goTo(anchor: string) {
   max-width: 46rem;
   margin: 0;
   padding: 0.125rem 0;
+  line-height: 1.55;
+}
+.acp-scroll :deep(.markdown-body p),
+.acp-scroll :deep(.markdown-body blockquote),
+.acp-scroll :deep(.markdown-body ul),
+.acp-scroll :deep(.markdown-body ol),
+.acp-scroll :deep(.markdown-body dl),
+.acp-scroll :deep(.markdown-body table),
+.acp-scroll :deep(.markdown-body pre),
+.acp-scroll :deep(.markdown-body details) {
+  margin-bottom: 0.6em;
+}
+.acp-scroll :deep(.markdown-body h1),
+.acp-scroll :deep(.markdown-body h2),
+.acp-scroll :deep(.markdown-body h3),
+.acp-scroll :deep(.markdown-body h4),
+.acp-scroll :deep(.markdown-body h5),
+.acp-scroll :deep(.markdown-body h6) {
+  margin: 1em 0 0.4em;
+}
+.acp-scroll :deep(.markdown-body ul),
+.acp-scroll :deep(.markdown-body ol) {
+  padding-left: 1.5em;
 }
 
 /* Speaker block: a hairline rule + micro-caps label + mono time, serif beneath. */
 .acp-speaker {
   scroll-margin-top: 0.5rem;
-  margin-top: 1.5rem;
+  margin-top: 1rem;
 }
 .acp-speaker:first-child {
   margin-top: 0.25rem;
@@ -895,7 +953,7 @@ function goTo(anchor: string) {
   gap: 0.625rem;
   border-top: 1px solid var(--line);
   padding-top: 0.375rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.375rem;
 }
 .acp-label {
   font-family: var(--font-sans);
@@ -941,7 +999,7 @@ function goTo(anchor: string) {
 /* Fold heads — one quiet mono voice for thinking + activity. */
 .acp-thought,
 .acp-activity {
-  margin-top: 0.625rem;
+  margin-top: 0.5rem;
   max-width: 46rem;
 }
 .acp-fold-head {
@@ -1139,7 +1197,7 @@ function goTo(anchor: string) {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 1.5rem 0 0.25rem;
+  margin: 1rem 0 0.25rem;
   max-width: 46rem;
   border-top: 1px dashed var(--line);
   padding-top: 0.55rem;
@@ -1159,7 +1217,7 @@ function goTo(anchor: string) {
 /* Live status — the one animated element: a soft shimmer naming the agent's
    current activity while a turn runs. */
 .acp-status {
-  margin-top: 1rem;
+  margin-top: 0.75rem;
   display: flex;
   align-items: baseline;
   gap: 0.6rem;
@@ -1201,9 +1259,9 @@ function goTo(anchor: string) {
 
 /* Composer. */
 .acp-composer {
-  margin-top: 0.75rem;
+  margin-top: 0.5rem;
   border-top: 1px solid var(--line);
-  padding-top: 0.75rem;
+  padding-top: 0.625rem;
 }
 .acp-input {
   width: 100%;

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -164,8 +164,12 @@ function onTurn(ev: SseTurn) {
 let source: EventSource | null = null;
 function openStream() {
   source = new EventSource(`/api/sessions/${id.value}/chat/stream`);
-  source.addEventListener('block', (e) => onBlock(JSON.parse((e as MessageEvent).data) as ChatBlock));
-  source.addEventListener('delta', (e) => onDelta(JSON.parse((e as MessageEvent).data) as SseDelta));
+  source.addEventListener('block', (e) =>
+    onBlock(JSON.parse((e as MessageEvent).data) as ChatBlock),
+  );
+  source.addEventListener('delta', (e) =>
+    onDelta(JSON.parse((e as MessageEvent).data) as SseDelta),
+  );
   source.addEventListener('tool', (e) => onTool(JSON.parse((e as MessageEvent).data) as SseTool));
   source.addEventListener('turn', (e) => onTurn(JSON.parse((e as MessageEvent).data) as SseTurn));
 }
@@ -306,7 +310,12 @@ interface TocItem {
 }
 
 function firstLine(s: string): string {
-  return s.split('\n').map((l) => l.trim()).find(Boolean) ?? '';
+  return (
+    s
+      .split('\n')
+      .map((l) => l.trim())
+      .find(Boolean) ?? ''
+  );
 }
 function titleOf(text: string): string {
   const f = firstLine(text) || '(no text)';
@@ -397,7 +406,11 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
         break;
       case 'mode_change':
         flushActivity();
-        rows.push({ type: 'mode', key: k, mode: (b.payload as { mode_id?: string }).mode_id ?? '' });
+        rows.push({
+          type: 'mode',
+          key: k,
+          mode: (b.payload as { mode_id?: string }).mode_id ?? '',
+        });
         break;
       case 'turn_end': {
         flushActivity();
@@ -424,11 +437,22 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
   if (lt != null) {
     const thought = shadows.get(`${lt}:thought`);
     if (thought && thought.text) {
-      rows.push({ type: 'thought', key: `shadow-${lt}-thought`, text: thought.text, streaming: true });
+      rows.push({
+        type: 'thought',
+        key: `shadow-${lt}-thought`,
+        text: thought.text,
+        streaming: true,
+      });
     }
     const msg = shadows.get(`${lt}:agent_message`);
     if (msg && msg.text) {
-      rows.push({ type: 'agent', key: `shadow-${lt}-agent`, time: '', text: msg.text, streaming: true });
+      rows.push({
+        type: 'agent',
+        key: `shadow-${lt}-agent`,
+        time: '',
+        text: msg.text,
+        streaming: true,
+      });
     }
   }
 
@@ -438,7 +462,11 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
 // The empty conversation, styled on purpose — a fresh session has no journal
 // yet, and a bare canvas reads as breakage.
 const isEmpty = computed(
-  () => state.value === 'ready' && !model.value.rows.length && !optimistic.value.length && !turnLive.value,
+  () =>
+    state.value === 'ready' &&
+    !model.value.rows.length &&
+    !optimistic.value.length &&
+    !turnLive.value,
 );
 
 // ── Live status line ─────────────────────────────────────────────────────────
@@ -460,11 +488,19 @@ const statusLabel = computed(() => {
 // ── Presentational helpers ───────────────────────────────────────────────────
 function toolGlyph(kind: string): string {
   return (
-    { edit: '✎', execute: '⌗', delete: '✕', move: '⇄', read: '❏', search: '⌕', fetch: '⤓', think: '✳' } as Record<
-      string,
-      string
-    >
-  )[kind] ?? '•';
+    (
+      {
+        edit: '✎',
+        execute: '⌗',
+        delete: '✕',
+        move: '⇄',
+        read: '❏',
+        search: '⌕',
+        fetch: '⤓',
+        think: '✳',
+      } as Record<string, string>
+    )[kind] ?? '•'
+  );
 }
 // The kind census on a collapsed group: `7 read · 2 search`, commonest first.
 function activityBreakdown(items: ActivityItem[]): string {
@@ -500,7 +536,11 @@ function planGlyph(status: string): string {
   return status === 'completed' ? '✓' : status === 'in_progress' ? '▸' : '○';
 }
 function planTone(status: string): string {
-  return status === 'completed' ? 'text-ok' : status === 'in_progress' ? 'text-agent' : 'text-faint';
+  return status === 'completed'
+    ? 'text-ok'
+    : status === 'in_progress'
+      ? 'text-agent'
+      : 'text-faint';
 }
 function isAllow(kind: string): boolean {
   return kind.startsWith('allow');
@@ -643,7 +683,9 @@ function goTo(anchor: string) {
             >
               <span
                 >turn {{ row.turn + 1 }} · {{ row.stop
-                }}<template v-if="row.ctx != null"> · {{ Math.round(row.ctx / 1000) }}k ctx</template></span
+                }}<template v-if="row.ctx != null">
+                  · {{ Math.round(row.ctx / 1000) }}k ctx</template
+                ></span
               >
             </div>
 
@@ -688,7 +730,11 @@ function goTo(anchor: string) {
             </div>
 
             <!-- Apparatus: one folded activity line per run of tool calls. -->
-            <div v-else-if="row.type === 'activity'" class="acp-activity" data-testid="acp-activity">
+            <div
+              v-else-if="row.type === 'activity'"
+              class="acp-activity"
+              data-testid="acp-activity"
+            >
               <button
                 type="button"
                 class="acp-fold-head"
@@ -698,17 +744,26 @@ function goTo(anchor: string) {
                 <span class="chev" :class="{ open: foldOpen(row.key, row.failures > 0) }">▸</span>
                 <span v-if="row.items.length === 1" class="acp-activity-solo">
                   <span class="acp-tool-glyph">{{ toolGlyph(row.items[0].tool.tool_kind) }}</span>
-                  <span class="truncate">{{ row.items[0].tool.title || row.items[0].tool.tool_kind }}</span>
+                  <span class="truncate">{{
+                    row.items[0].tool.title || row.items[0].tool.tool_kind
+                  }}</span>
                 </span>
                 <span v-else
                   >{{ row.items.length }} steps — {{ activityBreakdown(row.items) }}</span
                 >
-                <span v-if="row.failures" class="acp-activity-failbadge" data-testid="acp-activity-failed"
+                <span
+                  v-if="row.failures"
+                  class="acp-activity-failbadge"
+                  data-testid="acp-activity-failed"
                   >{{ row.failures }} failed</span
                 >
               </button>
               <ul v-if="foldOpen(row.key, row.failures > 0)" class="acp-activity-list">
-                <li v-for="it in row.items" :key="it.tool.tool_call_id" data-testid="acp-activity-item">
+                <li
+                  v-for="it in row.items"
+                  :key="it.tool.tool_call_id"
+                  data-testid="acp-activity-item"
+                >
                   <button
                     type="button"
                     class="acp-activity-line"
@@ -718,7 +773,10 @@ function goTo(anchor: string) {
                     <span class="acp-tool-glyph">{{ toolGlyph(it.tool.tool_kind) }}</span>
                     <span class="truncate">{{ it.tool.title || it.tool.tool_kind }}</span>
                     <span v-if="it.failed" class="acp-activity-status text-block">failed</span>
-                    <span v-else-if="hasDetail(it.tool)" class="chev sm" :class="{ open: foldOpen(`tool-${it.tool.tool_call_id}`, it.failed) }"
+                    <span
+                      v-else-if="hasDetail(it.tool)"
+                      class="chev sm"
+                      :class="{ open: foldOpen(`tool-${it.tool.tool_call_id}`, it.failed) }"
                       >▸</span
                     >
                   </button>
@@ -737,7 +795,9 @@ function goTo(anchor: string) {
                       >{{ l.sign }} {{ l.text }}
   </code></pre>
                       <!-- Text / command output on the recessed panel tone. -->
-                      <pre v-else-if="c.type === 'text' && c.text" class="acp-payload">{{ c.text }}</pre>
+                      <pre v-else-if="c.type === 'text' && c.text" class="acp-payload">{{
+                        c.text
+                      }}</pre>
                     </template>
                   </div>
                 </li>
@@ -745,10 +805,18 @@ function goTo(anchor: string) {
             </div>
 
             <!-- Permission — the one interactive block. -->
-            <div v-else-if="row.type === 'permission'" class="acp-perm" data-testid="acp-permission">
+            <div
+              v-else-if="row.type === 'permission'"
+              class="acp-perm"
+              data-testid="acp-permission"
+            >
               <div class="acp-perm-label">Permission</div>
               <p class="acp-perm-title">{{ row.perm.title }}</p>
-              <div v-if="row.perm.outcome" class="acp-perm-receipt" data-testid="acp-permission-receipt">
+              <div
+                v-if="row.perm.outcome"
+                class="acp-perm-receipt"
+                data-testid="acp-permission-receipt"
+              >
                 {{ row.perm.outcome.option_id }} · {{ shortTime(row.perm.outcome.at) }}
               </div>
               <div v-else class="acp-perm-options">
@@ -768,7 +836,9 @@ function goTo(anchor: string) {
             </div>
 
             <!-- Mode change — a quiet centred marker. -->
-            <div v-else-if="row.type === 'mode'" class="acp-mode-note">mode → {{ modeLabel(row.mode) }}</div>
+            <div v-else-if="row.type === 'mode'" class="acp-mode-note">
+              mode → {{ modeLabel(row.mode) }}
+            </div>
           </template>
 
           <!-- Optimistic (in-flight / queued) user messages. -->
@@ -780,13 +850,21 @@ function goTo(anchor: string) {
           >
             <header class="acp-rule">
               <span class="acp-label text-accent">You</span>
-              <span v-if="o.queued" class="acp-queued" data-testid="acp-queued">queued for next turn</span>
+              <span v-if="o.queued" class="acp-queued" data-testid="acp-queued"
+                >queued for next turn</span
+              >
             </header>
             <MarkdownView :id="id" path="" :source="o.text" />
           </section>
 
           <!-- Live status — what the agent is doing right now, at the tail. -->
-          <div v-if="turnLive" class="acp-status" data-testid="acp-working" role="status" aria-live="polite">
+          <div
+            v-if="turnLive"
+            class="acp-status"
+            data-testid="acp-working"
+            role="status"
+            aria-live="polite"
+          >
             <span class="acp-live-label">{{ statusLabel }}…</span>
             <span class="acp-status-meta"
               >turn {{ (liveTurnNo ?? 0) + 1 }} · {{ elapsedLabel }}</span
@@ -823,8 +901,12 @@ function goTo(anchor: string) {
           <p class="acp-rail-head">Plan</p>
           <ul class="space-y-1" data-testid="acp-plan">
             <li v-for="(e, i) in latestPlan" :key="i" class="acp-plan-item">
-              <span class="acp-plan-glyph" :class="planTone(e.status)">{{ planGlyph(e.status) }}</span>
-              <span :class="e.status === 'pending' ? 'text-faint' : 'text-muted'">{{ e.content }}</span>
+              <span class="acp-plan-glyph" :class="planTone(e.status)">{{
+                planGlyph(e.status)
+              }}</span>
+              <span :class="e.status === 'pending' ? 'text-faint' : 'text-muted'">{{
+                e.content
+              }}</span>
             </li>
           </ul>
         </template>
@@ -838,7 +920,9 @@ function goTo(anchor: string) {
       data-testid="acp-composer"
       @submit.prevent="submitPrompt"
     >
-      <p v-if="sendError" class="mb-1.5 text-xs text-block" data-testid="acp-composer-error">{{ sendError }}</p>
+      <p v-if="sendError" class="mb-1.5 text-xs text-block" data-testid="acp-composer-error">
+        {{ sendError }}
+      </p>
       <textarea
         v-model="draft"
         rows="2"
@@ -859,7 +943,8 @@ function goTo(anchor: string) {
               :disabled="!modeInteractive"
               @click.stop="modeOpen = !modeOpen"
             >
-              {{ modeLabel(currentMode) }}<span v-if="modeInteractive" class="acp-mode-caret">▾</span>
+              {{ modeLabel(currentMode)
+              }}<span v-if="modeInteractive" class="acp-mode-caret">▾</span>
             </button>
             <ul v-if="modeOpen" class="acp-mode-menu" data-testid="acp-mode-menu">
               <li v-for="m in modeOptions" :key="m">

--- a/crates/loom/frontend/src/components/AgentProfileEditor.vue
+++ b/crates/loom/frontend/src/components/AgentProfileEditor.vue
@@ -24,9 +24,7 @@ const emit = defineEmits<{
   reset: [];
 }>();
 
-const selectedAgent = computed(() =>
-  props.agents.find((agent) => agent.kind === props.agentKind),
-);
+const selectedAgent = computed(() => props.agents.find((agent) => agent.kind === props.agentKind));
 
 function agentLabel(kind: string): string {
   return props.agents.find((agent) => agent.kind === kind)?.label ?? kind;
@@ -34,7 +32,8 @@ function agentLabel(kind: string): string {
 
 function choiceLabel(kind: 'model' | 'effort', value: string): string {
   if (!value) return 'Default';
-  const choices = kind === 'model' ? selectedAgent.value?.models ?? [] : selectedAgent.value?.efforts ?? [];
+  const choices =
+    kind === 'model' ? (selectedAgent.value?.models ?? []) : (selectedAgent.value?.efforts ?? []);
   return choices.find((choice) => choice.id === value)?.label ?? value;
 }
 </script>

--- a/crates/loom/frontend/src/components/AgentRuntimePicker.vue
+++ b/crates/loom/frontend/src/components/AgentRuntimePicker.vue
@@ -35,9 +35,7 @@ const emit = defineEmits<{
   'update:effort': [string];
 }>();
 
-const selectedAgent = computed(() =>
-  props.agents.find((agent) => agent.kind === props.agentKind),
-);
+const selectedAgent = computed(() => props.agents.find((agent) => agent.kind === props.agentKind));
 
 function updateRawModel(e: Event) {
   emit('update:model', (e.target as HTMLInputElement).value);
@@ -83,8 +81,12 @@ function updateRawModel(e: Event) {
           </span>
         </span>
         <span v-if="showAgentCounts" class="mt-0.5 block text-xs text-faint">
-          {{ agentOption.models.length || 'Default' }} model{{ agentOption.models.length === 1 ? '' : 's' }}
-          <template v-if="agentOption.efforts.length">, {{ agentOption.efforts.length }} effort levels</template>
+          {{ agentOption.models.length || 'Default' }} model{{
+            agentOption.models.length === 1 ? '' : 's'
+          }}
+          <template v-if="agentOption.efforts.length"
+            >, {{ agentOption.efforts.length }} effort levels</template
+          >
         </span>
       </button>
     </div>
@@ -92,9 +94,7 @@ function updateRawModel(e: Event) {
     <div :class="choiceGridClass">
       <div>
         <div class="mb-1 flex items-center justify-between gap-2">
-          <label class="text-2xs font-semibold uppercase tracking-wider text-muted">
-            Model
-          </label>
+          <label class="text-2xs font-semibold uppercase tracking-wider text-muted"> Model </label>
           <code v-if="modelKey" class="truncate font-mono text-2xs text-faint">{{ modelKey }}</code>
         </div>
         <div class="flex flex-wrap gap-1.5">
@@ -138,10 +138,10 @@ function updateRawModel(e: Event) {
 
       <div>
         <div class="mb-1 flex items-center justify-between gap-2">
-          <label class="text-2xs font-semibold uppercase tracking-wider text-muted">
-            Effort
-          </label>
-          <code v-if="effortKey" class="truncate font-mono text-2xs text-faint">{{ effortKey }}</code>
+          <label class="text-2xs font-semibold uppercase tracking-wider text-muted"> Effort </label>
+          <code v-if="effortKey" class="truncate font-mono text-2xs text-faint">{{
+            effortKey
+          }}</code>
         </div>
         <div class="flex flex-wrap gap-1.5">
           <button

--- a/crates/loom/frontend/src/components/AgentTerminal.vue
+++ b/crates/loom/frontend/src/components/AgentTerminal.vue
@@ -400,7 +400,10 @@ onUnmounted(() => {
   <div class="group relative h-full min-h-0">
     <!-- FitAddon subtracts the host's padding when sizing, so the p-2 gives the
          grid breathing room inside the framed panel. -->
-    <div ref="host" class="h-full w-full overflow-hidden rounded bg-code p-2 text-code-fg ring-1 ring-line"></div>
+    <div
+      ref="host"
+      class="h-full w-full overflow-hidden rounded bg-code p-2 text-code-fg ring-1 ring-line"
+    ></div>
 
     <!-- Find bar (Ctrl/Cmd+F). Top-left so it never collides with the
          connection-status badge in the top-right corner. -->
@@ -418,10 +421,30 @@ onUnmounted(() => {
         @keydown.enter.prevent="(e: KeyboardEvent) => (e.shiftKey ? findPrev() : findNext())"
         @keydown.esc.prevent="closeSearch"
       />
-      <span class="min-w-[2.75rem] text-center text-xs tabular-nums text-muted">{{ matchCount ? `${matchIndex}/${matchCount}` : '0/0' }}</span>
-      <button class="rounded px-1.5 py-1 text-xs text-muted hover:bg-block-soft hover:text-fg" title="Previous (Shift+Enter)" @click="findPrev">↑</button>
-      <button class="rounded px-1.5 py-1 text-xs text-muted hover:bg-block-soft hover:text-fg" title="Next (Enter)" @click="findNext">↓</button>
-      <button class="rounded px-1.5 py-1 text-xs text-muted hover:bg-block-soft hover:text-fg" title="Close (Esc)" @click="closeSearch">✕</button>
+      <span class="min-w-[2.75rem] text-center text-xs tabular-nums text-muted">{{
+        matchCount ? `${matchIndex}/${matchCount}` : '0/0'
+      }}</span>
+      <button
+        class="rounded px-1.5 py-1 text-xs text-muted hover:bg-block-soft hover:text-fg"
+        title="Previous (Shift+Enter)"
+        @click="findPrev"
+      >
+        ↑
+      </button>
+      <button
+        class="rounded px-1.5 py-1 text-xs text-muted hover:bg-block-soft hover:text-fg"
+        title="Next (Enter)"
+        @click="findNext"
+      >
+        ↓
+      </button>
+      <button
+        class="rounded px-1.5 py-1 text-xs text-muted hover:bg-block-soft hover:text-fg"
+        title="Close (Esc)"
+        @click="closeSearch"
+      >
+        ✕
+      </button>
     </div>
 
     <!-- Hover-revealed actions. Bottom-right keeps them out of the way of the
@@ -453,9 +476,11 @@ onUnmounted(() => {
       v-if="state !== 'open' && statusVisible"
       data-testid="term-status"
       class="absolute right-2 top-2 rounded px-2 py-1 text-xs font-medium ring-1"
-      :class="state === 'error'
-        ? 'bg-block text-block-fg ring-block-line'
-        : 'bg-surface/95 text-muted ring-line'"
+      :class="
+        state === 'error'
+          ? 'bg-block text-block-fg ring-block-line'
+          : 'bg-surface/95 text-muted ring-line'
+      "
     >
       <span v-if="state === 'connecting'">connecting…</span>
       <span v-else-if="state === 'reconnecting'">reconnecting…</span>

--- a/crates/loom/frontend/src/components/AppRail.vue
+++ b/crates/loom/frontend/src/components/AppRail.vue
@@ -28,7 +28,11 @@ const MAIN: RailItem[] = [
     label: 'Sessions',
     match: (p) => p === '/' || p.startsWith('/s/'),
     // square-terminal — a session is a live agent terminal.
-    paths: ['m7 11 2-2-2-2', 'M13 15h4', 'M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z'],
+    paths: [
+      'm7 11 2-2-2-2',
+      'M13 15h4',
+      'M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z',
+    ],
   },
   {
     to: '/issues',
@@ -94,8 +98,16 @@ const active = computed(() => (item: RailItem) => item.match(route.path));
       title="loom — agent sessions"
       aria-label="loom home"
     >
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-        stroke-width="1.75" stroke-linecap="round" aria-hidden="true">
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.75"
+        stroke-linecap="round"
+        aria-hidden="true"
+      >
         <path d="M4 9h16M4 15h16M9 4v16M15 4v16" />
       </svg>
     </router-link>
@@ -115,8 +127,17 @@ const active = computed(() => (item: RailItem) => item.match(route.path));
         class="absolute inset-y-1.5 left-0 w-0.5 rounded-r bg-accent"
         aria-hidden="true"
       ></span>
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-        stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
         <path v-for="(d, i) in item.paths" :key="i" :d="d" />
       </svg>
       <span class="text-[10px] leading-3">{{ item.label }}</span>
@@ -131,13 +152,34 @@ const active = computed(() => (item: RailItem) => item.match(route.path));
         aria-label="Toggle color theme"
         @click="toggleTheme"
       >
-        <svg v-if="theme === 'dark'" width="20" height="20" viewBox="0 0 24 24" fill="none"
-          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true">
+        <svg
+          v-if="theme === 'dark'"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          aria-hidden="true"
+        >
           <circle cx="12" cy="12" r="4" />
-          <path d="M12 2v2M12 20v2m-7.07-2.93 1.41-1.41m11.32 0 1.41 1.41M2 12h2m16 0h2M4.93 4.93l1.41 1.41m11.32 0 1.41-1.41" />
+          <path
+            d="M12 2v2M12 20v2m-7.07-2.93 1.41-1.41m11.32 0 1.41 1.41M2 12h2m16 0h2M4.93 4.93l1.41 1.41m11.32 0 1.41-1.41"
+          />
         </svg>
-        <svg v-else width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-          stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg
+          v-else
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
           <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
         </svg>
       </button>
@@ -154,8 +196,17 @@ const active = computed(() => (item: RailItem) => item.match(route.path));
           class="absolute inset-y-1.5 left-0 w-0.5 rounded-r bg-accent"
           aria-hidden="true"
         ></span>
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-          stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
           <path v-for="(d, i) in SETTINGS.paths" :key="i" :d="d" />
         </svg>
       </router-link>

--- a/crates/loom/frontend/src/components/AppearancePanel.vue
+++ b/crates/loom/frontend/src/components/AppearancePanel.vue
@@ -261,7 +261,9 @@ onUnmounted(() => {
       <div class="grid gap-3 border-t border-line pt-4 md:grid-cols-[10rem_minmax(0,1fr)]">
         <div class="min-w-0">
           <div class="text-sm font-medium">Size</div>
-          <p class="mt-0.5 text-xs text-muted">Pixel size, {{ MIN_FONT_SIZE }}–{{ MAX_FONT_SIZE }}.</p>
+          <p class="mt-0.5 text-xs text-muted">
+            Pixel size, {{ MIN_FONT_SIZE }}–{{ MAX_FONT_SIZE }}.
+          </p>
         </div>
         <div class="flex flex-wrap items-center gap-2">
           <button
@@ -327,7 +329,9 @@ onUnmounted(() => {
         >
           Reset to defaults
         </button>
-        <span v-if="dirty" class="text-2xs text-faint">Unsaved changes — applies to terminals opened after saving.</span>
+        <span v-if="dirty" class="text-2xs text-faint"
+          >Unsaved changes — applies to terminals opened after saving.</span
+        >
       </div>
     </section>
   </div>

--- a/crates/loom/frontend/src/components/ArtifactDocument.vue
+++ b/crates/loom/frontend/src/components/ArtifactDocument.vue
@@ -433,7 +433,11 @@ function renderComposer(): VNode {
         ),
         h(
           'button',
-          { type: 'button', class: 'btn-secondary px-2 py-1 text-2xs', onClick: withStop(onCancel) },
+          {
+            type: 'button',
+            class: 'btn-secondary px-2 py-1 text-2xs',
+            onClick: withStop(onCancel),
+          },
           'Cancel',
         ),
       ]),
@@ -471,19 +475,27 @@ function renderOrphaned(): VNode {
             'div',
             { class: 'mt-1.5 space-y-2' },
             orphaned.value.map((t) =>
-              h('div', { key: t.id, class: 'rounded border border-line bg-subtle/40 p-2 text-xs' }, [
-                h('div', { class: 'truncate italic text-faint' }, `“${t.anchor.quote}”`),
-                h('div', { class: 'mt-0.5 truncate text-fg' }, t.comments[t.comments.length - 1]?.body),
-                h(
-                  'button',
-                  {
-                    type: 'button',
-                    class: 'btn-secondary mt-1 px-2 py-0.5 text-2xs',
-                    onClick: withStop(() => onResolve(t.id)),
-                  },
-                  'Resolve',
-                ),
-              ]),
+              h(
+                'div',
+                { key: t.id, class: 'rounded border border-line bg-subtle/40 p-2 text-xs' },
+                [
+                  h('div', { class: 'truncate italic text-faint' }, `“${t.anchor.quote}”`),
+                  h(
+                    'div',
+                    { class: 'mt-0.5 truncate text-fg' },
+                    t.comments[t.comments.length - 1]?.body,
+                  ),
+                  h(
+                    'button',
+                    {
+                      type: 'button',
+                      class: 'btn-secondary mt-1 px-2 py-0.5 text-2xs',
+                      onClick: withStop(() => onResolve(t.id)),
+                    },
+                    'Resolve',
+                  ),
+                ],
+              ),
             ),
           )
         : null,

--- a/crates/loom/frontend/src/components/ArtifactsPanel.vue
+++ b/crates/loom/frontend/src/components/ArtifactsPanel.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onActivated, onDeactivated, onUnmounted, nextTick } from 'vue';
+import {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  onActivated,
+  onDeactivated,
+  onUnmounted,
+  nextTick,
+} from 'vue';
 import { useRouter } from 'vue-router';
 import { getArtifacts, getArtifact, putArtifact, deleteArtifact } from '../api';
 import type { ArtifactMeta, ArtifactView } from '../types';
@@ -251,7 +260,8 @@ function openStream() {
       // and snap a reader out of Source back to Preview. Only a genuinely newer
       // revision refreshes, and it keeps the current preview/source choice.
       if (d.rev != null && onLatest.value && view.value && d.rev <= view.value.meta.rev) return;
-      if (isActive.value) openArtifact(selected.value, undefined, { keepMode: true }).catch(() => {});
+      if (isActive.value)
+        openArtifact(selected.value, undefined, { keepMode: true }).catch(() => {});
       else pendingRefresh.value = true;
     }
   });
@@ -331,10 +341,7 @@ onUnmounted(() => {
 
     <div class="flex min-h-0 flex-1" :class="compact ? 'flex-col' : ''">
       <!-- List — a sidebar at full width, a dropdown in the narrow rail. -->
-      <div
-        v-if="!compact"
-        class="flex w-72 shrink-0 flex-col border-r border-line"
-      >
+      <div v-if="!compact" class="flex w-72 shrink-0 flex-col border-r border-line">
         <div
           class="border-b border-line px-2 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint"
         >
@@ -371,10 +378,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Compact list: a dropdown header for the rail. -->
-      <div
-        v-else
-        class="flex shrink-0 items-center gap-2 border-b border-line px-2 py-1.5 text-xs"
-      >
+      <div v-else class="flex shrink-0 items-center gap-2 border-b border-line px-2 py-1.5 text-xs">
         <span class="text-faint">Artifact</span>
         <select
           class="min-w-0 flex-1 rounded border border-line bg-surface px-1.5 py-0.5 text-xs text-fg"
@@ -423,7 +427,7 @@ onUnmounted(() => {
                 class="flex items-center overflow-hidden rounded border border-line"
               >
                 <button
-                  v-for="m in (['preview', 'source'] as const)"
+                  v-for="m in ['preview', 'source'] as const"
                   :key="m"
                   class="px-2 py-0.5"
                   :class="viewMode === m ? 'bg-subtle text-fg' : 'text-muted hover:bg-subtle/60'"

--- a/crates/loom/frontend/src/components/CommentThread.vue
+++ b/crates/loom/frontend/src/components/CommentThread.vue
@@ -60,7 +60,9 @@ watch(
     <span
       class="inline-flex h-4 shrink-0 items-center rounded-full px-1.5 text-2xs font-medium"
       :class="
-        lastComment(thread)?.author === 'agent' ? 'bg-agent-soft text-agent' : 'bg-surface text-muted'
+        lastComment(thread)?.author === 'agent'
+          ? 'bg-agent-soft text-agent'
+          : 'bg-surface text-muted'
       "
     >
       {{ authorLabel(lastComment(thread)?.author ?? 'user') }}

--- a/crates/loom/frontend/src/components/CustomAgentsPanel.vue
+++ b/crates/loom/frontend/src/components/CustomAgentsPanel.vue
@@ -235,7 +235,12 @@ async function remove(agent: CustomAgent) {
         >
           {{ isNew ? 'Add agent' : 'Save' }}
         </button>
-        <button type="button" class="btn-secondary px-2.5 py-1 text-xs" :disabled="busy" @click="cancel">
+        <button
+          type="button"
+          class="btn-secondary px-2.5 py-1 text-xs"
+          :disabled="busy"
+          @click="cancel"
+        >
           Cancel
         </button>
       </div>

--- a/crates/loom/frontend/src/components/EnvPanel.vue
+++ b/crates/loom/frontend/src/components/EnvPanel.vue
@@ -21,8 +21,7 @@ const newValue = ref('');
 // server enforces, mirrored here so the Add button can disable on an obviously
 // bad name (bad shape, or a name that would shadow loom's WEAVER_*/LOOM_ env)
 // before the round-trip.
-const nameOk = (n: string) =>
-  /^[A-Za-z_][A-Za-z0-9_]*$/.test(n) && !/^(WEAVER_|LOOM_)/.test(n);
+const nameOk = (n: string) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(n) && !/^(WEAVER_|LOOM_)/.test(n);
 const newNameValid = computed(() => nameOk(newName.value.trim()));
 
 function sync(list: EnvVar[]) {
@@ -141,7 +140,10 @@ const add = () =>
           </button>
         </div>
       </div>
-      <p v-if="newName.trim() && !newNameValid" class="border-b border-line px-3 py-2 text-2xs text-block">
+      <p
+        v-if="newName.trim() && !newNameValid"
+        class="border-b border-line px-3 py-2 text-2xs text-block"
+      >
         A name must start with a letter or underscore and contain only letters, digits, and
         underscores, and cannot start with <code>WEAVER_</code> or <code>LOOM_</code>.
       </p>

--- a/crates/loom/frontend/src/components/GithubStatus.vue
+++ b/crates/loom/frontend/src/components/GithubStatus.vue
@@ -56,15 +56,22 @@ const conflicting = computed(() => props.gh.mergeable === 'CONFLICTING');
 
 <template>
   <!-- Compact: a single tight line for the dashboard's far-right column. -->
-  <span v-if="compact" class="inline-flex items-center gap-1.5 text-xs" data-testid="github-compact">
+  <span
+    v-if="compact"
+    class="inline-flex items-center gap-1.5 text-xs"
+    data-testid="github-compact"
+  >
     <a
       :href="gh.pr_url"
       target="_blank"
       rel="noopener"
       class="font-mono text-accent hover:underline"
       @click.stop
-    >PR #{{ gh.pr_number }}</a>
-    <span :class="stateChip.cls" class="font-mono uppercase tracking-wide">{{ stateChip.label }}</span>
+      >PR #{{ gh.pr_number }}</a
+    >
+    <span :class="stateChip.cls" class="font-mono uppercase tracking-wide">{{
+      stateChip.label
+    }}</span>
     <span v-if="checksChip" :class="checksChip.cls" class="font-mono" title="CI checks">●</span>
   </span>
 

--- a/crates/loom/frontend/src/components/IdeFrame.vue
+++ b/crates/loom/frontend/src/components/IdeFrame.vue
@@ -80,8 +80,8 @@ onMounted(probe);
         <template v-else-if="state === 'unavailable'">
           <p class="font-medium text-fg">code-server isn't installed</p>
           <p class="max-w-sm text-muted">
-            The embedded editor needs <code class="font-mono text-fg">code-server</code> on the
-            loom host. Install it and reopen this panel.
+            The embedded editor needs <code class="font-mono text-fg">code-server</code> on the loom
+            host. Install it and reopen this panel.
           </p>
           <code class="rounded bg-subtle px-2 py-1 font-mono text-xs text-muted"
             >curl -fsSL https://code-server.dev/install.sh | sh</code

--- a/crates/loom/frontend/src/components/IdleChip.vue
+++ b/crates/loom/frontend/src/components/IdleChip.vue
@@ -10,9 +10,7 @@ import type { Tag } from '../types';
 // the status watch manages it, so there is no × to clear by hand.
 const props = defineProps<{ tag: Tag }>();
 
-const tooltip = computed(
-  () => props.tag.note || 'Idle — the agent is resting; no one is needed.',
-);
+const tooltip = computed(() => props.tag.note || 'Idle — the agent is resting; no one is needed.');
 </script>
 
 <template>

--- a/crates/loom/frontend/src/components/LogsPanel.vue
+++ b/crates/loom/frontend/src/components/LogsPanel.vue
@@ -229,9 +229,15 @@ onUnmounted(() => {
       v-if="status"
       class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border border-line bg-surface px-3 py-2 font-mono text-2xs text-muted"
     >
-      <span>v<span class="text-accent">{{ status.version }}</span></span>
-      <span>pid <span class="text-accent">{{ status.pid }}</span></span>
-      <span>up <span class="text-accent">{{ uptime }}</span></span>
+      <span
+        >v<span class="text-accent">{{ status.version }}</span></span
+      >
+      <span
+        >pid <span class="text-accent">{{ status.pid }}</span></span
+      >
+      <span
+        >up <span class="text-accent">{{ uptime }}</span></span
+      >
       <span :title="status.started_at">started {{ shortTime(status.started_at) }}</span>
     </div>
 
@@ -260,14 +266,13 @@ onUnmounted(() => {
               <td colspan="5" class="px-2 py-2 text-muted">No background tasks yet.</td>
             </tr>
             <tr v-for="t in tasks" :key="t.id" class="border-t border-line/40 align-top">
-              <td class="px-2 py-1 font-semibold" :class="taskStateClass(t.state)">{{ t.state }}</td>
+              <td class="px-2 py-1 font-semibold" :class="taskStateClass(t.state)">
+                {{ t.state }}
+              </td>
               <td class="whitespace-nowrap px-2 py-1 text-muted">{{ t.kind }}</td>
               <td class="px-2 py-1 break-all">{{ t.label }}</td>
               <td class="px-2 py-1 break-all text-muted">{{ t.detail || '—' }}</td>
-              <td
-                class="whitespace-nowrap px-2 py-1 text-faint"
-                :title="t.started_at"
-              >
+              <td class="whitespace-nowrap px-2 py-1 text-faint" :title="t.started_at">
                 {{ shortTime(t.started_at) }}
               </td>
             </tr>
@@ -280,8 +285,8 @@ onUnmounted(() => {
     <h2 class="mb-1.5 text-2xs font-semibold uppercase tracking-wider text-muted">Server logs</h2>
     <p class="mb-3 text-xs text-faint">
       The running server's log stream, live. The same lines go to
-      <code>docker compose logs</code>; this is a read-only mirror so you can debug from the browser.
-      May contain secrets — visible to approved operators only.
+      <code>docker compose logs</code>; this is a read-only mirror so you can debug from the
+      browser. May contain secrets — visible to approved operators only.
     </p>
 
     <!-- Controls -->

--- a/crates/loom/frontend/src/components/MarkdownView.vue
+++ b/crates/loom/frontend/src/components/MarkdownView.vue
@@ -38,8 +38,7 @@ const { body, error, tokens, ctx } = useMarkdownDoc(props, (el) => emit('rendere
 // The vnode body, recreated on every render so no vnode is ever reused across
 // renders (fresh nodes; Vue keeps child component state via keys). Reads the
 // reactive `tokens`/`ctx`, so it re-renders when a build lands.
-const RenderedBody = () =>
-  ctx.value ? h(Fragment, renderTokens(tokens.value, ctx.value)) : null;
+const RenderedBody = () => (ctx.value ? h(Fragment, renderTokens(tokens.value, ctx.value)) : null);
 
 function onClick(e: MouseEvent) {
   routeDocLink(e, router, body.value);
@@ -51,7 +50,10 @@ defineExpose({ body });
 
 <template>
   <div class="h-full w-full overflow-auto bg-surface">
-    <p v-if="error" class="m-4 rounded border border-block-line bg-block-soft p-3 text-sm text-block">
+    <p
+      v-if="error"
+      class="m-4 rounded border border-block-line bg-block-soft p-3 text-sm text-block"
+    >
       {{ error }}
     </p>
     <article ref="body" class="markdown-body mx-auto max-w-3xl px-6 py-5" @click="onClick">

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -274,7 +274,8 @@ loadAgents();
           <h3 class="text-2xs font-semibold uppercase tracking-wider text-muted">Repository</h3>
           <div class="relative">
             <label class="block text-xs text-muted mb-1">
-              Repository - a server path, or a GitHub <span class="font-mono">owner/name</span> to clone
+              Repository - a server path, or a GitHub <span class="font-mono">owner/name</span> to
+              clone
               <span v-if="recentRepos.length" class="text-faint">- or pick a recent one</span>
             </label>
             <input
@@ -301,8 +302,12 @@ loadAgents();
                   @mousedown.prevent="addAndCloneRepo"
                 >
                   <span class="shrink-0 text-sm">+ Clone new repo</span>
-                  <span class="min-w-0 truncate font-mono text-xs text-muted">{{ cloneCandidate }}</span>
-                  <span v-if="cloningRepo" class="ml-auto shrink-0 text-2xs text-faint">adding...</span>
+                  <span class="min-w-0 truncate font-mono text-xs text-muted">{{
+                    cloneCandidate
+                  }}</span>
+                  <span v-if="cloningRepo" class="ml-auto shrink-0 text-2xs text-faint"
+                    >adding...</span
+                  >
                 </button>
               </li>
               <li v-for="r in repoMatches" :key="r.repo_root">
@@ -314,7 +319,9 @@ loadAgents();
                 >
                   <span class="min-w-0">
                     <span class="block truncate text-sm">{{ repoName(r.repo_root) }}</span>
-                    <span class="block truncate text-xs text-muted font-mono">{{ r.repo_root }}</span>
+                    <span class="block truncate text-xs text-muted font-mono">{{
+                      r.repo_root
+                    }}</span>
                   </span>
                   <span
                     v-if="r.active_branches"
@@ -362,7 +369,9 @@ loadAgents();
                 type="button"
                 :class="[
                   'px-3 py-1',
-                  branchMode === 'new' ? 'bg-accent text-accent-fg' : 'bg-input text-muted hover:bg-subtle',
+                  branchMode === 'new'
+                    ? 'bg-accent text-accent-fg'
+                    : 'bg-input text-muted hover:bg-subtle',
                 ]"
                 @click="branchMode = 'new'"
               >
@@ -372,7 +381,9 @@ loadAgents();
                 type="button"
                 :class="[
                   'px-3 py-1 border-l border-line',
-                  branchMode === 'existing' ? 'bg-accent text-accent-fg' : 'bg-input text-muted hover:bg-subtle',
+                  branchMode === 'existing'
+                    ? 'bg-accent text-accent-fg'
+                    : 'bg-input text-muted hover:bg-subtle',
                 ]"
                 @click="branchMode = 'existing'"
               >
@@ -443,10 +454,9 @@ loadAgents();
                         {{ b.name }}
                         <span v-if="b.current" class="ml-1 text-xs text-accent">(current)</span>
                       </span>
-                      <span
-                        v-if="b.worktree"
-                        class="block truncate text-xs text-muted font-mono"
-                      >-&gt; {{ b.worktree }}</span>
+                      <span v-if="b.worktree" class="block truncate text-xs text-muted font-mono"
+                        >-&gt; {{ b.worktree }}</span
+                      >
                     </span>
                   </button>
                 </li>
@@ -464,8 +474,12 @@ loadAgents();
       <aside class="space-y-4 border-t border-line pt-4 lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
         <section class="space-y-3">
           <div>
-            <h3 class="text-2xs font-semibold uppercase tracking-wider text-muted">Runtime profile</h3>
-            <p class="mt-1 text-xs text-faint">Agent runtime, model selector, and reasoning effort.</p>
+            <h3 class="text-2xs font-semibold uppercase tracking-wider text-muted">
+              Runtime profile
+            </h3>
+            <p class="mt-1 text-xs text-faint">
+              Agent runtime, model selector, and reasoning effort.
+            </p>
           </div>
 
           <AgentRuntimePicker
@@ -497,17 +511,14 @@ loadAgents();
       >
         {{ creating ? 'Creating...' : 'Create' }}
       </button>
-      <button
-        type="button"
-        class="btn-secondary px-3 py-1.5 text-sm font-medium"
-        @click="cancel"
-      >
+      <button type="button" class="btn-secondary px-3 py-1.5 text-sm font-medium" @click="cancel">
         Cancel
       </button>
       <!-- Keyboard affordance: submit from anywhere in the form (the goal
            textarea swallows a plain Enter) without reaching for the mouse. -->
       <span class="ml-auto text-2xs text-faint">
-        <kbd class="font-mono">{{ metaKeyLabel }}</kbd> + <kbd class="font-mono">Enter</kbd> to create
+        <kbd class="font-mono">{{ metaKeyLabel }}</kbd> + <kbd class="font-mono">Enter</kbd> to
+        create
       </span>
     </div>
   </form>

--- a/crates/loom/frontend/src/components/OutcomeBadge.vue
+++ b/crates/loom/frontend/src/components/OutcomeBadge.vue
@@ -23,7 +23,9 @@ const styles: Record<string, Style> = {
 
 const style = computed<Style>(() => {
   if (!props.outcome) return { label: 'never run', cls: 'text-faint ring-1 ring-inset ring-line' };
-  return styles[props.outcome] ?? { label: props.outcome, cls: 'text-muted ring-1 ring-inset ring-line' };
+  return (
+    styles[props.outcome] ?? { label: props.outcome, cls: 'text-muted ring-1 ring-inset ring-line' }
+  );
 });
 </script>
 

--- a/crates/loom/frontend/src/components/ScratchPanel.vue
+++ b/crates/loom/frontend/src/components/ScratchPanel.vue
@@ -140,14 +140,29 @@ onUnmounted(() => {
     <button
       type="button"
       class="flex shrink-0 cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-faint hover:bg-subtle hover:text-fg focus:outline-none focus-visible:ring-1 focus-visible:ring-accent disabled:cursor-wait disabled:opacity-60"
-      :title="busy ? 'Uploading scratch file(s)…' : 'Attach a file — the agent sees it as scratch/<name> (or drop one anywhere on the page)'"
+      :title="
+        busy
+          ? 'Uploading scratch file(s)…'
+          : 'Attach a file — the agent sees it as scratch/<name> (or drop one anywhere on the page)'
+      "
       :aria-label="busy ? 'Uploading scratch file(s)' : 'Attach a scratch file'"
       :disabled="busy"
       @click="fileInput?.click()"
     >
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-        stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+      <svg
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path
+          d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"
+        />
       </svg>
       <span v-if="busy" class="text-2xs text-faint">Uploading…</span>
       <span v-else-if="files.length" class="pill">{{ files.length }}</span>

--- a/crates/loom/frontend/src/components/ScratchPicker.vue
+++ b/crates/loom/frontend/src/components/ScratchPicker.vue
@@ -47,12 +47,18 @@ function remove(name: string) {
   <div data-testid="scratch-picker">
     <div class="flex items-center justify-between mb-1">
       <label class="text-xs text-muted">Scratch files — optional</label>
-      <span class="text-xs text-faint">dropped into <code>scratch/</code>; the agent is told they're there</span>
+      <span class="text-xs text-faint"
+        >dropped into <code>scratch/</code>; the agent is told they're there</span
+      >
     </div>
 
     <div
       class="rounded border border-dashed px-3 py-5 text-center text-sm transition-colors cursor-pointer"
-      :class="dragging ? 'border-accent bg-accent/10 text-fg' : 'border-line text-muted hover:border-accent'"
+      :class="
+        dragging
+          ? 'border-accent bg-accent/10 text-fg'
+          : 'border-line text-muted hover:border-accent'
+      "
       data-testid="scratch-picker-dropzone"
       @dragover.prevent="dragging = true"
       @dragleave.prevent="dragging = false"

--- a/crates/loom/frontend/src/components/SessionActivity.vue
+++ b/crates/loom/frontend/src/components/SessionActivity.vue
@@ -20,7 +20,10 @@ const MEANINGFUL = new Set([
 
 const showAll = ref(false);
 const meaningfulEvents = computed(() =>
-  props.events.filter((e) => MEANINGFUL.has(e.kind)).slice().reverse(),
+  props.events
+    .filter((e) => MEANINGFUL.has(e.kind))
+    .slice()
+    .reverse(),
 );
 const visibleEvents = computed(() =>
   showAll.value ? meaningfulEvents.value : meaningfulEvents.value.slice(0, 6),
@@ -29,13 +32,11 @@ const visibleEvents = computed(() =>
 
 <template>
   <div>
-    <div class="mb-2 text-2xs font-semibold uppercase tracking-wider text-muted">Recent activity</div>
+    <div class="mb-2 text-2xs font-semibold uppercase tracking-wider text-muted">
+      Recent activity
+    </div>
     <ul class="fade-in space-y-1 text-sm">
-      <li
-        v-for="ev in visibleEvents"
-        :key="ev.id"
-        class="flex gap-2"
-      >
+      <li v-for="ev in visibleEvents" :key="ev.id" class="flex gap-2">
         <span class="shrink-0 font-mono text-xs text-faint">{{ ev.created_at.slice(11, 19) }}</span>
         <span class="text-muted">{{ format(ev) }}</span>
       </li>

--- a/crates/loom/frontend/src/components/SessionOverview.vue
+++ b/crates/loom/frontend/src/components/SessionOverview.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { computed, ref, watch, onMounted } from 'vue';
-import type { Session, WeaverEvent, Issue, IssueRefStatus, ArtifactView, ArtifactMeta } from '../types';
+import type {
+  Session,
+  WeaverEvent,
+  Issue,
+  IssueRefStatus,
+  ArtifactView,
+  ArtifactMeta,
+} from '../types';
 import { getArtifact, getArtifacts } from '../api';
 import { timeAgo } from '../lib/time';
 import { effectiveAttention, lifecycleDot, messageOf } from '../lib/sessionState';
@@ -152,10 +159,7 @@ watch(
   <div class="space-y-5">
     <!-- State — the synopsis: what the agent last said, when, at what level.
          The one line to read when coming back to a session. -->
-    <section
-      class="rounded border border-line bg-surface px-4 py-3"
-      data-testid="session-state"
-    >
+    <section class="rounded border border-line bg-surface px-4 py-3" data-testid="session-state">
       <div class="flex items-baseline gap-2">
         <span
           class="h-2 w-2 shrink-0 self-center rounded-full"
@@ -214,7 +218,8 @@ watch(
             target="_blank"
             rel="noopener"
             class="min-w-0 truncate text-sm text-accent hover:underline"
-          >{{ l.label }}</a>
+            >{{ l.label }}</a
+          >
           <span class="ml-auto shrink-0 text-2xs text-faint">{{ l.source }}</span>
         </li>
       </ul>
@@ -238,23 +243,14 @@ watch(
         </router-link>
       </header>
       <div data-testid="session-goal" class="px-1 py-1">
-        <MarkdownView
-          :id="ws.id"
-          path="goal.md"
-          :source="ws.branch.goal"
-          :refs="goalRefs"
-        />
+        <MarkdownView :id="ws.id" path="goal.md" :source="ws.branch.goal" :refs="goalRefs" />
       </div>
     </section>
 
     <!-- Plan — the pinned well-known `plan` artifact. Markdown renders through
          MarkdownView (projection included); a non-markdown plan shows its
          source. Absent → nothing. -->
-    <section
-      v-if="plan"
-      class="rounded border border-line bg-surface"
-      data-testid="session-plan"
-    >
+    <section v-if="plan" class="rounded border border-line bg-surface" data-testid="session-plan">
       <header class="flex flex-wrap items-center gap-2 border-b border-line px-4 py-2.5">
         <div class="text-2xs font-semibold uppercase tracking-wider text-muted">Plan</div>
         <span class="text-sm font-medium text-fg">{{ plan.meta.title || 'plan' }}</span>
@@ -273,7 +269,9 @@ watch(
         :source="plan.content"
         :refs="plan.refs.issues"
       />
-      <pre v-else class="m-4 overflow-auto rounded bg-code p-3 text-xs text-code-fg">{{ plan.content }}</pre>
+      <pre v-else class="m-4 overflow-auto rounded bg-code p-3 text-xs text-code-fg">{{
+        plan.content
+      }}</pre>
     </section>
 
     <!-- The PR snapshot lives as a small link in the session header now (one

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -231,7 +231,10 @@ const quiet = computed(() => quietTags(props.ws));
       </span>
       <span class="text-faint">·</span>
       <span class="shrink-0 text-muted">
-        {{ ws.agent_kind }}<template v-if="ws.model"> · <span :class="modelTint" class="font-medium">{{ ws.model }}</span></template>
+        {{ ws.agent_kind
+        }}<template v-if="ws.model">
+          · <span :class="modelTint" class="font-medium">{{ ws.model }}</span></template
+        >
       </span>
       <!-- The branch's PR, surfaced inline as a small link — the one place you
            already look — rather than buried in the Overview tab. Compact mode is

--- a/crates/loom/frontend/src/components/SessionRowActions.vue
+++ b/crates/loom/frontend/src/components/SessionRowActions.vue
@@ -79,9 +79,7 @@ async function invoke(verb: Parameters<typeof run>[0]) {
       >
         <span class="block text-xs font-medium">{{ isShelved ? 'Keep live' : 'Park' }}</span>
         <span class="block text-2xs text-faint">{{
-          isShelved
-            ? 'Return it to the live list'
-            : 'Rest it on the shelf — kept, not archived'
+          isShelved ? 'Return it to the live list' : 'Rest it on the shelf — kept, not archived'
         }}</span>
       </button>
       <button

--- a/crates/loom/frontend/src/components/SessionTabs.vue
+++ b/crates/loom/frontend/src/components/SessionTabs.vue
@@ -62,7 +62,12 @@ const tabs = computed(() => (props.protocol === 'acp' ? ACP_TABS : TERMINAL_TABS
       <span v-if="t.key === 'overview' && issueCount" class="pill ml-1">{{ issueCount }}</span>
       <!-- When popped out, the Artifacts surface lives in the rail, not here —
            a small glyph marks it open without claiming the work area. -->
-      <span v-if="t.key === 'artifacts' && artifactsPopped" class="ml-1 text-faint" title="Open in the side panel">⤢</span>
+      <span
+        v-if="t.key === 'artifacts' && artifactsPopped"
+        class="ml-1 text-faint"
+        title="Open in the side panel"
+        >⤢</span
+      >
     </button>
     <!-- The tab row's right side is otherwise dead space — hosts compact,
          always-relevant extras (the scratch attach strip on the detail page). -->

--- a/crates/loom/frontend/src/components/SessionTerminals.vue
+++ b/crates/loom/frontend/src/components/SessionTerminals.vue
@@ -123,7 +123,10 @@ onMounted(loadShells);
       <!-- Debug shells: mounted when opened and kept mounted (v-show) so switching
            tabs never drops the PTY; unmounted only when the tab is closed. -->
       <section v-for="idx in shells" v-show="active === idx" :key="idx" class="h-full">
-        <AgentTerminal :ws-path="`/api/sessions/${props.id}/shell/${idx}/terminal`" class="h-full" />
+        <AgentTerminal
+          :ws-path="`/api/sessions/${props.id}/shell/${idx}/terminal`"
+          class="h-full"
+        />
       </section>
       <!-- A headless session with no shells open yet: a quiet invitation, so the
            tab isn't a blank void. -->

--- a/crates/loom/frontend/src/components/SignalChip.vue
+++ b/crates/loom/frontend/src/components/SignalChip.vue
@@ -17,9 +17,7 @@ const emit = defineEmits<{ clear: [key: string] }>();
 
 // The chip's label is its tag key, humanized — the type of attention it names.
 const label = computed(() =>
-  props.chip.key
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase()),
+  props.chip.key.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
 );
 const cls = computed(() =>
   props.chip.level === 'blocked' ? 'bg-block text-block-fg' : 'bg-attn text-attn-fg',
@@ -29,9 +27,7 @@ const fromWatch = computed(() => props.chip.raisedBy === 'watch');
 const tooltip = computed(() => {
   if (fromWatch.value) {
     const who = props.chip.by && props.chip.by !== 'manual' ? ` (${props.chip.by})` : '';
-    const base = props.chip.note
-      ? `Watch${who}: ${props.chip.note}`
-      : `Raised by watch${who}`;
+    const base = props.chip.note ? `Watch${who}: ${props.chip.note}` : `Raised by watch${who}`;
     return props.chip.stale ? `${base} — stale, session has moved on` : base;
   }
   return props.chip.note || label.value;

--- a/crates/loom/frontend/src/components/StatusBar.vue
+++ b/crates/loom/frontend/src/components/StatusBar.vue
@@ -39,7 +39,11 @@ onUnmounted(() => clearInterval(clockTimer));
   >
     <!-- Counts dim while the server is unreachable — they're the last good
          snapshot, not live truth, and the offline dot on the right says why. -->
-    <span class="flex items-center gap-4" :class="online ? '' : 'opacity-50'" :title="online ? '' : 'Last known counts — server unreachable'">
+    <span
+      class="flex items-center gap-4"
+      :class="online ? '' : 'opacity-50'"
+      :title="online ? '' : 'Last known counts — server unreachable'"
+    >
       <router-link to="/" class="hover:text-fg" data-testid="status-bar-sessions">
         {{ live.length }} session{{ live.length === 1 ? '' : 's' }}
       </router-link>
@@ -58,7 +62,10 @@ onUnmounted(() => clearInterval(clockTimer));
       </span>
     </span>
 
-    <span class="ml-auto flex items-center gap-1.5" :title="online ? 'Connected' : 'Server unreachable'">
+    <span
+      class="ml-auto flex items-center gap-1.5"
+      :title="online ? 'Connected' : 'Server unreachable'"
+    >
       <span
         class="h-1.5 w-1.5 rounded-full"
         :class="online ? 'bg-accent' : 'bg-block-line'"

--- a/crates/loom/frontend/src/components/TagPill.vue
+++ b/crates/loom/frontend/src/components/TagPill.vue
@@ -22,12 +22,7 @@ const tooltip = computed(() => {
 </script>
 
 <template>
-  <span
-    class="tag-pill"
-    data-testid="tag-pill"
-    :data-tag-key="tag.key"
-    :title="tooltip"
-  >
+  <span class="tag-pill" data-testid="tag-pill" :data-tag-key="tag.key" :title="tooltip">
     <span class="truncate">{{ label }}</span>
     <button
       v-if="!readonly"

--- a/crates/loom/frontend/src/components/TerminalConversation.vue
+++ b/crates/loom/frontend/src/components/TerminalConversation.vue
@@ -13,6 +13,7 @@ import {
 import { get, sendMessage } from '../api';
 import type { IrisLog, IrisBlock, Session } from '../types';
 import { canSend, conversationState, effectiveAttention, TONE_TEXT } from '../lib/sessionState';
+import { useFollowFoot } from '../lib/followFoot';
 import MarkdownView from './MarkdownView.vue';
 
 // The Conversation tab for a *terminal-backend* session (`protocol='terminal'`):
@@ -406,45 +407,14 @@ function toggleAll() {
   open.value = allOpen.value ? new Set() : new Set(model.value.foldKeys);
 }
 
-// ── Follow-the-foot scroll ──────────────────────────────────────────────────
-// The chat opens at its newest exchange and stays *pinned* there while content
-// grows; scrolling up releases the pin, scrolling back to the foot re-arms it.
-// Growth lands asynchronously — markdown parses off-tick, images load, the pane
-// un-hides from a v-show tab — so a ResizeObserver on the transcript body does
-// the following; a one-shot scroll after nextTick would race the paint and
-// strand the view mid-history.
+// ── Follow-the-foot scroll (lib/followFoot.ts): pinned-at-the-newest-exchange. ──
 const convScroll = ref<HTMLElement | null>(null);
 const convBody = ref<HTMLElement | null>(null);
-const pinned = ref(true);
-
-// Whether the stream is scrolled to (near) its foot. A missing scroll root
-// counts as "at the bottom" (nothing scrolled yet).
-function nearBottom(): boolean {
-  const el = convScroll.value;
-  if (!el) return true;
-  return el.scrollHeight - el.scrollTop - el.clientHeight < 120;
-}
-function scrollToBottom() {
-  const el = convScroll.value;
-  if (el) el.scrollTop = el.scrollHeight;
-}
+const { pinned, scrollToBottom, trackPin } = useFollowFoot(convScroll, convBody);
 function onScroll() {
-  pinned.value = nearBottom();
+  trackPin();
   updateActive();
 }
-let bodyRO: ResizeObserver | null = null;
-watch(convBody, (el) => {
-  bodyRO?.disconnect();
-  if (!el) return;
-  bodyRO ??= new ResizeObserver(() => {
-    if (pinned.value) scrollToBottom();
-  });
-  bodyRO.observe(el);
-});
-onUnmounted(() => {
-  bodyRO?.disconnect();
-  bodyRO = null;
-});
 
 // ── Prompt jump-list (scroll-spy) ───────────────────────────────────────────
 const activeAnchor = ref('');

--- a/crates/loom/frontend/src/components/TerminalConversation.vue
+++ b/crates/loom/frontend/src/components/TerminalConversation.vue
@@ -562,7 +562,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
       <div
         ref="convScroll"
         data-testid="conversation"
-        class="conv-scroll min-h-0 flex-1 overflow-auto pb-6 pr-1"
+        class="conv-scroll chat-prose min-h-0 flex-1 overflow-auto pb-6 pr-1"
         @scroll.passive="onScroll"
       >
         <div ref="convBody" class="space-y-2">
@@ -812,7 +812,9 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
 /* The shared MarkdownView wraps prose in a padded, centred surface card — right
    for a standalone document, too heavy for a chat line. Inside the conversation
    we flatten it to tight, left-aligned prose directly on the canvas so the agent's
-   replies read as conversation, not as a stack of cards. */
+   replies read as conversation, not as a stack of cards. The denser chat rhythm
+   (leading, block gaps, list indents) is the shared `chat-prose` layer in
+   markdown.css; only this surface's geometry lives here. */
 .conv-scroll :deep(div:has(> .markdown-body)) {
   background: transparent;
   overflow: visible;
@@ -821,29 +823,6 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
   max-width: none;
   margin: 0;
   padding: 0.125rem 0;
-  line-height: 1.55;
-}
-.conv-scroll :deep(.markdown-body p),
-.conv-scroll :deep(.markdown-body blockquote),
-.conv-scroll :deep(.markdown-body ul),
-.conv-scroll :deep(.markdown-body ol),
-.conv-scroll :deep(.markdown-body dl),
-.conv-scroll :deep(.markdown-body table),
-.conv-scroll :deep(.markdown-body pre),
-.conv-scroll :deep(.markdown-body details) {
-  margin-bottom: 0.6em;
-}
-.conv-scroll :deep(.markdown-body h1),
-.conv-scroll :deep(.markdown-body h2),
-.conv-scroll :deep(.markdown-body h3),
-.conv-scroll :deep(.markdown-body h4),
-.conv-scroll :deep(.markdown-body h5),
-.conv-scroll :deep(.markdown-body h6) {
-  margin: 1em 0 0.4em;
-}
-.conv-scroll :deep(.markdown-body ul),
-.conv-scroll :deep(.markdown-body ol) {
-  padding-left: 1.5em;
 }
 
 /* The clickable header of any fold (context, thinking, a tool group). */

--- a/crates/loom/frontend/src/components/TerminalConversation.vue
+++ b/crates/loom/frontend/src/components/TerminalConversation.vue
@@ -62,7 +62,8 @@ const agentWorking = computed(() => convState.value.label === 'Working');
 // the resolved attention level, not the tone, so the calm-state hues (Idle cyan,
 // Working green) don't accidentally force the cue on.
 const showAgentStatus = computed(
-  () => canSend(live.value) && (agentWorking.value || effectiveAttention(live.value).level !== 'ok'),
+  () =>
+    canSend(live.value) && (agentWorking.value || effectiveAttention(live.value).level !== 'ok'),
 );
 
 type LoadState = 'loading' | 'ready' | 'empty' | 'error';
@@ -262,7 +263,12 @@ function rle(items: ToolItem[]): ToolGroup[] {
 
 /** The first non-blank line of a string, trimmed (`''` if there is none). */
 function firstLine(s: string): string {
-  return s.split('\n').map((l) => l.trim()).find(Boolean) ?? '';
+  return (
+    s
+      .split('\n')
+      .map((l) => l.trim())
+      .find(Boolean) ?? ''
+  );
 }
 
 /** A user prompt's jump-list label: the first non-empty line, lightly de-marked. */
@@ -294,7 +300,10 @@ const model = computed<Model>(() => {
     if (msg.role === 'context') {
       flushTools();
       const text = msg.blocks
-        .filter((b): b is { kind: 'text' | 'thinking'; text: string } => b.kind === 'text' || b.kind === 'thinking')
+        .filter(
+          (b): b is { kind: 'text' | 'thinking'; text: string } =>
+            b.kind === 'text' || b.kind === 'thinking',
+        )
         .map((b) => b.text)
         .join('\n\n')
         .trim();
@@ -310,7 +319,14 @@ const model = computed<Model>(() => {
       flushTools();
       turn++;
       const anchor = `conv-turn-${turn}`;
-      rows.push({ type: 'user', key: key++, anchor, n: turn, time: msg.timestamp, blocks: msg.blocks });
+      rows.push({
+        type: 'user',
+        key: key++,
+        anchor,
+        n: turn,
+        time: msg.timestamp,
+        blocks: msg.blocks,
+      });
       toc.push({ anchor, n: turn, title: userTitle(msg.blocks) });
       continue;
     }
@@ -338,7 +354,12 @@ const model = computed<Model>(() => {
         case 'tool_result': {
           const last = toolBuf[toolBuf.length - 1];
           if (last && !last.result) last.result = { output: b.output, is_error: b.is_error };
-          else toolBuf.push({ name: '↳ result', input: undefined, result: { output: b.output, is_error: b.is_error } });
+          else
+            toolBuf.push({
+              name: '↳ result',
+              input: undefined,
+              result: { output: b.output, is_error: b.is_error },
+            });
           break;
         }
         case 'image':
@@ -507,7 +528,11 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
     <div class="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
       <p class="min-w-0 flex-1 truncate text-xs text-muted">{{ banner }}</p>
 
-      <div v-if="state === 'ready'" class="flex items-center gap-1" data-testid="conversation-filters">
+      <div
+        v-if="state === 'ready'"
+        class="flex items-center gap-1"
+        data-testid="conversation-filters"
+      >
         <button
           type="button"
           class="chip"
@@ -524,7 +549,9 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
           aria-label="Toggle thinking"
           @click="show.thinking = !show.thinking"
         >
-          Thinking<span v-if="model.counts.thinking" class="chip-n">{{ model.counts.thinking }}</span>
+          Thinking<span v-if="model.counts.thinking" class="chip-n">{{
+            model.counts.thinking
+          }}</span>
         </button>
         <button
           v-if="model.counts.context"
@@ -537,12 +564,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
           Context<span class="chip-n">{{ model.counts.context }}</span>
         </button>
         <span class="mx-0.5 h-3.5 w-px bg-line"></span>
-        <button
-          type="button"
-          class="chip"
-          :disabled="!model.foldKeys.length"
-          @click="toggleAll"
-        >
+        <button type="button" class="chip" :disabled="!model.foldKeys.length" @click="toggleAll">
           {{ allOpen ? 'Collapse all' : 'Expand all' }}
         </button>
       </div>
@@ -576,7 +598,10 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
         <div ref="convBody" class="space-y-2">
           <template v-for="row in visibleRows" :key="row.key">
             <!-- Injected context (primers, system/permissions) — folded away. -->
-            <div v-if="row.type === 'context'" class="overflow-hidden rounded border border-line bg-subtle/30">
+            <div
+              v-if="row.type === 'context'"
+              class="overflow-hidden rounded border border-line bg-subtle/30"
+            >
               <button
                 type="button"
                 class="fold-head text-muted"
@@ -604,7 +629,9 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
               <header class="mb-1 flex items-center gap-2 text-xs font-medium text-accent">
                 <span class="turn-badge">{{ row.n }}</span>
                 <span>▍ You</span>
-                <span v-if="row.time" class="font-normal text-muted">{{ shortTime(row.time) }}</span>
+                <span v-if="row.time" class="font-normal text-muted">{{
+                  shortTime(row.time)
+                }}</span>
               </header>
               <template v-for="(b, j) in row.blocks" :key="j">
                 <MarkdownView v-if="b.kind === 'text'" :id="id" path="" :source="b.text" />
@@ -619,7 +646,10 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
             </div>
 
             <!-- Thinking — folded. -->
-            <div v-else-if="row.type === 'thinking'" class="overflow-hidden rounded border border-line bg-subtle/30">
+            <div
+              v-else-if="row.type === 'thinking'"
+              class="overflow-hidden rounded border border-line bg-subtle/30"
+            >
               <button
                 type="button"
                 class="fold-head text-muted"
@@ -655,17 +685,32 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
                   <span class="chev" :class="{ open: isOpen(`tg-${row.key}-${gi}`) }">▸</span>
                   <span class="shrink-0">🔧</span>
                   <span class="shrink-0 font-mono text-fg">{{ g.name }}</span>
-                  <span v-if="g.items.length > 1" class="rle-badge" data-testid="rle-count">{{ g.items.length }}×</span>
-                  <span v-else class="min-w-0 truncate font-mono text-faint">{{ preview(g.items[0]) }}</span>
-                  <span v-if="groupHasError(g)" class="ml-auto shrink-0 text-2xs font-medium text-block">error</span>
+                  <span v-if="g.items.length > 1" class="rle-badge" data-testid="rle-count"
+                    >{{ g.items.length }}×</span
+                  >
+                  <span v-else class="min-w-0 truncate font-mono text-faint">{{
+                    preview(g.items[0])
+                  }}</span>
+                  <span
+                    v-if="groupHasError(g)"
+                    class="ml-auto shrink-0 text-2xs font-medium text-block"
+                    >error</span
+                  >
                 </button>
-                <div v-if="isOpen(`tg-${row.key}-${gi}`)" :id="`tg-${row.key}-${gi}-panel`" class="border-t border-line">
+                <div
+                  v-if="isOpen(`tg-${row.key}-${gi}`)"
+                  :id="`tg-${row.key}-${gi}-panel`"
+                  class="border-t border-line"
+                >
                   <div
                     v-for="(it, ii) in g.items"
                     :key="ii"
                     :class="ii > 0 ? 'border-t border-line/60' : ''"
                   >
-                    <div v-if="g.items.length > 1" class="px-3 pt-1.5 font-mono text-2xs text-faint">
+                    <div
+                      v-if="g.items.length > 1"
+                      class="px-3 pt-1.5 font-mono text-2xs text-faint"
+                    >
                       #{{ ii + 1 }} · {{ it.name }}
                     </div>
                     <pre v-if="inputText(it)" class="conv-pre text-fg">{{ inputText(it) }}</pre>
@@ -911,7 +956,9 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
   font-weight: 500;
   color: var(--faint);
   cursor: pointer;
-  transition: color 0.12s ease, background-color 0.12s ease;
+  transition:
+    color 0.12s ease,
+    background-color 0.12s ease;
   display: inline-flex;
   align-items: center;
   gap: 0.3125rem;
@@ -948,7 +995,9 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
   line-height: 1.1rem;
   color: var(--muted);
   cursor: pointer;
-  transition: color 0.12s ease, background-color 0.12s ease;
+  transition:
+    color 0.12s ease,
+    background-color 0.12s ease;
 }
 .toc-item:hover {
   background: color-mix(in srgb, var(--subtle) 55%, transparent);

--- a/crates/loom/frontend/src/components/TerminalConversation.vue
+++ b/crates/loom/frontend/src/components/TerminalConversation.vue
@@ -87,10 +87,11 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
     // Fold keys are per-render row indices (`ctx-0`, `tg-1-0`) and the highlight
     // tracks this session's turns — so reset both on a fresh load, or the next
     // session would inherit the previous one's open folds and active anchor.
+    // The pin resets too: a chat opens at its newest exchange.
     open.value = new Set();
     activeAnchor.value = '';
+    pinned.value = true;
   }
-  const stick = preserve && nearBottom();
   try {
     const data = (await get(`/sessions/${id.value}/conversation`)) as IrisLog;
     if (seq !== loadSeq) return;
@@ -110,9 +111,10 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
   }
   await nextTick();
   if (seq !== loadSeq) return;
-  // Chat behaviour: only follow the conversation to the newest message when the
-  // reader was already at the foot — never yank them down out of the history.
-  if (stick) scrollToBottom();
+  // Chat behaviour: follow to the foot while pinned — a fresh load opens at the
+  // newest message, and an auto-refresh follows only when the reader was already
+  // there — never yank them down out of the history.
+  if (pinned.value) scrollToBottom();
   updateActive();
 }
 
@@ -383,13 +385,19 @@ function toggleAll() {
   open.value = allOpen.value ? new Set() : new Set(model.value.foldKeys);
 }
 
-// ── Prompt jump-list (scroll-spy) ───────────────────────────────────────────
+// ── Follow-the-foot scroll ──────────────────────────────────────────────────
+// The chat opens at its newest exchange and stays *pinned* there while content
+// grows; scrolling up releases the pin, scrolling back to the foot re-arms it.
+// Growth lands asynchronously — markdown parses off-tick, images load, the pane
+// un-hides from a v-show tab — so a ResizeObserver on the transcript body does
+// the following; a one-shot scroll after nextTick would race the paint and
+// strand the view mid-history.
 const convScroll = ref<HTMLElement | null>(null);
-const activeAnchor = ref('');
+const convBody = ref<HTMLElement | null>(null);
+const pinned = ref(true);
 
-// Whether the stream is scrolled to (near) its foot — the cue for whether an
-// auto-refresh should follow new content down. A missing scroll root counts as
-// "at the bottom" (nothing scrolled yet).
+// Whether the stream is scrolled to (near) its foot. A missing scroll root
+// counts as "at the bottom" (nothing scrolled yet).
 function nearBottom(): boolean {
   const el = convScroll.value;
   if (!el) return true;
@@ -399,6 +407,26 @@ function scrollToBottom() {
   const el = convScroll.value;
   if (el) el.scrollTop = el.scrollHeight;
 }
+function onScroll() {
+  pinned.value = nearBottom();
+  updateActive();
+}
+let bodyRO: ResizeObserver | null = null;
+watch(convBody, (el) => {
+  bodyRO?.disconnect();
+  if (!el) return;
+  bodyRO ??= new ResizeObserver(() => {
+    if (pinned.value) scrollToBottom();
+  });
+  bodyRO.observe(el);
+});
+onUnmounted(() => {
+  bodyRO?.disconnect();
+  bodyRO = null;
+});
+
+// ── Prompt jump-list (scroll-spy) ───────────────────────────────────────────
+const activeAnchor = ref('');
 
 // The "current" prompt is the last user turn scrolled to (or past) the top of
 // the viewport — so the index highlight tracks the turn you're reading.
@@ -542,116 +570,118 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
       <div
         ref="convScroll"
         data-testid="conversation"
-        class="conv-scroll min-h-0 flex-1 space-y-3 overflow-auto pb-8 pr-1"
-        @scroll.passive="updateActive"
+        class="conv-scroll min-h-0 flex-1 overflow-auto pb-6 pr-1"
+        @scroll.passive="onScroll"
       >
-        <template v-for="row in visibleRows" :key="row.key">
-          <!-- Injected context (primers, system/permissions) — folded away. -->
-          <div v-if="row.type === 'context'" class="overflow-hidden rounded border border-line bg-subtle/30">
-            <button
-              type="button"
-              class="fold-head text-muted"
-              :aria-expanded="isOpen('ctx-' + row.key)"
-              :aria-controls="'ctx-' + row.key + '-panel'"
-              @click="toggle('ctx-' + row.key)"
-            >
-              <span class="chev" :class="{ open: isOpen('ctx-' + row.key) }">▸</span>
-              <span>📎 Context</span>
-            </button>
-            <pre
-              v-if="isOpen('ctx-' + row.key)"
-              :id="'ctx-' + row.key + '-panel'"
-              class="conv-pre border-t border-line text-muted"
-              >{{ row.text }}</pre>
-          </div>
-
-          <!-- User turn — the anchor for the jump list; always shown in full. -->
-          <section
-            v-else-if="row.type === 'user'"
-            :id="row.anchor"
-            :data-anchor="row.anchor"
-            class="conv-anchor rounded-md border-l-2 border-accent bg-subtle/40 px-3 py-2"
-          >
-            <header class="mb-1 flex items-center gap-2 text-xs font-medium text-accent">
-              <span class="turn-badge">{{ row.n }}</span>
-              <span>▍ You</span>
-              <span v-if="row.time" class="font-normal text-muted">{{ shortTime(row.time) }}</span>
-            </header>
-            <template v-for="(b, j) in row.blocks" :key="j">
-              <MarkdownView v-if="b.kind === 'text'" :id="id" path="" :source="b.text" />
-              <p v-else-if="b.kind === 'image'" class="text-xs italic text-muted">[image]</p>
-            </template>
-          </section>
-
-          <!-- Assistant prose. No role heading — the boxed/accented user turns
-               are the dividers, so the agent's replies just flow as plain text. -->
-          <div v-else-if="row.type === 'text'" class="px-3">
-            <MarkdownView :id="id" path="" :source="row.text" />
-          </div>
-
-          <!-- Thinking — folded. -->
-          <div v-else-if="row.type === 'thinking'" class="overflow-hidden rounded border border-line bg-subtle/30">
-            <button
-              type="button"
-              class="fold-head text-muted"
-              :aria-expanded="isOpen('think-' + row.key)"
-              :aria-controls="'think-' + row.key + '-panel'"
-              @click="toggle('think-' + row.key)"
-            >
-              <span class="chev" :class="{ open: isOpen('think-' + row.key) }">▸</span>
-              <span>💭 Thinking</span>
-            </button>
-            <pre
-              v-if="isOpen('think-' + row.key)"
-              :id="'think-' + row.key + '-panel'"
-              class="conv-pre border-t border-line text-muted"
-              >{{ row.text }}</pre>
-          </div>
-
-          <!-- Tool activity — each run-length group a compact, collapsed strip. -->
-          <div v-else-if="row.type === 'tools'" class="space-y-1">
-            <div
-              v-for="(g, gi) in row.groups"
-              :key="gi"
-              class="overflow-hidden rounded border border-line bg-subtle/30"
-              data-testid="tool-fold"
-            >
+        <div ref="convBody" class="space-y-2">
+          <template v-for="row in visibleRows" :key="row.key">
+            <!-- Injected context (primers, system/permissions) — folded away. -->
+            <div v-if="row.type === 'context'" class="overflow-hidden rounded border border-line bg-subtle/30">
               <button
                 type="button"
-                class="fold-head"
-                :aria-expanded="isOpen(`tg-${row.key}-${gi}`)"
-                :aria-controls="`tg-${row.key}-${gi}-panel`"
-                @click="toggle(`tg-${row.key}-${gi}`)"
+                class="fold-head text-muted"
+                :aria-expanded="isOpen('ctx-' + row.key)"
+                :aria-controls="'ctx-' + row.key + '-panel'"
+                @click="toggle('ctx-' + row.key)"
               >
-                <span class="chev" :class="{ open: isOpen(`tg-${row.key}-${gi}`) }">▸</span>
-                <span class="shrink-0">🔧</span>
-                <span class="shrink-0 font-mono text-fg">{{ g.name }}</span>
-                <span v-if="g.items.length > 1" class="rle-badge" data-testid="rle-count">{{ g.items.length }}×</span>
-                <span v-else class="min-w-0 truncate font-mono text-faint">{{ preview(g.items[0]) }}</span>
-                <span v-if="groupHasError(g)" class="ml-auto shrink-0 text-2xs font-medium text-block">error</span>
+                <span class="chev" :class="{ open: isOpen('ctx-' + row.key) }">▸</span>
+                <span>📎 Context</span>
               </button>
-              <div v-if="isOpen(`tg-${row.key}-${gi}`)" :id="`tg-${row.key}-${gi}-panel`" class="border-t border-line">
-                <div
-                  v-for="(it, ii) in g.items"
-                  :key="ii"
-                  :class="ii > 0 ? 'border-t border-line/60' : ''"
+              <pre
+                v-if="isOpen('ctx-' + row.key)"
+                :id="'ctx-' + row.key + '-panel'"
+                class="conv-pre border-t border-line text-muted"
+                >{{ row.text }}</pre>
+            </div>
+
+            <!-- User turn — the anchor for the jump list; always shown in full. -->
+            <section
+              v-else-if="row.type === 'user'"
+              :id="row.anchor"
+              :data-anchor="row.anchor"
+              class="conv-anchor rounded-md border-l-2 border-accent bg-subtle/40 px-3 py-2"
+            >
+              <header class="mb-1 flex items-center gap-2 text-xs font-medium text-accent">
+                <span class="turn-badge">{{ row.n }}</span>
+                <span>▍ You</span>
+                <span v-if="row.time" class="font-normal text-muted">{{ shortTime(row.time) }}</span>
+              </header>
+              <template v-for="(b, j) in row.blocks" :key="j">
+                <MarkdownView v-if="b.kind === 'text'" :id="id" path="" :source="b.text" />
+                <p v-else-if="b.kind === 'image'" class="text-xs italic text-muted">[image]</p>
+              </template>
+            </section>
+
+            <!-- Assistant prose. No role heading — the boxed/accented user turns
+                 are the dividers, so the agent's replies just flow as plain text. -->
+            <div v-else-if="row.type === 'text'" class="px-3">
+              <MarkdownView :id="id" path="" :source="row.text" />
+            </div>
+
+            <!-- Thinking — folded. -->
+            <div v-else-if="row.type === 'thinking'" class="overflow-hidden rounded border border-line bg-subtle/30">
+              <button
+                type="button"
+                class="fold-head text-muted"
+                :aria-expanded="isOpen('think-' + row.key)"
+                :aria-controls="'think-' + row.key + '-panel'"
+                @click="toggle('think-' + row.key)"
+              >
+                <span class="chev" :class="{ open: isOpen('think-' + row.key) }">▸</span>
+                <span>💭 Thinking</span>
+              </button>
+              <pre
+                v-if="isOpen('think-' + row.key)"
+                :id="'think-' + row.key + '-panel'"
+                class="conv-pre border-t border-line text-muted"
+                >{{ row.text }}</pre>
+            </div>
+
+            <!-- Tool activity — each run-length group a compact, collapsed strip. -->
+            <div v-else-if="row.type === 'tools'" class="space-y-1">
+              <div
+                v-for="(g, gi) in row.groups"
+                :key="gi"
+                class="overflow-hidden rounded border border-line bg-subtle/30"
+                data-testid="tool-fold"
+              >
+                <button
+                  type="button"
+                  class="fold-head"
+                  :aria-expanded="isOpen(`tg-${row.key}-${gi}`)"
+                  :aria-controls="`tg-${row.key}-${gi}-panel`"
+                  @click="toggle(`tg-${row.key}-${gi}`)"
                 >
-                  <div v-if="g.items.length > 1" class="px-3 pt-1.5 font-mono text-2xs text-faint">
-                    #{{ ii + 1 }} · {{ it.name }}
+                  <span class="chev" :class="{ open: isOpen(`tg-${row.key}-${gi}`) }">▸</span>
+                  <span class="shrink-0">🔧</span>
+                  <span class="shrink-0 font-mono text-fg">{{ g.name }}</span>
+                  <span v-if="g.items.length > 1" class="rle-badge" data-testid="rle-count">{{ g.items.length }}×</span>
+                  <span v-else class="min-w-0 truncate font-mono text-faint">{{ preview(g.items[0]) }}</span>
+                  <span v-if="groupHasError(g)" class="ml-auto shrink-0 text-2xs font-medium text-block">error</span>
+                </button>
+                <div v-if="isOpen(`tg-${row.key}-${gi}`)" :id="`tg-${row.key}-${gi}-panel`" class="border-t border-line">
+                  <div
+                    v-for="(it, ii) in g.items"
+                    :key="ii"
+                    :class="ii > 0 ? 'border-t border-line/60' : ''"
+                  >
+                    <div v-if="g.items.length > 1" class="px-3 pt-1.5 font-mono text-2xs text-faint">
+                      #{{ ii + 1 }} · {{ it.name }}
+                    </div>
+                    <pre v-if="inputText(it)" class="conv-pre text-fg">{{ inputText(it) }}</pre>
+                    <pre
+                      v-if="it.result && it.result.output.trim()"
+                      class="conv-pre conv-result"
+                      :class="it.result.is_error ? 'text-block' : 'text-muted'"
+                      >{{ it.result.output }}</pre>
                   </div>
-                  <pre v-if="inputText(it)" class="conv-pre text-fg">{{ inputText(it) }}</pre>
-                  <pre
-                    v-if="it.result && it.result.output.trim()"
-                    class="conv-pre conv-result"
-                    :class="it.result.is_error ? 'text-block' : 'text-muted'"
-                    >{{ it.result.output }}</pre>
                 </div>
               </div>
             </div>
-          </div>
 
-          <p v-else-if="row.type === 'image'" class="text-xs italic text-muted">[image]</p>
-        </template>
+            <p v-else-if="row.type === 'image'" class="text-xs italic text-muted">[image]</p>
+          </template>
+        </div>
       </div>
 
       <!-- Prompt jump-list: one entry per user turn, with scroll-spy highlight. -->
@@ -686,7 +716,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
          operator. Hidden while the agent rests, so it only ever signals. -->
     <div
       v-if="showAgentStatus"
-      class="mt-3 flex shrink-0 items-center gap-1.5 text-xs font-medium"
+      class="mt-2 flex shrink-0 items-center gap-1.5 text-xs font-medium"
       :class="TONE_TEXT[convState.tone]"
       data-testid="agent-status"
       role="status"
@@ -703,7 +733,7 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
          a torn-down session stays a read-only log. -->
     <form
       v-if="composerVisible"
-      class="mt-3 shrink-0 border-t border-line pt-3"
+      class="mt-2 shrink-0 border-t border-line pt-2.5"
       data-testid="conversation-composer"
       @submit.prevent="submitPrompt"
     >
@@ -776,6 +806,29 @@ const groupHasError = (g: ToolGroup) => g.items.some((it) => it.result?.is_error
   max-width: none;
   margin: 0;
   padding: 0.125rem 0;
+  line-height: 1.55;
+}
+.conv-scroll :deep(.markdown-body p),
+.conv-scroll :deep(.markdown-body blockquote),
+.conv-scroll :deep(.markdown-body ul),
+.conv-scroll :deep(.markdown-body ol),
+.conv-scroll :deep(.markdown-body dl),
+.conv-scroll :deep(.markdown-body table),
+.conv-scroll :deep(.markdown-body pre),
+.conv-scroll :deep(.markdown-body details) {
+  margin-bottom: 0.6em;
+}
+.conv-scroll :deep(.markdown-body h1),
+.conv-scroll :deep(.markdown-body h2),
+.conv-scroll :deep(.markdown-body h3),
+.conv-scroll :deep(.markdown-body h4),
+.conv-scroll :deep(.markdown-body h5),
+.conv-scroll :deep(.markdown-body h6) {
+  margin: 1em 0 0.4em;
+}
+.conv-scroll :deep(.markdown-body ul),
+.conv-scroll :deep(.markdown-body ol) {
+  padding-left: 1.5em;
 }
 
 /* The clickable header of any fold (context, thinking, a tool group). */

--- a/crates/loom/frontend/src/components/TokensPanel.vue
+++ b/crates/loom/frontend/src/components/TokensPanel.vue
@@ -87,14 +87,19 @@ onMounted(load);
     <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
 
     <!-- One-time secret: shown once, right after creation. -->
-    <div v-if="created" class="mb-3 rounded-md border border-accent bg-surface p-2.5" data-testid="new-token">
+    <div
+      v-if="created"
+      class="mb-3 rounded-md border border-accent bg-surface p-2.5"
+      data-testid="new-token"
+    >
       <p class="mb-2 text-xs font-medium text-accent">
         Copy this token now. It will not be shown again.
       </p>
       <div class="flex items-center gap-2">
-        <code class="min-w-0 flex-1 select-all break-all rounded bg-input px-2 py-1 font-mono text-xs">{{
-          created.token
-        }}</code>
+        <code
+          class="min-w-0 flex-1 select-all break-all rounded bg-input px-2 py-1 font-mono text-xs"
+          >{{ created.token }}</code
+        >
         <button class="btn-secondary px-2.5 py-1 text-xs" @click="copy">
           {{ copied ? 'Copied' : 'Copy' }}
         </button>
@@ -103,7 +108,9 @@ onMounted(load);
 
     <!-- Create form. -->
     <div class="mb-4 overflow-hidden rounded-md border border-line bg-surface">
-      <div class="grid grid-cols-1 gap-2 border-b border-line px-3 py-2.5 md:grid-cols-[minmax(0,1.4fr)_minmax(12rem,0.95fr)_auto] md:items-end">
+      <div
+        class="grid grid-cols-1 gap-2 border-b border-line px-3 py-2.5 md:grid-cols-[minmax(0,1.4fr)_minmax(12rem,0.95fr)_auto] md:items-end"
+      >
         <label class="flex flex-col gap-1 md:min-w-0">
           <span class="text-2xs text-muted">Name</span>
           <input

--- a/crates/loom/frontend/src/index.html
+++ b/crates/loom/frontend/src/index.html
@@ -1,17 +1,17 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Weaver</title>
-  <!-- App icon: a spool of thread on the brand blue. SVG for modern browsers,
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weaver</title>
+    <!-- App icon: a spool of thread on the brand blue. SVG for modern browsers,
        PNG fallbacks for the rest / for iOS home-screen. -->
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <link rel="alternate icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-  <meta name="theme-color" content="#2f6fed">
-</head>
-<body>
-  <div id="app"></div>
-</body>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="alternate icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <meta name="theme-color" content="#2f6fed" />
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
 </html>

--- a/crates/loom/frontend/src/lib/followFoot.ts
+++ b/crates/loom/frontend/src/lib/followFoot.ts
@@ -1,0 +1,76 @@
+// Follow-the-foot scroll for a chat surface (shared by AcpConversation and
+// TerminalConversation). The transcript opens at its newest exchange and stays
+// *pinned* there while content grows; scrolling up releases the pin, scrolling
+// back to the foot re-arms it. Growth lands asynchronously — markdown parses
+// off-tick, images load, the pane un-hides from a v-show tab — so a
+// ResizeObserver on the transcript body does the following; a one-shot scroll
+// after nextTick would race the paint and strand the view mid-history.
+
+import { ref, watch, onUnmounted, nextTick, type Ref } from 'vue';
+
+export function useFollowFoot(scrollEl: Ref<HTMLElement | null>, bodyEl: Ref<HTMLElement | null>) {
+  // Starts pinned, so a fresh chat scrolls to the foot as soon as it has height.
+  const pinned = ref(true);
+
+  // Whether the stream is scrolled to (near) its foot. A missing scroll root
+  // counts as "at the bottom" (nothing scrolled yet).
+  function nearBottom(): boolean {
+    const el = scrollEl.value;
+    if (!el) return true;
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+  }
+  // Scroll events dispatch asynchronously, so a stale event from one of our own
+  // scrollToBottom calls can land *after* the content has grown again — and a
+  // handler that re-derived the pin from that snapshot would see "far from the
+  // foot" and wrongly release it, stranding the view mid-history. So trackPin
+  // swallows our own echoes, recognised by position: while the view still sits
+  // exactly where the last programmatic scroll put it, the pin stands; the pin
+  // only ever re-derives from a scroll that actually moved the view.
+  let autoScrollTarget: number | null = null;
+  function scrollToBottom() {
+    const el = scrollEl.value;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    autoScrollTarget = el.scrollTop; // the clamped position actually applied
+  }
+  /** Post-mutation follow: scroll after the DOM settles, only while pinned. */
+  function autoFollow() {
+    if (pinned.value) nextTick(scrollToBottom);
+  }
+  /** The scroll-handler half: re-derive the pin from the reader's position. */
+  function trackPin() {
+    const el = scrollEl.value;
+    if (!el) return;
+    if (autoScrollTarget != null) {
+      if (Math.abs(el.scrollTop - autoScrollTarget) < 1) return; // our echo — the pin stands
+      autoScrollTarget = null; // the reader has scrolled since — fall through and derive
+    }
+    pinned.value = nearBottom();
+  }
+
+  // Browser scroll anchoring must be off on the container: when a late-painting
+  // block lands above the viewport, anchoring silently moves scrollTop to keep
+  // the view stable — a scroll we didn't make, at a position that no longer
+  // matches our target, which trackPin would misread as the reader scrolling
+  // away and wrongly release the pin. This surface has exactly two legitimate
+  // scrollers: this composable and the reader.
+  watch(scrollEl, (el) => {
+    if (el) el.style.overflowAnchor = 'none';
+  });
+
+  let bodyRO: ResizeObserver | null = null;
+  watch(bodyEl, (el) => {
+    bodyRO?.disconnect();
+    if (!el) return;
+    bodyRO ??= new ResizeObserver(() => {
+      if (pinned.value) scrollToBottom();
+    });
+    bodyRO.observe(el);
+  });
+  onUnmounted(() => {
+    bodyRO?.disconnect();
+    bodyRO = null;
+  });
+
+  return { pinned, scrollToBottom, autoFollow, trackPin };
+}

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -283,10 +283,7 @@ export function signalChips(s: Session): SignalChip[] {
 export function quietTags(s: Session): Tag[] {
   if (s.status === 'archived') return [];
   return (s.branch.tags ?? []).filter(
-    (t) =>
-      severityOf(t.value) === 0 &&
-      t.key !== IDLE_KEY &&
-      !BOOKKEEPING_KEYS.includes(t.key),
+    (t) => severityOf(t.value) === 0 && t.key !== IDLE_KEY && !BOOKKEEPING_KEYS.includes(t.key),
   );
 }
 
@@ -329,9 +326,9 @@ export function idleTag(s: Session): Tag | null {
 // "Waiting for input" slab. Returns a glyph + short label; glyphs are plain
 // unicode (offline-safe, no icon dependency).
 export interface ConvState {
-  glyph: string;   // ● / ▶ / ✓ / ◦ — BMP geometric chars only (emoji like the
-                   // hourglass render as tofu in the system sans/mono stacks)
-  label: string;   // e.g. "Blocked — needs input"
+  glyph: string; // ● / ▶ / ✓ / ◦ — BMP geometric chars only (emoji like the
+  // hourglass render as tofu in the system sans/mono stacks)
+  label: string; // e.g. "Blocked — needs input"
   tone: 'block' | 'attn' | 'ok' | 'info' | 'muted'; // which token family colors it
 }
 

--- a/crates/loom/frontend/src/lib/terminalConfig.ts
+++ b/crates/loom/frontend/src/lib/terminalConfig.ts
@@ -101,7 +101,9 @@ function valueOf(settings: SettingView[], key: string, fallback: string): string
 export function resolveTerminalConfig(settings: SettingView[]): TerminalConfig {
   const themeToken = valueOf(settings, 'terminal.theme', DEFAULT_THEME);
   const fontToken = valueOf(settings, 'terminal.font', DEFAULT_FONT);
-  const fontSize = clampFontSize(Number(valueOf(settings, 'terminal.font_size', String(DEFAULT_FONT_SIZE))));
+  const fontSize = clampFontSize(
+    Number(valueOf(settings, 'terminal.font_size', String(DEFAULT_FONT_SIZE))),
+  );
   return {
     themeToken,
     theme: themeFor(themeToken),

--- a/crates/loom/frontend/src/lib/watch.ts
+++ b/crates/loom/frontend/src/lib/watch.ts
@@ -3,7 +3,14 @@ import type { Watch, WatchTrigger, WatchScope } from '../types';
 // The intervention ladder, calm → loud (mirrors weaver-core's CAPABILITIES).
 // `observe` is implicit — always granted — so the create/edit forms only offer
 // the explicit grants below it.
-export const CAPABILITIES = ['observe', 'mark', 'escalate', 'nudge', 'interrupt', 'launch'] as const;
+export const CAPABILITIES = [
+  'observe',
+  'mark',
+  'escalate',
+  'nudge',
+  'interrupt',
+  'launch',
+] as const;
 export const GRANTABLE_CAPABILITIES = ['mark', 'escalate', 'nudge', 'interrupt', 'launch'] as const;
 
 // Final path segment of a repo root, for a short chip label.

--- a/crates/loom/frontend/src/markdown-render.ts
+++ b/crates/loom/frontend/src/markdown-render.ts
@@ -116,7 +116,11 @@ function walk(tokens: Token[], ctx: RenderCtx): Child[] {
     // strong, em, link, …).
     if (tok.nesting === 1) {
       const hidden = tok.hidden === true;
-      stack.push({ tag: hidden ? null : tok.tag, props: hidden ? {} : elementProps(tok), children: [] });
+      stack.push({
+        tag: hidden ? null : tok.tag,
+        props: hidden ? {} : elementProps(tok),
+        children: [],
+      });
     } else if (tok.nesting === -1) {
       const frame = stack.pop();
       if (!frame) continue;

--- a/crates/loom/frontend/src/markdown.css
+++ b/crates/loom/frontend/src/markdown.css
@@ -173,6 +173,36 @@
   background: var(--surface);
 }
 
+/* Chat density — a conversation surface (`chat-prose` on its scroll root)
+   reads denser than a document page: tighter leading, smaller block gaps,
+   shallower list indents. The printed-page defaults above stay untouched for
+   the document surfaces (artifacts, previews, goals). */
+.chat-prose .markdown-body {
+  line-height: 1.55;
+}
+.chat-prose .markdown-body p,
+.chat-prose .markdown-body blockquote,
+.chat-prose .markdown-body ul,
+.chat-prose .markdown-body ol,
+.chat-prose .markdown-body dl,
+.chat-prose .markdown-body table,
+.chat-prose .markdown-body pre,
+.chat-prose .markdown-body details {
+  margin-bottom: 0.6em;
+}
+.chat-prose .markdown-body h1,
+.chat-prose .markdown-body h2,
+.chat-prose .markdown-body h3,
+.chat-prose .markdown-body h4,
+.chat-prose .markdown-body h5,
+.chat-prose .markdown-body h6 {
+  margin: 1em 0 0.4em;
+}
+.chat-prose .markdown-body ul,
+.chat-prose .markdown-body ol {
+  padding-left: 1.5em;
+}
+
 /* Heading anchors injected by markdown-it-anchor. */
 .markdown-body .header-anchor {
   color: var(--faint);

--- a/crates/loom/frontend/src/markdown.ts
+++ b/crates/loom/frontend/src/markdown.ts
@@ -155,8 +155,7 @@ async function getMarkdownIt(): Promise<MarkdownIt> {
 
 /** A reference smartdoc recognises inside running prose. */
 type SmartRef =
-  | { kind: 'issue'; raw: string; id: number }
-  | { kind: 'artifact'; raw: string; name: string };
+  { kind: 'issue'; raw: string; id: number } | { kind: 'artifact'; raw: string; name: string };
 
 // `#123` (issue) or `artifact:<name>`. The issue form requires a non-word char
 // (or string start) before the `#` so `foo#3` / `abc#1` (anchors, fragments)
@@ -181,11 +180,7 @@ function issueChipLabel(s: IssueRefStatus): string {
  *  rendering context (for the artifact deep-link base). Returns null when the
  *  reference can't be projected (unknown issue, no session) — the caller then
  *  leaves the raw text in place. `esc` is markdown-it's HTML escaper. */
-function refHtml(
-  ref: SmartRef,
-  ctx: RenderContext,
-  esc: (s: string) => string,
-): string | null {
+function refHtml(ref: SmartRef, ctx: RenderContext, esc: (s: string) => string): string | null {
   if (ref.kind === 'issue') {
     const status = ctx.refs?.[String(ref.id)];
     if (!status) return null;
@@ -230,20 +225,12 @@ function installSmartdoc(md: MarkdownIt): void {
 /** Split one `text` token into a run of `text`/`html_inline` tokens, replacing
  *  recognised references with chip/link HTML. Tokens that aren't projectable are
  *  left as text so nothing is lost. */
-function splitTextToken(
-  md: MarkdownIt,
-  tok: Token,
-  ctx: RenderContext,
-): Token[] {
+function splitTextToken(md: MarkdownIt, tok: Token, ctx: RenderContext): Token[] {
   const text = tok.content;
   const esc = md.utils.escapeHtml;
   // markdown-it doesn't export Token as a value here; reuse the token ctor via
   // the live token's prototype so we don't need the class import.
-  const TokenCtor = tok.constructor as new (
-    type: string,
-    tag: string,
-    nesting: number,
-  ) => Token;
+  const TokenCtor = tok.constructor as new (type: string, tag: string, nesting: number) => Token;
   SMARTDOC_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   let last = 0;

--- a/crates/loom/frontend/src/styles.css
+++ b/crates/loom/frontend/src/styles.css
@@ -1,8 +1,8 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 /* Rendered-markdown typography for the file browser's Preview mode. Split out
    so the viewer styles live next to `markdown.ts`/`MarkdownView.vue`; it relies
    on the semantic tokens declared below. */
-@import "./markdown.css";
+@import './markdown.css';
 
 /* Manual (class-based) dark mode: `dark:` applies when <html> has `.dark`,
    rather than tracking the OS preference. theme.ts toggles the class. */
@@ -74,13 +74,13 @@
        micro-caps. It stays out of the way so the serif reads.
      - `mono` (IBM Plex Mono) is everything machine-made: ids, refs, paths,
        timestamps, counts, and the terminal. */
-  --font-serif: "Source Serif 4 Variable", ui-serif, Georgia, Cambria,
-    "Times New Roman", serif;
-  --font-sans: "Source Sans 3 Variable", ui-sans-serif, system-ui, -apple-system,
-    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-  --font-mono: "IBM Plex Mono", ui-monospace, "Cascadia Code", "SF Mono",
-    "JetBrains Mono", "Fira Code", Menlo, Consolas, "DejaVu Sans Mono",
-    monospace;
+  --font-serif: 'Source Serif 4 Variable', ui-serif, Georgia, Cambria, 'Times New Roman', serif;
+  --font-sans:
+    'Source Sans 3 Variable', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  --font-mono:
+    'IBM Plex Mono', ui-monospace, 'Cascadia Code', 'SF Mono', 'JetBrains Mono', 'Fira Code', Menlo,
+    Consolas, 'DejaVu Sans Mono', monospace;
 }
 
 /* Light palette (default) — "the reading room, by daylight". Warm stone paper,
@@ -90,47 +90,47 @@
    iron-gall ink: the muted blue-black of a fountain pen and old manuscripts,
    which advances against the paper without the cold of SaaS blue. */
 :root {
-  --canvas: #eceadf;        /* warm stone — page background */
-  --rail: #e3e0d4;          /* nav rail + status bar — the recessed chrome */
-  --surface: #f7f5ee;       /* cards / panels — a lighter leaf of the same paper */
-  --input: #e6e3d7;         /* form fields */
-  --line: #dbd7c9;          /* warm hairline borders */
-  --fg: #26221a;            /* primary ink — warm near-black */
-  --muted: #5f584b;         /* secondary text */
-  --faint: #8c8574;         /* tertiary text */
-  --subtle: #e4e0d3;        /* secondary buttons / hover fills */
+  --canvas: #eceadf; /* warm stone — page background */
+  --rail: #e3e0d4; /* nav rail + status bar — the recessed chrome */
+  --surface: #f7f5ee; /* cards / panels — a lighter leaf of the same paper */
+  --input: #e6e3d7; /* form fields */
+  --line: #dbd7c9; /* warm hairline borders */
+  --fg: #26221a; /* primary ink — warm near-black */
+  --muted: #5f584b; /* secondary text */
+  --faint: #8c8574; /* tertiary text */
+  --subtle: #e4e0d3; /* secondary buttons / hover fills */
   --subtle-hover: #d8d3c3;
-  --tree-line: #a8a08c;     /* session-tree guides; warm and well above --line
+  --tree-line: #a8a08c; /* session-tree guides; warm and well above --line
                                so the threading connectors read clearly */
-  --accent: #345b7d;        /* iron-gall ink blue — primary action / link */
+  --accent: #345b7d; /* iron-gall ink blue — primary action / link */
   --accent-hover: #274a68;
   --accent-fg: #f7f5ee;
-  --code: #e8e5d8;          /* preformatted blocks (diffs, prompts) */
+  --code: #e8e5d8; /* preformatted blocks (diffs, prompts) */
   --code-fg: #37322a;
 
   /* Attention (ochre) + Blocked (oxblood) — the reserved loud signal, warmed
      toward pigment so it stays urgent without the fire-engine glare. */
-  --attn: #90621a;          /* ochre — loud fill */
-  --attn-fg: #f7f0dd;       /* text on fill */
-  --attn-soft: #efe7cf;     /* ochre wash — row background */
-  --attn-line: #bf8f30;     /* ochre — left accent border / dot */
-  --block: #8f342c;         /* oxblood */
+  --attn: #90621a; /* ochre — loud fill */
+  --attn-fg: #f7f0dd; /* text on fill */
+  --attn-soft: #efe7cf; /* ochre wash — row background */
+  --attn-line: #bf8f30; /* ochre — left accent border / dot */
+  --block: #8f342c; /* oxblood */
   --block-fg: #f4e6e1;
-  --block-soft: #ecdcd4;    /* oxblood wash */
-  --block-line: #b5564a;    /* oxblood — left accent / dot */
+  --block-soft: #ecdcd4; /* oxblood wash */
+  --block-line: #b5564a; /* oxblood — left accent / dot */
 
   /* Calm semantic hues — a naturalist's plate, not a crayon box: muted sage,
      slate-teal, dusk plum. A step softer than the loud axis so they add rhythm
      without out-shouting attention. */
-  --ok: #59703f;            /* sage green — healthy / live / passing */
-  --ok-soft: #e6e8d5;       /* sage wash */
-  --ok-line: #7d9257;       /* sage dot / hairline */
-  --info: #3d6b76;          /* slate-teal — resting / neutral-positive */
-  --info-soft: #dde7e7;     /* slate-teal wash */
-  --info-line: #5f8b95;     /* slate-teal dot / hairline */
-  --agent: #6f5484;         /* dusk plum — model / AI identity accent */
-  --agent-soft: #e7e0e9;    /* plum wash */
-  --agent-line: #9880a8;    /* plum dot / hairline */
+  --ok: #59703f; /* sage green — healthy / live / passing */
+  --ok-soft: #e6e8d5; /* sage wash */
+  --ok-line: #7d9257; /* sage dot / hairline */
+  --info: #3d6b76; /* slate-teal — resting / neutral-positive */
+  --info-soft: #dde7e7; /* slate-teal wash */
+  --info-line: #5f8b95; /* slate-teal dot / hairline */
+  --agent: #6f5484; /* dusk plum — model / AI identity accent */
+  --agent-soft: #e7e0e9; /* plum wash */
+  --agent-line: #9880a8; /* plum dot / hairline */
 }
 
 /* Dark palette — "the reading room, by lamplight". Warm charcoal, not a neutral
@@ -139,46 +139,46 @@
    rather than a black terminal. Surfaces step up in small warm increments; the
    accent is a lifted iron-gall ink that glows without going cold. */
 .dark {
-  --canvas: #1b1915;        /* warm charcoal — editor background */
-  --rail: #151310;          /* nav rail + status bar — deepest chrome */
-  --surface: #232019;       /* cards / panels, one warm step up */
-  --input: #2a271f;         /* form fields */
-  --line: #332f27;          /* warm hairline borders */
-  --fg: #e9e3d6;            /* primary text — warm paper-white */
-  --muted: #a49b8b;         /* secondary text */
-  --faint: #726a5c;         /* tertiary text */
-  --subtle: #2c2921;        /* secondary buttons / hover fills */
+  --canvas: #1b1915; /* warm charcoal — editor background */
+  --rail: #151310; /* nav rail + status bar — deepest chrome */
+  --surface: #232019; /* cards / panels, one warm step up */
+  --input: #2a271f; /* form fields */
+  --line: #332f27; /* warm hairline borders */
+  --fg: #e9e3d6; /* primary text — warm paper-white */
+  --muted: #a49b8b; /* secondary text */
+  --faint: #726a5c; /* tertiary text */
+  --subtle: #2c2921; /* secondary buttons / hover fills */
   --subtle-hover: #38342a;
-  --tree-line: #726a5c;     /* session-tree guides; lifted off the
+  --tree-line: #726a5c; /* session-tree guides; lifted off the
                                warm canvas so the connectors read clearly */
-  --accent: #7ea6c6;        /* lifted iron-gall ink */
+  --accent: #7ea6c6; /* lifted iron-gall ink */
   --accent-hover: #95b8d3;
   --accent-fg: #16130f;
-  --code: #141210;          /* terminal / preformatted — a recessed panel */
+  --code: #141210; /* terminal / preformatted — a recessed panel */
   --code-fg: #c7c0b0;
 
   /* Attention (ochre) + Blocked (oxblood) — tuned for the warm charcoal canvas.
      Washes are a low-alpha pigment tint so they read as a faint glow, not a slab. */
-  --attn: #c99433;          /* lifted ochre */
+  --attn: #c99433; /* lifted ochre */
   --attn-fg: #211a0c;
-  --attn-soft: #4a350f33;   /* ochre @ ~20% — subtle row wash on dark */
+  --attn-soft: #4a350f33; /* ochre @ ~20% — subtle row wash on dark */
   --attn-line: #c99433;
-  --block: #c76a5c;         /* lifted oxblood */
+  --block: #c76a5c; /* lifted oxblood */
   --block-fg: #1f120f;
-  --block-soft: #4a231c33;  /* oxblood @ ~20% */
+  --block-soft: #4a231c33; /* oxblood @ ~20% */
   --block-line: #c76a5c;
 
   /* Calm semantic hues — lifted for the warm charcoal; washes are a low-alpha
      tint so they read as a faint glow, not a slab. */
-  --ok: #8fa877;            /* sage — healthy / live / passing */
-  --ok-soft: #33401f33;     /* sage @ ~20% — faint row wash */
-  --ok-line: #6f8557;       /* sage dot / hairline */
-  --info: #6fa0aa;          /* slate-teal — resting / neutral-positive */
-  --info-soft: #1f3a4033;   /* slate-teal @ ~20% */
-  --info-line: #5f8b95;     /* slate-teal dot / hairline */
-  --agent: #a98cc0;         /* dusk plum — model / AI identity accent */
-  --agent-soft: #2f234533;  /* plum @ ~20% */
-  --agent-line: #8b6fa8;    /* plum dot / hairline */
+  --ok: #8fa877; /* sage — healthy / live / passing */
+  --ok-soft: #33401f33; /* sage @ ~20% — faint row wash */
+  --ok-line: #6f8557; /* sage dot / hairline */
+  --info: #6fa0aa; /* slate-teal — resting / neutral-positive */
+  --info-soft: #1f3a4033; /* slate-teal @ ~20% */
+  --info-line: #5f8b95; /* slate-teal dot / hairline */
+  --agent: #a98cc0; /* dusk plum — model / AI identity accent */
+  --agent-soft: #2f234533; /* plum @ ~20% */
+  --agent-line: #8b6fa8; /* plum dot / hairline */
 }
 
 html,
@@ -233,7 +233,7 @@ body {
    anchor; genuinely-interactive descendants opt back out with `relative z-10`.
    (The Bootstrap idiom.) */
 .stretched-link::after {
-  content: "";
+  content: '';
   position: absolute;
   inset: 0;
   z-index: 0;
@@ -311,7 +311,7 @@ body {
 .tree-col--through::before,
 .tree-col--tee::before,
 .tree-col--elbow::before {
-  content: "";
+  content: '';
   position: absolute;
   left: 50%;
   width: 0;
@@ -333,7 +333,7 @@ body {
    connector meets the badge instead of stopping short of it. */
 .tree-col--tee::after,
 .tree-col--elbow::after {
-  content: "";
+  content: '';
   position: absolute;
   left: 50%;
   right: -0.55rem;

--- a/crates/loom/frontend/src/views/Chat.vue
+++ b/crates/loom/frontend/src/views/Chat.vue
@@ -71,8 +71,8 @@ onMounted(load);
       <div class="min-w-0 flex-1">
         <h1 class="text-sm font-semibold text-fg">Chat</h1>
         <p class="text-xs text-muted">
-          Ask the concierge about your fleet — stale sessions, what needs you — and
-          have it act on your behalf.
+          Ask the concierge about your fleet — stale sessions, what needs you — and have it act on
+          your behalf.
         </p>
       </div>
       <!-- Reset: archive this concierge (its transcript is kept) and start a
@@ -83,7 +83,11 @@ onMounted(load);
         class="btn-secondary shrink-0 px-2 py-0.5 text-xs"
         :class="{ 'text-block': armed }"
         :disabled="resetting"
-        :title="armed ? 'Click again to confirm — the current conversation is archived' : 'Start a fresh conversation'"
+        :title="
+          armed
+            ? 'Click again to confirm — the current conversation is archived'
+            : 'Start a fresh conversation'
+        "
         data-testid="chat-reset"
         @click="reset"
       >

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -190,12 +190,7 @@ const visible = computed(() => {
     if (!showClosed.value && i.status !== 'open') return false;
     if (repoFilter.value && i.repo_root !== repoFilter.value) return false;
     if (!q) return true;
-    const hay = [
-      `#${i.id}`,
-      i.title,
-      i.body,
-      ...i.tags.map((t) => `${t.key} ${t.value}`),
-    ]
+    const hay = [`#${i.id}`, i.title, i.body, ...i.tags.map((t) => `${t.key} ${t.value}`)]
       .join(' ')
       .toLowerCase();
     return hay.includes(q);
@@ -368,7 +363,12 @@ async function removeTag(i: Issue, key: string) {
           <option v-for="r in repos" :key="r" :value="r">{{ repoName(r) }}</option>
         </select>
         <label class="flex items-center gap-1.5 text-xs text-muted">
-          <input v-model="showClosed" type="checkbox" class="accent-accent" data-testid="issues-show-closed" />
+          <input
+            v-model="showClosed"
+            type="checkbox"
+            class="accent-accent"
+            data-testid="issues-show-closed"
+          />
           Show closed
         </label>
         <button
@@ -396,7 +396,9 @@ async function removeTag(i: Issue, key: string) {
       <!-- Repository: the backlog this lands in. A static label when one repo is
            in play, a picker when several, a free path when the board is empty. -->
       <div>
-        <span class="mb-1 block text-2xs font-semibold uppercase tracking-wider text-muted">Repository</span>
+        <span class="mb-1 block text-2xs font-semibold uppercase tracking-wider text-muted"
+          >Repository</span
+        >
         <select
           v-if="repoChoices.length > 1"
           v-model="createRepo"
@@ -410,7 +412,9 @@ async function removeTag(i: Issue, key: string) {
           class="font-mono text-sm text-muted"
           :title="createRepo"
           data-testid="issue-create-repo"
-        >{{ repoName(createRepo) }}</p>
+        >
+          {{ repoName(createRepo) }}
+        </p>
         <input
           v-else
           v-model="createRepo"
@@ -422,7 +426,9 @@ async function removeTag(i: Issue, key: string) {
       </div>
 
       <label class="block">
-        <span class="mb-1 block text-2xs font-semibold uppercase tracking-wider text-muted">Title</span>
+        <span class="mb-1 block text-2xs font-semibold uppercase tracking-wider text-muted"
+          >Title</span
+        >
         <input
           ref="createTitleInput"
           v-model="createDraft.title"
@@ -434,7 +440,9 @@ async function removeTag(i: Issue, key: string) {
       </label>
 
       <label class="block">
-        <span class="mb-1 block text-2xs font-semibold uppercase tracking-wider text-muted">Body</span>
+        <span class="mb-1 block text-2xs font-semibold uppercase tracking-wider text-muted"
+          >Body</span
+        >
         <textarea
           v-model="createDraft.body"
           rows="4"
@@ -445,14 +453,11 @@ async function removeTag(i: Issue, key: string) {
       </label>
 
       <div>
-        <span class="mb-1 block text-2xs font-semibold uppercase tracking-wider text-muted">Tags</span>
+        <span class="mb-1 block text-2xs font-semibold uppercase tracking-wider text-muted"
+          >Tags</span
+        >
         <div class="flex flex-wrap items-center gap-1.5">
-          <TagPill
-            v-for="t in createTags"
-            :key="t.key"
-            :tag="t"
-            @clear="removeCreateTag"
-          />
+          <TagPill v-for="t in createTags" :key="t.key" :tag="t" @clear="removeCreateTag" />
           <span class="flex items-center gap-1">
             <input
               v-model="createTagInput"
@@ -467,12 +472,16 @@ async function removeTag(i: Issue, key: string) {
               class="btn-secondary px-2 py-0.5 text-xs"
               data-testid="issue-create-tag-add"
               @click="addCreateTag"
-            >Add</button>
+            >
+              Add
+            </button>
           </span>
         </div>
       </div>
 
-      <p v-if="createError" class="text-sm text-block" data-testid="issue-create-error">{{ createError }}</p>
+      <p v-if="createError" class="text-sm text-block" data-testid="issue-create-error">
+        {{ createError }}
+      </p>
 
       <div class="flex items-center gap-2">
         <button
@@ -480,13 +489,17 @@ async function removeTag(i: Issue, key: string) {
           class="btn-primary px-2.5 py-1 text-xs font-medium"
           data-testid="issue-create-submit"
           :disabled="creating"
-        >{{ creating ? 'Creating…' : 'Create issue' }}</button>
+        >
+          {{ creating ? 'Creating…' : 'Create issue' }}
+        </button>
         <button
           type="button"
           class="btn-secondary px-2.5 py-1 text-xs font-medium"
           :disabled="creating"
           @click="cancelCreate"
-        >Cancel</button>
+        >
+          Cancel
+        </button>
       </div>
     </form>
 
@@ -504,7 +517,11 @@ async function removeTag(i: Issue, key: string) {
     <!-- One bordered board, hairline-divided rows (the fleet-list anatomy).
          Per-row actions are ghost buttons revealed on hover/focus, so the
          board reads as data, not as a wall of buttons. -->
-    <ul v-else class="overflow-hidden rounded-md border border-line bg-surface" data-testid="issues-list">
+    <ul
+      v-else
+      class="overflow-hidden rounded-md border border-line bg-surface"
+      data-testid="issues-list"
+    >
       <li
         v-for="i in visible"
         :key="i.id"
@@ -539,11 +556,9 @@ async function removeTag(i: Issue, key: string) {
           >
             {{ i.title }}
           </button>
-          <span
-            v-if="multiRepo"
-            class="pill shrink-0 font-mono"
-            :title="i.repo_root"
-          >{{ repoName(i.repo_root) }}</span>
+          <span v-if="multiRepo" class="pill shrink-0 font-mono" :title="i.repo_root">{{
+            repoName(i.repo_root)
+          }}</span>
           <a
             v-if="i.github_issue && i.github_repo"
             :href="`https://github.com/${i.github_repo}/issues/${i.github_issue}`"
@@ -551,7 +566,8 @@ async function removeTag(i: Issue, key: string) {
             rel="noopener"
             class="shrink-0 font-mono text-2xs text-muted hover:text-accent"
             @click.stop
-          >gh #{{ i.github_issue }}</a>
+            >gh #{{ i.github_issue }}</a
+          >
 
           <div
             class="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
@@ -567,7 +583,9 @@ async function removeTag(i: Issue, key: string) {
               :disabled="busy[i.id] || launching === i.id"
               :title="`Launch a session to work issue #${i.id}`"
               @click="launch(i)"
-            >{{ launching === i.id ? 'Launching…' : 'Launch' }}</button>
+            >
+              {{ launching === i.id ? 'Launching…' : 'Launch' }}
+            </button>
             <button
               v-if="i.status === 'open'"
               type="button"
@@ -575,7 +593,9 @@ async function removeTag(i: Issue, key: string) {
               data-testid="issue-close"
               :disabled="busy[i.id]"
               @click="setStatus(i, 'closed')"
-            >Close</button>
+            >
+              Close
+            </button>
             <button
               v-else
               type="button"
@@ -583,27 +603,34 @@ async function removeTag(i: Issue, key: string) {
               data-testid="issue-reopen"
               :disabled="busy[i.id]"
               @click="setStatus(i, 'open')"
-            >Reopen</button>
+            >
+              Reopen
+            </button>
             <button
               type="button"
               class="rounded px-1.5 py-0.5 text-2xs text-muted hover:bg-subtle hover:text-fg"
               data-testid="issue-edit"
               :disabled="busy[i.id]"
               @click="startEdit(i)"
-            >{{ editing === i.id ? 'Cancel' : 'Edit' }}</button>
+            >
+              {{ editing === i.id ? 'Cancel' : 'Edit' }}
+            </button>
             <button
               type="button"
               class="rounded px-1.5 py-0.5 text-2xs text-muted hover:bg-block-soft hover:text-block"
               data-testid="issue-delete"
               :disabled="busy[i.id]"
               @click="remove(i)"
-            >Delete</button>
+            >
+              Delete
+            </button>
           </div>
 
           <span
             class="shrink-0 font-mono text-2xs text-faint"
             :title="`updated ${i.updated_at} · created ${i.created_at}`"
-          >{{ timeAgo(i.updated_at) }}</span>
+            >{{ timeAgo(i.updated_at) }}</span
+          >
         </div>
 
         <!-- Row 2 (only when there's something): tag pills + referencing sessions -->
@@ -628,7 +655,8 @@ async function removeTag(i: Issue, key: string) {
                 :to="`/s/${r.session.id}`"
                 class="font-mono text-accent hover:underline"
                 data-testid="issue-session-ref"
-              >{{ r.rel }}: {{ r.session.branch.name }}</router-link>
+                >{{ r.rel }}: {{ r.session.branch.name }}</router-link
+              >
             </template>
           </div>
           <span
@@ -636,7 +664,11 @@ async function removeTag(i: Issue, key: string) {
             class="font-mono text-faint"
             data-testid="issue-branch-ref"
           >
-            {{ i.claimed_branch ? `claimed: ${branchLabel(i.claimed_branch)}` : `from: ${branchLabel(i.source_branch!)}` }}
+            {{
+              i.claimed_branch
+                ? `claimed: ${branchLabel(i.claimed_branch)}`
+                : `from: ${branchLabel(i.source_branch!)}`
+            }}
           </span>
         </div>
 
@@ -688,7 +720,9 @@ async function removeTag(i: Issue, key: string) {
                   class="btn-secondary px-2 py-0.5 text-xs"
                   data-testid="issue-tag-add"
                   :disabled="busy[i.id]"
-                >Add</button>
+                >
+                  Add
+                </button>
               </form>
             </div>
           </div>
@@ -700,13 +734,17 @@ async function removeTag(i: Issue, key: string) {
               data-testid="issue-save"
               :disabled="busy[i.id]"
               @click="saveEdit(i)"
-            >Save</button>
+            >
+              Save
+            </button>
             <button
               type="button"
               class="btn-secondary px-3 py-1 text-xs"
               :disabled="busy[i.id]"
               @click="editing = null"
-            >Cancel</button>
+            >
+              Cancel
+            </button>
           </div>
         </div>
       </li>

--- a/crates/loom/frontend/src/views/Login.vue
+++ b/crates/loom/frontend/src/views/Login.vue
@@ -49,8 +49,16 @@ async function submit() {
     <div class="w-full max-w-sm">
       <div class="mb-6 flex items-center justify-center gap-2">
         <span class="text-accent">
-          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-            stroke-width="1.75" stroke-linecap="round" aria-hidden="true">
+          <svg
+            width="26"
+            height="26"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.75"
+            stroke-linecap="round"
+            aria-hidden="true"
+          >
             <path d="M4 9h16M4 15h16M9 4v16M15 4v16" />
           </svg>
         </span>
@@ -61,7 +69,9 @@ async function submit() {
         <h1 class="mb-1 text-sm font-semibold">Sign in</h1>
         <p class="mb-4 text-xs text-muted">Authenticate to manage the fleet.</p>
 
-        <p v-if="error" class="mb-3 rounded bg-input px-2.5 py-1.5 text-xs text-block">{{ error }}</p>
+        <p v-if="error" class="mb-3 rounded bg-input px-2.5 py-1.5 text-xs text-block">
+          {{ error }}
+        </p>
 
         <a
           v-if="me.methods.github"
@@ -69,7 +79,9 @@ async function submit() {
           class="btn-secondary mb-3 flex w-full items-center justify-center gap-2 py-2 text-sm"
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+            <path
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+            />
           </svg>
           Continue with GitHub
         </a>

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-import { ref, reactive, computed, watch, onMounted, onActivated, onDeactivated, onUnmounted } from 'vue';
+import {
+  ref,
+  reactive,
+  computed,
+  watch,
+  onMounted,
+  onActivated,
+  onDeactivated,
+  onUnmounted,
+} from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { get, ideInfo } from '../api';
 import type { Session, WeaverEvent, Issue } from '../types';
@@ -54,7 +63,9 @@ const initialTab = route.query.tab;
 // `null` means "follow the backend's default tab"; a real value is an explicit
 // pick (from the URL or a click) that sticks.
 const localTab = ref<LocalTab | null>(
-  typeof initialTab === 'string' && VALID_LOCAL.includes(initialTab) ? (initialTab as LocalTab) : null,
+  typeof initialTab === 'string' && VALID_LOCAL.includes(initialTab)
+    ? (initialTab as LocalTab)
+    : null,
 );
 const effectiveLocalTab = computed<LocalTab>(() => localTab.value ?? defaultTab.value);
 
@@ -69,7 +80,9 @@ const railOpen = computed(() => artifactsActive.value && poppedOut.value);
 
 // The pane the work area shows: the artifacts panel when docked, else the
 // effective local tab (so a popped-out artifact leaves the work pane in place).
-const workTab = computed<WorkTab>(() => (artifactsDocked.value ? 'artifacts' : effectiveLocalTab.value));
+const workTab = computed<WorkTab>(() =>
+  artifactsDocked.value ? 'artifacts' : effectiveLocalTab.value,
+);
 
 // Lazy-mount panes on first visit, then keep them (v-show) so re-selecting is
 // instant. The terminal is always mounted; the rest start cold so a session-open

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -66,9 +66,7 @@ function setFilter(f: AttentionFilter) {
 // so the list never reads as empty while archived rows exist.
 const showArchived = ref(false);
 
-const archivedCount = computed(
-  () => sessions.value.filter((s) => s.status === 'archived').length,
-);
+const archivedCount = computed(() => sessions.value.filter((s) => s.status === 'archived').length);
 
 // The archived-aware, filtered set to display (membership only — the tree below
 // imposes the order). Archived rows are hidden by default; a reveal chip brings
@@ -262,7 +260,7 @@ function onRowDragOver(rowId: string, e: DragEvent) {
   if (idx === -1) return;
   const anchor = below ? roots[idx + 1] : roots[idx];
   dropAtEnd.value = below && idx === roots.length - 1;
-  dropBeforeId.value = dropAtEnd.value ? '' : anchor?.id ?? '';
+  dropBeforeId.value = dropAtEnd.value ? '' : (anchor?.id ?? '');
 }
 
 function neighbourKey(root: Session | undefined): number | null {
@@ -289,10 +287,13 @@ async function commitReorder() {
   const kb = neighbourKey(below);
   // Midpoint, with a wide gap when dropping past an end so there's room to spare.
   const key =
-    ka !== null && kb !== null ? (ka + kb) / 2
-    : ka !== null ? ka + 1e9
-    : kb !== null ? kb - 1e9
-    : 0;
+    ka !== null && kb !== null
+      ? (ka + kb) / 2
+      : ka !== null
+        ? ka + 1e9
+        : kb !== null
+          ? kb - 1e9
+          : 0;
   const dragged = sessions.value.find((s) => s.id === id);
   const wasShelved = dragged ? shelved(dragged) : false;
   // Optimistic: reflect immediately, then persist.
@@ -390,9 +391,12 @@ async function handleCreated() {
       <!-- Attention filter: jump straight to the sessions that need a human.
            Each segment pairs a label with its count in a small pill so the
            number reads as a count, not a suffix glued to the word. -->
-      <div v-if="sessions.length" class="inline-flex overflow-hidden rounded border border-line text-xs">
+      <div
+        v-if="sessions.length"
+        class="inline-flex overflow-hidden rounded border border-line text-xs"
+      >
         <button
-          v-for="opt in (['all', 'attention', 'ok'] as const)"
+          v-for="opt in ['all', 'attention', 'ok'] as const"
           :key="opt"
           type="button"
           :data-testid="`filter-${opt}`"
@@ -410,7 +414,8 @@ async function handleCreated() {
               'rounded-full px-1.5 text-2xs leading-4',
               filter === opt ? 'bg-accent-fg/20 text-accent-fg' : 'bg-subtle text-faint',
             ]"
-          >{{ counts[opt] }}</span>
+            >{{ counts[opt] }}</span
+          >
         </button>
       </div>
 
@@ -442,12 +447,7 @@ async function handleCreated() {
       </button>
     </div>
 
-
-    <NewSessionDrawer
-      v-if="showForm"
-      @close="closeForm"
-      @created="handleCreated"
-    />
+    <NewSessionDrawer v-if="showForm" @close="closeForm" @created="handleCreated" />
 
     <div v-if="error" class="mb-4 text-sm text-block">
       <template v-if="tokenConfigWarning">
@@ -455,12 +455,12 @@ async function handleCreated() {
         <RouterLink
           class="text-accent underline"
           :to="{ path: '/settings', query: { tab: 'account' } }"
-        >Add your GitHub token</RouterLink>
+          >Add your GitHub token</RouterLink
+        >
         or configure
-        <RouterLink
-          class="text-accent underline"
-          :to="{ path: '/settings', query: { tab: 'env' } }"
-        >GH_TOKEN</RouterLink>
+        <RouterLink class="text-accent underline" :to="{ path: '/settings', query: { tab: 'env' } }"
+          >GH_TOKEN</RouterLink
+        >
         before creating an agent session.
       </template>
       <template v-else>{{ error }}</template>
@@ -537,7 +537,9 @@ async function handleCreated() {
           @dragstart="onDragStart(s.id, $event)"
           @dragend="onDragEnd"
           @click.prevent
-        >⠿</button>
+        >
+          ⠿
+        </button>
         <span v-else class="-ml-1 w-3 shrink-0" aria-hidden="true"></span>
 
         <!-- Tree gutter: threads a child session under the one that launched it.
@@ -611,10 +613,7 @@ async function handleCreated() {
                margin annotation; the goal is roman and quieter beneath it. On an
                attention row the goal steps up from faint to muted so the metadata
                doesn't recede next to the loud chip. -->
-          <p
-            v-if="messageOf(s)"
-            class="mt-0.5 truncate font-serif text-[13px] italic text-muted"
-          >
+          <p v-if="messageOf(s)" class="mt-0.5 truncate font-serif text-[13px] italic text-muted">
             {{ messageOf(s) }}
           </p>
           <p
@@ -639,14 +638,21 @@ async function handleCreated() {
             by <span class="font-mono">{{ s.created_by }}</span>
           </span>
           <!-- PR snapshot (if any) — a quiet link straight to the GitHub PR. -->
-          <GithubStatus v-if="s.branch.github" :gh="s.branch.github" compact class="relative z-10 mt-0.5 justify-end" />
+          <GithubStatus
+            v-if="s.branch.github"
+            :gh="s.branch.github"
+            compact
+            class="relative z-10 mt-0.5 justify-end"
+          />
           <router-link
             v-if="s.branch.open_issue_count"
             :to="`/s/${s.id}?tab=overview`"
             class="relative z-10 block font-mono text-2xs text-muted hover:text-accent"
             @click.stop
           >
-            {{ s.branch.open_issue_count }} open issue{{ s.branch.open_issue_count === 1 ? '' : 's' }}
+            {{ s.branch.open_issue_count }} open issue{{
+              s.branch.open_issue_count === 1 ? '' : 's'
+            }}
           </router-link>
           <span v-if="s.last_activity_at" class="mt-0.5 block font-mono text-2xs text-faint">
             {{ timeAgo(s.last_activity_at) }}
@@ -696,9 +702,15 @@ async function handleCreated() {
         class="flex w-full items-center gap-2 px-1 py-1.5 text-2xs font-medium uppercase tracking-wider text-faint transition-colors hover:text-muted"
         @click="parkedOpen = !parkedOpen"
       >
-        <span class="inline-block w-2 transition-transform" :class="parkedOpen || draggingId ? 'rotate-90' : ''">▸</span>
+        <span
+          class="inline-block w-2 transition-transform"
+          :class="parkedOpen || draggingId ? 'rotate-90' : ''"
+          >▸</span
+        >
         Parked
-        <span class="font-serif text-[11px] normal-case italic tracking-normal text-faint">resting — nothing for you</span>
+        <span class="font-serif text-[11px] normal-case italic tracking-normal text-faint"
+          >resting — nothing for you</span
+        >
         <span class="h-px flex-1 bg-line"></span>
         <span class="font-mono lowercase tracking-normal">{{ shelfCount }}</span>
       </button>
@@ -725,7 +737,9 @@ async function handleCreated() {
             @dragstart="onDragStart(s.id, $event)"
             @dragend="onDragEnd"
             @click.prevent
-          >⠿</button>
+          >
+            ⠿
+          </button>
           <span v-else class="-ml-1 w-3 shrink-0" aria-hidden="true"></span>
 
           <span
@@ -742,7 +756,9 @@ async function handleCreated() {
               >
                 {{ s.branch.title || s.branch.name }}
               </router-link>
-              <span class="meta-chip !text-[10px] uppercase tracking-wide text-info">{{ parkLabel(s) }}</span>
+              <span class="meta-chip !text-[10px] uppercase tracking-wide text-info">{{
+                parkLabel(s)
+              }}</span>
             </div>
             <p v-if="s.branch.goal" class="mt-0.5 truncate font-serif text-[13px] text-faint">
               {{ s.branch.goal }}
@@ -773,10 +789,15 @@ async function handleCreated() {
             class="relative z-10 mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-2xs text-muted opacity-0 transition-opacity hover:bg-subtle hover:text-fg focus-visible:opacity-100 group-hover:opacity-100"
             title="Return this session to the live list"
             @click.stop="setPark(s.id, 'active')"
-          >Keep live</button>
+          >
+            Keep live
+          </button>
         </li>
 
-        <li v-if="!shelfRows.length" class="px-3 py-4 text-center font-serif text-[13px] italic text-faint">
+        <li
+          v-if="!shelfRows.length"
+          class="px-3 py-4 text-center font-serif text-[13px] italic text-faint"
+        >
           Drop a session here to rest it.
         </li>
       </ul>

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -102,7 +102,8 @@ const categories: CategoryItem[] = [
   {
     id: 'logs',
     label: 'Debug',
-    summary: 'Background tasks, live server logs, and build status for debugging this loom deployment.',
+    summary:
+      'Background tasks, live server logs, and build status for debugging this loom deployment.',
   },
 ];
 
@@ -298,7 +299,7 @@ function adopt(res: SettingsEnvelope, changedKeys: string[]) {
 }
 
 function patchBody(keys: string[], reset = false): Record<string, string | null> {
-  return Object.fromEntries(keys.map((key) => [key, reset ? null : drafts.value[key] ?? '']));
+  return Object.fromEntries(keys.map((key) => [key, reset ? null : (drafts.value[key] ?? '')]));
 }
 
 async function saveKeys(keys: string[], label: string) {

--- a/crates/loom/frontend/src/views/Shell.vue
+++ b/crates/loom/frontend/src/views/Shell.vue
@@ -38,8 +38,8 @@ async function restart() {
         <h1 class="text-sm font-semibold text-fg">Shell</h1>
         <p class="text-xs text-muted">
           A login shell inside the container — for one-time setup like
-          <code class="rounded bg-code px-1 py-0.5 text-[11px]">gcloud auth login</code>.
-          It persists across restarts.
+          <code class="rounded bg-code px-1 py-0.5 text-[11px]">gcloud auth login</code>. It
+          persists across restarts.
         </p>
       </div>
       <button

--- a/crates/loom/frontend/src/views/Watches.vue
+++ b/crates/loom/frontend/src/views/Watches.vue
@@ -138,7 +138,9 @@ async function run(dry: boolean) {
   busy.value = true;
   error.value = '';
   try {
-    const res = (await post(`/watches/${selected.value.id}/run`, { dry_run: dry })) as WatchRunResult;
+    const res = (await post(`/watches/${selected.value.id}/run`, {
+      dry_run: dry,
+    })) as WatchRunResult;
     lastRun.value = { outcome: res.outcome, summary: res.summary, dry };
     tab.value = 'activity';
     adopt((await get(`/watches/${selected.value.id}`)) as Watch);
@@ -241,7 +243,13 @@ const form = reactive({
   prompt: '',
   scopeAttention: '',
   repo: '',
-  capabilities: { mark: true, escalate: true, nudge: false, interrupt: false, launch: false } as Record<string, boolean>,
+  capabilities: {
+    mark: true,
+    escalate: true,
+    nudge: false,
+    interrupt: false,
+    launch: false,
+  } as Record<string, boolean>,
 });
 
 function resetForm() {
@@ -416,8 +424,7 @@ onActivated(() => {
         >
           <p class="mb-1 text-sm text-muted">No watches yet.</p>
           <p class="text-xs text-faint">
-            Builtins are seeded when the daemon starts; add a custom one with
-            “New watch”.
+            Builtins are seeded when the daemon starts; add a custom one with “New watch”.
           </p>
         </div>
         <ul v-else class="fade-in" data-testid="watch-list">
@@ -445,7 +452,9 @@ onActivated(() => {
                   data-testid="watch-active-dot"
                   :data-active="w.enabled ? 'true' : 'false'"
                 ></span>
-                <span class="min-w-0 flex-1 truncate text-sm font-semibold text-fg">{{ w.name }}</span>
+                <span class="min-w-0 flex-1 truncate text-sm font-semibold text-fg">{{
+                  w.name
+                }}</span>
                 <OutcomeBadge :outcome="w.last_outcome" />
               </span>
               <span class="mt-1 flex items-baseline gap-2 pl-4">
@@ -522,19 +531,31 @@ onActivated(() => {
             <label class="mb-1 block text-xs text-muted">Trigger — what wakes a round</label>
             <div class="mb-2 inline-flex overflow-hidden rounded border border-line text-xs">
               <button
-                v-for="k in (['auto', 'cron', 'every', 'on'] as const)"
+                v-for="k in ['auto', 'cron', 'every', 'on'] as const"
                 :key="k"
                 type="button"
                 class="border-l border-line px-3 py-1 first:border-l-0"
-                :class="form.triggerKind === k ? 'bg-accent text-accent-fg' : 'bg-input text-muted hover:bg-subtle'"
+                :class="
+                  form.triggerKind === k
+                    ? 'bg-accent text-accent-fg'
+                    : 'bg-input text-muted hover:bg-subtle'
+                "
                 @click="form.triggerKind = k"
               >
-                {{ k === 'auto' ? 'From script' : k === 'cron' ? 'Cron' : k === 'every' ? 'Every' : 'On events' }}
+                {{
+                  k === 'auto'
+                    ? 'From script'
+                    : k === 'cron'
+                      ? 'Cron'
+                      : k === 'every'
+                        ? 'Every'
+                        : 'On events'
+                }}
               </button>
             </div>
             <p v-if="form.triggerKind === 'auto'" class="text-xs text-faint">
-              Wakes on the events the script subscribes to (its manifest) — the
-              recommended default, so the script decides what it reacts to.
+              Wakes on the events the script subscribes to (its manifest) — the recommended default,
+              so the script decides what it reacts to.
             </p>
             <input
               v-else-if="form.triggerKind === 'cron'"
@@ -564,8 +585,8 @@ onActivated(() => {
                 Comma-separated trigger events:
                 <code>session.started/idle/exited/attention/stale</code>,
                 <code>triage.changed</code>,
-                <code>pr.opened/checks_red/checks_green/merged/review_changed</code>.
-                Append <code>=level</code> to filter (e.g. <code>session.attention=blocked</code>).
+                <code>pr.opened/checks_red/checks_green/merged/review_changed</code>. Append
+                <code>=level</code> to filter (e.g. <code>session.attention=blocked</code>).
               </p>
             </div>
           </div>
@@ -647,7 +668,8 @@ onActivated(() => {
                 v-if="isBuiltin(selected)"
                 class="meta-chip"
                 title="A stock program shipped with loom — disable it rather than delete it"
-              >builtin</span>
+                >builtin</span
+              >
               <OutcomeBadge :outcome="selected.last_outcome" />
               <div class="ml-auto flex items-center gap-2">
                 <label class="mr-1 flex items-center gap-2 text-xs text-muted">
@@ -687,12 +709,19 @@ onActivated(() => {
                 v-if="selected.trigger.repo || selected.scope.repo"
                 :title="selected.trigger.repo || selected.scope.repo"
                 class="meta-chip"
-              >📁 {{ repoLabel(selected.trigger.repo || selected.scope.repo || '') }}</span>
+                >📁 {{ repoLabel(selected.trigger.repo || selected.scope.repo || '') }}</span
+              >
               <span class="ml-auto font-mono text-2xs text-faint">
-                <span v-if="selected.last_run_at">last run {{ timeAgo(selected.last_run_at) }}</span>
+                <span v-if="selected.last_run_at"
+                  >last run {{ timeAgo(selected.last_run_at) }}</span
+                >
                 <span v-else>never run</span>
-                <span v-if="selected.enabled && selected.next_run_at"> · next {{ timeAgo(selected.next_run_at) }}</span>
-                <span v-if="selected.enabled && selected.wake_at"> · recheck {{ timeAgo(selected.wake_at) }}</span>
+                <span v-if="selected.enabled && selected.next_run_at">
+                  · next {{ timeAgo(selected.next_run_at) }}</span
+                >
+                <span v-if="selected.enabled && selected.wake_at">
+                  · recheck {{ timeAgo(selected.wake_at) }}</span
+                >
               </span>
             </div>
             <p v-if="programInfo" class="mt-2 max-w-3xl text-xs leading-relaxed text-faint">
@@ -702,14 +731,20 @@ onActivated(() => {
             <!-- Tabs. -->
             <div class="mt-3 flex gap-1" role="tablist">
               <button
-                v-for="t in ([['activity', 'Activity'], ['script', 'Script'], ['config', 'Config']] as const)"
+                v-for="t in [
+                  ['activity', 'Activity'],
+                  ['script', 'Script'],
+                  ['config', 'Config'],
+                ] as const"
                 :key="t[0]"
                 type="button"
                 role="tab"
                 :aria-selected="tab === t[0]"
                 :data-testid="`watch-tab-${t[0]}`"
                 class="rounded px-2.5 py-1 text-xs font-medium"
-                :class="tab === t[0] ? 'bg-subtle text-fg' : 'text-muted hover:bg-subtle/60 hover:text-fg'"
+                :class="
+                  tab === t[0] ? 'bg-subtle text-fg' : 'text-muted hover:bg-subtle/60 hover:text-fg'
+                "
                 @click="tab = t[0]"
               >
                 {{ t[1] }}
@@ -739,7 +774,9 @@ onActivated(() => {
               class="rounded border border-dashed border-line bg-surface p-6 text-center"
             >
               <p class="text-sm text-muted">No rounds yet.</p>
-              <p class="mt-1 text-xs text-faint">Run one now (or dry-run it) to populate the log.</p>
+              <p class="mt-1 text-xs text-faint">
+                Run one now (or dry-run it) to populate the log.
+              </p>
             </div>
 
             <ul v-else data-testid="watch-runs" class="space-y-2">
@@ -758,16 +795,24 @@ onActivated(() => {
                   <div class="flex flex-wrap items-center gap-2">
                     <OutcomeBadge :outcome="r.outcome" />
                     <span class="text-sm text-muted">{{ r.summary || 'No summary.' }}</span>
-                    <span class="ml-auto font-mono text-xs text-faint">{{ timeAgo(r.started_at) }}</span>
+                    <span class="ml-auto font-mono text-xs text-faint">{{
+                      timeAgo(r.started_at)
+                    }}</span>
                   </div>
                   <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-faint">
-                    <span class="meta-chip">{{ r.trigger_reason || r.trigger_event || 'manual' }}</span>
-                    <span v-if="r.duration_ms != null" class="meta-chip">{{ formatMs(r.duration_ms) }}</span>
+                    <span class="meta-chip">{{
+                      r.trigger_reason || r.trigger_event || 'manual'
+                    }}</span>
+                    <span v-if="r.duration_ms != null" class="meta-chip">{{
+                      formatMs(r.duration_ms)
+                    }}</span>
                     <span v-if="r.exit_code != null" class="meta-chip">exit {{ r.exit_code }}</span>
                     <span v-if="r.actions && r.actions.length">
                       {{ r.actions.length }} action{{ r.actions.length === 1 ? '' : 's' }}
                     </span>
-                    <span class="ml-auto text-accent">{{ expanded[r.id] ? 'Hide' : 'Details' }}</span>
+                    <span class="ml-auto text-accent">{{
+                      expanded[r.id] ? 'Hide' : 'Details'
+                    }}</span>
                   </div>
                 </button>
 
@@ -783,27 +828,34 @@ onActivated(() => {
                   >
                     <li v-for="(a, j) in r.actions" :key="j" class="flex items-start gap-2 text-xs">
                       <span class="meta-chip shrink-0">
-                        <span v-if="a.would" class="text-faint">would </span>{{ a.action || a.would || 'action' }}
+                        <span v-if="a.would" class="text-faint">would </span
+                        >{{ a.action || a.would || 'action' }}
                         <span v-if="a.level" class="text-faint">={{ a.level }}</span>
                       </span>
-                      <span v-if="a.session" class="shrink-0 font-mono text-faint">{{ a.session }}</span>
+                      <span v-if="a.session" class="shrink-0 font-mono text-faint">{{
+                        a.session
+                      }}</span>
                       <span class="min-w-0 text-muted">{{ a.note || a.text || '' }}</span>
                     </li>
                   </ul>
 
                   <div v-if="r.stdout">
-                    <h3 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-faint">stdout</h3>
+                    <h3 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-faint">
+                      stdout
+                    </h3>
                     <pre
                       data-testid="watch-run-stdout"
                       class="max-h-64 overflow-auto whitespace-pre-wrap rounded bg-input p-2 font-mono text-xs"
-                    >{{ r.stdout }}</pre>
+                      >{{ r.stdout }}</pre>
                   </div>
                   <div v-if="r.stderr">
-                    <h3 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-faint">stderr</h3>
+                    <h3 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-faint">
+                      stderr
+                    </h3>
                     <pre
                       data-testid="watch-run-stderr"
                       class="max-h-64 overflow-auto whitespace-pre-wrap rounded bg-input p-2 font-mono text-xs text-block"
-                    >{{ r.stderr }}</pre>
+                      >{{ r.stderr }}</pre>
                   </div>
 
                   <p
@@ -821,26 +873,22 @@ onActivated(() => {
           <div v-else-if="tab === 'script'" class="p-5">
             <template v-if="programInfo">
               <p class="mb-2 text-xs text-faint">
-                <span class="font-mono">{{ programInfo.program }}</span> —
-                {{ programInfo.title }}. A stock script shipped inside loom; the
-                source is read-only. Start a custom watch from a copy with
-                <code>loom watch new &lt;name&gt;</code>.
+                <span class="font-mono">{{ programInfo.program }}</span> — {{ programInfo.title }}.
+                A stock script shipped inside loom; the source is read-only. Start a custom watch
+                from a copy with <code>loom watch new &lt;name&gt;</code>.
               </p>
               <pre
                 data-testid="watch-script"
                 class="overflow-auto rounded border border-line bg-input p-3 font-mono text-xs leading-relaxed"
-              >{{ programInfo.source }}</pre>
+                >{{ programInfo.source }}</pre>
             </template>
-            <div
-              v-else
-              class="rounded border border-dashed border-line bg-surface p-6 text-center"
-            >
+            <div v-else class="rounded border border-dashed border-line bg-surface p-6 text-center">
               <p class="text-sm text-muted">
                 Custom program: <span class="font-mono">{{ selected.program }}</span>
               </p>
               <p class="mt-1 text-xs text-faint">
-                The script lives on the server's disk; edit it there — each round
-                runs the file as it is on disk.
+                The script lives on the server's disk; edit it there — each round runs the file as
+                it is on disk.
               </p>
             </div>
           </div>
@@ -892,7 +940,9 @@ onActivated(() => {
                 <dt class="pt-1 text-faint">Capabilities</dt>
                 <dd>
                   <div v-if="!editing" class="flex flex-wrap gap-1.5">
-                    <span v-for="c in selected.capabilities" :key="c" class="meta-chip">{{ c }}</span>
+                    <span v-for="c in selected.capabilities" :key="c" class="meta-chip">{{
+                      c
+                    }}</span>
                   </div>
                   <div v-else class="flex flex-wrap gap-3">
                     <label
@@ -963,20 +1013,22 @@ onActivated(() => {
 
             <!-- Warm session: its live terminal when warm mode is on. -->
             <section v-if="selected.warm_session_id" class="mt-5" data-testid="watch-warm-terminal">
-              <h3 class="mb-2 text-2xs font-semibold uppercase tracking-wider text-muted">Warm session</h3>
+              <h3 class="mb-2 text-2xs font-semibold uppercase tracking-wider text-muted">
+                Warm session
+              </h3>
               <AgentTerminal :id="selected.warm_session_id" />
             </section>
             <section v-else class="mt-5 rounded border border-dashed border-line bg-surface p-4">
-              <h3 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-muted">Warm session</h3>
+              <h3 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-muted">
+                Warm session
+              </h3>
               <p v-if="selected.warm" class="text-xs text-faint" data-testid="watch-warm-pending">
-                Warm mode is on. The engine brings up a persistent session on the
-                next round; its live terminal appears here, and it carries memory
-                from one round to the next.
+                Warm mode is on. The engine brings up a persistent session on the next round; its
+                live terminal appears here, and it carries memory from one round to the next.
               </p>
               <p v-else class="text-xs text-faint" data-testid="watch-warm-off">
-                Each round runs fresh. Turn on warm mode (set <code>params.warm</code>)
-                to keep one persistent session with across-round memory — its
-                terminal lives here.
+                Each round runs fresh. Turn on warm mode (set <code>params.warm</code>) to keep one
+                persistent session with across-round memory — its terminal lives here.
               </p>
             </section>
 

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -183,7 +183,12 @@ from becoming a wall of stale rows:
   streams — set in a soft text shimmer (the one licensed animation beyond
   `fade-in`, stilled under `prefers-reduced-motion`) beside a mono
   `turn N · M:SS` elapsed count. An empty conversation states itself: a dashed
-  card ("No conversation yet") instead of a bare canvas. The right rail
+  card ("No conversation yet") instead of a bare canvas. Both conversation
+  surfaces (ACP and the terminal-log tab) open **pinned to the foot** — the
+  newest exchange — and follow growth while the reader stays there; scrolling
+  up releases the pin, scrolling back to the foot re-arms it (a ResizeObserver
+  on the transcript body, so async markdown paints can't strand the view
+  mid-history). The right rail
   carries the user-turn jump list plus the current `plan` checklist (✓/▸/○ in
   ok/agent/faint), folding away at narrow widths. The composer is a serif
   input with a mono mode chip (`bypass ▾` → `session/set_mode`) on the left

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -106,11 +106,16 @@ test.describe('acp conversation', () => {
     // The turn has settled — its closing rule renders after the prose.
     await expect(page.getByTestId('acp-turn-rule')).toBeVisible({ timeout: 20_000 });
 
-    // The transcript genuinely overflows…
-    await expect.poll(() => conv.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(300);
+    // The transcript genuinely overflows… (generous timeouts: markdown paints
+    // asynchronously and can lag well behind the stream on a loaded machine)
+    await expect
+      .poll(() => conv.evaluate((el) => el.scrollHeight - el.clientHeight), { timeout: 30_000 })
+      .toBeGreaterThan(300);
     // …and the view rests pinned at its foot, where the newest prose reads.
     await expect
-      .poll(() => conv.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight))
+      .poll(() => conv.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight), {
+        timeout: 30_000,
+      })
       .toBeLessThan(120);
   });
 

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -92,6 +92,28 @@ async function openAcp(
 }
 
 test.describe('acp conversation', () => {
+  // A chat opens at its newest exchange: the transcript scrolls to its foot on
+  // load and stays there while the async markdown paint grows the content.
+  test('opens scrolled to the foot of a long transcript', async ({ page, weaver }) => {
+    // Interleave tool calls so each say stays its own speaker block (consecutive
+    // message chunks would otherwise consolidate into one short message).
+    const goal = Array.from(
+      { length: 15 },
+      (_, i) => `say:Paragraph ${i + 1} of a long transcript.|tool:read:Read file ${i + 1}`,
+    ).join('|');
+    await openAcp(page, weaver, { goal, name: 'acp-foot' });
+    const conv = page.getByTestId('acp-conversation');
+    // The turn has settled — its closing rule renders after the prose.
+    await expect(page.getByTestId('acp-turn-rule')).toBeVisible({ timeout: 20_000 });
+
+    // The transcript genuinely overflows…
+    await expect.poll(() => conv.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(300);
+    // …and the view rests pinned at its foot, where the newest prose reads.
+    await expect
+      .poll(() => conv.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight))
+      .toBeLessThan(120);
+  });
+
   test('renders the journaled transcript — user, agent, tool blocks', async ({ page, weaver }) => {
     await openAcp(page, weaver, {
       goal: 'say:The route resolves against auth.base_url now.|tool:edit:Edit web.rs',

--- a/e2e/tests/conversation.spec.ts
+++ b/e2e/tests/conversation.spec.ts
@@ -75,10 +75,13 @@ test.describe('conversation view', () => {
     await openConversation(page, weaver, { name: 'conv-foot', log: longLog() });
     const conv = page.getByTestId('conversation');
 
-    // The transcript genuinely overflows…
-    await expect.poll(() => conv.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(300);
+    // The transcript genuinely overflows… (generous timeouts: markdown paints
+    // asynchronously and can lag well behind the fetch on a loaded machine)
+    await expect
+      .poll(() => conv.evaluate((el) => el.scrollHeight - el.clientHeight), { timeout: 30_000 })
+      .toBeGreaterThan(300);
     // …and the view rests at its foot, where the newest reply reads.
-    await expect.poll(() => footDistance(conv)).toBeLessThan(120);
+    await expect.poll(() => footDistance(conv), { timeout: 30_000 }).toBeLessThan(120);
     await expect(page.getByText('Progress note 40', { exact: false })).toBeVisible();
   });
 
@@ -90,7 +93,7 @@ test.describe('conversation view', () => {
   }) => {
     const s = await openConversation(page, weaver, { name: 'conv-pin', log: longLog() });
     const conv = page.getByTestId('conversation');
-    await expect.poll(() => footDistance(conv)).toBeLessThan(120);
+    await expect.poll(() => footDistance(conv), { timeout: 30_000 }).toBeLessThan(120);
 
     // The reader scrolls up into the history — the pin releases…
     await conv.evaluate((el) => {

--- a/e2e/tests/conversation.spec.ts
+++ b/e2e/tests/conversation.spec.ts
@@ -41,9 +41,21 @@ function demoLog() {
   };
 }
 
-async function openConversation(page: Page, weaver: WeaverFixture) {
-  const s = await weaver.seedSession({ goal: 'demo', name: 'conv' });
-  await weaver.seedConversation(s, demoLog());
+/** demoLog grown past a 900px viewport: forty extra assistant paragraphs, so
+ *  scroll behaviour (open-at-the-foot, pin release) has real overflow to bite. */
+function longLog() {
+  const base = demoLog();
+  const notes = Array.from({ length: 40 }, (_, i) => ({
+    role: 'assistant',
+    timestamp: `2026-06-21T10:${String(10 + Math.floor(i / 10)).padStart(2, '0')}:00.000Z`,
+    blocks: [{ kind: 'text', text: `Progress note ${i + 1}: the change builds and the suite stays green.` }],
+  }));
+  return { ...base, messages: [...base.messages, ...notes] };
+}
+
+async function openConversation(page: Page, weaver: WeaverFixture, opts?: { name: string; log: unknown }) {
+  const s = await weaver.seedSession({ goal: 'demo', name: opts?.name ?? 'conv' });
+  await weaver.seedConversation(s, opts?.log ?? demoLog());
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${weaver.baseUrl}/s/${s.id}`);
   await page.locator('[data-tab="conversation"]').click();
@@ -51,7 +63,58 @@ async function openConversation(page: Page, weaver: WeaverFixture) {
   return s;
 }
 
+/** px between the scroll position and the transcript's foot. */
+function footDistance(conv: ReturnType<Page['getByTestId']>) {
+  return conv.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight);
+}
+
 test.describe('conversation view', () => {
+  // A chat opens at its newest exchange — the transcript scrolls to its foot on
+  // load (waiting out the async markdown paint), not to turn one.
+  test('opens scrolled to the foot — the newest exchange shows first', async ({ page, weaver }) => {
+    await openConversation(page, weaver, { name: 'conv-foot', log: longLog() });
+    const conv = page.getByTestId('conversation');
+
+    // The transcript genuinely overflows…
+    await expect.poll(() => conv.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(300);
+    // …and the view rests at its foot, where the newest reply reads.
+    await expect.poll(() => footDistance(conv)).toBeLessThan(120);
+    await expect(page.getByText('Progress note 40', { exact: false })).toBeVisible();
+  });
+
+  // Scrolling up releases the pin: content growing underneath (an auto-refresh
+  // landing a new reply) must not yank the reader back down out of the history.
+  test('scrolling up releases the pin — a refresh keeps the reader in place', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await openConversation(page, weaver, { name: 'conv-pin', log: longLog() });
+    const conv = page.getByTestId('conversation');
+    await expect.poll(() => footDistance(conv)).toBeLessThan(120);
+
+    // The reader scrolls up into the history — the pin releases…
+    await conv.evaluate((el) => {
+      el.scrollTop = 0;
+    });
+    // …so a new reply arriving on a lifecycle edge renders without a yank.
+    const base = longLog();
+    const grown = {
+      ...base,
+      messages: [
+        ...base.messages,
+        {
+          role: 'assistant',
+          timestamp: '2026-06-21T10:59:00.000Z',
+          blocks: [{ kind: 'text', text: 'A fresh reply just landed.' }],
+        },
+      ],
+    };
+    await weaver.seedConversation(s, grown);
+    await weaver.hook(s, 'idle');
+    await expect(page.getByText('A fresh reply just landed.')).toBeAttached({ timeout: 15_000 });
+    expect(await conv.evaluate((el) => el.scrollTop)).toBeLessThan(300);
+  });
+
   test('folds tool activity and run-length collapses repeated calls', async ({ page, weaver }) => {
     await openConversation(page, weaver);
     const conv = page.getByTestId('conversation');

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -42,8 +42,14 @@ if command -v npm >/dev/null 2>&1; then
     npm --prefix "$frontend" install
   fi
   npm --prefix "$frontend" run typecheck
-  echo "✓ fmt + clippy + typecheck clean"
+  echo "▶ prettier --check ($frontend/src)"
+  if ! npm --prefix "$frontend" run format:check; then
+    echo >&2
+    echo "✗ frontend formatting check failed — run \`npm --prefix $frontend run format\`, then re-stage and commit." >&2
+    exit 1
+  fi
+  echo "✓ fmt + clippy + typecheck + prettier clean"
 else
-  echo "▶ vue-tsc typecheck — skipped (npm not found)"
+  echo "▶ vue-tsc typecheck + prettier — skipped (npm not found)"
   echo "✓ fmt + clippy clean"
 fi


### PR DESCRIPTION
Both conversation surfaces (ACP and the terminal-log tab) now open scrolled to their newest exchange and stay pinned there while content grows; scrolling up releases the pin, scrolling back to the foot re-arms it. Previously the terminal tab never scrolled on a fresh load, and the ACP surface's one-shot scroll raced the async markdown paint, so a long chat routinely opened mid-history.

The pin lives in a shared composable (lib/followFoot.ts) built around a ResizeObserver on the transcript body, so late paints (markdown, images, a v-show reveal) re-scroll instead of stranding the view. Two subtle races are handled explicitly: a stale echo of our own scroll-to-foot arriving after further growth must not read as the reader scrolling away (the pin only re-derives from a scroll that moved the view off the last programmatic target), and browser scroll anchoring is disabled on the container so it cannot move scrollTop behind the pin's back.

The transcript rhythm also tightens toward chat-app density — smaller inter-turn gaps, denser prose leading, block gaps, and list indents — via a chat-prose layer in markdown.css that only the conversation surfaces opt into; document surfaces keep the printed-page defaults.

The branch also adds prettier for the frontend (config, npm run format / format:check, one-time reformat of src) and wires the check into scripts/pre-commit.sh next to vue-tsc, so the gate matches locally and in CI.

New e2e coverage: both surfaces assert open-at-the-foot on a long transcript, and the terminal view asserts that scrolling up releases the pin so an auto-refresh cannot yank the reader out of the history.

Tracked as weaver issue 525.
