### PR TITLE
fix(loom): repair ACP turn and recovery state

### DIFF
--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -99,6 +99,7 @@ const steeringSupported = computed(() => metadata.value.steering_supported);
 // The live mode, seeded from the session and advanced by `mode_change` blocks or
 // a local set — so the composer chip reads true without a refetch.
 const currentMode = ref<string | null>(props.session.current_mode);
+const effectiveMode = ref<string | null>(null);
 watch(
   () => props.session.current_mode,
   (m) => {
@@ -138,6 +139,7 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
     liveTools.clear();
     liveTurnNo.value = snap.live_turn;
     turnLive.value = snap.live_turn != null;
+    effectiveMode.value = snap.effective_mode ?? null;
     pendingPrompt.value = snap.pending_prompt?.trim() ? snap.pending_prompt : null;
     applyMetadata(snap.metadata ?? emptyMetadata());
     state.value = 'ready';
@@ -195,10 +197,12 @@ function onTurn(ev: SseTurn) {
   if (ev.state === 'started') {
     turnLive.value = true;
     liveTurnNo.value = ev.turn;
+    effectiveMode.value = ev.effective_mode ?? null;
     autoFollow();
   } else {
     turnLive.value = false;
     liveTurnNo.value = null;
+    effectiveMode.value = null;
   }
 }
 
@@ -541,6 +545,18 @@ function configValueLabel(option: AcpConfigOption): string {
   const current = String(option.currentValue);
   return configChoices(option).find((choice) => choice.value === current)?.name ?? current;
 }
+function selectionAppliesNextTurn(value: unknown): boolean {
+  return (
+    turnLive.value &&
+    effectiveMode.value !== null &&
+    typeof value === 'string' &&
+    value !== effectiveMode.value
+  );
+}
+function configAppliesNextTurn(option: AcpConfigOption): boolean {
+  return isModeOption(option) && selectionAppliesNextTurn(option.currentValue);
+}
+const permissionModeAppliesNextTurn = computed(() => selectionAppliesNextTurn(currentMode.value));
 async function pickConfig(option: AcpConfigOption, value: string | boolean) {
   configOpen.value = '';
   if (value === option.currentValue || configBusy.value) return;
@@ -1352,7 +1368,8 @@ function goTo(anchor: string) {
             >
               <span class="acp-config-name">{{ configName(option) }}</span>
               {{ configValueLabel(option)
-              }}<span v-if="option.type === 'select'" class="acp-mode-caret">▾</span>
+              }}<span v-if="configAppliesNextTurn(option)" class="acp-config-timing">next turn</span
+              ><span v-if="option.type === 'select'" class="acp-mode-caret">▾</span>
             </button>
             <ul v-if="configOpen === option.id" class="acp-mode-menu" data-testid="acp-config-menu">
               <li v-for="choice in configChoices(option)" :key="choice.value">
@@ -1378,7 +1395,8 @@ function goTo(anchor: string) {
             >
               <span class="acp-config-name">Permissions</span>
               {{ modeLabel(currentMode)
-              }}<span v-if="modeInteractive" class="acp-mode-caret">▾</span>
+              }}<span v-if="permissionModeAppliesNextTurn" class="acp-config-timing">next turn</span
+              ><span v-if="modeInteractive" class="acp-mode-caret">▾</span>
             </button>
             <ul v-if="modeOpen" class="acp-mode-menu" data-testid="acp-mode-menu">
               <li v-for="m in modeOptions" :key="m">
@@ -1893,6 +1911,10 @@ function goTo(anchor: string) {
 }
 .acp-config-name {
   color: var(--faint);
+}
+.acp-config-timing {
+  color: var(--attn);
+  font-size: 0.625rem;
 }
 .acp-config-permission {
   border-color: color-mix(in srgb, var(--attn) 40%, var(--line));

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -164,6 +164,9 @@ export interface ChatBlock {
 export interface ChatSnapshot {
   blocks: ChatBlock[];
   live_turn: number | null;
+  /** Permission posture captured when the live turn started. A different selected
+   *  mode is queued for the next turn. */
+  effective_mode: string | null;
   pending_prompt: string | null;
   metadata: AcpMetadata;
 }
@@ -264,6 +267,7 @@ export interface PermissionPayload {
   tool_call_id: string | null;
   title: string;
   options: PermissionOption[];
+  effective_mode?: string | null;
   outcome: PermissionOutcome | null;
 }
 export interface UsagePayload {
@@ -306,6 +310,7 @@ export interface SseTool {
 export interface SseTurn {
   turn: number;
   state: 'started' | 'ended';
+  effective_mode?: string | null;
   stop_reason?: string;
 }
 

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -629,7 +629,10 @@ struct PendingSteer {
     /// the adapter accepts steering, preserving messages appended behind it.
     promoted_queue: Option<String>,
     resources: Vec<Value>,
-    reply: oneshot::Sender<Result<PromptAck>>,
+    /// Forced steering waits for the adapter's final answer. An ordinary send is
+    /// acknowledged as durably queued before steering starts, so it carries no
+    /// waiting HTTP reply and cannot lock the composer behind a private RPC.
+    reply: Option<oneshot::Sender<Result<PromptAck>>>,
 }
 
 struct Task {
@@ -662,6 +665,10 @@ struct Task {
     tools: HashMap<String, LiveTool>,
     pending_perms: HashMap<String, PendingPerm>,
 
+    /// Permission posture captured when the active turn started. `current_mode`
+    /// may advance while that turn is running, but a provider cannot retroactively
+    /// rebuild the turn's approval policy or sandbox.
+    effective_mode: Option<String>,
     current_mode: Option<String>,
     metadata: Arc<Mutex<AcpMetadata>>,
     pending_mode: HashMap<u64, PendingMode>,
@@ -722,6 +729,7 @@ impl Task {
             buf: None,
             tools: HashMap::new(),
             pending_perms: HashMap::new(),
+            effective_mode: None,
             current_mode: None,
             metadata: Arc::new(Mutex::new(AcpMetadata::default())),
             pending_mode: HashMap::new(),
@@ -765,6 +773,11 @@ impl Task {
         let inflight = inflight_value
             .as_ref()
             .and_then(|v| Some((v.get("prompt_id")?.as_u64()?, v.get("turn")?.as_i64()?)));
+        let effective_mode = inflight_value
+            .as_ref()
+            .and_then(|v| v.get("mode"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
         let current_turn = live_turn.unwrap_or(max_turn);
         // The journal always holds at least this turn's `user_message`, so
         // `max_seq + 1` continues the turn without colliding.
@@ -790,6 +803,9 @@ impl Task {
             buf: None,
             tools: HashMap::new(),
             pending_perms: HashMap::new(),
+            // Old in-flight records have no mode. Keep that unknown rather than
+            // applying a newer session selection to an older turn.
+            effective_mode,
             current_mode: session.current_mode.clone(),
             metadata: Arc::new(Mutex::new(AcpMetadata::default())),
             pending_mode: HashMap::new(),
@@ -1311,6 +1327,7 @@ impl Task {
         // client that reacts to the event sees a consistent `live_turn`.
         self.turn_live = false;
         self.inflight_prompt = None;
+        self.effective_mode = None;
         let _ = session::set_inflight(&self.db, &self.session_id, None).await;
         self.emit(
             "turn",
@@ -1400,11 +1417,13 @@ impl Task {
                     }),
                 )
                 .await;
-                let _ = pending.reply.send(Ok(PromptAck {
-                    queued: false,
-                    steered: true,
-                    turn: Some(pending.turn),
-                }));
+                if let Some(reply) = pending.reply {
+                    let _ = reply.send(Ok(PromptAck {
+                        queued: false,
+                        steered: true,
+                        turn: Some(pending.turn),
+                    }));
+                }
                 if !self.turn_live {
                     self.dispatch_pending_prompt().await;
                 }
@@ -1431,9 +1450,9 @@ impl Task {
                     let detail = error
                         .map(|e| e.to_string())
                         .unwrap_or_else(|| format!("adapter returned {outcome:?}"));
-                    let _ = pending
-                        .reply
-                        .send(Err(anyhow!("adapter rejected forced steer: {detail}")));
+                    if let Some(reply) = pending.reply {
+                        let _ = reply.send(Err(anyhow!("adapter rejected forced steer: {detail}")));
+                    }
                 } else {
                     self.fallback_prompt(pending).await;
                 }
@@ -1471,24 +1490,49 @@ impl Task {
     }
 
     async fn fallback_prompt(&mut self, pending: PendingSteer) {
-        let ack = if self.turn_live {
+        let ack = if pending.promoted_queue.is_some() {
+            if self.turn_live {
+                Ok(PromptAck {
+                    queued: true,
+                    steered: false,
+                    turn: Some(self.current_turn),
+                })
+            } else {
+                self.start_pending_prompt(pending.by).await
+            }
+        } else if self.turn_live {
             self.queue_prompt(&pending.text, &pending.resources).await
         } else {
             self.start_prompt(pending.text, pending.by, pending.resources)
                 .await
         };
-        let _ = pending.reply.send(ack);
+        if let Some(reply) = pending.reply {
+            let _ = reply.send(ack);
+        }
     }
 
     async fn queue_prompt(&self, text: &str, resources: &[Value]) -> Result<PromptAck> {
+        self.queue_prompt_with_value(text, resources)
+            .await
+            .map(|(ack, _)| ack)
+    }
+
+    async fn queue_prompt_with_value(
+        &self,
+        text: &str,
+        resources: &[Value],
+    ) -> Result<(PromptAck, String)> {
         let queued = queued_prompt_text(text, resources);
         let pending = session::append_pending_prompt(&self.db, &self.session_id, &queued).await?;
         self.emit_queue(Some(&pending));
-        Ok(PromptAck {
-            queued: true,
-            steered: false,
-            turn: Some(self.current_turn),
-        })
+        Ok((
+            PromptAck {
+                queued: true,
+                steered: false,
+                turn: Some(self.current_turn),
+            },
+            pending,
+        ))
     }
 
     async fn start_pending_prompt(&mut self, by: Option<String>) -> Result<PromptAck> {
@@ -1519,10 +1563,18 @@ impl Task {
         } else {
             self.current_turn
         };
-        let inflight = json!({ "turn": turn, "external": true }).to_string();
+        self.effective_mode = self.current_mode.clone();
+        let inflight = json!({
+            "turn": turn,
+            "external": true,
+            "mode": self.effective_mode,
+        })
+        .to_string();
         let persisted = session::set_inflight(&self.db, &self.session_id, Some(&inflight)).await;
         if let Err(e) = persisted {
-            let _ = pending.reply.send(Err(e));
+            if let Some(reply) = pending.reply {
+                let _ = reply.send(Err(e));
+            }
             return;
         }
         self.current_turn = turn;
@@ -1532,7 +1584,11 @@ impl Task {
         self.external_turn = true;
         self.emit(
             "turn",
-            json!({ "turn": self.current_turn, "state": "started" }),
+            json!({
+                "turn": self.current_turn,
+                "state": "started",
+                "effective_mode": self.effective_mode,
+            }),
         );
         let by = pending.by.map(Value::from).unwrap_or(Value::Null);
         self.journal_block(
@@ -1547,11 +1603,13 @@ impl Task {
         .await;
         crate::monitor::record_acp_lifecycle(&self.db, &self.bus, &self.session_id, "working")
             .await;
-        let _ = pending.reply.send(Ok(PromptAck {
-            queued: false,
-            steered: false,
-            turn: Some(self.current_turn),
-        }));
+        if let Some(reply) = pending.reply {
+            let _ = reply.send(Ok(PromptAck {
+                queued: false,
+                steered: false,
+                turn: Some(self.current_turn),
+            }));
+        }
     }
 
     async fn start_turn(
@@ -1588,16 +1646,26 @@ impl Task {
         }
         self.turns_dispatched += 1;
         self.turn_live = true;
+        self.effective_mode = self.current_mode.clone();
 
         self.emit(
             "turn",
-            json!({ "turn": self.current_turn, "state": "started" }),
+            json!({
+                "turn": self.current_turn,
+                "state": "started",
+                "effective_mode": self.effective_mode,
+            }),
         );
         self.journal_block(opening_kind, opening_payload).await;
 
         let id = self.next_id();
         self.inflight_prompt = Some((id, self.current_turn));
-        let inflight = json!({ "prompt_id": id, "turn": self.current_turn }).to_string();
+        let inflight = json!({
+            "prompt_id": id,
+            "turn": self.current_turn,
+            "mode": self.effective_mode,
+        })
+        .to_string();
         session::set_inflight(&self.db, &self.session_id, Some(&inflight)).await?;
         self.stream
             .write(&wire::request_line(
@@ -1652,6 +1720,7 @@ impl Task {
                     "tool_call_id": params.tool_call.tool_call_id.clone(),
                     "title": params.tool_call.title.clone().unwrap_or_default(),
                     "options": options,
+                    "effective_mode": self.effective_mode,
                     "outcome": Value::Null,
                 });
                 self.journal_block(kind::PERMISSION_REQUEST, payload).await;
@@ -1665,13 +1734,11 @@ impl Task {
             }
         }
 
-        // Policy: auto-answer under a full-access mode; every other mode leaves
-        // the request pending for the REST route. Recognizing both provider
-        // spellings (claude's `bypassPermissions`, codex's `agent-full-access`)
-        // is what makes "full access" mean "never prompt me" regardless of
-        // provider — see [`crate::agent::is_full_access_mode`].
+        // Policy follows the mode captured when this turn started. A config write
+        // during the turn changes `current_mode` for the next prompt only; using it
+        // here would auto-approve a request raised by an older, restricted turn.
         let bypass = self
-            .current_mode
+            .effective_mode
             .as_deref()
             .is_some_and(crate::agent::is_full_access_mode);
         if bypass {
@@ -1724,10 +1791,14 @@ impl Task {
             .await;
         if result.is_ok() && self.turn_live {
             for (_, pending) in self.pending_steers.drain() {
-                let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
+                if let Some(reply) = pending.reply {
+                    let _ = reply.send(Err(anyhow!("turn was cancelled")));
+                }
             }
             if let Some(pending) = self.pending_external.take() {
-                let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
+                if let Some(reply) = pending.reply {
+                    let _ = reply.send(Err(anyhow!("turn was cancelled")));
+                }
             }
             // Cancellation is a client-owned boundary. Some adapters do not
             // answer the cancelled prompt, so settle loom's journal and
@@ -1773,23 +1844,62 @@ impl Task {
                             method::SESSION_STEERING,
                             wire::steering_params(&self.acp_session_id, &text, &resources),
                         );
-                        match self.stream.write(&request).await {
-                            Ok(()) => {
-                                self.pending_steers.insert(
-                                    id,
-                                    PendingSteer {
-                                        text,
-                                        by,
-                                        turn: self.current_turn,
-                                        forced: force_steer,
-                                        promoted_queue: None,
-                                        resources,
-                                        reply,
-                                    },
-                                );
+                        if force_steer {
+                            // Explicit steering reports the adapter's real answer
+                            // and does not also leave a queued copy behind if the
+                            // private extension is rejected.
+                            match self.stream.write(&request).await {
+                                Ok(()) => {
+                                    self.pending_steers.insert(
+                                        id,
+                                        PendingSteer {
+                                            text,
+                                            by,
+                                            turn: self.current_turn,
+                                            forced: true,
+                                            promoted_queue: None,
+                                            resources,
+                                            reply: Some(reply),
+                                        },
+                                    );
+                                }
+                                Err(error) => {
+                                    let _ = reply.send(Err(error));
+                                }
                             }
-                            Err(e) => {
-                                let _ = reply.send(Err(e));
+                        } else {
+                            // Durability and the HTTP acknowledgement come before
+                            // the private steering RPC. If the adapter hangs,
+                            // rejects, or disappears, the message remains visibly
+                            // queued and the browser can keep accepting feedback.
+                            match self.queue_prompt_with_value(&text, &resources).await {
+                                Ok((queued_ack, promoted_queue)) => {
+                                    match self.stream.write(&request).await {
+                                        Ok(()) => {
+                                            let _ = reply.send(Ok(queued_ack));
+                                            self.pending_steers.insert(
+                                                id,
+                                                PendingSteer {
+                                                    text,
+                                                    by,
+                                                    turn: self.current_turn,
+                                                    forced: false,
+                                                    promoted_queue: Some(promoted_queue),
+                                                    resources,
+                                                    reply: None,
+                                                },
+                                            );
+                                        }
+                                        Err(error) => {
+                                            tracing::warn!(session = %self.session_id, %error,
+                                                "steering write failed; feedback remains queued");
+                                            let _ = reply.send(Ok(queued_ack));
+                                        }
+                                    }
+                                }
+                                Err(error) => {
+                                    let _ = reply.send(Err(error));
+                                }
                             }
                         }
                     } else if force_steer {
@@ -1853,7 +1963,7 @@ impl Task {
                                         forced: true,
                                         promoted_queue: Some(queued),
                                         resources: Vec::new(),
-                                        reply,
+                                        reply: Some(reply),
                                     },
                                 );
                             }
@@ -1955,6 +2065,7 @@ impl Task {
             );
             self.turn_live = false;
             self.external_turn = false;
+            self.effective_mode = None;
             let _ = session::set_inflight(&self.db, &self.session_id, None).await;
         }
     }
@@ -2033,12 +2144,14 @@ impl Task {
     }
 }
 
-/// The option an auto-answer picks: the first allow-ish option, else the first.
+/// The one-shot grant an auto-answer may select, if the adapter offers one.
 fn auto_choice(options: &[PermissionOption]) -> Option<String> {
     options
         .iter()
-        .find(|o| o.is_allow())
-        .or_else(|| options.first())
+        // Never turn a no-prompt posture into a persisted policy mutation. If
+        // the adapter offers no one-shot grant, surface the request for an
+        // explicit answer instead of guessing.
+        .find(|o| o.kind == "allow_once")
         .map(|o| o.option_id.clone())
 }
 
@@ -2093,7 +2206,7 @@ fn queued_prompt_text(text: &str, resources: &[Value]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::queued_prompt_text;
+    use super::{auto_choice, queued_prompt_text, PermissionOption};
     use serde_json::json;
 
     #[test]
@@ -2107,5 +2220,23 @@ mod tests {
             queued_prompt_text("review", &resources),
             "review\n\nReferenced files:\n- src/main.rs\n- https://example.test/context\n"
         );
+    }
+
+    #[test]
+    fn automatic_permission_choice_never_persists_policy() {
+        let options = [
+            PermissionOption {
+                option_id: "persist".to_string(),
+                name: "Always allow".to_string(),
+                kind: "allow_always".to_string(),
+            },
+            PermissionOption {
+                option_id: "once".to_string(),
+                name: "Allow once".to_string(),
+                kind: "allow_once".to_string(),
+            },
+        ];
+        assert_eq!(auto_choice(&options).as_deref(), Some("once"));
+        assert_eq!(auto_choice(&options[..1]), None);
     }
 }

--- a/crates/loom/src/acp/wire.rs
+++ b/crates/loom/src/acp/wire.rs
@@ -305,14 +305,6 @@ pub struct PermissionOption {
     pub kind: String,
 }
 
-impl PermissionOption {
-    /// Whether this option grants the action (an `allow_*` kind) — used to pick a
-    /// default when auto-answering.
-    pub fn is_allow(&self) -> bool {
-        self.kind.starts_with("allow")
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Response bodies loom parses
 // ---------------------------------------------------------------------------
@@ -699,8 +691,8 @@ mod tests {
         .unwrap();
         assert_eq!(p.tool_call.tool_call_id, "call_9");
         assert_eq!(p.options.len(), 2);
-        assert!(p.options[0].is_allow());
-        assert!(!p.options[1].is_allow());
+        assert_eq!(p.options[0].kind, "allow_once");
+        assert_eq!(p.options[1].kind, "reject_once");
     }
 
     #[test]

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -1094,14 +1094,16 @@ fn codex_acp_mode(mode: &str) -> String {
     }
 }
 
-/// Whether an ACP mode id is a "full access" posture — the user asked never to
-/// be prompted, so loom auto-answers every permission request the adapter sends.
+/// Whether an ACP mode id is a "full access" posture — the user asked not to be
+/// prompted, so loom may auto-answer a one-shot permission request from a turn
+/// that started in this mode.
 /// Each provider vocabulary spells it differently: claude's `bypassPermissions`
 /// and codex's `agent-full-access` (the id [`codex_acp_mode`] maps the former to,
 /// and the id a codex session reports as its `current_mode`). This is the single
-/// source of truth for the auto-approve gate in [`crate::acp`]; adding a mode id
-/// here is how "full access" starts silencing prompts for a new provider. No
-/// other posture (`auto`, `acceptEdits`, `default`, `plan`) auto-approves.
+/// source of truth for the turn-scoped auto-approve gate in [`crate::acp`]; adding
+/// a mode id here is how "full access" starts silencing one-shot prompts for a
+/// new provider. No other posture (`auto`, `acceptEdits`, `default`, `plan`)
+/// auto-approves.
 pub fn is_full_access_mode(mode: &str) -> bool {
     matches!(mode.trim(), "bypassPermissions" | "agent-full-access")
 }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1792,7 +1792,7 @@ pub(crate) async fn adopt(
     branch: &Branch,
 ) -> Result<(), AppError> {
     if session.protocol == "acp" {
-        return adopt_acp(st, session, branch).await;
+        return adopt_acp(st, session, branch, "session adopted").await;
     }
     tracing::info!(session = %session.id, branch = %branch.id, "adopting orphaned session");
     if backend::has_session(&session.term_session).await {
@@ -1913,7 +1913,12 @@ async fn adopt_terminal_into_acp(
 /// task), just re-attach ([`crate::acp::attach`]). When the relay is gone, respawn
 /// it and reopen via `session/load` (the adapter advertised `loadSession` and we
 /// have its id), falling back to a fresh session re-oriented from the goal file.
-async fn adopt_acp(st: &AppState, session: &Session, branch: &Branch) -> Result<(), AppError> {
+async fn adopt_acp(
+    st: &AppState,
+    session: &Session,
+    branch: &Branch,
+    reason: &str,
+) -> Result<(), AppError> {
     tracing::info!(session = %session.id, branch = %branch.id, "adopting acp session");
     if st.acp.is_live(&session.id) {
         return Err(AppError::conflict("session already has a live ACP task"));
@@ -1943,15 +1948,7 @@ async fn adopt_acp(st: &AppState, session: &Session, branch: &Branch) -> Result<
         } else {
             custom_agents::get(&st.db, &runtime).await?
         };
-        let run_dir = db::run_dir(&session.id);
-        let primer_file = {
-            let f = run_dir.join("primer.txt");
-            f.exists().then_some(f)
-        };
-        let goal_file = {
-            let f = run_dir.join("goal.txt");
-            f.exists().then_some(f)
-        };
+        let (primer_file, goal_file) = resume_prompt_files(st, session, branch).await;
         let mode = session
             .current_mode
             .clone()
@@ -2001,12 +1998,46 @@ async fn adopt_acp(st: &AppState, session: &Session, branch: &Branch) -> Result<
         &st.bus,
         &branch.id,
         "status",
-        json!({ "status": status, "reason": "session adopted" }),
+        json!({ "status": status, "reason": reason }),
     )
     .await
     .ok();
     tracing::info!(session = %session.id, branch = %branch.id, "acp session adopted");
     Ok(())
+}
+
+/// Resolve the persisted primer/goal files used to resume either backend. Refresh
+/// the positional goal from the authoritative branch artifact first: an ACP
+/// adapter that cannot load its old provider session falls back to this prompt in
+/// exactly the same way as a native terminal resume.
+async fn resume_prompt_files(
+    st: &AppState,
+    session: &Session,
+    branch: &Branch,
+) -> (Option<PathBuf>, Option<PathBuf>) {
+    let run_dir = db::run_dir(&session.id);
+    let primer_file = {
+        let f = run_dir.join("primer.txt");
+        f.exists().then_some(f)
+    };
+    let goal_file = {
+        let f = run_dir.join("goal.txt");
+        if f.exists() {
+            match branch_mod::current_goal(&st.db, branch).await {
+                Ok(goal) => {
+                    if let Err(e) = tokio::fs::write(&f, &goal).await {
+                        tracing::warn!(error = %e, "failed to refresh goal.txt on resume");
+                    }
+                }
+                Err(e) => tracing::warn!(error = %e, "failed to read goal for resume refresh"),
+            }
+            tracing::debug!(session = %session.id, "refreshed goal file for resume");
+            Some(f)
+        } else {
+            None
+        }
+    };
+    (primer_file, goal_file)
 }
 
 /// Re-launch a session's agent in a worktree that already exists on disk: the
@@ -2024,33 +2055,7 @@ async fn resume_agent(
     tracing::info!(session = %session.id, branch = %branch.id, reason = %reason, "resuming agent");
     let work_dir = PathBuf::from(&session.work_dir);
     // Restore the persisted positional prompt and any optional system primer.
-    let run_dir = db::run_dir(&session.id);
-    let primer_file = {
-        let f = run_dir.join("primer.txt");
-        f.exists().then_some(f)
-    };
-    let goal_file = {
-        let f = run_dir.join("goal.txt");
-        if f.exists() {
-            // Refresh from the authoritative goal artifact before the spawned
-            // shell cats this file in as the opening prompt, so a restart picks
-            // up the newest goal rather than reseeding a stale on-disk copy. A
-            // failure here is non-fatal — the existing goal.txt is still a valid
-            // prompt — but log it so a silently-stale goal is diagnosable.
-            match branch_mod::current_goal(&st.db, branch).await {
-                Ok(goal) => {
-                    if let Err(e) = tokio::fs::write(&f, &goal).await {
-                        tracing::warn!(error = %e, "failed to refresh goal.txt on adopt");
-                    }
-                }
-                Err(e) => tracing::warn!(error = %e, "failed to read goal for adopt refresh"),
-            }
-            tracing::debug!(session = %session.id, "refreshed goal file for resume");
-            Some(f)
-        } else {
-            None
-        }
-    };
+    let (primer_file, goal_file) = resume_prompt_files(st, session, branch).await;
     // Re-launch with the same layered env the session started with, so a resumed
     // session keeps its per-repo / config-file environment (not just the global
     // agent_env). Setup is NOT re-run on adopt — the worktree is already
@@ -2166,8 +2171,12 @@ async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<()
     )
     .await
     .ok();
-    tracing::debug!(session = %session.id, branch = %branch.id, "marked session recovered, resuming agent");
-    resume_agent(st, session, branch, "session recovered").await?;
+    tracing::debug!(session = %session.id, branch = %branch.id, protocol = %session.protocol, "marked session recovered, resuming agent");
+    if session.protocol == "acp" {
+        adopt_acp(st, session, branch, "session recovered").await?;
+    } else {
+        resume_agent(st, session, branch, "session recovered").await?;
+    }
     Ok(())
 }
 
@@ -2622,6 +2631,17 @@ fn live_turn(session: &Session) -> Option<i64> {
         .and_then(|v| v.get("turn").and_then(Value::as_i64))
 }
 
+/// Permission posture captured when the persisted in-flight turn started. This
+/// differs from `Session.current_mode` after a live config change: that selection
+/// applies to the next prompt.
+fn effective_turn_mode(session: &Session) -> Option<String> {
+    session
+        .acp_inflight
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<Value>(s).ok())
+        .and_then(|v| v.get("mode").and_then(Value::as_str).map(str::to_string))
+}
+
 /// The journaled conversation plus the agent-owned composer metadata. The
 /// journal works without a live task; metadata is empty until an adapter is
 /// attached and advertises its commands/configuration controls.
@@ -2637,10 +2657,17 @@ pub(super) async fn get_session_chat(
         .get(&session.id)
         .map(|handle| handle.metadata())
         .unwrap_or_default();
+    // Storage uses '' for compatibility with long-lived NOT NULL databases;
+    // keep that sentinel out of the public conversation contract.
+    let pending_prompt = session
+        .pending_prompt
+        .as_deref()
+        .filter(|pending| !pending.trim().is_empty());
     Ok(Json(json!({
         "blocks": blocks,
         "live_turn": live_turn(&session),
-        "pending_prompt": session.pending_prompt,
+        "effective_mode": effective_turn_mode(&session),
+        "pending_prompt": pending_prompt,
         "metadata": metadata,
     })))
 }

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -33,6 +33,7 @@ let sessionCounter = 0;
 let cancelled = false;
 const steeringSupported = process.env.FAKE_ACP_STEERING === "1";
 const forceSteeringNewTurn = process.env.FAKE_ACP_STEERING_FORCE_NEW_TURN === "1";
+const steeringDelayMs = Number(process.env.FAKE_ACP_STEERING_DELAY_MS || "0");
 let promptActive = false;
 let promptResources = [];
 const steeringQueue = [];
@@ -271,7 +272,8 @@ async function handlePrompt(id, params) {
   }
 }
 
-function handleSteering(id, params) {
+async function handleSteering(id, params) {
+  if (steeringDelayMs > 0) await sleep(steeringDelayMs);
   const text = (params.prompt || []).map((b) => b.text || "").join("");
   if (!promptActive || forceSteeringNewTurn) {
     if (promptActive) {
@@ -341,7 +343,7 @@ function handleMessage(msg) {
       void handlePrompt(msg.id, msg.params);
       break;
     case "_session/steering":
-      if (steeringSupported) handleSteering(msg.id, msg.params);
+      if (steeringSupported) void handleSteering(msg.id, msg.params);
       else rejectMethod(msg.id, msg.method);
       break;
     case "session/cancel":

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -621,6 +621,94 @@ async fn permission_answered_over_rest() {
     );
 }
 
+/// A permission-mode change during a live turn applies to the next turn. The
+/// running turn keeps its captured posture, so selecting full access cannot
+/// auto-approve a request raised by an older restricted turn.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn permission_policy_uses_the_turn_start_mode() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-turn-mode", Some("default"), None).await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-turn-mode/prompt",
+            json!({ "text": "wait:250|permission:old-turn|say:old-done" }),
+        )
+        .await
+        .unwrap();
+    let live = ts
+        .client
+        .get("/api/sessions/acp-turn-mode/chat")
+        .await
+        .unwrap();
+    assert_eq!(live["effective_mode"], "default");
+
+    ts.client
+        .put(
+            "/api/sessions/acp-turn-mode/config/mode",
+            json!({ "value": "bypassPermissions" }),
+        )
+        .await
+        .expect("next-turn mode changes while the turn is live");
+
+    let blocked = poll_chat(&ts, "acp-turn-mode", Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|b| b["kind"] == "permission_request")
+    })
+    .await;
+    assert_eq!(blocked["effective_mode"], "default");
+    let old_permission = blocked["blocks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|b| b["kind"] == "permission_request")
+        .unwrap();
+    assert_eq!(old_permission["payload"]["effective_mode"], "default");
+    assert!(
+        old_permission["payload"]["outcome"].is_null(),
+        "the next-turn full-access selection must not approve the old turn"
+    );
+    let request_id = old_permission["payload"]["request_id"].as_str().unwrap();
+    ts.client
+        .post(
+            &format!("/api/sessions/acp-turn-mode/permissions/{request_id}"),
+            json!({ "option_id": "allow-once" }),
+        )
+        .await
+        .unwrap();
+    poll_chat(&ts, "acp-turn-mode", Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|b| b["kind"] == "turn_end")
+    })
+    .await;
+
+    // A fresh turn captures the selected full-access posture and can apply the
+    // explicit no-prompt policy safely.
+    ts.client
+        .post(
+            "/api/sessions/acp-turn-mode/prompt",
+            json!({ "text": "permission:new-turn|say:new-done" }),
+        )
+        .await
+        .unwrap();
+    let completed = poll_chat(&ts, "acp-turn-mode", Duration::from_secs(10), |blocks| {
+        blocks
+            .iter()
+            .any(|b| b["kind"] == "agent_message" && b["payload"]["text"] == "new-done")
+    })
+    .await;
+    let new_permission = completed["blocks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .rfind(|b| b["kind"] == "permission_request")
+        .unwrap();
+    assert_eq!(
+        new_permission["payload"]["effective_mode"],
+        "bypassPermissions"
+    );
+    assert_eq!(new_permission["payload"]["outcome"]["by"], "policy");
+}
+
 /// 4. Prompt queueing: a send during a live turn queues, sets `pending_prompt`,
 ///    and dispatches as a second turn once the first ends.
 #[serial]
@@ -789,8 +877,8 @@ async fn queue_consume_failure_does_not_dispatch_or_replay() {
     );
 }
 
-/// 4b. A steering-capable adapter injects a mid-turn prompt into the active
-/// turn instead of writing the durable next-turn queue.
+/// 4b. A steering-capable adapter durably queues a mid-turn prompt, acknowledges
+/// it immediately, then consumes the queue after the adapter accepts injection.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn prompt_steers_a_live_turn_when_advertised() {
@@ -828,18 +916,9 @@ async fn prompt_steers_a_live_turn_when_advertised() {
         )
         .await
         .unwrap();
-    assert_eq!(second["queued"], false);
-    assert_eq!(second["steered"], true, "response: {second}");
+    assert_eq!(second["queued"], true);
+    assert_eq!(second["steered"], false, "response: {second}");
     assert_eq!(second["turn"], 0);
-
-    let session = session_mod::get(&ts.state.db, "acp-steer")
-        .await
-        .unwrap()
-        .unwrap();
-    assert!(
-        session.pending_prompt.as_deref().unwrap_or("").is_empty(),
-        "a successful steer must not touch the next-turn queue"
-    );
 
     let chat = poll_chat(&ts, "acp-steer", Duration::from_secs(10), |blocks| {
         count_kind(blocks, "turn_end") >= 1
@@ -856,6 +935,69 @@ async fn prompt_steers_a_live_turn_when_advertised() {
             && b["payload"]["text"] == "say:changed course"
             && b["payload"]["steered"] == true
     }));
+    let session = session_mod::get(&ts.state.db, "acp-steer")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        session.pending_prompt.as_deref().unwrap_or("").is_empty(),
+        "a successful steer consumes its durable queue copy"
+    );
+}
+
+/// Ordinary sends must not hold the HTTP response (and browser composer) behind
+/// a delayed private steering RPC. The queue is the immediate durable receipt;
+/// adapter acceptance later promotes it into the live turn.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prompt_ack_does_not_wait_for_steering() {
+    let ts = TestServer::start().await;
+    start_new_with_env(
+        &ts,
+        "acp-steer-delay",
+        None,
+        None,
+        vec![
+            ("FAKE_ACP_STEERING".to_string(), "1".to_string()),
+            ("FAKE_ACP_STEERING_DELAY_MS".to_string(), "1000".to_string()),
+        ],
+    )
+    .await;
+    ts.client
+        .post(
+            "/api/sessions/acp-steer-delay/prompt",
+            json!({ "text": "wait:1800|say:first" }),
+        )
+        .await
+        .unwrap();
+
+    let ack = tokio::time::timeout(
+        Duration::from_millis(300),
+        ts.client.post(
+            "/api/sessions/acp-steer-delay/prompt",
+            json!({ "text": "say:feedback" }),
+        ),
+    )
+    .await
+    .expect("the send acknowledgement must not wait for steering")
+    .unwrap();
+    assert_eq!(ack["queued"], true);
+    let queued = ts
+        .client
+        .get("/api/sessions/acp-steer-delay/chat")
+        .await
+        .unwrap();
+    assert_eq!(queued["pending_prompt"], "say:feedback");
+
+    poll_chat_state(&ts, "acp-steer-delay", Duration::from_secs(10), |chat| {
+        chat["pending_prompt"].is_null()
+            && chat["blocks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|b| b["kind"] == "user_message" && b["payload"]["steered"] == true)
+    })
+    .await;
 }
 
 /// An adapter that does not advertise steering must never be probed with the
@@ -985,9 +1127,9 @@ async fn prompt_adopts_a_turn_started_by_steering() {
         )
         .await
         .unwrap();
-    assert_eq!(second["queued"], false);
+    assert_eq!(second["queued"], true);
     assert_eq!(second["steered"], false);
-    assert_eq!(second["turn"], 1);
+    assert_eq!(second["turn"], 0);
 
     let chat = poll_chat_state(&ts, "acp-steer-race", Duration::from_secs(10), |chat| {
         chat["live_turn"].is_null()
@@ -1236,9 +1378,9 @@ async fn interrupt_leaves_queued_feedback_idle_until_sent() {
         })
     })
     .await;
-    // Drained queue is the canonical empty string, never NULL (see
-    // `session::take_pending_prompt`); the frontend treats '' and null alike.
-    assert_eq!(chat["pending_prompt"], "");
+    // Storage keeps its canonical empty-string sentinel, while the public chat
+    // contract normalizes an empty queue to null.
+    assert_eq!(chat["pending_prompt"], Value::Null);
     assert!(chat["blocks"].as_array().unwrap().iter().any(|block| {
         block["kind"] == "user_message"
             && block["turn"] == 1
@@ -1771,6 +1913,61 @@ async fn conversation_is_live_and_archive_captures_it() {
         chat_json.contains("say:archived"),
         "the goal survived the capture"
     );
+}
+
+/// Archived ACP sessions must recover through the relay/adapter path. A terminal
+/// resume leaves `protocol='acp'` on the row but registers no ACP task, making
+/// every conversation control fail with "no live ACP task to drive".
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn archive_recover_restores_the_acp_driver() {
+    let ts = TestServer::start().await;
+    seed_acp_agent(&ts, "fakeacp").await;
+
+    let created = rest_create(&ts, "fakeacp", "say:before-archive").await;
+    let id = created["id"].as_str().unwrap().to_string();
+    let relay = created["term_session"].as_str().unwrap().to_string();
+    poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
+        blocks.iter().any(|b| b["kind"] == "turn_end")
+    })
+    .await;
+
+    ts.client
+        .post(&format!("/api/sessions/{id}/archive"), json!({}))
+        .await
+        .expect("archive succeeds");
+    assert!(!ts.state.acp.is_live(&id), "archive removes the ACP task");
+    assert!(
+        !backend::has_session(&relay).await,
+        "archive removes the relay supervisor"
+    );
+
+    let recovered = ts
+        .client
+        .post(&format!("/api/sessions/{id}/recover"), json!({}))
+        .await
+        .expect("ACP recovery succeeds");
+    assert_eq!(recovered["protocol"], "acp");
+    assert!(ts.state.acp.is_live(&id), "recovery registers an ACP task");
+    assert!(
+        backend::has_session(&relay).await,
+        "recovery recreates the relay supervisor"
+    );
+    poll_metadata(&ts, &id, Duration::from_secs(10)).await;
+
+    ts.client
+        .post(
+            &format!("/api/sessions/{id}/prompt"),
+            json!({ "text": "say:after-recovery" }),
+        )
+        .await
+        .expect("the recovered ACP task accepts a prompt");
+    poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
+        blocks
+            .iter()
+            .any(|b| b["kind"] == "agent_message" && b["payload"]["text"] == "after-recovery")
+    })
+    .await;
 }
 
 /// D. `/preview` renders the last journal blocks as compact plain text — the CLI's

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -494,6 +494,27 @@ test.describe('acp conversation', () => {
     await expect(fast).toContainText('On');
   });
 
+  test('a live permission change is labelled for the next turn', async ({ page, weaver }) => {
+    await openAcp(page, weaver, { goal: 'say:ready', mode: 'default' });
+    const input = page.getByTestId('acp-composer-input');
+    await input.fill('wait:5000|say:done');
+    await page.getByTestId('acp-composer-send').click();
+    await expect(page.getByTestId('acp-working')).toBeVisible({ timeout: 15_000 });
+
+    const permissions = page.getByTestId('acp-config-mode');
+    await permissions.getByRole('button').first().click();
+    await page
+      .getByTestId('acp-config-menu')
+      .getByText('Bypass permissions', { exact: true })
+      .click();
+    await expect(permissions).toContainText('Bypass permissions');
+    await expect(permissions).toContainText('next turn');
+
+    await page.getByTestId('acp-composer-stop').click();
+    await expect(page.getByTestId('acp-working')).toBeHidden({ timeout: 5_000 });
+    await expect(permissions).not.toContainText('next turn');
+  });
+
   test('a permission card answers and collapses to a receipt', async ({ page, weaver }) => {
     // A supervised mode surfaces the request as an interactive card (bypass mode
     // would auto-answer it).


### PR DESCRIPTION
## Summary

- recover archived ACP sessions through the ACP relay/session-load driver instead of leaving a protocol=acp row backed by a native terminal process
- capture the permission mode effective at turn start, label live changes as applying next turn, and restrict full-access auto-answers to one-shot grants
- persist and acknowledge ordinary live feedback before private steering so a delayed adapter cannot lock the composer; retain the queue copy unless steering is accepted
- normalize the empty queue sentinel at the REST boundary and add hermetic integration/browser coverage for the reported failures

The broader recommendation is to keep Weaver's capability-bearing session contract authoritative over ACP and terminal drivers; this PR is the bounded reliability repair, not a default-driver flip.

Reviewed plan: https://loom.rjp.io/s/shrcv23u/artifacts/plan

Loom session: https://loom.rjp.io/s/c7ypxqit