### PR TITLE
fix(loom): harden session lifecycle and agent controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Edit them in the **Settings** pane of the web UI, or from the CLI:
 weaver config ls
 weaver config get agent.default
 weaver config set agent.default codex
+weaver config set agent.mode bypassPermissions
 weaver config rm agent.default
 ```
 
@@ -373,6 +374,9 @@ Notable settings:
   launch` is given no `--agent` (`claude`, `codex`, or any custom agent).
 - `agent.model` / `agent.effort` — default model and reasoning effort for new
   sessions. The Settings UI populates these from the selected agent type.
+- `agent.mode` — default permission posture for new ACP sessions and handoffs:
+  `auto` (the default), `default`, `acceptEdits`, `plan`, or
+  `bypassPermissions` (“Always allow”). An explicit launch `--mode` overrides it.
 - `server.auto_adopt` — adopt every recoverable session on daemon startup.
 - `github.poll` — poll GitHub (via `gh`) for each session's PR, review, and
   check status (on by default; a no-op without `gh` or a GitHub remote).

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -409,6 +409,10 @@ async function submitPrompt(forceSteer = false) {
     emit('command', local.name, local.args);
     return;
   }
+  // Disabling a focused textarea moves focus to the document body. Remember an
+  // Enter-key submission so the composer can resume typing after the request;
+  // button submits and users who move to another control keep their new focus.
+  const restoreComposerFocus = document.activeElement === composerInput.value;
   sending.value = true;
   sendError.value = '';
   const text = draft.value;
@@ -431,6 +435,13 @@ async function submitPrompt(forceSteer = false) {
     sendError.value = (e as Error).message ?? 'Failed to send';
   } finally {
     sending.value = false;
+    if (
+      restoreComposerFocus &&
+      (!document.activeElement || document.activeElement === document.body)
+    ) {
+      await nextTick();
+      composerInput.value?.focus();
+    }
   }
 }
 

--- a/crates/loom/frontend/src/components/AgentProfileEditor.vue
+++ b/crates/loom/frontend/src/components/AgentProfileEditor.vue
@@ -6,11 +6,12 @@ import AgentRuntimePicker from './AgentRuntimePicker.vue';
 const props = defineProps<{
   title: string;
   note: string;
-  keys: { agent: string; model: string; effort: string };
+  keys: { agent: string; model: string; effort: string; mode: string };
   agents: AgentMetadata[];
   agentKind: string;
   model: string;
   effort: string;
+  mode: string;
   dirty: boolean;
   isDefault: boolean;
   busy: boolean;
@@ -20,11 +21,40 @@ const emit = defineEmits<{
   'update-agent': [string];
   'update-model': [string];
   'update-effort': [string];
+  'update-mode': [string];
   save: [];
   reset: [];
 }>();
 
 const selectedAgent = computed(() => props.agents.find((agent) => agent.kind === props.agentKind));
+
+const permissionModes = [
+  {
+    id: 'auto',
+    label: 'Auto',
+    description: 'Allow routine work and ask before risky actions.',
+  },
+  {
+    id: 'default',
+    label: 'Ask',
+    description: 'Use the provider’s standard permission prompts.',
+  },
+  {
+    id: 'acceptEdits',
+    label: 'Accept edits',
+    description: 'Allow file edits while asking for other actions.',
+  },
+  {
+    id: 'plan',
+    label: 'Plan only',
+    description: 'Keep the agent read-only while it plans.',
+  },
+  {
+    id: 'bypassPermissions',
+    label: 'Always allow',
+    description: 'Run without permission prompts.',
+  },
+];
 
 function agentLabel(kind: string): string {
   return props.agents.find((agent) => agent.kind === kind)?.label ?? kind;
@@ -35,6 +65,10 @@ function choiceLabel(kind: 'model' | 'effort', value: string): string {
   const choices =
     kind === 'model' ? (selectedAgent.value?.models ?? []) : (selectedAgent.value?.efforts ?? []);
   return choices.find((choice) => choice.id === value)?.label ?? value;
+}
+
+function permissionLabel(value: string): string {
+  return permissionModes.find((mode) => mode.id === value)?.label ?? value;
 }
 </script>
 
@@ -50,6 +84,7 @@ function choiceLabel(kind: 'model' | 'effort', value: string): string {
           {{ agentLabel(agentKind) }}
           <template v-if="model"> · {{ choiceLabel('model', model) }}</template>
           <template v-if="effort"> · {{ choiceLabel('effort', effort) }}</template>
+          · {{ permissionLabel(mode) }} permissions
         </span>
         <button
           class="btn-primary px-2.5 py-1 text-xs disabled:opacity-50"
@@ -80,6 +115,34 @@ function choiceLabel(kind: 'model' | 'effort', value: string): string {
         @update:model="emit('update-model', $event)"
         @update:effort="emit('update-effort', $event)"
       />
+    </div>
+
+    <div class="border-t border-line px-3 py-3">
+      <div class="mb-2 flex items-baseline justify-between gap-3">
+        <div>
+          <h4 class="text-xs font-medium">Default permissions</h4>
+          <p class="text-2xs text-muted">Used for new ACP sessions and handoffs.</p>
+        </div>
+        <code class="font-mono text-2xs text-faint">{{ keys.mode }}</code>
+      </div>
+      <div class="grid gap-1.5 sm:grid-cols-2 lg:grid-cols-5" data-testid="agent-mode-picker">
+        <button
+          v-for="option in permissionModes"
+          :key="option.id"
+          type="button"
+          class="rounded border px-2.5 py-2 text-left"
+          :class="
+            mode === option.id
+              ? 'border-accent bg-accent text-accent-fg'
+              : 'border-line bg-input text-muted hover:bg-subtle hover:text-fg'
+          "
+          :data-active="mode === option.id"
+          @click="emit('update-mode', option.id)"
+        >
+          <span class="block text-xs font-medium">{{ option.label }}</span>
+          <span class="mt-0.5 block text-2xs opacity-80">{{ option.description }}</span>
+        </button>
+      </div>
     </div>
   </section>
 </template>

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -91,7 +91,12 @@ const categories: CategoryItem[] = [
   },
 ];
 
-const agentKeys = { agent: 'agent.default', model: 'agent.model', effort: 'agent.effort' };
+const agentKeys = {
+  agent: 'agent.default',
+  model: 'agent.model',
+  effort: 'agent.effort',
+  mode: 'agent.mode',
+};
 const agentProfileTitle = 'Session default runtime';
 
 function categoryFromQuery(q: unknown): Category {
@@ -283,7 +288,7 @@ function setAgent(kind: string) {
   sanitizeAgentDraft();
 }
 
-function setProfileChoice(key: 'model' | 'effort', value: string) {
+function setProfileChoice(key: 'model' | 'effort' | 'mode', value: string) {
   drafts.value[agentKeys[key]] = value;
   sanitizeAgentDraft();
 }
@@ -370,18 +375,20 @@ onMounted(load);
         <div v-else-if="category === 'agents'" class="space-y-4">
           <AgentProfileEditor
             :title="agentProfileTitle"
-            note="Used when a new work session does not specify an agent."
+            note="Runtime, model, effort, and permissions used when a new session does not override them."
             :keys="agentKeys"
             :agents="availableAgents()"
             :agent-kind="drafts[agentKeys.agent] ?? ''"
             :model="drafts[agentKeys.model] ?? ''"
             :effort="drafts[agentKeys.effort] ?? ''"
+            :mode="drafts[agentKeys.mode] ?? 'auto'"
             :dirty="dirtyKeys(profileKeys()).length > 0"
             :is-default="profileIsDefault()"
             :busy="busy === agentProfileTitle"
             @update-agent="setAgent"
             @update-model="(value) => setProfileChoice('model', value)"
             @update-effort="(value) => setProfileChoice('effort', value)"
+            @update-mode="(value) => setProfileChoice('mode', value)"
             @save="saveKeys(profileKeys(), agentProfileTitle)"
             @reset="resetKeys(profileKeys(), agentProfileTitle)"
           />

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -800,7 +800,7 @@ fn weaver_bin_path() -> String {
 /// `mode` / `--mode` still overrides — e.g. `bypassPermissions` for a fully
 /// unattended run. (For a codex session this maps to codex's `agent` mode; see
 /// [`codex_acp_mode`].)
-pub const DEFAULT_ACP_MODE: &str = "auto";
+pub const DEFAULT_ACP_MODE: &str = weaver_core::config::DEFAULT_AGENT_MODE;
 
 /// Resolve the execution backend for a launch: the agent's declared `protocol`
 /// unless the create request overrides it. A blank/absent override keeps the

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -329,7 +329,7 @@ enum SessionCmd {
         /// Target reasoning effort; omit for the runtime default.
         #[arg(long)]
         effort: Option<String>,
-        /// Target ACP permission posture; omit for `auto`.
+        /// Target ACP permission posture; omit for configured `agent.mode`.
         #[arg(long)]
         mode: Option<String>,
     },
@@ -654,8 +654,9 @@ struct LaunchOpts {
     /// builtins).
     #[arg(long)]
     protocol: Option<String>,
-    /// ACP launch permission posture: `auto` (the default), `bypassPermissions`,
-    /// `acceptEdits`, `default`, or `plan`. Ignored for a terminal launch.
+    /// ACP launch permission posture: `auto`, `bypassPermissions`, `acceptEdits`,
+    /// `default`, or `plan`. Omit for configured `agent.mode`; ignored for a
+    /// terminal launch.
     #[arg(long)]
     mode: Option<String>,
 }

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -119,6 +119,9 @@ pub async fn run(state: AppState) {
                 .await;
             }
             if !backend::has_session(&session.term_session).await {
+                if session.status == "orphaned" {
+                    continue;
+                }
                 match session_mod::mark_orphaned(&state.db, &session.id).await {
                     Ok(true) => {
                         tracing::info!(
@@ -139,7 +142,7 @@ pub async fn run(state: AppState) {
                     Ok(false) => tracing::debug!(
                         id = %session.id,
                         snapshot_status = %session.status,
-                        "terminal ended after session reached a terminal state"
+                        "session no longer eligible for orphan transition"
                     ),
                     Err(e) => tracing::warn!(
                         id = %session.id,

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -119,22 +119,33 @@ pub async fn run(state: AppState) {
                 .await;
             }
             if !backend::has_session(&session.term_session).await {
-                if session.status != "orphaned" {
-                    tracing::info!(
+                match session_mod::mark_orphaned(&state.db, &session.id).await {
+                    Ok(true) => {
+                        tracing::info!(
+                            id = %session.id,
+                            term_session = %session.term_session,
+                            "terminal session ended; marked orphaned"
+                        );
+                        let _ = events::record(
+                            &state.db,
+                            &state.bus,
+                            &session.branch_id,
+                            "status",
+                            json!({ "status": "orphaned", "reason": "terminal session ended" }),
+                        )
+                        .await;
+                        last_event = events::max_id(&state.db).await.unwrap_or(last_event);
+                    }
+                    Ok(false) => tracing::debug!(
                         id = %session.id,
-                        term_session = %session.term_session,
-                        "terminal session ended; marking orphaned"
-                    );
-                    let _ = session_mod::set_status(&state.db, &session.id, "orphaned").await;
-                    let _ = events::record(
-                        &state.db,
-                        &state.bus,
-                        &session.branch_id,
-                        "status",
-                        json!({ "status": "orphaned", "reason": "terminal session ended" }),
-                    )
-                    .await;
-                    last_event = events::max_id(&state.db).await.unwrap_or(last_event);
+                        snapshot_status = %session.status,
+                        "terminal ended after session reached a terminal state"
+                    ),
+                    Err(e) => tracing::warn!(
+                        id = %session.id,
+                        error = %e,
+                        "could not mark ended terminal session orphaned"
+                    ),
                 }
                 continue;
             }

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -300,7 +300,7 @@ pub async fn mark_orphaned(db: &Db, id: &str) -> Result<bool> {
     .await?;
     let changed = result.rows_affected() == 1;
     if changed {
-        tracing::info!(%id, new = "orphaned", "session status changed");
+        tracing::info!(%id, "session marked orphaned atomically");
     }
     Ok(changed)
 }

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -283,6 +283,28 @@ pub async fn set_status(db: &Db, id: &str, status: &str) -> Result<()> {
     Ok(())
 }
 
+/// Mark a live session orphaned after its terminal disappears.
+///
+/// The monitor discovers liveness from a fleet snapshot, which can be stale by
+/// the time teardown finishes. Keep the terminal-state guard in the UPDATE so
+/// an archive racing that snapshot cannot be overwritten back to `orphaned`.
+/// Returns whether this call performed the transition.
+pub async fn mark_orphaned(db: &Db, id: &str) -> Result<bool> {
+    let result = sqlx::query(
+        "UPDATE sessions SET status = 'orphaned'
+         WHERE id = ?
+           AND status NOT IN ('orphaned', 'done', 'error', 'archived')",
+    )
+    .bind(id)
+    .execute(db)
+    .await?;
+    let changed = result.rows_affected() == 1;
+    if changed {
+        tracing::info!(%id, new = "orphaned", "session status changed");
+    }
+    Ok(changed)
+}
+
 pub async fn touch(db: &Db, id: &str) -> Result<()> {
     sqlx::query("UPDATE sessions SET last_activity_at = ? WHERE id = ?")
         .bind(now_iso())
@@ -598,6 +620,53 @@ mod tests {
         assert!(
             active_managed_by(&db, "ov-other").await.unwrap().is_none(),
             "no warm session for a watch that owns none"
+        );
+    }
+
+    /// Regression: archive kills the terminal before its final status write, so
+    /// the monitor can still be holding a `running` fleet snapshot when it sees
+    /// that terminal disappear. Its orphan transition must compare-and-set the
+    /// current row, not overwrite a terminal status from that stale snapshot.
+    #[tokio::test]
+    async fn orphan_transition_cannot_resurrect_an_archived_session() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let branch = branch_id(&db, "weaver/archive-race").await;
+        insert(&db, &new_session("archive-race", &branch, None))
+            .await
+            .unwrap();
+
+        let stale_monitor_snapshot = get(&db, "archive-race").await.unwrap().unwrap();
+        assert_eq!(stale_monitor_snapshot.status, "running");
+        set_status(&db, "archive-race", "archived").await.unwrap();
+
+        assert!(
+            !mark_orphaned(&db, &stale_monitor_snapshot.id)
+                .await
+                .unwrap(),
+            "terminal rows reject a stale monitor's orphan transition"
+        );
+        assert_eq!(
+            get(&db, "archive-race").await.unwrap().unwrap().status,
+            "archived"
+        );
+    }
+
+    #[tokio::test]
+    async fn orphan_transition_is_edge_triggered_for_a_live_session() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let branch = branch_id(&db, "weaver/orphan").await;
+        insert(&db, &new_session("orphan", &branch, None))
+            .await
+            .unwrap();
+
+        assert!(mark_orphaned(&db, "orphan").await.unwrap());
+        assert_eq!(
+            get(&db, "orphan").await.unwrap().unwrap().status,
+            "orphaned"
+        );
+        assert!(
+            !mark_orphaned(&db, "orphan").await.unwrap(),
+            "an already-orphaned row does not emit another edge"
         );
     }
 

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -37,6 +37,18 @@ use super::{ApiResult, AppError, AppState};
 const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub token configured. Add your personal GitHub token in Settings > Account, or configure GH_TOKEN in Settings > Environment.";
 const HANDOFF_HISTORY_CHARS: usize = 64 * 1024;
 
+/// Resolve an optional per-request ACP permission posture over the workspace
+/// default. Empty request values behave like omission, matching model/effort.
+async fn launch_mode(db: &Db, requested: Option<&str>) -> String {
+    if let Some(mode) = requested.map(str::trim).filter(|mode| !mode.is_empty()) {
+        return mode.to_string();
+    }
+    config::get_or(db, "agent.mode", agent::DEFAULT_ACP_MODE)
+        .await
+        .trim()
+        .to_string()
+}
+
 pub(super) async fn list_agents(State(st): State<AppState>) -> ApiResult<Json<Value>> {
     let default_agent = configured_agent(&st.db, "agent.default", config::DEFAULT_AGENT).await;
     Ok(Json(json!({
@@ -617,16 +629,9 @@ pub(crate) async fn create_session_core(
         }
         None => return Err(AppError::bad_request(format!("unknown agent '{runtime}'"))),
     };
-    // The ACP launch permission posture (ignored for a terminal launch): the
-    // request's mode, else the `auto` default — a background classifier vets each
-    // tool call and escalates only risky actions as a permission card.
-    let mode = req
-        .mode
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .unwrap_or(agent::DEFAULT_ACP_MODE)
-        .to_string();
+    // The ACP launch permission posture (ignored for a terminal launch): an
+    // explicit request wins, then the workspace's `agent.mode` default.
+    let mode = launch_mode(&st.db, req.mode.as_deref()).await;
     tracing::debug!(model = %model, effort = %effort, protocol = %protocol, "resolved and validated model/effort/protocol");
     ensure_github_token_available(&st.db, &extra_env, created_by.as_deref(), &runtime).await?;
     tracing::debug!(runtime = %runtime, "github token availability check passed");
@@ -2554,13 +2559,7 @@ pub(super) async fn handoff_session(
             "handoff target matches the current runtime profile",
         ));
     }
-    let mode = req
-        .mode
-        .as_deref()
-        .map(str::trim)
-        .filter(|m| !m.is_empty())
-        .unwrap_or(agent::DEFAULT_ACP_MODE)
-        .to_string();
+    let mode = launch_mode(&st.db, req.mode.as_deref()).await;
 
     // Resolve every fallible launch input before quiescing the current task.
     let repo_root = PathBuf::from(&branch.repo_root);

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1557,6 +1557,36 @@ async fn rest_create(ts: &TestServer, agent: &str, goal: &str) -> Value {
         .expect("acp session creates")
 }
 
+/// A workspace permission default applies when REST create omits `mode`; the
+/// adapter-reported session state proves it reached the ACP handshake rather
+/// than merely round-tripping through the settings endpoint.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rest_create_uses_the_configured_permission_default() {
+    let ts = TestServer::start().await;
+    seed_acp_agent(&ts, "fake-mode-default").await;
+    loom::config::apply(
+        &ts.state.db,
+        &[(
+            "agent.mode".to_string(),
+            Some("bypassPermissions".to_string()),
+        )],
+    )
+    .await
+    .unwrap();
+
+    let created = rest_create(&ts, "fake-mode-default", "say:configured").await;
+    let id = created["id"].as_str().unwrap();
+    poll_view(&ts, id, Duration::from_secs(10), |view| {
+        view["current_mode"] == "bypassPermissions"
+    })
+    .await;
+    ts.client
+        .post(&format!("/api/sessions/{id}/archive"), json!({}))
+        .await
+        .unwrap();
+}
+
 /// Poll `GET /api/sessions/{id}` until `pred` accepts the view, returning it.
 async fn poll_view(
     ts: &TestServer,
@@ -1798,6 +1828,13 @@ async fn handoff_recovers_without_a_live_task_and_preserves_the_queue() {
     let id = created["id"].as_str().unwrap().to_string();
     poll_chat(&ts, &id, Duration::from_secs(10), |blocks| {
         blocks.iter().any(|block| block["kind"] == "turn_end")
+    })
+    .await;
+    // `turn_end` is journaled before the task finishes its lifecycle work and
+    // checks the durable queue. Wait for the later idle edge so this simulated
+    // crash cannot race the old task into consuming the queue we add below.
+    poll_view(&ts, &id, Duration::from_secs(10), |view| {
+        branch_tag_value(view, "idle") == "idle"
     })
     .await;
 

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -608,9 +608,9 @@ pub struct CreateReq {
     #[serde(default)]
     pub protocol: Option<String>,
     /// The ACP launch permission posture (`auto` | `bypassPermissions` |
-    /// `acceptEdits` | `default` | `plan`). Blank/absent defaults to `auto` — a
-    /// background classifier vets each tool call, escalating only risky actions as
-    /// a permission card. Ignored for a terminal launch.
+    /// `acceptEdits` | `default` | `plan`). Blank/absent uses the configured
+    /// `agent.mode` (which defaults to `auto`: a background classifier vets each
+    /// tool call and escalates only risky actions). Ignored for a terminal launch.
     #[serde(default)]
     pub mode: Option<String>,
 }
@@ -626,7 +626,7 @@ pub struct HandoffReq {
     /// Blank/absent uses the target runtime's default.
     #[serde(default)]
     pub effort: Option<String>,
-    /// ACP permission posture. Blank/absent uses loom's ACP default.
+    /// ACP permission posture. Blank/absent uses the configured `agent.mode`.
     #[serde(default)]
     pub mode: Option<String>,
 }

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -16,6 +16,9 @@ use crate::db::{now_iso, Db};
 pub const DEFAULT_AGENT: &str = "claude";
 pub const DEFAULT_AGENT_MODEL: &str = "";
 pub const DEFAULT_AGENT_EFFORT: &str = "";
+/// Provider-neutral permission posture for new ACP sessions. Claude uses this
+/// value directly; Codex maps it onto its own mode vocabulary at launch.
+pub const DEFAULT_AGENT_MODE: &str = "auto";
 /// Whether the server adopts orphaned sessions on startup. Off by default:
 /// the operator opts in via `weaver config set server.auto_adopt true`.
 pub const DEFAULT_AUTO_ADOPT: bool = false;
@@ -135,6 +138,24 @@ pub const REGISTRY: &[SettingSpec] = &[
         default: DEFAULT_AGENT_EFFORT,
         group: "Agents",
         options: &[],
+    },
+    SettingSpec {
+        key: "agent.mode",
+        label: "Default permissions",
+        description: "Permission posture used for new ACP sessions and agent \
+            handoffs when the request does not specify one. `auto` approves \
+            routine work and asks for risky actions; `bypassPermissions` runs \
+            without permission prompts. Ignored by terminal sessions.",
+        kind: SettingKind::Enum,
+        default: DEFAULT_AGENT_MODE,
+        group: "Agents",
+        options: &[
+            "auto",
+            "default",
+            "acceptEdits",
+            "plan",
+            "bypassPermissions",
+        ],
     },
     SettingSpec {
         key: "server.auto_adopt",
@@ -688,6 +709,15 @@ mod tests {
         assert_eq!(json["options"], serde_json::json!(["dark", "light"]));
         assert_eq!(json["value"], "dark");
         assert_eq!(json["is_default"], true);
+
+        let mode = views
+            .iter()
+            .find(|v| v.spec.key == "agent.mode")
+            .expect("agent.mode should be registered");
+        let json = serde_json::to_value(mode).unwrap();
+        assert_eq!(json["kind"], "enum");
+        assert_eq!(json["value"], "auto");
+        assert_eq!(json["options"][4], "bypassPermissions");
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -195,7 +195,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | Method + path | What it does |
 |---|---|
 | `GET /api/health` | liveness probe |
-| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]`, `parent_branch`, `protocol` (`terminal`\|`acp`, an opt-in override of the agent's declared default), and `mode` (the initial ACP permission posture); opens a tracking issue and returns its id as `tracking_issue`) |
+| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]`, `parent_branch`, `protocol` (`terminal`\|`acp`, an opt-in override of the agent's declared default), and `mode` (the initial ACP permission posture; omitted uses `agent.mode`); opens a tracking issue and returns its id as `tracking_issue`) |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear a branch tag — the well-known `attention` and `triage` keys plus any free-form key |
 | `GET /api/sessions/{id}/url` | the session's dashboard URL as `{url}`, built from the externally-visible origin (`auth.base_url`, else the request's own Host) — what `loom session url` prints, so an agent can link a PR back to its session without inventing a loopback link |

--- a/docs/plans/acp.md
+++ b/docs/plans/acp.md
@@ -329,11 +329,12 @@ HTTP, orthogonal to the execution backend).
 ### Permissions & modes
 
 The launch posture is a per-session choice, not a hard-coded constant: the
-create form (and `loom session launch --mode`) picks the **`auto`** default
-(Claude Code's background-classifier posture — a safety model vets each tool
+create form (and `loom session launch --mode`) uses the configurable
+**`agent.mode`** default (`auto` unless changed) or an explicit posture. `auto`
+is Claude Code's background-classifier posture — a safety model vets each tool
 call, running routine work on its own and escalating only genuinely risky
-actions) or an explicit posture — **autonomous** (`bypassPermissions`) for a
-fully unattended run, or a supervised mode (`acceptEdits`, `default`, `plan`).
+actions. Other choices are **autonomous** (`bypassPermissions`) for a fully
+unattended run, or a supervised mode (`acceptEdits`, `default`, `plan`).
 The mode is live thereafter — the
 composer's mode chip drives `session/set_mode`. In any gated mode a
 `session/request_permission` surfaces as an interactive card in the

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -299,6 +299,19 @@ test.describe('acp conversation', () => {
     await expect(status).toBeHidden({ timeout: 15_000 });
   });
 
+  test('Enter returns focus to the composer after sending', async ({ page, weaver }) => {
+    await openAcp(page, weaver, { goal: 'say:ready', name: 'acp-composer-focus' });
+    const input = page.getByTestId('acp-composer-input');
+
+    await input.fill('say:first message');
+    await input.press('Enter');
+
+    await expect(input).toHaveValue('');
+    await expect(input).toBeFocused();
+    await input.pressSequentially('say:second message');
+    await expect(input).toHaveValue('say:second message');
+  });
+
   test('streaming deltas appear, then consolidate into one message', async ({ page, weaver }) => {
     // A `wait` keeps the turn live long enough for the streamed text to arrive
     // as a delta before its block journals.

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -35,6 +35,34 @@ test.describe('settings · agent defaults', () => {
     await expect(page.getByText('Fleet concierge runtime', { exact: true })).toHaveCount(0);
   });
 
+  test('default agent permissions can be set to always allow', async ({ page, weaver }) => {
+    await page.goto(`${weaver.baseUrl}/settings`);
+    const session = page.locator('section').filter({
+      has: page.getByRole('heading', { name: 'Session default runtime' }),
+    });
+    const permissions = session.getByTestId('agent-mode-picker');
+
+    await expect(permissions.getByRole('button', { name: /Auto/ })).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+    await permissions.getByRole('button', { name: /Always allow/ }).click();
+    await session.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Saved Session default runtime.')).toBeVisible();
+
+    const settings = (await (await fetch(`${weaver.baseUrl}/api/settings`)).json()) as {
+      settings: { key: string; value: string; is_default: boolean }[];
+    };
+    expect(settings.settings.find((setting) => setting.key === 'agent.mode')).toMatchObject({
+      value: 'bypassPermissions',
+      is_default: false,
+    });
+    await expect(permissions.getByRole('button', { name: /Always allow/ })).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+  });
+
   test('overlapping settings are consolidated into workspace and access', async ({ page, weaver }) => {
     await page.goto(`${weaver.baseUrl}/settings`);
     await expect(page.getByRole('button', { name: 'Workspace', exact: true })).toBeVisible();


### PR DESCRIPTION
## What

- make orphan detection an atomic state transition so a stale monitor snapshot cannot resurrect an archived session
- return focus to the ACP chat composer after Enter submits a message, without stealing focus from another control
- add a registry-backed `agent.mode` workspace default with an Agent settings picker, including an “Always allow” option; explicit create and handoff modes still win
- synchronize the disconnected-handoff regression test at the completed idle lifecycle edge so its durable queue setup cannot race the old task

## Why

A merged PR could successfully tear down its agent yet remain visible as orphaned because the monitor wrote from a stale pre-archive snapshot. The adjacent UX changes keep rapid chat input fluid and let operators choose the default permission posture for new ACP sessions and handoffs from the settings screen.