### PR TITLE
fix(loom): stop conversations wedging on queued prompts; make full access silence prompts

### DIFF
--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -1665,9 +1665,15 @@ impl Task {
             }
         }
 
-        // Policy: auto-answer under bypass mode; every other mode leaves the
-        // request pending for the REST route.
-        let bypass = self.current_mode.as_deref() == Some("bypassPermissions");
+        // Policy: auto-answer under a full-access mode; every other mode leaves
+        // the request pending for the REST route. Recognizing both provider
+        // spellings (claude's `bypassPermissions`, codex's `agent-full-access`)
+        // is what makes "full access" mean "never prompt me" regardless of
+        // provider — see [`crate::agent::is_full_access_mode`].
+        let bypass = self
+            .current_mode
+            .as_deref()
+            .is_some_and(crate::agent::is_full_access_mode);
         if bypass {
             if let Some(opt) = auto_choice(&params.options) {
                 let _ = self.answer_permission(&req_key, &opt, "policy").await;

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -1094,6 +1094,18 @@ fn codex_acp_mode(mode: &str) -> String {
     }
 }
 
+/// Whether an ACP mode id is a "full access" posture — the user asked never to
+/// be prompted, so loom auto-answers every permission request the adapter sends.
+/// Each provider vocabulary spells it differently: claude's `bypassPermissions`
+/// and codex's `agent-full-access` (the id [`codex_acp_mode`] maps the former to,
+/// and the id a codex session reports as its `current_mode`). This is the single
+/// source of truth for the auto-approve gate in [`crate::acp`]; adding a mode id
+/// here is how "full access" starts silencing prompts for a new provider. No
+/// other posture (`auto`, `acceptEdits`, `default`, `plan`) auto-approves.
+pub fn is_full_access_mode(mode: &str) -> bool {
+    matches!(mode.trim(), "bypassPermissions" | "agent-full-access")
+}
+
 /// The `_meta.claudeCode.options` object for the claude adapter — only the fields
 /// that are actually configured (model, the primer as `appendSystemPrompt`, the
 /// permission mode). `None` when nothing is set.
@@ -1937,6 +1949,31 @@ mod tests {
         // Codex's own ids are honoured verbatim.
         assert_eq!(codex_acp_mode("read-only"), "read-only");
         assert_eq!(codex_acp_mode("agent-full-access"), "agent-full-access");
+    }
+
+    #[test]
+    fn full_access_mode_covers_both_provider_spellings() {
+        // The two "never prompt me" postures — claude's and the id a codex
+        // full-access session reports as its current mode. Both must gate the
+        // auto-approve path, or "full access" silently keeps prompting.
+        assert!(is_full_access_mode("bypassPermissions"));
+        assert!(is_full_access_mode("agent-full-access"));
+        assert!(is_full_access_mode("  agent-full-access  "));
+        // codex full access round-trips through the launch mapping into the id
+        // the gate recognizes.
+        assert!(is_full_access_mode(&codex_acp_mode("bypassPermissions")));
+        // Everything else must still prompt.
+        for mode in [
+            "auto",
+            "acceptEdits",
+            "default",
+            "plan",
+            "agent",
+            "read-only",
+            "",
+        ] {
+            assert!(!is_full_access_mode(mode), "{mode} must not auto-approve");
+        }
     }
 
     #[test]

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -350,8 +350,21 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
     add_column_if_missing(pool, "sessions", "current_mode", "TEXT").await?;
     // The durable prompt queue: a paragraph-appended user message accumulated
     // while a turn is in flight, dispatched as one `session/prompt` at the next
-    // turn boundary. Empty/NULL when nothing is queued.
-    add_column_if_missing(pool, "sessions", "pending_prompt", "TEXT").await?;
+    // turn boundary. Canonically the empty string when nothing is queued — never
+    // NULL. Declared `NOT NULL DEFAULT ''` so a fresh database matches the shape
+    // long-lived databases already carry (older schemas created the column inside
+    // `CREATE TABLE sessions` as `TEXT NOT NULL DEFAULT ''`; `CREATE TABLE IF NOT
+    // EXISTS` is then a no-op and this additive migration is swallowed as a
+    // duplicate). Keeping every database on one shape means the queue-clearing
+    // writes below can never trip a `NOT NULL` constraint on one database while
+    // passing on another — see `session::take_pending_prompt`.
+    add_column_if_missing(
+        pool,
+        "sessions",
+        "pending_prompt",
+        "TEXT NOT NULL DEFAULT ''",
+    )
+    .await?;
     // The custom agent's execution backend: 'terminal' (a PTY running its launch
     // command) or 'acp' (its launch command is an ACP adapter driven over stdio).
     // Added here for databases created before the column; a fresh DB has it from

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -76,7 +76,10 @@ pub struct Session {
     pub current_mode: Option<String>,
     /// The durable prompt queue: a paragraph-appended user message accumulated
     /// while a turn is in flight, dispatched as one prompt at the next turn
-    /// boundary. `None`/empty when nothing is queued.
+    /// boundary. Canonically the empty string when nothing is queued — the column
+    /// is `NOT NULL DEFAULT ''`, so the queue-clearing writes store `''`, never
+    /// NULL (an `Option` only because a legacy row may still hold NULL; treat
+    /// `None` and `Some("")` identically). See [`take_pending_prompt`].
     pub pending_prompt: Option<String>,
 }
 
@@ -378,7 +381,7 @@ pub async fn prepare_handoff(
         "UPDATE sessions
          SET agent_kind = ?, model = ?, effort = ?, status = ?,
              acp_session_id = NULL, acp_ack_seq = 0, acp_inflight = NULL,
-             current_mode = NULL, pending_prompt = NULL
+             current_mode = NULL, pending_prompt = ''
          WHERE id = ?",
     )
     .bind(agent_kind)
@@ -445,7 +448,11 @@ pub async fn take_pending_prompt(db: &Db, id: &str) -> Result<Option<String>> {
     };
 
     let result = sqlx::query(
-        "UPDATE sessions SET pending_prompt = NULL
+        // Clear to '' (the canonical empty), never NULL: the column is
+        // `NOT NULL DEFAULT ''` on long-lived databases, so writing NULL here
+        // fails the consume, the queue can never drain, and the conversation
+        // wedges. See the module note on `pending_prompt`.
+        "UPDATE sessions SET pending_prompt = ''
          WHERE id = ? AND pending_prompt = ?",
     )
     .bind(id)
@@ -463,13 +470,13 @@ pub async fn take_pending_prompt(db: &Db, id: &str) -> Result<Option<String>> {
 /// appended behind it while the steering request was in flight.
 pub async fn consume_pending_prompt(db: &Db, id: &str, promoted: &str) -> Result<()> {
     let current = read_pending_prompt(db, id).await?;
-    let remaining = if current == promoted {
-        None
+    // Canonically '' (never NULL) when the whole queue was promoted — the column
+    // is `NOT NULL DEFAULT ''` on long-lived databases.
+    let remaining: &str = if current == promoted {
+        ""
     } else if let Some(rest) = current.strip_prefix(promoted) {
-        Some(
-            rest.strip_prefix("\n\n")
-                .ok_or_else(|| anyhow!("queued prompt changed while it was being steered"))?,
-        )
+        rest.strip_prefix("\n\n")
+            .ok_or_else(|| anyhow!("queued prompt changed while it was being steered"))?
     } else {
         bail!("queued prompt changed while it was being steered");
     };
@@ -610,6 +617,51 @@ mod tests {
         assert_eq!(session.acp_ack_seq, 0);
         assert!(session.acp_inflight.is_none());
         assert!(session.current_mode.is_none());
-        assert!(session.pending_prompt.is_none());
+        assert!(
+            session.pending_prompt.as_deref().unwrap_or("").is_empty(),
+            "handoff clears the queue to empty, never NULL"
+        );
+    }
+
+    /// Regression: the queue clears to `''`, never NULL. `sessions.pending_prompt`
+    /// is `NOT NULL DEFAULT ''` (the shape long-lived databases carry), so a
+    /// clearing write of NULL raises `NOT NULL constraint failed` — which used to
+    /// make the queued prompt unconsumable and wedge the whole conversation. The
+    /// in-memory schema now matches that shape, so this exercises the real
+    /// constraint that shipped unguarded.
+    #[tokio::test]
+    async fn draining_the_queue_clears_to_empty_not_null() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        // The column must actually carry the constraint, or this guards nothing.
+        let notnull: i64 = sqlx::query_scalar(
+            "SELECT \"notnull\" FROM pragma_table_info('sessions') WHERE name = 'pending_prompt'",
+        )
+        .fetch_one(&db)
+        .await
+        .unwrap();
+        assert_eq!(notnull, 1, "pending_prompt must be NOT NULL");
+
+        let branch = branch_id(&db, "weaver/drain").await;
+        insert(&db, &new_session("drain", &branch, None))
+            .await
+            .unwrap();
+        append_pending_prompt(&db, "drain", "queued text")
+            .await
+            .unwrap();
+
+        // take: the wedge path — this UPDATE used to write NULL and fail here.
+        let taken = take_pending_prompt(&db, "drain").await.unwrap();
+        assert_eq!(taken.as_deref(), Some("queued text"));
+        let row = get(&db, "drain").await.unwrap().unwrap();
+        assert_eq!(
+            row.pending_prompt.as_deref(),
+            Some(""),
+            "cleared to '', not NULL"
+        );
+
+        // consume of the whole queue and a full handoff must clear the same way.
+        append_pending_prompt(&db, "drain", "again").await.unwrap();
+        consume_pending_prompt(&db, "drain", "again").await.unwrap();
+        assert_eq!(read_pending_prompt(&db, "drain").await.unwrap(), "");
     }
 }

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -738,15 +738,17 @@ async fn queue_consume_failure_does_not_dispatch_or_replay() {
         .unwrap();
     assert_eq!(queued["queued"], true);
 
-    // Reproduce a failed queue-consumption write. The production incident's
-    // error was discarded, so its exact SQLite cause is unavailable; the
-    // invariant is that a failed consume must keep loom from dispatching.
+    // Reproduce a failed queue-consumption write. The production incident was a
+    // `NOT NULL constraint failed: sessions.pending_prompt` — the clearing write
+    // now stores '' rather than NULL, so this injects the same class of failure
+    // on the real clearing update. The invariant is that a failed consume must
+    // keep loom from dispatching.
     sqlx::query(
         "CREATE TRIGGER reject_queue_consume
          BEFORE UPDATE OF pending_prompt ON sessions
          WHEN OLD.id = 'acp-queue-failure'
-              AND OLD.pending_prompt IS NOT NULL
-              AND NEW.pending_prompt IS NULL
+              AND OLD.pending_prompt <> ''
+              AND NEW.pending_prompt = ''
          BEGIN
              SELECT RAISE(FAIL, 'injected queue consume failure');
          END",
@@ -1234,7 +1236,9 @@ async fn interrupt_leaves_queued_feedback_idle_until_sent() {
         })
     })
     .await;
-    assert_eq!(chat["pending_prompt"], Value::Null);
+    // Drained queue is the canonical empty string, never NULL (see
+    // `session::take_pending_prompt`); the frontend treats '' and null alike.
+    assert_eq!(chat["pending_prompt"], "");
     assert!(chat["blocks"].as_array().unwrap().iter().any(|block| {
         block["kind"] == "user_message"
             && block["turn"] == 1


### PR DESCRIPTION
Two independent bugs made a conversation read as **permanently broken** — one wedged the queue, the other is why "full access" never silenced permission prompts. Both are fixed here, and the wedge is now structurally hard to reintroduce.

Full write-up (what's going on / how conversation state works now / how to make it impossible): artifact `conversation-state-cleanup` on this branch.

## Bug 1 — the permanent wedge (`NOT NULL constraint failed: sessions.pending_prompt`, code 1299)

A message sent mid-turn goes into the durable queue (`sessions.pending_prompt`) and dispatches at the next turn boundary. Dispatch first *clears* the column, and the code cleared it by writing SQL `NULL`.

Long-lived databases (the live `~/.weaver/weaver.db` and the deployed server) declare that column `TEXT NOT NULL DEFAULT ''` — baked into an **older** `CREATE TABLE sessions`. The current source adds it with a *nullable* additive migration, but `CREATE TABLE IF NOT EXISTS` is a no-op on an existing table and `add_column_if_missing` can't relax an existing constraint, so the strict shape silently persists. The clearing write was therefore rejected; the transactional consume rolled back (correctly refusing to dispatch, else the text would replay forever); and the queued message stuck at `queued · agent hasn't seen this yet`, with hand-off blocked too.

**Fix:** one canonical "empty" — the empty string, never NULL.
- `take_pending_prompt`, `consume_pending_prompt`, `prepare_handoff` clear to `''` (valid on both a `NOT NULL DEFAULT ''` and a nullable column).
- The additive migration declares the column `NOT NULL DEFAULT ''` so fresh and long-lived databases share one shape — and the test DBs now exercise the real constraint that shipped unguarded.
- Frontend already treats `''` and `null` identically, so no UI change.

Currently-wedged sessions self-recover once the server runs this: **Send now** drains the queue (the clear no longer errors) and unblocks hand-off.

## Bug 2 — "full access" never stopped the prompts

The auto-approve gate matched only the literal `bypassPermissions` (claude's id). A **codex** session's full-access mode is `agent-full-access`, which never matched — so codex full access kept prompting.

**Fix:** `agent::is_full_access_mode` is the single source of truth recognizing both provider spellings (`bypassPermissions`, `agent-full-access`); the gate calls it. No other posture (`auto`, `acceptEdits`, `default`, `plan`) auto-approves.

## Tests
- `draining_the_queue_clears_to_empty_not_null` — asserts the column is NOT NULL and the queue drains to `''`.
- `full_access_mode_covers_both_provider_spellings`.
- Existing failure-injection (`queue_consume_failure_does_not_dispatch_or_replay`) and interrupt tests updated for the `''` representation.

Full loom lib suite (256), the ACP integration suite (27), and clippy all pass.

## Not in this PR (recommended follow-ups, in the artifact)
Adjacent ways a conversation can still wedge — a prompt-send that fails after `turn_live` is set, a stale `acp_inflight` after restart, `journal_failed` never resetting, and a user-facing "reset conversation state" escape hatch + a schema-drift boot guard.