### PR TITLE
fix(loom): recover stalled ACP session creation

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -16,6 +16,7 @@ export class ApiError extends Error {
     public readonly body: Record<string, unknown>,
   ) {
     super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'ApiError';
   }
 }

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -7,6 +7,19 @@ export function setUnauthorizedHandler(fn: () => void): void {
   onUnauthorized = fn;
 }
 
+/** HTTP failure with the server's structured body preserved. Create failures
+ * use `body.session_id` to route the browser to the durable error session. */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
 async function request(path: string, opts: RequestInit = {}): Promise<unknown> {
   const res = await fetch('/api' + path, {
     headers: { 'content-type': 'application/json' },
@@ -17,13 +30,15 @@ async function request(path: string, opts: RequestInit = {}): Promise<unknown> {
   }
   if (!res.ok) {
     let message = res.statusText;
+    let body: Record<string, unknown> = {};
     try {
-      const body = await res.json();
-      if (body && typeof body.error === 'string') message = body.error;
+      const parsed: unknown = await res.json();
+      if (parsed && typeof parsed === 'object') body = parsed as Record<string, unknown>;
+      if (typeof body.error === 'string') message = body.error;
     } catch {
       /* keep statusText */
     }
-    throw new Error(message);
+    throw new ApiError(message, res.status, body);
   }
   if (res.status === 204) return null;
   const text = await res.text();
@@ -36,13 +51,15 @@ async function rawBody(method: string, path: string, body: BodyInit): Promise<un
   const res = await fetch('/api' + path, { method, body });
   if (!res.ok) {
     let message = res.statusText;
+    let failure: Record<string, unknown> = {};
     try {
-      const b = await res.json();
-      if (b && typeof b.error === 'string') message = b.error;
+      const parsed: unknown = await res.json();
+      if (parsed && typeof parsed === 'object') failure = parsed as Record<string, unknown>;
+      if (typeof failure.error === 'string') message = failure.error;
     } catch {
       /* keep statusText */
     }
-    throw new Error(message);
+    throw new ApiError(message, res.status, failure);
   }
   if (res.status === 204) return null;
   const text = await res.text();
@@ -58,6 +75,12 @@ export const put = (path: string, body?: unknown) =>
 export const patch = (path: string, body: unknown) =>
   request(path, { method: 'PATCH', body: JSON.stringify(body) });
 export const del = (path: string) => request(path, { method: 'DELETE' });
+
+/** Upload one prompt/reference attachment into the session-owned scratch dir. */
+export const uploadSessionScratch = (id: string, file: File) =>
+  upload(`/sessions/${id}/scratch?name=${encodeURIComponent(file.name)}`, file) as Promise<
+    ScratchFile & { path: string }
+  >;
 
 // --- Issues ----------------------------------------------------------------
 
@@ -77,6 +100,7 @@ import type {
   Comment,
   NewCommentBody,
   RepoEnvVar,
+  ScratchFile,
 } from './types';
 
 // --- Managed repos ---------------------------------------------------------

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -20,6 +20,19 @@ export class ApiError extends Error {
   }
 }
 
+async function responseError(res: Response): Promise<ApiError> {
+  let message = res.statusText;
+  let body: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = await res.json();
+    if (parsed && typeof parsed === 'object') body = parsed as Record<string, unknown>;
+    if (typeof body.error === 'string') message = body.error;
+  } catch {
+    /* keep statusText */
+  }
+  return new ApiError(message, res.status, body);
+}
+
 async function request(path: string, opts: RequestInit = {}): Promise<unknown> {
   const res = await fetch('/api' + path, {
     headers: { 'content-type': 'application/json' },
@@ -29,16 +42,7 @@ async function request(path: string, opts: RequestInit = {}): Promise<unknown> {
     onUnauthorized?.();
   }
   if (!res.ok) {
-    let message = res.statusText;
-    let body: Record<string, unknown> = {};
-    try {
-      const parsed: unknown = await res.json();
-      if (parsed && typeof parsed === 'object') body = parsed as Record<string, unknown>;
-      if (typeof body.error === 'string') message = body.error;
-    } catch {
-      /* keep statusText */
-    }
-    throw new ApiError(message, res.status, body);
+    throw await responseError(res);
   }
   if (res.status === 204) return null;
   const text = await res.text();
@@ -50,16 +54,7 @@ async function request(path: string, opts: RequestInit = {}): Promise<unknown> {
 async function rawBody(method: string, path: string, body: BodyInit): Promise<unknown> {
   const res = await fetch('/api' + path, { method, body });
   if (!res.ok) {
-    let message = res.statusText;
-    let failure: Record<string, unknown> = {};
-    try {
-      const parsed: unknown = await res.json();
-      if (parsed && typeof parsed === 'object') failure = parsed as Record<string, unknown>;
-      if (typeof failure.error === 'string') message = failure.error;
-    } catch {
-      /* keep statusText */
-    }
-    throw new ApiError(message, res.status, failure);
+    throw await responseError(res);
   }
   if (res.status === 204) return null;
   const text = await res.text();

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -267,12 +267,15 @@ function onQueue(ev: SseQueue) {
 // ── SSE lifecycle (kept-alive discipline) ────────────────────────────────────
 let source: EventSource | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-function rebindAfterHandoff(event: Event) {
-  const handedOffId = (event as CustomEvent<{ id?: string }>).detail?.id;
-  if (handedOffId !== id.value) return;
+function rebindStream() {
   closeStream();
   openStream();
   load({ preserve: true });
+}
+function rebindAfterHandoff(event: Event) {
+  const handedOffId = (event as CustomEvent<{ id?: string }>).detail?.id;
+  if (handedOffId !== id.value) return;
+  rebindStream();
 }
 function openStream() {
   const stream = new EventSource(`/api/sessions/${id.value}/chat/stream`);
@@ -342,9 +345,7 @@ watch(
     // A handoff replaces the task and its broadcast channel without replacing
     // loom's stable session id. Rebind deterministically when the header reloads
     // the new provider; clean SSE EOF is not reported consistently by browsers.
-    closeStream();
-    openStream();
-    load({ preserve: true });
+    rebindStream();
   },
 );
 

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -20,6 +20,7 @@ import {
   setSessionMode,
   setSessionConfigOption,
   listSessionFiles,
+  uploadSessionScratch,
 } from '../api';
 import type {
   Session,
@@ -43,10 +44,12 @@ import type {
   AcpConfigOption,
   AcpConfigChoice,
   HandoffPayload,
+  AcpUsage,
 } from '../types';
 import { canSend } from '../lib/sessionState';
 import { useFollowFoot } from '../lib/followFoot';
 import MarkdownView from './MarkdownView.vue';
+import AgentUsage from './AgentUsage.vue';
 
 // The Conversation surface for an *ACP* session (`protocol='acp'`): typeset
 // dialogue, not chat bubbles. Serif prose for the humans and the agent; the
@@ -263,6 +266,13 @@ function onQueue(ev: SseQueue) {
 // ── SSE lifecycle (kept-alive discipline) ────────────────────────────────────
 let source: EventSource | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+function rebindAfterHandoff(event: Event) {
+  const handedOffId = (event as CustomEvent<{ id?: string }>).detail?.id;
+  if (handedOffId !== id.value) return;
+  closeStream();
+  openStream();
+  load({ preserve: true });
+}
 function openStream() {
   const stream = new EventSource(`/api/sessions/${id.value}/chat/stream`);
   source = stream;
@@ -305,6 +315,7 @@ function closeStream() {
 }
 
 onMounted(() => {
+  window.addEventListener('loom:acp-handoff', rebindAfterHandoff);
   openStream();
   load();
 });
@@ -314,12 +325,27 @@ onActivated(() => {
   load({ preserve: true });
 });
 onDeactivated(closeStream);
-onUnmounted(closeStream);
+onUnmounted(() => {
+  window.removeEventListener('loom:acp-handoff', rebindAfterHandoff);
+  closeStream();
+});
 watch(id, () => {
   closeStream();
   openStream();
   load();
 });
+watch(
+  () => props.session.agent_kind,
+  (runtime, previous) => {
+    if (runtime === previous) return;
+    // A handoff replaces the task and its broadcast channel without replacing
+    // loom's stable session id. Rebind deterministically when the header reloads
+    // the new provider; clean SSE EOF is not reported consistently by browsers.
+    closeStream();
+    openStream();
+    load({ preserve: true });
+  },
+);
 
 // ── Composer ─────────────────────────────────────────────────────────────────
 const draft = ref('');
@@ -329,9 +355,52 @@ const editingQueued = ref(false);
 const sendError = ref('');
 const composerVisible = computed(() => canSend(props.session));
 const selectedFiles = ref<string[]>([]);
+const attachmentInput = ref<HTMLInputElement | null>(null);
+const uploadingAttachment = ref(false);
+
+function resizeComposer() {
+  nextTick(() => {
+    const input = composerInput.value;
+    if (!input) return;
+    input.style.height = 'auto';
+    input.style.height = `${Math.min(input.scrollHeight, 256)}px`;
+  });
+}
+watch(draft, resizeComposer);
+watch(id, () => {
+  draft.value = '';
+  selectedFiles.value = [];
+  sendError.value = '';
+});
+
+function removeSelectedFile(path: string) {
+  selectedFiles.value = selectedFiles.value.filter((selected) => selected !== path);
+}
+
+async function onAttachmentPick(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const files = Array.from(input.files ?? []);
+  input.value = '';
+  if (!files.length || uploadingAttachment.value) return;
+  uploadingAttachment.value = true;
+  sendError.value = '';
+  try {
+    for (const file of files) {
+      const uploaded = await uploadSessionScratch(id.value, file);
+      if (!selectedFiles.value.includes(uploaded.path)) selectedFiles.value.push(uploaded.path);
+    }
+    window.dispatchEvent(new CustomEvent('loom:scratch-changed', { detail: { id: id.value } }));
+    resizeComposer();
+  } catch (e) {
+    sendError.value = (e as Error).message ?? 'Failed to attach file';
+  } finally {
+    uploadingAttachment.value = false;
+  }
+}
 
 async function submitPrompt(forceSteer = false) {
-  if (!draft.value.trim() || sending.value || editingQueued.value) return;
+  if (!draft.value.trim() || sending.value || editingQueued.value || uploadingAttachment.value)
+    return;
   const local = localCommand(draft.value);
   if (local) {
     draft.value = '';
@@ -345,8 +414,7 @@ async function submitPrompt(forceSteer = false) {
   optimistic.value.push(pending);
   autoFollow();
   try {
-    const files = selectedFiles.value.filter((path) => text.includes(`@${path}`));
-    await promptSession(id.value, text, undefined, forceSteer, files);
+    await promptSession(id.value, text, undefined, forceSteer, [...selectedFiles.value]);
     const index = optimistic.value.findIndex((o) => o.key === pending.key);
     if (index >= 0) optimistic.value.splice(index, 1);
     draft.value = '';
@@ -472,7 +540,9 @@ onUnmounted(() => {
 const activeFile = computed(() => fileMatches.value[fileIndex.value] ?? null);
 
 function chooseFile(path: string) {
-  draft.value = draft.value.replace(/@[^\s@]*$/, `@${path} `);
+  // The visible pill owns the attachment. Remove the completion token so a
+  // long path does not pollute the prose the agent receives.
+  draft.value = draft.value.replace(/@[^\s@]*$/, '').replace(/[ \t]+$/, ' ');
   if (!selectedFiles.value.includes(path)) selectedFiles.value.push(path);
   fileMatches.value = [];
   nextTick(() => composerInput.value?.focus());
@@ -697,7 +767,14 @@ interface ActivityItem {
 }
 
 type Row =
-  | { type: 'turnRule'; key: string; turn: number; stop: string; ctx: number | null; loud: boolean }
+  | {
+      type: 'turnRule';
+      key: string;
+      turn: number;
+      stop: string;
+      usage: AcpUsage | null;
+      loud: boolean;
+    }
   | {
       type: 'user';
       key: string;
@@ -737,6 +814,30 @@ function shortTime(ts: string): string {
   return ts.length >= 16 && ts[10] === 'T' ? ts.slice(11, 16) : ts;
 }
 
+function usageFromPayload(payload: UsagePayload): AcpUsage | null {
+  return typeof payload.used === 'number' && typeof payload.size === 'number' && payload.size > 0
+    ? { used: payload.used, size: payload.size, cost: payload.cost }
+    : null;
+}
+
+function shortTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}m`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
+  return String(tokens);
+}
+
+const latestUsage = computed<AcpUsage | null>(() => {
+  let usage: AcpUsage | null = null;
+  const sorted = [...blocks.values()].sort((a, b) => a.turn - b.turn || a.seq - b.seq);
+  for (const block of sorted) {
+    if (block.kind === 'handoff') usage = null;
+    if (block.kind === 'usage') {
+      usage = usageFromPayload(block.payload as unknown as UsagePayload);
+    }
+  }
+  return usage;
+});
+
 // The latest plan block feeds the right rail, not the transcript flow.
 const latestPlan = computed<PlanEntry[]>(() => {
   let entries: PlanEntry[] = [];
@@ -753,14 +854,7 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
 
   const sorted = [...blocks.values()].sort((a, b) => a.turn - b.turn || a.seq - b.seq);
 
-  const usageBlocks = sorted.filter((b) => b.kind === 'usage');
-  const usageAt = (turn: number): number | null => {
-    let used: number | null = null;
-    for (const u of usageBlocks) {
-      if (u.turn <= turn) used = (u.payload as unknown as UsagePayload).used ?? used;
-    }
-    return used;
-  };
+  let currentUsage: AcpUsage | null = null;
 
   let activity: ActivityItem[] = [];
   let activityKey = '';
@@ -848,6 +942,7 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
         break;
       case 'handoff':
         flushActivity();
+        currentUsage = null;
         rows.push({
           type: 'handoff',
           key: k,
@@ -862,12 +957,15 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
           key: k,
           turn: b.turn,
           stop,
-          ctx: usageAt(b.turn),
+          usage: currentUsage ? { ...currentUsage } : null,
           loud: stop === 'refusal',
         });
         break;
       }
-      // plan / usage: not rendered inline.
+      case 'usage':
+        currentUsage = usageFromPayload(b.payload as unknown as UsagePayload);
+        break;
+      // plan: rendered in the rail rather than inline.
     }
   }
   flushActivity();
@@ -1115,8 +1213,9 @@ function goTo(anchor: string) {
             >
               <span
                 >turn {{ row.turn + 1 }} · {{ row.stop
-                }}<template v-if="row.ctx != null">
-                  · {{ Math.round(row.ctx / 1000) }}k ctx</template
+                }}<template v-if="row.usage">
+                  · {{ shortTokens(row.usage.used) }} /
+                  {{ shortTokens(row.usage.size) }} context</template
                 ></span
               >
             </div>
@@ -1401,19 +1500,53 @@ function goTo(anchor: string) {
       data-testid="acp-composer"
       @submit.prevent="submitPrompt(false)"
     >
-      <p v-if="sendError" class="mb-1.5 text-xs text-block" data-testid="acp-composer-error">
+      <p
+        v-if="sendError"
+        class="acp-composer-error text-xs text-block"
+        data-testid="acp-composer-error"
+      >
         {{ sendError }}
       </p>
       <textarea
         ref="composerInput"
         v-model="draft"
-        rows="2"
+        rows="4"
         :disabled="sending || editingQueued"
         :placeholder="commandHint || 'Message the agent…'"
         data-testid="acp-composer-input"
         class="acp-input"
         @keydown="onComposerKeydown"
       ></textarea>
+      <ul v-if="selectedFiles.length" class="acp-attachments" data-testid="acp-attachments">
+        <li
+          v-for="path in selectedFiles"
+          :key="path"
+          class="acp-attachment-pill"
+          data-testid="acp-attachment-pill"
+        >
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.7"
+            aria-hidden="true"
+          >
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <path d="M14 2v6h6" />
+          </svg>
+          <span class="truncate">{{ path }}</span>
+          <button
+            type="button"
+            :aria-label="`Remove ${path}`"
+            :title="`Remove ${path}`"
+            @click="removeSelectedFile(path)"
+          >
+            ×
+          </button>
+        </li>
+      </ul>
       <ul
         v-if="fileMatches.length"
         class="acp-command-menu"
@@ -1459,6 +1592,39 @@ function goTo(anchor: string) {
       <div class="acp-composer-actions">
         <!-- Agent-owned config selectors + slash discovery on the left. -->
         <div class="acp-composer-left">
+          <button
+            type="button"
+            class="acp-attach-button"
+            data-testid="acp-composer-attach"
+            :disabled="uploadingAttachment"
+            :title="uploadingAttachment ? 'Attaching…' : 'Attach files'"
+            @click="attachmentInput?.click()"
+          >
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.7"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="m21.4 11-9.2 9.2a6 6 0 0 1-8.5-8.5l8.6-8.6A4 4 0 1 1 18 8.8l-8.6 8.6a2 2 0 1 1-2.8-2.8l8.5-8.5"
+              />
+            </svg>
+            <span>{{ uploadingAttachment ? 'Attaching…' : 'Attach' }}</span>
+          </button>
+          <input
+            ref="attachmentInput"
+            type="file"
+            multiple
+            class="hidden"
+            data-testid="acp-composer-file-input"
+            @change="onAttachmentPick"
+          />
           <div
             v-for="option in configOptions"
             :key="option.id"
@@ -1536,12 +1702,14 @@ function goTo(anchor: string) {
           </button>
         </div>
         <div class="acp-composer-right">
+          <AgentUsage v-if="latestUsage" :usage="latestUsage" />
+          <span class="acp-send-hint">Enter to send · Shift+Enter for a new line</span>
           <button
             v-if="turnLive && steeringSupported"
             type="button"
             class="btn-secondary px-3 py-1 text-xs"
             data-testid="acp-composer-force-steer"
-            :disabled="sending || editingQueued || !draft.trim()"
+            :disabled="sending || editingQueued || uploadingAttachment || !draft.trim()"
             title="Inject this feedback into the running turn"
             @click="submitPrompt(true)"
           >
@@ -1561,7 +1729,7 @@ function goTo(anchor: string) {
             type="submit"
             class="btn-primary px-3 py-1 text-sm"
             data-testid="acp-composer-send"
-            :disabled="sending || editingQueued || !draft.trim()"
+            :disabled="sending || editingQueued || uploadingAttachment || !draft.trim()"
           >
             {{ sending ? 'Sending…' : 'Send' }}
           </button>
@@ -1926,38 +2094,115 @@ function goTo(anchor: string) {
 
 /* Composer. */
 .acp-composer {
-  margin-top: 0.5rem;
-  border-top: 1px solid var(--line);
-  padding-top: 0.625rem;
+  position: relative;
+  margin-top: 0.75rem;
+  overflow: visible;
+  border: 1px solid var(--line);
+  border-radius: 0.625rem;
+  background: var(--input);
+  box-shadow: 0 7px 24px rgb(0 0 0 / 0.08);
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+.acp-composer:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 70%, var(--line));
+  box-shadow:
+    0 7px 24px rgb(0 0 0 / 0.08),
+    0 0 0 2px color-mix(in srgb, var(--accent) 13%, transparent);
+}
+.acp-composer-error {
+  margin: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--block) 28%, var(--line));
+  padding: 0.5rem 0.75rem;
 }
 .acp-input {
+  display: block;
   width: 100%;
-  resize: vertical;
-  max-height: 12rem;
-  border-radius: 0.25rem;
-  background: var(--input);
-  padding: 0.55rem 0.7rem;
+  min-height: 7.25rem;
+  max-height: 16rem;
+  resize: none;
+  border: 0;
+  border-radius: 0.625rem 0.625rem 0 0;
+  background: transparent;
+  padding: 0.8rem 0.9rem;
   font-family: var(--font-serif);
-  font-size: 0.9375rem;
-  line-height: 1.5;
+  font-size: 1rem;
+  line-height: 1.55;
   outline: none;
 }
 .acp-input:focus {
-  box-shadow: 0 0 0 1px var(--accent);
+  box-shadow: none;
+}
+.acp-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  padding: 0 0.75rem 0.65rem;
+}
+.acp-attachment-pill {
+  display: inline-flex;
+  min-width: 0;
+  max-width: min(22rem, 100%);
+  align-items: center;
+  gap: 0.375rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--line));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+  padding: 0.24rem 0.35rem 0.24rem 0.55rem;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+}
+.acp-attachment-pill svg {
+  flex: none;
+  color: var(--accent);
+}
+.acp-attachment-pill button {
+  display: grid;
+  width: 1rem;
+  height: 1rem;
+  flex: none;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--faint);
+}
+.acp-attachment-pill button:hover {
+  background: var(--subtle-hover);
+  color: var(--block);
 }
 .acp-composer-actions {
-  margin-top: 0.55rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.625rem;
+  border-top: 1px solid var(--line);
+  padding: 0.55rem 0.65rem;
 }
 .acp-composer-left {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.45rem;
   min-width: 0;
+}
+.acp-attach-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border-radius: 0.25rem;
+  padding: 0.2rem 0.35rem;
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+}
+.acp-attach-button:hover:not(:disabled) {
+  background: var(--subtle);
+  color: var(--fg);
+}
+.acp-attach-button:disabled {
+  cursor: wait;
+  opacity: 0.6;
 }
 
 /* Slash-command autocomplete, populated by ACP `available_commands_update`. */
@@ -2000,9 +2245,34 @@ function goTo(anchor: string) {
 }
 .acp-composer-right {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 0.5rem;
-  flex: none;
+  min-width: 0;
+}
+.acp-send-hint {
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .acp-composer-actions {
+    align-items: flex-end;
+    flex-direction: column;
+  }
+  .acp-composer-left,
+  .acp-composer-right {
+    width: 100%;
+  }
+  .acp-composer-right {
+    justify-content: flex-end;
+  }
+  .acp-send-hint {
+    display: none;
+  }
 }
 
 /* Mode chip + dropdown. */

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -821,18 +821,6 @@ function usageFromPayload(payload: UsagePayload): AcpUsage | null {
     : null;
 }
 
-const latestUsage = computed<AcpUsage | null>(() => {
-  let usage: AcpUsage | null = null;
-  const sorted = [...blocks.values()].sort((a, b) => a.turn - b.turn || a.seq - b.seq);
-  for (const block of sorted) {
-    if (block.kind === 'handoff') usage = null;
-    if (block.kind === 'usage') {
-      usage = usageFromPayload(block.payload as unknown as UsagePayload);
-    }
-  }
-  return usage;
-});
-
 // The latest plan block feeds the right rail, not the transcript flow.
 const latestPlan = computed<PlanEntry[]>(() => {
   let entries: PlanEntry[] = [];
@@ -842,7 +830,7 @@ const latestPlan = computed<PlanEntry[]>(() => {
   return entries;
 });
 
-const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
+const model = computed<{ rows: Row[]; toc: TocItem[]; usage: AcpUsage | null }>(() => {
   const rows: Row[] = [];
   const toc: TocItem[] = [];
   let n = 0;
@@ -997,7 +985,7 @@ const model = computed<{ rows: Row[]; toc: TocItem[] }>(() => {
     }
   }
 
-  return { rows, toc };
+  return { rows, toc, usage: currentUsage };
 });
 
 // The empty conversation, styled on purpose — a fresh session has no journal
@@ -1697,7 +1685,7 @@ function goTo(anchor: string) {
           </button>
         </div>
         <div class="acp-composer-right">
-          <AgentUsage v-if="latestUsage" :usage="latestUsage" />
+          <AgentUsage v-if="model.usage" :usage="model.usage" />
           <span class="acp-send-hint">Enter to send · Shift+Enter for a new line</span>
           <button
             v-if="turnLive && steeringSupported"

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -48,6 +48,7 @@ import type {
 } from '../types';
 import { canSend } from '../lib/sessionState';
 import { useFollowFoot } from '../lib/followFoot';
+import { formatTokens } from '../lib/usage';
 import MarkdownView from './MarkdownView.vue';
 import AgentUsage from './AgentUsage.vue';
 
@@ -820,12 +821,6 @@ function usageFromPayload(payload: UsagePayload): AcpUsage | null {
     : null;
 }
 
-function shortTokens(tokens: number): string {
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}m`;
-  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
-  return String(tokens);
-}
-
 const latestUsage = computed<AcpUsage | null>(() => {
   let usage: AcpUsage | null = null;
   const sorted = [...blocks.values()].sort((a, b) => a.turn - b.turn || a.seq - b.seq);
@@ -1214,8 +1209,8 @@ function goTo(anchor: string) {
               <span
                 >turn {{ row.turn + 1 }} · {{ row.stop
                 }}<template v-if="row.usage">
-                  · {{ shortTokens(row.usage.used) }} /
-                  {{ shortTokens(row.usage.size) }} context</template
+                  · {{ formatTokens(row.usage.used) }} /
+                  {{ formatTokens(row.usage.size) }} context</template
                 ></span
               >
             </div>

--- a/crates/loom/frontend/src/components/AgentUsage.vue
+++ b/crates/loom/frontend/src/components/AgentUsage.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { AcpUsage } from '../types';
+
+const props = withDefaults(defineProps<{ usage: AcpUsage; compact?: boolean }>(), {
+  compact: false,
+});
+
+const percent = computed(() =>
+  props.usage.size > 0 ? Math.max(0, (props.usage.used / props.usage.size) * 100) : 0,
+);
+const barPercent = computed(() => Math.min(100, percent.value));
+const tone = computed(() => {
+  if (percent.value > 95) return 'critical';
+  if (percent.value >= 75) return 'warning';
+  return 'normal';
+});
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(tokens >= 10_000_000 ? 0 : 1)}m`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
+  return String(tokens);
+}
+
+const costLabel = computed(() => {
+  const cost = props.usage.cost;
+  if (!cost || !Number.isFinite(cost.amount)) return '';
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: cost.currency,
+      maximumFractionDigits: 4,
+    }).format(cost.amount);
+  } catch {
+    return `${cost.amount.toFixed(4)} ${cost.currency}`;
+  }
+});
+const label = computed(
+  () =>
+    `${formatTokens(props.usage.used)} / ${formatTokens(props.usage.size)} context · ${Math.round(percent.value)}%`,
+);
+const title = computed(() => {
+  const remaining = Math.max(0, props.usage.size - props.usage.used);
+  const pieces = [`${formatTokens(remaining)} tokens remain in the current context window`];
+  if (costLabel.value) pieces.push(`${costLabel.value} reported cost`);
+  return pieces.join(' · ');
+});
+</script>
+
+<template>
+  <div
+    class="agent-usage"
+    :class="[`agent-usage--${tone}`, { 'agent-usage--compact': compact }]"
+    data-testid="agent-usage"
+    :title="title"
+  >
+    <span class="agent-usage-label">{{ label }}</span>
+    <span v-if="!compact" class="agent-usage-track" aria-hidden="true">
+      <span class="agent-usage-bar" :style="{ width: `${barPercent}%` }"></span>
+    </span>
+    <span v-if="!compact && costLabel" class="agent-usage-cost">{{ costLabel }}</span>
+  </div>
+</template>
+
+<style scoped>
+.agent-usage {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+}
+.agent-usage--compact {
+  color: var(--faint);
+  white-space: nowrap;
+}
+.agent-usage--warning {
+  color: var(--attn);
+}
+.agent-usage--critical {
+  color: var(--block);
+}
+.agent-usage-label {
+  white-space: nowrap;
+}
+.agent-usage-track {
+  width: clamp(4rem, 12vw, 8rem);
+  height: 0.25rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--line);
+}
+.agent-usage-bar {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+}
+.agent-usage--warning .agent-usage-bar {
+  background: var(--attn);
+}
+.agent-usage--critical .agent-usage-bar {
+  background: var(--block);
+}
+.agent-usage-cost {
+  color: var(--faint);
+  white-space: nowrap;
+}
+</style>

--- a/crates/loom/frontend/src/components/AgentUsage.vue
+++ b/crates/loom/frontend/src/components/AgentUsage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { AcpUsage } from '../types';
+import { formatTokens } from '../lib/usage';
 
 const props = withDefaults(defineProps<{ usage: AcpUsage; compact?: boolean }>(), {
   compact: false,
@@ -15,12 +16,6 @@ const tone = computed(() => {
   if (percent.value >= 75) return 'warning';
   return 'normal';
 });
-
-function formatTokens(tokens: number): string {
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(tokens >= 10_000_000 ? 0 : 1)}m`;
-  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
-  return String(tokens);
-}
 
 const costLabel = computed(() => {
   const cost = props.usage.cost;

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { get, listAgents, listRepos, post, registerRepo } from '../api';
+import { useRouter } from 'vue-router';
+import { ApiError, get, listAgents, listRepos, post, registerRepo } from '../api';
 import type { AgentMetadata, ManagedRepo, RecentRepo, RepoBranch } from '../types';
 import AgentRuntimePicker from './AgentRuntimePicker.vue';
 import ScratchPicker from './ScratchPicker.vue';
@@ -9,6 +10,7 @@ const emit = defineEmits<{
   close: [];
   created: [];
 }>();
+const router = useRouter();
 
 const recentRepos = ref<RecentRepo[]>([]);
 const managedRepos = ref<ManagedRepo[]>([]);
@@ -237,6 +239,17 @@ async function create() {
     emit('created');
     emit('close');
   } catch (e) {
+    const failedSession = e instanceof ApiError ? e.body.session_id : undefined;
+    if (typeof failedSession === 'string' && failedSession) {
+      // Provisioning succeeded far enough to leave a recoverable session, but
+      // its agent setup failed. Refresh the fleet and take the user straight to
+      // the visible error/handoff controls instead of marooning the drawer.
+      emit('created');
+      resetForm();
+      emit('close');
+      await router.push(`/s/${failedSession}`);
+      return;
+    }
     error.value = (e as Error).message;
   } finally {
     creating.value = false;

--- a/crates/loom/frontend/src/components/ScratchPanel.vue
+++ b/crates/loom/frontend/src/components/ScratchPanel.vue
@@ -84,6 +84,11 @@ function onDrop(e: DragEvent) {
   if (dropped && dropped.length) uploadFiles(dropped);
 }
 
+function onScratchChanged(event: Event) {
+  const changedId = (event as CustomEvent<{ id?: string }>).detail?.id;
+  if (changedId === props.id) refresh();
+}
+
 const fileInput = ref<HTMLInputElement | null>(null);
 function onPick(e: Event) {
   const input = e.target as HTMLInputElement;
@@ -106,12 +111,14 @@ onMounted(() => {
   window.addEventListener('dragleave', onDragLeave);
   window.addEventListener('dragover', onDragOver);
   window.addEventListener('drop', onDrop);
+  window.addEventListener('loom:scratch-changed', onScratchChanged);
 });
 onUnmounted(() => {
   window.removeEventListener('dragenter', onDragEnter);
   window.removeEventListener('dragleave', onDragLeave);
   window.removeEventListener('dragover', onDragOver);
   window.removeEventListener('drop', onDrop);
+  window.removeEventListener('loom:scratch-changed', onScratchChanged);
 });
 </script>
 

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -126,7 +126,9 @@ const handoffModel = ref('');
 const handoffEffort = ref('');
 const handoffBusy = ref(false);
 const handoffError = ref('');
-const canHandoff = computed(() => props.ws.protocol === 'acp' && props.ws.status === 'running');
+const canHandoff = computed(
+  () => props.ws.protocol === 'acp' && ['running', 'orphaned', 'error'].includes(props.ws.status),
+);
 const unchangedHandoff = computed(
   () =>
     handoffAgent.value === props.ws.agent_kind &&
@@ -177,6 +179,7 @@ async function submitHandoff() {
     handoffOpen.value = false;
     showDetails.value = false;
     notice.value = `Handed off to ${handoffAgent.value}.`;
+    window.dispatchEvent(new CustomEvent('loom:acp-handoff', { detail: { id: props.ws.id } }));
     await emit('reload');
   } catch (e) {
     handoffError.value = (e as Error).message;

--- a/crates/loom/frontend/src/lib/usage.ts
+++ b/crates/loom/frontend/src/lib/usage.ts
@@ -1,0 +1,6 @@
+/** Compact token count shared by fleet, composer, and transcript usage labels. */
+export function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(tokens >= 10_000_000 ? 0 : 1)}m`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
+  return String(tokens);
+}

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -116,7 +116,7 @@ export interface Session {
    *  `acceptEdits`, `default`, `plan`), or null for a terminal session / before
    *  one is set. */
   current_mode: string | null;
-  /** The latest context-window usage an ACP agent reported, or null. */
+  /** The latest context-window usage the current ACP provider reported, or null. */
   usage: AcpUsage | null;
   /** The ACP modes the adapter offers, when the server exposes them. Absent today
    *  (SessionView carries only `current_mode`), so the mode chip falls back to the
@@ -130,10 +130,16 @@ export interface Session {
 // These hand-mirror loom's `chat.rs` / `acp/mod.rs` serde shapes: the block
 // contract (`GET /sessions/{id}/chat`) and the `/chat/stream` SSE events.
 
-/** Context-window usage `{used, size}` (tokens). */
+export interface AcpCost {
+  amount: number;
+  currency: string;
+}
+
+/** Context-window usage (tokens), plus optional cumulative session cost. */
 export interface AcpUsage {
-  used?: number | null;
-  size?: number | null;
+  used: number;
+  size: number;
+  cost?: AcpCost | null;
 }
 
 /** The closed set of chat-journal block kinds. */
@@ -273,6 +279,8 @@ export interface PermissionPayload {
 export interface UsagePayload {
   used: number | null;
   size: number | null;
+  cost?: AcpCost | null;
+  reset?: boolean;
 }
 export interface TurnEndPayload {
   stop_reason: string;

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -10,6 +10,7 @@ import GithubStatus from '../components/GithubStatus.vue';
 import NewSessionDrawer from '../components/NewSessionDrawer.vue';
 import SessionRowActions from '../components/SessionRowActions.vue';
 import SessionRemedyButton from '../components/SessionRemedyButton.vue';
+import AgentUsage from '../components/AgentUsage.vue';
 import { timeAgo } from '../lib/time';
 import {
   effectiveAttention,
@@ -597,6 +598,7 @@ async function handleCreated() {
             <!-- Soothing idle mark: a calm, neutral chip when the agent is
                  resting (no loud signal). Reassures rather than alarms. -->
             <IdleChip v-if="idleTag(s)" :tag="idleTag(s)!" />
+            <AgentUsage v-if="s.usage" :usage="s.usage" compact />
             <!-- Quiet free-form tags: deletable pills, never the loud fill. -->
             <TagPill
               v-for="t in quietTags(s)"

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -27,7 +27,8 @@
 //! - `permission_request` `{ request_id, tool_call_id, title, options, outcome }`
 //!   — inserted open, `UPDATE`d in place on resolution.
 //! - `mode_change`    `{ mode_id, by }`.
-//! - `usage`          `{ used, size }`.
+//! - `usage`          `{ used, size, cost? }` (or an internal null marker at a
+//!   provider boundary).
 //! - `turn_end`       `{ stop_reason }`.
 //! - `handoff`        `{ from, to, model, effort }` — the provider boundary
 //!   that replaces the synthetic bootstrap prompt in the visible journal.
@@ -47,6 +48,7 @@ mod wire;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::{anyhow, bail, Result};
 use serde::Serialize;
@@ -58,6 +60,7 @@ use crate::chat::{self, kind, ChatBlockView};
 use crate::db::{now_iso, Db};
 use crate::session;
 use crate::web::AppState;
+use weaver_api::{AcpCost, AcpUsage};
 use wire::{
     method, Incoming, IncomingKind, PermissionOption, RequestPermissionParams, SessionNotification,
     SessionUpdate, ToolCall, ToolCallContent, ToolCallLocation,
@@ -97,6 +100,9 @@ pub struct AcpLaunch {
     /// The session's goal, sent as the first `session/prompt` (journaled as the
     /// first `user_message`). `None` waits for the first REST prompt.
     pub goal: Option<String>,
+    /// Maximum time to wait for one ACP setup response. Kept on the launch so
+    /// integration tests can exercise a silent adapter without a 30-second wait.
+    pub setup_timeout: Duration,
 }
 
 /// How a prompt was accepted plus the turn it belongs to — the `POST /prompt`
@@ -391,11 +397,46 @@ async fn start_inner(
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
     crate::backend::new_relay_session(&relay_name, &launch.adapter_cmd, &env, &launch.cwd).await?;
-    let stream = crate::backend::subscribe_relay(&relay_name, 0).await?;
-
     let (events_tx, _) = broadcast::channel(256);
-    let mut task = Task::fresh(state, &session, relay_name, stream, events_tx.clone()).await?;
-    task.handshake(&launch, handoff).await?;
+    // From this point onward the detached relay exists. Any failure must tear it
+    // down and clear partially-persisted provider state before returning, or the
+    // caller gets a stuck row plus a relay name handoff cannot safely reuse.
+    let prepared: Result<Task> = async {
+        let stream = crate::backend::subscribe_relay(&relay_name, 0).await?;
+        let mut task = Task::fresh(
+            state,
+            &session,
+            relay_name.clone(),
+            stream,
+            events_tx.clone(),
+        )
+        .await?;
+        task.handshake(&launch, handoff).await?;
+        Ok(task)
+    }
+    .await;
+    let mut task = match prepared {
+        Ok(task) => task,
+        Err(error) => {
+            state.acp.stop(session_id);
+            let latest = session::get(&state.db, session_id).await.ok().flatten();
+            if let Some(turn) = latest
+                .as_ref()
+                .and_then(|session| session.acp_inflight.as_deref())
+                .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+                .and_then(|value| value.get("turn").and_then(Value::as_i64))
+            {
+                let _ = chat::close_abandoned_turn(&state.db, session_id, turn).await;
+            }
+            let _ = session::clear_acp_state(&state.db, session_id).await;
+            if let Err(cleanup) = crate::backend::kill_session_and_wait(&relay_name).await {
+                return Err(anyhow!(
+                    "{error}; failed to clean up ACP relay after setup error: {cleanup}"
+                ));
+            }
+            return Err(error);
+        }
+    };
 
     let (cmd_tx, cmd_rx) = mpsc::channel(64);
     task.generation = state.acp.register(
@@ -905,7 +946,9 @@ impl Task {
                 wire::initialize_params(),
             ))
             .await?;
-        let (res, err) = self.recv_until_response(id).await?;
+        let (res, err) = self
+            .recv_until_response(id, method::INITIALIZE, launch.setup_timeout)
+            .await?;
         let res = res.ok_or_else(|| anyhow!("initialize failed: {err:?}"))?;
         if let Ok(init) = serde_json::from_value::<wire::InitializeResult>(res) {
             self.load_session_cap = init.agent_capabilities.load_session;
@@ -920,7 +963,9 @@ impl Task {
                 self.stream
                     .write(&wire::request_line(id, method::SESSION_NEW, params))
                     .await?;
-                let (res, err) = self.recv_until_response(id).await?;
+                let (res, err) = self
+                    .recv_until_response(id, method::SESSION_NEW, launch.setup_timeout)
+                    .await?;
                 let res = res.ok_or_else(|| anyhow!("session/new failed: {err:?}"))?;
                 let ns: wire::NewSessionResult = serde_json::from_value(res)?;
                 self.acp_session_id = ns.session_id.clone();
@@ -954,7 +999,10 @@ impl Task {
                     .write(&wire::request_line(id, method::SESSION_LOAD, params))
                     .await?;
                 // History replays as `session/update` notifications during the call.
-                let (res, err) = self.recv_until_response(id).await?;
+                let load_timeout = launch.setup_timeout.saturating_mul(4);
+                let (res, err) = self
+                    .recv_until_response(id, method::SESSION_LOAD, load_timeout)
+                    .await?;
                 self.suppress_journal = false;
                 // Drop any consolidation the suppressed replay left half-open so it
                 // can't flush stale history into a later turn.
@@ -986,7 +1034,9 @@ impl Task {
                     wire::set_mode_params(&self.acp_session_id, mode),
                 ))
                 .await?;
-            let (result, error) = self.recv_until_response(id).await?;
+            let (result, error) = self
+                .recv_until_response(id, method::SESSION_SET_MODE, launch.setup_timeout)
+                .await?;
             if result.is_none() {
                 bail!("session/set_mode failed: {error:?}");
             }
@@ -1007,9 +1057,24 @@ impl Task {
 
     /// Drive frames until the response to `want` arrives, processing interleaved
     /// notifications/requests normally. Used only during the synchronous handshake.
-    async fn recv_until_response(&mut self, want: u64) -> Result<(Option<Value>, Option<Value>)> {
+    async fn recv_until_response(
+        &mut self,
+        want: u64,
+        method_name: &str,
+        timeout: Duration,
+    ) -> Result<(Option<Value>, Option<Value>)> {
+        let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            match self.stream.recv().await {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                bail!("timed out waiting for ACP {method_name} response after {timeout:?}");
+            }
+            let event = tokio::time::timeout(remaining, self.stream.recv())
+                .await
+                .map_err(|_| {
+                    anyhow!("timed out waiting for ACP {method_name} response after {timeout:?}")
+                })?;
+            match event {
                 Some(RelayEvent::Frame { seq, payload }) => {
                     self.highest_seq = seq;
                     let inc: Incoming = match serde_json::from_slice(&payload) {
@@ -1157,11 +1222,26 @@ impl Task {
                     .await;
                 }
             }
-            SessionUpdate::UsageUpdate { used, size } => {
+            SessionUpdate::UsageUpdate { used, size, cost } => {
                 // Usage is metadata, not a prose boundary. Flushing here split
                 // replies into tiny blocks when an adapter reported it often.
-                self.journal_block(kind::USAGE, json!({ "used": used, "size": size }))
+                // ACP requires both context fields; silently ignore a malformed
+                // legacy update instead of publishing a misleading 0/0 meter.
+                if let (Some(used), Some(size)) = (used, size) {
+                    let usage = AcpUsage {
+                        used,
+                        size,
+                        cost: cost.map(|cost| AcpCost {
+                            amount: cost.amount,
+                            currency: cost.currency,
+                        }),
+                    };
+                    self.journal_block(
+                        kind::USAGE,
+                        serde_json::to_value(usage).unwrap_or(Value::Null),
+                    )
                     .await;
+                }
             }
             SessionUpdate::SessionInfoUpdate { meta } => {
                 let status = meta

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -420,12 +420,7 @@ async fn start_inner(
         Err(error) => {
             state.acp.stop(session_id);
             let latest = session::get(&state.db, session_id).await.ok().flatten();
-            if let Some(turn) = latest
-                .as_ref()
-                .and_then(|session| session.acp_inflight.as_deref())
-                .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
-                .and_then(|value| value.get("turn").and_then(Value::as_i64))
-            {
+            if let Some(turn) = latest.as_ref().and_then(session::acp_inflight_turn) {
                 let _ = chat::close_abandoned_turn(&state.db, session_id, turn).await;
             }
             let _ = session::clear_acp_state(&state.db, session_id).await;

--- a/crates/loom/src/acp/wire.rs
+++ b/crates/loom/src/acp/wire.rs
@@ -149,12 +149,16 @@ pub enum SessionUpdate {
         #[serde(rename = "currentModeId")]
         current_mode_id: String,
     },
-    /// Context-window / cost usage.
+    /// Context-window / cumulative cost usage. `used` and `size` are required by
+    /// ACP, but remain optional here so one malformed adapter notification does
+    /// not make the whole stream undecodable; loom drops incomplete updates.
     UsageUpdate {
         #[serde(default)]
         used: Option<u64>,
         #[serde(default)]
         size: Option<u64>,
+        #[serde(default)]
+        cost: Option<UsageCost>,
     },
     /// codex-acp's thread lifecycle. Loom normally owns turn boundaries through
     /// the `session/prompt` response; this closes the rare turn that the
@@ -178,6 +182,12 @@ pub enum SessionUpdate {
     /// Anything else (prompt_suggestion, …): ignored.
     #[serde(other)]
     Other,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UsageCost {
+    pub amount: f64,
+    pub currency: String,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -613,12 +623,16 @@ mod tests {
 
         let usage: SessionUpdate = serde_json::from_value(json!({
             "sessionUpdate": "usage_update", "used": 41000, "size": 200000,
+            "cost": { "amount": 1.25, "currency": "USD" },
         }))
         .unwrap();
         match usage {
-            SessionUpdate::UsageUpdate { used, size } => {
+            SessionUpdate::UsageUpdate { used, size, cost } => {
                 assert_eq!(used, Some(41000));
                 assert_eq!(size, Some(200000));
+                let cost = cost.unwrap();
+                assert_eq!(cost.amount, 1.25);
+                assert_eq!(cost.currency, "USD");
             }
             other => panic!("wrong variant: {other:?}"),
         }

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -969,6 +969,7 @@ pub async fn build_acp_launch(
         // does not advertise.
         mode: (!is_codex).then(|| spec.mode.to_string()),
         goal,
+        setup_timeout: std::time::Duration::from_secs(30),
     })
 }
 

--- a/crates/loom/src/chat.rs
+++ b/crates/loom/src/chat.rs
@@ -406,11 +406,13 @@ fn preview_line(b: &ChatBlockView) -> String {
             format!("[permission] {title} ({outcome})")
         }
         kind::MODE_CHANGE => format!("[mode] {}", text("mode_id")),
-        kind::USAGE => {
-            let used = p.get("used").and_then(Value::as_i64).unwrap_or(0);
-            let size = p.get("size").and_then(Value::as_i64).unwrap_or(0);
-            format!("[usage] {used}/{size}")
-        }
+        kind::USAGE => match (
+            p.get("used").and_then(Value::as_u64),
+            p.get("size").and_then(Value::as_u64),
+        ) {
+            (Some(used), Some(size)) => format!("[usage] {used}/{size}"),
+            _ => String::new(),
+        },
         kind::TURN_END => {
             let reason = p.get("stop_reason").and_then(Value::as_str).unwrap_or("");
             format!("— turn {} · {reason} —", b.turn)
@@ -599,6 +601,24 @@ mod tests {
         let tail = preview_text(&blocks, 1);
         assert!(tail.contains("end_turn"));
         assert!(!tail.contains("[you]"), "only the last block: {tail}");
+    }
+
+    #[test]
+    fn preview_text_skips_usage_resets_and_malformed_usage() {
+        let usage = |payload: Value| ChatBlockView {
+            turn: 0,
+            seq: 0,
+            kind: kind::USAGE.to_string(),
+            payload,
+            created_at: String::new(),
+        };
+        let blocks = vec![
+            usage(json!({"used":10,"size":100})),
+            usage(json!({"used":null,"size":null,"reset":true})),
+            usage(json!({"used":"unknown","size":100})),
+        ];
+
+        assert_eq!(preview_text(&blocks, blocks.len()), "[usage] 10/100\n");
     }
 
     #[tokio::test]

--- a/crates/loom/src/chat.rs
+++ b/crates/loom/src/chat.rs
@@ -15,7 +15,7 @@
 
 use anyhow::Result;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use sqlx::Row;
 
 use crate::db::{now_iso, Db};
@@ -312,6 +312,53 @@ pub async fn has_turn_end(db: &Db, session_id: &str, turn: i64) -> Result<bool> 
     Ok(n > 0)
 }
 
+/// Close a turn abandoned by a vanished ACP task. The opening user block is
+/// already durable before `acp_inflight` is written; this supplies the missing
+/// terminal boundary before a replacement provider starts.
+pub async fn close_abandoned_turn(db: &Db, session_id: &str, turn: i64) -> Result<()> {
+    if has_turn_end(db, session_id, turn).await? {
+        return Ok(());
+    }
+    let seq: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(seq), -1) + 1 FROM chat_blocks
+         WHERE session_id = ? AND turn = ?",
+    )
+    .bind(session_id)
+    .bind(turn)
+    .fetch_one(db)
+    .await?;
+    insert(
+        db,
+        session_id,
+        turn,
+        seq,
+        kind::TURN_END,
+        &json!({ "stop_reason": "error" }),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Append an internal context-usage reset at the journal tail. Handoff keeps
+/// historical usage blocks, but current usage must read as unknown until the
+/// replacement provider reports its own context window.
+pub async fn reset_usage(db: &Db, session_id: &str) -> Result<()> {
+    let (turn, seq) = match max_turn_seq(db, session_id).await? {
+        Some((turn, seq)) => (turn, seq + 1),
+        None => (0, 0),
+    };
+    insert(
+        db,
+        session_id,
+        turn,
+        seq,
+        kind::USAGE,
+        &json!({ "used": null, "size": null, "reset": true }),
+    )
+    .await?;
+    Ok(())
+}
+
 /// Render the last `last_n` journal blocks as compact plain text — the ACP
 /// analogue of the terminal `preview` screen (`[who] text` lines for prose, a
 /// one-liner for the machine's apparatus). CLI convenience only.
@@ -377,9 +424,11 @@ fn preview_line(b: &ChatBlockView) -> String {
     }
 }
 
-/// The latest `usage` block's payload for a session (`{used, size}`), or `None`.
+/// The latest `usage` block's payload for a session, or `None`. A provider
+/// handoff appends a null marker, which intentionally parses as `None` until the
+/// replacement reports its own context.
 /// A cheap query feeding [`SessionView::usage`](weaver_api::SessionView).
-pub async fn latest_usage(db: &Db, session_id: &str) -> Result<Option<Value>> {
+pub async fn latest_usage(db: &Db, session_id: &str) -> Result<Option<weaver_api::AcpUsage>> {
     let row = sqlx::query(
         "SELECT payload FROM chat_blocks WHERE session_id = ? AND kind = ?
          ORDER BY turn DESC, seq DESC LIMIT 1",
@@ -562,7 +611,37 @@ mod tests {
         insert(&db, &s, 1, 4, kind::USAGE, &json!({"used":150,"size":200}))
             .await
             .unwrap();
-        assert_eq!(latest_usage(&db, &s).await.unwrap().unwrap()["used"], 150);
+        assert_eq!(latest_usage(&db, &s).await.unwrap().unwrap().used, 150);
+        reset_usage(&db, &s).await.unwrap();
+        assert_eq!(latest_usage(&db, &s).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn close_abandoned_turn_is_idempotent() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let s = seed_session(&db).await;
+        insert(
+            &db,
+            &s,
+            2,
+            0,
+            kind::USER_MESSAGE,
+            &json!({"text":"unfinished"}),
+        )
+        .await
+        .unwrap();
+        close_abandoned_turn(&db, &s, 2).await.unwrap();
+        close_abandoned_turn(&db, &s, 2).await.unwrap();
+        assert!(has_turn_end(&db, &s, 2).await.unwrap());
+        assert_eq!(
+            list(&db, &s)
+                .await
+                .unwrap()
+                .iter()
+                .filter(|block| block.kind == kind::TURN_END)
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -366,9 +366,26 @@ pub async fn set_current_mode(db: &Db, id: &str, mode_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Clear state owned by one ACP adapter process after setup fails. The stable
+/// loom session, journal, runtime profile, and durable human prompt queue stay
+/// intact so the failed session can be inspected or handed off.
+pub async fn clear_acp_state(db: &Db, id: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE sessions
+         SET acp_session_id = NULL, acp_ack_seq = 0, acp_inflight = NULL,
+             current_mode = NULL
+         WHERE id = ?",
+    )
+    .bind(id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
 /// Replace an ACP session's runtime profile and clear every piece of
-/// provider-private relay/session state. The journal is deliberately untouched:
-/// it is keyed by loom's stable session id and continues across the handoff.
+/// provider-private relay/session state. The journal and durable prompt queue
+/// are deliberately untouched: both belong to loom's stable session and must
+/// continue across a disconnected handoff.
 pub async fn prepare_handoff(
     db: &Db,
     id: &str,
@@ -381,7 +398,7 @@ pub async fn prepare_handoff(
         "UPDATE sessions
          SET agent_kind = ?, model = ?, effort = ?, status = ?,
              acp_session_id = NULL, acp_ack_seq = 0, acp_inflight = NULL,
-             current_mode = NULL, pending_prompt = ''
+             current_mode = NULL
          WHERE id = ?",
     )
     .bind(agent_kind)
@@ -617,10 +634,7 @@ mod tests {
         assert_eq!(session.acp_ack_seq, 0);
         assert!(session.acp_inflight.is_none());
         assert!(session.current_mode.is_none());
-        assert!(
-            session.pending_prompt.as_deref().unwrap_or("").is_empty(),
-            "handoff clears the queue to empty, never NULL"
-        );
+        assert_eq!(session.pending_prompt.as_deref(), Some("queued"));
     }
 
     /// Regression: the queue clears to `''`, never NULL. `sessions.pending_prompt`

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -460,7 +460,12 @@ pub async fn read_pending_prompt(db: &Db, id: &str) -> Result<String> {
 /// the prompt stays visibly queued instead of becoming eligible for replay at
 /// every later turn boundary.
 pub async fn take_pending_prompt(db: &Db, id: &str) -> Result<Option<String>> {
-    let mut tx = db.begin().await?;
+    // Take the writer lock before reading. A deferred transaction can read while
+    // another writer holds WAL's reserved lock, then fail its read -> write
+    // upgrade immediately with SQLITE_BUSY instead of honoring busy_timeout.
+    // Stop-and-send reaches this just after persisting its cancellation boundary,
+    // so that race used to leak "database is locked" to the composer.
+    let mut tx = weaver_core::db::begin_immediate(db).await?;
     let pending: Option<String> =
         sqlx::query_scalar::<_, Option<String>>("SELECT pending_prompt FROM sessions WHERE id = ?")
             .bind(id)
@@ -686,5 +691,39 @@ mod tests {
         append_pending_prompt(&db, "drain", "again").await.unwrap();
         consume_pending_prompt(&db, "drain", "again").await.unwrap();
         assert_eq!(read_pending_prompt(&db, "drain").await.unwrap(), "");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn take_pending_prompt_waits_for_a_concurrent_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::db::connect(&dir.path().join("weaver.db"))
+            .await
+            .unwrap();
+        let branch = branch_id(&db, "weaver/busy-queue").await;
+        insert(&db, &new_session("busy-queue", &branch, None))
+            .await
+            .unwrap();
+        append_pending_prompt(&db, "busy-queue", "send after stop")
+            .await
+            .unwrap();
+
+        let writer = weaver_core::db::begin_immediate(&db).await.unwrap();
+        let contender_db = db.clone();
+        let take =
+            tokio::spawn(async move { take_pending_prompt(&contender_db, "busy-queue").await });
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            !take.is_finished(),
+            "queue consumption should wait for the writer instead of returning SQLITE_BUSY"
+        );
+        writer.commit().await.unwrap();
+
+        let taken = tokio::time::timeout(std::time::Duration::from_secs(1), take)
+            .await
+            .expect("queue consumption resumes once the writer commits")
+            .unwrap()
+            .unwrap();
+        assert_eq!(taken.as_deref(), Some("send after stop"));
     }
 }

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -382,6 +382,15 @@ pub async fn clear_acp_state(db: &Db, id: &str) -> Result<()> {
     Ok(())
 }
 
+/// The turn recorded in a session's durable ACP in-flight state, when valid.
+pub fn acp_inflight_turn(session: &Session) -> Option<i64> {
+    session
+        .acp_inflight
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| value.get("turn").and_then(serde_json::Value::as_i64))
+}
+
 /// Replace an ACP session's runtime profile and clear every piece of
 /// provider-private relay/session state. The journal and durable prompt queue
 /// are deliberately untouched: both belong to loom's stable session and must

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1083,22 +1083,47 @@ pub(crate) async fn create_session_core(
         .await
         .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         if let Err(e) = crate::acp::start(&st, &session.id, launch).await {
-            // Mark the row errored (visible, inspectable) rather than leaving a
-            // running row with no live task behind it.
+            // Keep the durable row/worktree visible and recoverable, but retain
+            // non-2xx create semantics so CLI/webhook callers never announce a
+            // failed agent as successfully launched. The browser uses the
+            // returned session id to navigate to its handoff controls.
             let _ = session_mod::set_status(&st.db, &session.id, "error").await;
+            let note =
+                format!("Agent failed to start: {e}. Hand off this session to another provider.");
+            tags::set(
+                &st.db,
+                &branch.id,
+                tags::ATTENTION_KEY,
+                "blocked",
+                &note,
+                "loom",
+            )
+            .await
+            .ok();
+            events::record_tag(
+                &st.db,
+                &st.bus,
+                &branch.id,
+                tags::ATTENTION_KEY,
+                "blocked",
+                &note,
+                "loom",
+            )
+            .await
+            .ok();
             events::record(
                 &st.db,
                 &st.bus,
                 &branch.id,
                 "status",
-                json!({ "status": "error", "reason": "acp launch failed" }),
+                json!({ "status": "error", "reason": "acp launch failed", "error": e.to_string() }),
             )
             .await
             .ok();
-            return Err(AppError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("acp launch failed: {e}"),
-            ));
+            return Err(
+                AppError::new(StatusCode::BAD_GATEWAY, format!("acp launch failed: {e}"))
+                    .with_fields(json!({ "session_id": session.id })),
+            );
         }
         tracing::info!(session = %session.id, branch = %branch.id, "acp session launched");
         session
@@ -2495,9 +2520,9 @@ pub(super) async fn handoff_session(
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
     require_acp(&session)?;
-    if session.status != "running" {
+    if !matches!(session.status.as_str(), "running" | "orphaned" | "error") {
         return Err(AppError::conflict(format!(
-            "session '{}' is {}, not running",
+            "session '{}' is {}, not handoff-capable",
             session.id, session.status
         )));
     }
@@ -2540,6 +2565,12 @@ pub(super) async fn handoff_session(
     // Resolve every fallible launch input before quiescing the current task.
     let repo_root = PathBuf::from(&branch.repo_root);
     let work_dir = PathBuf::from(&session.work_dir);
+    if !work_dir.exists() {
+        return Err(AppError::bad_request(format!(
+            "worktree {} no longer exists on disk — cannot hand off",
+            session.work_dir
+        )));
+    }
     let repo_cfg = repo_cfg_or_default(&repo_root);
     let mut extra_env = launch_env(&st.db, &repo_root, &repo_cfg).await;
     apply_user_github_token(&st.db, &mut extra_env, session.created_by.as_deref()).await;
@@ -2574,12 +2605,37 @@ pub(super) async fn handoff_session(
     .await
     .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let handle = require_acp_task(&st, &session)?;
-    handle
-        .prepare_handoff()
-        .await
-        .map_err(|e| AppError::conflict(e.to_string()))?;
+    // A healthy task quiesces on its ordered command channel, preserving the
+    // active-turn/queue safety gate. A missing task is the recovery case: settle
+    // its persisted in-flight turn, retain the durable queue, and continue.
+    if let Some(handle) = st.acp.get(&session.id) {
+        if let Err(error) = handle.prepare_handoff().await {
+            tokio::task::yield_now().await;
+            if st.acp.is_live(&session.id) {
+                return Err(AppError::conflict(error.to_string()));
+            }
+            tracing::warn!(session = %session.id, %error,
+                "ACP task vanished while preparing handoff; using persisted recovery state");
+        }
+    } else {
+        tracing::warn!(session = %session.id,
+            "handing off without a live ACP task; using persisted recovery state");
+    }
+    // Re-read after the task handshake: it may have vanished after our initial
+    // route snapshot while persisting a newer in-flight turn.
+    let persisted = session_mod::get(&st.db, &session.id)
+        .await?
+        .ok_or_else(|| AppError::not_found("session"))?;
+    if let Some(turn) = persisted
+        .acp_inflight
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .and_then(|value| value.get("turn").and_then(Value::as_i64))
+    {
+        crate::chat::close_abandoned_turn(&st.db, &session.id, turn).await?;
+    }
     backend::kill_session_and_wait(&session.term_session).await?;
+    crate::chat::reset_usage(&st.db, &session.id).await?;
     session_mod::prepare_handoff(&st.db, &session.id, target, &model, &effort, "running").await?;
 
     let boundary = json!({

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2626,12 +2626,7 @@ pub(super) async fn handoff_session(
     let persisted = session_mod::get(&st.db, &session.id)
         .await?
         .ok_or_else(|| AppError::not_found("session"))?;
-    if let Some(turn) = persisted
-        .acp_inflight
-        .as_deref()
-        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
-        .and_then(|value| value.get("turn").and_then(Value::as_i64))
-    {
+    if let Some(turn) = session_mod::acp_inflight_turn(&persisted) {
         crate::chat::close_abandoned_turn(&st.db, &session.id, turn).await?;
     }
     backend::kill_session_and_wait(&session.term_session).await?;
@@ -2678,15 +2673,6 @@ pub(super) async fn handoff_session(
     Ok(Json(session_view(&st.db, &session, &branch).await?))
 }
 
-/// The in-flight turn number from a session's persisted `acp_inflight`, or `None`.
-fn live_turn(session: &Session) -> Option<i64> {
-    session
-        .acp_inflight
-        .as_deref()
-        .and_then(|s| serde_json::from_str::<Value>(s).ok())
-        .and_then(|v| v.get("turn").and_then(Value::as_i64))
-}
-
 /// Permission posture captured when the persisted in-flight turn started. This
 /// differs from `Session.current_mode` after a live config change: that selection
 /// applies to the next prompt.
@@ -2721,7 +2707,7 @@ pub(super) async fn get_session_chat(
         .filter(|pending| !pending.trim().is_empty());
     Ok(Json(json!({
         "blocks": blocks,
-        "live_turn": live_turn(&session),
+        "live_turn": session_mod::acp_inflight_turn(&session),
         "effective_mode": effective_turn_mode(&session),
         "pending_prompt": pending_prompt,
         "metadata": metadata,

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -299,6 +299,11 @@ function handleMessage(msg) {
     }
     return;
   }
+  // Integration tests use this to model an adapter process that stays alive
+  // but never answers one setup stage — the production failure behind a create
+  // request that otherwise waits forever.
+  const ignoredMethods = new Set((process.env.FAKE_ACP_IGNORE_METHOD || "").split(",").filter(Boolean));
+  if (ignoredMethods.has(msg.method)) return;
   switch (msg.method) {
     case "initialize":
       respond(msg.id, {

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -95,10 +95,49 @@ async fn start_new_with_env(
         new_or_load: NewOrLoad::New { cwd, meta: None },
         mode: mode.map(str::to_string),
         goal: goal.map(str::to_string),
+        setup_timeout: Duration::from_secs(5),
     };
     acp::start(&ts.state, id, launch)
         .await
         .expect("acp session starts");
+}
+
+/// A live adapter that withholds a setup response must not keep create/start
+/// open forever or leave its detached relay behind.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn silent_setup_stage_times_out_and_cleans_provider_state() {
+    let ts = TestServer::start().await;
+    make_session(&ts, "acp-setup-timeout").await;
+    let cwd = ts.repo_path().to_path_buf();
+    let launch = AcpLaunch {
+        adapter_cmd: agent_cmd(),
+        cwd: cwd.clone(),
+        env: vec![(
+            "FAKE_ACP_IGNORE_METHOD".to_string(),
+            "session/new".to_string(),
+        )],
+        new_or_load: NewOrLoad::New { cwd, meta: None },
+        mode: None,
+        goal: Some("say:never starts".to_string()),
+        setup_timeout: Duration::from_millis(150),
+    };
+
+    let error = acp::start(&ts.state, "acp-setup-timeout", launch)
+        .await
+        .expect_err("silent session/new times out");
+    assert!(error.to_string().contains("session/new"), "{error}");
+    assert!(error.to_string().contains("timed out"), "{error}");
+    let session = session_mod::get(&ts.state.db, "acp-setup-timeout")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(session.acp_session_id.is_none());
+    assert_eq!(session.acp_ack_seq, 0);
+    assert!(session.acp_inflight.is_none());
+    assert!(session.current_mode.is_none());
+    assert!(!ts.state.acp.is_live("acp-setup-timeout"));
+    assert!(!backend::has_session(&session.term_session).await);
 }
 
 /// Collect broadcast SSE events until `until` matches one (or the timeout).
@@ -1627,6 +1666,54 @@ async fn rest_create_drives_the_turn_lifecycle() {
     assert_eq!(nudges, 1, "the send recorded exactly one nudge audit event");
 }
 
+/// REST keeps failure semantics for non-browser callers, while returning the
+/// durable failed session id so the UI can navigate to its recovery controls.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rest_create_failure_exposes_the_recoverable_error_session() {
+    let ts = TestServer::start().await;
+    loom::custom_agents::set(
+        &ts.state.db,
+        &loom::custom_agents::CustomAgent {
+            name: "broken-create".to_string(),
+            label: "Broken create".to_string(),
+            setup: String::new(),
+            launch: "exit 7".to_string(),
+            resume: String::new(),
+            reports_status: false,
+            protocol: "acp".to_string(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/api/sessions", ts.addr))
+        .json(&json!({
+            "goal": "cannot start",
+            "cwd": ts.cwd(),
+            "agent": "broken-create",
+            "name": "broken-create"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_GATEWAY);
+    let body: Value = response.json().await.unwrap();
+    let id = body["session_id"].as_str().expect("failed session id");
+    assert!(body["error"]
+        .as_str()
+        .unwrap_or("")
+        .contains("acp launch failed"));
+    let view = ts.client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(view["status"], "error");
+    assert_eq!(branch_tag_value(&view, "attention"), "blocked");
+    assert!(!ts.state.acp.is_live(id));
+    assert!(!backend::has_session(view["term_session"].as_str().unwrap()).await);
+}
+
 /// A provider handoff keeps loom's identity and canonical journal, records one
 /// compact boundary instead of the synthetic bootstrap prompt, and continues at
 /// the next turn under the replacement adapter.
@@ -1695,6 +1782,80 @@ async fn handoff_replaces_provider_and_continues_the_journal() {
     .await;
     assert!(chat["blocks"].as_array().unwrap().iter().any(|b| {
         b["kind"] == "user_message" && b["turn"] == 2 && b["payload"]["text"] == "say:after"
+    }));
+}
+
+/// A missing task is a supported recovery state: close its abandoned turn,
+/// preserve unseen queued feedback, reset old-provider usage, and replace it.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handoff_recovers_without_a_live_task_and_preserves_the_queue() {
+    let ts = TestServer::start().await;
+    seed_acp_agent(&ts, "fake-dead").await;
+    seed_acp_agent(&ts, "fake-replacement").await;
+
+    let created = rest_create(&ts, "fake-dead", "usage:90:100|say:ready").await;
+    let id = created["id"].as_str().unwrap().to_string();
+    poll_chat(&ts, &id, Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| block["kind"] == "turn_end")
+    })
+    .await;
+
+    ts.state.acp.stop(&id);
+    backend::kill_session_and_wait(created["term_session"].as_str().unwrap())
+        .await
+        .unwrap();
+    loom::chat::insert(
+        &ts.state.db,
+        &id,
+        1,
+        0,
+        loom::chat::kind::USER_MESSAGE,
+        &json!({ "text": "abandoned request", "by": "manual" }),
+    )
+    .await
+    .unwrap();
+    session_mod::set_inflight(
+        &ts.state.db,
+        &id,
+        Some(r#"{"prompt_id":99,"turn":1,"mode":"default"}"#),
+    )
+    .await
+    .unwrap();
+    session_mod::append_pending_prompt(&ts.state.db, &id, "say:queued survives")
+        .await
+        .unwrap();
+    session_mod::set_status(&ts.state.db, &id, "error")
+        .await
+        .unwrap();
+
+    let handed = ts
+        .client
+        .post(
+            &format!("/api/sessions/{id}/handoff"),
+            json!({ "agent": "fake-replacement" }),
+        )
+        .await
+        .expect("disconnected handoff succeeds");
+    assert_eq!(handed["agent_kind"], "fake-replacement");
+    assert_eq!(handed["status"], "running");
+    assert_eq!(handed["usage"], Value::Null, "old provider usage reset");
+
+    let chat = poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "queued survives"
+        })
+    })
+    .await;
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 1
+            && block["kind"] == "turn_end"
+            && block["payload"]["stop_reason"] == "error"
+    }));
+    assert!(blocks.iter().any(|block| {
+        block["kind"] == "user_message"
+            && block["payload"]["text"].as_str() == Some("say:queued survives")
     }));
 }
 

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -266,6 +266,25 @@ async fn wait_for_comments(fake: &FakeGithub, n: usize) {
     panic!("expected >= {n} replies, saw {have}");
 }
 
+/// The fake records a reply inside `post_issue_comment`, one await before the
+/// detached webhook task persists the reply id. Wait for that durable boundary
+/// when a test needs to assert the bookkeeping tag rather than racing it.
+async fn wait_for_session_tag(ts: &TestServer, session_id: &str, key: &str) -> serde_json::Value {
+    for _ in 0..200 {
+        let sessions = ts.client.get("/api/sessions").await.unwrap();
+        if let Some(session) = sessions.as_array().unwrap().iter().find(|session| {
+            session["id"] == session_id
+                && session["branch"]["tags"]
+                    .as_array()
+                    .is_some_and(|tags| tags.iter().any(|tag| tag["key"] == key))
+        }) {
+            return session.clone();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("session {session_id} never acquired tag {key}");
+}
+
 /// Poll until the fake gateway has recorded at least `n` reactions.
 async fn wait_for_reactions(fake: &FakeGithub, n: usize) {
     for _ in 0..200 {
@@ -482,8 +501,8 @@ async fn status_writes_mirror_onto_the_on_it_comment() {
     wait_for_comments(&fake, 1).await;
 
     let sessions = ts.client.get("/api/sessions").await.unwrap();
-    let session = &sessions.as_array().unwrap()[0];
-    let session_id = session["id"].as_str().unwrap().to_string();
+    let session_id = sessions[0]["id"].as_str().unwrap().to_string();
+    let session = wait_for_session_tag(&ts, &session_id, "github.status_comment").await;
     let branch_id = session["branch"]["id"].as_str().unwrap().to_string();
     let tags = session["branch"]["tags"].as_array().unwrap();
     let tag = |key: &str| {

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -163,11 +163,28 @@ pub struct SessionView {
     /// before one is set.
     #[serde(default)]
     pub current_mode: Option<String>,
-    /// The latest context-window usage (`{used, size}`) reported by an ACP agent,
-    /// or `null`.
+    /// The latest context-window usage reported by the current ACP provider, or
+    /// `null` before it reports (and immediately after a provider handoff).
     #[serde(default)]
-    pub usage: Option<serde_json::Value>,
+    pub usage: Option<AcpUsage>,
     pub branch: BranchView,
+}
+
+/// Cumulative session cost optionally reported alongside ACP context usage.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AcpCost {
+    pub amount: f64,
+    pub currency: String,
+}
+
+/// Current model-context utilization for an ACP session. This is context-window
+/// state, not a provider account/rate-limit quota.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AcpUsage {
+    pub used: u64,
+    pub size: u64,
+    #[serde(default)]
+    pub cost: Option<AcpCost>,
 }
 
 fn default_protocol() -> String {

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -187,6 +187,15 @@ test.describe('acp conversation', () => {
     await expect.poll(async () => (await weaver.getSession(s.id)).agent_kind).toBe('acp-fake-next');
     await expect(page.getByText('acp-fake-next', { exact: true })).toBeVisible();
     await expect(conv.getByText('before handoff', { exact: true })).toBeVisible();
+    await expect
+      .poll(async () => {
+        const res = await fetch(`${weaver.baseUrl}/api/sessions/${s.id}/chat`);
+        const chat = (await res.json()) as {
+          blocks: Array<{ kind: string; payload: { from?: string; to?: string } }>;
+        };
+        return chat.blocks.find((block) => block.kind === 'handoff')?.payload;
+      })
+      .toEqual({ from: 'acp-fake', to: 'acp-fake-next', model: '', effort: '' });
     await expect(page.getByTestId('acp-handoff')).toContainText('acp-fake → acp-fake-next');
 
     const input = page.getByTestId('acp-composer-input');
@@ -320,6 +329,7 @@ test.describe('acp conversation', () => {
       }),
     ).toBeVisible();
     await expect(conv.locator('.acp-label', { hasText: 'Agent' })).toHaveCount(1);
+    await expect(page.getByTestId('agent-usage')).toContainText('41k / 200k context · 21%');
   });
 
   test('stop settles working and leaves unseen feedback idle until sent', async ({ page, weaver }) => {
@@ -461,12 +471,32 @@ test.describe('acp conversation', () => {
     const menu = page.getByTestId('acp-file-menu');
     await expect(menu.getByText('@README.md', { exact: true })).toBeVisible();
     await menu.getByText('@README.md', { exact: true }).click();
-    await expect(input).toHaveValue('resources|@README.md ');
+    await expect(input).toHaveValue('resources|');
+    await expect(page.getByTestId('acp-attachment-pill')).toContainText('README.md');
 
     await page.getByTestId('acp-composer-send').click();
     await expect(page.getByTestId('acp-conversation').getByText('README.md', { exact: true })).toBeVisible({
       timeout: 15_000,
     });
+  });
+
+  test('composer uploads become removable ACP resource pills', async ({ page, weaver }) => {
+    await openAcp(page, weaver, { goal: 'say:ready', name: 'acp-upload-resource' });
+    await page.getByTestId('acp-composer-file-input').setInputFiles({
+      name: 'long-notes.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('notes for the agent'),
+    });
+
+    const pill = page.getByTestId('acp-attachment-pill');
+    await expect(pill).toContainText('scratch/long-notes.txt');
+    await expect(page.getByTestId('scratch-panel')).toContainText('long-notes.txt');
+    await page.getByTestId('acp-composer-input').fill('resources');
+    await page.getByTestId('acp-composer-send').click();
+    await expect(
+      page.getByTestId('acp-conversation').getByText('scratch/long-notes.txt', { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('acp-attachment-pill')).toHaveCount(0);
   });
 
   test('the composer steers a prompt into a live turn', async ({ page, weaver }) => {

--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -81,6 +81,26 @@ test.describe('creating a session via the UI form', () => {
     expect(files.map((f) => f.name).sort()).toEqual(['shot.png', 'trace.log']);
   });
 
+  test('an agent startup failure opens its recoverable session', async ({ page, weaver }) => {
+    const failed = await weaver.seedSession({ goal: 'Recover me', name: 'failed-create' });
+    await page.route('**/api/sessions', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'acp launch failed: agent did not respond', session_id: failed.id }),
+      });
+    });
+    await page.goto(weaver.baseUrl);
+    await page.getByRole('button', { name: 'New session' }).click();
+    await page.getByPlaceholder(repoPlaceholder).fill(weaver.repoPath);
+    await page.getByPlaceholder('Add a /health endpoint').fill('Start a limited agent');
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/s/${failed.id}$`));
+    await expect(page.getByTestId('new-session-drawer')).toHaveCount(0);
+  });
+
   test('agent selection drives model and effort choices', async ({ page, weaver }) => {
     const registry = (await (await fetch(`${weaver.baseUrl}/api/agents`)).json()) as {
       agents: { kind: string; models: { label: string }[]; efforts: { label: string }[] }[];


### PR DESCRIPTION
## What changed

- Bound each ACP setup stage so a silent or exhausted provider cannot hold session creation open forever, and clean up its relay and private state on failure.
- Keep failed sessions visible with a blocked explanation and route the browser to their recovery controls while preserving non-success API semantics.
- Allow best-effort provider handoff when the ACP task is already gone, closing abandoned turns, preserving queued prompts, and resetting provider-specific usage.
- Make queued prompt consumption acquire the SQLite write lock before reading, so Stop and send honors the busy timeout instead of leaking a code 5 database-is-locked error.
- Persist typed ACP context-window usage and optional cost, then surface it in the fleet and conversation composer with warning states.
- Rework the conversation composer into a larger integrated surface with auto-growth, explicit file pills, direct uploads, keyboard guidance, and reliable journal refresh across handoff.

Fixes #557