### PR TITLE
feat(loom): make chat controls agent-driven

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -258,7 +258,7 @@ export const sendMessage = (id: string, text: string, submit = true) =>
 
 // --- ACP conversation (protocol='acp' sessions) ----------------------------
 
-import type { ChatSnapshot, PromptAck } from './types';
+import type { AcpMetadata, ChatSnapshot, PromptAck } from './types';
 
 /** The journaled conversation snapshot for an ACP session — the transcript a
  *  client paints before tailing `/chat/stream` (`GET /sessions/{id}/chat`). A
@@ -287,6 +287,15 @@ export const answerPermission = (id: string, requestId: string, optionId: string
 /** Change an ACP session's mode (`session/set_mode`). */
 export const setSessionMode = (id: string, modeId: string, by?: string) =>
   put(`/sessions/${id}/mode`, { mode_id: modeId, by }) as Promise<{ mode_id: string }>;
+
+/** Change an agent-owned ACP session configuration selector (model, reasoning
+ * effort, or an adapter-specific option). */
+export const setSessionConfigOption = (id: string, configId: string, value: string | boolean) =>
+  put(`/sessions/${id}/config/${encodeURIComponent(configId)}`, { value }) as Promise<{
+    config_id: string;
+    value: string | boolean;
+    metadata: AcpMetadata;
+  }>;
 
 /** Set a session's park override — the fleet list's resting shelf. `'parked'`
  *  pins it to the shelf, `'active'` keeps it live even when idle, `'auto'` clears

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -439,6 +439,10 @@ async function pickConfig(option: AcpConfigOption, value: string | boolean) {
   configBusy.value = option.id;
   try {
     const response = await setSessionConfigOption(id.value, option.id, value);
+    // Clear the write lock before publishing the acknowledged value. Vue can
+    // paint that value before this async function's `finally` runs; keeping the
+    // lock through that paint makes an immediate click on the next pill vanish.
+    configBusy.value = '';
     // The response is the full state acknowledged by the agent. This matters
     // when changing one value also changes another control's choices (a model
     // switch can alter its supported reasoning efforts).

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -16,6 +16,7 @@ import {
   interruptSession,
   answerPermission,
   setSessionMode,
+  setSessionConfigOption,
 } from '../api';
 import type {
   Session,
@@ -33,6 +34,10 @@ import type {
   PermissionPayload,
   UsagePayload,
   TurnEndPayload,
+  AcpMetadata,
+  AcpCommand,
+  AcpConfigOption,
+  AcpConfigChoice,
 } from '../types';
 import { canSend } from '../lib/sessionState';
 import { useFollowFoot } from '../lib/followFoot';
@@ -51,7 +56,16 @@ import MarkdownView from './MarkdownView.vue';
 // live tool state (feeding the status line), `turn` drives the live-turn state.
 // The composer posts to `/prompt`; Stop posts `/interrupt`; permission cards
 // answer via `/permissions/{id}`; the mode chip drives `/mode`.
-const props = defineProps<{ session: Session }>();
+const props = withDefaults(
+  defineProps<{
+    session: Session;
+    /** Client-local commands owned by the embedding surface (Chat supplies
+     * `/clear`; everything else comes from the ACP agent). */
+    localCommands?: AcpCommand[];
+  }>(),
+  { localCommands: () => [] },
+);
+const emit = defineEmits<{ command: [name: string, args: string] }>();
 const id = computed(() => props.session.id);
 
 // ── The render state the stream feeds ────────────────────────────────────────
@@ -63,6 +77,7 @@ const liveTools = reactive(new Map<string, SseTool>());
 const turnLive = ref(false);
 const liveTurnNo = ref<number | null>(null);
 const optimistic = ref<{ text: string; queued: boolean }[]>([]);
+const metadata = ref<AcpMetadata>({ commands: [], config_options: [], modes: [] });
 
 // The live mode, seeded from the session and advanced by `mode_change` blocks or
 // a local set — so the composer chip reads true without a refetch.
@@ -98,6 +113,7 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
     liveTools.clear();
     liveTurnNo.value = snap.live_turn;
     turnLive.value = snap.live_turn != null;
+    metadata.value = snap.metadata ?? { commands: [], config_options: [], modes: [] };
     state.value = 'ready';
   } catch (e) {
     if (seq !== loadSeq) return;
@@ -173,6 +189,9 @@ function openStream() {
   );
   source.addEventListener('tool', (e) => onTool(JSON.parse((e as MessageEvent).data) as SseTool));
   source.addEventListener('turn', (e) => onTurn(JSON.parse((e as MessageEvent).data) as SseTurn));
+  source.addEventListener('metadata', (e) => {
+    metadata.value = JSON.parse((e as MessageEvent).data) as AcpMetadata;
+  });
 }
 function closeStream() {
   source?.close();
@@ -198,12 +217,19 @@ watch(id, () => {
 
 // ── Composer ─────────────────────────────────────────────────────────────────
 const draft = ref('');
+const composerInput = ref<HTMLTextAreaElement | null>(null);
 const sending = ref(false);
 const sendError = ref('');
 const composerVisible = computed(() => canSend(props.session));
 
 async function submitPrompt() {
   if (!draft.value.trim() || sending.value) return;
+  const local = localCommand(draft.value);
+  if (local) {
+    draft.value = '';
+    emit('command', local.name, local.args);
+    return;
+  }
   sending.value = true;
   sendError.value = '';
   const text = draft.value;
@@ -216,6 +242,72 @@ async function submitPrompt() {
     sendError.value = (e as Error).message ?? 'Failed to send';
   } finally {
     sending.value = false;
+  }
+}
+
+// ── Agent-owned slash commands ---------------------------------------------
+// The adapter replaces its command catalogue at runtime. Local surface hooks
+// win on a duplicate name (`/clear` in fleet Chat), then the remainder is
+// filtered as the user types. Selecting a command with input leaves a trailing
+// space and exposes the adapter's hint in the composer placeholder.
+const commands = computed<AcpCommand[]>(() => {
+  const seen = new Set<string>();
+  const out: AcpCommand[] = [];
+  for (const command of [...props.localCommands, ...metadata.value.commands]) {
+    if (!command.name || seen.has(command.name)) continue;
+    seen.add(command.name);
+    out.push(command);
+  }
+  return out;
+});
+const slashQuery = computed(() => draft.value.match(/^\/([^\s/]*)$/)?.[1] ?? null);
+const commandMatches = computed(() => {
+  if (slashQuery.value == null) return [];
+  const q = slashQuery.value.toLowerCase();
+  return commands.value.filter((command) => command.name.toLowerCase().includes(q)).slice(0, 10);
+});
+const commandIndex = ref(0);
+watch(slashQuery, () => (commandIndex.value = 0));
+const activeCommand = computed(() => commandMatches.value[commandIndex.value] ?? null);
+const commandHint = computed(() => {
+  const match = draft.value.match(/^\/([^\s]+)\s*$/);
+  if (!match) return '';
+  return commands.value.find((command) => command.name === match[1])?.input?.hint ?? '';
+});
+
+function chooseCommand(command: AcpCommand) {
+  // Keep a trailing space even for argument-less commands. It closes the
+  // autocomplete so the next Enter submits instead of selecting forever.
+  draft.value = `/${command.name} `;
+  nextTick(() => composerInput.value?.focus());
+}
+function showCommands() {
+  draft.value = '/';
+  nextTick(() => composerInput.value?.focus());
+}
+function localCommand(text: string): { name: string; args: string } | null {
+  const match = text.trim().match(/^\/([^\s]+)(?:\s+(.*))?$/s);
+  if (!match || !props.localCommands.some((command) => command.name === match[1])) return null;
+  return { name: match[1], args: match[2] ?? '' };
+}
+function onComposerKeydown(e: KeyboardEvent) {
+  if (commandMatches.value.length) {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const d = e.key === 'ArrowDown' ? 1 : -1;
+      commandIndex.value =
+        (commandIndex.value + d + commandMatches.value.length) % commandMatches.value.length;
+      return;
+    }
+    if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+      e.preventDefault();
+      if (activeCommand.value) chooseCommand(activeCommand.value);
+      return;
+    }
+  }
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    submitPrompt();
   }
 }
 
@@ -244,28 +336,102 @@ const MODE_LABEL: Record<string, string> = {
   plan: 'plan',
   bypassPermissions: 'bypass',
 };
-const modeOptions = computed(() => props.session.available_modes ?? KNOWN_MODES);
-const modeLabel = (m: string | null) => (m ? (MODE_LABEL[m] ?? m) : 'mode');
+const modeOptions = computed(() =>
+  metadata.value.modes.length ? metadata.value.modes.map((mode) => mode.id) : KNOWN_MODES,
+);
+const modeLabel = (m: string | null) => {
+  if (!m) return 'mode';
+  return metadata.value.modes.find((mode) => mode.id === m)?.name ?? MODE_LABEL[m] ?? m;
+};
 const modeInteractive = computed(() => canSend(props.session) && modeOptions.value.length > 1);
+const legacyModeVisible = computed(
+  () =>
+    !metadata.value.config_options.some(
+      (option) => option.category === 'mode' || option.id === 'mode',
+    ),
+);
 const modeOpen = ref(false);
 async function pickMode(m: string) {
   modeOpen.value = false;
   if (m === currentMode.value) return;
-  const prev = currentMode.value;
-  currentMode.value = m; // optimistic
   try {
     await setSessionMode(id.value, m);
-  } catch {
-    currentMode.value = prev; // the adapter refused it
+    currentMode.value = m;
+  } catch (e) {
+    sendError.value = (e as Error).message ?? 'Failed to change agent permissions';
   }
 }
 function onDocClick(e: MouseEvent) {
   if (modeOpen.value && !(e.target as HTMLElement).closest('[data-testid="acp-mode-chip"]')) {
     modeOpen.value = false;
   }
+  if (configOpen.value && !(e.target as HTMLElement).closest('[data-acp-config]')) {
+    configOpen.value = '';
+  }
 }
 onMounted(() => document.addEventListener('click', onDocClick));
 onUnmounted(() => document.removeEventListener('click', onDocClick));
+
+// ── Agent-owned model / reasoning / config controls -------------------------
+const configOpen = ref('');
+const configBusy = ref('');
+const configOptions = computed(() =>
+  metadata.value.config_options
+    .filter(
+      (option) =>
+        (option.type === 'select' && typeof option.currentValue === 'string') ||
+        (option.type === 'boolean' && typeof option.currentValue === 'boolean'),
+    )
+    .sort((a, b) => configRank(a) - configRank(b)),
+);
+function configRank(option: AcpConfigOption): number {
+  if (option.category === 'mode' || option.id === 'mode') return 0;
+  if (option.category === 'model' || option.id === 'model') return 1;
+  if (option.category === 'thought_level' || option.id.includes('reasoning')) return 2;
+  return 3;
+}
+function configName(option: AcpConfigOption): string {
+  if (option.category === 'mode' || option.id === 'mode') return 'Permissions';
+  if (option.category === 'thought_level') return 'Effort';
+  return option.name;
+}
+function configTone(option: AcpConfigOption): string {
+  if (option.category !== 'mode' && option.id !== 'mode') return '';
+  return option.currentValue === 'agent-full-access' || option.currentValue === 'bypassPermissions'
+    ? 'acp-config-danger'
+    : 'acp-config-permission';
+}
+function configChoices(option: AcpConfigOption): AcpConfigChoice[] {
+  const choices = option.options ?? [];
+  if (!choices.length) return [];
+  if ('value' in choices[0]) return choices as AcpConfigChoice[];
+  return (choices as { options: AcpConfigChoice[] }[]).flatMap((group) => group.options ?? []);
+}
+function configValueLabel(option: AcpConfigOption): string {
+  if (typeof option.currentValue === 'boolean') return option.currentValue ? 'On' : 'Off';
+  const current = String(option.currentValue);
+  return configChoices(option).find((choice) => choice.value === current)?.name ?? current;
+}
+async function pickConfig(option: AcpConfigOption, value: string | boolean) {
+  configOpen.value = '';
+  if (value === option.currentValue || configBusy.value) return;
+  configBusy.value = option.id;
+  try {
+    const response = await setSessionConfigOption(id.value, option.id, value);
+    // The response is the full state acknowledged by the agent. This matters
+    // when changing one value also changes another control's choices (a model
+    // switch can alter its supported reasoning efforts).
+    metadata.value = response.metadata;
+    const mode = response.metadata.config_options.find(
+      (item) => item.category === 'mode' || item.id === 'mode',
+    )?.currentValue;
+    if (typeof mode === 'string') currentMode.value = mode;
+  } catch (e) {
+    sendError.value = (e as Error).message ?? 'Failed to change agent configuration';
+  } finally {
+    configBusy.value = '';
+  }
+}
 
 // ── Permission answering ─────────────────────────────────────────────────────
 const answering = ref<Set<string>>(new Set());
@@ -376,16 +542,19 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
         toc.push({ anchor, n, title: titleOf(text) });
         break;
       }
-      case 'agent_message':
+      case 'agent_message': {
         flushActivity();
+        const text = (b.payload as unknown as AgentMessagePayload).text ?? '';
+        if (!text.trim()) break;
         rows.push({
           type: 'agent',
           key: k,
           time: shortTime(b.created_at),
-          text: (b.payload as unknown as AgentMessagePayload).text ?? '',
+          text,
           streaming: false,
         });
         break;
+      }
       case 'thought':
         flushActivity();
         rows.push({
@@ -894,18 +1063,79 @@ function goTo(anchor: string) {
         {{ sendError }}
       </p>
       <textarea
+        ref="composerInput"
         v-model="draft"
         rows="2"
         :disabled="sending"
-        placeholder="Message the agent…"
+        :placeholder="commandHint || 'Message the agent…'"
         data-testid="acp-composer-input"
         class="acp-input"
-        @keydown.enter.exact.prevent="submitPrompt"
+        @keydown="onComposerKeydown"
       ></textarea>
+      <ul
+        v-if="commandMatches.length"
+        class="acp-command-menu"
+        data-testid="acp-command-menu"
+        role="listbox"
+        aria-label="Agent commands"
+      >
+        <li v-for="(command, index) in commandMatches" :key="command.name">
+          <button
+            type="button"
+            class="acp-command-item"
+            :data-active="index === commandIndex"
+            :aria-selected="index === commandIndex"
+            role="option"
+            @click="chooseCommand(command)"
+          >
+            <code>/{{ command.name }}</code>
+            <span>{{ command.description }}</span>
+            <kbd v-if="command.input?.hint">{{ command.input.hint }}</kbd>
+          </button>
+        </li>
+      </ul>
       <div class="acp-composer-actions">
-        <!-- Mode chip + slash hint on the left. -->
+        <!-- Agent-owned config selectors + slash discovery on the left. -->
         <div class="acp-composer-left">
-          <div class="acp-mode-wrap" data-testid="acp-mode-chip">
+          <div
+            v-for="option in configOptions"
+            :key="option.id"
+            class="acp-mode-wrap"
+            data-acp-config
+            :data-testid="`acp-config-${option.id}`"
+          >
+            <button
+              type="button"
+              class="acp-mode-chip"
+              :class="configTone(option)"
+              :disabled="configBusy === option.id"
+              :title="option.description ?? option.name"
+              :aria-pressed="option.type === 'boolean' ? Boolean(option.currentValue) : undefined"
+              @click.stop="
+                option.type === 'boolean'
+                  ? pickConfig(option, !option.currentValue)
+                  : (configOpen = configOpen === option.id ? '' : option.id)
+              "
+            >
+              <span class="acp-config-name">{{ configName(option) }}</span>
+              {{ configValueLabel(option)
+              }}<span v-if="option.type === 'select'" class="acp-mode-caret">▾</span>
+            </button>
+            <ul v-if="configOpen === option.id" class="acp-mode-menu" data-testid="acp-config-menu">
+              <li v-for="choice in configChoices(option)" :key="choice.value">
+                <button
+                  type="button"
+                  class="acp-mode-item"
+                  :data-active="choice.value === option.currentValue"
+                  :title="choice.description ?? undefined"
+                  @click="pickConfig(option, choice.value)"
+                >
+                  {{ choice.name }}
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div v-if="legacyModeVisible" class="acp-mode-wrap" data-testid="acp-mode-chip">
             <button
               type="button"
               class="acp-mode-chip"
@@ -913,6 +1143,7 @@ function goTo(anchor: string) {
               :disabled="!modeInteractive"
               @click.stop="modeOpen = !modeOpen"
             >
+              <span class="acp-config-name">Permissions</span>
               {{ modeLabel(currentMode)
               }}<span v-if="modeInteractive" class="acp-mode-caret">▾</span>
             </button>
@@ -929,7 +1160,16 @@ function goTo(anchor: string) {
               </li>
             </ul>
           </div>
-          <span class="acp-slash-hint" aria-hidden="true">/ commands</span>
+          <button
+            v-if="commands.length"
+            type="button"
+            class="acp-slash-hint"
+            data-testid="acp-command-hint"
+            title="Show commands"
+            @click="showCommands"
+          >
+            / {{ commands.length }} commands
+          </button>
         </div>
         <div class="acp-composer-right">
           <button
@@ -1319,9 +1559,49 @@ function goTo(anchor: string) {
 }
 .acp-composer-left {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.65rem;
   min-width: 0;
+}
+
+/* Slash-command autocomplete, populated by ACP `available_commands_update`. */
+.acp-command-menu {
+  max-height: 16rem;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-top: 0;
+  border-radius: 0 0 0.375rem 0.375rem;
+  background: var(--surface);
+  box-shadow: 0 8px 20px rgb(0 0 0 / 0.12);
+  padding: 0.2rem;
+}
+.acp-command-item {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(8rem, auto) minmax(10rem, 1fr) auto;
+  align-items: baseline;
+  gap: 0.75rem;
+  border-radius: 0.25rem;
+  padding: 0.4rem 0.55rem;
+  text-align: left;
+  color: var(--muted);
+}
+.acp-command-item[data-active='true'],
+.acp-command-item:hover {
+  background: var(--subtle);
+  color: var(--fg);
+}
+.acp-command-item code,
+.acp-command-item kbd {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+.acp-command-item code {
+  color: var(--accent);
+}
+.acp-command-item kbd {
+  color: var(--faint);
 }
 .acp-composer-right {
   display: flex;
@@ -1357,6 +1637,16 @@ function goTo(anchor: string) {
 .acp-mode-caret {
   color: var(--faint);
 }
+.acp-config-name {
+  color: var(--faint);
+}
+.acp-config-permission {
+  border-color: color-mix(in srgb, var(--attn) 40%, var(--line));
+}
+.acp-config-danger {
+  border-color: color-mix(in srgb, var(--block) 55%, var(--line));
+  color: var(--block);
+}
 .acp-mode-menu {
   position: absolute;
   bottom: calc(100% + 0.3rem);
@@ -1391,6 +1681,10 @@ function goTo(anchor: string) {
   font-family: var(--font-mono);
   font-size: 0.6875rem;
   color: var(--faint);
+  cursor: pointer;
+}
+.acp-slash-hint:hover {
+  color: var(--fg);
 }
 
 /* Right rail. */

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -346,9 +346,8 @@ async function stopTurn() {
 }
 
 // ── Mode chip ────────────────────────────────────────────────────────────────
-// The well-known claude/codex ACP modes, used when the session doesn't expose an
-// explicit `available_modes` list (SessionView carries only `current_mode`
-// today). Wire the chip to `session.available_modes` the moment the server adds it.
+// The well-known claude/codex ACP modes, used until the adapter advertises its
+// live mode catalogue through the conversation metadata.
 const KNOWN_MODES = ['auto', 'default', 'acceptEdits', 'plan', 'bypassPermissions'];
 const MODE_LABEL: Record<string, string> = {
   auto: 'auto',
@@ -365,12 +364,7 @@ const modeLabel = (m: string | null) => {
   return metadata.value.modes.find((mode) => mode.id === m)?.name ?? MODE_LABEL[m] ?? m;
 };
 const modeInteractive = computed(() => canSend(props.session) && modeOptions.value.length > 1);
-const legacyModeVisible = computed(
-  () =>
-    !metadata.value.config_options.some(
-      (option) => option.category === 'mode' || option.id === 'mode',
-    ),
-);
+const legacyModeVisible = computed(() => !metadata.value.config_options.some(isModeOption));
 const modeOpen = ref(false);
 async function pickMode(m: string) {
   modeOpen.value = false;
@@ -406,18 +400,18 @@ const configOptions = computed(() =>
     .sort((a, b) => configRank(a) - configRank(b)),
 );
 function configRank(option: AcpConfigOption): number {
-  if (option.category === 'mode' || option.id === 'mode') return 0;
+  if (isModeOption(option)) return 0;
   if (option.category === 'model' || option.id === 'model') return 1;
   if (option.category === 'thought_level' || option.id.includes('reasoning')) return 2;
   return 3;
 }
 function configName(option: AcpConfigOption): string {
-  if (option.category === 'mode' || option.id === 'mode') return 'Permissions';
+  if (isModeOption(option)) return 'Permissions';
   if (option.category === 'thought_level') return 'Effort';
   return option.name;
 }
 function configTone(option: AcpConfigOption): string {
-  if (option.category !== 'mode' && option.id !== 'mode') return '';
+  if (!isModeOption(option)) return '';
   return option.currentValue === 'agent-full-access' || option.currentValue === 'bypassPermissions'
     ? 'acp-config-danger'
     : 'acp-config-permission';
@@ -447,15 +441,17 @@ async function pickConfig(option: AcpConfigOption, value: string | boolean) {
     // when changing one value also changes another control's choices (a model
     // switch can alter its supported reasoning efforts).
     metadata.value = response.metadata;
-    const mode = response.metadata.config_options.find(
-      (item) => item.category === 'mode' || item.id === 'mode',
-    )?.currentValue;
+    const mode = response.metadata.config_options.find(isModeOption)?.currentValue;
     if (typeof mode === 'string') currentMode.value = mode;
   } catch (e) {
     sendError.value = (e as Error).message ?? 'Failed to change agent configuration';
   } finally {
     configBusy.value = '';
   }
+}
+
+function isModeOption(option: AcpConfigOption): boolean {
+  return option.category === 'mode' || option.id === 'mode';
 }
 
 // ── Permission answering ─────────────────────────────────────────────────────

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { Session } from '../types';
+import type { Session, AcpCommand } from '../types';
 import TerminalConversation from './TerminalConversation.vue';
 import AcpConversation from './AcpConversation.vue';
 
@@ -9,11 +9,20 @@ import AcpConversation from './AcpConversation.vue';
 // (`/chat` + `/chat/stream`); a terminal session keeps the iris scrape path
 // (`/conversation`) untouched. One prop, one seam — everything backend-specific
 // lives in the two child components.
-const props = defineProps<{ session: Session }>();
+const props = withDefaults(defineProps<{ session: Session; localCommands?: AcpCommand[] }>(), {
+  localCommands: () => [],
+});
+const emit = defineEmits<{ command: [name: string, args: string] }>();
 const isAcp = computed(() => props.session.protocol === 'acp');
+const forwardCommand = (name: string, args: string) => emit('command', name, args);
 </script>
 
 <template>
-  <AcpConversation v-if="isAcp" :session="session" />
+  <AcpConversation
+    v-if="isAcp"
+    :session="session"
+    :local-commands="localCommands"
+    @command="forwardCommand"
+  />
   <TerminalConversation v-else :session="session" />
 </template>

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -161,6 +161,43 @@ export interface ChatBlock {
 export interface ChatSnapshot {
   blocks: ChatBlock[];
   live_turn: number | null;
+  metadata: AcpMetadata;
+}
+
+/** Agent-owned command/configuration metadata for a live ACP conversation. */
+export interface AcpCommand {
+  name: string;
+  description: string;
+  input?: { type?: string; hint?: string } | null;
+}
+export interface AcpConfigChoice {
+  value: string;
+  name: string;
+  description?: string | null;
+}
+export interface AcpConfigGroup {
+  group: string;
+  name: string;
+  options: AcpConfigChoice[];
+}
+export interface AcpConfigOption {
+  id: string;
+  name: string;
+  description?: string | null;
+  category?: string | null;
+  type: string;
+  currentValue: string | boolean;
+  options?: AcpConfigChoice[] | AcpConfigGroup[];
+}
+export interface AcpMode {
+  id: string;
+  name: string;
+  description?: string | null;
+}
+export interface AcpMetadata {
+  commands: AcpCommand[];
+  config_options: AcpConfigOption[];
+  modes: AcpMode[];
 }
 
 // -- block payloads (by kind) --

--- a/crates/loom/frontend/src/views/Chat.vue
+++ b/crates/loom/frontend/src/views/Chat.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { getChat, resetChat } from '../api';
-import type { Session } from '../types';
+import type { Session, AcpCommand } from '../types';
 import SessionConversation from '../components/SessionConversation.vue';
 
 // The Chat surface: a conversation with the fleet **concierge** — an agent that
@@ -15,6 +15,13 @@ type LoadState = 'loading' | 'ready' | 'error';
 const state = ref<LoadState>('loading');
 const session = ref<Session | null>(null);
 const errorMsg = ref('');
+const localCommands: AcpCommand[] = [
+  {
+    name: 'clear',
+    description: 'Start a fresh concierge conversation',
+    input: null,
+  },
+];
 
 async function load() {
   state.value = 'loading';
@@ -42,11 +49,8 @@ function armReset() {
   disarmTimer = setTimeout(() => (armed.value = false), 4000);
 }
 
-async function reset() {
-  if (!armed.value) {
-    armReset();
-    return;
-  }
+async function startFresh() {
+  if (resetting.value) return;
   if (disarmTimer) clearTimeout(disarmTimer);
   armed.value = false;
   resetting.value = true;
@@ -60,6 +64,18 @@ async function reset() {
   } finally {
     resetting.value = false;
   }
+}
+
+async function reset() {
+  if (!armed.value) {
+    armReset();
+    return;
+  }
+  await startFresh();
+}
+
+function handleCommand(name: string) {
+  if (name === 'clear') startFresh();
 }
 
 onMounted(load);
@@ -91,7 +107,7 @@ onMounted(load);
         data-testid="chat-reset"
         @click="reset"
       >
-        {{ resetting ? 'Resetting…' : armed ? 'Confirm reset' : 'Reset' }}
+        {{ resetting ? 'Starting…' : armed ? 'Confirm new chat' : 'New chat' }}
       </button>
     </header>
 
@@ -110,7 +126,9 @@ onMounted(load);
       v-else-if="session"
       :key="session.id"
       :session="session"
+      :local-commands="localCommands"
       class="min-h-0 flex-1"
+      @command="handleCommand"
     />
   </div>
 </template>

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -117,11 +117,22 @@ pub enum PermAnswer {
 }
 
 /// One SSE event the `/chat/stream` route emits: an event name (`block`, `delta`,
-/// `tool`, `turn`) and its JSON data.
+/// `tool`, `turn`, `metadata`) and its JSON data.
 #[derive(Debug, Clone, Serialize)]
 pub struct SseEvent {
     pub event: String,
     pub data: Value,
+}
+
+/// Agent-owned controls for the conversation composer. These are deliberately
+/// kept as ACP-shaped JSON: command inputs and session config options are an
+/// extensible protocol surface, and loom forwards fields it does not yet render
+/// instead of narrowing the wire contract and making adapters stale again.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct AcpMetadata {
+    pub commands: Vec<Value>,
+    pub config_options: Vec<Value>,
+    pub modes: Vec<Value>,
 }
 
 /// A live session's control surface, held in the [`AcpRegistry`]: send commands
@@ -130,12 +141,19 @@ pub struct SseEvent {
 pub struct AcpHandle {
     cmd_tx: mpsc::Sender<Command>,
     events_tx: broadcast::Sender<SseEvent>,
+    metadata: Arc<Mutex<AcpMetadata>>,
 }
 
 impl AcpHandle {
     /// Subscribe to the session's SSE broadcast.
     pub fn subscribe(&self) -> broadcast::Receiver<SseEvent> {
         self.events_tx.subscribe()
+    }
+
+    /// Snapshot the latest agent-owned composer metadata. The `/chat` snapshot
+    /// carries this before the browser tails updates over SSE.
+    pub fn metadata(&self) -> AcpMetadata {
+        self.metadata.lock().unwrap().clone()
     }
 
     /// Send a user message: dispatched as a `session/prompt` when idle, appended
@@ -192,6 +210,24 @@ impl AcpHandle {
             .send(Command::SetMode {
                 mode_id,
                 by,
+                reply: tx,
+            })
+            .await
+            .map_err(|_| anyhow!("acp task is gone"))?;
+        rx.await
+            .map_err(|_| anyhow!("acp task dropped the reply"))?
+    }
+
+    /// Change an ACP session configuration option (`model`, reasoning effort,
+    /// mode, or another adapter-defined value). The task waits for the agent's
+    /// full refreshed option set before acknowledging the REST write and returns
+    /// that authoritative state to the caller.
+    pub async fn set_config_option(&self, config_id: String, value: Value) -> Result<AcpMetadata> {
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::SetConfigOption {
+                config_id,
+                value,
                 reply: tx,
             })
             .await
@@ -285,9 +321,14 @@ pub async fn start(state: &AppState, session_id: &str, launch: AcpLaunch) -> Res
     task.handshake(&launch).await?;
 
     let (cmd_tx, cmd_rx) = mpsc::channel(64);
-    task.generation = state
-        .acp
-        .register(session_id, AcpHandle { cmd_tx, events_tx });
+    task.generation = state.acp.register(
+        session_id,
+        AcpHandle {
+            cmd_tx,
+            events_tx,
+            metadata: task.metadata.clone(),
+        },
+    );
     tokio::spawn(async move { task.run(cmd_rx).await });
     Ok(())
 }
@@ -323,9 +364,14 @@ pub async fn attach(state: &AppState, session_id: &str) -> Result<()> {
     .await?;
 
     let (cmd_tx, cmd_rx) = mpsc::channel(64);
-    task.generation = state
-        .acp
-        .register(session_id, AcpHandle { cmd_tx, events_tx });
+    task.generation = state.acp.register(
+        session_id,
+        AcpHandle {
+            cmd_tx,
+            events_tx,
+            metadata: task.metadata.clone(),
+        },
+    );
     tokio::spawn(async move { task.run(cmd_rx).await });
     Ok(())
 }
@@ -354,6 +400,17 @@ enum Command {
         by: Option<String>,
         reply: oneshot::Sender<Result<()>>,
     },
+    SetConfigOption {
+        config_id: String,
+        value: Value,
+        reply: oneshot::Sender<Result<AcpMetadata>>,
+    },
+}
+
+struct PendingMode {
+    mode_id: String,
+    by: Option<String>,
+    reply: oneshot::Sender<Result<()>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -520,6 +577,9 @@ struct Task {
     pending_perms: HashMap<String, PendingPerm>,
 
     current_mode: Option<String>,
+    metadata: Arc<Mutex<AcpMetadata>>,
+    pending_mode: HashMap<u64, PendingMode>,
+    pending_config: HashMap<u64, oneshot::Sender<Result<AcpMetadata>>>,
     #[allow(dead_code)]
     load_session_cap: bool,
     /// Latched for the duration of a `session/load` replay: the adapter re-streams
@@ -563,6 +623,9 @@ impl Task {
             tools: HashMap::new(),
             pending_perms: HashMap::new(),
             current_mode: None,
+            metadata: Arc::new(Mutex::new(AcpMetadata::default())),
+            pending_mode: HashMap::new(),
+            pending_config: HashMap::new(),
             load_session_cap: false,
             suppress_journal: false,
             highest_seq: 0,
@@ -613,6 +676,9 @@ impl Task {
             tools: HashMap::new(),
             pending_perms: HashMap::new(),
             current_mode: session.current_mode.clone(),
+            metadata: Arc::new(Mutex::new(AcpMetadata::default())),
+            pending_mode: HashMap::new(),
+            pending_config: HashMap::new(),
             load_session_cap: false,
             suppress_journal: false,
             highest_seq: session.acp_ack_seq.max(0) as u64,
@@ -631,6 +697,46 @@ impl Task {
             event: event.to_string(),
             data,
         });
+    }
+
+    fn emit_metadata(&self) {
+        let metadata = self.metadata.lock().unwrap().clone();
+        self.emit(
+            "metadata",
+            serde_json::to_value(metadata).unwrap_or(Value::Null),
+        );
+    }
+
+    fn replace_commands(&self, commands: Vec<Value>, emit: bool) {
+        self.metadata.lock().unwrap().commands = commands;
+        if emit {
+            self.emit_metadata();
+        }
+    }
+
+    fn replace_config_options(&mut self, config_options: Vec<Value>, emit: bool) {
+        if let Some(mode) = config_options.iter().find_map(|option| {
+            let is_mode = option.get("category").and_then(Value::as_str) == Some("mode")
+                || option.get("id").and_then(Value::as_str) == Some("mode");
+            is_mode
+                .then(|| option.get("currentValue").and_then(Value::as_str))
+                .flatten()
+                .map(str::to_string)
+        }) {
+            self.current_mode = Some(mode);
+        }
+        self.metadata.lock().unwrap().config_options = config_options;
+        if emit {
+            self.emit_metadata();
+        }
+    }
+
+    fn replace_modes(&mut self, modes: wire::SessionModeState, emit: bool) {
+        self.current_mode = Some(modes.current_mode_id.clone());
+        self.metadata.lock().unwrap().modes = modes.available_modes;
+        if emit {
+            self.emit_metadata();
+        }
     }
 
     // -- handshake ----------------------------------------------------------
@@ -662,7 +768,10 @@ impl Task {
                 let ns: wire::NewSessionResult = serde_json::from_value(res)?;
                 self.acp_session_id = ns.session_id.clone();
                 if let Some(m) = ns.modes {
-                    self.current_mode = Some(m.current_mode_id);
+                    self.replace_modes(m, false);
+                }
+                if let Some(options) = ns.config_options {
+                    self.replace_config_options(options, false);
                 }
             }
             NewOrLoad::Load { acp_session_id } => {
@@ -697,11 +806,15 @@ impl Task {
                 if res.is_none() {
                     bail!("session/load failed: {err:?}");
                 }
-                if let Some(m) = res
-                    .and_then(|r| serde_json::from_value::<wire::LoadSessionResult>(r).ok())
-                    .and_then(|l| l.modes)
+                if let Some(load) =
+                    res.and_then(|r| serde_json::from_value::<wire::LoadSessionResult>(r).ok())
                 {
-                    self.current_mode = Some(m.current_mode_id);
+                    if let Some(m) = load.modes {
+                        self.replace_modes(m, false);
+                    }
+                    if let Some(options) = load.config_options {
+                        self.replace_config_options(options, false);
+                    }
                 }
             }
         }
@@ -716,6 +829,10 @@ impl Task {
                     wire::set_mode_params(&self.acp_session_id, mode),
                 ))
                 .await?;
+            let (result, error) = self.recv_until_response(id).await?;
+            if result.is_none() {
+                bail!("session/set_mode failed: {error:?}");
+            }
             self.current_mode = Some(mode.clone());
         }
         if let Some(mode) = &self.current_mode {
@@ -870,6 +987,15 @@ impl Task {
                 self.journal_block(kind::USAGE, json!({ "used": used, "size": size }))
                     .await;
             }
+            SessionUpdate::AvailableCommandsUpdate { available_commands } => {
+                self.replace_commands(available_commands, true);
+            }
+            SessionUpdate::ConfigOptionUpdate { config_options } => {
+                self.replace_config_options(config_options, true);
+                if let Some(mode) = &self.current_mode {
+                    let _ = session::set_current_mode(&self.db, &self.session_id, mode).await;
+                }
+            }
             SessionUpdate::Other => {}
         }
         Ok(())
@@ -929,12 +1055,56 @@ impl Task {
         let Some(id) = inc.id.as_ref().and_then(Value::as_u64) else {
             return;
         };
+        if let Some(pending) = self.pending_mode.remove(&id) {
+            let result = if let Some(error) = inc.error {
+                Err(anyhow!("session/set_mode failed: {error}"))
+            } else {
+                if self.current_mode.as_deref() != Some(pending.mode_id.as_str()) {
+                    self.current_mode = Some(pending.mode_id.clone());
+                    let _ = session::set_current_mode(&self.db, &self.session_id, &pending.mode_id)
+                        .await;
+                    let by = pending.by.map(Value::from).unwrap_or(Value::Null);
+                    self.journal_block(
+                        kind::MODE_CHANGE,
+                        json!({ "mode_id": pending.mode_id, "by": by }),
+                    )
+                    .await;
+                }
+                Ok(())
+            };
+            let _ = pending.reply.send(result);
+            return;
+        }
+        if let Some(reply) = self.pending_config.remove(&id) {
+            let result = if let Some(error) = inc.error {
+                Err(anyhow!("session/set_config_option failed: {error}"))
+            } else {
+                match inc
+                    .result
+                    .and_then(|v| serde_json::from_value::<wire::SetConfigOptionResult>(v).ok())
+                {
+                    Some(updated) => {
+                        self.replace_config_options(updated.config_options, true);
+                        if let Some(mode) = &self.current_mode {
+                            let _ =
+                                session::set_current_mode(&self.db, &self.session_id, mode).await;
+                        }
+                        Ok(self.metadata.lock().unwrap().clone())
+                    }
+                    None => Err(anyhow!(
+                        "session/set_config_option returned an invalid response"
+                    )),
+                }
+            };
+            let _ = reply.send(result);
+            return;
+        }
         if let Some((pid, turn)) = self.inflight_prompt {
             if id == pid {
                 self.on_turn_end(turn, inc.result, inc.error).await;
             }
         }
-        // Other responses (set_mode, …) need no follow-up.
+        // Other responses need no follow-up.
     }
 
     async fn on_turn_end(&mut self, turn: i64, result: Option<Value>, error: Option<Value>) {
@@ -1177,7 +1347,7 @@ impl Task {
             }
             Command::SetMode { mode_id, by, reply } => {
                 let id = self.next_id();
-                let r = self
+                let write = self
                     .stream
                     .write(&wire::request_line(
                         id,
@@ -1185,12 +1355,42 @@ impl Task {
                         wire::set_mode_params(&self.acp_session_id, &mode_id),
                     ))
                     .await;
-                self.current_mode = Some(mode_id.clone());
-                let _ = session::set_current_mode(&self.db, &self.session_id, &mode_id).await;
-                let by_v = by.map(Value::from).unwrap_or(Value::Null);
-                self.journal_block(kind::MODE_CHANGE, json!({ "mode_id": mode_id, "by": by_v }))
+                match write {
+                    Ok(()) => {
+                        self.pending_mode
+                            .insert(id, PendingMode { mode_id, by, reply });
+                    }
+                    Err(error) => {
+                        let _ = reply.send(Err(error));
+                    }
+                }
+            }
+            Command::SetConfigOption {
+                config_id,
+                value,
+                reply,
+            } => {
+                let id = self.next_id();
+                let write = self
+                    .stream
+                    .write(&wire::request_line(
+                        id,
+                        method::SESSION_SET_CONFIG_OPTION,
+                        wire::set_config_option_params(
+                            self.acp_session_id.as_str(),
+                            &config_id,
+                            value,
+                        ),
+                    ))
                     .await;
-                let _ = reply.send(r);
+                match write {
+                    Ok(()) => {
+                        self.pending_config.insert(id, reply);
+                    }
+                    Err(error) => {
+                        let _ = reply.send(Err(error));
+                    }
+                }
             }
         }
     }

--- a/crates/loom/src/acp/wire.rs
+++ b/crates/loom/src/acp/wire.rs
@@ -64,6 +64,7 @@ pub mod method {
     pub const SESSION_PROMPT: &str = "session/prompt";
     pub const SESSION_CANCEL: &str = "session/cancel";
     pub const SESSION_SET_MODE: &str = "session/set_mode";
+    pub const SESSION_SET_CONFIG_OPTION: &str = "session/set_config_option";
     pub const SESSION_UPDATE: &str = "session/update";
     pub const SESSION_REQUEST_PERMISSION: &str = "session/request_permission";
 }
@@ -153,7 +154,19 @@ pub enum SessionUpdate {
         #[serde(default)]
         size: Option<u64>,
     },
-    /// Anything else (available_commands_update, session_info_update, …): ignored.
+    /// The agent-owned slash-command catalogue. Clients replace their cached
+    /// list wholesale on every update.
+    AvailableCommandsUpdate {
+        #[serde(default, rename = "availableCommands")]
+        available_commands: Vec<Value>,
+    },
+    /// The full set of live session configuration controls (model, reasoning
+    /// effort, mode, and adapter-specific options).
+    ConfigOptionUpdate {
+        #[serde(default, rename = "configOptions")]
+        config_options: Vec<Value>,
+    },
+    /// Anything else (session_info_update, prompt_suggestion, …): ignored.
     #[serde(other)]
     Other,
 }
@@ -283,6 +296,8 @@ pub struct NewSessionResult {
     pub session_id: String,
     #[serde(default)]
     pub modes: Option<SessionModeState>,
+    #[serde(default)]
+    pub config_options: Option<Vec<Value>>,
 }
 
 /// The `session/load` result (mode state only; history arrives as `session/update`
@@ -292,6 +307,8 @@ pub struct NewSessionResult {
 pub struct LoadSessionResult {
     #[serde(default)]
     pub modes: Option<SessionModeState>,
+    #[serde(default)]
+    pub config_options: Option<Vec<Value>>,
 }
 
 /// The active mode + available modes.
@@ -299,6 +316,18 @@ pub struct LoadSessionResult {
 #[serde(rename_all = "camelCase")]
 pub struct SessionModeState {
     pub current_mode_id: String,
+    #[serde(default)]
+    pub available_modes: Vec<Value>,
+}
+
+/// The `session/set_config_option` result. ACP returns the complete refreshed
+/// option set so the client never has to guess coupled changes (for example a
+/// model switch changing the available reasoning levels).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetConfigOptionResult {
+    #[serde(default)]
+    pub config_options: Vec<Value>,
 }
 
 /// The `session/prompt` result — the turn's stop reason.
@@ -370,6 +399,13 @@ pub fn cancel_params(session_id: &str) -> Value {
 /// `session/set_mode` params.
 pub fn set_mode_params(session_id: &str, mode_id: &str) -> Value {
     serde_json::json!({ "sessionId": session_id, "modeId": mode_id })
+}
+
+/// `session/set_config_option` params. ACP configuration values are typed: most
+/// composer controls are select strings, while flags such as Codex fast mode are
+/// booleans.
+pub fn set_config_option_params(session_id: &str, config_id: &str, value: Value) -> Value {
+    serde_json::json!({ "sessionId": session_id, "configId": config_id, "value": value })
 }
 
 /// A `session/request_permission` response selecting an option.
@@ -541,9 +577,33 @@ mod tests {
             other => panic!("wrong variant: {other:?}"),
         }
 
+        let commands: SessionUpdate = serde_json::from_value(json!({
+            "sessionUpdate": "available_commands_update",
+            "availableCommands": [{"name":"review","description":"Review changes"}],
+        }))
+        .unwrap();
+        match commands {
+            SessionUpdate::AvailableCommandsUpdate { available_commands } => {
+                assert_eq!(available_commands[0]["name"], "review");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+
+        let config: SessionUpdate = serde_json::from_value(json!({
+            "sessionUpdate": "config_option_update",
+            "configOptions": [{"id":"model","name":"Model","type":"select"}],
+        }))
+        .unwrap();
+        match config {
+            SessionUpdate::ConfigOptionUpdate { config_options } => {
+                assert_eq!(config_options[0]["id"], "model");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+
         // An update kind loom does not model must not fail the stream.
         let other: SessionUpdate = serde_json::from_value(json!({
-            "sessionUpdate": "available_commands_update", "availableCommands": [],
+            "sessionUpdate": "session_info_update", "title": "hello",
         }))
         .unwrap();
         assert!(matches!(other, SessionUpdate::Other));
@@ -571,10 +631,12 @@ mod tests {
         let ns: NewSessionResult = serde_json::from_value(json!({
             "sessionId": "acp-abc",
             "modes": { "currentModeId": "default", "availableModes": [] },
+            "configOptions": [{"id":"model","name":"Model","type":"select"}],
         }))
         .unwrap();
         assert_eq!(ns.session_id, "acp-abc");
         assert_eq!(ns.modes.unwrap().current_mode_id, "default");
+        assert_eq!(ns.config_options.unwrap()[0]["id"], "model");
 
         let pr: PromptResult = serde_json::from_value(json!({ "stopReason": "end_turn" })).unwrap();
         assert_eq!(pr.stop_reason, "end_turn");

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -3,11 +3,13 @@
 //! run for a judgement call.
 
 use anyhow::{anyhow, Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use std::collections::HashSet;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::time::Duration;
 
 use crate::acp::{AcpLaunch, NewOrLoad};
 use crate::backend;
@@ -100,6 +102,9 @@ const MODEL_CHOICES: &[(&str, &str)] = &[
 ];
 
 const CODEX_MODEL_CHOICES: &[(&str, &str)] = &[
+    ("gpt-5.6-sol", "GPT-5.6 Sol"),
+    ("gpt-5.6-terra", "GPT-5.6 Terra"),
+    ("gpt-5.6-luna", "GPT-5.6 Luna"),
     ("gpt-5.5", "GPT-5.5"),
     ("gpt-5.4", "GPT-5.4"),
     ("gpt-5.4-mini", "GPT-5.4 Mini"),
@@ -143,6 +148,97 @@ pub fn builtin_metadata() -> Vec<AgentMetadata> {
         .collect()
 }
 
+#[derive(Debug, Deserialize)]
+struct CodexModelCatalog {
+    #[serde(default)]
+    models: Vec<CodexCatalogModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexCatalogModel {
+    slug: String,
+    display_name: String,
+    #[serde(default)]
+    visibility: String,
+    #[serde(default)]
+    supported_reasoning_levels: Vec<CodexReasoningLevel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexReasoningLevel {
+    effort: String,
+}
+
+/// Ask the installed Codex binary for its bundled model catalogue. This is a
+/// stateless local query (`--bundled` forbids a network refresh), so Settings
+/// reflects the version actually installed on the loom host without launching
+/// a throwaway agent session. Older CLIs without `debug models` and malformed
+/// catalogues simply retain the code-shipped fallback above.
+async fn refresh_codex_metadata(metadata: &mut AgentMetadata) {
+    let output = tokio::time::timeout(
+        Duration::from_secs(3),
+        tokio::process::Command::new("codex")
+            .args(["debug", "models", "--bundled"])
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await;
+    let Ok(Ok(output)) = output else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    apply_codex_catalog(metadata, &output.stdout);
+}
+
+fn apply_codex_catalog(metadata: &mut AgentMetadata, bytes: &[u8]) {
+    let Ok(catalog) = serde_json::from_slice::<CodexModelCatalog>(bytes) else {
+        return;
+    };
+
+    let mut models = Vec::new();
+    let mut efforts = Vec::new();
+    let mut seen_models = HashSet::new();
+    let mut seen_efforts = HashSet::new();
+    for model in catalog.models {
+        if model.visibility != "list" || !seen_models.insert(model.slug.clone()) {
+            continue;
+        }
+        models.push(AgentChoice {
+            id: model.slug,
+            label: model.display_name,
+        });
+        for level in model.supported_reasoning_levels {
+            if seen_efforts.insert(level.effort.clone()) {
+                efforts.push(AgentChoice {
+                    label: effort_label(&level.effort),
+                    id: level.effort,
+                });
+            }
+        }
+    }
+    if !models.is_empty() {
+        metadata.models = models;
+    }
+    if !efforts.is_empty() {
+        metadata.efforts = efforts;
+    }
+}
+
+fn effort_label(effort: &str) -> String {
+    match effort {
+        "xhigh" => "X-High".to_string(),
+        other => {
+            let mut chars = other.chars();
+            chars
+                .next()
+                .map(|first| first.to_uppercase().collect::<String>() + chars.as_str())
+                .unwrap_or_default()
+        }
+    }
+}
+
 /// A launchable agent resolved from a kind: either a builtin static type or a
 /// database-backed custom agent (owned, since it carries the row's commands).
 pub enum ResolvedAgent {
@@ -174,6 +270,9 @@ pub async fn resolve(db: &Db, kind: &str) -> Result<Option<ResolvedAgent>> {
 /// (name order). What `GET /api/agents` lists and the picker renders.
 pub async fn agent_metadata(db: &Db) -> Result<Vec<AgentMetadata>> {
     let mut out = builtin_metadata();
+    if let Some(codex) = out.iter_mut().find(|meta| meta.kind == "codex") {
+        refresh_codex_metadata(codex).await;
+    }
     for a in crate::custom_agents::list(db).await? {
         out.push(CustomAgentType::new(a).metadata());
     }
@@ -182,7 +281,14 @@ pub async fn agent_metadata(db: &Db) -> Result<Vec<AgentMetadata>> {
 
 /// The metadata for one agent kind, or `None` when it names no agent.
 pub async fn metadata_for(db: &Db, kind: &str) -> Result<Option<AgentMetadata>> {
-    Ok(resolve(db, kind).await?.map(|r| r.as_type().metadata()))
+    let Some(resolved) = resolve(db, kind).await? else {
+        return Ok(None);
+    };
+    let mut metadata = resolved.as_type().metadata();
+    if metadata.kind == "codex" {
+        refresh_codex_metadata(&mut metadata).await;
+    }
+    Ok(Some(metadata))
 }
 
 /// Whether `kind` names a known agent (builtin or custom).
@@ -1374,6 +1480,36 @@ mod tests {
         // The `"shell"` runtime in the test helper builds the same bare shell.
         let script = launch_script("shell", None, None, LaunchMode::Fresh, "", "");
         assert_eq!(script, "exec \"${SHELL:-/bin/sh}\"");
+    }
+
+    #[test]
+    fn codex_catalog_replaces_stale_fallback_choices() {
+        let mut metadata = CODEX_AGENT_TYPE.metadata();
+        apply_codex_catalog(
+            &mut metadata,
+            br#"{"models":[
+                {"slug":"gpt-next","display_name":"GPT Next","visibility":"list",
+                 "supported_reasoning_levels":[{"effort":"low"},{"effort":"ultra"}]},
+                {"slug":"hidden","display_name":"Hidden","visibility":"hide",
+                 "supported_reasoning_levels":[{"effort":"medium"}]}
+            ]}"#,
+        );
+        assert_eq!(
+            metadata
+                .models
+                .iter()
+                .map(|choice| choice.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gpt-next"]
+        );
+        assert_eq!(
+            metadata
+                .efforts
+                .iter()
+                .map(|choice| (choice.id.as_str(), choice.label.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("low", "Low"), ("ultra", "Ultra")]
+        );
     }
 
     /// A nested headless agent must not carry `$WEAVER_BRANCH`, or it fires the

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -610,6 +610,10 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/sessions/{id}/mode", axum::routing::put(set_mode))
         .route(
+            "/sessions/{id}/config/{config_id}",
+            axum::routing::put(set_config_option),
+        )
+        .route(
             "/sessions/{id}/tags/{key}",
             axum::routing::put(set_session_tag).delete(clear_session_tag),
         )

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2564,8 +2564,9 @@ fn live_turn(session: &Session) -> Option<i64> {
         .and_then(|v| v.get("turn").and_then(Value::as_i64))
 }
 
-/// The journaled conversation: `{ blocks: [...], live_turn }`. Works whether or
-/// not a task is currently running (it reads the durable journal).
+/// The journaled conversation plus the agent-owned composer metadata. The
+/// journal works without a live task; metadata is empty until an adapter is
+/// attached and advertises its commands/configuration controls.
 pub(super) async fn get_session_chat(
     State(st): State<AppState>,
     Path(key): Path<String>,
@@ -2573,9 +2574,16 @@ pub(super) async fn get_session_chat(
     let (session, _) = require_session(&st.db, &key).await?;
     require_acp(&session)?;
     let blocks = crate::chat::list(&st.db, &session.id).await?;
-    Ok(Json(
-        json!({ "blocks": blocks, "live_turn": live_turn(&session) }),
-    ))
+    let metadata = st
+        .acp
+        .get(&session.id)
+        .map(|handle| handle.metadata())
+        .unwrap_or_default();
+    Ok(Json(json!({
+        "blocks": blocks,
+        "live_turn": live_turn(&session),
+        "metadata": metadata,
+    })))
 }
 
 /// The live SSE tail of the conversation — `block` / `delta` / `tool` / `turn`
@@ -2641,6 +2649,33 @@ pub(super) async fn prompt_session(
         StatusCode::ACCEPTED,
         Json(json!({ "queued": ack.queued, "turn": ack.turn })),
     ))
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ConfigOptionBody {
+    pub value: Value,
+}
+
+/// Change one agent-owned session configuration selector. Unlike the legacy
+/// mode route this waits for the adapter's response, whose full refreshed
+/// option list is broadcast to chat clients as a `metadata` event.
+pub(super) async fn set_config_option(
+    State(st): State<AppState>,
+    Path((key, config_id)): Path<(String, String)>,
+    Json(req): Json<ConfigOptionBody>,
+) -> ApiResult<Json<Value>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    require_acp(&session)?;
+    let handle = require_acp_task(&st, &session)?;
+    let metadata = handle
+        .set_config_option(config_id.clone(), req.value.clone())
+        .await
+        .map_err(|e| AppError::conflict(e.to_string()))?;
+    Ok(Json(json!({
+        "config_id": config_id,
+        "value": req.value,
+        "metadata": metadata,
+    })))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2793,9 +2793,9 @@ pub(super) struct ConfigOptionBody {
     pub value: Value,
 }
 
-/// Change one agent-owned session configuration selector. Unlike the legacy
-/// mode route this waits for the adapter's response, whose full refreshed
-/// option list is broadcast to chat clients as a `metadata` event.
+/// Change one agent-owned session configuration selector. This waits for the
+/// adapter's response, whose full refreshed option list is broadcast to chat
+/// clients as a `metadata` event.
 pub(super) async fn set_config_option(
     State(st): State<AppState>,
     Path((key, config_id)): Path<(String, String)>,

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -59,6 +59,70 @@ const MODES = [
   { id: "bypassPermissions", name: "Bypass permissions" },
   { id: "plan", name: "Plan" },
 ];
+let currentModel = "fake-fast";
+let currentEffort = "medium";
+let currentMode = "default";
+let fastMode = false;
+
+function configOptions() {
+  return [
+    {
+      id: "mode",
+      name: "Mode",
+      description: "Approval and sandboxing preset for the session",
+      category: "mode",
+      type: "select",
+      currentValue: currentMode,
+      options: MODES.map((mode) => ({ value: mode.id, name: mode.name })),
+    },
+    {
+      id: "model",
+      name: "Model",
+      description: "Model used for the next turn",
+      category: "model",
+      type: "select",
+      currentValue: currentModel,
+      options: [
+        { value: "fake-fast", name: "Fake fast" },
+        { value: "fake-deep", name: "Fake deep" },
+      ],
+    },
+    {
+      id: "thought_level",
+      name: "Reasoning",
+      description: "Reasoning effort",
+      category: "thought_level",
+      type: "select",
+      currentValue: currentEffort,
+      options: [
+        { value: "low", name: "Low" },
+        { value: "medium", name: "Medium" },
+        { value: "high", name: "High" },
+      ],
+    },
+    {
+      id: "fast-mode",
+      name: "Fast",
+      description: "Use the faster service tier",
+      type: "boolean",
+      currentValue: fastMode,
+    },
+  ];
+}
+
+function advertiseCommands() {
+  notify({
+    sessionUpdate: "available_commands_update",
+    availableCommands: [
+      { name: "resume", description: "Resume a previous conversation" },
+      {
+        name: "review",
+        description: "Review the current changes",
+        input: { hint: "instructions" },
+      },
+    ],
+  });
+}
 
 function askPermission(name) {
   const reqId = 10000 + pending.size + Math.floor(Math.random() * 1000);
@@ -182,19 +246,33 @@ function handleMessage(msg) {
       sessionId = "fake-session-" + ++sessionCounter;
       respond(msg.id, {
         sessionId,
-        modes: { currentModeId: "default", availableModes: MODES },
+        modes: { currentModeId: currentMode, availableModes: MODES },
+        configOptions: configOptions(),
       });
+      advertiseCommands();
       break;
     case "session/load":
       sessionId = msg.params.sessionId;
       // Replay a tiny scripted history as the spec's load notifications.
       notify({ sessionUpdate: "user_message_chunk", content: { type: "text", text: "earlier question" } });
       notify({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "earlier answer" } });
-      respond(msg.id, { modes: { currentModeId: "default", availableModes: MODES } });
+      respond(msg.id, {
+        modes: { currentModeId: currentMode, availableModes: MODES },
+        configOptions: configOptions(),
+      });
+      advertiseCommands();
       break;
     case "session/set_mode":
+      currentMode = msg.params.modeId;
       notify({ sessionUpdate: "current_mode_update", currentModeId: msg.params.modeId });
       respond(msg.id, {});
+      break;
+    case "session/set_config_option":
+      if (msg.params.configId === "model") currentModel = msg.params.value;
+      if (msg.params.configId === "thought_level") currentEffort = msg.params.value;
+      if (msg.params.configId === "mode") currentMode = msg.params.value;
+      if (msg.params.configId === "fast-mode") fastMode = msg.params.value;
+      respond(msg.id, { configOptions: configOptions() });
       break;
     case "session/prompt":
       handlePrompt(msg.id, msg.params);

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -156,6 +156,124 @@ fn count_kind(blocks: &[Value], kind: &str) -> usize {
     blocks.iter().filter(|b| b["kind"] == kind).count()
 }
 
+async fn poll_metadata(ts: &TestServer, id: &str, timeout: Duration) -> Value {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let chat = ts
+            .client
+            .get(&format!("/api/sessions/{id}/chat"))
+            .await
+            .unwrap();
+        if chat["metadata"]["commands"]
+            .as_array()
+            .is_some_and(|commands| !commands.is_empty())
+        {
+            return chat["metadata"].clone();
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("ACP metadata was never advertised; last: {chat}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// The adapter owns command discovery and live permission/model/reasoning
+/// controls. The `/chat` snapshot exposes the initial state, a config write
+/// waits for the ACP response, and the refreshed full option set is returned
+/// and broadcast over SSE.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn composer_metadata_and_config_options_round_trip() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-meta", None, None).await;
+
+    let metadata = poll_metadata(&ts, "acp-meta", Duration::from_secs(5)).await;
+    let commands = metadata["commands"].as_array().unwrap();
+    assert!(commands.iter().any(|command| command["name"] == "resume"));
+    assert!(commands.iter().any(|command| {
+        command["name"] == "review" && command["input"]["hint"] == "instructions"
+    }));
+    let options = metadata["config_options"].as_array().unwrap();
+    assert!(options
+        .iter()
+        .any(|option| { option["id"] == "model" && option["currentValue"] == "fake-fast" }));
+    assert!(options.iter().any(|option| {
+        option["category"] == "thought_level" && option["currentValue"] == "medium"
+    }));
+    assert!(options
+        .iter()
+        .any(|option| { option["category"] == "mode" && option["currentValue"] == "default" }));
+    assert!(options
+        .iter()
+        .any(|option| { option["id"] == "fast-mode" && option["currentValue"] == false }));
+
+    let mut rx = ts
+        .state
+        .acp
+        .get("acp-meta")
+        .expect("task registered")
+        .subscribe();
+    let changed = ts
+        .client
+        .put(
+            "/api/sessions/acp-meta/config/model",
+            json!({ "value": "fake-deep" }),
+        )
+        .await
+        .expect("model config changes");
+    assert_eq!(changed["value"], "fake-deep");
+    assert!(changed["metadata"]["config_options"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|option| option["id"] == "model" && option["currentValue"] == "fake-deep"));
+
+    let events = drain_events(&mut rx, Duration::from_secs(5), |event| {
+        event.event == "metadata"
+            && event.data["config_options"]
+                .as_array()
+                .is_some_and(|options| {
+                    options.iter().any(|option| {
+                        option["id"] == "model" && option["currentValue"] == "fake-deep"
+                    })
+                })
+    })
+    .await;
+    assert!(
+        events.iter().any(|event| event.event == "metadata"),
+        "the refreshed option set was broadcast: {events:?}"
+    );
+
+    let changed = ts
+        .client
+        .put(
+            "/api/sessions/acp-meta/config/mode",
+            json!({ "value": "acceptEdits" }),
+        )
+        .await
+        .expect("permission posture changes");
+    assert!(changed["metadata"]["config_options"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|option| option["id"] == "mode" && option["currentValue"] == "acceptEdits"));
+    let session = session_mod::get(&ts.state.db, "acp-meta")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(session.current_mode.as_deref(), Some("acceptEdits"));
+
+    let changed = ts
+        .client
+        .put(
+            "/api/sessions/acp-meta/config/fast-mode",
+            json!({ "value": true }),
+        )
+        .await
+        .expect("boolean config changes");
+    assert_eq!(changed["value"], true);
+}
+
 /// 1. New session end to end: prompt → journal has user_message + agent_message +
 ///    turn_end; SSE delivered delta + block + turn events.
 #[serial]

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -258,6 +258,92 @@ test.describe('acp conversation', () => {
     });
   });
 
+  test('discovers slash commands from the agent and forwards them', async ({ page, weaver }) => {
+    await openAcp(page, weaver, { goal: 'say:ready' });
+    const input = page.getByTestId('acp-composer-input');
+
+    await input.fill('/');
+    const menu = page.getByTestId('acp-command-menu');
+    await expect(menu.getByText('/resume', { exact: true })).toBeVisible();
+    await expect(menu.getByText('/review', { exact: true })).toBeVisible();
+    await menu.getByText('/review', { exact: true }).click();
+    await expect(input).toHaveValue('/review ');
+    await expect(input).toHaveAttribute('placeholder', 'instructions');
+
+    // `/resume` belongs to the adapter, not loom: it is sent as a real prompt
+    // and appears once in the durable transcript.
+    await input.fill('/resume');
+    await page.getByTestId('acp-composer-send').click();
+    await expect(page.getByTestId('acp-conversation').getByText('/resume', { exact: true })).toBeVisible();
+  });
+
+  test('permission, model, and effort pills change the live agent config', async ({ page, weaver }) => {
+    await openAcp(page, weaver, { goal: 'say:ready' });
+
+    const permissions = page.getByTestId('acp-config-mode');
+    await expect(permissions).toContainText('Permissions');
+    await expect(permissions).toContainText('Default');
+    await permissions.getByRole('button').first().click();
+    await page.getByTestId('acp-config-menu').getByText('Accept edits', { exact: true }).click();
+    await expect(permissions).toContainText('Accept edits');
+
+    const model = page.getByTestId('acp-config-model');
+    await expect(model).toContainText('Fake fast');
+    await model.getByRole('button').first().click();
+    await page.getByTestId('acp-config-menu').getByText('Fake deep', { exact: true }).click();
+    await expect(model).toContainText('Fake deep');
+
+    const effort = page.getByTestId('acp-config-thought_level');
+    await expect(effort).toContainText('Medium');
+    await effort.getByRole('button').first().click();
+    await page.getByTestId('acp-config-menu').getByText('High', { exact: true }).click();
+    await expect(effort).toContainText('High');
+
+    const fast = page.getByTestId('acp-config-fast-mode');
+    await expect(fast).toContainText('Off');
+    await fast.getByRole('button').click();
+    await expect(fast).toContainText('On');
+  });
+
+  test('/clear is a local Chat hook that starts with a clean transcript', async ({ page, weaver }) => {
+    const s = await launchAcpSession(weaver, { goal: 'say:old concierge context', name: 'chat-clear' });
+    test.skip(s === null, SKIP_MSG);
+    const fresh = { ...s!, id: 'fresh-concierge', term_session: 'fresh-concierge' };
+    let resetCalls = 0;
+    await page.route('**/api/chat', (route) => route.fulfill({ json: s }));
+    await page.route('**/api/chat/reset', (route) => {
+      resetCalls += 1;
+      return route.fulfill({ json: fresh });
+    });
+    await page.route('**/api/sessions/fresh-concierge/chat', (route) =>
+      route.fulfill({
+        json: {
+          blocks: [],
+          live_turn: null,
+          metadata: { commands: [], config_options: [], modes: [] },
+        },
+      }),
+    );
+    await page.route('**/api/sessions/fresh-concierge/chat/stream', (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+        body: '',
+      }),
+    );
+
+    await page.goto(`${weaver.baseUrl}/chat`);
+    await expect(page.getByText('old concierge context', { exact: true })).toBeVisible();
+    const input = page.getByTestId('acp-composer-input');
+    await input.fill('/');
+    await page.getByTestId('acp-command-menu').getByText('/clear', { exact: true }).click();
+    await page.getByTestId('acp-composer-send').click();
+
+    await expect(page.getByTestId('acp-empty')).toBeVisible();
+    await expect(page.getByText('old concierge context', { exact: true })).toHaveCount(0);
+    expect(resetCalls).toBe(1);
+  });
+
   test('a permission card answers and collapses to a receipt', async ({ page, weaver }) => {
     // A supervised mode surfaces the request as an interactive card (bypass mode
     // would auto-answer it).

--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -82,6 +82,10 @@ test.describe('creating a session via the UI form', () => {
   });
 
   test('agent selection drives model and effort choices', async ({ page, weaver }) => {
+    const registry = (await (await fetch(`${weaver.baseUrl}/api/agents`)).json()) as {
+      agents: { kind: string; models: { label: string }[]; efforts: { label: string }[] }[];
+    };
+    const codex = registry.agents.find((agent) => agent.kind === 'codex')!;
     await page.goto(weaver.baseUrl);
     await page.getByRole('button', { name: 'New session' }).click();
 
@@ -99,15 +103,16 @@ test.describe('creating a session via the UI form', () => {
     await expect(form.getByRole('button', { name: 'Max' })).toBeVisible();
 
     await form.getByRole('radio', { name: /Codex/ }).click();
-    await expect(form.getByRole('button', { name: 'GPT-5.5' })).toBeVisible();
-    await expect(form.getByRole('button', { name: 'GPT-5.4', exact: true })).toBeVisible();
-    await expect(form.getByRole('button', { name: 'GPT-5.4 Mini' })).toBeVisible();
-    await expect(form.getByRole('button', { name: 'GPT-5.3 Codex Spark' })).toBeVisible();
+    for (const model of codex.models) {
+      await expect(form.getByRole('button', { name: model.label, exact: true })).toBeVisible();
+    }
+    for (const effort of codex.efforts) {
+      await expect(form.getByRole('button', { name: effort.label, exact: true })).toBeVisible();
+    }
     await expect(form.getByRole('button', { name: 'Haiku' })).toHaveCount(0);
     await expect(form.getByRole('button', { name: 'Sonnet' })).toHaveCount(0);
     await expect(form.getByRole('button', { name: 'Opus' })).toHaveCount(0);
     await expect(form.getByRole('button', { name: 'Fable' })).toHaveCount(0);
-    await expect(form.getByRole('button', { name: 'Max' })).toHaveCount(0);
   });
 
   test('Cancel hides the form again', async ({ page, weaver }) => {

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -2,6 +2,10 @@ import { test, expect } from '../fixtures/weaver';
 
 test.describe('settings · agent defaults', () => {
   test('agent settings use registry-backed model and effort choices', async ({ page, weaver }) => {
+    const registry = (await (await fetch(`${weaver.baseUrl}/api/agents`)).json()) as {
+      agents: { kind: string; models: { label: string }[]; efforts: { label: string }[] }[];
+    };
+    const codex = registry.agents.find((agent) => agent.kind === 'codex')!;
     await page.goto(`${weaver.baseUrl}/settings`);
 
     const session = page.locator('section').filter({
@@ -16,12 +20,13 @@ test.describe('settings · agent defaults', () => {
     await expect(session.getByRole('radio', { name: /Shell/ })).toBeVisible();
 
     await session.getByRole('radio', { name: /Codex/ }).click();
-    await expect(session.getByRole('button', { name: 'GPT-5.5' })).toBeVisible();
-    await expect(session.getByRole('button', { name: 'GPT-5.4', exact: true })).toBeVisible();
-    await expect(session.getByRole('button', { name: 'GPT-5.4 Mini' })).toBeVisible();
-    await expect(session.getByRole('button', { name: 'GPT-5.3 Codex Spark' })).toBeVisible();
+    for (const model of codex.models) {
+      await expect(session.getByRole('button', { name: model.label, exact: true })).toBeVisible();
+    }
+    for (const effort of codex.efforts) {
+      await expect(session.getByRole('button', { name: effort.label, exact: true })).toBeVisible();
+    }
     await expect(session.getByRole('button', { name: 'Haiku' })).toHaveCount(0);
-    await expect(session.getByRole('button', { name: 'Max' })).toHaveCount(0);
 
     await session.getByRole('radio', { name: /Claude/ }).click();
     await expect(session.getByRole('button', { name: 'Haiku' })).toBeVisible();
@@ -35,10 +40,11 @@ test.describe('settings · agent defaults', () => {
     await expect(concierge.getByRole('radio', { name: /Shell/ })).toHaveCount(0);
 
     await concierge.getByRole('radio', { name: /Codex/ }).click();
-    await expect(concierge.getByRole('button', { name: 'GPT-5.5' })).toBeVisible();
-    await expect(concierge.getByRole('button', { name: 'GPT-5.4', exact: true })).toBeVisible();
-    await expect(concierge.getByRole('button', { name: 'GPT-5.4 Mini' })).toBeVisible();
-    await expect(concierge.getByRole('button', { name: 'GPT-5.3 Codex Spark' })).toBeVisible();
-    await expect(concierge.getByRole('button', { name: 'Max' })).toHaveCount(0);
+    for (const model of codex.models) {
+      await expect(concierge.getByRole('button', { name: model.label, exact: true })).toBeVisible();
+    }
+    for (const effort of codex.efforts) {
+      await expect(concierge.getByRole('button', { name: effort.label, exact: true })).toBeVisible();
+    }
   });
 });


### PR DESCRIPTION
Expose ACP-owned slash commands and live session configuration in the chat composer, including permission, model, reasoning effort, and boolean controls. Configuration changes wait for the agent acknowledgment and reconcile from its full option set, while /clear remains a local concierge hook and other commands are forwarded.

Refresh Codex model and effort choices from the installed CLI bundled catalog so Settings follows the runtime instead of a stale hard-coded list, with a fallback for older CLIs.

The branch includes the latest origin/main handoff work and keeps metadata synchronized across provider changes.

Fixes #155