### PR TITLE
feat(loom): steer prompts into live ACP turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ re-poll on demand.
 Every session detail has a **Conversation** tab that renders the agent's chat
 with the model — user turns, replies, thinking, and tool calls — live and
 (via the archive capture below) still there to review after the terminal is gone.
+For ACP sessions, a prompt submitted while the agent is working steers the live
+turn when the adapter supports steering; otherwise loom safely queues it as the
+next turn.
 
 Whenever a session is archived — by the Archive button or automatically on merge
 — loom first captures that conversation to disk: it finds the agent's transcript

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -272,9 +272,9 @@ import type { ChatSnapshot, PromptAck } from './types';
  *  terminal session 409s (it has no chat journal). */
 export const getSessionChat = (id: string) => get(`/sessions/${id}/chat`) as Promise<ChatSnapshot>;
 
-/** Send a user message to an ACP session (`session/prompt`). Returns 202 with
- *  `{ queued, turn }` — `queued` when a turn was already in flight (the message
- *  joins the durable queue for the next turn). */
+/** Send a user message to an ACP session. Returns 202 with
+ *  `{ queued, steered, turn }`: a live turn is steered when the adapter supports
+ *  it, with the durable next-turn queue retained as the fallback. */
 export const promptSession = (id: string, text: string, by?: string) =>
   post(`/sessions/${id}/prompt`, { text, by }) as Promise<PromptAck>;
 

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -63,7 +63,8 @@ const shadows = reactive(
 const liveTools = reactive(new Map<string, SseTool>());
 const turnLive = ref(false);
 const liveTurnNo = ref<number | null>(null);
-const optimistic = ref<{ text: string; queued: boolean }[]>([]);
+const optimistic = ref<{ key: number; text: string; state: 'sent' | 'steered' | 'queued' }[]>([]);
+let nextOptimisticKey = 0;
 
 // The live mode, seeded from the session and advanced by `mode_change` blocks or
 // a local set — so the composer chip reads true without a refetch.
@@ -158,7 +159,7 @@ function onTurn(ev: SseTurn) {
   } else {
     turnLive.value = false;
     liveTurnNo.value = null;
-    optimistic.value = optimistic.value.filter((o) => o.queued);
+    optimistic.value = optimistic.value.filter((o) => o.state === 'queued');
   }
 }
 
@@ -228,12 +229,20 @@ async function submitPrompt() {
   sending.value = true;
   sendError.value = '';
   const text = draft.value;
+  const pending = { key: nextOptimisticKey++, text, state: 'sent' as const };
+  optimistic.value.push(pending);
+  autoFollow();
   try {
     const ack = await promptSession(id.value, text);
-    optimistic.value.push({ text, queued: ack.queued });
+    const index = optimistic.value.findIndex((o) => o.key === pending.key);
+    if (index >= 0) {
+      optimistic.value[index].state = ack.queued ? 'queued' : ack.steered ? 'steered' : 'sent';
+    }
     draft.value = '';
     autoFollow();
   } catch (e) {
+    const index = optimistic.value.findIndex((o) => o.key === pending.key);
+    if (index >= 0) optimistic.value.splice(index, 1);
     sendError.value = (e as Error).message ?? 'Failed to send';
   } finally {
     sending.value = false;
@@ -318,7 +327,16 @@ interface ActivityItem {
 
 type Row =
   | { type: 'turnRule'; key: string; turn: number; stop: string; ctx: number | null; loud: boolean }
-  | { type: 'user'; key: string; anchor: string; n: number; time: string; text: string }
+  | {
+      type: 'user';
+      key: string;
+      anchor: string;
+      n: number;
+      turn: number;
+      time: string;
+      text: string;
+      steered: boolean;
+    }
   | { type: 'agent'; key: string; time: string; text: string; streaming: boolean }
   | { type: 'thought'; key: string; text: string; streaming: boolean }
   | { type: 'activity'; key: string; items: ActivityItem[]; failures: number }
@@ -391,11 +409,22 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
     switch (b.kind) {
       case 'user_message': {
         flushActivity();
-        n += 1;
-        const anchor = `acp-turn-${b.turn}`;
-        const text = (b.payload as unknown as UserMessagePayload).text ?? '';
-        rows.push({ type: 'user', key: k, anchor, n, time: shortTime(b.created_at), text });
-        toc.push({ anchor, n, title: titleOf(text) });
+        const user = b.payload as unknown as UserMessagePayload;
+        const steered = user.steered === true;
+        if (!steered) n += 1;
+        const anchor = steered ? `acp-steer-${b.turn}-${b.seq}` : `acp-turn-${b.turn}`;
+        const text = user.text ?? '';
+        rows.push({
+          type: 'user',
+          key: k,
+          anchor,
+          n,
+          turn: b.turn,
+          time: shortTime(b.created_at),
+          text,
+          steered,
+        });
+        if (!steered) toc.push({ anchor, n, title: titleOf(text) });
         break;
       }
       case 'agent_message':
@@ -698,6 +727,9 @@ function goTo(anchor: string) {
             >
               <header class="acp-rule">
                 <span class="acp-label text-accent">You</span>
+                <span v-if="row.steered" class="acp-queued" data-testid="acp-steered"
+                  >steered turn {{ row.turn + 1 }}</span
+                >
                 <span class="acp-time">{{ row.time }}</span>
               </header>
               <MarkdownView :id="id" path="" :source="row.text" />
@@ -850,15 +882,18 @@ function goTo(anchor: string) {
 
           <!-- Optimistic (in-flight / queued) user messages. -->
           <section
-            v-for="(o, i) in optimistic"
-            :key="`opt-${i}`"
+            v-for="o in optimistic"
+            :key="`opt-${o.key}`"
             class="acp-speaker"
             data-testid="acp-optimistic"
           >
             <header class="acp-rule">
               <span class="acp-label text-accent">You</span>
-              <span v-if="o.queued" class="acp-queued" data-testid="acp-queued"
+              <span v-if="o.state === 'queued'" class="acp-queued" data-testid="acp-queued"
                 >queued for next turn</span
+              >
+              <span v-else-if="o.state === 'steered'" class="acp-queued" data-testid="acp-steered"
+                >steering current turn</span
               >
             </header>
             <MarkdownView :id="id" path="" :source="o.text" />

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -727,7 +727,7 @@ function goTo(anchor: string) {
             >
               <header class="acp-rule">
                 <span class="acp-label text-accent">You</span>
-                <span v-if="row.steered" class="acp-queued" data-testid="acp-steered"
+                <span v-if="row.steered" class="acp-prompt-state" data-testid="acp-steered"
                   >steered turn {{ row.turn + 1 }}</span
                 >
                 <span class="acp-time">{{ row.time }}</span>
@@ -889,10 +889,13 @@ function goTo(anchor: string) {
           >
             <header class="acp-rule">
               <span class="acp-label text-accent">You</span>
-              <span v-if="o.state === 'queued'" class="acp-queued" data-testid="acp-queued"
+              <span v-if="o.state === 'queued'" class="acp-prompt-state" data-testid="acp-queued"
                 >queued for next turn</span
               >
-              <span v-else-if="o.state === 'steered'" class="acp-queued" data-testid="acp-steered"
+              <span
+                v-else-if="o.state === 'steered'"
+                class="acp-prompt-state"
+                data-testid="acp-steered"
                 >steering current turn</span
               >
             </header>
@@ -1073,7 +1076,7 @@ function goTo(anchor: string) {
   color: var(--faint);
   font-variant-numeric: tabular-nums;
 }
-.acp-queued {
+.acp-prompt-state {
   font-family: var(--font-mono);
   font-size: 0.6875rem;
   color: var(--attn);

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -168,6 +168,7 @@ export interface ChatSnapshot {
 export interface UserMessagePayload {
   text: string;
   by: string | null;
+  steered?: boolean;
 }
 export interface AgentMessagePayload {
   text: string;
@@ -266,10 +267,11 @@ export interface SseTurn {
   stop_reason?: string;
 }
 
-/** `POST /sessions/{id}/prompt` 202 body: whether the message queued behind a
- *  live turn, and the turn it belongs to. */
+/** `POST /sessions/{id}/prompt` 202 body: whether the message steered the live
+ *  turn, queued behind it, or started normally, plus the turn it belongs to. */
 export interface PromptAck {
   queued: boolean;
+  steered: boolean;
   turn: number | null;
 }
 

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -1179,31 +1179,43 @@ impl Task {
                     self.begin_external_turn(pending).await;
                 }
             }
-            _ => self.fallback_prompt(pending).await,
+            (outcome, error) => {
+                tracing::warn!(
+                    session = %self.session_id,
+                    ?outcome,
+                    ?error,
+                    "steering failed; falling back to ordinary prompt handling"
+                );
+                self.fallback_prompt(pending).await;
+            }
         }
     }
 
     async fn fallback_prompt(&mut self, pending: PendingSteer) {
-        if self.turn_live {
-            let ack = session::append_pending_prompt(&self.db, &self.session_id, &pending.text)
-                .await
-                .map(|_| PromptAck {
-                    queued: true,
-                    steered: false,
-                    turn: Some(self.current_turn),
-                });
-            let _ = pending.reply.send(ack);
+        let ack = if self.turn_live {
+            self.queue_prompt(&pending.text).await
         } else {
-            let ack = self
-                .start_turn(pending.text, pending.by)
-                .await
-                .map(|_| PromptAck {
-                    queued: false,
-                    steered: false,
-                    turn: Some(self.current_turn),
-                });
-            let _ = pending.reply.send(ack);
-        }
+            self.start_prompt(pending.text, pending.by).await
+        };
+        let _ = pending.reply.send(ack);
+    }
+
+    async fn queue_prompt(&self, text: &str) -> Result<PromptAck> {
+        session::append_pending_prompt(&self.db, &self.session_id, text).await?;
+        Ok(PromptAck {
+            queued: true,
+            steered: false,
+            turn: Some(self.current_turn),
+        })
+    }
+
+    async fn start_prompt(&mut self, text: String, by: Option<String>) -> Result<PromptAck> {
+        self.start_turn(text, by).await?;
+        Ok(PromptAck {
+            queued: false,
+            steered: false,
+            turn: Some(self.current_turn),
+        })
     }
 
     async fn begin_external_turn(&mut self, pending: PendingSteer) {
@@ -1422,21 +1434,11 @@ impl Task {
                     } else {
                         // A failed queue write must surface — a 202 that silently
                         // dropped the prompt would be worse than an error.
-                        let ack = session::append_pending_prompt(&self.db, &self.session_id, &text)
-                            .await
-                            .map(|_| PromptAck {
-                                queued: true,
-                                steered: false,
-                                turn: Some(self.current_turn),
-                            });
+                        let ack = self.queue_prompt(&text).await;
                         let _ = reply.send(ack);
                     }
                 } else {
-                    let ack = self.start_turn(text, by).await.map(|_| PromptAck {
-                        queued: false,
-                        steered: false,
-                        turn: Some(self.current_turn),
-                    });
+                    let ack = self.start_prompt(text, by).await;
                     let _ = reply.send(ack);
                 }
             }

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -99,11 +99,13 @@ pub struct AcpLaunch {
     pub goal: Option<String>,
 }
 
-/// Whether a prompt was queued (a turn was already in flight) plus the turn it
-/// belongs to — the `POST /prompt` 202 body.
+/// How a prompt was accepted plus the turn it belongs to — the `POST /prompt`
+/// 202 body. `steered` is true only when the adapter injected it into the
+/// already-running turn; unsupported adapters retain the durable queue.
 #[derive(Debug, Clone, Serialize)]
 pub struct PromptAck {
     pub queued: bool,
+    pub steered: bool,
     pub turn: Option<i64>,
 }
 
@@ -140,8 +142,9 @@ impl AcpHandle {
         self.events_tx.subscribe()
     }
 
-    /// Send a user message: dispatched as a `session/prompt` when idle, appended
-    /// to the durable queue when a turn is in flight.
+    /// Send a user message: dispatched as a `session/prompt` when idle, steered
+    /// into a live turn when the adapter advertises support, or appended to the
+    /// durable queue otherwise.
     pub async fn prompt(&self, text: String, by: Option<String>) -> Result<PromptAck> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
@@ -528,6 +531,14 @@ struct PendingPerm {
     frame_seq: u64,
 }
 
+/// A `_session/steering` request waiting for the adapter's acceptance response.
+struct PendingSteer {
+    text: String,
+    by: Option<String>,
+    turn: i64,
+    reply: oneshot::Sender<Result<PromptAck>>,
+}
+
 struct Task {
     db: Db,
     /// The loom event bus — used to drive the turn-boundary status/idle lifecycle
@@ -561,6 +572,15 @@ struct Task {
     current_mode: Option<String>,
     #[allow(dead_code)]
     load_session_cap: bool,
+    /// codex-acp advertises this experimental extension in
+    /// `_meta.steering.supported`; other adapters keep queue semantics.
+    steering_cap: bool,
+    pending_steers: HashMap<u64, PendingSteer>,
+    /// A turn started internally by the steering extension after the previous
+    /// turn raced to completion. It has no `session/prompt` response id, so its
+    /// end is taken from codex-acp's `session_info_update` idle edge.
+    external_turn: bool,
+    pending_external: Option<PendingSteer>,
     /// Latched for the duration of a `session/load` replay: the adapter re-streams
     /// the whole conversation as `session/update` notifications, but we already
     /// hold it in the journal, so journal writes are suppressed (and the seq
@@ -608,6 +628,10 @@ impl Task {
             pending_perms: HashMap::new(),
             current_mode: None,
             load_session_cap: false,
+            steering_cap: false,
+            pending_steers: HashMap::new(),
+            external_turn: false,
+            pending_external: None,
             suppress_journal: false,
             highest_seq: 0,
             acked: 0,
@@ -626,12 +650,23 @@ impl Task {
         let (max_turn, max_seq) = chat::max_turn_seq(&state.db, &session.id)
             .await?
             .unwrap_or((0, -1));
-        let inflight = session
+        let inflight_value = session
             .acp_inflight
             .as_deref()
-            .and_then(|s| serde_json::from_str::<Value>(s).ok())
+            .and_then(|s| serde_json::from_str::<Value>(s).ok());
+        let live_turn = inflight_value
+            .as_ref()
+            .and_then(|v| v.get("turn"))
+            .and_then(Value::as_i64);
+        let external_turn = inflight_value
+            .as_ref()
+            .and_then(|v| v.get("external"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let inflight = inflight_value
+            .as_ref()
             .and_then(|v| Some((v.get("prompt_id")?.as_u64()?, v.get("turn")?.as_i64()?)));
-        let current_turn = inflight.map(|(_, t)| t).unwrap_or(max_turn);
+        let current_turn = live_turn.unwrap_or(max_turn);
         // The journal always holds at least this turn's `user_message`, so
         // `max_seq + 1` continues the turn without colliding.
         let next_seq = max_seq + 1;
@@ -652,12 +687,16 @@ impl Task {
             current_turn,
             next_seq,
             turns_dispatched,
-            turn_live: inflight.is_some(),
+            turn_live: live_turn.is_some(),
             buf: None,
             tools: HashMap::new(),
             pending_perms: HashMap::new(),
             current_mode: session.current_mode.clone(),
             load_session_cap: false,
+            steering_cap: false,
+            pending_steers: HashMap::new(),
+            external_turn,
+            pending_external: None,
             suppress_journal: false,
             highest_seq: session.acp_ack_seq.max(0) as u64,
             acked: session.acp_ack_seq.max(0) as u64,
@@ -692,6 +731,7 @@ impl Task {
         let res = res.ok_or_else(|| anyhow!("initialize failed: {err:?}"))?;
         if let Ok(init) = serde_json::from_value::<wire::InitializeResult>(res) {
             self.load_session_cap = init.agent_capabilities.load_session;
+            self.steering_cap = init.meta.steering.supported;
         }
 
         match &launch.new_or_load {
@@ -932,6 +972,26 @@ impl Task {
                 self.journal_block(kind::USAGE, json!({ "used": used, "size": size }))
                     .await;
             }
+            SessionUpdate::SessionInfoUpdate { meta } => {
+                let status = meta
+                    .codex
+                    .and_then(|codex| codex.thread_status)
+                    .map(|s| s.kind);
+                if self.external_turn && matches!(status.as_deref(), Some("idle" | "systemError")) {
+                    self.external_turn = false;
+                    let reason = if status.as_deref() == Some("systemError") {
+                        "error"
+                    } else {
+                        "end_turn"
+                    };
+                    self.on_turn_end(
+                        self.current_turn,
+                        Some(json!({ "stopReason": reason })),
+                        None,
+                    )
+                    .await;
+                }
+            }
             SessionUpdate::Other => {}
         }
         Ok(())
@@ -991,6 +1051,11 @@ impl Task {
         let Some(id) = inc.id.as_ref().and_then(Value::as_u64) else {
             return;
         };
+        if let Some(pending) = self.pending_steers.remove(&id) {
+            self.on_steering_response(pending, inc.result, inc.error)
+                .await;
+            return;
+        }
         if let Some((pid, turn)) = self.inflight_prompt {
             if id == pid {
                 self.on_turn_end(turn, inc.result, inc.error).await;
@@ -1044,6 +1109,25 @@ impl Task {
         // "resting, no one needed" state). Mirrors the terminal path's `Stop` hook.
         crate::monitor::record_acp_lifecycle(&self.db, &self.bus, &self.session_id, "idle").await;
 
+        // The steering extension may have raced this boundary and started the
+        // user's message as a fresh adapter-owned turn. Adopt it before the
+        // ordinary durable queue so prompts retain their arrival order.
+        if let Some(pending) = self.pending_external.take() {
+            self.begin_external_turn(pending).await;
+            return;
+        }
+
+        // A steering request can finish just after the original prompt. Let its
+        // response decide whether the adapter already started the next turn
+        // before dispatching any later, durably queued message.
+        if !self.pending_steers.is_empty() {
+            return;
+        }
+
+        self.dispatch_pending_prompt().await;
+    }
+
+    async fn dispatch_pending_prompt(&mut self) {
         // Dispatch the durable queue as the next turn, if non-empty.
         let pending = session::read_pending_prompt(&self.db, &self.session_id)
             .await
@@ -1052,6 +1136,110 @@ impl Task {
             let _ = session::clear_pending_prompt(&self.db, &self.session_id).await;
             let _ = self.start_turn(pending, None).await;
         }
+    }
+
+    async fn on_steering_response(
+        &mut self,
+        pending: PendingSteer,
+        result: Option<Value>,
+        error: Option<Value>,
+    ) {
+        let outcome = result
+            .and_then(|v| serde_json::from_value::<wire::SteeringResult>(v).ok())
+            .map(|r| r.outcome);
+        match (outcome, error) {
+            (Some(wire::SteeringOutcome::Injected), None) => {
+                // A steer belongs to the live turn rather than opening another
+                // item in the turn index. Journal it only after the adapter has
+                // accepted it; a rejected extension falls back without leaving
+                // a phantom message in the transcript.
+                self.current_turn = pending.turn;
+                let by = pending.by.map(Value::from).unwrap_or(Value::Null);
+                self.journal_block(
+                    kind::USER_MESSAGE,
+                    json!({ "text": pending.text, "by": by, "steered": true }),
+                )
+                .await;
+                let _ = pending.reply.send(Ok(PromptAck {
+                    queued: false,
+                    steered: true,
+                    turn: Some(pending.turn),
+                }));
+                if !self.turn_live {
+                    self.dispatch_pending_prompt().await;
+                }
+            }
+            (Some(wire::SteeringOutcome::StartedNewTurn), None) => {
+                if self.turn_live {
+                    // codex-acp waits for its old prompt to settle before taking
+                    // this branch. Keep the request until loom consumes that
+                    // prompt response, then adopt the already-started turn.
+                    self.pending_external = Some(pending);
+                } else {
+                    self.begin_external_turn(pending).await;
+                }
+            }
+            _ => self.fallback_prompt(pending).await,
+        }
+    }
+
+    async fn fallback_prompt(&mut self, pending: PendingSteer) {
+        if self.turn_live {
+            let ack = session::append_pending_prompt(&self.db, &self.session_id, &pending.text)
+                .await
+                .map(|_| PromptAck {
+                    queued: true,
+                    steered: false,
+                    turn: Some(self.current_turn),
+                });
+            let _ = pending.reply.send(ack);
+        } else {
+            let ack = self
+                .start_turn(pending.text, pending.by)
+                .await
+                .map(|_| PromptAck {
+                    queued: false,
+                    steered: false,
+                    turn: Some(self.current_turn),
+                });
+            let _ = pending.reply.send(ack);
+        }
+    }
+
+    async fn begin_external_turn(&mut self, pending: PendingSteer) {
+        let turn = if self.turns_dispatched > 0 {
+            self.current_turn + 1
+        } else {
+            self.current_turn
+        };
+        let inflight = json!({ "turn": turn, "external": true }).to_string();
+        let persisted = session::set_inflight(&self.db, &self.session_id, Some(&inflight)).await;
+        if let Err(e) = persisted {
+            let _ = pending.reply.send(Err(e));
+            return;
+        }
+        self.current_turn = turn;
+        self.next_seq = 0;
+        self.turns_dispatched += 1;
+        self.turn_live = true;
+        self.external_turn = true;
+        self.emit(
+            "turn",
+            json!({ "turn": self.current_turn, "state": "started" }),
+        );
+        let by = pending.by.map(Value::from).unwrap_or(Value::Null);
+        self.journal_block(
+            kind::USER_MESSAGE,
+            json!({ "text": pending.text, "by": by, "steered": false }),
+        )
+        .await;
+        crate::monitor::record_acp_lifecycle(&self.db, &self.bus, &self.session_id, "working")
+            .await;
+        let _ = pending.reply.send(Ok(PromptAck {
+            queued: false,
+            steered: false,
+            turn: Some(self.current_turn),
+        }));
     }
 
     async fn start_turn(&mut self, text: String, by: Option<String>) -> Result<()> {
@@ -1205,18 +1393,48 @@ impl Task {
         match cmd {
             Command::Prompt { text, by, reply } => {
                 if self.turn_live {
-                    // A failed queue write must surface — a 202 that silently
-                    // dropped the prompt would be worse than an error.
-                    let ack = session::append_pending_prompt(&self.db, &self.session_id, &text)
-                        .await
-                        .map(|_| PromptAck {
-                            queued: true,
-                            turn: Some(self.current_turn),
-                        });
-                    let _ = reply.send(ack);
+                    if self.steering_cap
+                        && self.pending_steers.is_empty()
+                        && self.pending_external.is_none()
+                    {
+                        let id = self.next_id();
+                        let request = wire::request_line(
+                            id,
+                            method::SESSION_STEERING,
+                            wire::steering_params(&self.acp_session_id, &text),
+                        );
+                        match self.stream.write(&request).await {
+                            Ok(()) => {
+                                self.pending_steers.insert(
+                                    id,
+                                    PendingSteer {
+                                        text,
+                                        by,
+                                        turn: self.current_turn,
+                                        reply,
+                                    },
+                                );
+                            }
+                            Err(e) => {
+                                let _ = reply.send(Err(e));
+                            }
+                        }
+                    } else {
+                        // A failed queue write must surface — a 202 that silently
+                        // dropped the prompt would be worse than an error.
+                        let ack = session::append_pending_prompt(&self.db, &self.session_id, &text)
+                            .await
+                            .map(|_| PromptAck {
+                                queued: true,
+                                steered: false,
+                                turn: Some(self.current_turn),
+                            });
+                        let _ = reply.send(ack);
+                    }
                 } else {
                     let ack = self.start_turn(text, by).await.map(|_| PromptAck {
                         queued: false,
+                        steered: false,
                         turn: Some(self.current_turn),
                     });
                     let _ = reply.send(ack);
@@ -1281,7 +1499,12 @@ impl Task {
 
     async fn on_exit(&mut self, status: Option<i32>) {
         tracing::warn!(session = %self.session_id, ?status, "acp agent exited");
-        if let Some((_, turn)) = self.inflight_prompt.take() {
+        let ending_turn = self
+            .inflight_prompt
+            .take()
+            .map(|(_, turn)| turn)
+            .or_else(|| self.external_turn.then_some(self.current_turn));
+        if let Some(turn) = ending_turn {
             self.flush_buf().await;
             if !chat::has_turn_end(&self.db, &self.session_id, turn)
                 .await
@@ -1295,6 +1518,7 @@ impl Task {
                 json!({ "turn": turn, "state": "ended", "stop_reason": "error" }),
             );
             self.turn_live = false;
+            self.external_turn = false;
             let _ = session::set_inflight(&self.db, &self.session_id, None).await;
         }
     }

--- a/crates/loom/src/acp/wire.rs
+++ b/crates/loom/src/acp/wire.rs
@@ -422,10 +422,8 @@ pub fn prompt_params(session_id: &str, text: &str) -> Value {
 
 /// codex-acp `_session/steering` params carrying a single text block.
 pub fn steering_params(session_id: &str, text: &str) -> Value {
-    serde_json::json!({
-        "sessionId": session_id,
-        "prompt": [ { "type": "text", "text": text } ],
-    })
+    // The extension deliberately uses ACP's ordinary text-prompt shape.
+    prompt_params(session_id, text)
 }
 
 /// `session/cancel` notification params.

--- a/crates/loom/src/acp/wire.rs
+++ b/crates/loom/src/acp/wire.rs
@@ -62,6 +62,8 @@ pub mod method {
     pub const SESSION_NEW: &str = "session/new";
     pub const SESSION_LOAD: &str = "session/load";
     pub const SESSION_PROMPT: &str = "session/prompt";
+    /// Experimental codex-acp extension for adding input to the active turn.
+    pub const SESSION_STEERING: &str = "_session/steering";
     pub const SESSION_CANCEL: &str = "session/cancel";
     pub const SESSION_SET_MODE: &str = "session/set_mode";
     pub const SESSION_UPDATE: &str = "session/update";
@@ -153,9 +155,35 @@ pub enum SessionUpdate {
         #[serde(default)]
         size: Option<u64>,
     },
-    /// Anything else (available_commands_update, session_info_update, …): ignored.
+    /// codex-acp's thread lifecycle. Loom normally owns turn boundaries through
+    /// the `session/prompt` response; this closes the rare turn that the
+    /// steering extension starts internally after racing an end-of-turn.
+    SessionInfoUpdate {
+        #[serde(default, rename = "_meta")]
+        meta: SessionInfoMeta,
+    },
+    /// Anything else (available_commands_update, …): ignored.
     #[serde(other)]
     Other,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SessionInfoMeta {
+    #[serde(default)]
+    pub codex: Option<CodexSessionInfo>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSessionInfo {
+    #[serde(default)]
+    pub thread_status: Option<ThreadStatus>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ThreadStatus {
+    #[serde(rename = "type")]
+    pub kind: String,
 }
 
 /// A content block. Only text is consumed; other types degrade to
@@ -308,12 +336,15 @@ pub struct PromptResult {
     pub stop_reason: String,
 }
 
-/// The `initialize` result — the agent's capabilities (we read `loadSession`).
+/// The `initialize` result — the standard agent capabilities plus extension
+/// metadata advertised by individual adapters.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeResult {
     #[serde(default)]
     pub agent_capabilities: AgentCapabilities,
+    #[serde(default, rename = "_meta")]
+    pub meta: InitializeMeta,
 }
 
 /// The subset of agent capabilities loom checks.
@@ -322,6 +353,33 @@ pub struct InitializeResult {
 pub struct AgentCapabilities {
     #[serde(default)]
     pub load_session: bool,
+}
+
+/// Adapter-specific capabilities carried in the initialize result's `_meta`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct InitializeMeta {
+    #[serde(default)]
+    pub steering: SteeringCapability,
+}
+
+/// The codex-acp steering capability (`_meta.steering.supported`).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SteeringCapability {
+    #[serde(default)]
+    pub supported: bool,
+}
+
+/// The result of codex-acp's `_session/steering` extension.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SteeringOutcome {
+    Injected,
+    StartedNewTurn,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SteeringResult {
+    pub outcome: SteeringOutcome,
 }
 
 // ---------------------------------------------------------------------------
@@ -356,6 +414,14 @@ pub fn load_session_params(session_id: &str, cwd: &str) -> Value {
 
 /// `session/prompt` params carrying a single text block.
 pub fn prompt_params(session_id: &str, text: &str) -> Value {
+    serde_json::json!({
+        "sessionId": session_id,
+        "prompt": [ { "type": "text", "text": text } ],
+    })
+}
+
+/// codex-acp `_session/steering` params carrying a single text block.
+pub fn steering_params(session_id: &str, text: &str) -> Value {
     serde_json::json!({
         "sessionId": session_id,
         "prompt": [ { "type": "text", "text": text } ],
@@ -578,6 +644,18 @@ mod tests {
 
         let pr: PromptResult = serde_json::from_value(json!({ "stopReason": "end_turn" })).unwrap();
         assert_eq!(pr.stop_reason, "end_turn");
+
+        let init: InitializeResult = serde_json::from_value(json!({
+            "agentCapabilities": { "loadSession": true },
+            "_meta": { "steering": { "supported": true } },
+        }))
+        .unwrap();
+        assert!(init.agent_capabilities.load_session);
+        assert!(init.meta.steering.supported);
+
+        let steer: SteeringResult =
+            serde_json::from_value(json!({ "outcome": "startedNewTurn" })).unwrap();
+        assert_eq!(steer.outcome, SteeringOutcome::StartedNewTurn);
     }
 
     #[test]
@@ -588,6 +666,16 @@ mod tests {
         assert_eq!(v["method"], "initialize");
         assert_eq!(v["id"], 1);
         assert_eq!(v["params"]["protocolVersion"], 1);
+
+        let steer = request_line(
+            2,
+            method::SESSION_STEERING,
+            steering_params("sess-1", "pivot"),
+        );
+        let v: Value = serde_json::from_slice(&steer[..steer.len() - 1]).unwrap();
+        assert_eq!(v["method"], "_session/steering");
+        assert_eq!(v["params"]["sessionId"], "sess-1");
+        assert_eq!(v["params"]["prompt"][0]["text"], "pivot");
 
         let resp = response_line(&json!(7), permission_selected("allow-once"));
         let v: Value = serde_json::from_slice(&resp[..resp.len() - 1]).unwrap();

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2422,9 +2422,9 @@ pub(super) async fn send_session(
     Json(req): Json<SendReq>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
-    // For an ACP session a send *is* a `session/prompt` (queued when a turn is in
-    // flight): delegate to the prompt queue, keeping the same `nudge` audit. This
-    // is what makes `loom session send` work uniformly across both backends.
+    // For an ACP session a send is a prompt (steered into a supported live turn,
+    // otherwise queued): delegate to the ACP task while keeping the same `nudge`
+    // audit. This makes `loom session send` uniform across both backends.
     if session.protocol == "acp" {
         let handle = require_acp_task(&st, &session)?;
         let by = author_or_manual(req.by.as_deref());
@@ -2441,9 +2441,13 @@ pub(super) async fn send_session(
         )
         .await
         .ok();
-        return Ok(Json(
-            json!({ "sent": true, "submitted": true, "queued": ack.queued, "turn": ack.turn }),
-        ));
+        return Ok(Json(json!({
+            "sent": true,
+            "submitted": true,
+            "queued": ack.queued,
+            "steered": ack.steered,
+            "turn": ack.turn,
+        })));
     }
     require_live_terminal(&session).await?;
     backend::paste(&session.term_session, &req.text)
@@ -2528,7 +2532,7 @@ pub(super) async fn preview_session(
 //
 // The conversation-first surface for ACP sessions: the journaled transcript
 // (`/chat`), its live delta stream (`/chat/stream`), and the drive routes a
-// person or watch uses — a `session/prompt` queueing send (`/prompt`), a
+// person or watch uses — a steering/queueing send (`/prompt`), a
 // permission answer (`/permissions/{request_id}`), and a mode change (`/mode`).
 // ---------------------------------------------------------------------------
 
@@ -2750,8 +2754,9 @@ pub(super) struct PromptBody {
 }
 
 /// Send a user message to an ACP session: dispatched as a `session/prompt` when
-/// idle, appended to the durable queue when a turn is in flight. Returns 202
-/// `{ queued, turn }`. Every send records a `nudge` event (the audit rule).
+/// idle, steered into a live turn when supported, or appended to the durable
+/// queue otherwise. Returns 202 `{ queued, steered, turn }`. Every send records
+/// a `nudge` event (the audit rule).
 pub(super) async fn prompt_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
@@ -2776,7 +2781,11 @@ pub(super) async fn prompt_session(
     .ok();
     Ok((
         StatusCode::ACCEPTED,
-        Json(json!({ "queued": ack.queued, "turn": ack.turn })),
+        Json(json!({
+            "queued": ack.queued,
+            "steered": ack.steered,
+            "turn": ack.turn,
+        })),
     ))
 }
 

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -30,6 +30,11 @@ const JSONRPC = "2.0";
 let sessionId = null;
 let sessionCounter = 0;
 let cancelled = false;
+const steeringSupported = process.env.FAKE_ACP_STEERING === "1";
+const forceSteeringNewTurn = process.env.FAKE_ACP_STEERING_FORCE_NEW_TURN === "1";
+let promptActive = false;
+const steeringQueue = [];
+let deferredSteering = null;
 const pending = new Map(); // our request id -> resolver awaiting the client's response
 
 function send(obj) {
@@ -145,6 +150,13 @@ async function runToken(tok) {
 
 async function handlePrompt(id, params) {
   cancelled = false;
+  promptActive = true;
+  if (steeringSupported) {
+    notify({
+      sessionUpdate: "session_info_update",
+      _meta: { codex: { threadStatus: { type: "active" } } },
+    });
+  }
   // The script is the prompt's first paragraph only. A real launch prompt
   // appends orientation prose (the entrance note, which echoes the session
   // title — i.e. the script itself) after a blank line; parsing past it would
@@ -157,8 +169,43 @@ async function handlePrompt(id, params) {
     if (cancelled) break;
     if (tok.length === 0) continue;
     await runToken(tok);
+    while (steeringQueue.length > 0 && !cancelled) {
+      const steering = steeringQueue.shift();
+      for (const steeringToken of steering.split("|")) {
+        if (steeringToken.length > 0) await runToken(steeringToken);
+      }
+    }
   }
-  respond(id, { stopReason: cancelled ? "cancelled" : "end_turn" });
+  promptActive = false;
+  if (id !== null) respond(id, { stopReason: cancelled ? "cancelled" : "end_turn" });
+  if (steeringSupported) {
+    notify({
+      sessionUpdate: "session_info_update",
+      _meta: { codex: { threadStatus: { type: "idle" } } },
+    });
+  }
+  if (deferredSteering !== null) {
+    const next = deferredSteering;
+    deferredSteering = null;
+    void handlePrompt(null, next.params);
+    respond(next.id, { outcome: "startedNewTurn" });
+  }
+}
+
+function handleSteering(id, params) {
+  const text = (params.prompt || []).map((b) => b.text || "").join("");
+  if (!promptActive || forceSteeringNewTurn) {
+    if (promptActive) {
+      deferredSteering = { id, params };
+    } else {
+      void handlePrompt(null, params);
+      respond(id, { outcome: "startedNewTurn" });
+    }
+    return;
+  }
+  notify({ sessionUpdate: "user_message_chunk", content: { type: "text", text } });
+  steeringQueue.push(text);
+  respond(id, { outcome: "injected" });
 }
 
 function handleMessage(msg) {
@@ -176,6 +223,7 @@ function handleMessage(msg) {
       respond(msg.id, {
         protocolVersion: 1,
         agentCapabilities: { loadSession: true, promptCapabilities: {} },
+        ...(steeringSupported ? { _meta: { steering: { supported: true } } } : {}),
       });
       break;
     case "session/new":
@@ -197,7 +245,10 @@ function handleMessage(msg) {
       respond(msg.id, {});
       break;
     case "session/prompt":
-      handlePrompt(msg.id, msg.params);
+      void handlePrompt(msg.id, msg.params);
+      break;
+    case "_session/steering":
+      handleSteering(msg.id, msg.params);
       break;
     case "session/cancel":
       cancelled = true;

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -75,12 +75,22 @@ async fn make_session(ts: &TestServer, id: &str) {
 /// Bring up a fresh ACP session (relay + handshake + task) with the given launch
 /// mode and optional goal.
 async fn start_new(ts: &TestServer, id: &str, mode: Option<&str>, goal: Option<&str>) {
+    start_new_with_env(ts, id, mode, goal, vec![]).await;
+}
+
+async fn start_new_with_env(
+    ts: &TestServer,
+    id: &str,
+    mode: Option<&str>,
+    goal: Option<&str>,
+    env: Vec<(String, String)>,
+) {
     make_session(ts, id).await;
     let cwd = ts.repo_path().to_path_buf();
     let launch = AcpLaunch {
         adapter_cmd: agent_cmd(),
         cwd: cwd.clone(),
-        env: vec![],
+        env,
         new_or_load: NewOrLoad::New { cwd, meta: None },
         mode: mode.map(str::to_string),
         goal: goal.map(str::to_string),
@@ -542,6 +552,129 @@ async fn prompt_queues_during_a_live_turn() {
             .any(|b| b["kind"] == "agent_message" && b["payload"]["text"] == "second"),
         "the queued turn ran"
     );
+}
+
+/// 4b. A steering-capable adapter injects a mid-turn prompt into the active
+/// turn instead of writing the durable next-turn queue.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prompt_steers_a_live_turn_when_advertised() {
+    let ts = TestServer::start().await;
+    start_new_with_env(
+        &ts,
+        "acp-steer",
+        None,
+        None,
+        vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
+    )
+    .await;
+
+    let first = ts
+        .client
+        .post(
+            "/api/sessions/acp-steer/prompt",
+            json!({ "text": "wait:1500|say:first" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first["queued"], false);
+    assert_eq!(first["steered"], false);
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let second = ts
+        .client
+        .post(
+            "/api/sessions/acp-steer/prompt",
+            json!({ "text": "say:changed course" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second["queued"], false);
+    assert_eq!(second["steered"], true, "response: {second}");
+    assert_eq!(second["turn"], 0);
+
+    let session = session_mod::get(&ts.state.db, "acp-steer")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        session.pending_prompt.as_deref().unwrap_or("").is_empty(),
+        "a successful steer must not touch the next-turn queue"
+    );
+
+    let chat = poll_chat(&ts, "acp-steer", Duration::from_secs(10), |blocks| {
+        count_kind(blocks, "turn_end") >= 1
+            && blocks.iter().any(|b| {
+                b["kind"] == "agent_message" && b["payload"]["text"] == "changed coursefirst"
+            })
+    })
+    .await;
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert_eq!(count_kind(blocks, "turn_end"), 1);
+    assert!(blocks.iter().any(|b| {
+        b["kind"] == "user_message"
+            && b["turn"] == 0
+            && b["payload"]["text"] == "say:changed course"
+            && b["payload"]["steered"] == true
+    }));
+}
+
+/// 4c. If a turn ends during injection, codex-acp starts the message itself and
+/// reports `startedNewTurn`; loom adopts and closes that adapter-owned turn.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prompt_adopts_a_turn_started_by_steering() {
+    let ts = TestServer::start().await;
+    start_new_with_env(
+        &ts,
+        "acp-steer-race",
+        None,
+        None,
+        vec![
+            ("FAKE_ACP_STEERING".to_string(), "1".to_string()),
+            (
+                "FAKE_ACP_STEERING_FORCE_NEW_TURN".to_string(),
+                "1".to_string(),
+            ),
+        ],
+    )
+    .await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-steer-race/prompt",
+            json!({ "text": "wait:300|say:first" }),
+        )
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let second = ts
+        .client
+        .post(
+            "/api/sessions/acp-steer-race/prompt",
+            json!({ "text": "wait:100|say:second" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second["queued"], false);
+    assert_eq!(second["steered"], false);
+    assert_eq!(second["turn"], 1);
+
+    let chat = poll_chat(&ts, "acp-steer-race", Duration::from_secs(10), |blocks| {
+        count_kind(blocks, "turn_end") == 2
+    })
+    .await;
+    assert_eq!(chat["live_turn"], Value::Null);
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert!(blocks.iter().any(|b| {
+        b["kind"] == "user_message"
+            && b["turn"] == 1
+            && b["payload"]["text"] == "wait:100|say:second"
+            && b["payload"]["steered"] == false
+    }));
+    assert!(blocks.iter().any(|b| {
+        b["kind"] == "agent_message" && b["turn"] == 1 && b["payload"]["text"] == "second"
+    }));
 }
 
 /// 5. Crash recovery: stop the loom-side task mid-turn, re-attach, and the

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -136,6 +136,20 @@ async fn poll_chat(
     timeout: Duration,
     pred: impl Fn(&[Value]) -> bool,
 ) -> Value {
+    poll_chat_state(ts, id, timeout, |chat| {
+        let empty = vec![];
+        pred(chat["blocks"].as_array().unwrap_or(&empty))
+    })
+    .await
+}
+
+/// Poll `GET /chat` until `pred` accepts the whole snapshot.
+async fn poll_chat_state(
+    ts: &TestServer,
+    id: &str,
+    timeout: Duration,
+    pred: impl Fn(&Value) -> bool,
+) -> Value {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         let chat = ts
@@ -143,9 +157,7 @@ async fn poll_chat(
             .get(&format!("/api/sessions/{id}/chat"))
             .await
             .unwrap();
-        let empty = vec![];
-        let blocks = chat["blocks"].as_array().unwrap_or(&empty);
-        if pred(blocks) {
+        if pred(&chat) {
             return chat;
         }
         if tokio::time::Instant::now() >= deadline {
@@ -508,8 +520,8 @@ async fn prompt_queues_during_a_live_turn() {
     assert_eq!(first["queued"], false);
     assert_eq!(first["turn"], 0);
 
-    // Give the first turn a moment to be in flight, then send again.
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    // The first 202 arrives after loom marks the turn live, so this send
+    // deterministically takes the unsupported-adapter queue path.
     let second = ts
         .client
         .post(
@@ -580,7 +592,8 @@ async fn prompt_steers_a_live_turn_when_advertised() {
     assert_eq!(first["queued"], false);
     assert_eq!(first["steered"], false);
 
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    // Relay writes are ordered: the fake marks the first prompt active before
+    // it receives this steering request.
     let second = ts
         .client
         .post(
@@ -647,7 +660,8 @@ async fn prompt_adopts_a_turn_started_by_steering() {
         )
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Relay writes are ordered, so the forced steering race is deterministic
+    // without a wall-clock delay.
     let second = ts
         .client
         .post(
@@ -660,8 +674,9 @@ async fn prompt_adopts_a_turn_started_by_steering() {
     assert_eq!(second["steered"], false);
     assert_eq!(second["turn"], 1);
 
-    let chat = poll_chat(&ts, "acp-steer-race", Duration::from_secs(10), |blocks| {
-        count_kind(blocks, "turn_end") == 2
+    let chat = poll_chat_state(&ts, "acp-steer-race", Duration::from_secs(10), |chat| {
+        chat["live_turn"].is_null()
+            && count_kind(chat["blocks"].as_array().unwrap(), "turn_end") == 2
     })
     .await;
     assert_eq!(chat["live_turn"], Value::Null);

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -260,7 +260,8 @@ impl Client {
     }
 
     /// Type a message into a session's agent pane, submitting it by default
-    /// (`POST /api/sessions/{key}/send`). Returns the raw `{sent, submitted}`.
+    /// (`POST /api/sessions/{key}/send`). ACP responses also report whether the
+    /// message steered the live turn or queued for the next one.
     pub async fn nudge(&self, key: &str, req: &SendReq) -> Result<Value> {
         let body = serde_json::to_value(req)?;
         self.post(&format!("/api/sessions/{}/send", Self::seg(key)), body)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,12 +209,12 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
 | `GET /api/sessions/{id}/conversation` | the agent conversation as a normalized iris log (live transcript, else the archive capture); 404 when there is none — backs the Conversation tab |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ the session's tapestry PTY (the interaction surface) |
-| `POST /api/sessions/{id}/send` | type `{text}` into the agent's terminal (`submit`, default true, follows it with Enter); for an `acp` session it delegates to the prompt queue (a `session/prompt`), keeping the same `nudge` audit |
+| `POST /api/sessions/{id}/send` | type `{text}` into the agent's terminal (`submit`, default true, follows it with Enter); for an `acp` session it delegates to the prompt path (steering a supported live turn, otherwise queueing), keeping the same `nudge` audit |
 | `POST /api/sessions/{id}/interrupt` | stop the current turn — a break (Escape) to the terminal for a `terminal` session, `session/cancel` for an `acp` one |
 | `GET /api/sessions/{id}/preview?lines=N` | capture the screen as `{screen}`; `lines` adds scrollback above the visible screen (for an `acp` session, `{screen}` is the last `lines` journal blocks rendered as compact text) |
 | `GET /api/sessions/{id}/chat` | `{blocks: [ChatBlockView], live_turn}` — the ACP session's journal snapshot (per-block conversation record) plus the in-flight turn, if any |
 | `GET /api/sessions/{id}/chat/stream` | SSE tail of the live journal: `block` (a committed block), `delta` (a streaming message/thought chunk), `tool` (a live tool-call update), `turn` (started / ended) |
-| `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, turn}` — dispatch a user message as a `session/prompt`, or append it to the durable queue when a turn is already in flight |
+| `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, steered, turn}` — dispatch a user message as a `session/prompt`; a live turn uses the advertised codex-acp steering extension, with the durable next-turn queue as fallback |
 | `POST /api/sessions/{id}/permissions/{request_id}` | `{option_id}` → answer an open permission request (200 / 404 unknown / 409 already resolved) |
 | `PUT /api/sessions/{id}/mode` | `{mode_id}` → change the ACP session's permission mode (`session/set_mode`), journaled as a `mode_change` |
 | `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |
@@ -307,8 +307,8 @@ let an agent or script type into, interrupt, or read back a child session
 uniformly. For a `terminal` session each requires a live terminal (else 409). An
 `acp` session has no PTY, so the same verbs map onto the protocol — keeping the
 CLI (`loom session {send,break,preview}`) and its `nudge` audit uniform across
-backends: `send` delegates to the prompt queue (a `session/prompt`, queued when a
-turn is in flight), `interrupt` is a `session/cancel`, and `preview` renders the
+backends: `send` delegates to the prompt path (steered when supported, otherwise
+queued while a turn is live), `interrupt` is a `session/cancel`, and `preview` renders the
 last journal blocks as compact plain text instead of a vt100 screen capture.
 
 ## Runtime conventions

--- a/docs/plans/acp.md
+++ b/docs/plans/acp.md
@@ -300,18 +300,18 @@ the fallback for terminal-backend sessions.
 
 | Route | Purpose |
 |---|---|
-| `POST /api/sessions/{id}/prompt` | send a user message (`session/prompt`); queues when a turn is in flight — `loom session send` maps here for ACP sessions |
+| `POST /api/sessions/{id}/prompt` | send a user message (`session/prompt`); steers a supported live turn and otherwise queues — `loom session send` maps here for ACP sessions |
 | `POST /api/sessions/{id}/interrupt` | unchanged route, now `session/cancel` |
 | `GET /api/sessions/{id}/chat` + `/chat/stream` | journal + SSE deltas |
 | `POST /api/sessions/{id}/permissions/{request_id}` | answer `{option_id}` — also grantable to watches as a capability |
 | `PUT /api/sessions/{id}/mode` | `session/set_mode` |
 | `GET /api/sessions/{id}/preview` | ACP sessions: last N journal blocks as plain text — CLI convenience, nothing more |
 
-Queued prompts are durable and simple: the existing `pending_prompt` column
-holds the queue (sends during a turn append as paragraphs, each audited as a
-`nudge` event, clearable from the UI); it dispatches as one `session/prompt`
-at the next turn boundary. Cancel stops the in-flight turn and leaves the
-queue. `SessionView` grows `protocol: "terminal" | "acp"`, `acp_session_id`,
+The fallback prompt queue is durable and simple: the existing `pending_prompt`
+column holds messages for adapters that do not advertise steering (each send is
+audited as a `nudge` event); it dispatches as one `session/prompt` at the next
+turn boundary. Cancel stops the in-flight turn and leaves the queue.
+`SessionView` grows `protocol: "terminal" | "acp"`, `acp_session_id`,
 `current_mode`, `usage`. Note the session-scoped `/chat` routes are distinct
 from the fleet-level concierge `/api/chat` (`docs/plans/meta-chat.md`) — and
 the UI keeps the *Conversation* name precisely so the concierge keeps
@@ -348,7 +348,7 @@ sub-session's approach becomes possible from the couch. (One container
 detail: the Claude adapter refuses `bypassPermissions` when running as root;
 the deploy's `app` user is fine.)
 
-Watch parity: `send`→prompt-queue and `interrupt`→cancel remain
+Watch parity: `send`→prompt steering/queue and `interrupt`→cancel remain
 watch-drivable through the same routes and capability gates as today's nudge
 audit; answering permissions becomes its own grantable capability.
 
@@ -482,9 +482,9 @@ Anatomy, in the order a reader meets it:
   (`session/prompt`), Shift+Enter breaks. Left: the mode chip (`bypass ▾` →
   `session/set_mode`) and slash-command autocomplete fed by
   `available_commands_update`. Right: **Stop** (`session/cancel`, shown
-  while a turn runs) and **Send**. Sending mid-turn queues visibly
-  ("queued for next turn"), which the protocol makes exact rather than
-  hopeful. While the agent works, the turn shows the existing sage
+  while a turn runs) and **Send**. Sending mid-turn steers visibly when the
+  adapter advertises support; other adapters retain the explicit "queued for
+  next turn" fallback. While the agent works, the turn shows the existing sage
   `▶ working` cue; instant, not animated.
 - **Streaming.** First journal fetch paints the transcript; the SSE tail
   appends in place. Kept-alive view discipline applies: pause the stream on

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -32,7 +32,12 @@ const FAKE_AGENT = join(__dirname, '..', '..', 'crates', 'loom', 'tests', 'fixtu
 const HEADERS = { 'content-type': 'application/json' };
 const SKIP_MSG = 'ACP lifecycle backend (weaver #508) not merged: the server does not launch acp sessions over REST yet';
 
-async function defineFakeAcpAgent(weaver: WeaverFixture, name: string, label: string): Promise<void> {
+async function defineFakeAcpAgent(
+  weaver: WeaverFixture,
+  name: string,
+  label: string,
+  steering = false,
+): Promise<void> {
   const res = await fetch(`${weaver.baseUrl}/api/agents/custom`, {
     method: 'POST',
     headers: HEADERS,
@@ -40,7 +45,7 @@ async function defineFakeAcpAgent(weaver: WeaverFixture, name: string, label: st
       name,
       label,
       setup: '',
-      launch: `node ${FAKE_AGENT}`,
+      launch: `${steering ? 'FAKE_ACP_STEERING=1 ' : ''}node ${FAKE_AGENT}`,
       resume: '',
       reports_status: false,
       protocol: 'acp',
@@ -61,7 +66,7 @@ async function launchAcpSession(
   // `protocol` axis marks it ACP rather than a PTY TUI (added by the lifecycle
   // phase; ignored by the current backend, which is exactly why the probe below
   // detects support).
-  await defineFakeAcpAgent(weaver, 'acp-fake', 'ACP fake');
+  await defineFakeAcpAgent(weaver, 'acp-fake', 'ACP fake', true);
 
   const res = await fetch(`${weaver.baseUrl}/api/sessions`, {
     method: 'POST',
@@ -286,7 +291,7 @@ test.describe('acp conversation', () => {
     await expect(conv.getByText('streamed reply lands here', { exact: true })).toHaveCount(1);
   });
 
-  test('the composer sends a prompt and queues one behind a live turn', async ({ page, weaver }) => {
+  test('the composer steers a prompt into a live turn', async ({ page, weaver }) => {
     await openAcp(page, weaver, { goal: 'say:ready' });
     const input = page.getByTestId('acp-composer-input');
 
@@ -295,15 +300,20 @@ test.describe('acp conversation', () => {
     await page.getByTestId('acp-composer-send').click();
     await expect(page.getByTestId('acp-working')).toBeVisible({ timeout: 15_000 });
 
-    // A second prompt sent mid-turn queues visibly rather than starting a turn.
+    // A second prompt sent mid-turn is injected into the active turn.
     await input.fill('say:second turn');
     await page.getByTestId('acp-composer-send').click();
-    await expect(page.getByTestId('acp-queued')).toBeVisible({ timeout: 15_000 });
-
-    // It dispatches once the first turn ends.
-    await expect(page.getByTestId('acp-conversation').getByText('second turn')).toBeVisible({
-      timeout: 20_000,
+    await expect(page.getByTestId('acp-steered').filter({ hasText: /^steered turn/ })).toBeVisible({
+      timeout: 15_000,
     });
+
+    // The steer is handled before that same turn ends.
+    await expect(
+      page.getByTestId('acp-conversation').getByText('second turnfirst turn done', { exact: true }),
+    ).toBeVisible({ timeout: 20_000 });
+    // One rule for the launch goal and one for this interaction: the steer did
+    // not create a third turn.
+    await expect(page.getByTestId('acp-turn-rule')).toHaveCount(2, { timeout: 20_000 });
   });
 
   test('a permission card answers and collapses to a receipt', async ({ page, weaver }) => {


### PR DESCRIPTION
Negotiate the codex-acp steering extension and inject mid-turn prompts into the active turn, while retaining the durable pending queue for unsupported adapters and failed steering calls.

Propagate steering outcomes through the REST API and conversation UI, including adapter-owned replacement turns, transcript labeling, and deterministic fake-adapter coverage.

Keep the behavior API-first so REST clients and the browser observe the same queued-versus-steered result.