### PR TITLE
feat(loom): support live agent handoff

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -256,6 +256,13 @@ export const resolveThread = (id: string, name: string, tid: number) =>
 export const sendMessage = (id: string, text: string, submit = true) =>
   post(`/sessions/${id}/send`, { text, submit });
 
+/** Replace the provider behind an idle ACP session while preserving its stable
+ * loom session, worktree, branch, and canonical conversation journal. */
+export const handoffSession = (
+  id: string,
+  body: { agent: string; model?: string; effort?: string; mode?: string },
+) => post(`/sessions/${id}/handoff`, body) as Promise<Session>;
+
 // --- ACP conversation (protocol='acp' sessions) ----------------------------
 
 import type { ChatSnapshot, PromptAck } from './types';

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -33,6 +33,7 @@ import type {
   PermissionPayload,
   UsagePayload,
   TurnEndPayload,
+  HandoffPayload,
 } from '../types';
 import { canSend } from '../lib/sessionState';
 import { useFollowFoot } from '../lib/followFoot';
@@ -163,18 +164,38 @@ function onTurn(ev: SseTurn) {
 
 // ── SSE lifecycle (kept-alive discipline) ────────────────────────────────────
 let source: EventSource | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 function openStream() {
-  source = new EventSource(`/api/sessions/${id.value}/chat/stream`);
-  source.addEventListener('block', (e) =>
+  const stream = new EventSource(`/api/sessions/${id.value}/chat/stream`);
+  source = stream;
+  stream.addEventListener('block', (e) =>
     onBlock(JSON.parse((e as MessageEvent).data) as ChatBlock),
   );
-  source.addEventListener('delta', (e) =>
+  stream.addEventListener('delta', (e) =>
     onDelta(JSON.parse((e as MessageEvent).data) as SseDelta),
   );
-  source.addEventListener('tool', (e) => onTool(JSON.parse((e as MessageEvent).data) as SseTool));
-  source.addEventListener('turn', (e) => onTurn(JSON.parse((e as MessageEvent).data) as SseTurn));
+  stream.addEventListener('tool', (e) => onTool(JSON.parse((e as MessageEvent).data) as SseTool));
+  stream.addEventListener('turn', (e) => onTurn(JSON.parse((e as MessageEvent).data) as SseTurn));
+  // Once the server has installed the subscription, reconcile from the durable
+  // journal. Subscribing first avoids a snapshot-to-stream gap during handoff.
+  stream.addEventListener('open', () => load({ preserve: true }));
+  // A provider handoff cleanly closes the old task's broadcast. Browsers do not
+  // consistently reconnect an EventSource after a clean EOF, so explicitly
+  // replace it and refetch the durable snapshot before tailing the new task.
+  stream.onerror = () => {
+    if (source !== stream) return;
+    stream.close();
+    source = null;
+    if (reconnectTimer) return;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      if (!source) openStream();
+    }, 100);
+  };
 }
 function closeStream() {
+  if (reconnectTimer) clearTimeout(reconnectTimer);
+  reconnectTimer = null;
   source?.close();
   source = null;
 }
@@ -302,7 +323,8 @@ type Row =
   | { type: 'thought'; key: string; text: string; streaming: boolean }
   | { type: 'activity'; key: string; items: ActivityItem[]; failures: number }
   | { type: 'permission'; key: string; perm: PermissionPayload }
-  | { type: 'mode'; key: string; mode: string };
+  | { type: 'mode'; key: string; mode: string }
+  | { type: 'handoff'; key: string; handoff: HandoffPayload };
 
 interface TocItem {
   anchor: string;
@@ -411,6 +433,14 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
           type: 'mode',
           key: k,
           mode: (b.payload as { mode_id?: string }).mode_id ?? '',
+        });
+        break;
+      case 'handoff':
+        flushActivity();
+        rows.push({
+          type: 'handoff',
+          key: k,
+          handoff: b.payload as unknown as HandoffPayload,
         });
         break;
       case 'turn_end': {
@@ -808,6 +838,13 @@ function goTo(anchor: string) {
             <!-- Mode change — a quiet centred marker. -->
             <div v-else-if="row.type === 'mode'" class="acp-mode-note">
               mode → {{ modeLabel(row.mode) }}
+            </div>
+
+            <!-- Provider boundary — the injected bootstrap stays hidden; this
+                 compact receipt is the honest journal provenance. -->
+            <div v-else-if="row.type === 'handoff'" class="acp-mode-note" data-testid="acp-handoff">
+              handoff · {{ row.handoff.from }} → {{ row.handoff.to
+              }}<template v-if="row.handoff.model"> · {{ row.handoff.model }}</template>
             </div>
           </template>
 

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
-import type { Session } from '../types';
+import type { AgentMetadata, Session } from '../types';
+import { handoffSession, listAgents } from '../api';
 import {
   messageOf,
   conversationState,
@@ -108,6 +109,75 @@ const lastActivity = computed(() => timeAgo(props.ws.last_activity_at));
 // means here; clearing a chip DELETEs that tag (there is no "Mark OK" verb).
 const signals = computed(() => signalChips(props.ws));
 const quiet = computed(() => quietTags(props.ws));
+
+// Provider handoff is an ACP-only, between-turn server operation. The manage
+// menu exposes the profile picker for a live ACP fleet session; the endpoint is
+// still authoritative when a turn starts between paint and submit.
+const handoffOpen = ref(false);
+const handoffAgents = ref<AgentMetadata[]>([]);
+const handoffAgent = ref('');
+const handoffModel = ref('');
+const handoffEffort = ref('');
+const handoffBusy = ref(false);
+const handoffError = ref('');
+const canHandoff = computed(() => props.ws.protocol === 'acp' && props.ws.status === 'running');
+const unchangedHandoff = computed(
+  () =>
+    handoffAgent.value === props.ws.agent_kind &&
+    handoffModel.value === props.ws.model &&
+    handoffEffort.value === props.ws.effort,
+);
+const handoffMetadata = computed(() =>
+  handoffAgents.value.find((a) => a.kind === handoffAgent.value),
+);
+
+async function toggleHandoff() {
+  handoffOpen.value = !handoffOpen.value;
+  handoffError.value = '';
+  if (!handoffOpen.value) return;
+  handoffAgent.value = props.ws.agent_kind;
+  handoffModel.value = props.ws.model;
+  handoffEffort.value = props.ws.effort;
+  if (!handoffAgents.value.length) {
+    try {
+      handoffAgents.value = (await listAgents()).agents.filter((a) => a.supports_acp);
+    } catch (e) {
+      handoffError.value = (e as Error).message;
+    }
+  }
+}
+
+function chooseHandoffAgent(kind: string) {
+  if (kind === handoffAgent.value) return;
+  handoffAgent.value = kind;
+  handoffModel.value = '';
+  handoffEffort.value = '';
+}
+
+function chooseHandoffAgentFromEvent(event: Event) {
+  chooseHandoffAgent((event.target as HTMLSelectElement).value);
+}
+
+async function submitHandoff() {
+  if (handoffBusy.value || unchangedHandoff.value) return;
+  handoffBusy.value = true;
+  handoffError.value = '';
+  try {
+    await handoffSession(props.ws.id, {
+      agent: handoffAgent.value,
+      model: handoffModel.value,
+      effort: handoffEffort.value,
+    });
+    handoffOpen.value = false;
+    showDetails.value = false;
+    notice.value = `Handed off to ${handoffAgent.value}.`;
+    await emit('reload');
+  } catch (e) {
+    handoffError.value = (e as Error).message;
+  } finally {
+    handoffBusy.value = false;
+  }
+}
 </script>
 
 <template>
@@ -177,6 +247,72 @@ const quiet = computed(() => quietTags(props.ws));
           <SessionDetailsPopover :ws="ws" v-model:open="showDetails">
             <template #actions>
               <div class="space-y-1">
+                <button
+                  v-if="canHandoff"
+                  type="button"
+                  data-testid="action-handoff"
+                  class="block w-full rounded px-2 py-1.5 text-left text-fg transition-colors hover:bg-subtle"
+                  @click="toggleHandoff"
+                >
+                  <span class="block text-xs font-medium">Hand off</span>
+                  <span class="block text-2xs text-faint"
+                    >Replace the provider; keep work and conversation.</span
+                  >
+                </button>
+                <form
+                  v-if="handoffOpen"
+                  class="space-y-3 rounded border border-line bg-input p-2"
+                  data-testid="handoff-form"
+                  @submit.prevent="submitHandoff"
+                >
+                  <label class="block text-2xs font-semibold uppercase tracking-wider text-muted">
+                    Provider
+                    <select
+                      :value="handoffAgent"
+                      class="mt-1 block w-full rounded bg-surface px-2 py-1.5 text-xs font-normal normal-case tracking-normal text-fg"
+                      @change="chooseHandoffAgentFromEvent"
+                    >
+                      <option v-for="a in handoffAgents" :key="a.kind" :value="a.kind">
+                        {{ a.label }}
+                      </option>
+                    </select>
+                  </label>
+                  <label class="block text-2xs font-semibold uppercase tracking-wider text-muted">
+                    Model
+                    <select
+                      v-model="handoffModel"
+                      class="mt-1 block w-full rounded bg-surface px-2 py-1.5 text-xs font-normal normal-case tracking-normal text-fg"
+                    >
+                      <option value="">Default</option>
+                      <option v-for="m in handoffMetadata?.models ?? []" :key="m.id" :value="m.id">
+                        {{ m.label }}
+                      </option>
+                    </select>
+                  </label>
+                  <label class="block text-2xs font-semibold uppercase tracking-wider text-muted">
+                    Effort
+                    <select
+                      v-model="handoffEffort"
+                      class="mt-1 block w-full rounded bg-surface px-2 py-1.5 text-xs font-normal normal-case tracking-normal text-fg"
+                    >
+                      <option value="">Default</option>
+                      <option v-for="e in handoffMetadata?.efforts ?? []" :key="e.id" :value="e.id">
+                        {{ e.label }}
+                      </option>
+                    </select>
+                  </label>
+                  <p class="text-2xs text-faint">
+                    Starts the replacement with this session's goal and conversation history.
+                  </p>
+                  <p v-if="handoffError" class="text-xs text-block">{{ handoffError }}</p>
+                  <button
+                    type="submit"
+                    class="btn-primary px-2.5 py-1 text-xs"
+                    :disabled="handoffBusy || unchangedHandoff || !handoffAgent"
+                  >
+                    {{ handoffBusy ? 'Handing off…' : 'Hand off now' }}
+                  </button>
+                </form>
                 <button
                   v-for="a in lifecycle"
                   :key="a.verb"

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -144,7 +144,8 @@ export type ChatBlockKind =
   | 'permission_request'
   | 'mode_change'
   | 'usage'
-  | 'turn_end';
+  | 'turn_end'
+  | 'handoff';
 
 /** One journaled block. `payload` is opaque JSON keyed by `kind` (the payload
  *  interfaces below). Addressed by `(turn, seq)`. Mirrors `chat::ChatBlockView`. */
@@ -229,6 +230,12 @@ export interface UsagePayload {
 export interface TurnEndPayload {
   stop_reason: string;
 }
+export interface HandoffPayload {
+  from: string;
+  to: string;
+  model: string;
+  effort: string;
+}
 
 // -- `/chat/stream` SSE events --
 /** `block` — a whole journaled block (upsert by `(turn, seq)`). Same shape as a
@@ -282,6 +289,10 @@ export interface AgentMetadata {
   /** True for the builtin `claude`/`codex`; false for an operator-defined custom
    *  agent (which the UI may edit or delete). */
   builtin: boolean;
+  /** Whether this runtime can replace another live ACP provider. */
+  supports_acp: boolean;
+  /** The runtime's declared/default execution backend. */
+  protocol: 'terminal' | 'acp';
 }
 
 /** An operator-defined custom agent: the shell commands loom runs at each launch

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -234,7 +234,7 @@ function openStream() {
   // `tag` covers every status axis (the agent's attention, a watch's
   // triage, any free-form key); a tag write re-fetches the session so the
   // resolved badge and the pill row refresh.
-  for (const kind of ['status', 'tag', 'github']) {
+  for (const kind of ['status', 'tag', 'github', 'handoff']) {
     source.addEventListener(kind, (e) => {
       const ev = JSON.parse((e as MessageEvent).data) as WeaverEvent;
       events.value.push(ev);

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -29,6 +29,8 @@
 //! - `mode_change`    `{ mode_id, by }`.
 //! - `usage`          `{ used, size }`.
 //! - `turn_end`       `{ stop_reason }`.
+//! - `handoff`        `{ from, to, model, effort }` — the provider boundary
+//!   that replaces the synthetic bootstrap prompt in the visible journal.
 //!
 //! ## Acking
 //!
@@ -199,6 +201,19 @@ impl AcpHandle {
         rx.await
             .map_err(|_| anyhow!("acp task dropped the reply"))?
     }
+
+    /// Atomically quiesce an idle task for provider replacement. The command is
+    /// ordered with prompts on the same channel; acknowledgement arrives only
+    /// after the task has removed its registry slot and will accept no more work.
+    pub async fn prepare_handoff(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::PrepareHandoff { reply: tx })
+            .await
+            .map_err(|_| anyhow!("acp task is gone"))?;
+        rx.await
+            .map_err(|_| anyhow!("acp task dropped the handoff reply"))?
+    }
 }
 
 /// The registry of live ACP session tasks, held on [`AppState`]. Clone-cheap
@@ -267,6 +282,27 @@ impl AcpRegistry {
 /// `initialize`, open (or load) the ACP session, store its id on the session row,
 /// send the goal as the first prompt when present, then run the session task.
 pub async fn start(state: &AppState, session_id: &str, launch: AcpLaunch) -> Result<()> {
+    start_inner(state, session_id, launch, None).await
+}
+
+/// Start a fresh provider against an existing loom session. The opening prompt
+/// carries the provider-neutral history to the adapter, while `handoff` is the
+/// compact block journaled in its place.
+pub async fn start_handoff(
+    state: &AppState,
+    session_id: &str,
+    launch: AcpLaunch,
+    handoff: Value,
+) -> Result<()> {
+    start_inner(state, session_id, launch, Some(handoff)).await
+}
+
+async fn start_inner(
+    state: &AppState,
+    session_id: &str,
+    launch: AcpLaunch,
+    handoff: Option<Value>,
+) -> Result<()> {
     let session = session::get(&state.db, session_id)
         .await?
         .ok_or_else(|| anyhow!("session {session_id} not found"))?;
@@ -281,8 +317,8 @@ pub async fn start(state: &AppState, session_id: &str, launch: AcpLaunch) -> Res
     let stream = crate::backend::subscribe_relay(&relay_name, 0).await?;
 
     let (events_tx, _) = broadcast::channel(256);
-    let mut task = Task::fresh(state, &session, relay_name, stream, events_tx.clone());
-    task.handshake(&launch).await?;
+    let mut task = Task::fresh(state, &session, relay_name, stream, events_tx.clone()).await?;
+    task.handshake(&launch, handoff).await?;
 
     let (cmd_tx, cmd_rx) = mpsc::channel(64);
     task.generation = state
@@ -352,6 +388,9 @@ enum Command {
     SetMode {
         mode_id: String,
         by: Option<String>,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    PrepareHandoff {
         reply: oneshot::Sender<Result<()>>,
     },
 }
@@ -536,14 +575,19 @@ struct Task {
 }
 
 impl Task {
-    fn fresh(
+    async fn fresh(
         state: &AppState,
         session: &session::Session,
         relay_name: String,
         stream: tapestry::RelayStream,
         events_tx: broadcast::Sender<SseEvent>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let cursor = chat::max_turn_seq(&state.db, &session.id).await?;
+        let (current_turn, next_seq, turns_dispatched) = match cursor {
+            Some((turn, seq)) => (turn, seq + 1, turn + 1),
+            None => (0, 0, 0),
+        };
+        Ok(Self {
             db: state.db.clone(),
             bus: state.bus.clone(),
             registry: state.acp.clone(),
@@ -555,9 +599,9 @@ impl Task {
             stream,
             next_req_id: 0,
             inflight_prompt: None,
-            current_turn: 0,
-            next_seq: 0,
-            turns_dispatched: 0,
+            current_turn,
+            next_seq,
+            turns_dispatched,
             turn_live: false,
             buf: None,
             tools: HashMap::new(),
@@ -568,7 +612,7 @@ impl Task {
             highest_seq: 0,
             acked: 0,
             journal_failed: false,
-        }
+        })
     }
 
     async fn recover(
@@ -635,7 +679,7 @@ impl Task {
 
     // -- handshake ----------------------------------------------------------
 
-    async fn handshake(&mut self, launch: &AcpLaunch) -> Result<()> {
+    async fn handshake(&mut self, launch: &AcpLaunch, handoff: Option<Value>) -> Result<()> {
         let id = self.next_id();
         self.stream
             .write(&wire::request_line(
@@ -723,7 +767,10 @@ impl Task {
         }
 
         if let Some(goal) = &launch.goal {
-            self.start_turn(goal.clone(), None).await?;
+            match handoff {
+                Some(payload) => self.start_handoff_turn(goal.clone(), payload).await?,
+                None => self.start_turn(goal.clone(), None).await?,
+            }
         }
         Ok(())
     }
@@ -762,6 +809,7 @@ impl Task {
     // -- main loop ----------------------------------------------------------
 
     async fn run(mut self, mut cmd_rx: mpsc::Receiver<Command>) {
+        let mut handoff_reply = None;
         loop {
             tokio::select! {
                 ev = self.stream.recv() => match ev {
@@ -782,12 +830,26 @@ impl Task {
                     None => break,
                 },
                 cmd = cmd_rx.recv() => match cmd {
+                    Some(Command::PrepareHandoff { reply }) => {
+                        let pending = session::read_pending_prompt(&self.db, &self.session_id)
+                            .await
+                            .unwrap_or_default();
+                        if self.turn_live || !pending.trim().is_empty() {
+                            let _ = reply.send(Err(anyhow!("cannot hand off while a turn or queued prompt is active")));
+                        } else {
+                            handoff_reply = Some(reply);
+                            break;
+                        }
+                    }
                     Some(c) => self.on_command(c).await,
                     None => break,
                 },
             }
         }
         self.registry.remove_own(&self.session_id, self.generation);
+        if let Some(reply) = handoff_reply {
+            let _ = reply.send(Ok(()));
+        }
         tracing::info!(session = %self.session_id, "acp task stopped");
     }
 
@@ -993,6 +1055,26 @@ impl Task {
     }
 
     async fn start_turn(&mut self, text: String, by: Option<String>) -> Result<()> {
+        let by_v = by.map(Value::from).unwrap_or(Value::Null);
+        self.start_turn_with_block(
+            text.clone(),
+            kind::USER_MESSAGE,
+            json!({ "text": text, "by": by_v }),
+        )
+        .await
+    }
+
+    async fn start_handoff_turn(&mut self, text: String, payload: Value) -> Result<()> {
+        self.start_turn_with_block(text, kind::HANDOFF, payload)
+            .await
+    }
+
+    async fn start_turn_with_block(
+        &mut self,
+        text: String,
+        opening_kind: &str,
+        opening_payload: Value,
+    ) -> Result<()> {
         if self.turns_dispatched > 0 {
             self.current_turn += 1;
             self.next_seq = 0;
@@ -1004,12 +1086,7 @@ impl Task {
             "turn",
             json!({ "turn": self.current_turn, "state": "started" }),
         );
-        let by_v = by.map(Value::from).unwrap_or(Value::Null);
-        self.journal_block(
-            kind::USER_MESSAGE,
-            json!({ "text": text.clone(), "by": by_v }),
-        )
-        .await;
+        self.journal_block(opening_kind, opening_payload).await;
 
         let id = self.next_id();
         self.inflight_prompt = Some((id, self.current_turn));
@@ -1191,6 +1268,11 @@ impl Task {
                 self.journal_block(kind::MODE_CHANGE, json!({ "mode_id": mode_id, "by": by_v }))
                     .await;
                 let _ = reply.send(r);
+            }
+            // The run loop intercepts this variant so it can acknowledge only
+            // after registry removal. Keep the match exhaustive defensively.
+            Command::PrepareHandoff { reply } => {
+                let _ = reply.send(Err(anyhow!("handoff command reached the task dispatcher")));
             }
         }
     }

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -51,6 +51,9 @@ pub struct AgentMetadata {
     /// True for the code-shipped `claude`/`codex`; false for an operator-defined
     /// custom agent (which the UI may edit or delete).
     pub builtin: bool,
+    /// Whether this runtime can be driven through ACP. Kept separate from its
+    /// declared/default protocol so callers test a capability, not a default.
+    pub supports_acp: bool,
     /// The agent's declared execution backend: `"terminal"` or `"acp"`. The
     /// builtins declare `"acp"`; a custom agent reports its stored `protocol`.
     /// A create request may override a builtin's default (`--protocol
@@ -393,6 +396,7 @@ impl AgentType for ClaudeAgentType {
             supports_hooks: true,
             supports_concierge: true,
             builtin: true,
+            supports_acp: true,
             // ACP is the builtin default; `--protocol terminal` keeps the PTY
             // fallback.
             protocol: "acp".to_string(),
@@ -425,6 +429,7 @@ impl AgentType for CodexAgentType {
             supports_hooks: false,
             supports_concierge: true,
             builtin: true,
+            supports_acp: true,
             // ACP is the builtin default; `--protocol terminal` keeps the PTY
             // fallback.
             protocol: "acp".to_string(),
@@ -453,6 +458,7 @@ impl AgentType for CustomAgentType {
             supports_hooks: self.agent.reports_status,
             supports_concierge: false,
             builtin: false,
+            supports_acp: self.agent.protocol == "acp",
             protocol: if self.agent.protocol.is_empty() {
                 "terminal".to_string()
             } else {
@@ -1750,6 +1756,7 @@ mod tests {
             supports_hooks: false,
             supports_concierge: false,
             builtin,
+            supports_acp: builtin || protocol == "acp",
             protocol: protocol.to_string(),
         }
     }

--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -12,7 +12,7 @@
 //! restart leaves running terminals untouched — the recovery property that keeps
 //! agents alive across restarts.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 use crate::db::Db;
 
@@ -233,6 +233,23 @@ pub async fn kill_session(name: &str) -> Result<()> {
             Ok(()) => tracing::info!(name = %name, "terminal killed"),
             Err(e) => tracing::warn!(name = %name, error = %e, "failed to kill terminal"),
         }
+    }
+    Ok(())
+}
+
+/// Kill a session and wait until its supervisor has released the control socket.
+///
+/// A kill request is acknowledged before the supervisor finishes teardown. A
+/// caller that immediately reuses the same name (provider handoff does this)
+/// must wait, or the replacement can connect to the dying supervisor.
+pub async fn kill_session_and_wait(name: &str) -> Result<()> {
+    kill_session(name).await?;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    while has_session(name).await {
+        if tokio::time::Instant::now() >= deadline {
+            bail!("terminal {name} did not stop within 5 seconds");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
     Ok(())
 }

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -315,6 +315,24 @@ enum SessionCmd {
     Adopt { branch: String },
     /// Recover an archived session: rebuild its worktree and resume the agent.
     Recover { branch: String },
+    /// Replace the provider behind a live ACP session, preserving its worktree
+    /// and canonical conversation journal.
+    Handoff {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+        /// Target ACP agent runtime (for example `claude` or `codex`).
+        #[arg(long)]
+        agent: String,
+        /// Target model selector; omit for the runtime default.
+        #[arg(long)]
+        model: Option<String>,
+        /// Target reasoning effort; omit for the runtime default.
+        #[arg(long)]
+        effort: Option<String>,
+        /// Target ACP permission posture; omit for `auto`.
+        #[arg(long)]
+        mode: Option<String>,
+    },
     /// Remove a session (worktree + terminal + DB row).
     Rm {
         branch: String,
@@ -720,6 +738,13 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
         SessionCmd::Archive { branch } => cmd_archive(branch).await,
         SessionCmd::Adopt { branch } => cmd_adopt(branch).await,
         SessionCmd::Recover { branch } => cmd_recover(branch).await,
+        SessionCmd::Handoff {
+            session,
+            agent,
+            model,
+            effort,
+            mode,
+        } => cmd_handoff(session, agent, model, effort, mode).await,
         SessionCmd::Rm {
             branch,
             keep_branch,
@@ -2622,6 +2647,36 @@ async fn cmd_recover(key: String) -> Result<()> {
     println!("  status:  {}", str_field(&ws, "status"));
     println!("  session: {}", str_field(&ws, "term_session"));
     println!("  attach:  loom attach {}", str_field(&ws, "id"));
+    Ok(())
+}
+
+async fn cmd_handoff(
+    key: String,
+    agent: String,
+    model: Option<String>,
+    effort: Option<String>,
+    mode: Option<String>,
+) -> Result<()> {
+    let client = client::default();
+    let ws = client
+        .handoff_session(
+            &key,
+            &weaver_api::HandoffReq {
+                agent,
+                model,
+                effort,
+                mode,
+            },
+        )
+        .await?;
+    println!("handed off session {} to {}", ws.id, ws.agent_kind);
+    if !ws.model.is_empty() {
+        println!("  model:   {}", ws.model);
+    }
+    if !ws.effort.is_empty() {
+        println!("  effort:  {}", ws.effort);
+    }
+    println!("  session: {}", ws.term_session);
     Ok(())
 }
 

--- a/crates/loom/src/chat.rs
+++ b/crates/loom/src/chat.rs
@@ -32,6 +32,58 @@ pub mod kind {
     pub const MODE_CHANGE: &str = "mode_change";
     pub const USAGE: &str = "usage";
     pub const TURN_END: &str = "turn_end";
+    pub const HANDOFF: &str = "handoff";
+}
+
+/// Build the provider-neutral bootstrap given to a replacement agent. Only the
+/// authored dialogue is replayed: the worktree already carries tool effects,
+/// while thoughts and raw tool output are noisy, provider-specific machinery.
+/// Keep a bounded tail so a long-running session cannot consume the target's
+/// whole context window before it starts useful work.
+pub fn handoff_prompt(goal: &str, blocks: &[ChatBlockView], max_chars: usize) -> String {
+    let mut dialogue = String::new();
+    for block in blocks {
+        let speaker = match block.kind.as_str() {
+            kind::USER_MESSAGE => "User",
+            kind::AGENT_MESSAGE => "Agent",
+            _ => continue,
+        };
+        let text = block
+            .payload
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        if text.is_empty() {
+            continue;
+        }
+        dialogue.push_str(speaker);
+        dialogue.push_str(":\n");
+        dialogue.push_str(text);
+        dialogue.push_str("\n\n");
+    }
+
+    let (dialogue, omitted) = tail_chars(&dialogue, max_chars);
+    let omission = omitted.then_some(
+        "Earlier dialogue was omitted to fit the handoff context; the canonical journal remains in loom.\n\n",
+    );
+    format!(
+        "You are taking over an existing coding session from another agent provider. Continue the work in the current worktree; do not restart completed work.\n\nGoal:\n{}\n\nPrior conversation:\n{}{}",
+        goal.trim(),
+        omission.unwrap_or(""),
+        dialogue.trim()
+    )
+}
+
+fn tail_chars(text: &str, max_chars: usize) -> (String, bool) {
+    let count = text.chars().count();
+    if count <= max_chars {
+        return (text.to_string(), false);
+    }
+    (
+        text.chars().skip(count.saturating_sub(max_chars)).collect(),
+        true,
+    )
 }
 
 /// One journaled block as the `/chat` routes expose it. `payload` is passed
@@ -316,6 +368,11 @@ fn preview_line(b: &ChatBlockView) -> String {
             let reason = p.get("stop_reason").and_then(Value::as_str).unwrap_or("");
             format!("— turn {} · {reason} —", b.turn)
         }
+        kind::HANDOFF => {
+            let from = p.get("from").and_then(Value::as_str).unwrap_or("agent");
+            let to = p.get("to").and_then(Value::as_str).unwrap_or("agent");
+            format!("[handoff] {from} → {to}")
+        }
         _ => String::new(),
     }
 }
@@ -506,5 +563,28 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(latest_usage(&db, &s).await.unwrap().unwrap()["used"], 150);
+    }
+
+    #[test]
+    fn handoff_prompt_replays_only_dialogue_and_bounds_the_tail() {
+        let block = |kind: &str, text: &str| ChatBlockView {
+            turn: 0,
+            seq: 0,
+            kind: kind.to_string(),
+            payload: json!({"text": text}),
+            created_at: String::new(),
+        };
+        let blocks = vec![
+            block(kind::USER_MESSAGE, "old user context"),
+            block(kind::THOUGHT, "private reasoning"),
+            block(kind::AGENT_MESSAGE, "recent answer"),
+            block(kind::TOOL_CALL, "large tool output"),
+        ];
+        let prompt = handoff_prompt("finish it", &blocks, 20);
+        assert!(prompt.contains("Goal:\nfinish it"));
+        assert!(prompt.contains("recent answer"));
+        assert!(prompt.contains("Earlier dialogue was omitted"));
+        assert!(!prompt.contains("private reasoning"));
+        assert!(!prompt.contains("large tool output"));
     }
 }

--- a/crates/loom/src/chatlog.rs
+++ b/crates/loom/src/chatlog.rs
@@ -141,7 +141,7 @@ pub async fn conversation(db: &Db, session: &Session, branch: &Branch) -> Option
 /// export and the Conversation viewer speak. `user_message` → User/Text,
 /// `agent_message` → Assistant/Text, `thought` → Assistant/Thinking, `tool_call`
 /// → Assistant ToolUse+ToolResult; the ACP-only kinds (`plan`, `permission_
-/// request`, `mode_change`, `usage`) flatten to Context notes; `turn_end` is a
+/// request`, `mode_change`, `usage`, `handoff`) flatten to Context notes; `turn_end` is a
 /// boundary marker with no conversational content, so it is dropped. `None` when
 /// the journal is empty.
 pub async fn journal_to_log(db: &Db, session: &Session) -> Option<Log> {
@@ -200,7 +200,11 @@ pub async fn journal_to_log(db: &Db, session: &Session) -> Option<Log> {
                     ],
                 ));
             }
-            kind::PLAN | kind::PERMISSION_REQUEST | kind::MODE_CHANGE | kind::USAGE => {
+            kind::PLAN
+            | kind::PERMISSION_REQUEST
+            | kind::MODE_CHANGE
+            | kind::USAGE
+            | kind::HANDOFF => {
                 messages.push(Message::new(
                     Role::Context,
                     ts,
@@ -280,6 +284,11 @@ fn context_note(kind: &str, p: &Value) -> String {
             let used = p.get("used").and_then(Value::as_i64).unwrap_or(0);
             let size = p.get("size").and_then(Value::as_i64).unwrap_or(0);
             format!("context usage: {used}/{size}")
+        }
+        kind::HANDOFF => {
+            let from = p.get("from").and_then(Value::as_str).unwrap_or("agent");
+            let to = p.get("to").and_then(Value::as_str).unwrap_or("agent");
+            format!("agent handoff: {from} -> {to}")
         }
         _ => kind.to_string(),
     }

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -382,6 +382,35 @@ pub async fn set_current_mode(db: &Db, id: &str, mode_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Replace an ACP session's runtime profile and clear every piece of
+/// provider-private relay/session state. The journal is deliberately untouched:
+/// it is keyed by loom's stable session id and continues across the handoff.
+pub async fn prepare_handoff(
+    db: &Db,
+    id: &str,
+    agent_kind: &str,
+    model: &str,
+    effort: &str,
+    status: &str,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE sessions
+         SET agent_kind = ?, model = ?, effort = ?, status = ?,
+             acp_session_id = NULL, acp_ack_seq = 0, acp_inflight = NULL,
+             current_mode = NULL, pending_prompt = NULL
+         WHERE id = ?",
+    )
+    .bind(agent_kind)
+    .bind(model)
+    .bind(effort)
+    .bind(status)
+    .bind(id)
+    .execute(db)
+    .await?;
+    tracing::info!(session = %id, agent_kind, model, effort, status, "session runtime handed off");
+    Ok(())
+}
+
 /// Append `text` to the durable prompt queue as a new paragraph (the queue holds
 /// sends that arrived while a turn was in flight; it dispatches as one prompt at
 /// the next turn boundary). Returns the full queued text after the append.
@@ -505,5 +534,40 @@ mod tests {
             active_managed_by(&db, "ov-other").await.unwrap().is_none(),
             "no warm session for a watch that owns none"
         );
+    }
+
+    #[tokio::test]
+    async fn handoff_replaces_profile_and_clears_provider_state() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let branch = branch_id(&db, "weaver/handoff").await;
+        let mut input = new_session("handoff", &branch, None);
+        input.agent_kind = "claude".to_string();
+        input.protocol = "acp".to_string();
+        insert(&db, &input).await.unwrap();
+        set_acp(&db, "handoff", "claude-private").await.unwrap();
+        set_ack_seq(&db, "handoff", 99).await.unwrap();
+        set_inflight(&db, "handoff", Some(r#"{"prompt_id":4,"turn":2}"#))
+            .await
+            .unwrap();
+        set_current_mode(&db, "handoff", "acceptEdits")
+            .await
+            .unwrap();
+        append_pending_prompt(&db, "handoff", "queued")
+            .await
+            .unwrap();
+
+        prepare_handoff(&db, "handoff", "codex", "gpt-5.4", "high", "running")
+            .await
+            .unwrap();
+        let session = get(&db, "handoff").await.unwrap().unwrap();
+        assert_eq!(session.agent_kind, "codex");
+        assert_eq!(session.model, "gpt-5.4");
+        assert_eq!(session.effort, "high");
+        assert_eq!(session.status, "running");
+        assert!(session.acp_session_id.is_none());
+        assert_eq!(session.acp_ack_seq, 0);
+        assert!(session.acp_inflight.is_none());
+        assert!(session.current_mode.is_none());
+        assert!(session.pending_prompt.is_none());
     }
 }

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -537,6 +537,7 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{id}/url", get(session_url_route))
         .route("/sessions/{id}/archive", post(archive_session))
         .route("/sessions/{id}/adopt", post(adopt_session))
+        .route("/sessions/{id}/handoff", post(handoff_session))
         .route("/sessions/{id}/recover", post(recover_session))
         .route("/sessions/{id}/github", post(refresh_github_session))
         .route("/sessions/{id}/raw", get(raw_session))

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -24,7 +24,7 @@ use crate::{
     agent, agent_env, backend, config, custom_agents, db, events, git, github, repo, repo_env,
     setup,
 };
-use weaver_api::{CreateReq, PatchSessionReq, SendReq, SessionView, TagReq};
+use weaver_api::{CreateReq, HandoffReq, PatchSessionReq, SendReq, SessionView, TagReq};
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::Branch;
 use weaver_core::tags;
@@ -35,6 +35,7 @@ use super::{author_or_manual, require_branch, require_session, session_view};
 use super::{ApiResult, AppError, AppState};
 
 const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub token configured. Add your personal GitHub token in Settings > Account, or configure GH_TOKEN in Settings > Environment.";
+const HANDOFF_HISTORY_CHARS: usize = 64 * 1024;
 
 pub(super) async fn list_agents(State(st): State<AppState>) -> ApiResult<Json<Value>> {
     let default_agent = configured_agent(&st.db, "agent.default", config::DEFAULT_AGENT).await;
@@ -2553,6 +2554,142 @@ fn require_acp_task(st: &AppState, session: &Session) -> ApiResult<crate::acp::A
             session.id
         ))
     })
+}
+
+/// Replace the provider behind an idle ACP work session while preserving loom's
+/// stable session/branch/worktree identity and canonical journal.
+pub(super) async fn handoff_session(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Json(req): Json<HandoffReq>,
+) -> ApiResult<Json<SessionView>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    require_acp(&session)?;
+    if session.status != "running" {
+        return Err(AppError::conflict(format!(
+            "session '{}' is {}, not running",
+            session.id, session.status
+        )));
+    }
+    if session.agent_kind == agent::CONCIERGE_KIND || session.managed_by.is_some() {
+        return Err(AppError::conflict(
+            "engine-managed sessions cannot be handed off manually",
+        ));
+    }
+
+    let target = req.agent.trim();
+    if target.is_empty() {
+        return Err(AppError::bad_request("handoff agent is required"));
+    }
+    let runtime = launch_runtime(&st.db, target).await;
+    let metadata = agent::metadata_for(&st.db, &runtime)
+        .await?
+        .ok_or_else(|| AppError::bad_request(format!("unknown agent '{runtime}'")))?;
+    if !metadata.supports_acp {
+        return Err(AppError::bad_request(format!(
+            "agent '{runtime}' does not support ACP handoff"
+        )));
+    }
+    let model = req.model.as_deref().unwrap_or("").trim().to_string();
+    let effort = req.effort.as_deref().unwrap_or("").trim().to_string();
+    agent::validate_model(&metadata, &model).map_err(AppError::bad_request)?;
+    agent::validate_effort(&metadata, &effort).map_err(AppError::bad_request)?;
+    if target == session.agent_kind && model == session.model && effort == session.effort {
+        return Err(AppError::bad_request(
+            "handoff target matches the current runtime profile",
+        ));
+    }
+    let mode = req
+        .mode
+        .as_deref()
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .unwrap_or(agent::DEFAULT_ACP_MODE)
+        .to_string();
+
+    // Resolve every fallible launch input before quiescing the current task.
+    let repo_root = PathBuf::from(&branch.repo_root);
+    let work_dir = PathBuf::from(&session.work_dir);
+    let repo_cfg = repo_cfg_or_default(&repo_root);
+    let mut extra_env = launch_env(&st.db, &repo_root, &repo_cfg).await;
+    apply_user_github_token(&st.db, &mut extra_env, session.created_by.as_deref()).await;
+    ensure_github_token_available(&st.db, &extra_env, session.created_by.as_deref(), &runtime)
+        .await?;
+    let blocks = crate::chat::list(&st.db, &session.id).await?;
+    let prompt = crate::chat::handoff_prompt(&branch.goal, &blocks, HANDOFF_HISTORY_CHARS);
+    let prompt_file = db::run_dir(&session.id).join("handoff.txt");
+    tokio::fs::write(&prompt_file, prompt).await?;
+    let custom = if agent::builtin_agent_type(&runtime).is_some() {
+        None
+    } else {
+        custom_agents::get(&st.db, &runtime).await?
+    };
+    let launch = agent::build_acp_launch(
+        &st.db,
+        &agent::AcpLaunchSpec {
+            branch_id: &branch.id,
+            runtime: &runtime,
+            work_dir: &work_dir,
+            server_addr: &st.addr,
+            model: &model,
+            effort: &effort,
+            goal_file: Some(&prompt_file),
+            primer_file: None,
+            extra_env: &extra_env,
+            mode: &mode,
+            custom: custom.as_ref(),
+        },
+        agent::AcpOpen::Fresh,
+    )
+    .await
+    .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let handle = require_acp_task(&st, &session)?;
+    handle
+        .prepare_handoff()
+        .await
+        .map_err(|e| AppError::conflict(e.to_string()))?;
+    backend::kill_session_and_wait(&session.term_session).await?;
+    session_mod::prepare_handoff(&st.db, &session.id, target, &model, &effort, "running").await?;
+
+    let boundary = json!({
+        "from": session.agent_kind,
+        "to": target,
+        "model": model,
+        "effort": effort,
+    });
+    if let Err(e) = crate::acp::start_handoff(&st, &session.id, launch, boundary).await {
+        st.acp.stop(&session.id);
+        backend::kill_session(&session.term_session).await.ok();
+        session_mod::prepare_handoff(&st.db, &session.id, target, &model, &effort, "error")
+            .await
+            .ok();
+        events::record(
+            &st.db,
+            &st.bus,
+            &branch.id,
+            "status",
+            json!({ "status": "error", "reason": "agent handoff failed" }),
+        )
+        .await
+        .ok();
+        return Err(AppError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("agent handoff failed: {e}"),
+        ));
+    }
+
+    events::record(
+        &st.db,
+        &st.bus,
+        &branch.id,
+        "handoff",
+        json!({ "from": session.agent_kind, "to": target, "model": model, "effort": effort }),
+    )
+    .await
+    .ok();
+    let (session, branch) = require_session(&st.db, &session.id).await?;
+    Ok(Json(session_view(&st.db, &session, &branch).await?))
 }
 
 /// The in-flight turn number from a session's persisted `acp_inflight`, or `None`.

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -894,6 +894,172 @@ async fn rest_create_drives_the_turn_lifecycle() {
     assert_eq!(nudges, 1, "the send recorded exactly one nudge audit event");
 }
 
+/// A provider handoff keeps loom's identity and canonical journal, records one
+/// compact boundary instead of the synthetic bootstrap prompt, and continues at
+/// the next turn under the replacement adapter.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handoff_replaces_provider_and_continues_the_journal() {
+    let ts = TestServer::start().await;
+    seed_acp_agent(&ts, "fake-a").await;
+    seed_acp_agent(&ts, "fake-b").await;
+
+    let created = rest_create(&ts, "fake-a", "say:before").await;
+    let id = created["id"].as_str().unwrap().to_string();
+    let branch_id = created["branch"]["id"].clone();
+    let work_dir = created["work_dir"].clone();
+    poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
+        blocks.iter().any(|b| b["kind"] == "turn_end")
+    })
+    .await;
+
+    let handed = ts
+        .client
+        .post(
+            &format!("/api/sessions/{id}/handoff"),
+            json!({ "agent": "fake-b" }),
+        )
+        .await
+        .expect("handoff succeeds");
+    assert_eq!(handed["id"], id, "loom session id stays stable");
+    assert_eq!(handed["branch"]["id"], branch_id);
+    assert_eq!(handed["work_dir"], work_dir);
+    assert_eq!(handed["agent_kind"], "fake-b");
+    assert!(handed["acp_session_id"].as_str().is_some());
+
+    let chat = poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
+        blocks.iter().filter(|b| b["kind"] == "turn_end").count() >= 2
+    })
+    .await;
+    let blocks = chat["blocks"].as_array().unwrap();
+    let handoffs: Vec<&Value> = blocks.iter().filter(|b| b["kind"] == "handoff").collect();
+    assert_eq!(handoffs.len(), 1, "one durable provider boundary");
+    assert_eq!(handoffs[0]["turn"], 1);
+    assert_eq!(handoffs[0]["seq"], 0);
+    assert_eq!(handoffs[0]["payload"]["from"], "fake-a");
+    assert_eq!(handoffs[0]["payload"]["to"], "fake-b");
+    assert_eq!(
+        count_kind(blocks, "user_message"),
+        1,
+        "the synthetic handoff bootstrap is not shown as a human message"
+    );
+    assert!(blocks
+        .iter()
+        .any(|b| { b["kind"] == "agent_message" && b["payload"]["text"] == "before" }));
+
+    ts.client
+        .post(
+            &format!("/api/sessions/{id}/prompt"),
+            json!({ "text": "say:after" }),
+        )
+        .await
+        .expect("replacement accepts later work");
+    let chat = poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
+        blocks
+            .iter()
+            .any(|b| b["kind"] == "agent_message" && b["payload"]["text"] == "after")
+    })
+    .await;
+    assert!(chat["blocks"].as_array().unwrap().iter().any(|b| {
+        b["kind"] == "user_message" && b["turn"] == 2 && b["payload"]["text"] == "say:after"
+    }));
+}
+
+/// Handoff is ordered with prompts on the task command channel: a turn that
+/// starts first wins and the provider remains untouched.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handoff_rejects_an_inflight_turn_without_stopping_it() {
+    let ts = TestServer::start().await;
+    seed_acp_agent(&ts, "fake-a").await;
+    seed_acp_agent(&ts, "fake-b").await;
+    let created = rest_create(&ts, "fake-a", "say:ready").await;
+    let id = created["id"].as_str().unwrap().to_string();
+    poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
+        blocks.iter().any(|b| b["kind"] == "turn_end")
+    })
+    .await;
+
+    ts.client
+        .post(
+            &format!("/api/sessions/{id}/send"),
+            json!({ "text": "wait:500|say:finished" }),
+        )
+        .await
+        .unwrap();
+    let err = ts
+        .client
+        .post(
+            &format!("/api/sessions/{id}/handoff"),
+            json!({ "agent": "fake-b" }),
+        )
+        .await
+        .expect_err("live turn blocks handoff");
+    assert!(
+        err.to_string().contains("cannot hand off while a turn"),
+        "{err}"
+    );
+    let view = ts.client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(view["agent_kind"], "fake-a", "old provider stays live");
+    poll_chat(&ts, &id, Duration::from_secs(10), |blocks| {
+        blocks
+            .iter()
+            .any(|b| b["kind"] == "agent_message" && b["payload"]["text"] == "finished")
+    })
+    .await;
+}
+
+/// Once the old provider is quiesced, a replacement handshake failure leaves a
+/// coherent visible error and no leaked relay/task.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handoff_failure_cleans_up_the_replacement() {
+    let ts = TestServer::start().await;
+    seed_acp_agent(&ts, "fake-a").await;
+    loom::custom_agents::set(
+        &ts.state.db,
+        &loom::custom_agents::CustomAgent {
+            name: "broken-acp".to_string(),
+            label: "Broken ACP".to_string(),
+            setup: String::new(),
+            launch: "exit 7".to_string(),
+            resume: String::new(),
+            reports_status: false,
+            protocol: "acp".to_string(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        },
+    )
+    .await
+    .unwrap();
+    let created = rest_create(&ts, "fake-a", "say:ready").await;
+    let id = created["id"].as_str().unwrap().to_string();
+    let relay = created["term_session"].as_str().unwrap().to_string();
+    poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
+        blocks.iter().any(|b| b["kind"] == "turn_end")
+    })
+    .await;
+
+    let err = ts
+        .client
+        .post(
+            &format!("/api/sessions/{id}/handoff"),
+            json!({ "agent": "broken-acp" }),
+        )
+        .await
+        .expect_err("broken replacement fails");
+    assert!(err.to_string().contains("agent handoff failed"), "{err}");
+    let view = ts.client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(view["status"], "error");
+    assert_eq!(view["agent_kind"], "broken-acp");
+    assert_eq!(view["acp_session_id"], Value::Null);
+    assert!(!ts.state.acp.is_live(&id), "replacement task is gone");
+    assert!(
+        !backend::has_session(&relay).await,
+        "replacement relay is gone"
+    );
+}
+
 /// B. Adopt after a full crash (task + relay gone): the monitor orphans the row,
 ///    `/adopt` respawns the relay and reopens via `session/load`, and the journal
 ///    continues without duplicating the replayed history.

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -13,9 +13,9 @@ use serde_json::Value;
 use crate::dto::{
     AnchorDto, ArtifactMeta, ArtifactUpsertReq, ArtifactView, BranchStatusReq, BranchView,
     CommentDto, CreateEventReq, CreateIssueReq, CreateRepoIssueReq, CreateReq, CreateTokenReq,
-    CreateWatchReq, CreatedTokenView, IssueView, NewCommentBody, NewThreadBody, PatchIssueReq,
-    PatchSessionReq, PatchWatchReq, RunWatchReq, SendReq, SessionView, SettingsEnvelope, TagReq,
-    ThreadDto, TokenView, WatchView,
+    CreateWatchReq, CreatedTokenView, HandoffReq, IssueView, NewCommentBody, NewThreadBody,
+    PatchIssueReq, PatchSessionReq, PatchWatchReq, RunWatchReq, SendReq, SessionView,
+    SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
 };
 
 /// A client for one loom server, identified by its base URL.
@@ -167,6 +167,17 @@ impl Client {
         self.send_typed(
             Method::PATCH,
             &format!("/api/sessions/{}", Self::seg(key)),
+            Some(req),
+        )
+        .await
+    }
+
+    /// Replace the provider behind a live ACP session while preserving the
+    /// loom session, worktree, branch, and canonical journal.
+    pub async fn handoff_session(&self, key: &str, req: &HandoffReq) -> Result<SessionView> {
+        self.send_typed(
+            Method::POST,
+            &format!("/api/sessions/{}/handoff", Self::seg(key)),
             Some(req),
         )
         .await

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -592,6 +592,22 @@ pub struct CreateReq {
     pub mode: Option<String>,
 }
 
+/// Body for `POST /api/sessions/{id}/handoff`: replace the live ACP runtime
+/// while keeping the loom session, worktree, and canonical chat journal.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HandoffReq {
+    pub agent: String,
+    /// Blank/absent uses the target runtime's default.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Blank/absent uses the target runtime's default.
+    #[serde(default)]
+    pub effort: Option<String>,
+    /// ACP permission posture. Blank/absent uses loom's ACP default.
+    #[serde(default)]
+    pub mode: Option<String>,
+}
+
 /// Body for `PATCH /api/sessions/{id}`. Branch-level fields (goal/title/
 /// description) are forwarded to the underlying branch row. The attention *level*
 /// is set through the tags endpoints (`PUT/DELETE /sessions/{id}/tags/{key}`),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -200,6 +200,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear a branch tag — the well-known `attention` and `triage` keys plus any free-form key |
 | `GET /api/sessions/{id}/url` | the session's dashboard URL as `{url}`, built from the externally-visible origin (`auth.base_url`, else the request's own Host) — what `loom session url` prints, so an agent can link a PR back to its session without inventing a loopback link |
 | `POST /api/sessions/{id}/{archive,adopt}` | actions |
+| `POST /api/sessions/{id}/handoff` | replace an idle ACP session's agent runtime/profile while preserving its loom session, worktree, branch, and canonical chat journal; the new provider receives a bounded dialogue replay and the journal records a compact handoff boundary |
 | `POST /api/sessions/{id}/github` | re-poll the branch's GitHub PR now and return the updated session |
 | `GET POST DELETE /api/sessions/{id}/scratch` | list / drop / remove worktree `scratch/` reference files |
 | `PUT /api/sessions/{id}/file?path=…` | write raw bytes to a worktree file (the editor save primitive) |

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -32,6 +32,24 @@ const FAKE_AGENT = join(__dirname, '..', '..', 'crates', 'loom', 'tests', 'fixtu
 const HEADERS = { 'content-type': 'application/json' };
 const SKIP_MSG = 'ACP lifecycle backend (weaver #508) not merged: the server does not launch acp sessions over REST yet';
 
+async function defineFakeAcpAgent(weaver: WeaverFixture, name: string, label: string): Promise<void> {
+  const res = await fetch(`${weaver.baseUrl}/api/agents/custom`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify({
+      name,
+      label,
+      setup: '',
+      launch: `node ${FAKE_AGENT}`,
+      resume: '',
+      reports_status: false,
+      protocol: 'acp',
+    }),
+  });
+  // Tests sharing a worker can race to define the common source adapter.
+  if (!res.ok && res.status !== 409) throw new Error(`defining ${name} failed: ${await res.text()}`);
+}
+
 /** Define (idempotently) a custom agent that runs the fake ACP adapter over
  *  stdio, then create a session with it. Returns the session when the backend
  *  brought it up as `protocol='acp'`, else null (the acp axis isn't wired yet). */
@@ -43,21 +61,7 @@ async function launchAcpSession(
   // `protocol` axis marks it ACP rather than a PTY TUI (added by the lifecycle
   // phase; ignored by the current backend, which is exactly why the probe below
   // detects support).
-  await fetch(`${weaver.baseUrl}/api/agents/custom`, {
-    method: 'POST',
-    headers: HEADERS,
-    body: JSON.stringify({
-      name: 'acp-fake',
-      label: 'ACP fake',
-      setup: '',
-      launch: `node ${FAKE_AGENT}`,
-      resume: '',
-      reports_status: false,
-      protocol: 'acp',
-    }),
-  }).catch(() => {
-    /* already defined by an earlier test in this worker — fine */
-  });
+  await defineFakeAcpAgent(weaver, 'acp-fake', 'ACP fake');
 
   const res = await fetch(`${weaver.baseUrl}/api/sessions`, {
     method: 'POST',
@@ -152,6 +156,50 @@ test.describe('acp conversation', () => {
     // is the dispatched prompt (whose text is the whole script).
     await expect(conv.getByText('hello from the echo', { exact: true })).toHaveCount(0);
     await expect(conv.locator('.acp-label', { hasText: 'You' })).toHaveCount(1);
+  });
+
+  test('hands an idle conversation to another ACP provider in place', async ({ page, weaver }) => {
+    const s = await openAcp(page, weaver, {
+      goal: 'say:before handoff',
+      name: 'acp-handoff',
+    });
+    const conv = page.getByTestId('acp-conversation');
+    await expect(conv.getByText('before handoff', { exact: true })).toBeVisible();
+    await expect(page.getByTestId('acp-turn-rule')).toBeVisible();
+    await defineFakeAcpAgent(weaver, 'acp-fake-next', 'ACP fake next');
+
+    await page.getByRole('button', { name: 'manage' }).click();
+    await page.getByTestId('action-handoff').click();
+    const form = page.getByTestId('handoff-form');
+    await form.getByLabel('Provider').selectOption('acp-fake-next');
+    await form.getByRole('button', { name: 'Hand off now' }).click();
+
+    // The stable session URL and earlier prose survive; only the provider and
+    // its private ACP connection change. The journal makes that boundary clear.
+    await expect(page).toHaveURL(new RegExp(`/s/${s.id}$`));
+    await expect.poll(async () => (await weaver.getSession(s.id)).agent_kind).toBe('acp-fake-next');
+    await expect(page.getByText('acp-fake-next', { exact: true })).toBeVisible();
+    await expect(conv.getByText('before handoff', { exact: true })).toBeVisible();
+    await expect(page.getByTestId('acp-handoff')).toContainText('acp-fake → acp-fake-next');
+
+    const input = page.getByTestId('acp-composer-input');
+    await input.fill('say:after');
+    await page.getByTestId('acp-composer-send').click();
+    await expect
+      .poll(
+        async () => {
+          const res = await fetch(`${weaver.baseUrl}/api/sessions/${s.id}/chat`);
+          const chat = (await res.json()) as {
+            blocks: Array<{ kind: string; payload: { text?: string } }>;
+          };
+          return chat.blocks.some((b) => b.kind === 'agent_message' && b.payload.text === 'after');
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(true);
+    await expect(conv.getByText('after', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
   test('a run of tool calls folds to one collapsed activity line', async ({ page, weaver }) => {


### PR DESCRIPTION
Add provider handoff for idle ACP sessions while preserving the stable loom session, worktree, branch, and canonical journal. The replacement provider receives a bounded replay of user/agent dialogue, and the conversation records a compact provider boundary.

Serialize handoff with prompt dispatch, clear provider-private ACP state, and clean up partial replacement launches. Expose the operation through REST, `loom session handoff`, and the Manage menu.

Fixes #156

loom: https://loom.rjp.io/s/tew5anel