### PR TITLE
fix(loom): make queued prompts durable and observable

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -298,8 +298,8 @@ export const promptSession = (
     files,
   }) as Promise<PromptAck>;
 
-/** Send all durable next-turn feedback now, steering a live turn or starting an
- * idle session after cancellation. */
+/** Send all durable next-turn feedback now: steer when the adapter advertises
+ * support, otherwise stop the live turn and start one normal queued turn. */
 export const forceQueuedSession = (id: string, by?: string) =>
   post(`/sessions/${id}/prompt`, {
     text: '',

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -26,6 +26,7 @@ import type {
   SseDelta,
   SseTool,
   SseTurn,
+  SseQueue,
   UserMessagePayload,
   AgentMessagePayload,
   ThoughtPayload,
@@ -56,7 +57,8 @@ import MarkdownView from './MarkdownView.vue';
 // Its data source is the durable chat journal: it paints the `GET /chat`
 // snapshot, then applies the `/chat/stream` SSE tail in place — `block` upserts
 // by (turn, seq), `delta` streams into a shadow message/thought, `tool` tracks
-// live tool state (feeding the status line), `turn` drives the live-turn state.
+// live tool state (feeding the status line), `turn` drives the live-turn state,
+// and `queue` carries the complete durable next-turn prompt.
 // The composer posts to `/prompt`; Stop posts `/interrupt`; permission cards
 // answer via `/permissions/{id}`; the mode chip drives `/mode`.
 const props = withDefaults(
@@ -79,15 +81,20 @@ const shadows = reactive(
 const liveTools = reactive(new Map<string, SseTool>());
 const turnLive = ref(false);
 const liveTurnNo = ref<number | null>(null);
-const optimistic = ref<{ key: number; text: string; state: 'sent' | 'steered' | 'queued' }[]>([]);
-const forceQueueKey = computed(() => {
-  for (let index = optimistic.value.length - 1; index >= 0; index -= 1) {
-    if (optimistic.value[index].state === 'queued') return optimistic.value[index].key;
-  }
-  return null;
-});
+// Optimistic rows exist only while an HTTP send is unresolved. Delivery state
+// comes from the durable queue snapshot/SSE, never from the click that initiated
+// the request.
+const optimistic = ref<{ key: number; text: string }[]>([]);
+const pendingPrompt = ref<string | null>(null);
 let nextOptimisticKey = 0;
-const metadata = ref<AcpMetadata>({ commands: [], config_options: [], modes: [] });
+const emptyMetadata = (): AcpMetadata => ({
+  commands: [],
+  config_options: [],
+  modes: [],
+  steering_supported: false,
+});
+const metadata = ref<AcpMetadata>(emptyMetadata());
+const steeringSupported = computed(() => metadata.value.steering_supported);
 
 // The live mode, seeded from the session and advanced by `mode_change` blocks or
 // a local set — so the composer chip reads true without a refetch.
@@ -98,6 +105,14 @@ watch(
     if (m) currentMode.value = m;
   },
 );
+
+function applyMetadata(next: AcpMetadata) {
+  metadata.value = next;
+  // Config options are the state acknowledged or pushed by the adapter. Keep
+  // the permissions chip aligned even when the agent changes it unsolicited.
+  const mode = next.config_options.find(isModeOption)?.currentValue;
+  if (typeof mode === 'string') currentMode.value = mode;
+}
 
 const blockKey = (turn: number, seq: number) => `${turn}:${seq}`;
 
@@ -123,15 +138,8 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
     liveTools.clear();
     liveTurnNo.value = snap.live_turn;
     turnLive.value = snap.live_turn != null;
-    optimistic.value = optimistic.value.filter((item) => item.state !== 'queued');
-    if (snap.pending_prompt?.trim()) {
-      optimistic.value.push({
-        key: nextOptimisticKey++,
-        text: snap.pending_prompt,
-        state: 'queued',
-      });
-    }
-    metadata.value = snap.metadata ?? { commands: [], config_options: [], modes: [] };
+    pendingPrompt.value = snap.pending_prompt?.trim() ? snap.pending_prompt : null;
+    applyMetadata(snap.metadata ?? emptyMetadata());
     state.value = 'ready';
   } catch (e) {
     if (seq !== loadSeq) return;
@@ -191,8 +199,12 @@ function onTurn(ev: SseTurn) {
   } else {
     turnLive.value = false;
     liveTurnNo.value = null;
-    optimistic.value = optimistic.value.filter((o) => o.state === 'queued');
   }
+}
+
+function onQueue(ev: SseQueue) {
+  pendingPrompt.value = ev.pending_prompt?.trim() ? ev.pending_prompt : null;
+  autoFollow();
 }
 
 // ── SSE lifecycle (kept-alive discipline) ────────────────────────────────────
@@ -209,8 +221,11 @@ function openStream() {
   );
   stream.addEventListener('tool', (e) => onTool(JSON.parse((e as MessageEvent).data) as SseTool));
   stream.addEventListener('turn', (e) => onTurn(JSON.parse((e as MessageEvent).data) as SseTurn));
+  stream.addEventListener('queue', (e) =>
+    onQueue(JSON.parse((e as MessageEvent).data) as SseQueue),
+  );
   stream.addEventListener('metadata', (e) => {
-    metadata.value = JSON.parse((e as MessageEvent).data) as AcpMetadata;
+    applyMetadata(JSON.parse((e as MessageEvent).data) as AcpMetadata);
   });
   // Once the server has installed the subscription, reconcile from the durable
   // journal. Subscribing first avoids a snapshot-to-stream gap during handoff.
@@ -272,18 +287,19 @@ async function submitPrompt(forceSteer = false) {
   sending.value = true;
   sendError.value = '';
   const text = draft.value;
-  const pending = { key: nextOptimisticKey++, text, state: 'sent' as const };
+  const pending = { key: nextOptimisticKey++, text };
   optimistic.value.push(pending);
   autoFollow();
   try {
     const files = selectedFiles.value.filter((path) => text.includes(`@${path}`));
-    const ack = await promptSession(id.value, text, undefined, forceSteer, files);
+    await promptSession(id.value, text, undefined, forceSteer, files);
     const index = optimistic.value.findIndex((o) => o.key === pending.key);
-    if (index >= 0) {
-      optimistic.value[index].state = ack.queued ? 'queued' : ack.steered ? 'steered' : 'sent';
-    }
+    if (index >= 0) optimistic.value.splice(index, 1);
     draft.value = '';
     selectedFiles.value = [];
+    // Reconcile against the journal + durable queue that produced the ack. SSE
+    // covers other clients; this closes the request/event race for this client.
+    await load({ preserve: true });
     autoFollow();
   } catch (e) {
     const index = optimistic.value.findIndex((o) => o.key === pending.key);
@@ -300,10 +316,10 @@ async function forceQueued() {
   sendError.value = '';
   try {
     await forceQueuedSession(id.value);
-    optimistic.value = optimistic.value.filter((item) => item.state !== 'queued');
+    await load({ preserve: true });
     autoFollow();
   } catch (e) {
-    sendError.value = (e as Error).message ?? 'Failed to steer queued feedback';
+    sendError.value = (e as Error).message ?? 'Failed to send queued feedback';
   } finally {
     sending.value = false;
   }
@@ -798,6 +814,7 @@ const isEmpty = computed(
     state.value === 'ready' &&
     !model.value.rows.length &&
     !optimistic.value.length &&
+    !pendingPrompt.value &&
     !turnLive.value,
 );
 
@@ -1152,7 +1169,34 @@ function goTo(anchor: string) {
             </div>
           </template>
 
-          <!-- Optimistic (in-flight / queued) user messages. -->
+          <!-- The server-owned durable queue is one coalesced next-turn prompt. -->
+          <section v-if="pendingPrompt" class="acp-speaker" data-testid="acp-pending">
+            <header class="acp-rule">
+              <span class="acp-label text-accent">You</span>
+              <span class="acp-prompt-state" data-testid="acp-queued"
+                >queued · agent hasn’t seen this yet</span
+              >
+              <button
+                type="button"
+                class="acp-prompt-action"
+                data-testid="acp-force-queued"
+                :disabled="sending"
+                :title="
+                  turnLive
+                    ? steeringSupported
+                      ? 'Inject all queued feedback into the running turn now'
+                      : 'Stop the running turn and send all queued feedback as the next turn'
+                    : 'Start a new turn with all queued feedback'
+                "
+                @click="forceQueued"
+              >
+                {{ turnLive ? (steeringSupported ? 'Force now' : 'Stop & send') : 'Send now' }}
+              </button>
+            </header>
+            <MarkdownView :id="id" path="" :source="pendingPrompt" />
+          </section>
+
+          <!-- A local send remains unclassified only until the server answers. -->
           <section
             v-for="o in optimistic"
             :key="`opt-${o.key}`"
@@ -1161,32 +1205,6 @@ function goTo(anchor: string) {
           >
             <header class="acp-rule">
               <span class="acp-label text-accent">You</span>
-              <template v-if="o.state === 'queued'">
-                <span class="acp-prompt-state" data-testid="acp-queued"
-                  >queued · agent hasn’t seen this yet</span
-                >
-                <button
-                  v-if="o.key === forceQueueKey"
-                  type="button"
-                  class="acp-prompt-action"
-                  data-testid="acp-force-queued"
-                  :disabled="sending"
-                  :title="
-                    turnLive
-                      ? 'Inject all queued feedback into the running turn now'
-                      : 'Start a new turn with all queued feedback'
-                  "
-                  @click="forceQueued"
-                >
-                  {{ turnLive ? 'Force now' : 'Send now' }}
-                </button>
-              </template>
-              <span
-                v-else-if="o.state === 'steered'"
-                class="acp-prompt-state"
-                data-testid="acp-steered"
-                >steering current turn</span
-              >
             </header>
             <MarkdownView :id="id" path="" :source="o.text" />
           </section>
@@ -1388,12 +1406,12 @@ function goTo(anchor: string) {
         </div>
         <div class="acp-composer-right">
           <button
-            v-if="turnLive"
+            v-if="turnLive && steeringSupported"
             type="button"
             class="btn-secondary px-3 py-1 text-xs"
             data-testid="acp-composer-force-steer"
             :disabled="sending || !draft.trim()"
-            title="Inject this feedback into the running turn even if the agent did not advertise steering"
+            title="Inject this feedback into the running turn"
             @click="submitPrompt(true)"
           >
             Force steer

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -128,7 +128,7 @@ export interface Session {
 // ── ACP conversation surface ────────────────────────────────────────────────
 // The chat journal + live SSE tail an `acp` session's Conversation renders from.
 // These hand-mirror loom's `chat.rs` / `acp/mod.rs` serde shapes: the block
-// contract (`GET /sessions/{id}/chat`) and the four `/chat/stream` SSE events.
+// contract (`GET /sessions/{id}/chat`) and the `/chat/stream` SSE events.
 
 /** Context-window usage `{used, size}` (tokens). */
 export interface AcpUsage {
@@ -202,6 +202,8 @@ export interface AcpMetadata {
   commands: AcpCommand[];
   config_options: AcpConfigOption[];
   modes: AcpMode[];
+  /** Adapter-advertised support for the private steering extension. */
+  steering_supported: boolean;
 }
 
 // -- block payloads (by kind) --
@@ -305,6 +307,11 @@ export interface SseTurn {
   turn: number;
   state: 'started' | 'ended';
   stop_reason?: string;
+}
+
+/** `queue` — the complete durable next-turn prompt after a queue mutation. */
+export interface SseQueue {
+  pending_prompt: string | null;
 }
 
 /** `POST /sessions/{id}/prompt` 202 body: whether the message steered the live

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -1457,10 +1457,16 @@ impl Task {
                 "steered queued feedback but could not consume its durable copy"
             );
         } else {
-            let remaining = session::read_pending_prompt(&self.db, &self.session_id)
-                .await
-                .unwrap_or_default();
-            self.emit_queue((!remaining.trim().is_empty()).then_some(remaining.as_str()));
+            match session::read_pending_prompt(&self.db, &self.session_id).await {
+                Ok(remaining) => {
+                    self.emit_queue((!remaining.trim().is_empty()).then_some(remaining.as_str()));
+                }
+                Err(error) => tracing::error!(
+                    session = %self.session_id,
+                    %error,
+                    "consumed steered feedback but could not refresh the queue view"
+                ),
+            }
         }
     }
 
@@ -1483,6 +1489,14 @@ impl Task {
             steered: false,
             turn: Some(self.current_turn),
         })
+    }
+
+    async fn start_pending_prompt(&mut self, by: Option<String>) -> Result<PromptAck> {
+        let pending = session::take_pending_prompt(&self.db, &self.session_id)
+            .await?
+            .ok_or_else(|| anyhow!("there is no queued feedback to send"))?;
+        self.emit_queue(None);
+        self.start_prompt(pending, by, Vec::new()).await
     }
 
     async fn start_prompt(
@@ -1807,29 +1821,11 @@ impl Task {
                     if queued.trim().is_empty() {
                         let _ = reply.send(Err(anyhow!("there is no queued feedback to send")));
                     } else if !self.turn_live {
-                        let result =
-                            match session::take_pending_prompt(&self.db, &self.session_id).await {
-                                Ok(Some(pending)) => {
-                                    self.emit_queue(None);
-                                    self.start_prompt(pending, by, Vec::new()).await
-                                }
-                                Ok(None) => Err(anyhow!("there is no queued feedback to send")),
-                                Err(error) => Err(error),
-                            };
+                        let result = self.start_pending_prompt(by).await;
                         let _ = reply.send(result);
                     } else if !self.steering_cap {
                         let result = match self.cancel_live_turn().await {
-                            Ok(()) => {
-                                match session::take_pending_prompt(&self.db, &self.session_id).await
-                                {
-                                    Ok(Some(pending)) => {
-                                        self.emit_queue(None);
-                                        self.start_prompt(pending, by, Vec::new()).await
-                                    }
-                                    Ok(None) => Err(anyhow!("there is no queued feedback to send")),
-                                    Err(error) => Err(error),
-                                }
-                            }
+                            Ok(()) => self.start_pending_prompt(by).await,
                             Err(error) => Err(error),
                         };
                         let _ = reply.send(result);

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -121,7 +121,7 @@ pub enum PermAnswer {
 }
 
 /// One SSE event the `/chat/stream` route emits: an event name (`block`, `delta`,
-/// `tool`, `turn`, `metadata`) and its JSON data.
+/// `tool`, `turn`, `queue`, `metadata`) and its JSON data.
 #[derive(Debug, Clone, Serialize)]
 pub struct SseEvent {
     pub event: String,
@@ -137,6 +137,10 @@ pub struct AcpMetadata {
     pub commands: Vec<Value>,
     pub config_options: Vec<Value>,
     pub modes: Vec<Value>,
+    /// Whether the adapter advertised the codex-acp steering extension during
+    /// initialize. The browser uses this observed capability instead of
+    /// optimistically probing a private method that may not exist.
+    pub steering_supported: bool,
 }
 
 /// A live session's control surface, held in the [`AcpRegistry`]: send commands
@@ -185,8 +189,8 @@ impl AcpHandle {
             .map_err(|_| anyhow!("acp task dropped the reply"))?
     }
 
-    /// Send the current durable next-turn queue now: promote it into a live turn,
-    /// or start it as a normal turn when the session is idle after cancellation.
+    /// Send the current durable next-turn queue now: promote it when the adapter
+    /// advertises steering, otherwise cancel the live turn and start it normally.
     /// The task reads the queue itself so the browser cannot accidentally send
     /// stale or partial text.
     pub async fn force_pending(&self, by: Option<String>) -> Result<PromptAck> {
@@ -814,6 +818,10 @@ impl Task {
         });
     }
 
+    fn emit_queue(&self, pending_prompt: Option<&str>) {
+        self.emit("queue", json!({ "pending_prompt": pending_prompt }));
+    }
+
     fn emit_metadata(&self) {
         let metadata = self.metadata.lock().unwrap().clone();
         self.emit(
@@ -870,6 +878,7 @@ impl Task {
         if let Ok(init) = serde_json::from_value::<wire::InitializeResult>(res) {
             self.load_session_cap = init.agent_capabilities.load_session;
             self.steering_cap = init.meta.steering.supported;
+            self.metadata.lock().unwrap().steering_supported = self.steering_cap;
         }
 
         match &launch.new_or_load {
@@ -1338,13 +1347,28 @@ impl Task {
     }
 
     async fn dispatch_pending_prompt(&mut self) {
-        // Dispatch the durable queue as the next turn, if non-empty.
-        let pending = session::read_pending_prompt(&self.db, &self.session_id)
-            .await
-            .unwrap_or_default();
-        if !pending.trim().is_empty() {
-            let _ = session::clear_pending_prompt(&self.db, &self.session_id).await;
-            let _ = self.start_turn(pending, None, Vec::new()).await;
+        // Consuming the durable copy is a precondition for dispatch. Starting a
+        // turn after a failed clear leaves the same text eligible at every later
+        // boundary and turns one SQLite error into an unbounded replay loop.
+        match session::take_pending_prompt(&self.db, &self.session_id).await {
+            Ok(Some(pending)) => {
+                self.emit_queue(None);
+                if let Err(error) = self.start_turn(pending, None, Vec::new()).await {
+                    tracing::error!(
+                        session = %self.session_id,
+                        %error,
+                        "consumed queued prompt but could not start its turn"
+                    );
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::error!(
+                    session = %self.session_id,
+                    %error,
+                    "could not consume queued prompt; leaving it idle"
+                );
+            }
         }
     }
 
@@ -1432,6 +1456,11 @@ impl Task {
                 %error,
                 "steered queued feedback but could not consume its durable copy"
             );
+        } else {
+            let remaining = session::read_pending_prompt(&self.db, &self.session_id)
+                .await
+                .unwrap_or_default();
+            self.emit_queue((!remaining.trim().is_empty()).then_some(remaining.as_str()));
         }
     }
 
@@ -1447,7 +1476,8 @@ impl Task {
 
     async fn queue_prompt(&self, text: &str, resources: &[Value]) -> Result<PromptAck> {
         let queued = queued_prompt_text(text, resources);
-        session::append_pending_prompt(&self.db, &self.session_id, &queued).await?;
+        let pending = session::append_pending_prompt(&self.db, &self.session_id, &queued).await?;
+        self.emit_queue(Some(&pending));
         Ok(PromptAck {
             queued: true,
             steered: false,
@@ -1664,6 +1694,45 @@ impl Task {
 
     // -- commands -----------------------------------------------------------
 
+    async fn cancel_live_turn(&mut self) -> Result<()> {
+        let result = self
+            .stream
+            .write(&wire::notification_line(
+                method::SESSION_CANCEL,
+                wire::cancel_params(&self.acp_session_id),
+            ))
+            .await;
+        if result.is_ok() && self.turn_live {
+            for (_, pending) in self.pending_steers.drain() {
+                let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
+            }
+            if let Some(pending) = self.pending_external.take() {
+                let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
+            }
+            // Cancellation is a client-owned boundary. Some adapters do not
+            // answer the cancelled prompt, so settle loom's journal and
+            // lifecycle immediately after the notification lands.
+            self.on_turn_end(
+                self.current_turn,
+                Some(json!({ "stopReason": "cancelled" })),
+                None,
+            )
+            .await;
+        }
+        // ACP requires the client to answer every pending permission request
+        // with the `cancelled` outcome when it cancels a turn.
+        for (_, pp) in self.pending_perms.drain() {
+            let _ = self
+                .stream
+                .write(&wire::response_line(
+                    &pp.jsonrpc_id,
+                    wire::permission_cancelled(),
+                ))
+                .await;
+        }
+        result
+    }
+
     async fn on_command(&mut self, cmd: Command) {
         match cmd {
             Command::Prompt {
@@ -1674,7 +1743,7 @@ impl Task {
                 reply,
             } => {
                 if self.turn_live {
-                    if (self.steering_cap || force_steer)
+                    if self.steering_cap
                         && self.pending_steers.is_empty()
                         && self.pending_external.is_none()
                     {
@@ -1704,9 +1773,12 @@ impl Task {
                             }
                         }
                     } else if force_steer {
-                        let _ = reply.send(Err(anyhow!(
+                        let message = if self.steering_cap {
                             "another steer is still pending; retry when it settles"
-                        )));
+                        } else {
+                            "this agent does not support steering; queue the feedback or stop and send it"
+                        };
+                        let _ = reply.send(Err(anyhow!(message)));
                     } else {
                         // A failed queue write must surface — a 202 that silently
                         // dropped the prompt would be worse than an error.
@@ -1736,10 +1808,30 @@ impl Task {
                         let _ = reply.send(Err(anyhow!("there is no queued feedback to send")));
                     } else if !self.turn_live {
                         let result =
-                            match session::clear_pending_prompt(&self.db, &self.session_id).await {
-                                Ok(()) => self.start_prompt(queued.clone(), by, Vec::new()).await,
+                            match session::take_pending_prompt(&self.db, &self.session_id).await {
+                                Ok(Some(pending)) => {
+                                    self.emit_queue(None);
+                                    self.start_prompt(pending, by, Vec::new()).await
+                                }
+                                Ok(None) => Err(anyhow!("there is no queued feedback to send")),
                                 Err(error) => Err(error),
                             };
+                        let _ = reply.send(result);
+                    } else if !self.steering_cap {
+                        let result = match self.cancel_live_turn().await {
+                            Ok(()) => {
+                                match session::take_pending_prompt(&self.db, &self.session_id).await
+                                {
+                                    Ok(Some(pending)) => {
+                                        self.emit_queue(None);
+                                        self.start_prompt(pending, by, Vec::new()).await
+                                    }
+                                    Ok(None) => Err(anyhow!("there is no queued feedback to send")),
+                                    Err(error) => Err(error),
+                                }
+                            }
+                            Err(error) => Err(error),
+                        };
                         let _ = reply.send(result);
                     } else {
                         let id = self.next_id();
@@ -1771,42 +1863,7 @@ impl Task {
                 }
             }
             Command::Cancel { reply } => {
-                let r = self
-                    .stream
-                    .write(&wire::notification_line(
-                        method::SESSION_CANCEL,
-                        wire::cancel_params(&self.acp_session_id),
-                    ))
-                    .await;
-                if r.is_ok() && self.turn_live {
-                    for (_, pending) in self.pending_steers.drain() {
-                        let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
-                    }
-                    if let Some(pending) = self.pending_external.take() {
-                        let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
-                    }
-                    // Cancellation is a client-owned boundary. Some adapters do
-                    // not answer the cancelled prompt, so settle loom's journal
-                    // and lifecycle immediately after the notification lands.
-                    self.on_turn_end(
-                        self.current_turn,
-                        Some(json!({ "stopReason": "cancelled" })),
-                        None,
-                    )
-                    .await;
-                }
-                // ACP requires the client to answer every pending permission
-                // request with the `cancelled` outcome when it cancels a turn.
-                for (_, pp) in self.pending_perms.drain() {
-                    let _ = self
-                        .stream
-                        .write(&wire::response_line(
-                            &pp.jsonrpc_id,
-                            wire::permission_cancelled(),
-                        ))
-                        .await;
-                }
-                let _ = reply.send(r);
+                let _ = reply.send(self.cancel_live_turn().await);
             }
             Command::AnswerPermission {
                 request_id,

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -415,7 +415,7 @@ pub async fn append_pending_prompt(db: &Db, id: &str, text: &str) -> Result<Stri
 }
 
 /// Read the durable prompt queue (empty string when nothing is queued).
-/// [`clear_pending_prompt`] empties it once the text has been dispatched.
+/// [`take_pending_prompt`] consumes it before the text is dispatched.
 pub async fn read_pending_prompt(db: &Db, id: &str) -> Result<String> {
     let existing: Option<String> =
         sqlx::query_scalar("SELECT pending_prompt FROM sessions WHERE id = ?")
@@ -426,13 +426,37 @@ pub async fn read_pending_prompt(db: &Db, id: &str) -> Result<String> {
     Ok(existing.unwrap_or_default())
 }
 
-/// Clear the durable prompt queue (called once it has been dispatched as a prompt).
-pub async fn clear_pending_prompt(db: &Db, id: &str) -> Result<()> {
-    sqlx::query("UPDATE sessions SET pending_prompt = NULL WHERE id = ?")
-        .bind(id)
-        .execute(db)
-        .await?;
-    Ok(())
+/// Atomically remove and return the durable prompt queue. A caller may dispatch
+/// only a returned value: if the update fails, the transaction rolls back and
+/// the prompt stays visibly queued instead of becoming eligible for replay at
+/// every later turn boundary.
+pub async fn take_pending_prompt(db: &Db, id: &str) -> Result<Option<String>> {
+    let mut tx = db.begin().await?;
+    let pending: Option<String> =
+        sqlx::query_scalar::<_, Option<String>>("SELECT pending_prompt FROM sessions WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .flatten()
+            .filter(|text| !text.trim().is_empty());
+    let Some(pending) = pending else {
+        tx.commit().await?;
+        return Ok(None);
+    };
+
+    let result = sqlx::query(
+        "UPDATE sessions SET pending_prompt = NULL
+         WHERE id = ? AND pending_prompt = ?",
+    )
+    .bind(id)
+    .bind(&pending)
+    .execute(&mut *tx)
+    .await?;
+    if result.rows_affected() != 1 {
+        bail!("queued prompt changed while it was being consumed");
+    }
+    tx.commit().await?;
+    Ok(Some(pending))
 }
 
 /// Remove a promoted prefix from the durable queue without dropping messages

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -45,6 +45,13 @@ function send(obj) {
 function respond(id, result) {
   send({ jsonrpc: JSONRPC, id, result });
 }
+function rejectMethod(id, method) {
+  send({
+    jsonrpc: JSONRPC,
+    id,
+    error: { code: -32601, message: `Method not found: ${method}`, data: { method } },
+  });
+}
 function notify(update) {
   send({ jsonrpc: JSONRPC, method: "session/update", params: { sessionId, update } });
 }
@@ -334,7 +341,8 @@ function handleMessage(msg) {
       void handlePrompt(msg.id, msg.params);
       break;
     case "_session/steering":
-      handleSteering(msg.id, msg.params);
+      if (steeringSupported) handleSteering(msg.id, msg.params);
+      else rejectMethod(msg.id, msg.method);
       break;
     case "session/cancel":
       cancelled = true;

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -211,6 +211,7 @@ async fn composer_metadata_and_config_options_round_trip() {
     start_new(&ts, "acp-meta", None, None).await;
 
     let metadata = poll_metadata(&ts, "acp-meta", Duration::from_secs(5)).await;
+    assert_eq!(metadata["steering_supported"], false);
     let commands = metadata["commands"].as_array().unwrap();
     assert!(commands.iter().any(|command| command["name"] == "resume"));
     assert!(commands.iter().any(|command| {
@@ -627,6 +628,12 @@ async fn permission_answered_over_rest() {
 async fn prompt_queues_during_a_live_turn() {
     let ts = TestServer::start().await;
     start_new(&ts, "acp-queue", None, None).await;
+    let mut rx = ts
+        .state
+        .acp
+        .get("acp-queue")
+        .expect("task registered")
+        .subscribe();
 
     let first = ts
         .client
@@ -651,18 +658,32 @@ async fn prompt_queues_during_a_live_turn() {
         .unwrap();
     assert_eq!(second["queued"], true, "a send during a turn queues");
     assert_eq!(second["turn"], 0, "queued against the live turn");
+    let third = ts
+        .client
+        .post(
+            "/api/sessions/acp-queue/prompt",
+            json!({ "text": "say:third" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(third["queued"], true);
+
+    let queue_events = drain_events(&mut rx, Duration::from_secs(5), |event| {
+        event.event == "queue" && event.data["pending_prompt"] == "say:second\n\nsay:third"
+    })
+    .await;
+    assert!(queue_events
+        .iter()
+        .any(|event| { event.event == "queue" && event.data["pending_prompt"] == "say:second" }));
 
     let session = session_mod::get(&ts.state.db, "acp-queue")
         .await
         .unwrap()
         .unwrap();
-    assert!(
-        session
-            .pending_prompt
-            .as_deref()
-            .unwrap_or("")
-            .contains("say:second"),
-        "the queue is persisted"
+    assert_eq!(
+        session.pending_prompt.as_deref(),
+        Some("say:second\n\nsay:third"),
+        "multiple sends coalesce into one durable next-turn prompt"
     );
 
     // The queued prompt dispatches as turn 1 once turn 0 ends.
@@ -674,14 +695,80 @@ async fn prompt_queues_during_a_live_turn() {
     assert!(
         blocks.iter().any(|b| b["kind"] == "user_message"
             && b["turn"] == 1
-            && b["payload"]["text"] == "say:second"),
-        "the queued text became turn 1's user_message"
+            && b["payload"]["text"] == "say:second\n\nsay:third"),
+        "the coalesced queue became one turn 1 user_message"
     );
     assert!(
         blocks
             .iter()
             .any(|b| b["kind"] == "agent_message" && b["payload"]["text"] == "second"),
         "the queued turn ran"
+    );
+}
+
+/// A queued prompt must not be dispatched unless removing its durable copy
+/// succeeds. Otherwise every turn boundary can dispatch the same still-pending
+/// text again, growing the journal until the session is stopped.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn queue_consume_failure_does_not_dispatch_or_replay() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-queue-failure", None, None).await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-queue-failure/prompt",
+            json!({ "text": "wait:300|say:first" }),
+        )
+        .await
+        .unwrap();
+    let queued = ts
+        .client
+        .post(
+            "/api/sessions/acp-queue-failure/prompt",
+            json!({ "text": "say:must-stay-queued" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(queued["queued"], true);
+
+    // Reproduce a failed queue-consumption write. The production incident's
+    // error was discarded, so its exact SQLite cause is unavailable; the
+    // invariant is that a failed consume must keep loom from dispatching.
+    sqlx::query(
+        "CREATE TRIGGER reject_queue_consume
+         BEFORE UPDATE OF pending_prompt ON sessions
+         WHEN OLD.id = 'acp-queue-failure'
+              AND OLD.pending_prompt IS NOT NULL
+              AND NEW.pending_prompt IS NULL
+         BEGIN
+             SELECT RAISE(FAIL, 'injected queue consume failure');
+         END",
+    )
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+
+    poll_chat(
+        &ts,
+        "acp-queue-failure",
+        Duration::from_secs(10),
+        |blocks| count_kind(blocks, "turn_end") >= 1,
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    ts.state.acp.stop("acp-queue-failure");
+
+    let chat = ts
+        .client
+        .get("/api/sessions/acp-queue-failure/chat")
+        .await
+        .unwrap();
+    assert_eq!(chat["pending_prompt"], "say:must-stay-queued");
+    assert_eq!(
+        count_kind(chat["blocks"].as_array().unwrap(), "user_message"),
+        1,
+        "a prompt whose durable copy could not be consumed must stay unseen"
     );
 }
 
@@ -699,6 +786,9 @@ async fn prompt_steers_a_live_turn_when_advertised() {
         vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
     )
     .await;
+
+    let initial = ts.client.get("/api/sessions/acp-steer/chat").await.unwrap();
+    assert_eq!(initial["metadata"]["steering_supported"], true);
 
     let first = ts
         .client
@@ -751,12 +841,12 @@ async fn prompt_steers_a_live_turn_when_advertised() {
     }));
 }
 
-/// A person can promote already-queued feedback into the running turn even when
-/// an adapter did not advertise steering. The durable copy is consumed only
-/// after the adapter accepts it, so it cannot replay as another turn.
+/// An adapter that does not advertise steering must never be probed with the
+/// private extension. Sending its durable queue now cancels the current turn
+/// and starts one normal prompt with the combined feedback.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn prompt_promotes_queued_feedback_without_advertised_capability() {
+async fn prompt_stops_and_sends_queue_without_steering_capability() {
     let ts = TestServer::start().await;
     start_new(&ts, "acp-force-steer", None, None).await;
 
@@ -777,7 +867,7 @@ async fn prompt_promotes_queued_feedback_without_advertised_capability() {
         .unwrap();
     assert_eq!(queued["queued"], true, "response: {queued}");
 
-    let steered = ts
+    let sent = ts
         .client
         .post(
             "/api/sessions/acp-force-steer/prompt",
@@ -785,14 +875,24 @@ async fn prompt_promotes_queued_feedback_without_advertised_capability() {
         )
         .await
         .unwrap();
-    assert_eq!(steered["queued"], false);
-    assert_eq!(steered["steered"], true, "response: {steered}");
+    assert_eq!(sent["queued"], false);
+    assert_eq!(sent["steered"], false, "response: {sent}");
 
     let session = session_mod::get(&ts.state.db, "acp-force-steer")
         .await
         .unwrap()
         .unwrap();
     assert!(session.pending_prompt.as_deref().unwrap_or("").is_empty());
+
+    let chat = poll_chat(&ts, "acp-force-steer", Duration::from_secs(10), |blocks| {
+        blocks
+            .iter()
+            .any(|block| block["kind"] == "agent_message" && block["payload"]["text"] == "feedback")
+    })
+    .await;
+    assert!(chat["blocks"].as_array().unwrap().iter().any(|block| {
+        block["kind"] == "turn_end" && block["payload"]["stop_reason"] == "cancelled"
+    }));
 }
 
 /// Composer-selected files are resolved inside the worktree and forwarded as

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -714,6 +714,12 @@ async fn prompt_queues_during_a_live_turn() {
 async fn queue_consume_failure_does_not_dispatch_or_replay() {
     let ts = TestServer::start().await;
     start_new(&ts, "acp-queue-failure", None, None).await;
+    let mut rx = ts
+        .state
+        .acp
+        .get("acp-queue-failure")
+        .expect("task registered")
+        .subscribe();
 
     ts.client
         .post(
@@ -749,14 +755,23 @@ async fn queue_consume_failure_does_not_dispatch_or_replay() {
     .await
     .unwrap();
 
-    poll_chat(
-        &ts,
-        "acp-queue-failure",
-        Duration::from_secs(10),
-        |blocks| count_kind(blocks, "turn_end") >= 1,
-    )
+    drain_events(&mut rx, Duration::from_secs(10), |event| {
+        event.event == "turn" && event.data["state"] == "ended"
+    })
     .await;
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    let replay = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            let event = rx.recv().await.expect("ACP event stream remains open");
+            if event.event == "block" && event.data["kind"] == "user_message" {
+                return;
+            }
+        }
+    })
+    .await;
+    assert!(
+        replay.is_err(),
+        "the queued prompt was unexpectedly replayed"
+    );
     ts.state.acp.stop("acp-queue-failure");
 
     let chat = ts

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -342,7 +342,7 @@ test.describe('acp conversation', () => {
     await expect(page.getByText('after stop', { exact: true })).toBeVisible({ timeout: 15_000 });
   });
 
-  test('force steer injects feedback when the agent omitted its capability bit', async ({ page, weaver }) => {
+  test('force steer is offered only when the agent advertises it', async ({ page, weaver }) => {
     await openAcp(page, weaver, {
       goal: 'say:ready',
       name: 'acp-force-ui',
@@ -356,13 +356,7 @@ test.describe('acp conversation', () => {
     });
 
     await input.fill('say:feedback now');
-    await page.getByTestId('acp-composer-force-steer').click();
-    await expect(page.getByTestId('acp-steered')).toBeVisible({
-      timeout: 15_000,
-    });
-    await expect(
-      page.getByTestId('acp-conversation').getByText('feedback nowfirst turn done', { exact: true }),
-    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId('acp-composer-force-steer')).toBeHidden();
   });
 
   test('ordinary feedback says when the running agent has not seen it yet', async ({ page, weaver }) => {
@@ -381,21 +375,29 @@ test.describe('acp conversation', () => {
     await expect(page.getByTestId('acp-queued')).toHaveText(
       'queued · agent hasn’t seen this yet',
     );
+    await input.fill('say:and another thought');
+    await page.getByTestId('acp-composer-send').click();
+    await expect(page.getByTestId('acp-pending')).toHaveCount(1);
+    await expect(page.getByTestId('acp-pending')).toContainText('queued feedback');
+    await expect(page.getByTestId('acp-pending')).toContainText('and another thought');
     await page.reload();
     await expect(page.getByTestId('acp-queued')).toHaveText(
       'queued · agent hasn’t seen this yet',
     );
     const forceNow = page.getByTestId('acp-force-queued').last();
     await expect(forceNow).toBeEnabled();
+    await expect(forceNow).toHaveText('Stop & send');
     await page.screenshot({ path: test.info().outputPath('acp-queued-feedback.png') });
     await forceNow.click();
 
     await expect(page.getByTestId('acp-queued')).toBeHidden();
-    await expect(page.getByTestId('acp-steered')).toBeVisible({ timeout: 15_000 });
     await expect(
       page
         .getByTestId('acp-conversation')
-        .getByText('queued feedbackfirst turn done', { exact: true }),
+        .getByText('queued feedback', { exact: true }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.getByTestId('acp-conversation').getByText('say:and another thought', { exact: true }),
     ).toBeVisible({ timeout: 20_000 });
   });
 
@@ -427,6 +429,7 @@ test.describe('acp conversation', () => {
     await expect(page.getByTestId('acp-working')).toBeVisible({
       timeout: 15_000,
     });
+    await expect(page.getByTestId('acp-composer-force-steer')).toBeVisible();
 
     // A second prompt sent mid-turn is injected into the active turn.
     await input.fill('say:second turn');


### PR DESCRIPTION
Make pending-prompt consumption transactional and require it to commit before ACP dispatch begins. A failed clear previously still started the turn, leaving the same pending text eligible at every later boundary and growing the durable chat journal indefinitely.

Treat SQLite as the authoritative coalesced feedback queue. Queue mutations now stream to chat clients, which render one server-owned pending item instead of per-click optimistic rows. Adapter-advertised steering support controls the UI and request path; unsupported adapters use an explicit Stop & send flow rather than probing _session/steering and failing with Method not found. Agent-acknowledged configuration updates also resynchronize the permissions pill.

The regression suite covers failed queue consumption, multi-message coalescing, supported and unsupported steering, and the full browser conversation flow.

Investigation: https://loom.rjp.io/s/nh5s18sa/artifacts/conversation-dup-investigation

Session: https://loom.rjp.io/s/kmqsuutg