### PR TITLE
feat(loom): edit queued agent messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,10 @@ with the model — user turns, replies, thinking, and tool calls — live and
 (via the archive capture below) still there to review after the terminal is gone.
 For ACP sessions, a prompt submitted while the agent is working steers the live
 turn when the adapter supports steering; otherwise loom safely queues it as the
-next turn.
+next turn. Unseen queued feedback can be pulled back into the composer with its
+**Edit** action or ArrowUp from an empty composer. The live status names visible
+thinking, writing, or tool activity and reports how long it has been since the
+agent produced an observable update; quiet time is not guessed to mean stuck.
 
 Whenever a session is archived — by the Archive button or automatically on merge
 — loom first captures that conversation to disk: it finds the agent's transcript

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -310,7 +310,8 @@ export const forceQueuedSession = (id: string, by?: string) =>
   }) as Promise<PromptAck>;
 
 /** Atomically pull unseen next-turn feedback out of the server queue so it can
- * be edited in the composer. A 409 means dispatch/steering won the race. */
+ * be edited in the composer. A 409 means the current ACP state has no queue
+ * available to retract. */
 export const retractQueuedSession = (id: string) =>
   del(`/sessions/${id}/prompt`) as Promise<{ text: string }>;
 

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -309,6 +309,11 @@ export const forceQueuedSession = (id: string, by?: string) =>
     files: [],
   }) as Promise<PromptAck>;
 
+/** Atomically pull unseen next-turn feedback out of the server queue so it can
+ * be edited in the composer. A 409 means dispatch/steering won the race. */
+export const retractQueuedSession = (id: string) =>
+  del(`/sessions/${id}/prompt`) as Promise<{ text: string }>;
+
 /** Worktree-backed completion for `@file` mentions in the ACP composer. */
 export const listSessionFiles = (id: string, query: string) =>
   get(`/sessions/${id}/files?q=${encodeURIComponent(query)}`) as Promise<{ files: string[] }>;

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -1029,16 +1029,11 @@ function durationLabel(seconds: number): string {
   const s = seconds % 60;
   return `${m}:${String(s).padStart(2, '0')}`;
 }
-const elapsedSeconds = computed(() =>
-  turnStartedAt.value == null
-    ? 0
-    : Math.max(0, Math.floor((clock.value - turnStartedAt.value) / 1000)),
-);
-const progressAgeSeconds = computed(() =>
-  lastProgressAt.value == null
-    ? 0
-    : Math.max(0, Math.floor((clock.value - lastProgressAt.value) / 1000)),
-);
+function secondsSince(timestamp: number | null): number {
+  return timestamp == null ? 0 : Math.max(0, Math.floor((clock.value - timestamp) / 1000));
+}
+const elapsedSeconds = computed(() => secondsSince(turnStartedAt.value));
+const progressAgeSeconds = computed(() => secondsSince(lastProgressAt.value));
 const elapsedLabel = computed(() => durationLabel(elapsedSeconds.value));
 // A quiet turn is not necessarily stuck (the model may be reasoning without
 // streaming), so the UI reports the observable fact and lets the operator judge.

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -14,6 +14,7 @@ import {
   getSessionChat,
   promptSession,
   forceQueuedSession,
+  retractQueuedSession,
   interruptSession,
   answerPermission,
   setSessionMode,
@@ -81,6 +82,8 @@ const shadows = reactive(
 const liveTools = reactive(new Map<string, SseTool>());
 const turnLive = ref(false);
 const liveTurnNo = ref<number | null>(null);
+const turnStartedAt = ref<number | null>(null);
+const lastProgressAt = ref<number | null>(null);
 // Optimistic rows exist only while an HTTP send is unresolved. Delivery state
 // comes from the durable queue snapshot/SSE, never from the click that initiated
 // the request.
@@ -117,6 +120,43 @@ function applyMetadata(next: AcpMetadata) {
 
 const blockKey = (turn: number, seq: number) => `${turn}:${seq}`;
 
+function timeOf(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function markProgress(at?: string) {
+  const next = timeOf(at) ?? Date.now();
+  lastProgressAt.value = Math.max(lastProgressAt.value ?? 0, next);
+  if (turnStartedAt.value == null) turnStartedAt.value = next;
+}
+
+/** Rebuild timing from durable journal timestamps after a reload. The opening
+ * user message is the turn start; the newest block is the last server-observed
+ * progress. Live deltas/tools advance the latter in real time below. */
+function restoreLiveTiming(turn: number | null, preserveObserved = false) {
+  if (turn == null) {
+    turnStartedAt.value = null;
+    lastProgressAt.value = null;
+    return;
+  }
+  const current = [...blocks.values()].filter((block) => block.turn === turn);
+  const opening = current.find((block) => block.kind === 'user_message') ?? current[0];
+  const restoredStart = timeOf(opening?.created_at) ?? Date.now();
+  const restoredProgress =
+    current.reduce<number | null>((latest, block) => {
+      const at = timeOf(block.created_at);
+      return at == null ? latest : Math.max(latest ?? 0, at);
+    }, null) ?? restoredStart;
+  turnStartedAt.value = preserveObserved
+    ? Math.min(turnStartedAt.value ?? restoredStart, restoredStart)
+    : restoredStart;
+  lastProgressAt.value = preserveObserved
+    ? Math.max(lastProgressAt.value ?? restoredProgress, restoredProgress)
+    : restoredProgress;
+}
+
 type LoadState = 'loading' | 'ready' | 'error';
 const state = ref<LoadState>('loading');
 const errorMsg = ref('');
@@ -133,12 +173,14 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
   try {
     const snap = await getSessionChat(id.value);
     if (seq !== loadSeq) return;
+    const preserveObservedTiming = preserve && liveTurnNo.value === snap.live_turn;
     blocks.clear();
     for (const b of snap.blocks) blocks.set(blockKey(b.turn, b.seq), b);
     shadows.clear();
     liveTools.clear();
     liveTurnNo.value = snap.live_turn;
     turnLive.value = snap.live_turn != null;
+    restoreLiveTiming(snap.live_turn, preserveObservedTiming);
     effectiveMode.value = snap.effective_mode ?? null;
     pendingPrompt.value = snap.pending_prompt?.trim() ? snap.pending_prompt : null;
     applyMetadata(snap.metadata ?? emptyMetadata());
@@ -160,6 +202,7 @@ async function load({ preserve = false }: { preserve?: boolean } = {}) {
 // ── Stream application ───────────────────────────────────────────────────────
 function onBlock(b: ChatBlock) {
   blocks.set(blockKey(b.turn, b.seq), b);
+  if (b.turn === liveTurnNo.value) markProgress(b.created_at);
   if (b.kind === 'tool_call') {
     const tid = (b.payload as unknown as ToolCallPayload).tool_call_id;
     if (tid) liveTools.delete(tid);
@@ -179,6 +222,7 @@ function onBlock(b: ChatBlock) {
 function onDelta(d: SseDelta) {
   turnLive.value = true;
   liveTurnNo.value = d.turn;
+  markProgress();
   const k = `${d.turn}:${d.kind}`;
   const cur = shadows.get(k) ?? { turn: d.turn, kind: d.kind, text: '' };
   cur.text += d.text;
@@ -190,6 +234,7 @@ function onTool(t: SseTool) {
   liveTools.set(t.tool_call_id, t);
   turnLive.value = true;
   liveTurnNo.value = t.turn;
+  markProgress();
   autoFollow();
 }
 
@@ -197,11 +242,15 @@ function onTurn(ev: SseTurn) {
   if (ev.state === 'started') {
     turnLive.value = true;
     liveTurnNo.value = ev.turn;
+    turnStartedAt.value = Date.now();
+    lastProgressAt.value = turnStartedAt.value;
     effectiveMode.value = ev.effective_mode ?? null;
     autoFollow();
   } else {
     turnLive.value = false;
     liveTurnNo.value = null;
+    turnStartedAt.value = null;
+    lastProgressAt.value = null;
     effectiveMode.value = null;
   }
 }
@@ -276,12 +325,13 @@ watch(id, () => {
 const draft = ref('');
 const composerInput = ref<HTMLTextAreaElement | null>(null);
 const sending = ref(false);
+const editingQueued = ref(false);
 const sendError = ref('');
 const composerVisible = computed(() => canSend(props.session));
 const selectedFiles = ref<string[]>([]);
 
 async function submitPrompt(forceSteer = false) {
-  if (!draft.value.trim() || sending.value) return;
+  if (!draft.value.trim() || sending.value || editingQueued.value) return;
   const local = localCommand(draft.value);
   if (local) {
     draft.value = '';
@@ -315,7 +365,7 @@ async function submitPrompt(forceSteer = false) {
 }
 
 async function forceQueued() {
-  if (sending.value) return;
+  if (sending.value || editingQueued.value) return;
   sending.value = true;
   sendError.value = '';
   try {
@@ -326,6 +376,33 @@ async function forceQueued() {
     sendError.value = (e as Error).message ?? 'Failed to send queued feedback';
   } finally {
     sending.value = false;
+  }
+}
+
+async function editQueued() {
+  if (!pendingPrompt.value || sending.value || editingQueued.value) return;
+  editingQueued.value = true;
+  sendError.value = '';
+  let moved = false;
+  try {
+    const { text } = await retractQueuedSession(id.value);
+    // A click can race with typing in another tab or in the composer itself.
+    // Preserve both pieces of human-authored text instead of overwriting either.
+    draft.value = draft.value.trim() ? `${text}\n\n${draft.value}` : text;
+    pendingPrompt.value = null;
+    await load({ preserve: true });
+    moved = true;
+  } catch (e) {
+    sendError.value = (e as Error).message ?? 'Failed to edit queued feedback';
+    await load({ preserve: true });
+  } finally {
+    editingQueued.value = false;
+  }
+  if (moved) {
+    // Re-enable before focusing: disabled form controls cannot receive focus.
+    await nextTick();
+    composerInput.value?.focus();
+    composerInput.value?.setSelectionRange(draft.value.length, draft.value.length);
   }
 }
 
@@ -443,6 +520,13 @@ function onComposerKeydown(e: KeyboardEvent) {
       if (activeCommand.value) chooseCommand(activeCommand.value);
       return;
     }
+  }
+  // Chat-history convention, scoped to the only message that is still
+  // editable: ArrowUp in an empty composer retracts unseen queued feedback.
+  if (e.key === 'ArrowUp' && draft.value === '' && pendingPrompt.value) {
+    e.preventDefault();
+    editQueued();
+    return;
   }
   if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault();
@@ -924,8 +1008,8 @@ function toggleFold(key: string, dflt = false) {
   folds.value = m;
 }
 
-// ── Working timer (elapsed) ──────────────────────────────────────────────────
-const elapsed = ref(0);
+// ── Working timer (elapsed + time since observable progress) ─────────────────
+const clock = ref(Date.now());
 let elapsedTimer: ReturnType<typeof setInterval> | null = null;
 watch(turnLive, (live) => {
   if (elapsedTimer) {
@@ -933,17 +1017,36 @@ watch(turnLive, (live) => {
     elapsedTimer = null;
   }
   if (live) {
-    elapsed.value = 0;
-    elapsedTimer = setInterval(() => (elapsed.value += 1), 1000);
+    clock.value = Date.now();
+    elapsedTimer = setInterval(() => (clock.value = Date.now()), 1000);
   }
 });
 onUnmounted(() => {
   if (elapsedTimer) clearInterval(elapsedTimer);
 });
-const elapsedLabel = computed(() => {
-  const m = Math.floor(elapsed.value / 60);
-  const s = elapsed.value % 60;
+function durationLabel(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
   return `${m}:${String(s).padStart(2, '0')}`;
+}
+const elapsedSeconds = computed(() =>
+  turnStartedAt.value == null
+    ? 0
+    : Math.max(0, Math.floor((clock.value - turnStartedAt.value) / 1000)),
+);
+const progressAgeSeconds = computed(() =>
+  lastProgressAt.value == null
+    ? 0
+    : Math.max(0, Math.floor((clock.value - lastProgressAt.value) / 1000)),
+);
+const elapsedLabel = computed(() => durationLabel(elapsedSeconds.value));
+// A quiet turn is not necessarily stuck (the model may be reasoning without
+// streaming), so the UI reports the observable fact and lets the operator judge.
+const visiblyQuiet = computed(() => progressAgeSeconds.value >= 15);
+const progressLabel = computed(() => {
+  if (progressAgeSeconds.value < 2) return 'updated just now';
+  if (!visiblyQuiet.value) return `updated ${durationLabel(progressAgeSeconds.value)} ago`;
+  return `no updates for ${durationLabel(progressAgeSeconds.value)}`;
 });
 
 // ── Follow-the-foot scroll (lib/followFoot.ts): pinned-at-the-newest-exchange. ──
@@ -1192,22 +1295,34 @@ function goTo(anchor: string) {
               <span class="acp-prompt-state" data-testid="acp-queued"
                 >queued · agent hasn’t seen this yet</span
               >
-              <button
-                type="button"
-                class="acp-prompt-action"
-                data-testid="acp-force-queued"
-                :disabled="sending"
-                :title="
-                  turnLive
-                    ? steeringSupported
-                      ? 'Inject all queued feedback into the running turn now'
-                      : 'Stop the running turn and send all queued feedback as the next turn'
-                    : 'Start a new turn with all queued feedback'
-                "
-                @click="forceQueued"
-              >
-                {{ turnLive ? (steeringSupported ? 'Force now' : 'Stop & send') : 'Send now' }}
-              </button>
+              <span class="acp-prompt-actions">
+                <button
+                  type="button"
+                  class="acp-prompt-action"
+                  data-testid="acp-edit-queued"
+                  :disabled="sending || editingQueued"
+                  title="Move this unseen feedback back into the editor (ArrowUp from an empty editor)"
+                  @click="editQueued"
+                >
+                  {{ editingQueued ? 'Moving…' : 'Edit' }}
+                </button>
+                <button
+                  type="button"
+                  class="acp-prompt-action"
+                  data-testid="acp-force-queued"
+                  :disabled="sending || editingQueued"
+                  :title="
+                    turnLive
+                      ? steeringSupported
+                        ? 'Inject all queued feedback into the running turn now'
+                        : 'Stop the running turn and send all queued feedback as the next turn'
+                      : 'Start a new turn with all queued feedback'
+                  "
+                  @click="forceQueued"
+                >
+                  {{ turnLive ? (steeringSupported ? 'Force now' : 'Stop & send') : 'Send now' }}
+                </button>
+              </span>
             </header>
             <MarkdownView :id="id" path="" :source="pendingPrompt" />
           </section>
@@ -1229,13 +1344,16 @@ function goTo(anchor: string) {
           <div
             v-if="turnLive"
             class="acp-status"
+            :data-quiet="visiblyQuiet"
             data-testid="acp-working"
             role="status"
             aria-live="polite"
+            title="Update age measures visible agent output and tool activity; silence alone does not prove the agent is stuck."
           >
             <span class="acp-live-label">{{ statusLabel }}…</span>
             <span class="acp-status-meta"
-              >turn {{ (liveTurnNo ?? 0) + 1 }} · {{ elapsedLabel }}</span
+              >turn {{ (liveTurnNo ?? 0) + 1 }} · {{ elapsedLabel }} elapsed ·
+              {{ progressLabel }}</span
             >
           </div>
         </div>
@@ -1295,7 +1413,7 @@ function goTo(anchor: string) {
         ref="composerInput"
         v-model="draft"
         rows="2"
-        :disabled="sending"
+        :disabled="sending || editingQueued"
         :placeholder="commandHint || 'Message the agent…'"
         data-testid="acp-composer-input"
         class="acp-input"
@@ -1428,7 +1546,7 @@ function goTo(anchor: string) {
             type="button"
             class="btn-secondary px-3 py-1 text-xs"
             data-testid="acp-composer-force-steer"
-            :disabled="sending || !draft.trim()"
+            :disabled="sending || editingQueued || !draft.trim()"
             title="Inject this feedback into the running turn"
             @click="submitPrompt(true)"
           >
@@ -1448,7 +1566,7 @@ function goTo(anchor: string) {
             type="submit"
             class="btn-primary px-3 py-1 text-sm"
             data-testid="acp-composer-send"
-            :disabled="sending || !draft.trim()"
+            :disabled="sending || editingQueued || !draft.trim()"
           >
             {{ sending ? 'Sending…' : 'Send' }}
           </button>
@@ -1507,6 +1625,10 @@ function goTo(anchor: string) {
   font-family: var(--font-mono);
   font-size: 0.6875rem;
   color: var(--attn);
+}
+.acp-prompt-actions {
+  display: inline-flex;
+  gap: 0.625rem;
 }
 .acp-prompt-action {
   border-bottom: 1px solid currentColor;
@@ -1777,6 +1899,12 @@ function goTo(anchor: string) {
   background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: acp-shimmer 2.2s linear infinite;
+}
+.acp-status[data-quiet='true'] .acp-live-label {
+  animation: none;
+  background: none;
+  -webkit-text-fill-color: currentColor;
+  color: var(--muted);
 }
 @keyframes acp-shimmer {
   from {

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -203,6 +203,19 @@ impl AcpHandle {
             .map_err(|_| anyhow!("acp task dropped the reply"))?
     }
 
+    /// Atomically retract the durable next-turn queue for editing. This runs on
+    /// the ACP task so a turn boundary cannot dispatch the same text while the
+    /// browser is moving it back into the composer.
+    pub async fn retract_pending(&self) -> Result<String> {
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::RetractPending { reply: tx })
+            .await
+            .map_err(|_| anyhow!("acp task is gone"))?;
+        rx.await
+            .map_err(|_| anyhow!("acp task dropped the reply"))?
+    }
+
     /// Interrupt the in-flight turn (`session/cancel`).
     pub async fn cancel(&self) -> Result<()> {
         let (tx, rx) = oneshot::channel();
@@ -455,6 +468,9 @@ enum Command {
     ForcePending {
         by: Option<String>,
         reply: oneshot::Sender<Result<PromptAck>>,
+    },
+    RetractPending {
+        reply: oneshot::Sender<Result<String>>,
     },
     Cancel {
         reply: oneshot::Sender<Result<()>>,
@@ -1972,6 +1988,27 @@ impl Task {
                             }
                         }
                     }
+                }
+            }
+            Command::RetractPending { reply } => {
+                // A steering RPC may already have handed this text to the
+                // adapter even though its durable fallback is still visible.
+                // Once that request is in flight, claiming the text is editable
+                // would be a lie: the eventual response can consume or run it.
+                if !self.pending_steers.is_empty() || self.pending_external.is_some() {
+                    let _ = reply.send(Err(anyhow!(
+                        "queued feedback is already being steered; wait for it to settle"
+                    )));
+                } else {
+                    let result = session::take_pending_prompt(&self.db, &self.session_id)
+                        .await
+                        .and_then(|pending| {
+                            pending.ok_or_else(|| anyhow!("there is no queued feedback to edit"))
+                        });
+                    if result.is_ok() {
+                        self.emit_queue(None);
+                    }
+                    let _ = reply.send(result);
                 }
             }
             Command::Cancel { reply } => {

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -616,7 +616,10 @@ pub fn router(state: AppState) -> Router {
         // `session/prompt` queueing send, a permission answer, a mode change).
         .route("/sessions/{id}/chat", get(get_session_chat))
         .route("/sessions/{id}/chat/stream", get(chat_stream))
-        .route("/sessions/{id}/prompt", post(prompt_session))
+        .route(
+            "/sessions/{id}/prompt",
+            post(prompt_session).delete(retract_queued_prompt),
+        )
         .route(
             "/sessions/{id}/permissions/{request_id}",
             post(answer_permission),

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2872,6 +2872,23 @@ pub(super) async fn prompt_session(
     ))
 }
 
+/// Pull unseen next-turn feedback back out of the durable queue for editing.
+/// The ACP task owns the consume so this action is serialized with automatic
+/// dispatch at a turn boundary and with steering responses.
+pub(super) async fn retract_queued_prompt(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<Value>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    require_acp(&session)?;
+    let handle = require_acp_task(&st, &session)?;
+    let text = handle
+        .retract_pending()
+        .await
+        .map_err(|e| AppError::conflict(e.to_string()))?;
+    Ok(Json(json!({ "text": text })))
+}
+
 #[derive(Debug, Deserialize)]
 pub(super) struct ConfigOptionBody {
     pub value: Value,

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -794,6 +794,57 @@ async fn prompt_queues_during_a_live_turn() {
     );
 }
 
+/// Retracting unseen feedback is serialized by the ACP task: either the browser
+/// gets the exact durable text back for editing, or a turn boundary wins and the
+/// request conflicts. It can never both dispatch and return the same prompt.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn queued_prompt_can_be_retracted_for_editing() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-edit-queue", None, None).await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-edit-queue/prompt",
+            json!({ "text": "wait:900|say:first" }),
+        )
+        .await
+        .unwrap();
+    let queued = ts
+        .client
+        .post(
+            "/api/sessions/acp-edit-queue/prompt",
+            json!({ "text": "say:revise me" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(queued["queued"], true);
+
+    let retracted = ts
+        .client
+        .delete("/api/sessions/acp-edit-queue/prompt")
+        .await
+        .unwrap();
+    assert_eq!(retracted["text"], "say:revise me");
+
+    let chat = ts
+        .client
+        .get("/api/sessions/acp-edit-queue/chat")
+        .await
+        .unwrap();
+    assert!(chat["pending_prompt"].is_null());
+
+    let settled = poll_chat(&ts, "acp-edit-queue", Duration::from_secs(10), |blocks| {
+        count_kind(blocks, "turn_end") >= 1
+    })
+    .await;
+    assert_eq!(
+        count_kind(settled["blocks"].as_array().unwrap(), "user_message"),
+        1,
+        "retracted feedback must not also dispatch"
+    );
+}
+
 /// A queued prompt must not be dispatched unless removing its durable copy
 /// succeeds. Otherwise every turn boundary can dispatch the same still-pending
 /// text again, growing the journal until the session is stopped.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,7 +215,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/sessions/{id}/chat` | `{blocks: [ChatBlockView], live_turn}` — the ACP session's journal snapshot (per-block conversation record) plus the in-flight turn, if any |
 | `GET /api/sessions/{id}/chat/stream` | SSE tail of the live journal: `block` (a committed block), `delta` (a streaming message/thought chunk), `tool` (a live tool-call update), `turn` (started / ended) |
 | `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, steered, turn}` — dispatch a user message as a `session/prompt`; a live turn uses the advertised codex-acp steering extension, with the durable next-turn queue as fallback |
-| `DELETE /api/sessions/{id}/prompt` | atomically retract unseen next-turn feedback and return `{text}` for editing; 409 when dispatch or steering already won the race |
+| `DELETE /api/sessions/{id}/prompt` | atomically retract unseen next-turn feedback and return `{text}` for editing; 409 when the current ACP state has no queue available to retract |
 | `POST /api/sessions/{id}/permissions/{request_id}` | `{option_id}` → answer an open permission request (200 / 404 unknown / 409 already resolved) |
 | `PUT /api/sessions/{id}/mode` | `{mode_id}` → change the ACP session's permission mode (`session/set_mode`), journaled as a `mode_change` |
 | `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,6 +215,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/sessions/{id}/chat` | `{blocks: [ChatBlockView], live_turn}` — the ACP session's journal snapshot (per-block conversation record) plus the in-flight turn, if any |
 | `GET /api/sessions/{id}/chat/stream` | SSE tail of the live journal: `block` (a committed block), `delta` (a streaming message/thought chunk), `tool` (a live tool-call update), `turn` (started / ended) |
 | `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, steered, turn}` — dispatch a user message as a `session/prompt`; a live turn uses the advertised codex-acp steering extension, with the durable next-turn queue as fallback |
+| `DELETE /api/sessions/{id}/prompt` | atomically retract unseen next-turn feedback and return `{text}` for editing; 409 when dispatch or steering already won the race |
 | `POST /api/sessions/{id}/permissions/{request_id}` | `{option_id}` → answer an open permission request (200 / 404 unknown / 409 already resolved) |
 | `PUT /api/sessions/{id}/mode` | `{mode_id}` → change the ACP session's permission mode (`session/set_mode`), journaled as a `mode_change` |
 | `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |

--- a/docs/plans/chat-flows.md
+++ b/docs/plans/chat-flows.md
@@ -1,0 +1,51 @@
+# Agent chat flow catalogue
+
+Loom's ACP conversation is an operator console for an agent that can change the
+world, not a stateless chatbot. Chat conventions are useful when they preserve
+that distinction: queued text can be edited because the agent has not seen it;
+a completed turn cannot be silently rewritten or regenerated because its tool
+calls may already have had side effects.
+
+## Current flows
+
+| Flow | Treatment |
+| --- | --- |
+| Compose and send | Enter sends; Shift+Enter inserts a newline. Failed sends leave the draft intact. |
+| Follow up during a turn | The prompt is durably queued. Steering-capable adapters may consume it into the live turn; other adapters wait for the next turn. |
+| Revise unseen feedback | The queued block has **Edit**. ArrowUp in an empty composer performs the same action. Loom atomically retracts the server queue before placing its text in the editor. |
+| Resolve a draft/queue collision | Pulling a queue into a non-empty draft preserves both, with queued text first. It never overwrites human input. |
+| Deliver queued feedback now | **Force now** steers when supported; **Stop & send** cancels a non-steerable turn first; **Send now** starts an idle turn. |
+| Stop work without losing feedback | **Stop** cancels the live turn and leaves unseen queued feedback idle until the operator edits or sends it. |
+| Understand live work | The tail names streamed thinking, writing, or the current tool. It shows turn age and time since the last observable update; after 15 seconds of silence the shimmer stops and the UI says `no updates for …`. Silence is not labelled `stuck`. |
+| Inspect results | Thinking and tool runs fold; failures open loudly; turn endings retain stop reason and context usage. |
+| Agent interaction | Permission requests, modes, model/reasoning controls, slash commands, and `@file` resources stay in the same composer. |
+| Navigate a long thread | New output follows the foot until the reader scrolls away; the turn rail jumps between user prompts. |
+
+## Missing or deliberately deferred
+
+1. **Individual queue items.** Storage currently coalesces mid-turn sends into
+   one next-turn prompt. Editing the combined prompt is honest, but per-message
+   delete/reorder requires a structured queue with stable item ids and resource
+   metadata. Do that before adding item-level controls.
+2. **Sent-prompt history.** After the unseen queue case, ArrowUp could recall
+   earlier user prompts as a *copy*. It must not imply that already-dispatched
+   history was edited.
+3. **Reconnect state.** The transcript reconnects and reconciles automatically,
+   but does not tell the operator when it is replaying after a dropped stream.
+   Add a quiet `reconnecting` receipt if disconnects prove confusing in use.
+4. **Explicit retry.** A retry of an agentic turn can repeat writes, commands, or
+   external actions. Any future retry should copy the old prompt into the
+   composer and explain that it starts a new turn; never replay automatically.
+5. **Cross-device drafts.** Drafts are currently ephemeral component state. In
+   this API-first application, persistent draft recovery should use a small
+   server-owned resource with ownership and conflict semantics rather than
+   becoming an unobservable browser-only feature.
+6. **Conversation forks.** Exploring an alternative from an earlier turn needs
+   a new session/branch and clear provenance, not mutation of the canonical
+   journal.
+
+One-click “regenerate” and automatic “stuck” labels are intentionally absent.
+The former can duplicate side effects; the latter cannot distinguish private
+reasoning, a slow tool, provider latency, and a dead process from elapsed time
+alone. The observable update age gives a human (or a watch) evidence without
+inventing certainty.

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -263,9 +263,10 @@ test.describe('acp conversation', () => {
   });
 
   test('a live turn shows a status line naming the activity', async ({ page, weaver }) => {
+    await page.clock.install();
     await openAcp(page, weaver, { goal: 'say:ready' });
     const input = page.getByTestId('acp-composer-input');
-    await input.fill('wait:2500|say:done');
+    await input.fill('wait:3500|say:done');
     await page.getByTestId('acp-composer-send').click();
 
     // The status line sits at the transcript tail, names the activity, and
@@ -274,6 +275,17 @@ test.describe('acp conversation', () => {
     await expect(status).toBeVisible({ timeout: 15_000 });
     await expect(status).toContainText('Working…');
     await expect(status).toContainText('turn 2');
+    await expect(status).toContainText('elapsed');
+    await expect(status).toContainText(/updated (just now|0:0[1-9] ago)/);
+    await expect(status).toHaveAttribute(
+      'title',
+      /silence alone does not prove the agent is stuck/,
+    );
+    // Time alone never becomes a false "stuck" verdict. Once updates go quiet,
+    // the perpetual activity shimmer stops and the UI reports only that fact.
+    await page.clock.fastForward(16_000);
+    await expect(status).toHaveAttribute('data-quiet', 'true');
+    await expect(status).toContainText('no updates for 0:16');
     await page.screenshot({ path: test.info().outputPath('acp-live-status.png') });
     await expect(status).toBeHidden({ timeout: 15_000 });
   });
@@ -399,6 +411,44 @@ test.describe('acp conversation', () => {
     await expect(
       page.getByTestId('acp-conversation').getByText('say:and another thought', { exact: true }),
     ).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('ArrowUp and Edit pull unseen queued feedback back into the composer', async ({
+    page,
+    weaver,
+  }) => {
+    await openAcp(page, weaver, {
+      goal: 'say:ready',
+      name: 'acp-edit-queue-ui',
+      steering: false,
+    });
+    const input = page.getByTestId('acp-composer-input');
+    await input.fill('wait:5000|say:first turn done');
+    await page.getByTestId('acp-composer-send').click();
+    await expect(page.getByTestId('acp-working')).toBeVisible({ timeout: 15_000 });
+
+    await input.fill('say:before edit');
+    await page.getByTestId('acp-composer-send').click();
+    await expect(page.getByTestId('acp-edit-queued')).toBeVisible();
+
+    // Empty-composer ArrowUp follows chat-history convention, but only recalls
+    // the message the agent has not seen yet.
+    await input.focus();
+    await input.press('ArrowUp');
+    await expect(page.getByTestId('acp-pending')).toBeHidden();
+    await expect(input).toHaveValue('say:before edit');
+
+    await input.fill('say:after edit');
+    await page.getByTestId('acp-composer-send').click();
+    const pending = page.getByTestId('acp-pending');
+    await expect(pending).toContainText('say:after edit');
+    await expect(pending).not.toContainText('say:before edit');
+
+    // The visible action provides the same flow without a keyboard shortcut.
+    await page.getByTestId('acp-edit-queued').click();
+    await expect(pending).toBeHidden();
+    await expect(input).toHaveValue('say:after edit');
+    await expect(input).toBeFocused();
   });
 
   test('@file completion resolves server files and sends an ACP resource', async ({ page, weaver }) => {


### PR DESCRIPTION
Queued follow-up messages can now be atomically pulled back into the composer with Edit or ArrowUp. The ACP task serializes retraction against turn boundaries and steering so feedback cannot both dispatch and return for editing.

Live turn status now shows elapsed time plus the age of the last observable agent update. Its activity shimmer stops after quiet time without claiming that silence proves the agent is stuck.

The chat-flow catalogue records the supported interaction model and the safety constraints around history, retry, drafts, and conversation forks.

Session: https://loom.rjp.io/s/kveugrg9