### PR TITLE
feat(loom): add Slack Socket Mode integration (/marinbot)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1745,7 +1745,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2458,8 +2458,12 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2650,6 +2654,8 @@ dependencies = [
  "httparse",
  "log",
  "rand",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
 ]
@@ -2955,6 +2961,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/crates/loom/Cargo.toml
+++ b/crates/loom/Cargo.toml
@@ -68,6 +68,13 @@ toml = { version = "1", default-features = false, features = ["parse", "display"
 # before running them; the tests reuse it for fixtures.
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
+# The Slack Socket Mode client (crate::slack) dials `wss://` out to Slack, so it
+# needs a real (not dev-only) dependency *with* a TLS feature — the bare crate
+# can't open a secure socket ("TLS support not compiled in"). `rustls-tls-webpki-
+# roots` bundles the roots, matching reqwest's rustls stack above (no system dep).
+# 0.29 matches axum 0.8's own tokio-tungstenite so the two speak one protocol
+# stack; the terminal round-trip integration test reuses this same client.
+tokio-tungstenite = { version = "0.29", features = ["connect", "rustls-tls-webpki-roots"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tower-http = { version = "0.6", features = ["cors", "fs", "compression-full"] }
@@ -76,9 +83,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 croner = "3"
 
 [dev-dependencies]
-# WebSocket client for the terminal round-trip integration test. 0.29 matches
-# axum 0.8's own tokio-tungstenite, so the two speak the same protocol stack.
-tokio-tungstenite = "0.29"
 futures-util = "0.3"
 # Raw-body HTTP client for the scratch-upload integration test, plus `stream`
 # for reading the ACP `/chat/stream` SSE body chunk by chunk.

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -373,7 +373,7 @@ export const restartShell = () => post('/shell/restart');
 
 // --- Authentication --------------------------------------------------------
 
-import type { Me, Token, CreatedToken, User, GithubConfig } from './types';
+import type { Me, Token, CreatedToken, User, GithubConfig, SlackStatus } from './types';
 
 /** Who the caller is + which sign-in methods to offer. Never 401s. */
 export const getMe = () => get('/auth/me') as Promise<Me>;
@@ -425,6 +425,12 @@ export const setGithubConfig = (clientId: string, clientSecret?: string) =>
     client_id: clientId,
     ...(clientSecret !== undefined ? { client_secret: clientSecret } : {}),
   }) as Promise<GithubConfig>;
+
+// --- Slack -------------------------------------------------------------
+
+/** Read-only Slack connection state — configured/connected plus the bot
+ *  identity or error (`GET /api/slack/status`). */
+export const getSlackStatus = () => get('/slack/status') as Promise<SlackStatus>;
 
 // --- Server logs / debug ---------------------------------------------------
 

--- a/crates/loom/frontend/src/components/SlackPanel.vue
+++ b/crates/loom/frontend/src/components/SlackPanel.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import * as api from '../api';
+import type { SlackStatus } from '../types';
+
+// Read-only Slack connection state for the Connections settings pane — the
+// bot-token `auth.test` result, alongside GitHub's identity block above. The
+// tokens themselves are never exposed here (set via `LOOM_SLACK_APP_TOKEN` /
+// `LOOM_SLACK_BOT_TOKEN` in the server environment, outside the settings
+// registry); this card only reports whether they work. `slack.enabled` is the
+// kill switch, editable as a regular setting below.
+const status = ref<SlackStatus | null>(null);
+const error = ref('');
+
+async function load() {
+  try {
+    status.value = await api.getSlackStatus();
+    error.value = '';
+  } catch (e) {
+    error.value = (e as Error).message;
+  }
+}
+
+// Dot + label: sage once `auth.test` succeeds, ochre once configured but
+// failing (the same "wants a look" tone the fleet reserves for attention),
+// faint when the tokens aren't set at all.
+const indicator = computed(() => {
+  if (!status.value) return { dot: 'bg-faint/50', text: 'text-faint', label: 'Checking…' };
+  if (status.value.connected) return { dot: 'bg-ok-line', text: 'text-ok', label: 'Connected' };
+  if (status.value.configured) {
+    return { dot: 'bg-attn-line', text: 'text-attn', label: 'Not connected' };
+  }
+  return { dot: 'bg-faint/50', text: 'text-faint', label: 'Not configured' };
+});
+</script>
+
+<template>
+  <div>
+    <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">Slack</h2>
+    <div class="rounded-md border border-line bg-surface px-3 py-2.5">
+      <p v-if="error" class="text-sm text-block">{{ error }}</p>
+
+      <template v-else>
+        <div class="flex items-center gap-1.5">
+          <span class="h-1.5 w-1.5 rounded-full" :class="indicator.dot" aria-hidden="true"></span>
+          <span class="text-sm font-medium" :class="indicator.text">{{ indicator.label }}</span>
+          <span v-if="status?.configured && !status.enabled" class="text-2xs text-faint">
+            · disabled
+          </span>
+        </div>
+
+        <p v-if="status?.connected" class="mt-1 text-xs text-muted">
+          Bot <code class="font-mono">{{ status.bot_user }}</code> in workspace
+          <code class="font-mono">{{ status.team }}</code
+          >.
+        </p>
+        <p v-else-if="status?.configured && status.error" class="mt-1 text-xs text-block">
+          {{ status.error }}
+        </p>
+        <p v-else-if="status && !status.configured" class="mt-1 text-xs text-muted">
+          Set <code class="font-mono">LOOM_SLACK_APP_TOKEN</code> and
+          <code class="font-mono">LOOM_SLACK_BOT_TOKEN</code> in the server environment to enable
+          the <code class="font-mono">@loom</code> Slack trigger.
+        </p>
+      </template>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -31,10 +31,11 @@ function parkOf(value: string | undefined): number {
 // loud status. Mirrors weaver-core's `IDLE_KEY`.
 export const IDLE_KEY = 'idle';
 
-// Loom's machine bookkeeping for its GitHub side-effects (the PR back-link
-// mark, the status-card comment id). Not user-meaningful, so the pill row
-// hides them; the `github` wiring tag itself stays visible.
-const BOOKKEEPING_KEYS = ['github.linked', 'github.status_comment'];
+// Loom's machine bookkeeping for its GitHub/Slack side-effects (the PR
+// back-link mark, the status-card comment/message id). Not user-meaningful,
+// so the pill row hides them; the `github`/`slack` wiring tags themselves
+// stay visible.
+const BOOKKEEPING_KEYS = ['github.linked', 'github.status_comment', 'slack.status_message'];
 
 // Severity of a tag value: 0 is quiet (a pill), >0 is loud (a badge).
 function severityOf(value: string | undefined): number {

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -792,6 +792,21 @@ export interface GithubConfig {
   app_slug: string;
 }
 
+/** Read-only Slack connection state for the Connections settings pane
+ *  (`GET /api/slack/status`). `configured` means both the app-level and bot
+ *  tokens are set (via env, outside the settings registry); `connected` means
+ *  an `auth.test` with the bot token just succeeded — a live credential-health
+ *  check, not merely "tokens present". `bot_user`/`team` are populated only
+ *  when connected; `error` only when configured but not connected. */
+export interface SlackStatus {
+  configured: boolean;
+  enabled: boolean;
+  connected: boolean;
+  bot_user: string | null;
+  team: string | null;
+  error: string | null;
+}
+
 // --- Conversation log (iris format) ----------------------------------------
 // The normalized agent conversation served by `GET /sessions/{id}/conversation`.
 // Mirrors `weaver_core::transcript::iris`: a list of role-tagged messages, each

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -6,6 +6,7 @@ import type { AgentMetadata, CustomAgent, SettingView } from '../types';
 import ToggleSwitch from '../components/ToggleSwitch.vue';
 import TokensPanel from '../components/TokensPanel.vue';
 import AccountPanel from '../components/AccountPanel.vue';
+import SlackPanel from '../components/SlackPanel.vue';
 import EnvPanel from '../components/EnvPanel.vue';
 import LogsPanel from '../components/LogsPanel.vue';
 import AgentProfileEditor from '../components/AgentProfileEditor.vue';
@@ -53,9 +54,11 @@ const categories: CategoryItem[] = [
   },
   {
     id: 'github',
-    label: 'GitHub',
-    groups: ['GitHub'],
-    summary: 'Pull request polling, merge archiving, and issue-comment launch triggers.',
+    label: 'Connections',
+    groups: ['GitHub', 'Slack'],
+    summary:
+      'GitHub and Slack integrations: PR polling, merge archiving, issue-comment and ' +
+      '`/marinbot` launch triggers, and their connection state.',
   },
   {
     id: 'watches',
@@ -389,6 +392,7 @@ onMounted(load);
           <AccountPanel v-if="category === 'access'" />
           <TokensPanel v-if="category === 'access'" />
           <AppearancePanel v-if="category === 'workspace'" />
+          <SlackPanel v-if="category === 'github'" />
 
           <section
             v-if="currentSettings.length"

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -124,7 +124,7 @@ const POLL_TICK: Duration = Duration::from_secs(30);
 /// (posted the `…/s/{id}` comment). Set by the poll loop's back-link poster or,
 /// for a `@loom`-triggered PR, by the trigger reply — so exactly one link lands.
 /// Shared with [`crate::web`] (the trigger reply path).
-pub const LINKED_TAG: &str = "github.linked";
+pub const LINKED_TAG: &str = tags::GITHUB_LINKED_KEY;
 
 // ---------------------------------------------------------------------------
 // The status card
@@ -149,13 +149,11 @@ pub const STATUS_COMMENT_TAG: &str = tags::GITHUB_COMMENT_KEY;
 /// count line so a long session never turns the comment into a scroll.
 const STATUS_CARD_CAP: usize = 15;
 
-/// Keys loom stamps mechanically to track its own GitHub side-effects. The
-/// generic tag routes refuse to *set* them — a forged comment id would aim
-/// loom's edits at someone else's comment. Clearing stays allowed (harmless:
-/// loom re-creates its bookkeeping on the next pass).
-pub fn is_reserved_tag(key: &str) -> bool {
-    key == LINKED_TAG || key == STATUS_COMMENT_TAG
-}
+/// Keys loom stamps mechanically to track its own integration side-effects —
+/// now centralized as [`tags::is_reserved_tag`] (both generic tag routes gate on
+/// it, and Slack bookkeeping joins the same list). Re-exported here for the
+/// GitHub call sites that reference it.
+pub use tags::is_reserved_tag;
 
 /// Parse a [`WIRED_TAG`] value — `owner/name#number` — into its slug and
 /// thread number. `None` for anything else (the tag is free-form user input,

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -32,6 +32,7 @@ pub mod server;
 pub mod session;
 pub mod setup;
 pub mod shell;
+pub mod slack;
 pub mod tasks;
 pub mod terminal;
 pub mod user_token;

--- a/crates/loom/src/loom_config.rs
+++ b/crates/loom/src/loom_config.rs
@@ -62,6 +62,15 @@ pub struct LoomConfig {
     pub openai_api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gh_token: Option<String>,
+    /// Slack app-level token (`xapp-…`, needs `connections:write`) — opens the
+    /// Socket Mode websocket. With both this and `slack_bot_token` set, loom
+    /// connects to Slack and the `/marinbot` trigger goes live.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slack_app_token: Option<String>,
+    /// Slack bot-user OAuth token (`xoxb-…`) — every Web API call
+    /// (`chat.postMessage`, `conversations.history`, …) the integration makes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slack_bot_token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_email: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -160,6 +169,18 @@ pub static FIELDS: &[FieldSpec] = &[
         secret: true,
         get_fn: |c| c.gh_token.as_deref(),
         set_fn: |c, v| c.gh_token = Some(v),
+    },
+    FieldSpec {
+        env_name: "LOOM_SLACK_APP_TOKEN",
+        secret: true,
+        get_fn: |c| c.slack_app_token.as_deref(),
+        set_fn: |c, v| c.slack_app_token = Some(v),
+    },
+    FieldSpec {
+        env_name: "LOOM_SLACK_BOT_TOKEN",
+        secret: true,
+        get_fn: |c| c.slack_bot_token.as_deref(),
+        set_fn: |c, v| c.slack_bot_token = Some(v),
     },
     FieldSpec {
         env_name: "LOOM_TLS_EMAIL",
@@ -411,6 +432,8 @@ mod tests {
                 "ANTHROPIC_API_KEY",
                 "OPENAI_API_KEY",
                 "GH_TOKEN",
+                "LOOM_SLACK_APP_TOKEN",
+                "LOOM_SLACK_BOT_TOKEN",
             ]
         );
     }

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -329,7 +329,11 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
     tokio::spawn(watch::run(state.clone()));
     // Retire embedded code-server instances that have gone idle.
     tokio::spawn(crate::ide::reap_loop(state.clone()));
-    tracing::debug!("background tasks spawned (monitor, github poll, watch, ide reaper)");
+    // The Slack Socket Mode client. Always spawned; it self-gates on token
+    // presence and the `slack.enabled` switch, so an unconfigured loom idles
+    // here cheaply.
+    tokio::spawn(crate::slack::run(state.clone()));
+    tracing::debug!("background tasks spawned (monitor, github poll, watch, ide reaper, slack)");
     // `into_make_service_with_connect_info` surfaces the peer `SocketAddr` to the
     // auth middleware, which uses it to recognise (and optionally trust) loopback.
     axum::serve(

--- a/crates/loom/src/slack.rs
+++ b/crates/loom/src/slack.rs
@@ -1,0 +1,1236 @@
+//! Slack integration — Socket Mode.
+//!
+//! The Slack analog of the GitHub `@loom` trigger ([`crate::github_trigger`] +
+//! [`crate::github`]), with the transport inverted: instead of receiving an
+//! inbound, HMAC-verified webhook, loom is an **outbound websocket client**. A
+//! background task ([`run`]) opens a [Socket Mode] connection with the app-level
+//! token, receives `slash_commands` / `app_mention` envelopes, and — for an
+//! authorized trigger — pulls the conversation, launches a session, and replies
+//! in-thread with a live "On it" card. As the session reports `weaver status`,
+//! [`sync_status_message`] edits that Slack message in place, exactly as
+//! [`crate::github::sync_status_comment`] edits the GitHub comment.
+//!
+//! The socket is authenticated (the app token) and single-workspace, so there is
+//! no HMAC to verify — but delivery is still *at-least-once* (a missed 3-second
+//! ACK or a reconnect boundary redelivers), so we keep GitHub's
+//! [`crate::github_trigger::record_delivery`] dedupe, keyed on Slack's `event_id`.
+//!
+//! [Socket Mode]: https://docs.slack.dev/apis/events-api/using-socket-mode/
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use weaver_core::{config, events, tags};
+
+use crate::web::AppState;
+use crate::Db;
+
+/// Env var / settings key for the app-level token (`xapp-…`). Held outside the
+/// settings registry (like the GitHub webhook secret) so `GET /api/settings`
+/// never returns it; set it through the environment or `loom config`.
+pub const APP_TOKEN_ENV: &str = "LOOM_SLACK_APP_TOKEN";
+pub const APP_TOKEN_KEY: &str = "slack.app_token";
+/// Env var / settings key for the bot-user OAuth token (`xoxb-…`).
+pub const BOT_TOKEN_ENV: &str = "LOOM_SLACK_BOT_TOKEN";
+pub const BOT_TOKEN_KEY: &str = "slack.bot_token";
+
+/// Branch tag wiring a session to a Slack thread — see [`tags::SLACK_KEY`].
+pub const WIRED_TAG: &str = tags::SLACK_KEY;
+/// Branch tag holding the status card's message `ts` — see
+/// [`tags::SLACK_STATUS_MSG_KEY`].
+pub const STATUS_MSG_TAG: &str = tags::SLACK_STATUS_MSG_KEY;
+
+/// How many trail bullets the status card shows before older ones collapse into
+/// a count line — matches the GitHub card's [`crate::github`] cap.
+const STATUS_CARD_CAP: usize = 15;
+/// Cap on how many conversation messages seed a session, so a busy channel can't
+/// produce an unbounded launch prompt.
+const HISTORY_CAP: usize = 40;
+
+/// `env`, else the `key` setting; empty when neither is set. Mirrors
+/// [`crate::github_trigger`]'s private resolver — kept per-module by design.
+async fn env_or_setting(db: &Db, env: &str, key: &str) -> String {
+    if let Ok(v) = std::env::var(env) {
+        let v = v.trim().to_string();
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    config::get(db, key).await.unwrap_or_default()
+}
+
+/// The app-level token (`xapp-…`), empty when unset.
+pub async fn app_token(db: &Db) -> String {
+    env_or_setting(db, APP_TOKEN_ENV, APP_TOKEN_KEY).await
+}
+
+/// The bot token (`xoxb-…`), empty when unset.
+pub async fn bot_token(db: &Db) -> String {
+    env_or_setting(db, BOT_TOKEN_ENV, BOT_TOKEN_KEY).await
+}
+
+/// Whether the integration is switched on: both tokens present *and*
+/// `slack.enabled` not turned off. Token presence is the real enabler (a deploy
+/// that ships the tokens Just Works); `slack.enabled` is a kill switch that
+/// closes the socket without removing the tokens.
+pub async fn is_enabled(db: &Db) -> bool {
+    !app_token(db).await.is_empty()
+        && !bot_token(db).await.is_empty()
+        && config::get_bool(db, "slack.enabled", true).await
+}
+
+/// The Slack Web API base — overridable via `LOOM_SLACK_API_BASE` so a test can
+/// point the gateway at a local fixture. Defaults to the real API.
+fn api_base() -> String {
+    std::env::var("LOOM_SLACK_API_BASE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "https://slack.com/api".to_string())
+}
+
+/// The allowlist of Slack user IDs permitted to trigger, from
+/// `slack.allowed_users` (space/comma separated). Empty ⇒ deny-by-default.
+async fn allowed_users(db: &Db) -> Vec<String> {
+    config::get(db, "slack.allowed_users")
+        .await
+        .unwrap_or_default()
+        .split([' ', ',', '\n', '\t'])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The Web API gateway.
+// ---------------------------------------------------------------------------
+
+/// A message pulled from conversation history — the fields we seed a session
+/// with. `user` is `None` for a non-user message (a bot post, a system join).
+#[derive(Debug, Clone)]
+pub struct HistMsg {
+    pub user: Option<String>,
+    pub text: String,
+}
+
+/// The Slack Web API gateway: a thin `reqwest` client bound to the bot token.
+/// Cheap to build per use, so [`sync_status_message`] and the trigger handler
+/// each construct one rather than threading a shared object through `AppState`.
+#[derive(Clone)]
+pub struct SlackWeb {
+    http: reqwest::Client,
+    bot_token: String,
+    base: String,
+}
+
+impl SlackWeb {
+    pub fn new(bot_token: impl Into<String>) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            bot_token: bot_token.into(),
+            base: api_base(),
+        }
+    }
+
+    /// Build from the configured bot token, or `None` when it isn't set.
+    pub async fn from_db(db: &Db) -> Option<Self> {
+        let token = bot_token(db).await;
+        (!token.is_empty()).then(|| Self::new(token))
+    }
+
+    /// POST `method` with a JSON body and a Bearer token, returning the parsed
+    /// response. Slack signals application errors with `{"ok": false, "error":
+    /// …}` under an HTTP 200, so a 200 is *not* success — every call checks `ok`.
+    async fn call(&self, method: &str, body: Value, token: &str) -> Result<Value> {
+        let resp = self
+            .http
+            .post(format!("{}/{method}", self.base))
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| format!("slack {method}: request failed"))?;
+        // HTTP 429 carries a `Retry-After` (seconds); surface it so the caller
+        // can back off rather than hammer a rate-limited method.
+        if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let retry = resp
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("1");
+            return Err(anyhow!(
+                "slack {method}: rate limited (retry after {retry}s)"
+            ));
+        }
+        let value: Value = resp
+            .json()
+            .await
+            .with_context(|| format!("slack {method}: decoding response failed"))?;
+        if value.get("ok").and_then(Value::as_bool) != Some(true) {
+            let err = value
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            return Err(anyhow!("slack {method}: {err}"));
+        }
+        Ok(value)
+    }
+
+    /// Bot-token call (the common case).
+    async fn call_bot(&self, method: &str, body: Value) -> Result<Value> {
+        let token = self.bot_token.clone();
+        self.call(method, body, &token).await
+    }
+
+    /// Resolve our own identity — the bot user id (to skip our own events) and
+    /// the workspace `team_id` (the authorization boundary).
+    pub async fn auth_test(&self) -> Result<AuthTest> {
+        let v = self.call_bot("auth.test", json!({})).await?;
+        Ok(AuthTest {
+            user_id: v["user_id"].as_str().unwrap_or_default().to_string(),
+            team_id: v["team_id"].as_str().unwrap_or_default().to_string(),
+        })
+    }
+
+    /// Post a message, optionally threaded under `thread_ts`. Returns the new
+    /// message's `ts`.
+    pub async fn post_message(
+        &self,
+        channel: &str,
+        thread_ts: Option<&str>,
+        text: &str,
+    ) -> Result<String> {
+        let mut body = json!({ "channel": channel, "text": text, "unfurl_links": false });
+        if let Some(ts) = thread_ts {
+            body["thread_ts"] = json!(ts);
+        }
+        let v = self.call_bot("chat.postMessage", body).await?;
+        Ok(v["ts"].as_str().unwrap_or_default().to_string())
+    }
+
+    /// Edit a message in place. `Ok(false)` means the message is gone (deleted),
+    /// so the caller re-posts — mirroring the GitHub card's recreate path.
+    pub async fn update_message(&self, channel: &str, ts: &str, text: &str) -> Result<bool> {
+        let body = json!({ "channel": channel, "ts": ts, "text": text, "unfurl_links": false });
+        match self.call_bot("chat.update", body).await {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("message_not_found") || msg.contains("cant_update_message") {
+                    Ok(false)
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    /// Add an emoji reaction (best-effort ack). Swallows `already_reacted`.
+    pub async fn add_reaction(&self, channel: &str, ts: &str, name: &str) -> Result<()> {
+        let body = json!({ "channel": channel, "timestamp": ts, "name": name });
+        match self.call_bot("reactions.add", body).await {
+            Ok(_) => Ok(()),
+            Err(e) if e.to_string().contains("already_reacted") => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// One page of a thread's replies, oldest-first (Slack returns them in
+    /// order). Best-effort: a `not_in_channel` (the bot was never invited)
+    /// surfaces as the error so the caller can tell the user.
+    pub async fn conversations_replies(&self, channel: &str, ts: &str) -> Result<Vec<HistMsg>> {
+        let body = json!({ "channel": channel, "ts": ts, "limit": HISTORY_CAP });
+        let v = self.call_bot("conversations.replies", body).await?;
+        Ok(parse_history(&v))
+    }
+
+    /// The channel's recent top-level messages. Slack returns newest-first, so
+    /// the result is reversed to chronological order.
+    pub async fn conversations_history(&self, channel: &str) -> Result<Vec<HistMsg>> {
+        let body = json!({ "channel": channel, "limit": HISTORY_CAP });
+        let v = self.call_bot("conversations.history", body).await?;
+        let mut msgs = parse_history(&v);
+        msgs.reverse();
+        Ok(msgs)
+    }
+
+    /// Open a Socket Mode connection with the **app-level** token, returning the
+    /// short-lived `wss://` URL. The URL's `ticket` query param is a live
+    /// credential — never log it.
+    pub async fn open_connection(&self, app_token: &str) -> Result<String> {
+        let v = self
+            .call("apps.connections.open", json!({}), app_token)
+            .await?;
+        v["url"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("apps.connections.open: no url in response"))
+    }
+}
+
+/// The identity `auth.test` resolves at startup.
+#[derive(Debug, Clone)]
+pub struct AuthTest {
+    pub user_id: String,
+    pub team_id: String,
+}
+
+/// Extract `{user, text}` messages from a `conversations.*` response.
+fn parse_history(v: &Value) -> Vec<HistMsg> {
+    v["messages"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    let text = m["text"].as_str().unwrap_or_default().trim().to_string();
+                    if text.is_empty() {
+                        return None;
+                    }
+                    Some(HistMsg {
+                        user: m["user"].as_str().map(str::to_string),
+                        text,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Envelope + trigger parsing (pure — the unit-tested core).
+// ---------------------------------------------------------------------------
+
+/// Where a trigger's session thread is anchored. Slack slash commands are
+/// *thread-blind* (their payload has no `ts`/`thread_ts`), so a slash command
+/// can only start a new root — the card's own `ts` becomes the thread. A mention
+/// anchors on the thread it was typed in, or on its own `ts` at top level.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Anchor {
+    /// A `/marinbot` slash command — post the card as a new root message.
+    Slash,
+    /// An `@marinbot` mention. `root_ts` is the thread to attach to (the
+    /// mention's own `ts` at top level, or its `thread_ts` inside a thread), and
+    /// `event_ts` is the mention message itself (what we 👀-react to as an ack).
+    Mention { root_ts: String, event_ts: String },
+}
+
+/// A parsed, deduped trigger ready to authorize and act on.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Trigger {
+    pub team_id: String,
+    pub channel_id: String,
+    pub user_id: String,
+    pub text: String,
+    pub anchor: Anchor,
+    /// The id we dedupe on (`event_id` for events; the slash `trigger_id`).
+    pub dedupe_id: String,
+}
+
+/// A decoded Socket Mode envelope.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Envelope {
+    /// The connection is live.
+    Hello,
+    /// Slack is about to close this socket. `reason` is `warning` (a ~10s
+    /// pre-close notice), `refresh_requested`, or `link_disabled`.
+    Disconnect { reason: String },
+    /// A payload-bearing envelope (`events_api` / `slash_commands` /
+    /// `interactive`) that must be ACKed by echoing `envelope_id`.
+    Payload {
+        envelope_id: String,
+        kind: String,
+        payload: Value,
+    },
+    /// Anything else — acked if it carries an `envelope_id`, else ignored.
+    Other { envelope_id: Option<String> },
+}
+
+/// Decode a raw Socket Mode frame.
+pub fn parse_envelope(v: &Value) -> Envelope {
+    match v["type"].as_str().unwrap_or_default() {
+        "hello" => Envelope::Hello,
+        "disconnect" => Envelope::Disconnect {
+            reason: v["reason"].as_str().unwrap_or_default().to_string(),
+        },
+        kind @ ("events_api" | "slash_commands" | "interactive") => {
+            match v["envelope_id"].as_str() {
+                Some(id) => Envelope::Payload {
+                    envelope_id: id.to_string(),
+                    kind: kind.to_string(),
+                    payload: v["payload"].clone(),
+                },
+                None => Envelope::Other { envelope_id: None },
+            }
+        }
+        _ => Envelope::Other {
+            envelope_id: v["envelope_id"].as_str().map(str::to_string),
+        },
+    }
+}
+
+/// Build a [`Trigger`] from a `slash_commands` payload. Slash payloads have no
+/// thread anchor (see [`Anchor::Slash`]).
+pub fn trigger_from_slash(payload: &Value) -> Option<Trigger> {
+    let team_id = payload["team_id"].as_str()?.to_string();
+    let channel_id = payload["channel_id"].as_str()?.to_string();
+    let user_id = payload["user_id"].as_str()?.to_string();
+    let text = payload["text"]
+        .as_str()
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    // `trigger_id` is unique per invocation — a stable dedupe key.
+    let dedupe_id = payload["trigger_id"]
+        .as_str()
+        .map(|t| format!("slash:{t}"))
+        .unwrap_or_else(|| format!("slash:{team_id}:{channel_id}:{user_id}:{text}"));
+    Some(Trigger {
+        team_id,
+        channel_id,
+        user_id,
+        text,
+        anchor: Anchor::Slash,
+        dedupe_id,
+    })
+}
+
+/// Build a [`Trigger`] from an `events_api` payload, for `app_mention` only.
+/// Returns `None` for other event types and for the bot's own mentions (a
+/// self-trigger guard). `bot_user_id` is our own user id from `auth.test`.
+pub fn trigger_from_event(payload: &Value, bot_user_id: &str) -> Option<Trigger> {
+    let event = &payload["event"];
+    if event["type"].as_str() != Some("app_mention") {
+        return None;
+    }
+    let user_id = event["user"].as_str()?.to_string();
+    // Skip our own posts and any bot message — never trigger on ourselves.
+    if user_id == bot_user_id || event.get("bot_id").is_some() {
+        return None;
+    }
+    let team_id = payload["team_id"].as_str().unwrap_or_default().to_string();
+    let channel_id = event["channel"].as_str()?.to_string();
+    let event_ts = event["ts"].as_str()?.to_string();
+    // Anchor on the enclosing thread if there is one, else the mention itself.
+    let root_ts = event["thread_ts"].as_str().unwrap_or(&event_ts).to_string();
+    let text = strip_leading_mention(event["text"].as_str().unwrap_or_default());
+    let dedupe_id = payload["event_id"]
+        .as_str()
+        .map(|e| format!("slack:{e}"))
+        .unwrap_or_else(|| format!("slack:{channel_id}:{event_ts}"));
+    Some(Trigger {
+        team_id,
+        channel_id,
+        user_id,
+        text,
+        anchor: Anchor::Mention { root_ts, event_ts },
+        dedupe_id,
+    })
+}
+
+/// Drop a leading `<@U…>` bot mention (and following whitespace) from an
+/// app_mention's text, leaving just the user's instruction.
+fn strip_leading_mention(text: &str) -> String {
+    let t = text.trim_start();
+    if let Some(rest) = t.strip_prefix('<') {
+        if let Some((mention, tail)) = rest.split_once('>') {
+            if mention.starts_with('@') {
+                return tail.trim_start().to_string();
+            }
+        }
+    }
+    t.to_string()
+}
+
+/// Split an optional `owner/name:` repo prefix off the command text. Returns
+/// `(repo, remaining_text)`. Only a bare `owner/name:` at the very start counts
+/// — anything else leaves the text untouched and the repo `None`.
+pub fn parse_repo_prefix(text: &str) -> (Option<String>, String) {
+    let trimmed = text.trim_start();
+    if let Some((head, rest)) = trimmed.split_once(':') {
+        let head = head.trim();
+        // owner/name: exactly one slash, and both halves look like path atoms.
+        if let Some((owner, name)) = head.split_once('/') {
+            let atom = |s: &str| {
+                !s.is_empty()
+                    && s.chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+            };
+            if head.matches('/').count() == 1 && atom(owner) && atom(name) {
+                return (Some(head.to_string()), rest.trim_start().to_string());
+            }
+        }
+    }
+    (None, text.trim().to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Slack mrkdwn rendering.
+// ---------------------------------------------------------------------------
+
+/// Escape the three characters Slack mrkdwn treats specially in text spans, so
+/// an agent-controlled status note can't inject links or `<url|label>` markup.
+/// (Slack's documented escaping is exactly `&`, `<`, `>`.)
+fn escape_mrkdwn(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// One rendered bullet of the status trail. Mirrors the GitHub card's
+/// [`crate::github`] `status_bullet`, but emits Slack mrkdwn: single-`*` bold
+/// (Slack renders `**` literally) and escaped text.
+fn status_bullet(event: &events::Event) -> Option<String> {
+    let value = event.data["value"].as_str().unwrap_or_default();
+    let note = event.data["note"].as_str().unwrap_or_default().trim();
+    let loud = !value.is_empty();
+    if note.is_empty() && !loud {
+        return None;
+    }
+    let icon = match value {
+        "blocked" => "\u{1f534}",
+        "attention" => "\u{1f7e0}",
+        _ => "\u{1f7e2}",
+    };
+    let when = chrono::DateTime::parse_from_rfc3339(&event.created_at)
+        .map(|t| t.format("%b %e %H:%M").to_string())
+        .unwrap_or_default();
+    let mut line = format!("• {icon} `{when}Z`");
+    if loud {
+        line.push_str(&format!(" *{value}*"));
+        if !note.is_empty() {
+            line.push_str(" —");
+        }
+    }
+    if !note.is_empty() {
+        line.push_str(&format!(" {}", escape_mrkdwn(note)));
+    }
+    Some(line)
+}
+
+/// Render the Slack status card: the "On it" header linking the session, the
+/// published documents, then the `weaver status` trail (oldest-first, capped).
+/// Pure, so the mrkdwn format is unit-testable. Slack link syntax is
+/// `<url|label>`, not Markdown's `[label](url)`.
+pub fn render_status(session_url: &str, artifacts: &[String], events: &[events::Event]) -> String {
+    let bullets: Vec<String> = events
+        .iter()
+        .filter(|e| {
+            e.kind == "tag" && e.data["key"] == tags::ATTENTION_KEY && e.data["by"] == "agent"
+        })
+        .filter_map(status_bullet)
+        .collect();
+    let mut body = format!("On it — <{session_url}>");
+    if !artifacts.is_empty() {
+        let links: Vec<String> = artifacts
+            .iter()
+            .map(|name| {
+                use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+                let path = utf8_percent_encode(name, NON_ALPHANUMERIC);
+                format!("<{session_url}/artifacts/{path}|{}>", escape_mrkdwn(name))
+            })
+            .collect();
+        body.push_str(&format!("\nDocs: {}", links.join(" · ")));
+    }
+    if bullets.is_empty() {
+        return body;
+    }
+    let shown = if bullets.len() > STATUS_CARD_CAP {
+        let hidden = bullets.len() - STATUS_CARD_CAP;
+        let mut v = vec![format!("_… {hidden} earlier update(s)_")];
+        v.extend_from_slice(&bullets[bullets.len() - STATUS_CARD_CAP..]);
+        v
+    } else {
+        bullets
+    };
+    format!("{body}\n\n{}", shown.join("\n"))
+}
+
+// ---------------------------------------------------------------------------
+// The status-card mirror — the Slack twin of `github::sync_status_comment`.
+// ---------------------------------------------------------------------------
+
+/// Serializes card writes so two near-simultaneous status reports can't post two
+/// cards or interleave an edit — the same guard the GitHub mirror uses.
+static SYNC_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Mirror a wired branch's status trail onto its Slack thread: render the card
+/// and edit the tracked message in place — posting a fresh one the first time,
+/// or again if it was deleted. A no-op for unwired branches; best-effort
+/// everywhere (a Slack hiccup logs and never fails the status write that spawned
+/// it). Retries transient failures — a terminal status has no later write to
+/// self-heal through.
+pub async fn sync_status_message(state: AppState, branch_id: String) {
+    for attempt in 0..3u32 {
+        if attempt > 0 {
+            tokio::time::sleep(Duration::from_secs(3 * 3u64.pow(attempt - 1))).await;
+        }
+        if sync_status_message_once(&state, &branch_id).await {
+            return;
+        }
+    }
+    tracing::warn!(branch = %branch_id, "slack status card: giving up after retries");
+}
+
+/// One sync attempt. `true` = done (synced, or nothing to do); `false` = a
+/// transient Slack failure worth retrying.
+async fn sync_status_message_once(state: &AppState, branch_id: &str) -> bool {
+    let wired = match tags::get(&state.db, branch_id, WIRED_TAG).await {
+        Ok(Some(tag)) => tag,
+        Ok(None) => return true, // unwired — nothing to mirror
+        Err(e) => {
+            tracing::warn!(branch = %branch_id, error = %e, "slack status card: reading wiring tag failed");
+            return true;
+        }
+    };
+    let Some((_team, channel, _root)) = parse_wiring(&wired.value) else {
+        tracing::warn!(branch = %branch_id, value = %wired.value, "slack status card: unparsable `slack` tag");
+        return true;
+    };
+    // The card links the live session; without a public base_url the link would
+    // be a loopback URL a Slack reader can't follow, so require one (a socket
+    // task has no request headers to derive it from).
+    let base = config::get(&state.db, "auth.base_url")
+        .await
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    if base.is_empty() {
+        tracing::debug!(branch = %branch_id, "slack status card: no auth.base_url; skipping");
+        return true;
+    }
+    let session = match crate::session::active_for_branch(&state.db, branch_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return true,
+        Err(e) => {
+            tracing::warn!(branch = %branch_id, error = %e, "slack status card: session lookup failed");
+            return true;
+        }
+    };
+    let Some(web) = SlackWeb::from_db(&state.db).await else {
+        return true; // bot token gone — nothing to post through
+    };
+
+    let _guard = SYNC_LOCK.lock().await;
+    let mut events = match events::history(&state.db, branch_id, 500).await {
+        Ok(ev) => ev,
+        Err(e) => {
+            tracing::warn!(branch = %branch_id, error = %e, "slack status card: reading event history failed");
+            return true;
+        }
+    };
+    // Statuses from before the wiring stay private — hand-wiring an old session
+    // must not retroactively publish its history.
+    events.retain(|e| e.created_at >= wired.set_at);
+    let artifacts: Vec<String> = match crate::branch::get(&state.db, branch_id).await {
+        Ok(Some(branch)) => {
+            weaver_core::artifact::list_for_session(&state.db, &branch.repo_root, branch_id)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|a| a.name)
+                .filter(|n| n != "goal")
+                .collect()
+        }
+        _ => Vec::new(),
+    };
+    let body = render_status(
+        &crate::web::session_url(&base, &session.id),
+        &artifacts,
+        &events,
+    );
+
+    // Trust the tracked message ts only while its note still names the current
+    // wiring: a re-pointed `slack` tag must get a fresh card on the new thread,
+    // never an edit of the old one.
+    let tracked: Option<String> = match tags::get(&state.db, branch_id, STATUS_MSG_TAG).await {
+        Ok(tag) => tag.filter(|t| t.note == wired.value).map(|t| t.value),
+        Err(e) => {
+            tracing::warn!(branch = %branch_id, error = %e, "slack status card: reading message tag failed");
+            return true;
+        }
+    };
+    if let Some(ts) = tracked {
+        match web.update_message(&channel, &ts, &body).await {
+            Ok(true) => return true,
+            Ok(false) => {
+                tracing::info!(channel = %channel, ts = %ts, "slack status card: message gone; posting a fresh one");
+            }
+            Err(e) => {
+                tracing::warn!(channel = %channel, error = %e, "slack status card: update failed");
+                return false;
+            }
+        }
+    }
+    // The reply is threaded under the wiring's root ts.
+    let root = wired
+        .value
+        .rsplit('/')
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    match web.post_message(&channel, Some(&root), &body).await {
+        Ok(ts) => {
+            record_status_message(&state.db, branch_id, &wired.value, &ts).await;
+            true
+        }
+        Err(e) => {
+            tracing::warn!(channel = %channel, error = %e, "slack status card: posting failed");
+            false
+        }
+    }
+}
+
+/// Stamp the [`STATUS_MSG_TAG`] bookkeeping tag after a card lands. The note
+/// records the wiring the message belongs to — [`sync_status_message`] trusts
+/// the ts only while that note matches the current `slack` tag.
+pub async fn record_status_message(db: &Db, branch_id: &str, wiring: &str, ts: &str) {
+    tags::set(db, branch_id, STATUS_MSG_TAG, ts, wiring, "loom")
+        .await
+        .ok();
+}
+
+/// Parse a [`WIRED_TAG`] value — `team_id/channel_id/thread_ts` — into its
+/// parts. `None` for anything else.
+pub fn parse_wiring(value: &str) -> Option<(String, String, String)> {
+    let mut parts = value.trim().splitn(3, '/');
+    let team = parts.next()?.trim();
+    let channel = parts.next()?.trim();
+    let root = parts.next()?.trim();
+    if team.is_empty() || channel.is_empty() || root.is_empty() {
+        return None;
+    }
+    Some((team.to_string(), channel.to_string(), root.to_string()))
+}
+
+/// Spawn every status-card mirror a branch is wired for. The one seam the status
+/// write path (and artifact publish/delete) calls — GitHub self-gates on the
+/// `github` tag, Slack on the `slack` tag, so an unwired branch is a no-op for
+/// each. Fans a status change out to whichever origin thread(s) a session came
+/// from; adding a third surface is one line here, not another edit at five call
+/// sites.
+pub fn spawn_status_mirrors(state: AppState, branch_id: String) {
+    tokio::spawn(crate::github::sync_status_comment(
+        state.clone(),
+        branch_id.clone(),
+    ));
+    tokio::spawn(sync_status_message(state, branch_id));
+}
+
+// ---------------------------------------------------------------------------
+// The trigger handler.
+// ---------------------------------------------------------------------------
+
+/// Serializes the reuse-or-create decision so two triggers racing on the same
+/// thread can't both see "no session" and both launch. Slack trigger volume is
+/// tiny, so one global lock (rather than a per-wiring map) is ample.
+static CREATE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Act on an authorized-shaped trigger: dedupe, authorize, resolve the repo,
+/// launch (or forward), wire the branch, and post the "On it" card. Runs in a
+/// detached task after the envelope is ACKed. `bot` is our own identity (its
+/// `team_id` is the authorization boundary).
+async fn handle_trigger(state: AppState, web: SlackWeb, bot: AuthTest, trigger: Trigger) {
+    // Dedupe: a redelivered envelope (missed ACK / reconnect) is a no-op.
+    match crate::github_trigger::record_delivery(&state.db, &trigger.dedupe_id).await {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::info!(id = %trigger.dedupe_id, "slack: duplicate delivery ignored");
+            return;
+        }
+        Err(e) => tracing::warn!(error = %e, "slack: dedupe insert failed; proceeding"),
+    }
+
+    // Authorize. The socket is one workspace, but events still carry an explicit
+    // team_id, and Slack Connect delivers events from external teams — so gate on
+    // our own team, then on the allowlist.
+    if trigger.team_id != bot.team_id {
+        tracing::warn!(team = %trigger.team_id, "slack: rejecting event from another workspace");
+        return;
+    }
+    let allowed = allowed_users(&state.db).await;
+    if !allowed.iter().any(|u| u == &trigger.user_id) {
+        tracing::info!(user = %trigger.user_id, "slack: user not on slack.allowed_users; ignoring");
+        // A gentle nudge so the person knows to ask, rather than a silent drop.
+        let _ = notify(
+            &web,
+            &trigger,
+            "You're not on this bot's allowed-users list — ask an admin to add your Slack user id.",
+        )
+        .await;
+        return;
+    }
+
+    // Resolve the repo: an `owner/name:` prefix wins, else the configured
+    // default. Without either there's nothing to work on.
+    let (prefix_repo, instruction) = parse_repo_prefix(&trigger.text);
+    let repo = match prefix_repo {
+        Some(r) => r,
+        None => {
+            let d = config::get(&state.db, "slack.default_repo")
+                .await
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            if d.is_empty() {
+                let _ = notify(&web, &trigger, "No repository to work on. Prefix your request with `owner/name:` or set a Slack default repository in loom's settings.").await;
+                return;
+            }
+            d
+        }
+    };
+
+    if let Err(e) = launch(&state, &web, &bot, &trigger, &repo, &instruction).await {
+        tracing::warn!(error = %e, repo = %repo, "slack: launch failed");
+        let _ = notify(&web, &trigger, &format!("Couldn't start a session: {e}")).await;
+    }
+}
+
+/// Post a short message back to the trigger's thread (an error/ack). For a
+/// mention we thread under its root; a slash command posts a new message.
+async fn notify(web: &SlackWeb, trigger: &Trigger, text: &str) -> Result<()> {
+    let thread = match &trigger.anchor {
+        Anchor::Mention { root_ts, .. } => Some(root_ts.as_str()),
+        Anchor::Slash => None,
+    };
+    web.post_message(&trigger.channel_id, thread, text).await?;
+    Ok(())
+}
+
+/// The launch body: seed context, reuse-or-create the session, wire it, and post
+/// the card. Serialized on [`CREATE_LOCK`].
+async fn launch(
+    state: &AppState,
+    web: &SlackWeb,
+    bot: &AuthTest,
+    trigger: &Trigger,
+    repo: &str,
+    instruction: &str,
+) -> Result<()> {
+    let _guard = CREATE_LOCK.lock().await;
+
+    // Establish the thread root. A slash command is thread-blind, so we post the
+    // card first and let its ts be the root; a mention already has one.
+    let (root_ts, card_ts): (String, Option<String>) = match &trigger.anchor {
+        Anchor::Slash => {
+            let ts = web
+                .post_message(&trigger.channel_id, None, "On it — starting a session…")
+                .await
+                .context("posting the slash-command card")?;
+            (ts.clone(), Some(ts))
+        }
+        Anchor::Mention { root_ts, .. } => (root_ts.clone(), None),
+    };
+
+    let wiring = format!("{}/{}/{}", bot.team_id, trigger.channel_id, root_ts);
+    // A short, collision-free branch name — the full identity lives in the tag
+    // (slugify would truncate a raw channel/ts and collide).
+    let branch_name = format!("slack-{}", short_hash(&wiring));
+    let branch_ref = format!("weaver/{branch_name}");
+
+    // Pull the conversation to seed the session.
+    let history = pull_history(web, trigger).await;
+
+    // Reuse or relaunch: does a branch already exist for this thread?
+    let repo_root = crate::repo::resolve_clone(&state.db, repo, state.trigger.app())
+        .await
+        .map_err(|e| anyhow!("{e:?}"))?;
+    let repo_root_str = repo_root.to_string_lossy().to_string();
+    let existing = crate::branch::find_by_repo_branch(&state.db, &repo_root_str, &branch_ref)
+        .await
+        .ok()
+        .flatten();
+    if let Some(b) = &existing {
+        if let Ok(Some(sess)) = crate::session::active_for_branch(&state.db, &b.id).await {
+            if sess.status != "archived" {
+                // A live session already owns this thread — don't launch a
+                // second. Ack (👀 on the mention; a note for a slash) and stop.
+                if let Anchor::Mention { event_ts, .. } = &trigger.anchor {
+                    web.add_reaction(&trigger.channel_id, event_ts, "eyes")
+                        .await
+                        .ok();
+                } else {
+                    notify(web, trigger, "Already working on this thread.")
+                        .await
+                        .ok();
+                }
+                return Ok(());
+            }
+            // A session row that outlived its terminal — retire it (`error`, not
+            // `archived`, so the branch frees for a fresh launch) and fall through.
+            crate::session::set_status(&state.db, &sess.id, "error")
+                .await
+                .ok();
+        }
+    }
+
+    let goal = slack_goal(repo, trigger, instruction, &history);
+    let branch_exists = crate::git::branch_exists(&repo_root, &branch_ref).await;
+    let mut req = weaver_api::dto::CreateReq {
+        repo: Some(repo.to_string()),
+        goal: Some(goal),
+        ..Default::default()
+    };
+    if branch_exists || existing.is_some() {
+        req.existing_branch = Some(branch_ref.clone());
+    } else {
+        req.name = Some(branch_name.clone());
+    }
+
+    let view = crate::web::sessions::create_session_core(state.clone(), req, None)
+        .await
+        .map_err(|e| anyhow!("{e:?}"))?;
+
+    // Wire the branch to the thread — what `sync_status_message` reads to mirror
+    // every `weaver status` write. Left untouched if already wired to this thread.
+    let already = matches!(
+        tags::get(&state.db, &view.branch.id, WIRED_TAG).await,
+        Ok(Some(ref t)) if t.value == wiring
+    );
+    if !already {
+        tags::set(
+            &state.db,
+            &view.branch.id,
+            WIRED_TAG,
+            &wiring,
+            "wired by /marinbot",
+            "loom",
+        )
+        .await
+        .ok();
+    }
+
+    // Post (or reuse) the card, record its ts, then run one locked full sync so
+    // an early status that landed before wiring still renders.
+    let base = config::get(&state.db, "auth.base_url")
+        .await
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    let card_body = if base.is_empty() {
+        "On it — session started (set loom's public base URL to link it here).".to_string()
+    } else {
+        format!("On it — <{}>", crate::web::session_url(&base, &view.id))
+    };
+    let ts = match card_ts {
+        Some(ts) => {
+            web.update_message(&trigger.channel_id, &ts, &card_body)
+                .await
+                .ok();
+            ts
+        }
+        None => web
+            .post_message(&trigger.channel_id, Some(&root_ts), &card_body)
+            .await
+            .context("posting the mention card")?,
+    };
+    record_status_message(&state.db, &view.branch.id, &wiring, &ts).await;
+    tracing::info!(session = %view.id, repo = %repo, channel = %trigger.channel_id, "slack: launched session");
+    drop(_guard);
+    sync_status_message(state.clone(), view.branch.id.clone()).await;
+    Ok(())
+}
+
+/// Pull the conversation context to seed the session — the thread's replies for
+/// a mention, or the channel's recent messages for a slash command (which has no
+/// thread of its own). Best-effort: a `not_in_channel` becomes a note in the
+/// seed rather than a hard failure.
+async fn pull_history(web: &SlackWeb, trigger: &Trigger) -> String {
+    let result = match &trigger.anchor {
+        Anchor::Mention { root_ts, .. } => {
+            web.conversations_replies(&trigger.channel_id, root_ts)
+                .await
+        }
+        Anchor::Slash => web.conversations_history(&trigger.channel_id).await,
+    };
+    match result {
+        Ok(msgs) => msgs
+            .iter()
+            .map(|m| {
+                let who = m.user.as_deref().unwrap_or("someone");
+                format!("<@{who}>: {}", m.text)
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Err(e) => {
+            let note = e.to_string();
+            if note.contains("not_in_channel") {
+                "(loom's bot isn't a member of this conversation, so it couldn't read the history — invite it with /invite.)".to_string()
+            } else {
+                format!("(couldn't read the conversation history: {note})")
+            }
+        }
+    }
+}
+
+/// The seed goal handed to the session — the Slack analog of GitHub's
+/// `trigger_goal`.
+fn slack_goal(repo: &str, trigger: &Trigger, instruction: &str, history: &str) -> String {
+    let instruction = if instruction.trim().is_empty() {
+        "(no explicit instruction — infer the task from the conversation)"
+    } else {
+        instruction.trim()
+    };
+    format!(
+        "You've been summoned from Slack (channel {channel}) to work on `{repo}`.\n\n\
+         ## Request (from <@{user}>)\n{instruction}\n\n\
+         ## Conversation context\n{history}\n\n\
+         ## How to respond\n\
+         - Do the work on this branch and open a pull request against the default branch when it's ready.\n\
+         - Your `weaver status` messages are mirrored onto the Slack thread (loom edits its \"On it\" message into a live status trail), so progress reporting is automatic — write status messages for that audience.\n\
+         - Reply on the thread only when you need a person — a question, a design to review, the finished result — by POSTing to `$WEAVER_API/api/branches/$WEAVER_BRANCH/slack/reply` with `{{\"text\": \"…\"}}` and your `LOOM_TOKEN`.",
+        channel = trigger.channel_id,
+        user = trigger.user_id,
+    )
+}
+
+/// A short, filesystem-safe digest of the thread identity for the branch name.
+fn short_hash(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(s.as_bytes());
+    hex::encode(&digest[..6])
+}
+
+// ---------------------------------------------------------------------------
+// The Socket Mode supervisor.
+// ---------------------------------------------------------------------------
+
+/// The Slack background task: connect, receive/ACK/dispatch, reconnect. Always
+/// spawned; self-gates on [`is_enabled`], so an unconfigured deploy idles here.
+/// Never returns — any top-level error is caught, logged, and retried (the
+/// server discards this task's handle and won't restart it).
+pub async fn run(state: AppState) {
+    let mut backoff = 1u64;
+    loop {
+        if !is_enabled(&state.db).await {
+            // Not configured / switched off — poll occasionally for a later
+            // config change rather than spin.
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            continue;
+        }
+        match connect_and_run(&state).await {
+            Ok(reason) => {
+                // A clean disconnect (`warning`/`refresh_requested`) — reconnect
+                // promptly, no backoff, but with a 1s floor so a socket that
+                // drops the instant it opens can't spin `apps.connections.open`
+                // (itself rate-limited).
+                tracing::debug!(reason = %reason, "slack: reconnecting");
+                backoff = 1;
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, backoff, "slack: connection error; backing off");
+                // Jittered, capped backoff so a flapping endpoint isn't hammered
+                // in lockstep.
+                let jitter = rand::random::<u64>() % 500;
+                tokio::time::sleep(Duration::from_millis(backoff * 1000 + jitter)).await;
+                backoff = (backoff * 2).min(60);
+            }
+        }
+    }
+}
+
+/// One connection lifecycle: open the socket, then read/ACK/dispatch until Slack
+/// asks us to disconnect or the stream ends. Returns the disconnect reason on a
+/// clean close; `Err` on a connection/auth failure.
+async fn connect_and_run(state: &AppState) -> Result<String> {
+    use tokio_tungstenite::tungstenite::Message;
+
+    let app_tok = app_token(&state.db).await;
+    let web = SlackWeb::from_db(&state.db)
+        .await
+        .ok_or_else(|| anyhow!("bot token not configured"))?;
+    let bot = web.auth_test().await.context("auth.test")?;
+    let url = web
+        .open_connection(&app_tok)
+        .await
+        .context("apps.connections.open")?;
+
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .context("opening the socket")?;
+    tracing::info!(bot = %bot.user_id, team = %bot.team_id, "slack: socket connected");
+
+    while let Some(msg) = ws.next().await {
+        let msg = msg.context("reading from the socket")?;
+        let text = match msg {
+            Message::Text(t) => t.as_str().to_string(),
+            Message::Ping(p) => {
+                ws.send(Message::Pong(p)).await.ok();
+                continue;
+            }
+            Message::Close(_) => return Ok("close".to_string()),
+            _ => continue,
+        };
+        let Ok(frame) = serde_json::from_str::<Value>(&text) else {
+            continue;
+        };
+        match parse_envelope(&frame) {
+            Envelope::Hello => tracing::debug!("slack: hello"),
+            Envelope::Disconnect { reason } => return Ok(reason),
+            Envelope::Other {
+                envelope_id: Some(id),
+            } => {
+                ws.send(Message::text(json!({ "envelope_id": id }).to_string()))
+                    .await
+                    .ok();
+            }
+            Envelope::Other { envelope_id: None } => {}
+            Envelope::Payload {
+                envelope_id,
+                kind,
+                payload,
+            } => {
+                // ACK first — within Slack's 3s budget — then act detached.
+                ws.send(Message::text(
+                    json!({ "envelope_id": envelope_id }).to_string(),
+                ))
+                .await
+                .ok();
+                let trigger = match kind.as_str() {
+                    "slash_commands" => trigger_from_slash(&payload),
+                    "events_api" => trigger_from_event(&payload, &bot.user_id),
+                    _ => None, // `interactive` is unused in V1
+                };
+                if let Some(trigger) = trigger {
+                    tokio::spawn(handle_trigger(
+                        state.clone(),
+                        web.clone(),
+                        bot.clone(),
+                        trigger,
+                    ));
+                }
+            }
+        }
+    }
+    Ok("stream ended".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_envelope_classifies_frames() {
+        assert_eq!(parse_envelope(&json!({"type": "hello"})), Envelope::Hello);
+        assert_eq!(
+            parse_envelope(&json!({"type": "disconnect", "reason": "warning"})),
+            Envelope::Disconnect {
+                reason: "warning".into()
+            }
+        );
+        match parse_envelope(&json!({
+            "type": "slash_commands", "envelope_id": "e1", "payload": {"x": 1}
+        })) {
+            Envelope::Payload {
+                envelope_id, kind, ..
+            } => {
+                assert_eq!(envelope_id, "e1");
+                assert_eq!(kind, "slash_commands");
+            }
+            other => panic!("expected payload, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_trigger_has_no_thread_anchor() {
+        let t = trigger_from_slash(&json!({
+            "team_id": "T1", "channel_id": "C1", "user_id": "U1",
+            "text": "fix the flake", "trigger_id": "tr1"
+        }))
+        .unwrap();
+        assert_eq!(t.anchor, Anchor::Slash);
+        assert_eq!(t.user_id, "U1");
+        assert_eq!(t.dedupe_id, "slash:tr1");
+    }
+
+    #[test]
+    fn mention_anchors_on_thread_and_skips_self() {
+        let payload = json!({
+            "team_id": "T1", "event_id": "Ev1",
+            "event": {"type": "app_mention", "user": "U2", "channel": "C1",
+                      "ts": "1.1", "thread_ts": "0.9", "text": "<@BOT> do it"}
+        });
+        let t = trigger_from_event(&payload, "BOT").unwrap();
+        assert_eq!(
+            t.anchor,
+            Anchor::Mention {
+                root_ts: "0.9".into(),
+                event_ts: "1.1".into()
+            }
+        );
+        assert_eq!(t.text, "do it");
+        assert_eq!(t.dedupe_id, "slack:Ev1");
+        // The bot's own mention never triggers.
+        let mut own = payload.clone();
+        own["event"]["user"] = json!("BOT");
+        assert!(trigger_from_event(&own, "BOT").is_none());
+    }
+
+    #[test]
+    fn top_level_mention_anchors_on_its_own_ts() {
+        let t = trigger_from_event(
+            &json!({
+                "team_id": "T1", "event_id": "Ev2",
+                "event": {"type": "app_mention", "user": "U2", "channel": "C1",
+                          "ts": "5.5", "text": "<@BOT> hi"}
+            }),
+            "BOT",
+        )
+        .unwrap();
+        assert_eq!(
+            t.anchor,
+            Anchor::Mention {
+                root_ts: "5.5".into(),
+                event_ts: "5.5".into()
+            }
+        );
+    }
+
+    #[test]
+    fn repo_prefix_splits_only_a_leading_slug() {
+        assert_eq!(
+            parse_repo_prefix("acme/web: fix it"),
+            (Some("acme/web".into()), "fix it".into())
+        );
+        assert_eq!(parse_repo_prefix("just do it"), (None, "just do it".into()));
+        // A colon that isn't a repo prefix is left alone.
+        assert_eq!(parse_repo_prefix("note: hi"), (None, "note: hi".into()));
+    }
+
+    #[test]
+    fn wiring_round_trips_and_rejects_junk() {
+        assert_eq!(
+            parse_wiring("T1/C1/1720.5"),
+            Some(("T1".into(), "C1".into(), "1720.5".into()))
+        );
+        // The ts (last segment) is what a reply threads under and the card edits.
+        let (_t, _c, root) = parse_wiring("T1/C1/1720.5").unwrap();
+        assert_eq!(root, "1720.5");
+        assert_eq!(parse_wiring("T1/C1"), None);
+        assert_eq!(parse_wiring("T1//x"), None);
+        // Two branches for the same thread hash to the same short name.
+        assert_eq!(short_hash("T1/C1/1720.5"), short_hash("T1/C1/1720.5"));
+        assert_ne!(short_hash("T1/C1/1720.5"), short_hash("T1/C1/1720.6"));
+    }
+
+    #[test]
+    fn render_status_uses_slack_mrkdwn_and_escapes() {
+        let ev = events::Event {
+            id: 1,
+            branch_id: "b".into(),
+            kind: "tag".into(),
+            data: json!({"key": "attention", "value": "attention", "note": "ready <now>", "by": "agent"}),
+            created_at: "2026-07-20T21:04:00Z".into(),
+        };
+        let card = render_status("http://loom/s/abc", &[], std::slice::from_ref(&ev));
+        assert!(card.starts_with("On it — <http://loom/s/abc>"));
+        assert!(card.contains("*attention*"), "single-star bold: {card}");
+        assert!(card.contains("ready &lt;now&gt;"), "escaped: {card}");
+        assert!(!card.contains("**"), "no markdown bold: {card}");
+    }
+}

--- a/crates/loom/src/web/artifacts.rs
+++ b/crates/loom/src/web/artifacts.rs
@@ -206,12 +206,9 @@ pub(super) async fn write_artifact(
     )
     .await
     .ok();
-    // A wired GitHub thread's status card links the session's documents —
-    // refresh it so a new doc appears there without waiting for a status write.
-    tokio::spawn(crate::github::sync_status_comment(
-        st.clone(),
-        branch.id.clone(),
-    ));
+    // A wired thread's status card links the session's documents — refresh it so
+    // a new doc appears there without waiting for a status write.
+    crate::slack::spawn_status_mirrors(st.clone(), branch.id.clone());
     Ok(Json(
         artifact_view(&st.db, &branch.repo_root, &a, None).await?,
     ))
@@ -243,6 +240,9 @@ pub(super) async fn delete_artifact(
     )
     .await
     .ok();
+    // A wired thread's status card lists the session's documents — refresh it so
+    // a deleted doc stops appearing there.
+    crate::slack::spawn_status_mirrors(st.clone(), branch.id.clone());
     Ok(Json(json!({ "deleted": true, "name": a.name })))
 }
 
@@ -361,10 +361,7 @@ pub(super) async fn write_branch_artifact(
     .await
     .ok();
     // Same card refresh as the session-scoped write route above.
-    tokio::spawn(crate::github::sync_status_comment(
-        st.clone(),
-        branch.id.clone(),
-    ));
+    crate::slack::spawn_status_mirrors(st.clone(), branch.id.clone());
     Ok(Json(
         artifact_view(&st.db, &branch.repo_root, &a, None).await?,
     ))
@@ -418,6 +415,9 @@ pub(super) async fn delete_branch_artifact(
     )
     .await
     .ok();
+    // A wired thread's status card lists the session's documents — refresh it so
+    // a deleted doc stops appearing there.
+    crate::slack::spawn_status_mirrors(st.clone(), branch.id.clone());
     Ok(Json(json!({ "deleted": true, "name": a.name })))
 }
 

--- a/crates/loom/src/web/branches.rs
+++ b/crates/loom/src/web/branches.rs
@@ -13,6 +13,7 @@ use crate::events;
 use super::sessions::ByQuery;
 use super::{author_or_manual, branch_view, require_branch};
 use super::{ApiResult, AppError, AppState};
+use axum::http::StatusCode;
 
 // ---------------------------------------------------------------------------
 // Branches
@@ -131,17 +132,78 @@ pub(super) async fn set_branch_status(
         }),
     )
     .await?;
-    // Mirror the trail onto the branch's wired GitHub thread (a no-op when the
-    // `github` tag is absent) — detached, so a GitHub hiccup never slows or
-    // fails the status write.
-    tokio::spawn(crate::github::sync_status_comment(
-        st.clone(),
-        branch.id.clone(),
-    ));
+    // Mirror the trail onto every origin thread the branch is wired to — the
+    // GitHub comment and/or the Slack message (each a no-op when its wiring tag
+    // is absent) — detached, so an integration hiccup never slows or fails the
+    // status write.
+    crate::slack::spawn_status_mirrors(st.clone(), branch.id.clone());
     let branch = branch_mod::get(&st.db, &branch.id)
         .await?
         .ok_or_else(|| AppError::not_found("branch"))?;
     Ok(Json(branch_view(&st.db, &branch).await?))
+}
+
+/// `POST /api/branches/{id}/slack/reply` — post a message from the session back
+/// to its wired Slack thread. The token stays on the server: the agent (holding
+/// `LOOM_TOKEN`) calls this route rather than being handed the workspace-wide
+/// bot token, and loom derives the destination from the branch's `slack` wiring
+/// tag. The Slack analog of the GitHub-triggered session replying with `gh`.
+#[derive(Deserialize)]
+pub(super) struct SlackReplyReq {
+    pub text: String,
+}
+
+pub(super) async fn slack_reply(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Json(req): Json<SlackReplyReq>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let branch = require_branch(&st.db, &key).await?;
+    let text = req.text.trim();
+    if text.is_empty() {
+        return Err(AppError::bad_request("text is required"));
+    }
+    let wired = tags::get(&st.db, &branch.id, crate::slack::WIRED_TAG)
+        .await?
+        .ok_or_else(|| AppError::bad_request("this branch is not wired to a Slack thread"))?;
+    let (_team, channel, root) = crate::slack::parse_wiring(&wired.value)
+        .ok_or_else(|| AppError::bad_request("malformed slack wiring tag"))?;
+    let web = crate::slack::SlackWeb::from_db(&st.db)
+        .await
+        .ok_or_else(|| AppError::bad_request("Slack is not configured on this server"))?;
+    let ts = web
+        .post_message(&channel, Some(&root), text)
+        .await
+        .map_err(|e| AppError::new(StatusCode::BAD_GATEWAY, e.to_string()))?;
+    Ok(Json(json!({ "posted": true, "ts": ts })))
+}
+
+/// `GET /api/slack/status` — read-only connection state for the Connections
+/// settings pane. `connected` reflects whether an `auth.test` with the bot token
+/// succeeds (a credential-health proxy for the live socket).
+pub(super) async fn slack_status(State(st): State<AppState>) -> ApiResult<Json<serde_json::Value>> {
+    let configured = !crate::slack::app_token(&st.db).await.is_empty()
+        && !crate::slack::bot_token(&st.db).await.is_empty();
+    let enabled = crate::slack::is_enabled(&st.db).await;
+    let (connected, bot_user, team, error) = if configured {
+        match crate::slack::SlackWeb::from_db(&st.db).await {
+            Some(web) => match web.auth_test().await {
+                Ok(id) => (true, Some(id.user_id), Some(id.team_id), None),
+                Err(e) => (false, None, None, Some(e.to_string())),
+            },
+            None => (false, None, None, None),
+        }
+    } else {
+        (false, None, None, None)
+    };
+    Ok(Json(json!({
+        "configured": configured,
+        "enabled": enabled,
+        "connected": connected,
+        "bot_user": bot_user,
+        "team": team,
+        "error": error,
+    })))
 }
 
 /// Append a raw event row to a branch's log — the escape hatch for an event

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -73,7 +73,7 @@ mod logview;
 mod repo_env;
 mod repos;
 mod scratch;
-mod sessions;
+pub(crate) mod sessions;
 mod settings;
 mod watches;
 
@@ -639,6 +639,7 @@ pub fn router(state: AppState) -> Router {
         // partial write). No live session required — `weaver` runs as an
         // HTTP-only client of loom and these are its primary write path.
         .route("/branches/{id}/status", post(set_branch_status))
+        .route("/branches/{id}/slack/reply", post(slack_reply))
         .route("/branches/{id}/events", post(create_branch_event))
         .route(
             "/branches/{id}/tags/{key}",
@@ -706,6 +707,7 @@ pub fn router(state: AppState) -> Router {
             axum::routing::put(put_repo_env).delete(delete_repo_env),
         )
         .route("/settings", get(get_settings).patch(patch_settings))
+        .route("/slack/status", get(slack_status))
         // Operator-managed agent environment variables.
         .route("/env", get(get_env))
         .route(

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -188,6 +188,47 @@ pub const REGISTRY: &[SettingSpec] = &[
         options: &[],
     },
     SettingSpec {
+        key: "slack.enabled",
+        label: "Slack integration",
+        description: "Master switch for the Slack Socket Mode integration. loom \
+            only connects when both `LOOM_SLACK_APP_TOKEN` and \
+            `LOOM_SLACK_BOT_TOKEN` are configured; turning this OFF closes any \
+            live connection without removing the tokens. With it on and the \
+            tokens present, `/marinbot` (and `@marinbot`) launch sessions and \
+            mirror their status back to the Slack thread.",
+        kind: SettingKind::Bool,
+        default: "true",
+        group: "Slack",
+        options: &[],
+    },
+    SettingSpec {
+        key: "slack.allowed_users",
+        label: "Slack allowed users",
+        description: "Space- or comma-separated Slack user IDs (e.g. `U0123ABCD`) \
+            permitted to trigger `/marinbot`. A session is privileged — it holds \
+            repo and agent credentials — so the trigger is deny-by-default: with \
+            this empty, no one can launch even inside the installed workspace. \
+            Events from another workspace or an externally-shared (Slack Connect) \
+            channel are always rejected, regardless of this list.",
+        kind: SettingKind::String,
+        default: "",
+        group: "Slack",
+        options: &[],
+    },
+    SettingSpec {
+        key: "slack.default_repo",
+        label: "Slack default repository",
+        description: "The managed repository (`owner/name`) a `/marinbot` \
+            launch targets when the command text carries no `owner/name:` \
+            prefix. Slack conversations have no repo of their own, so without \
+            this — or an explicit prefix — a trigger has nothing to work on and \
+            replies asking for one.",
+        kind: SettingKind::String,
+        default: "",
+        group: "Slack",
+        options: &[],
+    },
+    SettingSpec {
         key: "auth.trust_loopback",
         label: "Trust loopback requests",
         description: "When enabled, requests from 127.0.0.1/::1 are trusted as \

--- a/crates/weaver-core/src/tags.rs
+++ b/crates/weaver-core/src/tags.rs
@@ -86,6 +86,36 @@ pub const GITHUB_KEY: &str = "github";
 /// else's comment); clearing it just makes the next status write post afresh.
 pub const GITHUB_COMMENT_KEY: &str = "github.status_comment";
 
+/// Loom's bookkeeping that a session's PR back-link comment was already posted,
+/// so the poll loop doesn't re-post it. Machine-owned like [`GITHUB_COMMENT_KEY`].
+pub const GITHUB_LINKED_KEY: &str = "github.linked";
+
+/// Branch tag wiring a session to a Slack thread; the value is
+/// `team_id/channel_id/thread_ts` (team-scoped — channel ids only mean something
+/// within a workspace). Quiet. While present, loom mirrors every `weaver status`
+/// write onto one message in that thread — the "On it" status card, edited in
+/// place. The `/marinbot` (and `@marinbot`) trigger stamps it at launch;
+/// clearing it stops the mirroring.
+pub const SLACK_KEY: &str = "slack";
+
+/// Loom's bookkeeping for the Slack status card: the message `ts` it edits, with
+/// the wiring it belongs to in the note. Machine-owned — the tag routes refuse
+/// to set it by hand (a forged `ts` would aim loom's edits at another message);
+/// clearing it just makes the next status write post afresh.
+pub const SLACK_STATUS_MSG_KEY: &str = "slack.status_message";
+
+/// Keys loom stamps mechanically to track its own integration side-effects. The
+/// generic tag routes refuse to *set* them — a forged comment id / message `ts`
+/// would aim loom's edits at someone else's content. Clearing stays allowed
+/// (harmless: loom re-creates its bookkeeping on the next pass). Centralized here
+/// (rather than per-integration) because both generic tag routes gate on it.
+pub fn is_reserved_tag(key: &str) -> bool {
+    matches!(
+        key,
+        GITHUB_LINKED_KEY | GITHUB_COMMENT_KEY | SLACK_STATUS_MSG_KEY
+    )
+}
+
 /// The loud keys: those that raise an attention signal on the dashboard. Any
 /// other key is quiet (a deletable pill) — including the soothing [`IDLE_KEY`].
 pub const LOUD_KEYS: &[&str] = &[ATTENTION_KEY, TRIAGE_KEY];

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -102,6 +102,7 @@ and why; you don't hand-edit `.env` itself.
 | `LOOM_OWNER_GITHUB` | **yes** | GitHub login seeded as the first approved user on a fresh database — the only account that can sign in until it approves others. Approved users are also who may drive the `@loom` trigger; add more in **Settings → Approved users**. |
 | `GH_TOKEN` | **yes** | GitHub token loom uses to clone private repos, push branches, and reply to `@loom` comments. |
 | `LOOM_GITHUB_WEBHOOK_SECRET` | for `@loom` | Shared secret for the inbound webhook; must match the secret on the GitHub webhook. Until set, the webhook rejects every delivery. |
+| `LOOM_SLACK_APP_TOKEN` / `LOOM_SLACK_BOT_TOKEN` | for `/marinbot` | App-level and bot OAuth tokens for the Slack Socket Mode trigger. Both unset (the default) leaves it off. See [docs/slack-trigger.md](../docs/slack-trigger.md). |
 | `ANTHROPIC_API_KEY` | for Claude | API key for the Claude agents. Alternatively log in interactively (see [first-run](#agent-authentication)). |
 | `OPENAI_API_KEY` | for Codex | API key for the Codex agents; only needed if you launch the `codex` runtime. Alternatively log in interactively (see [first-run](#agent-authentication)). |
 | `LOOM_GITHUB_CLIENT_ID` / `_SECRET` | for login | GitHub OAuth app — the owner's only way to sign in on a fresh DB (see [first-run](#first-run-login)). Callback: `https://<LOOM_DOMAIN>/api/auth/github/callback`. |
@@ -308,6 +309,15 @@ Without the App (the classic path), instead:
 
 Full behaviour, authorization rules, and hardening notes:
 [docs/github-trigger.md](../docs/github-trigger.md).
+
+## Wire the Slack `/marinbot` trigger
+
+Set `slack_app_token` and `slack_bot_token` in `loom.toml` (`loom config
+render-env` writes them into `.env` as `LOOM_SLACK_APP_TOKEN` /
+`LOOM_SLACK_BOT_TOKEN`), then add the Slack user ids allowed to trigger it to
+`slack.allowed_users` — empty means no one can, even from inside the
+workspace. Full behaviour, the Slack app's required scopes, and invite
+requirements: [docs/slack-trigger.md](../docs/slack-trigger.md).
 
 ## Where state lives
 

--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -55,6 +55,12 @@ ANTHROPIC_API_KEY=sk-ant-your-key
 #   docker compose exec loom codex login
 # OPENAI_API_KEY=sk-proj-your-key
 
+# App-level and bot OAuth tokens for the Slack Socket Mode `/marinbot` trigger.
+# Optional; both unset (the default) leaves it off. See
+# ../../docs/slack-trigger.md.
+# LOOM_SLACK_APP_TOKEN=xapp-your-app-level-token
+# LOOM_SLACK_BOT_TOKEN=xoxb-your-bot-token
+
 # ── GitHub sign-in ────────────────────────────────────────────────────────────
 # The owner's only way to log in on a fresh database (loopback trust is off for
 # this internet-facing deploy). Register an OAuth app with callback

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -1,0 +1,214 @@
+# Slack trigger (`/marinbot`)
+
+loom turns a Slack slash command or mention into a session. Type **`/marinbot
+<prompt>`** anywhere, or **`@marinbot <prompt>`** in a channel or thread, and
+loom pulls the surrounding conversation, launches a session against a repo,
+and replies in-thread with a link to the live session (`On it — {base}/s/{id}`).
+That reply is the session's **status card**: as the agent reports progress
+with `weaver status`, loom edits the message in place into a live trail — the
+Slack analog of the [GitHub `@loom` trigger](github-trigger.md)'s status
+comment (see [The status card](#the-status-card)).
+
+The transport is inverted from GitHub's: instead of receiving an inbound,
+HMAC-verified webhook, loom is an **outbound [Socket Mode]** websocket client
+— there is no public URL to expose or secret to verify a signature against.
+The connection self-gates on configuration: it only opens once both Slack
+tokens are set and the `slack.enabled` kill switch is on (see [Configure the
+tokens](#configure-the-tokens)). In place of GitHub's signature check, two
+authorization gates protect the trigger — the event's workspace must be the
+one the app is installed in, and the Slack user must be on an explicit
+allowlist (see [Who can trigger](#who-can-trigger)).
+
+[Socket Mode]: https://docs.slack.dev/apis/events-api/using-socket-mode/
+
+## How it works
+
+A background task holds the socket open for the whole process lifetime,
+reconnecting with jittered backoff on any error. Once connected, for every
+frame it receives, in order:
+
+1. **ACKs within budget.** Slack requires an `envelope_id` echo within 3
+   seconds of a payload-bearing frame (`slash_commands`, `events_api`); loom
+   sends that first and handles the trigger in a detached task, the same
+   reason GitHub's webhook handler returns `200` before finishing a clone.
+2. **Parses the trigger.** A `slash_commands` payload becomes a thread-blind
+   trigger (see [Anchor](#the-status-card)); an `events_api` payload is kept
+   only for `app_mention` — other event types, and any event from the bot's
+   own user id, are dropped without dispatch (a self-trigger guard, since
+   loom subscribes to `app_mention` only, not `message.*` — see [Slack app
+   configuration](#slack-app-configuration)).
+3. **Dedupes.** Socket Mode delivery is *at-least-once* — a missed ACK or a
+   reconnect boundary redelivers a frame — so loom keeps the same delivery
+   ledger the GitHub webhook uses, keyed on Slack's `event_id` (a mention) or
+   `trigger_id` (a slash command). A replay is a no-op.
+4. **Authorizes.** The event's `team_id` must match the workspace loom's bot
+   token belongs to, and the Slack user id must be on the [allowed-users
+   list](#who-can-trigger). Either failing drops the trigger — the second
+   with a reply nudging the user to ask an admin, rather than a silent drop.
+5. **Resolves the repo** from an `owner/name:` prefix on the command text, or
+   the `slack.default_repo` setting (see [Which repo](#which-repo)). Neither
+   set gets a reply asking for one.
+6. **Reuses or launches.** A thread that already has a live session attached
+   is acknowledged — a 👀 reaction on the mention, or an "Already working on
+   this thread." reply for a slash command — rather than launched again.
+   Otherwise loom clones/resolves the repo, pulls conversation history to
+   seed the session goal (the thread's replies for a mention, the channel's
+   recent messages for a slash command, capped at 40 messages), and creates
+   the session on a stable `slack-<hash>` branch derived from the thread
+   identity, so a later trigger on the same thread finds the same branch.
+7. **Wires and replies.** The branch is tagged with the thread's identity (the
+   `slack` tag — see [The status card](#the-status-card)), and loom posts (or,
+   for a slash command, edits its placeholder into) the "On it" card.
+
+## The status card
+
+The "On it" reply doubles as the thread's live view of the session, exactly
+as the GitHub comment does. At launch the trigger wires the branch to the
+thread — a `slack` tag whose value is `team_id/channel_id/thread_ts` — and
+records the card message's `ts`. From then on, every `weaver status <level>
+"<message>"` the agent writes re-renders that message via `chat.update`:
+
+> On it — <{base}/s/{id}>
+> Docs: <{base}/s/{id}/artifacts/design|design>
+>
+> • 🟢 `Jul 18 21:04` reading the thread; mapping the code
+> • 🟠 `Jul 18 22:15` *attention* — ready for review
+
+Up to 15 bullets show in full (oldest first); older ones collapse into a
+single `… N earlier update(s)` line rather than growing the message
+unbounded. If the tracked message was deleted, loom posts a fresh one and
+re-records its `ts` — the same recreate-on-drop behavior as the GitHub card.
+
+Where a trigger anchors differs by shape: a **slash command's payload carries
+no thread reference at all**, so it can only start a new thread — loom posts
+a placeholder card first and that message's own `ts` becomes the thread root.
+An **`@marinbot` mention** continues whatever thread it was typed in
+(`thread_ts`), or starts one at its own `ts` if it was posted at the top
+level. Either way, the card is edited in place — edits don't renotify — so a
+busy thread's status trail never spams the channel.
+
+## Who can trigger
+
+Two gates, both deny-by-default:
+
+- **Workspace.** The socket is authenticated as one workspace's bot, but
+  events still carry an explicit `team_id` — Slack Connect delivers events
+  from external, shared-channel teams over the same connection, so every
+  trigger's `team_id` is checked against the bot's own before anything else
+  runs. An event from another workspace is rejected outright.
+- **`slack.allowed_users`** — a space- or comma-separated list of Slack user
+  IDs (`U0123ABCD`, not display names) permitted to trigger. A session is
+  privileged — it holds repo and agent credentials — so this defaults to
+  empty, meaning **no one** can launch until it's set, even from inside the
+  installed workspace:
+
+  ```sh
+  weaver config set slack.allowed_users "U0123ABCD U0456EFGH"
+  ```
+
+  Also settable in **Settings → Slack**. Membership in a channel or workspace
+  admin status is not by itself a grant — the same principle as GitHub's
+  approved-users list being separate from repo write access.
+
+## Which repo
+
+The command text may start with a bare `owner/name:` prefix — exactly one
+slash, both halves plain path atoms — naming the repo for that trigger:
+
+```
+/marinbot acme/web: fix the flaky login test
+```
+
+Without a prefix, loom falls back to **`slack.default_repo`**, since a Slack
+conversation has no repo of its own the way a GitHub issue does:
+
+```sh
+weaver config set slack.default_repo "acme/web"
+```
+
+With neither, the trigger replies asking for one rather than guessing.
+
+## Configure the tokens
+
+Two secrets enable the integration — set **both**, or it stays idle
+(`slack.enabled` is a kill switch, not the enabler; token presence is):
+
+- **`LOOM_SLACK_APP_TOKEN`** (`loom.toml`'s `slack_app_token`) — the
+  app-level token (`xapp-…`) that opens the Socket Mode connection. Needs the
+  `connections:write` scope (see [Slack app
+  configuration](#slack-app-configuration)).
+- **`LOOM_SLACK_BOT_TOKEN`** (`loom.toml`'s `slack_bot_token`) — the bot-user
+  OAuth token (`xoxb-…`) every Web API call (`chat.postMessage`,
+  `conversations.history`, …) authenticates as.
+
+Both are held outside the settings registry — like the GitHub webhook secret
+and App private key — so `GET /api/settings` never returns them. Set them
+through the environment, or in `loom.toml` (see
+[`loom.toml.example`](../loom.toml.example)) and run `loom config render-env`
+to fold them into the deploy's `.env`.
+
+On the GCP deploy, the tokens travel the same handoff as every other
+credential: put them in `loom.toml` and push with
+
+```sh
+PROJECT=hai-gcp-models deploy/gcp/secrets.py
+```
+
+which re-renders the single `LOOM_DOTENV` blob the VM's startup script
+fetches on boot (see [`deploy/gcp/README.md` "Credential
+handoff"](../deploy/gcp/README.md#credential-handoff)). Don't push a Slack
+token as its own standalone Secret Manager secret — the startup script only
+ever reads `LOOM_DOTENV`, so a separately-stored secret is simply never
+fetched.
+
+`slack.enabled` (default on) closes the socket without discarding the tokens
+— use it to pause the integration without losing configuration. It, along
+with `slack.allowed_users` and `slack.default_repo`, lives in **Settings →
+Slack**.
+
+## The reply route
+
+A session's own replies — a question, a design to review, the finished
+result — post back to the wired thread through `POST
+/api/branches/{branch}/slack/reply` with `{"text": "…"}` and the session's
+`LOOM_TOKEN`. loom resolves the destination channel and thread from the
+branch's `slack` wiring tag server-side; the bot token itself never reaches
+the agent, the same separation the GitHub trigger keeps between an agent's
+`GH_TOKEN` and any App-level credential.
+
+## Slack app configuration
+
+Under **Settings → Socket Mode**, enable it and generate an app-level token
+with the **`connections:write`** scope — that's `LOOM_SLACK_APP_TOKEN`.
+
+Under **OAuth & Permissions → Bot Token Scopes**, add:
+
+- `commands` — receive the `/marinbot` slash command.
+- `app_mentions:read` — receive `@marinbot` mentions.
+- `chat:write` — post and edit the status card.
+- `reactions:write` — the 👀 acknowledgment on a reused thread.
+- History, per conversation type the bot should read: `channels:history`
+  (public), `groups:history` (private), `im:history` (DMs), `mpim:history`
+  (group DMs). Only add the types you intend to use it in.
+
+Under **Slash Commands**, create `/marinbot` — Socket Mode delivers it over
+the open connection, so it needs no Request URL.
+
+Under **Event Subscriptions**, subscribe to **`app_mention`** only.
+Subscribing to `message.*` as well is deliberately avoided: it would deliver
+every message in a watched conversation, including the bot's own status-card
+posts and edits, back over the same socket.
+
+Two things are easy to miss after any of the above:
+
+- **Reinstall the app** to the workspace after changing scopes — Slack does
+  not apply a new scope to an existing installation's token until you do.
+- **Invite the bot** to each channel it should trigger from or read history
+  in — `/invite @marinbot`. The bot scopes above grant *capability*; channel
+  membership is what makes a specific conversation reachable. A trigger from
+  a channel the bot hasn't been invited to still authorizes, but seeding the
+  session fails to read history (the reply notes it couldn't read the
+  conversation and to invite the bot).
+
+See [`crates/loom/src/slack.rs`](../crates/loom/src/slack.rs) for the
+implementation this document describes.

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -39,6 +39,13 @@ owner_github = "your-github-login"
 # openai_api_key = ""
 # gh_token = ""
 
+# Slack Socket Mode integration (the `/marinbot` / `@marinbot` trigger) —
+# optional; unset leaves it off. Both are secrets: an app-level token
+# (`xapp-…`, needs the `connections:write` scope) and a bot-user OAuth token
+# (`xoxb-…`). See docs/slack-trigger.md.
+# slack_app_token = ""
+# slack_bot_token = ""
+
 # Deploy-mechanism knobs — every one has a sensible compose-level default, so
 # leave them commented out unless you need to override one. (You can also
 # override any of these, or anything above, for a single invocation by


### PR DESCRIPTION
## Slack Socket Mode integration (`/marinbot`)

Mirrors loom's GitHub `@loom` trigger onto Slack, with the transport **inverted**: because the app runs in Socket Mode, loom is an **outbound websocket client** (a background task, like `github::poll`), not an inbound webhook. The authenticated, single-workspace socket means there is no HMAC to verify — the trust boundary is workspace membership plus an explicit allowlist.

A user types `/marinbot <prompt>` (slash command) or `@marinbot <prompt>` (mention). loom pulls the conversation, launches a session against a repo, and replies in-thread with an **"On it" status card** that is edited in place as the session reports `weaver status` — the direct Slack analog of the GitHub status comment. This is the "protocol to update the incoming channel" from the goal: the existing status-mirror spawn is generalized into `spawn_status_mirrors`, which fans a status change out to whichever origin thread(s) a branch is wired to.

**Design + reviews:** the [design artifact](https://loom.rjp.io/s/yvo8swfn/artifacts/design) was peer-reviewed by codex and claude-fable before building; their ~15 must-fix findings are folded in (dedupe kept — Socket Mode is at-least-once; `tokio-tungstenite` moved to a real dep with a TLS feature; slash commands are thread-blind so the card is posted first; the bot token stays server-side behind a reply route; per-workspace + allowlist auth; mrkdwn ≠ Markdown; deploy goes through the `LOOM_DOTENV` blob, not a standalone secret).

### What's here
- **`crates/loom/src/slack.rs`** — the socket supervisor (connect / ACK-within-3s / dedupe on `event_id` / jittered reconnect), a `SlackWeb` gateway (checks Slack's `ok`, honors 429), pure envelope/trigger parsing, a Slack-mrkdwn status renderer, and `sync_status_message`.
- **`spawn_status_mirrors`** seam at the status-write, artifact-publish, and artifact-delete routes.
- **Config/tags/auth**: `LOOM_SLACK_APP_TOKEN` / `LOOM_SLACK_BOT_TOKEN` secrets; token-presence gate + `slack.enabled` kill switch; `slack.default_repo`; deny-by-default `slack.allowed_users`; `slack` / `slack.status_message` tags (`is_reserved_tag` centralized in `weaver_core::tags`).
- **`POST /branches/{id}/slack/reply`** so the session posts back without ever holding the bot token.
- **Settings "GitHub" → "Connections"** pane + `SlackPanel.vue` fed by `GET /api/slack/status`.
- **`docs/slack-trigger.md`**, `loom.toml.example`, `.env.example`, deploy docs.

### Tests
`cargo test --workspace` green (incl. the PTY integration suites); 7 slack unit tests cover envelope/trigger parsing, thread anchoring, mrkdwn escaping, wiring round-trip. fmt + clippy + vue-tsc + prettier clean.

### Operator actions to go live
1. Put the app/bot tokens in `loom.toml` and run `PROJECT=hai-gcp-models deploy/gcp/secrets.py` (they ride the `LOOM_DOTENV` blob — a standalone Secret Manager secret is not read by the VM). *(The `xapp-` token is already stored as `marinbot-slack-app-token` for reference.)*
2. **Reinstall** the Slack app to activate the new scopes; **invite** the bot to each target channel.
3. Set `slack.allowed_users` (Slack user IDs) — deny-by-default, so no one can trigger until it's set.

### V1 scope / follow-ups (filed as weaver repo issues)
Forwarding a follow-up mention into the running session (V1 👀-acks), overlapping reconnect + live-disable, per-user `slack_id` attribution mapping, a local WS fixture integration test, and ephemeral slash responses.

Session: https://loom.rjp.io/s/yvo8swfn
