### PR TITLE
fix(loom): preserve reads during sqlite write contention

### DIFF
--- a/crates/weaver-core/src/db.rs
+++ b/crates/weaver-core/src/db.rs
@@ -191,6 +191,8 @@ async fn migrate(pool: &Db) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future::Future;
+    use std::task::Poll;
 
     /// Regression: the on-disk pool must serve a fully-migrated schema on every
     /// connection. A schema-changing migration once left some pooled connections
@@ -255,17 +257,30 @@ mod tests {
     async fn waiting_writers_do_not_starve_reads() {
         let dir = tempfile::tempdir().unwrap();
         let db = connect(&dir.path().join("weaver.db")).await.unwrap();
+
+        // Pre-open the whole pool so polling each waiter once gets as far as
+        // the writer lock rather than pausing to establish a connection.
+        let mut connections = Vec::new();
+        for _ in 0..5 {
+            connections.push(db.acquire().await.unwrap());
+        }
+        drop(connections);
+
         let writer = begin_immediate(&db).await.unwrap();
 
-        let mut waiters = Vec::new();
-        for _ in 0..4 {
-            let db = db.clone();
-            waiters.push(tokio::spawn(async move {
-                let tx = begin_immediate(&db).await.unwrap();
-                tx.commit().await.unwrap();
-            }));
+        let mut waiters = (0..4)
+            .map(|_| Box::pin(begin_immediate(&db)))
+            .collect::<Vec<_>>();
+        for waiter in &mut waiters {
+            std::future::poll_fn(|cx| {
+                assert!(
+                    waiter.as_mut().poll(cx).is_pending(),
+                    "writer unexpectedly acquired SQLite's lock"
+                );
+                Poll::Ready(())
+            })
+            .await;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let read = tokio::time::timeout(
             std::time::Duration::from_millis(250),
@@ -275,7 +290,7 @@ mod tests {
 
         writer.commit().await.unwrap();
         for waiter in waiters {
-            waiter.await.unwrap();
+            waiter.await.unwrap().commit().await.unwrap();
         }
         assert!(
             read.is_ok(),

--- a/crates/weaver-core/src/db.rs
+++ b/crates/weaver-core/src/db.rs
@@ -1,10 +1,52 @@
 use anyhow::{Context, Result};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
-use sqlx::SqlitePool;
+use sqlx::{Sqlite, SqliteConnection, SqlitePool, Transaction};
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use tokio::sync::{Mutex, MutexGuard};
 
 pub type Db = SqlitePool;
+
+// SQLite permits one writer at a time. Coordinate multi-statement writers
+// before they check out a pooled connection: relying on SQLite's busy handler
+// lets every contender occupy a connection while it waits, which can exhaust
+// the pool and make unrelated dashboard reads look hung.
+static WRITE_LOCK: Mutex<()> = Mutex::const_new(());
+
+/// A SQLite write transaction holding the process-wide writer permit.
+///
+/// The permit is released after the transaction is committed, rolled back, or
+/// dropped. Dereferencing exposes the connection so existing sqlx query calls
+/// can execute with `&mut *tx`.
+pub struct ImmediateTransaction<'a> {
+    tx: Transaction<'a, Sqlite>,
+    _writer: MutexGuard<'static, ()>,
+}
+
+impl Deref for ImmediateTransaction<'_> {
+    type Target = SqliteConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.tx
+    }
+}
+
+impl DerefMut for ImmediateTransaction<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.tx
+    }
+}
+
+impl ImmediateTransaction<'_> {
+    pub async fn commit(self) -> sqlx::Result<()> {
+        self.tx.commit().await
+    }
+
+    pub async fn rollback(self) -> sqlx::Result<()> {
+        self.tx.rollback().await
+    }
+}
 
 /// Root directory for all weaver state on this machine.
 pub fn weaver_home() -> PathBuf {
@@ -127,10 +169,17 @@ pub async fn connect_in_memory() -> Result<Db> {
 /// Open a write transaction that takes SQLite's write lock up front
 /// (`BEGIN IMMEDIATE`). A default deferred transaction starts as a reader and
 /// upgrades on its first write — and an upgrade that loses the race fails with
-/// SQLITE_BUSY *immediately*, bypassing the connection's `busy_timeout`. Every
-/// multi-statement write path begins here so it waits its turn instead.
-pub async fn begin_immediate(db: &Db) -> sqlx::Result<sqlx::Transaction<'_, sqlx::Sqlite>> {
-    db.begin_with("BEGIN IMMEDIATE").await
+/// SQLITE_BUSY *immediately*, bypassing the connection's `busy_timeout`.
+///
+/// Contenders queue on [`WRITE_LOCK`] before acquiring a pool connection. This
+/// preserves read capacity while writes wait for SQLite's single writer slot.
+pub async fn begin_immediate(db: &Db) -> sqlx::Result<ImmediateTransaction<'static>> {
+    let writer = WRITE_LOCK.lock().await;
+    let tx = db.begin_with("BEGIN IMMEDIATE").await?;
+    Ok(ImmediateTransaction {
+        tx,
+        _writer: writer,
+    })
 }
 
 /// Apply pending schema migrations. The migration framework (ordered SQL files
@@ -198,5 +247,39 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(n, 1);
+    }
+
+    /// Waiting for SQLite's single writer must not consume every pooled
+    /// connection. Dashboard reads should remain available while writes queue.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn waiting_writers_do_not_starve_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = connect(&dir.path().join("weaver.db")).await.unwrap();
+        let writer = begin_immediate(&db).await.unwrap();
+
+        let mut waiters = Vec::new();
+        for _ in 0..4 {
+            let db = db.clone();
+            waiters.push(tokio::spawn(async move {
+                let tx = begin_immediate(&db).await.unwrap();
+                tx.commit().await.unwrap();
+            }));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let read = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            sqlx::query_scalar::<_, i64>("SELECT 1").fetch_one(&db),
+        )
+        .await;
+
+        writer.commit().await.unwrap();
+        for waiter in waiters {
+            waiter.await.unwrap();
+        }
+        assert!(
+            read.is_ok(),
+            "writer contention exhausted the pool and blocked an unrelated read"
+        );
     }
 }

--- a/crates/weaver-core/src/db.rs
+++ b/crates/weaver-core/src/db.rs
@@ -275,7 +275,7 @@ mod tests {
             std::future::poll_fn(|cx| {
                 assert!(
                     waiter.as_mut().poll(cx).is_pending(),
-                    "writer unexpectedly acquired SQLite's lock"
+                    "waiter unexpectedly acquired SQLite's writer lock"
                 );
                 Poll::Ready(())
             })
@@ -283,7 +283,7 @@ mod tests {
         }
 
         let read = tokio::time::timeout(
-            std::time::Duration::from_millis(250),
+            std::time::Duration::from_secs(1),
             sqlx::query_scalar::<_, i64>("SELECT 1").fetch_one(&db),
         )
         .await;


### PR DESCRIPTION
Serialize immediate SQLite transactions before they acquire a pooled connection. This keeps writer contention from consuming all five connections and stalling unrelated dashboard reads while retaining busy-timeout retry behavior.\n\nAdd a deterministic regression that holds the active writer, queues enough contenders to exhaust the old pool, and verifies a read remains available.