### PR TITLE
feat(loom): separate automation sessions from the user workspace (phase 1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -294,8 +294,7 @@ EOF
 # (current_exe dir + /tapestry), so the two must land in the same directory.
 COPY --from=build /out/loom     /usr/local/bin/loom
 COPY --from=build /out/tapestry /usr/local/bin/tapestry
-# `weaver` is the agent-facing CLI — kept on PATH for `docker exec weaver
-# weaver config set …` (settings live in the shared sqlite db).
+# `weaver` is the agent-facing CLI loom injects into every session's PATH.
 COPY --from=build /out/weaver   /usr/local/bin/weaver
 COPY --from=build /out/dist     /app/static/dist
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Set `server.auto_adopt` to have loom adopt every recoverable session
 automatically on startup (off by default):
 
 ```sh
-weaver config set server.auto_adopt true
+loom config set server.auto_adopt true
 ```
 
 ## GitHub
@@ -256,8 +256,8 @@ same as the Archive button. Turn either behaviour off in **Settings** or from
 the CLI:
 
 ```sh
-weaver config set github.archive_on_merge false   # keep the worktree after merge
-weaver config set github.poll false               # stop polling GitHub entirely
+loom config set github.archive_on_merge false   # keep the worktree after merge
+loom config set github.poll false               # stop polling GitHub entirely
 ```
 
 Polling is a quiet no-op for repositories without a GitHub remote, or wherever
@@ -354,17 +354,17 @@ genuinely remote callers need to present a token or log in.
 ## Configuration
 
 Settings live in the `settings` table of the sqlite database, which only
-`loom` opens directly; `weaver config` reads and writes them over the REST
-API. Each known setting is declared in a registry (`config.rs`) with a
-label, help text, type, and default.
+`loom` opens directly. `weaver config` is read-only — it fetches the current
+values over the REST API. Each known setting is declared in a registry
+(`config.rs`) with a label, help text, type, and default.
 
-Edit them in the **Settings** pane of the web UI, or from the CLI:
+Edit them in the **Settings** pane of the web UI, or write them straight to
+sqlite with `loom config set` (no running server needed):
 
 ```sh
 weaver config ls
 weaver config get agent.default
-weaver config set agent.default codex
-weaver config rm agent.default
+loom config set agent.default codex
 ```
 
 Notable settings:

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -78,6 +78,21 @@ export const uploadSessionScratch = (id: string, file: File) =>
     ScratchFile & { path: string }
   >;
 
+// --- Sessions ----------------------------------------------------------------
+
+/** The fleet: every session, optionally widened past the two default-hidden
+ *  categories. `archived` includes torn-down sessions; `automation` includes
+ *  agent/system-launched sessions (`class: 'automation'`) — background work a
+ *  person didn't start, hidden from the fleet list by default. Symmetric flags,
+ *  both off by default (`GET /api/sessions`). */
+export const listSessions = (opts: { archived?: boolean; automation?: boolean } = {}) => {
+  const params = new URLSearchParams();
+  if (opts.archived) params.set('archived', 'true');
+  if (opts.automation) params.set('automation', 'true');
+  const qs = params.toString();
+  return get(`/sessions${qs ? `?${qs}` : ''}`) as Promise<Session[]>;
+};
+
 // --- Issues ----------------------------------------------------------------
 
 import type {
@@ -188,9 +203,16 @@ export const deleteCustomAgent = (name: string) =>
   );
 
 /** Every issue across every repo — the Issues pane's cross-repo board. Pass
- *  `all` to include closed issues. */
-export const listIssues = (all = false) =>
-  get(`/issues${all ? '?all=true' : ''}`) as Promise<Issue[]>;
+ *  `all` to include closed issues, `automation` to include issues claimed by an
+ *  automation-class session (hidden by default, symmetric with `archived` on
+ *  `listSessions`). */
+export const listIssues = (all = false, automation = false) => {
+  const params = new URLSearchParams();
+  if (all) params.set('all', 'true');
+  if (automation) params.set('automation', 'true');
+  const qs = params.toString();
+  return get(`/issues${qs ? `?${qs}` : ''}`) as Promise<Issue[]>;
+};
 
 /** Launch a new loom session that picks up (claims) an existing weaver issue:
  *  the issue's repo is the new session's cwd, and the backend seeds the branch's

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -206,10 +206,10 @@ export const deleteCustomAgent = (name: string) =>
  *  `all` to include closed issues, `automation` to include issues claimed by an
  *  automation-class session (hidden by default, symmetric with `archived` on
  *  `listSessions`). */
-export const listIssues = (all = false, automation = false) => {
+export const listIssues = (opts: { all?: boolean; automation?: boolean } = {}) => {
   const params = new URLSearchParams();
-  if (all) params.set('all', 'true');
-  if (automation) params.set('automation', 'true');
+  if (opts.all) params.set('all', 'true');
+  if (opts.automation) params.set('automation', 'true');
   const qs = params.toString();
   return get(`/issues${qs ? `?${qs}` : ''}`) as Promise<Issue[]>;
 };

--- a/crates/loom/frontend/src/components/StatusBar.vue
+++ b/crates/loom/frontend/src/components/StatusBar.vue
@@ -12,7 +12,12 @@ import { useFleet } from '../lib/sessionsStore';
 const { sessions, online } = useFleet();
 const clock = ref('');
 
-const live = computed(() => sessions.value.filter((s) => s.status !== 'archived'));
+// Automation-class sessions (agent/github/slack/watch/actions/ops launched)
+// stay out of the fleet vitals by default, same as archived — a background
+// session shouldn't move the "N sessions" count a person reads at a glance.
+const live = computed(() =>
+  sessions.value.filter((s) => s.status !== 'archived' && s.class !== 'automation'),
+);
 const needsMe = computed(
   () => live.value.filter((s) => effectiveAttention(s).level !== 'ok').length,
 );

--- a/crates/loom/frontend/src/lib/sessionsStore.ts
+++ b/crates/loom/frontend/src/lib/sessionsStore.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { get } from '../api';
+import { listSessions } from '../api';
 import type { Session } from '../types';
 
 // One shared snapshot of the fleet. The session list, the status bar, and the
@@ -20,14 +20,15 @@ const online = ref(true);
 
 let inflight: Promise<void> | null = null;
 
-// Pull the whole fleet, archived included — the superset the list's archive
-// toggle needs (the status bar just filters archived out locally). Concurrent
-// callers coalesce onto the one in-flight request.
+// Pull the whole fleet, archived and automation-class sessions included — the
+// superset the list's archive/automation toggles need (the status bar and the
+// list itself just filter each out locally). Concurrent callers coalesce onto
+// the one in-flight request.
 async function refresh(): Promise<void> {
   if (inflight) return inflight;
   inflight = (async () => {
     try {
-      sessions.value = (await get('/sessions?archived=true')) as Session[];
+      sessions.value = await listSessions({ archived: true, automation: true });
       online.value = true;
     } catch {
       // Keep the last good snapshot; the status bar's offline dot says why.

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -94,8 +94,18 @@ export interface Session {
    *  a security boundary: the fleet stays co-owned by everyone authenticated. */
   created_by: string | null;
   /** The tracking issue opened for this session's task at launch (the handle
-   *  the launcher follows). Only set on the create response. */
+   *  the launcher follows). Populated on every read. */
   tracking_issue: number | null;
+  /** Who/what launched this session: `user` (the New Session drawer or the CLI)
+   *  or an automation surface — `agent`, `github`, `slack`, `watch`, `actions`,
+   *  `ops`. Drives the origin pill on an automation-class row. */
+  origin: string;
+  /** `interactive` (a person's own session) or `automation` (agent/system
+   *  launched). Automation-class sessions are excluded from the default fleet
+   *  list and issue board — the Automation toggle reveals them. */
+  class: string;
+  /** Total agent turns run so far. */
+  turn_count: number;
   /** Manual park override for the fleet list's resting shelf: `'parked'` pins the
    *  row to the shelf, `'active'` keeps it live even when idle, `null` = auto (the
    *  client shelves it once idle past the threshold). Set by dragging a row

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, computed, nextTick, onMounted, onActivated } from 'vue';
 import { useRouter } from 'vue-router';
 import {
-  get,
+  listSessions,
   listIssues,
   createRepoIssue,
   patchIssue,
@@ -40,6 +40,10 @@ const error = ref('');
 // Client-side filters over the full (all-status) fetch — at fleet scale the
 // whole board is a cheap single GET, so toggles never re-hit the server.
 const showClosed = ref(false);
+// Issues claimed by an automation-class session (a background agent/watch/
+// trigger, not a person) are hidden by default — same shape as showClosed —
+// so the board reads as the human backlog unless asked to widen.
+const showAutomation = ref(false);
 const search = ref('');
 const repoFilter = ref('');
 
@@ -56,12 +60,13 @@ const busy = reactive<Record<number, boolean>>({});
 
 async function load() {
   try {
-    // Fetch everything (including closed issues / archived sessions) once;
-    // `showClosed` filters client-side, and archived sessions still reference
-    // their issues. The API hides archived by default, so ask for them.
+    // Fetch everything (including closed issues, archived sessions, and
+    // automation-claimed issues/sessions) once; `showClosed`/`showAutomation`
+    // filter client-side. The API hides archived and automation by default, so
+    // ask for both.
     const [iss, ses] = await Promise.all([
-      listIssues(true),
-      get('/sessions?archived=true') as Promise<Session[]>,
+      listIssues(true, true),
+      listSessions({ archived: true, automation: true }),
     ]);
     issues.value = iss;
     sessions.value = ses;
@@ -192,6 +197,7 @@ const visible = computed(() => {
   const q = search.value.trim().toLowerCase();
   return issues.value.filter((i) => {
     if (!showClosed.value && i.status !== 'open') return false;
+    if (!showAutomation.value && isAutomationClaimed(i)) return false;
     if (repoFilter.value && i.repo_root !== repoFilter.value) return false;
     if (!q) return true;
     const hay = [`#${i.id}`, i.title, i.body, ...i.tags.map((t) => `${t.key} ${t.value}`)]
@@ -217,6 +223,16 @@ const sessionsByBranch = computed(() => {
   }
   return m;
 });
+
+// An issue is automation-claimed when the session working it (`claimed_branch`)
+// is an automation-class session — a background agent/watch/trigger, not a
+// person. Mirrors the server's own default-hide rule (`GET /api/issues`).
+function isAutomationClaimed(i: Issue): boolean {
+  if (!i.claimed_branch) return false;
+  return (sessionsByBranch.value.get(`${i.repo_root}\0${i.claimed_branch}`) ?? []).some(
+    (s) => s.class === 'automation',
+  );
+}
 
 // Sessions that reference an issue: the branch working it (claimed) and the
 // branch it came from (source), matched against the live session list by
@@ -377,6 +393,15 @@ async function removeTag(i: Issue, key: string) {
             data-testid="issues-show-closed"
           />
           Show closed
+        </label>
+        <label class="flex items-center gap-1.5 text-xs text-muted">
+          <input
+            v-model="showAutomation"
+            type="checkbox"
+            class="accent-accent"
+            data-testid="issues-show-automation"
+          />
+          Show automation
         </label>
         <button
           type="button"

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -224,14 +224,20 @@ const sessionsByBranch = computed(() => {
   return m;
 });
 
-// An issue is automation-claimed when the session working it (`claimed_branch`)
-// is an automation-class session — a background agent/watch/trigger, not a
-// person. Mirrors the server's own default-hide rule (`GET /api/issues`).
+// An issue is automation-claimed when the session *currently* working its
+// branch (`claimed_branch`) is automation-class — the branch's active session
+// if one exists, else its most recently created. Archiving frees the branch
+// slot, so an archived automation run must not hide an issue a person has
+// since picked up on the re-let branch. Mirrors the server's own default-hide
+// rule (`GET /api/issues`).
 function isAutomationClaimed(i: Issue): boolean {
   if (!i.claimed_branch) return false;
-  return (sessionsByBranch.value.get(`${i.repo_root}\0${i.claimed_branch}`) ?? []).some(
-    (s) => s.class === 'automation',
-  );
+  const held = sessionsByBranch.value.get(`${i.repo_root}\0${i.claimed_branch}`) ?? [];
+  const active = (s: Session) => !['done', 'error', 'archived'].includes(s.status);
+  const holder = [...held].sort(
+    (a, b) => Number(active(b)) - Number(active(a)) || b.created_at.localeCompare(a.created_at),
+  )[0];
+  return holder?.class === 'automation';
 }
 
 // Sessions that reference an issue: the branch working it (claimed) and the

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -65,7 +65,7 @@ async function load() {
     // filter client-side. The API hides archived and automation by default, so
     // ask for both.
     const [iss, ses] = await Promise.all([
-      listIssues(true, true),
+      listIssues({ all: true, automation: true }),
       listSessions({ archived: true, automation: true }),
     ]);
     issues.value = iss;

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -67,7 +67,27 @@ function setFilter(f: AttentionFilter) {
 // so the list never reads as empty while archived rows exist.
 const showArchived = ref(false);
 
-const archivedCount = computed(() => sessions.value.filter((s) => s.status === 'archived').length);
+// Automation-class sessions (agent/github/slack/watch/actions/ops launched —
+// see docs/loom-ui.md) are a background fleet, not the one a person is minding.
+// Hidden by default, same shape as the archived toggle below: a reveal chip
+// brings them back as ordinary cards (see the origin pill on the row).
+const showAutomation = ref(false);
+const automationCount = computed(
+  () => sessions.value.filter((s) => s.class === 'automation').length,
+);
+
+// The automation-aware base: every session when the toggle is on, else the
+// fleet minus automation-class rows. Everything downstream (archived count,
+// visible rows, filter-pill counts) reads through this so automation stays
+// fully invisible — not just hidden from the list, but from the tallies too —
+// until a person asks to see it.
+const filteredBase = computed<Session[]>(() =>
+  showAutomation.value ? sessions.value : sessions.value.filter((s) => s.class !== 'automation'),
+);
+
+const archivedCount = computed(
+  () => filteredBase.value.filter((s) => s.status === 'archived').length,
+);
 
 // The archived-aware, filtered set to display (membership only — the tree below
 // imposes the order). Archived rows are hidden by default; a reveal chip brings
@@ -77,7 +97,7 @@ const archivedCount = computed(() => sessions.value.filter((s) => s.status === '
 // contains attention floats up (see treeRows), and attention rows carry their
 // loud signal chip, so they stay easy to spot.
 const visibleSessions = computed<Session[]>(() => {
-  const all = sessions.value;
+  const all = filteredBase.value;
   const live = all.filter((s) => s.status !== 'archived');
   const base = showArchived.value || live.length === 0 ? all : live;
   if (filter.value === 'attention') return base.filter((s) => effectiveAttention(s).level !== 'ok');
@@ -85,12 +105,13 @@ const visibleSessions = computed<Session[]>(() => {
   return base;
 });
 
-// Counts reflect the full fleet (NOT the archived-hidden view) so the filter
-// chips read the true picture; effectiveAttention() already forces archived → ok
-// and ignores stale watch marks, keeping "needs attention" honest.
+// Counts reflect the full fleet (NOT the archived-hidden view, but automation-
+// aware) so the filter chips read the true picture; effectiveAttention()
+// already forces archived → ok and ignores stale watch marks, keeping "needs
+// attention" honest.
 const counts = computed(() => {
-  const c = { all: sessions.value.length, attention: 0, ok: 0 };
-  for (const s of sessions.value) {
+  const c = { all: filteredBase.value.length, attention: 0, ok: 0 };
+  for (const s of filteredBase.value) {
     if (effectiveAttention(s).level === 'ok') c.ok += 1;
     else c.attention += 1; // 'attention' and 'blocked' both need a human
   }
@@ -393,7 +414,7 @@ async function handleCreated() {
            Each segment pairs a label with its count in a small pill so the
            number reads as a count, not a suffix glued to the word. -->
       <div
-        v-if="sessions.length"
+        v-if="filteredBase.length"
         class="inline-flex overflow-hidden rounded border border-line text-xs"
       >
         <button
@@ -434,6 +455,22 @@ async function handleCreated() {
         {{ showArchived ? 'Hide' : 'Show' }} {{ archivedCount }} archived
       </button>
 
+      <!-- Automation-class sessions live below the fold too: same anatomy as
+           the archived chip, right alongside it. -->
+      <button
+        v-if="automationCount"
+        type="button"
+        :aria-pressed="showAutomation"
+        data-testid="automation-toggle"
+        :class="[
+          'rounded border border-line px-2.5 py-1 text-xs text-muted transition-colors',
+          showAutomation ? 'bg-subtle text-fg' : 'bg-input hover:bg-subtle',
+        ]"
+        @click="showAutomation = !showAutomation"
+      >
+        {{ showAutomation ? 'Hide' : 'Show' }} {{ automationCount }} automation
+      </button>
+
       <!-- Toggles the create form. Closed → primary (accent) call-to-action;
            open → a neutral "Cancel" so it never reads as a second primary
            action competing with the form's own Create button. -->
@@ -468,7 +505,7 @@ async function handleCreated() {
     </div>
 
     <div
-      v-if="!sessions.length"
+      v-if="!filteredBase.length"
       class="rounded-md border border-dashed border-line p-6 text-center"
     >
       <p class="text-sm text-muted">No sessions yet.</p>
@@ -495,7 +532,7 @@ async function handleCreated() {
     <!-- Every session is resting — the live list is empty but the fleet isn't.
          Point at the shelf below rather than reading as "no sessions". -->
     <p
-      v-if="sessions.length && !liveRows.length"
+      v-if="filteredBase.length && !liveRows.length"
       class="rounded-md border border-dashed border-line px-4 py-3 text-center font-serif text-[13px] italic text-muted"
     >
       All sessions are resting on the shelf below.
@@ -576,6 +613,17 @@ async function handleCreated() {
             >
               {{ s.branch.title || s.branch.name }}
             </router-link>
+            <!-- Origin: the automation surface that launched this session
+                 (github, slack, watch, actions, ops) — a quiet identity pill,
+                 shown only for a non-human origin so an ordinary session
+                 (`user`) stays unmarked. -->
+            <span
+              v-if="s.origin && s.origin !== 'user'"
+              class="tag-pill"
+              data-testid="origin-pill"
+              :title="`origin: ${s.origin}`"
+              >{{ s.origin }}</span
+            >
             <!-- Loud signals: the agent's `attention` and a watch's
                  `triage`, each a deletable chip. The × clears that tag (calm is
                  its absence) — there is no separate "Mark OK" verb. -->
@@ -758,6 +806,13 @@ async function handleCreated() {
               >
                 {{ s.branch.title || s.branch.name }}
               </router-link>
+              <span
+                v-if="s.origin && s.origin !== 'user'"
+                class="tag-pill"
+                data-testid="origin-pill"
+                :title="`origin: ${s.origin}`"
+                >{{ s.origin }}</span
+              >
               <span class="meta-chip !text-[10px] uppercase tracking-wide text-info">{{
                 parkLabel(s)
               }}</span>

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -61,6 +61,8 @@ use crate::db::{now_iso, Db};
 use crate::session;
 use crate::web::AppState;
 use weaver_api::{AcpCost, AcpUsage};
+use weaver_core::config as core_config;
+use weaver_core::tags;
 use wire::{
     method, Incoming, IncomingKind, PermissionOption, RequestPermissionParams, SessionNotification,
     SessionUpdate, ToolCall, ToolCallContent, ToolCallLocation,
@@ -358,6 +360,20 @@ impl AcpRegistry {
         if inner.map.get(session_id).map(|(g, _)| *g) == Some(generation) {
             inner.map.remove(session_id);
         }
+    }
+
+    /// Whether `generation` is still the registered task for `session_id`.
+    /// `stop` drops the handle without aborting the task future, so a stopped
+    /// or superseded task can linger on a final turn boundary; it must not
+    /// consume shared durable state (the prompt queue) its successor owns.
+    fn is_current(&self, session_id: &str, generation: u64) -> bool {
+        self.inner
+            .lock()
+            .unwrap()
+            .map
+            .get(session_id)
+            .map(|(g, _)| *g)
+            == Some(generation)
     }
 }
 
@@ -1455,6 +1471,17 @@ impl Task {
     }
 
     async fn dispatch_pending_prompt(&mut self) {
+        // A lingering superseded task's deferred turn boundary can fire after a
+        // handoff has re-let the session; letting it drain the queue would lose
+        // the prompt against its dead relay.
+        if !self.registry.is_current(&self.session_id, self.generation) {
+            return;
+        }
+        // The cap gate runs before the durable queue is consumed, so a refused
+        // dispatch keeps the prompt queued and visible instead of dropping it.
+        if self.refuse_if_turn_capped().await.is_err() {
+            return;
+        }
         // Consuming the durable copy is a precondition for dispatch. Starting a
         // turn after a failed clear leaves the same text eligible at every later
         // boundary and turns one SQLite error into an unbounded replay loop.
@@ -1627,6 +1654,11 @@ impl Task {
     }
 
     async fn start_pending_prompt(&mut self, by: Option<String>) -> Result<PromptAck> {
+        if !self.registry.is_current(&self.session_id, self.generation) {
+            bail!("session task was superseded");
+        }
+        // Gate before consuming the durable copy so a capped session keeps it.
+        self.refuse_if_turn_capped().await?;
         let pending = session::take_pending_prompt(&self.db, &self.session_id)
             .await?
             .ok_or_else(|| anyhow!("there is no queued feedback to send"))?;
@@ -1724,6 +1756,66 @@ impl Task {
             .await
     }
 
+    /// Refuse to open a new turn once an automation-class session has spent its
+    /// `automation.turn_cap` turns: make sure the branch carries the loud
+    /// `blocked` attention tag (recorded on the bus so it lands on SSE) and
+    /// return the refusal as an error. Warm (watch-managed) sessions are exempt
+    /// infrastructure and 0 disables the cap. Only *new* turns are gated — an
+    /// in-flight turn is never interrupted. Best-effort reads: a lookup failure
+    /// never blocks a turn.
+    async fn refuse_if_turn_capped(&self) -> Result<()> {
+        let Some(session) = session::get(&self.db, &self.session_id)
+            .await
+            .ok()
+            .flatten()
+        else {
+            return Ok(());
+        };
+        if session.class != "automation" || session.managed_by.is_some() {
+            return Ok(());
+        }
+        let cap = core_config::get(&self.db, "automation.turn_cap")
+            .await
+            .and_then(|v| v.trim().parse::<i64>().ok())
+            .unwrap_or(core_config::DEFAULT_AUTOMATION_TURN_CAP);
+        if cap <= 0 || session.turn_count < cap {
+            return Ok(());
+        }
+        let note = format!("turn cap ({cap}) reached");
+        tracing::info!(
+            session = %self.session_id,
+            turn_count = session.turn_count,
+            "refusing new acp turn: {note}"
+        );
+        let already_blocked = tags::get(&self.db, &session.branch_id, tags::ATTENTION_KEY)
+            .await
+            .ok()
+            .flatten()
+            .is_some_and(|t| t.value == "blocked");
+        if !already_blocked {
+            let _ = tags::set(
+                &self.db,
+                &session.branch_id,
+                tags::ATTENTION_KEY,
+                "blocked",
+                &note,
+                "agent",
+            )
+            .await;
+            let _ = crate::events::record_tag(
+                &self.db,
+                &self.bus,
+                &session.branch_id,
+                tags::ATTENTION_KEY,
+                "blocked",
+                &note,
+                "agent",
+            )
+            .await;
+        }
+        bail!("{note}")
+    }
+
     async fn start_turn_with_block(
         &mut self,
         text: String,
@@ -1731,6 +1823,9 @@ impl Task {
         opening_kind: &str,
         opening_payload: Value,
     ) -> Result<()> {
+        // The cap gate sits before any turn state advances, so a refusal leaves
+        // the counters, the journal, and any queued prompt untouched.
+        self.refuse_if_turn_capped().await?;
         if self.turns_dispatched > 0 {
             self.current_turn += 1;
             self.next_seq = 0;

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -133,8 +133,8 @@ enum Cmd {
 
     /// The typed `loom.toml` `loom setup` writes and everything derived from
     /// it, plus `set` — a direct-to-sqlite write of the daemon's own runtime
-    /// `settings` table (the same keys `weaver config set` exposes over
-    /// HTTP), with no server required.
+    /// `settings` table (the keys the settings pane exposes over HTTP), with
+    /// no server required.
     ///
     /// `loom.toml` is the single authored source of truth for every
     /// credential/setting — the shared contract a deploy (e.g. the GCP
@@ -479,7 +479,7 @@ struct ConfigPathOpts {
 /// one to override a single invocation without editing the file.
 ///
 /// `set` is a different contract — the runtime `settings` table
-/// (`weaver_core::config::REGISTRY`, the same one `weaver config set` writes
+/// (`weaver_core::config::REGISTRY`, the same one the settings pane writes
 /// over HTTP) rather than `loom.toml` — written straight to the daemon's
 /// sqlite database with no server needed. This is what
 /// `deploy/standalone/docker-compose.yml`'s `loom-init` uses to seed the
@@ -494,7 +494,7 @@ enum ConfigCmd {
     /// echoes a value.
     PushSecrets(PushSecretsOpts),
     /// Set a runtime setting directly in the sqlite `settings` table — no
-    /// running server needed (unlike `weaver config set`, which needs one).
+    /// running server needed.
     Set {
         /// Dotted key, e.g. `auth.cookie_secure` (see the settings pane, or
         /// `weaver_core::config::REGISTRY`, for the full list).
@@ -1583,9 +1583,9 @@ async fn run_config(cmd: ConfigCmd) -> Result<()> {
 
 /// `loom config set` — write one runtime setting straight into the sqlite
 /// `settings` table, no running server needed. The direct-db counterpart to
-/// `weaver config set`, which does the same thing over `PATCH /api/settings`
-/// against a running daemon — the form a deploy's boot sequence needs, since
-/// it must seed the auth settings *before* loom starts listening.
+/// the settings pane's `PATCH /api/settings` against a running daemon — the
+/// form a deploy's boot sequence needs, since it must seed the auth settings
+/// *before* loom starts listening.
 async fn cmd_config_set(key: String, value: String) -> Result<()> {
     if let Err(why) = weaver_core::config::validate(&key, &value) {
         bail!("{key}: {why}");

--- a/crates/loom/src/chat.rs
+++ b/crates/loom/src/chat.rs
@@ -467,6 +467,9 @@ mod tests {
                 managed_by: None,
                 created_by: None,
                 protocol: "acp".to_string(),
+                origin: "user".to_string(),
+                class: "interactive".to_string(),
+                tracking_issue_id: None,
             },
         )
         .await

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -49,10 +49,26 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- the midpoint of its neighbours on drag). Shares one numeric axis with the
     -- derived auto-order so manually-placed and untouched rows interleave.
     sort_order         REAL,
+    -- How this session came to exist: 'user' (hand-launched), 'agent'
+    -- (delegated by another session), 'github' / 'slack' (chat triggers),
+    -- 'watch' (engine infrastructure). Stamped once at create.
+    origin             TEXT NOT NULL DEFAULT 'user',
+    -- Presentation tier: 'interactive' fleet work or 'automation' machinery,
+    -- which the fleet listing hides unless asked. Derived from origin at create
+    -- (watch/actions/ops -> automation), overridable per request.
+    class              TEXT NOT NULL DEFAULT 'interactive',
+    -- Completed agent turns on this session, incremented at each turn boundary.
+    turn_count         INTEGER NOT NULL DEFAULT 0,
+    -- The weaver issue opened (or claimed) as this session's tracker at launch,
+    -- or NULL when the launch tracked nothing.
+    tracking_issue_id  INTEGER,
     created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
+-- Archived counts as terminal here: an archived session keeps its history row
+-- but no longer occupies the branch slot, so a fresh session can attach to the
+-- same branch.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_active_branch
-    ON sessions(branch_id) WHERE status NOT IN ('done', 'error');
+    ON sessions(branch_id) WHERE status NOT IN ('done', 'error', 'archived');
 
 CREATE TABLE IF NOT EXISTS recent_repos (
     repo_root    TEXT PRIMARY KEY,
@@ -365,6 +381,52 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
         "TEXT NOT NULL DEFAULT ''",
     )
     .await?;
+    // Session provenance + class (see the `sessions` schema above). Backfilled
+    // only when the column was freshly added — the rows predating it are the
+    // ones whose origin must be reconstructed from the old heuristics: an
+    // engine-managed (warm) session is watch machinery, and a session with a
+    // recorded launcher was delegated by an agent.
+    let origin_added =
+        add_column_if_missing(pool, "sessions", "origin", "TEXT NOT NULL DEFAULT 'user'").await?;
+    add_column_if_missing(
+        pool,
+        "sessions",
+        "class",
+        "TEXT NOT NULL DEFAULT 'interactive'",
+    )
+    .await?;
+    add_column_if_missing(pool, "sessions", "turn_count", "INTEGER NOT NULL DEFAULT 0").await?;
+    add_column_if_missing(pool, "sessions", "tracking_issue_id", "INTEGER").await?;
+    if origin_added {
+        sqlx::query(
+            "UPDATE sessions SET origin = 'watch', class = 'automation'
+             WHERE managed_by IS NOT NULL",
+        )
+        .execute(pool)
+        .await
+        .context("backfilling watch session origin")?;
+        sqlx::query(
+            "UPDATE sessions SET origin = 'agent'
+             WHERE origin = 'user' AND parent_branch_id IS NOT NULL",
+        )
+        .execute(pool)
+        .await
+        .context("backfilling agent session origin")?;
+    }
+    // Recreate the one-active-session-per-branch index under its current
+    // predicate (archived no longer occupies the branch slot). `CREATE INDEX IF
+    // NOT EXISTS` above silently keeps an old definition, so drop first; the
+    // predicate indexes strictly fewer rows than any prior one, so recreation
+    // cannot conflict on existing data.
+    sqlx::query("DROP INDEX IF EXISTS idx_sessions_active_branch")
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_active_branch
+         ON sessions(branch_id) WHERE status NOT IN ('done', 'error', 'archived')",
+    )
+    .execute(pool)
+    .await?;
     // The custom agent's execution backend: 'terminal' (a PTY running its launch
     // command) or 'acp' (its launch command is an ACP adapter driven over stdio).
     // Added here for databases created before the column; a fresh DB has it from
@@ -436,15 +498,17 @@ async fn rename_column_if_present(pool: &Db, table: &str, from: &str, to: &str) 
     }
 }
 
-/// Run `ALTER TABLE … ADD COLUMN`, treating an already-present column as success.
-async fn add_column_if_missing(pool: &Db, table: &str, column: &str, decl: &str) -> Result<()> {
+/// Run `ALTER TABLE … ADD COLUMN`, treating an already-present column as
+/// success. Returns whether the column was freshly added (`false` when it
+/// already existed) so a caller can gate a one-time backfill on it.
+async fn add_column_if_missing(pool: &Db, table: &str, column: &str, decl: &str) -> Result<bool> {
     let sql = format!("ALTER TABLE {table} ADD COLUMN {column} {decl}");
     match sqlx::query(&sql).execute(pool).await {
         Ok(_) => {
             tracing::info!(%table, %column, "added column");
-            Ok(())
+            Ok(true)
         }
-        Err(e) if e.to_string().contains("duplicate column name") => Ok(()),
+        Err(e) if e.to_string().contains("duplicate column name") => Ok(false),
         Err(e) => Err(e).with_context(|| format!("adding column {table}.{column}")),
     }
 }

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -1298,6 +1298,9 @@ mod tests {
                 managed_by: None,
                 created_by: None,
                 protocol: "terminal".to_string(),
+                origin: "user".to_string(),
+                class: "interactive".to_string(),
+                tracking_issue_id: None,
             },
         )
         .await

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -18,10 +18,20 @@ use crate::events::EventBus;
 use crate::session::{self as session_mod, Session};
 use crate::web::AppState;
 use crate::{backend, events};
+use weaver_core::branch as branch_mod;
 use weaver_core::config as core_config;
 use weaver_core::tags;
 
 const TICK: Duration = Duration::from_millis(1500);
+
+/// The retention reaper runs at most once every this many monitor ticks
+/// (~90s at the 1.5s tick) — archiving is heavyweight next to the per-tick work.
+const REAP_EVERY_TICKS: u32 = 60;
+
+/// Neither reap trigger fires while the session's last activity is this recent.
+/// Archiving destroys the worktree, so a session that just moved is never
+/// reaped — even when its tracking issue has closed.
+const REAP_GRACE_SECS: i64 = 900;
 
 pub async fn run(state: AppState) {
     let mut screen_hash: HashMap<String, u64> = HashMap::new();
@@ -32,6 +42,8 @@ pub async fn run(state: AppState) {
     let mut stale_seen: HashSet<String> = HashSet::new();
     // Watermark: process every event written after this id, then advance.
     let mut last_event = events::max_id(&state.db).await.unwrap_or(0);
+    // Ticks since the retention reaper last ran (see [`REAP_EVERY_TICKS`]).
+    let mut reap_tick: u32 = 0;
     tracing::info!(tick_ms = TICK.as_millis() as u64, "monitor loop started");
 
     loop {
@@ -160,6 +172,108 @@ pub async fn run(state: AppState) {
 
         screen_hash.retain(|k, _| alive.contains(k));
         stale_seen.retain(|k| alive.contains(k));
+
+        // 3. Retention: reap finished / long-idle automation sessions, on a
+        //    slower cadence than the tick.
+        reap_tick += 1;
+        if reap_tick >= REAP_EVERY_TICKS {
+            reap_tick = 0;
+            reap_automation(&state, &sessions, now).await;
+        }
+    }
+}
+
+/// Why the reaper archives an automation session — [`reap_decision`]'s verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReapReason {
+    /// The tracking issue the session was launched for has been closed.
+    IssueClosed,
+    /// The session sat idle past `automation.idle_archive_secs`.
+    IdleTtl,
+}
+
+/// Whether the reaper may consider `session` at all: automation-class, not a
+/// warm (watch-managed) session — those are exempt infrastructure — and in a
+/// non-terminal status.
+fn reap_candidate(session: &Session) -> bool {
+    session.class == "automation"
+        && session.managed_by.is_none()
+        && matches!(session.status.as_str(), "created" | "running" | "orphaned")
+}
+
+/// The pure reaper verdict for one session. `issue_closed` is the pre-fetched
+/// status of the session's tracking issue (false when it has none), and
+/// `idle_archive_secs <= 0` disables the TTL trigger. Both triggers share a
+/// safety guard: no live ACP turn (`acp_inflight`; a terminal session's only
+/// liveness signal is `last_activity_at` itself) and at least
+/// [`REAP_GRACE_SECS`] of stillness — archiving destroys the worktree, so a
+/// session that just moved is never reaped.
+fn reap_decision(
+    session: &Session,
+    issue_closed: bool,
+    idle_archive_secs: i64,
+    now: DateTime<Utc>,
+) -> Option<ReapReason> {
+    if !reap_candidate(session) || session.acp_inflight.is_some() {
+        return None;
+    }
+    let idle = idle_secs(session, now);
+    if idle < REAP_GRACE_SECS {
+        return None;
+    }
+    if issue_closed {
+        return Some(ReapReason::IssueClosed);
+    }
+    if idle_archive_secs > 0 && idle >= idle_archive_secs {
+        return Some(ReapReason::IdleTtl);
+    }
+    None
+}
+
+/// One reaper pass: archive every automation session [`reap_decision`] convicts,
+/// via the shared archive path (worktree teardown + transcript capture + the
+/// `status` event that lands on SSE). Errors are logged, never fatal to a tick.
+async fn reap_automation(state: &AppState, sessions: &[Session], now: DateTime<Utc>) {
+    let ttl = core_config::get(&state.db, "automation.idle_archive_secs")
+        .await
+        .and_then(|v| v.trim().parse::<i64>().ok())
+        .unwrap_or(core_config::DEFAULT_AUTOMATION_IDLE_ARCHIVE_SECS);
+    for session in sessions {
+        // Only a candidate's tracking issue is worth a lookup.
+        if !reap_candidate(session) {
+            continue;
+        }
+        let issue_closed = match session.tracking_issue_id {
+            Some(issue_id) => match weaver_core::issue::get(&state.db, issue_id).await {
+                Ok(issue) => issue.is_some_and(|i| i.status == "closed"),
+                Err(e) => {
+                    tracing::warn!(id = %session.id, issue = issue_id, error = %e,
+                        "reaper: tracking issue lookup failed");
+                    false
+                }
+            },
+            None => false,
+        };
+        let Some(reason) = reap_decision(session, issue_closed, ttl, now) else {
+            continue;
+        };
+        let branch = match branch_mod::get(&state.db, &session.branch_id).await {
+            Ok(Some(b)) => b,
+            Ok(None) => {
+                tracing::warn!(id = %session.id, branch = %session.branch_id,
+                    "reaper: session's branch row is missing");
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(id = %session.id, error = %e, "reaper: branch lookup failed");
+                continue;
+            }
+        };
+        tracing::info!(id = %session.id, branch = %branch.branch, ?reason,
+            "reaping automation session");
+        if let Err(e) = crate::web::archive(state, session, &branch).await {
+            tracing::warn!(id = %session.id, error = %e.message(), "reaper: archive failed");
+        }
     }
 }
 
@@ -313,6 +427,32 @@ async fn promote_lifecycle(db: &Db, bus: &EventBus, session: &Session, kind: &st
     let mutations = lifecycle_mutations(kind)?;
     let branch_id = session.branch_id.as_str();
 
+    // Turn accounting: every `working` edge is one agent turn, counted for every
+    // session. The cap applies only to automation-class sessions that are not
+    // warm (watch-managed) infrastructure; past it, the branch is marked
+    // `blocked` below instead of returning the attention axis to calm.
+    let mut cap_note: Option<String> = None;
+    if kind == "working" {
+        match session_mod::increment_turn_count(db, &session.id).await {
+            Ok(count) => {
+                let cap = core_config::get(db, "automation.turn_cap")
+                    .await
+                    .and_then(|v| v.trim().parse::<i64>().ok())
+                    .unwrap_or(core_config::DEFAULT_AUTOMATION_TURN_CAP);
+                if cap > 0
+                    && count > cap
+                    && session.class == "automation"
+                    && session.managed_by.is_none()
+                {
+                    cap_note = Some(format!("turn cap ({cap}) reached"));
+                }
+            }
+            Err(e) => {
+                tracing::warn!(id = %session.id, error = %e, "turn count increment failed")
+            }
+        }
+    }
+
     // Lifecycle: alive → running. Idempotent once running; never overrides a
     // terminal state.
     let status_changed = session.status != "running" && !session_mod::is_terminal(&session.status);
@@ -347,6 +487,11 @@ async fn promote_lifecycle(db: &Db, bus: &EventBus, session: &Session, kind: &st
     // and dashboards refresh only on a real edge. The author is `agent` — these
     // are the agent's own lifecycle marks.
     for &(key, value) in mutations {
+        // A capped session owns the attention axis below: don't let the routine
+        // `working` calm-down clear the tag it is about to raise.
+        if cap_note.is_some() && key == tags::ATTENTION_KEY {
+            continue;
+        }
         let current = tags::get(db, branch_id, key)
             .await
             .ok()
@@ -363,6 +508,40 @@ async fn promote_lifecycle(db: &Db, bus: &EventBus, session: &Session, kind: &st
             let _ = tags::set(db, branch_id, key, value, "", "agent").await;
         }
         let _ = events::record_tag(db, bus, branch_id, key, value, "", "agent").await;
+    }
+
+    // Cap enforcement: past the cap an automation session reads as `blocked`, so
+    // the fleet surfaces it instead of letting it burn turns quietly. Set once —
+    // a repeated over-cap edge on an already-blocked branch is a no-op.
+    if let Some(note) = cap_note {
+        let already_blocked = tags::get(db, branch_id, tags::ATTENTION_KEY)
+            .await
+            .ok()
+            .flatten()
+            .is_some_and(|t| t.value == "blocked");
+        if !already_blocked {
+            tracing::info!(id = %session.id, branch = %branch_id, %note,
+                "automation session over its turn cap; marking blocked");
+            let _ = tags::set(
+                db,
+                branch_id,
+                tags::ATTENTION_KEY,
+                "blocked",
+                &note,
+                "agent",
+            )
+            .await;
+            let _ = events::record_tag(
+                db,
+                bus,
+                branch_id,
+                tags::ATTENTION_KEY,
+                "blocked",
+                &note,
+                "agent",
+            )
+            .await;
+        }
     }
 
     // Advance the watermark past our own freshly-recorded events so the next
@@ -448,6 +627,10 @@ mod tests {
             acp_inflight: None,
             current_mode: None,
             pending_prompt: None,
+            origin: "user".to_string(),
+            class: "interactive".to_string(),
+            turn_count: 0,
+            tracking_issue_id: None,
         }
     }
 
@@ -474,6 +657,63 @@ mod tests {
         // An unparseable timestamp is treated as not stale rather than panicking.
         let bad = session_with_activity(Some("not-a-time"), "also-bad");
         assert!(!is_stale(&bad, 0, now));
+    }
+
+    #[test]
+    fn reap_decision_triggers_and_guards() {
+        use super::{reap_decision, ReapReason, REAP_GRACE_SECS};
+        let now = Utc::now();
+        let iso = |t: chrono::DateTime<Utc>| t.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+        let long_ago = iso(now - Duration::hours(9));
+        let ttl = 28800; // the 8h default
+
+        let mut idle = session_with_activity(Some(&long_ago), &long_ago);
+        idle.class = "automation".to_string();
+
+        // Past the TTL → IdleTtl; a closed tracking issue wins even with the
+        // TTL disabled; neither trigger without a closed issue and TTL off.
+        assert_eq!(
+            reap_decision(&idle, false, ttl, now),
+            Some(ReapReason::IdleTtl)
+        );
+        assert_eq!(
+            reap_decision(&idle, true, 0, now),
+            Some(ReapReason::IssueClosed)
+        );
+        assert_eq!(reap_decision(&idle, false, 0, now), None);
+
+        // Past the grace window but under the TTL: kept on the TTL axis, but a
+        // closed tracking issue still reaps it.
+        let mid = iso(now - Duration::seconds(REAP_GRACE_SECS + 60));
+        let mut settled = session_with_activity(Some(&mid), &mid);
+        settled.class = "automation".to_string();
+        assert_eq!(reap_decision(&settled, false, ttl, now), None);
+        assert_eq!(
+            reap_decision(&settled, true, ttl, now),
+            Some(ReapReason::IssueClosed)
+        );
+
+        // The shared guard: recent activity or a live ACP turn blocks BOTH
+        // triggers — archive destroys the worktree.
+        let fresh_at = iso(now - Duration::minutes(5));
+        let mut fresh = session_with_activity(Some(&fresh_at), &fresh_at);
+        fresh.class = "automation".to_string();
+        assert_eq!(reap_decision(&fresh, true, ttl, now), None);
+        let mut inflight = idle.clone();
+        inflight.acp_inflight = Some("{}".to_string());
+        assert_eq!(reap_decision(&inflight, true, ttl, now), None);
+
+        // Not a candidate: interactive class, warm (watch-managed), or already
+        // in a terminal status.
+        let mut interactive = idle.clone();
+        interactive.class = "interactive".to_string();
+        assert_eq!(reap_decision(&interactive, true, ttl, now), None);
+        let mut warm = idle.clone();
+        warm.managed_by = Some("w1".to_string());
+        assert_eq!(reap_decision(&warm, true, ttl, now), None);
+        let mut archived = idle.clone();
+        archived.status = "archived".to_string();
+        assert_eq!(reap_decision(&archived, true, ttl, now), None);
     }
 
     #[test]
@@ -537,6 +777,9 @@ mod tests {
                 managed_by: None,
                 created_by: None,
                 protocol: protocol.to_string(),
+                origin: "user".to_string(),
+                class: "interactive".to_string(),
+                tracking_issue_id: None,
             },
         )
         .await

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -81,10 +81,36 @@ pub struct Session {
     /// NULL (an `Option` only because a legacy row may still hold NULL; treat
     /// `None` and `Some("")` identically). See [`take_pending_prompt`].
     pub pending_prompt: Option<String>,
+    /// How this session came to exist: `"user"` (hand-launched), `"agent"`
+    /// (delegated by another session), `"github"` / `"slack"` (chat triggers),
+    /// `"watch"` (engine infrastructure). Stamped once at create, never
+    /// re-derived.
+    #[serde(default = "default_origin")]
+    pub origin: String,
+    /// Presentation tier: `"interactive"` fleet work or `"automation"`
+    /// machinery, which the default fleet listing hides. Derived from `origin`
+    /// at create (watch/actions/ops → automation), overridable per request.
+    #[serde(default = "default_class")]
+    pub class: String,
+    /// Completed agent turns on this session, advanced at each turn boundary
+    /// via [`increment_turn_count`].
+    #[serde(default)]
+    pub turn_count: i64,
+    /// The weaver issue opened (or claimed) as this session's tracker at
+    /// launch, or `None` when the launch tracked nothing.
+    pub tracking_issue_id: Option<i64>,
 }
 
 fn default_protocol() -> String {
     "terminal".to_string()
+}
+
+fn default_origin() -> String {
+    "user".to_string()
+}
+
+fn default_class() -> String {
+    "interactive".to_string()
 }
 
 /// Session **lifecycle** states — the mechanical, orchestrator-owned axis: is
@@ -128,6 +154,13 @@ pub struct NewSession {
     /// Execution backend, stamped once at create from the resolved agent/override
     /// and immutable thereafter: `"terminal"` or `"acp"`. See [`Session::protocol`].
     pub protocol: String,
+    /// How this session came to exist. See [`Session::origin`].
+    pub origin: String,
+    /// `"interactive"` or `"automation"`. See [`Session::class`].
+    pub class: String,
+    /// The tracking issue opened/claimed for this session's task at launch, or
+    /// `None` when there is nothing to track. See [`Session::tracking_issue_id`].
+    pub tracking_issue_id: Option<i64>,
 }
 
 pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
@@ -141,8 +174,8 @@ pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
         "INSERT INTO sessions
          (id, branch_id, work_dir, term_session, agent_kind, model, effort, status,
           github_repo, parent_branch_id, managed_by, created_by, protocol,
-          last_activity_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          origin, class, tracking_issue_id, last_activity_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&s.id)
     .bind(&s.branch_id)
@@ -157,6 +190,9 @@ pub async fn insert(db: &Db, s: &NewSession) -> Result<Session> {
     .bind(&s.managed_by)
     .bind(&s.created_by)
     .bind(protocol)
+    .bind(&s.origin)
+    .bind(&s.class)
+    .bind(s.tracking_issue_id)
     .bind(&now)
     .bind(&now)
     .execute(db)
@@ -183,11 +219,14 @@ pub async fn get(db: &Db, id: &str) -> Result<Option<Session>> {
     Ok(row)
 }
 
-/// The active (non-terminal) session for a branch, if any.
+/// The active (non-terminal) session for a branch, if any. Archived counts as
+/// terminal here — an archived session keeps its history row but no longer
+/// occupies the branch slot — matching the `idx_sessions_active_branch`
+/// predicate.
 pub async fn active_for_branch(db: &Db, branch_id: &str) -> Result<Option<Session>> {
     let row = sqlx::query_as::<_, Session>(
         "SELECT * FROM sessions
-         WHERE branch_id = ? AND status NOT IN ('done', 'error')
+         WHERE branch_id = ? AND status NOT IN ('done', 'error', 'archived')
          ORDER BY created_at DESC
          LIMIT 1",
     )
@@ -281,6 +320,21 @@ pub async fn set_status(db: &Db, id: &str, status: &str) -> Result<()> {
         "session status changed"
     );
     Ok(())
+}
+
+/// Count one completed agent turn: increment [`Session::turn_count`] and return
+/// the new total. Called at each turn boundary (the monitor's terminal turn
+/// detection, the ACP task's turn end).
+pub async fn increment_turn_count(db: &Db, id: &str) -> Result<i64> {
+    sqlx::query("UPDATE sessions SET turn_count = turn_count + 1 WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+    let count: i64 = sqlx::query_scalar("SELECT turn_count FROM sessions WHERE id = ?")
+        .bind(id)
+        .fetch_one(db)
+        .await?;
+    Ok(count)
 }
 
 pub async fn touch(db: &Db, id: &str) -> Result<()> {
@@ -554,6 +608,9 @@ mod tests {
             managed_by: managed_by.map(str::to_string),
             created_by: None,
             protocol: "terminal".to_string(),
+            origin: "user".to_string(),
+            class: "interactive".to_string(),
+            tracking_issue_id: None,
         }
     }
 

--- a/crates/loom/src/slack.rs
+++ b/crates/loom/src/slack.rs
@@ -843,26 +843,22 @@ async fn launch(
         .ok()
         .flatten();
     if let Some(b) = &existing {
-        if let Ok(Some(sess)) = crate::session::active_for_branch(&state.db, &b.id).await {
-            if sess.status != "archived" {
-                // A live session already owns this thread — don't launch a
-                // second. Ack (👀 on the mention; a note for a slash) and stop.
-                if let Anchor::Mention { event_ts, .. } = &trigger.anchor {
-                    web.add_reaction(&trigger.channel_id, event_ts, "eyes")
-                        .await
-                        .ok();
-                } else {
-                    notify(web, trigger, "Already working on this thread.")
-                        .await
-                        .ok();
-                }
-                return Ok(());
+        // An archived session no longer counts as active, so a thread whose
+        // session was archived falls straight through to a fresh launch on the
+        // kept branch.
+        if let Ok(Some(_)) = crate::session::active_for_branch(&state.db, &b.id).await {
+            // A live session already owns this thread — don't launch a
+            // second. Ack (👀 on the mention; a note for a slash) and stop.
+            if let Anchor::Mention { event_ts, .. } = &trigger.anchor {
+                web.add_reaction(&trigger.channel_id, event_ts, "eyes")
+                    .await
+                    .ok();
+            } else {
+                notify(web, trigger, "Already working on this thread.")
+                    .await
+                    .ok();
             }
-            // A session row that outlived its terminal — retire it (`error`, not
-            // `archived`, so the branch frees for a fresh launch) and fall through.
-            crate::session::set_status(&state.db, &sess.id, "error")
-                .await
-                .ok();
+            return Ok(());
         }
     }
 
@@ -879,7 +875,7 @@ async fn launch(
         req.name = Some(branch_name.clone());
     }
 
-    let view = crate::web::sessions::create_session_core(state.clone(), req, None)
+    let view = crate::web::sessions::create_session_core(state.clone(), req, None, "slack")
         .await
         .map_err(|e| anyhow!("{e:?}"))?;
 

--- a/crates/loom/src/web/issues.rs
+++ b/crates/loom/src/web/issues.rs
@@ -27,6 +27,19 @@ pub(super) struct IssueListQuery {
     all: bool,
 }
 
+/// Query for the cross-repo board: `all` as above, plus the automation opt-in
+/// mirroring `GET /api/sessions?automation=true`.
+#[derive(Debug, Deserialize)]
+pub(super) struct AllIssuesQuery {
+    #[serde(default)]
+    all: bool,
+    /// Include issues claimed by an automation-class session's branch. Defaults
+    /// to `false` — the board shows the work of the interactive fleet, not the
+    /// trackers its machinery opens for itself.
+    #[serde(default)]
+    automation: bool,
+}
+
 /// Build an [`IssueView`] for an issue, gathering its tags (a separate query).
 async fn issue_view(db: &Db, issue: Issue) -> ApiResult<IssueView> {
     let tags = weaver_core::issue::list_tags(db, issue.id).await?;
@@ -45,9 +58,25 @@ async fn issue_views(db: &Db, issues: Vec<Issue>) -> ApiResult<Vec<IssueView>> {
 /// Every issue across every repo — the loom dashboard's cross-repo issue board.
 pub(super) async fn list_all_issues(
     State(st): State<AppState>,
-    Query(q): Query<IssueListQuery>,
+    Query(q): Query<AllIssuesQuery>,
 ) -> ApiResult<Json<Vec<IssueView>>> {
-    let issues = weaver_core::issue::list_all(&st.db, q.all).await?;
+    let mut issues = weaver_core::issue::list_all(&st.db, q.all).await?;
+    if !q.automation {
+        // Branches held by automation-class sessions, as (repo_root, branch)
+        // pairs — issues key their claim by branch name, not branch id.
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT b.repo_root, b.branch FROM sessions s
+             JOIN branches b ON b.id = s.branch_id
+             WHERE s.class = 'automation'",
+        )
+        .fetch_all(&st.db)
+        .await?;
+        let hidden: std::collections::HashSet<(String, String)> = rows.into_iter().collect();
+        issues.retain(|i| match &i.claimed_branch {
+            Some(claimed) => !hidden.contains(&(i.repo_root.clone(), claimed.clone())),
+            None => true,
+        });
+    }
     Ok(Json(issue_views(&st.db, issues).await?))
 }
 

--- a/crates/loom/src/web/issues.rs
+++ b/crates/loom/src/web/issues.rs
@@ -62,12 +62,24 @@ pub(super) async fn list_all_issues(
 ) -> ApiResult<Json<Vec<IssueView>>> {
     let mut issues = weaver_core::issue::list_all(&st.db, q.all).await?;
     if !q.automation {
-        // Branches held by automation-class sessions, as (repo_root, branch)
-        // pairs — issues key their claim by branch name, not branch id.
+        // Branches whose *current* claim-holder is an automation-class session,
+        // as (repo_root, branch) pairs — issues key their claim by branch name,
+        // not branch id. The holder is the branch's active session if one
+        // exists, else its most recently created: archiving frees the branch
+        // slot, so an archived automation run must not hide an issue a person
+        // has since picked up on the re-let branch, while a reaped run with no
+        // successor keeps its issue off the default board.
         let rows: Vec<(String, String)> = sqlx::query_as(
             "SELECT b.repo_root, b.branch FROM sessions s
              JOIN branches b ON b.id = s.branch_id
-             WHERE s.class = 'automation'",
+             WHERE s.class = 'automation'
+               AND s.id = (
+                   SELECT s2.id FROM sessions s2
+                   WHERE s2.branch_id = s.branch_id
+                   ORDER BY (s2.status NOT IN ('done', 'error', 'archived')) DESC,
+                            s2.created_at DESC
+                   LIMIT 1
+               )",
         )
         .fetch_all(&st.db)
         .await?;

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -272,8 +272,7 @@ pub(crate) async fn branch_view(db: &Db, branch: &Branch) -> ApiResult<BranchVie
     ))
 }
 
-/// Build a [`SessionView`] for a session + its branch. `tracking_issue` is left
-/// `None`; only the create path fills it.
+/// Build a [`SessionView`] for a session + its branch.
 pub(crate) async fn session_view(
     db: &Db,
     session: &Session,
@@ -307,7 +306,10 @@ pub(crate) async fn session_view(
         updated_at: branch.updated_at.clone(),
         parent_id: session.parent_branch_id.clone(),
         created_by: session.created_by.clone(),
-        tracking_issue: None,
+        origin: session.origin.clone(),
+        class: session.class.clone(),
+        turn_count: session.turn_count,
+        tracking_issue: session.tracking_issue_id,
         park: session.park.clone(),
         sort_order: session.sort_order,
         protocol: session.protocol.clone(),

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -18,7 +18,7 @@ use crate::session::{self as session_mod, Session};
 use weaver_core::branch as branch_mod;
 
 use super::auth::public_base;
-use super::sessions::create_session_core;
+use super::sessions::{archive, create_session_core};
 use super::{ApiResult, AppError, AppState};
 
 // ---------------------------------------------------------------------------
@@ -395,38 +395,26 @@ async fn handle_trigger(
                 }
                 // The session is active in the DB but its terminal is unreachable —
                 // an orphaned session that outlived its terminal (e.g. a crash the
-                // monitor hasn't marked yet). Retire it with a terminal status so the
-                // branch is free — `error`, not `archived`, because `active_for_branch`
-                // still counts `archived` as active and `create_session_core` would
-                // then reject the branch as busy. Then fall through to launch a fresh
-                // session: the trigger goal already carries this comment and the dead
-                // session's commits are on the branch, so nothing is dropped. The
-                // fresh launch reuses the existing worktree (see `existing_branch`).
+                // monitor hasn't marked yet). Archive it — the shared teardown
+                // captures its chatlog and frees the branch slot (archived no
+                // longer counts as active) — then fall through to launch a fresh
+                // session: the trigger goal already carries this comment and the
+                // dead session's commits are on the branch, so nothing is dropped.
+                // The fresh launch re-provisions the branch's worktree (see
+                // `existing_branch`).
                 tracing::warn!(
                     session = %sess.id,
                     branch = %b.id,
                     repo = %slug.slug(),
-                    "github webhook: session terminal unreachable; retiring it and launching a fresh session"
+                    "github webhook: session terminal unreachable; archiving it and launching a fresh session"
                 );
-                if let Err(e) = session_mod::set_status(&st.db, &sess.id, "error").await {
-                    tracing::warn!(session = %sess.id, error = %e, "github webhook: retiring unreachable session failed");
+                if let Err(e) = archive(&st, &sess, &b).await {
+                    tracing::warn!(session = %sess.id, error = ?e, "github webhook: archiving unreachable session failed");
                     return Err(format!(
-                        "retiring unreachable session {} failed: {e}",
+                        "archiving unreachable session {} failed: {e:?}",
                         sess.id
                     ));
                 }
-                crate::events::record(
-                    &st.db,
-                    &st.bus,
-                    &b.id,
-                    "status",
-                    serde_json::json!({
-                        "status": "error",
-                        "reason": "terminal unreachable when forwarding a new @loom comment; relaunching",
-                    }),
-                )
-                .await
-                .ok();
             }
         }
     }
@@ -455,7 +443,7 @@ async fn handle_trigger(
             req.name = Some(format!("issue-{number}"));
         }
     }
-    let view = match create_session_core(st.clone(), req, Some(username)).await {
+    let view = match create_session_core(st.clone(), req, Some(username), "github").await {
         Ok(v) => v,
         Err(e) => {
             tracing::warn!(repo = %slug.slug(), error = ?e, "github webhook: session create failed");

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -61,6 +61,11 @@ pub(super) struct ListSessionsQuery {
     /// its own "show archived" toggle, opts in with `?archived=true`.
     #[serde(default)]
     archived: bool,
+    /// Include automation-class sessions (watch/ops machinery). Defaults to
+    /// `false` — the fleet listing shows interactive work; a machinery view
+    /// opts in with `?automation=true`, symmetric with `archived`.
+    #[serde(default)]
+    automation: bool,
     /// Case-insensitive substring filter over a session's title, branch name,
     /// and goal (`loom session ls --search auth`). Absent/blank matches everything.
     #[serde(default)]
@@ -97,6 +102,10 @@ pub(super) async fn list_sessions(
         }
         // Archived sessions are torn down — hidden unless the caller opts in.
         if !q.archived && s.status == "archived" {
+            continue;
+        }
+        // Automation-class sessions are machinery — hidden unless asked.
+        if !q.automation && s.class == "automation" {
             continue;
         }
         if let Some(branch) = branch_mod::get(&st.db, &s.branch_id).await? {
@@ -160,8 +169,22 @@ pub(super) async fn create_session(
     // (cookie/token) → their username; a loopback/local-token call → the owner;
     // a future webhook → its bot principal. Read from the `Principal`, never
     // hardcoded and never client-supplied.
+    //
+    // A launch that names a parent branch is an agent delegating work; a plain
+    // launch is the human's own. The GitHub/Slack trigger paths stamp their own
+    // origin at their call sites.
+    let origin = if req
+        .parent_branch
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|s| !s.is_empty())
+    {
+        "agent"
+    } else {
+        "user"
+    };
     Ok(Json(
-        create_session_core(st, req, Some(principal.username)).await?,
+        create_session_core(st, req, Some(principal.username), origin).await?,
     ))
 }
 
@@ -495,18 +518,42 @@ fn tail_chars(s: &str, max: usize) -> String {
 /// the view directly so each caller can shape its own response.
 ///
 /// `created_by` is the launching principal's username (attribution for the shared
-/// board), or `None` for a system launch with no user behind it.
+/// board), or `None` for a system launch with no user behind it. `origin`
+/// records how the launch came to be (`user` / `agent` / `github` / `slack`);
+/// it derives the session's default class.
 pub(crate) async fn create_session_core(
     st: AppState,
     req: CreateReq,
     created_by: Option<String>,
+    origin: &str,
 ) -> ApiResult<SessionView> {
     tracing::info!(
         repo = ?req.repo,
         agent = ?req.agent,
         created_by = ?created_by,
+        origin,
         "create_session_core: starting session creation"
     );
+    // The session's class — automation machinery vs interactive fleet work. An
+    // explicit request value wins (validated); otherwise derived from the origin.
+    let class = match req
+        .class
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some("interactive") => "interactive".to_string(),
+        Some("automation") => "automation".to_string(),
+        Some(other) => {
+            return Err(AppError::bad_request(format!(
+                "invalid class '{other}' (expected 'interactive' or 'automation')"
+            )))
+        }
+        None => match origin {
+            "watch" | "actions" | "ops" => "automation".to_string(),
+            _ => "interactive".to_string(),
+        },
+    };
     // Resolve the repo root. An explicit managed `repo` (a slug/URL) is
     // allowlist-checked and cloned-if-absent into the managed store, then used
     // directly; otherwise fork from `cwd`'s repo (the default). The traversal /
@@ -971,6 +1018,9 @@ pub(crate) async fn create_session_core(
                         managed_by: None,
                         created_by: created_by.clone(),
                         protocol: protocol.clone(),
+                        origin: origin.to_string(),
+                        class: class.clone(),
+                        tracking_issue_id: tracking_issue,
                     },
                 )
                 .await?;
@@ -1012,9 +1062,7 @@ pub(crate) async fn create_session_core(
                 )
                 .await
                 .ok();
-                let mut view = session_view(&st.db, &session, &branch).await?;
-                view.tracking_issue = tracking_issue;
-                return Ok(view);
+                return session_view(&st.db, &session, &branch).await;
             }
         } else {
             tracing::info!(repo = %repo_root.display(),
@@ -1047,6 +1095,9 @@ pub(crate) async fn create_session_core(
         managed_by: None,
         created_by: created_by.clone(),
         protocol: protocol.clone(),
+        origin: origin.to_string(),
+        class: class.clone(),
+        tracking_issue_id: tracking_issue,
     };
     let session = if protocol == "acp" {
         // The ACP path inserts the row *first* — `acp::start` binds a relay to it
@@ -1180,9 +1231,7 @@ pub(crate) async fn create_session_core(
         "session created"
     );
 
-    let mut view = session_view(&st.db, &session, &branch).await?;
-    view.tracking_issue = tracking_issue;
-    Ok(view)
+    session_view(&st.db, &session, &branch).await
 }
 
 /// The session's launch prompt: a pointer to the goal rather than a copy of
@@ -1794,6 +1843,11 @@ pub(crate) async fn create_warm_session(
             // drives the judge by typing into its PTY, a flow the acp prompt
             // queue does not replace yet.
             protocol: "terminal".to_string(),
+            // Engine infrastructure: automation-class, so even a warm session
+            // that loses its `managed_by` stamp stays out of the fleet listing.
+            origin: "watch".to_string(),
+            class: "automation".to_string(),
+            tracking_issue_id: None,
         },
     )
     .await?;
@@ -1807,6 +1861,27 @@ pub(crate) async fn create_warm_session(
     Ok(session)
 }
 
+/// Guard for [`adopt`] and [`recover`]: 409 when a *different* session on the
+/// same branch is still active. Archived no longer occupies the branch slot, so
+/// the slot may have been re-let since this session left the fleet — resuming it
+/// then would collide on the worktree path and the one-active-session-per-branch
+/// index.
+async fn require_branch_slot_free(
+    st: &AppState,
+    session: &Session,
+    branch: &Branch,
+) -> Result<(), AppError> {
+    if let Some(other) = session_mod::active_for_branch(&st.db, &branch.id).await? {
+        if other.id != session.id {
+            return Err(AppError::conflict(format!(
+                "branch '{}' already has an active session ({})",
+                branch.branch, other.id
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Recreate an orphaned session's terminal and resume its agent. The worktree is
 /// expected to still be on disk (an orphaned session only lost its terminal); a
 /// missing worktree is an error here — recovering a *torn-down* (archived)
@@ -1816,6 +1891,7 @@ pub(crate) async fn adopt(
     session: &Session,
     branch: &Branch,
 ) -> Result<(), AppError> {
+    require_branch_slot_free(st, session, branch).await?;
     if session.protocol == "acp" {
         return adopt_acp(st, session, branch, "session adopted").await;
     }
@@ -2144,6 +2220,7 @@ pub(super) async fn adopt_session(
 /// [`adopt`] does). The session rejoins the active fleet.
 async fn recover(st: &AppState, session: &Session, branch: &Branch) -> Result<(), AppError> {
     tracing::info!(session = %session.id, branch = %branch.id, "recovering archived session");
+    require_branch_slot_free(st, session, branch).await?;
     if backend::has_session(&session.term_session).await {
         return Err(AppError::conflict(
             "session already has a running terminal process",

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -548,6 +548,9 @@ pub(crate) async fn create_session_core(
     );
     // The session's class — automation machinery vs interactive fleet work. An
     // explicit request value wins (validated); otherwise derived from the origin.
+    // github/slack default to interactive deliberately: a person asked for that
+    // session and expects to find it on their board. Only unattended machinery
+    // (watch rounds, actions, ops) defaults to automation.
     let class = match req
         .class
         .as_deref()

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -161,6 +161,22 @@ async fn hook_event_drives_session_status() {
         got, "running",
         "monitor should have flipped status to running"
     );
+    // The same `working` edge counts one agent turn. The hookless shell agent
+    // is `running` from create, so the status poll above can return before the
+    // monitor tick that drains the hook row — poll the count separately.
+    let mut turns = 0;
+    for _ in 0..40 {
+        turns = session_mod::get(&pool, &id)
+            .await
+            .unwrap()
+            .unwrap()
+            .turn_count;
+        if turns == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert_eq!(turns, 1, "a working hook counts one turn");
 
     // A `waiting` hook (a quiet lull) stamps the soothing, *quiet* `idle` mark —
     // the calm "resting, no one needed" state, never the loud `attention` axis,
@@ -207,5 +223,106 @@ async fn hook_event_drives_session_status() {
     assert!(
         kinds.contains(&"hook"),
         "events should include a hook row: {kinds:?}"
+    );
+}
+
+/// Seed a branch + session of the given `class` / `managed_by` and return the
+/// branch id. Class rides a direct UPDATE: launch paths own the column's
+/// provenance, and this test only needs the stored value.
+async fn seed_classed_session(
+    db: &loom::db::Db,
+    id: &str,
+    branch_name: &str,
+    class: &str,
+    managed_by: Option<&str>,
+) -> String {
+    let branch = weaver_core::branch::upsert(db, "/r", branch_name, "main")
+        .await
+        .unwrap();
+    session_mod::insert(
+        db,
+        &session_mod::NewSession {
+            id: id.to_string(),
+            branch_id: branch.id.clone(),
+            work_dir: "/w".to_string(),
+            term_session: format!("weaver-{id}"),
+            agent_kind: "claude".to_string(),
+            model: String::new(),
+            effort: String::new(),
+            status: "running".to_string(),
+            github_repo: None,
+            parent_branch_id: None,
+            managed_by: managed_by.map(str::to_string),
+            created_by: None,
+            protocol: "acp".to_string(),
+            origin: "user".to_string(),
+            class: "interactive".to_string(),
+            tracking_issue_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    sqlx::query("UPDATE sessions SET class = ? WHERE id = ?")
+        .bind(class)
+        .bind(id)
+        .execute(db)
+        .await
+        .unwrap();
+    branch.id
+}
+
+/// Exceeding `automation.turn_cap` on an automation-class session marks the
+/// branch `blocked`; warm (watch-managed) sessions are exempt. Drives the same
+/// `promote_lifecycle` path the hook consumer uses, via the ACP entry point —
+/// no server or monitor sleeps needed.
+#[tokio::test]
+async fn turn_cap_blocks_automation_session() {
+    let pool = db::connect_in_memory().await.unwrap();
+    let bus = EventBus::new();
+    weaver_core::config::apply(&pool, &[("automation.turn_cap".into(), Some("1".into()))])
+        .await
+        .unwrap();
+
+    let branch_id = seed_classed_session(&pool, "cap1", "weaver/cap", "automation", None).await;
+
+    // Turn 1 is within the cap: no attention tag raised.
+    loom::monitor::record_acp_lifecycle(&pool, &bus, "cap1", "working").await;
+    let s = session_mod::get(&pool, "cap1").await.unwrap().unwrap();
+    assert_eq!(s.turn_count, 1, "working edge counts a turn");
+    assert!(
+        weaver_core::tags::get(&pool, &branch_id, weaver_core::tags::ATTENTION_KEY)
+            .await
+            .unwrap()
+            .is_none(),
+        "within the cap the attention axis stays calm"
+    );
+
+    // Turn 2 exceeds the cap: blocked, with the cap note.
+    loom::monitor::record_acp_lifecycle(&pool, &bus, "cap1", "working").await;
+    let tag = weaver_core::tags::get(&pool, &branch_id, weaver_core::tags::ATTENTION_KEY)
+        .await
+        .unwrap()
+        .expect("over the cap the branch is marked blocked");
+    assert_eq!(tag.value, "blocked");
+    assert!(
+        tag.note.contains("turn cap (1) reached"),
+        "note carries the cap: {}",
+        tag.note
+    );
+
+    // A warm (watch-managed) automation session is exempt infrastructure: the
+    // count still advances but the cap never marks it blocked.
+    let warm_branch =
+        seed_classed_session(&pool, "warm1", "weaver/warm", "automation", Some("w1")).await;
+    loom::monitor::record_acp_lifecycle(&pool, &bus, "warm1", "working").await;
+    loom::monitor::record_acp_lifecycle(&pool, &bus, "warm1", "working").await;
+    let warm = session_mod::get(&pool, "warm1").await.unwrap().unwrap();
+    assert_eq!(warm.turn_count, 2, "warm sessions still count turns");
+    assert!(
+        weaver_core::tags::get(&pool, &warm_branch, weaver_core::tags::ATTENTION_KEY)
+            .await
+            .unwrap()
+            .is_none(),
+        "warm sessions are never capped"
     );
 }

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -67,6 +67,9 @@ async fn make_session(ts: &TestServer, id: &str) {
             managed_by: None,
             created_by: None,
             protocol: "acp".to_string(),
+            origin: "user".to_string(),
+            class: "interactive".to_string(),
+            tracking_issue_id: None,
         },
     )
     .await
@@ -2385,6 +2388,9 @@ async fn adopt_converts_a_terminal_builtin_session_to_acp() {
             managed_by: None,
             created_by: None,
             protocol: "terminal".to_string(),
+            origin: "user".to_string(),
+            class: "interactive".to_string(),
+            tracking_issue_id: None,
         },
     )
     .await

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -751,3 +751,82 @@ async fn archive_frees_the_branch_for_a_new_session() {
         .await
         .unwrap();
 }
+
+/// The issue board hides an issue only while its branch's *current* claim-holder
+/// is automation-class. An archived automation run with no successor keeps its
+/// issue off the default board, but once a person re-lets the branch with an
+/// interactive session (archiving freed the slot), the issue surfaces again —
+/// historical automation tenancy must not hide live interactive work.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn issue_hiding_follows_the_branch_current_claim_holder() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let auto = client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "background run",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "name": "relet",
+                "class": "automation",
+            }),
+        )
+        .await
+        .unwrap();
+    let auto_id = auto["id"].as_str().unwrap().to_string();
+    let branch_ref = auto["branch"]["branch"].as_str().unwrap().to_string();
+    let issue = auto["tracking_issue"].as_i64().unwrap();
+
+    let on_board = |board: serde_json::Value| {
+        board
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["id"].as_i64() == Some(issue))
+    };
+
+    let board = client.get("/api/issues").await.unwrap();
+    assert!(
+        !on_board(board),
+        "an issue claimed by a live automation session is hidden by default"
+    );
+
+    client
+        .post(&format!("/api/sessions/{auto_id}/archive"), json!({}))
+        .await
+        .unwrap();
+    let board = client.get("/api/issues").await.unwrap();
+    assert!(
+        !on_board(board),
+        "an archived automation run with no successor keeps its issue hidden"
+    );
+
+    // A person picks the branch back up: the freed slot is re-let interactively.
+    let human = client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "picked up by hand",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "existing_branch": branch_ref,
+            }),
+        )
+        .await
+        .unwrap();
+    let human_id = human["id"].as_str().unwrap().to_string();
+
+    let board = client.get("/api/issues").await.unwrap();
+    assert!(
+        on_board(board),
+        "an interactive re-let surfaces the branch's issues on the default board"
+    );
+
+    client
+        .delete(&format!("/api/sessions/{human_id}"))
+        .await
+        .unwrap();
+}

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -608,3 +608,146 @@ async fn session_url_resolves_by_key_and_honours_the_public_base() {
 
     client.delete(&format!("/api/sessions/{id}")).await.unwrap();
 }
+
+/// A hand-launched session is stamped `origin: user` / `class: interactive`, and
+/// its tracking issue lives on the session row — so a plain get-by-id carries
+/// it, not just the create response.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_records_origin_class_and_tracking_issue() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let ws = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "stamped provenance", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+    assert_eq!(ws["origin"], "user", "a plain HTTP launch is origin 'user'");
+    assert_eq!(ws["class"], "interactive");
+    let issue = ws["tracking_issue"]
+        .as_i64()
+        .expect("launch returns a tracking issue id");
+
+    // Stored, not recomputed: the same identity comes back on a get-by-id.
+    let got = client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(got["origin"], "user");
+    assert_eq!(got["class"], "interactive");
+    assert_eq!(
+        got["tracking_issue"].as_i64(),
+        Some(issue),
+        "the tracking issue persists past the create response"
+    );
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// An automation-class session is machinery: absent from the default fleet
+/// listing, present with `?automation=true` — symmetric with `archived`.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn automation_class_hidden_from_the_default_listing() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let auto = client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "background machinery",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "class": "automation",
+            }),
+        )
+        .await
+        .unwrap();
+    let auto_id = auto["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        auto["class"], "automation",
+        "the request's class override sticks"
+    );
+
+    let list = client.get("/api/sessions").await.unwrap();
+    assert!(
+        list.as_array()
+            .unwrap()
+            .iter()
+            .all(|s| s["id"] != auto_id.as_str()),
+        "automation-class sessions are hidden by default: {list}"
+    );
+
+    let shown = client.get("/api/sessions?automation=true").await.unwrap();
+    assert!(
+        shown
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|s| s["id"] == auto_id.as_str()),
+        "?automation=true includes the automation session: {shown}"
+    );
+
+    client
+        .delete(&format!("/api/sessions/{auto_id}"))
+        .await
+        .unwrap();
+}
+
+/// Archiving a session frees its branch slot: a fresh session can attach to the
+/// same branch via `existing_branch`, where the archived tenant used to make the
+/// create 409 as busy. The branch key then resolves to the live tenant.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn archive_frees_the_branch_for_a_new_session() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let first = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "first tenant", "cwd": ts.cwd(), "agent": "shell", "name": "slot" }),
+        )
+        .await
+        .unwrap();
+    let first_id = first["id"].as_str().unwrap().to_string();
+    let branch_ref = first["branch"]["branch"].as_str().unwrap().to_string();
+
+    client
+        .post(&format!("/api/sessions/{first_id}/archive"), json!({}))
+        .await
+        .unwrap();
+
+    // The archived session no longer occupies the slot: a fresh session attaches
+    // to the kept branch (re-provisioning its worktree).
+    let second = client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "second tenant",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "existing_branch": branch_ref,
+            }),
+        )
+        .await
+        .unwrap();
+    let second_id = second["id"].as_str().unwrap().to_string();
+    assert_eq!(second["branch"]["branch"], branch_ref.as_str());
+    assert_ne!(second_id, first_id, "a new session, not a resume");
+
+    // The branch key resolves to the live tenant, not the archived one.
+    let branch_id = second["branch"]["id"].as_str().unwrap().to_string();
+    let got = client
+        .get(&format!("/api/sessions/{branch_id}"))
+        .await
+        .unwrap();
+    assert_eq!(got["id"], second_id.as_str());
+
+    client
+        .delete(&format!("/api/sessions/{second_id}"))
+        .await
+        .unwrap();
+}

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -1365,7 +1365,7 @@ async fn insert_managed_session(
             created_by: None,
             protocol: "terminal".to_string(),
             origin: "watch".to_string(),
-            class: "interactive".to_string(),
+            class: "automation".to_string(),
             tracking_issue_id: None,
         },
     )

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -1364,6 +1364,9 @@ async fn insert_managed_session(
             managed_by: Some(watch_id.to_string()),
             created_by: None,
             protocol: "terminal".to_string(),
+            origin: "watch".to_string(),
+            class: "interactive".to_string(),
+            tracking_issue_id: None,
         },
     )
     .await

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -777,29 +777,47 @@ async fn orphaned_session_terminal_relaunches_instead_of_dropping() {
         200
     );
 
-    // A fresh session appears (two rows now: the retired one + the new one) and a
-    // second reply lands.
-    wait_for_sessions(&ts, 2).await;
+    // A fresh session appears, the unreachable one is archived out of the
+    // default fleet (both rows visible under `?archived=true`), and a second
+    // reply lands.
+    for _ in 0..200 {
+        let n = ts
+            .client
+            .get("/api/sessions?archived=true")
+            .await
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .len();
+        if n >= 2 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
     wait_for_comments(&fake, 2).await;
 
-    let sessions = ts.client.get("/api/sessions").await.unwrap();
+    let sessions = ts.client.get("/api/sessions?archived=true").await.unwrap();
     let sessions = sessions.as_array().unwrap().clone();
+    assert_eq!(sessions.len(), 2, "the archived session plus the fresh one");
     let retired = sessions
         .iter()
         .find(|s| s["id"].as_str() == Some(first_id.as_str()))
         .expect("the orphaned session is still recorded");
     assert_eq!(
         retired["status"].as_str(),
-        Some("error"),
-        "the unreachable session was retired to a terminal status so the branch is free"
+        Some("archived"),
+        "the unreachable session was archived so the branch is free"
     );
-    let fresh_id = sessions
-        .iter()
-        .find(|s| s["id"].as_str() != Some(first_id.as_str()))
-        .expect("a fresh session was launched")["id"]
-        .as_str()
-        .unwrap()
-        .to_string();
+    // The default fleet shows only the fresh session.
+    let visible = ts.client.get("/api/sessions").await.unwrap();
+    let visible = visible.as_array().unwrap().clone();
+    assert_eq!(
+        visible.len(),
+        1,
+        "the archived session is hidden by default"
+    );
+    let fresh_id = visible[0]["id"].as_str().unwrap().to_string();
+    assert_ne!(fresh_id, first_id, "a fresh session was launched");
 
     // The reply is the launch cue, not a forward ack — proving a relaunch happened
     // rather than the comment being silently swallowed by the dead terminal.

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -137,9 +137,23 @@ pub struct SessionView {
     /// that predate the column. A tracking/UX field,
     /// not a security boundary: the fleet stays co-owned by everyone authenticated.
     pub created_by: Option<String>,
-    /// The tracking issue opened for this session's task at launch (the handle
-    /// handed back to whoever launched it). Only populated on the create
-    /// response; `None` on the list/get/patch paths, which don't recompute it.
+    /// How this session came to exist: `"user"` (hand-launched), `"agent"`
+    /// (delegated by another session), `"github"` / `"slack"` (chat triggers),
+    /// `"watch"` (engine infrastructure). Stamped once at create.
+    #[serde(default = "default_origin")]
+    pub origin: String,
+    /// Presentation tier: `"interactive"` fleet work or `"automation"`
+    /// machinery. The default `GET /api/sessions` listing hides
+    /// automation-class rows; `?automation=true` includes them.
+    #[serde(default = "default_class")]
+    pub class: String,
+    /// Completed agent turns on this session.
+    #[serde(default)]
+    pub turn_count: i64,
+    /// The tracking issue opened (or claimed) for this session's task at launch
+    /// — the handle handed back to whoever launched it — or `null` when the
+    /// launch tracked nothing. Stored on the session row, so every read path
+    /// carries it.
     pub tracking_issue: Option<i64>,
     /// Manual park override for the fleet list's resting shelf: `"parked"` (pinned
     /// to the shelf), `"active"` (kept live even when idle), or `null` (auto — the
@@ -189,6 +203,14 @@ pub struct AcpUsage {
 
 fn default_protocol() -> String {
     "terminal".to_string()
+}
+
+fn default_origin() -> String {
+    "user".to_string()
+}
+
+fn default_class() -> String {
+    "interactive".to_string()
 }
 
 /// Issue as the API exposes it.
@@ -613,6 +635,12 @@ pub struct CreateReq {
     /// a permission card. Ignored for a terminal launch.
     #[serde(default)]
     pub mode: Option<String>,
+    /// Session class override: `"interactive"` or `"automation"` (anything else
+    /// is rejected). Blank/absent derives from the launch origin
+    /// (watch/actions/ops → automation, else interactive). Automation-class
+    /// sessions are hidden from the default fleet listing.
+    #[serde(default)]
+    pub class: Option<String>,
 }
 
 /// Body for `POST /api/sessions/{id}/handoff`: replace the live ACP runtime

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_AGENT: &str = "claude";
 pub const DEFAULT_AGENT_MODEL: &str = "";
 pub const DEFAULT_AGENT_EFFORT: &str = "";
 /// Whether the server adopts orphaned sessions on startup. Off by default:
-/// the operator opts in via `weaver config set server.auto_adopt true`.
+/// the operator opts in via `loom config set server.auto_adopt true`.
 pub const DEFAULT_AUTO_ADOPT: bool = false;
 /// Whether loom polls GitHub (via the `gh` CLI) for each session's PR, review,
 /// and check status. On by default, but a no-op wherever `gh` is missing.
@@ -364,6 +364,33 @@ pub const REGISTRY: &[SettingSpec] = &[
         options: &[],
     },
     SettingSpec {
+        key: "automation.turn_cap",
+        label: "Turn cap",
+        description: "Cap on agent turns for an automation-class session (one \
+            turn per `working` edge). Past the cap the session's branch is \
+            marked `blocked` and no new ACP turn is started — an in-flight turn \
+            is never interrupted. Warm (watch-managed) sessions are exempt. \
+            0 disables the cap.",
+        kind: SettingKind::Int,
+        default: "100",
+        group: "Automation",
+        options: &[],
+    },
+    SettingSpec {
+        key: "automation.idle_archive_secs",
+        label: "Idle archive (seconds)",
+        description: "Idle TTL for an automation-class session: once it has \
+            gone this long without any activity (and has no live turn), the \
+            retention reaper archives it — tearing down the terminal and \
+            worktree while keeping the branch and its history. Warm \
+            (watch-managed) sessions are exempt. 0 disables the TTL; a closed \
+            tracking issue still archives the session.",
+        kind: SettingKind::Int,
+        default: "28800",
+        group: "Automation",
+        options: &[],
+    },
+    SettingSpec {
         key: "ide.enabled",
         label: "Enable embedded editor",
         description: "Master switch for the per-session embedded VS Code \
@@ -456,6 +483,16 @@ pub const DEFAULT_WATCH_ADOPT_WARM: bool = true;
 /// How many seconds a non-terminal session may be idle before the monitor emits
 /// a one-shot `stale` event. 30 minutes by default.
 pub const DEFAULT_WATCH_STALE_AFTER_SECS: i64 = 1800;
+
+/// Cap on agent turns for an automation-class session (one turn per `working`
+/// edge). Past the cap the branch is marked `blocked` and no new ACP turn is
+/// started. 0 disables the cap.
+pub const DEFAULT_AUTOMATION_TURN_CAP: i64 = 100;
+
+/// Idle TTL after which the retention reaper archives an automation-class
+/// session (8 hours). 0 disables the TTL trigger; a closed tracking issue
+/// still archives the session.
+pub const DEFAULT_AUTOMATION_IDLE_ARCHIVE_SECS: i64 = 28800;
 
 /// Look up the [`SettingSpec`] for a key, if it is a registered setting.
 pub fn spec(key: &str) -> Option<&'static SettingSpec> {

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -117,7 +117,8 @@ enum Cmd {
         #[arg(long)]
         event: String,
     },
-    /// Get, set, or list configuration.
+    /// Get or list configuration. Settings are written by operators via
+    /// `loom config set` or the settings pane — not from here.
     Config {
         #[command(subcommand)]
         cmd: ConfigCmd,
@@ -321,10 +322,6 @@ enum ArtifactCmd {
 enum ConfigCmd {
     /// Print one setting's value.
     Get { key: String },
-    /// Set a setting.
-    Set { key: String, value: String },
-    /// Clear a setting, restoring its default.
-    Rm { key: String },
     /// List every setting and its value.
     Ls,
 }
@@ -1795,18 +1792,6 @@ async fn cmd_config(cmd: ConfigCmd) -> Result<()> {
                 Some(s) => println!("{}", s.value),
                 None => bail!("no setting '{key}' — see `weaver config ls`"),
             }
-        }
-        ConfigCmd::Set { key, value } => {
-            let mut changes = serde_json::Map::new();
-            changes.insert(key.clone(), json!(value));
-            client.patch_settings(changes).await?;
-            println!("set {key}");
-        }
-        ConfigCmd::Rm { key } => {
-            let mut changes = serde_json::Map::new();
-            changes.insert(key.clone(), Value::Null);
-            client.patch_settings(changes).await?;
-            println!("removed {key}");
         }
     }
     Ok(())

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -1016,20 +1016,25 @@ async fn set_status_rejects_unknown_level() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
-async fn config_get_set_ls_rm_roundtrip() {
+async fn config_get_ls_reads_settings() {
     let env = Env::start().await;
     // A known setting has a default value before anything is set.
     let out = env.run(&["config", "ls"]);
     assert!(out.contains("(default)"), "ls should mark defaults: {out}");
 
-    env.run(&["config", "set", "agent.default", "codex"]);
+    // Settings are written by operators (`loom config set` / the settings
+    // pane); the in-session surface only reads them.
+    weaver_core::config::apply(
+        &env.db,
+        &[("agent.default".to_string(), Some("codex".to_string()))],
+    )
+    .await
+    .unwrap();
     let out = env.run(&["config", "get", "agent.default"]);
     assert_eq!(out.trim(), "codex");
-
-    env.run(&["config", "rm", "agent.default"]);
     let out = env.run(&["config", "ls"]);
     assert!(
-        out.contains("agent.default") && out.contains("(default)"),
-        "rm should restore the default: {out}"
+        out.contains("agent.default") && out.contains("codex"),
+        "ls shows the stored value: {out}"
     );
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -170,7 +170,7 @@ Background on these knobs is in the repo
 [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md). To change one after the fact:
 
 ```sh
-docker compose exec loom weaver config set auth.trust_loopback false
+docker compose exec loom loom config set auth.trust_loopback false
 ```
 
 Access past the front-door is then gated by GitHub/password login for the UI and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ other `weaver` subcommand.
 | `crates/weaver-core/` | lib: `branches`, `issues`, `events`, `db`, `migrations` (ordered SQL + `schema_migrations` indicator), `git`, `config`, `artifacts` (versioned documents), `repo_config` (`.weaver/config.toml`), `transcript` (agent conversation logs: raw → iris format → markdown), agent helpers. Pure logic; used by `loom` for DB access, and by `weaver` only for the DB-free pieces (`transcript`, `tags` constants/validators, the agent primer). |
 | `crates/weaver-api/` | typed loom REST client + DTOs (`Client`, `*View`/`*Req` types, `endpoint::default_client()` for resolving `$WEAVER_API`/`$LOOM_TOKEN`). Zero server deps (no `axum`, no sqlite driver) — the one cross-process seam `weaver` links against instead of `weaver-core`'s DB layer. |
 | `crates/smartdoc/` | the markdown-convention layer: parse references (`#N`, `artifact:<name>`), project live status into the render. Dependency-free of weaver. See [artifacts.md](artifacts.md). |
-| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`summary`, `readme`, `status` [read or set level + message], `tag` [`set`/`rm`/`ls` a branch tag], `issue …`, `where`, `log`, `chatlog` [render the agent's conversation transcript], `hook`, `config`) — every command drives `weaver-api::Client` over HTTP; none touch sqlite |
+| `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`summary`, `readme`, `status` [read or set level + message], `tag` [`set`/`rm`/`ls` a branch tag], `issue …`, `where`, `log`, `chatlog` [render the agent's conversation transcript], `hook`, `config` [read-only: `get`/`ls`; writes go through `loom config set` or the settings pane]) — every command drives `weaver-api::Client` over HTTP; none touch sqlite |
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** (incl. the auth middleware + login/token/user handlers) |
 | `crates/loom/src/auth.rs` | authentication core: token/password crypto, the `users`/`api_tokens`/`auth_sessions` tables, the machine-local token, and the GitHub OAuth calls. `axum`-free so it unit-tests directly |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
@@ -150,7 +150,16 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
   opened only by `loom` — `weaver` reaches it over HTTP. WAL mode handles
   concurrency among loom's own connections.
   - Core tables: `branches`, `issues`, `events`, `settings`.
-  - Loom tables (`crates/loom/src/db.rs`): `sessions`, `recent_repos`,
+  - Loom tables (`crates/loom/src/db.rs`): `sessions` (`origin` — the channel
+    it was created through: `user`/`agent`/`github`/`slack`/`watch`/`actions`/
+    `ops`, stamped server-side at create; `class` — `interactive`/`automation`,
+    gating default-list visibility, see [Status & tags](#status--tags);
+    `turn_count` — incremented on each `working` lifecycle edge;
+    `tracking_issue_id` — the weaver issue opened at create. One *active*
+    session per branch is enforced by a partial unique index on `branch_id`
+    where `status NOT IN ('done', 'error', 'archived')` — an archived session
+    releases its branch slot, so relaunching a done/archived branch is never
+    blocked by its predecessor), `recent_repos`,
     `branch_github` (per-branch PR snapshot), `chat_blocks` (the ACP
     [chat journal](#rest-api): one row per `(session_id, turn, seq)` block),
     and the auth tables `users` (the approved-operator allowlist, seeded with
@@ -195,7 +204,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | Method + path | What it does |
 |---|---|
 | `GET /api/health` | liveness probe |
-| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (create takes optional `scratch: [{name, content_base64}]`, `parent_branch`, `protocol` (`terminal`\|`acp`, an opt-in override of the agent's declared default), and `mode` (the initial ACP permission posture); opens a tracking issue and returns its id as `tracking_issue`) |
+| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false`, include torn-down sessions — and `automation` — default `false`, include automation-class sessions, otherwise hidden from the default fleet view; create takes optional `scratch: [{name, content_base64}]`, `parent_branch`, `protocol` (`terminal`\|`acp`, an opt-in override of the agent's declared default), and `mode` (the initial ACP permission posture); opens a tracking issue and returns its id as `tracking_issue`) |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear a branch tag — the well-known `attention` and `triage` keys plus any free-form key |
 | `GET /api/sessions/{id}/url` | the session's dashboard URL as `{url}`, built from the externally-visible origin (`auth.base_url`, else the request's own Host) — what `loom session url` prints, so an agent can link a PR back to its session without inventing a loopback link |
@@ -220,7 +229,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `PUT /api/sessions/{id}/mode` | `{mode_id}` → change the ACP session's permission mode (`session/set_mode`), journaled as a `mode_change` |
 | `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |
 | `GET POST /api/branches/{id}/issues` | issues claimed by the branch / create one |
-| `GET /api/issues?all=…` | the cross-repo issue board (every repo's issues; `all=true` includes closed) — what the loom Issues pane reads |
+| `GET /api/issues?all=…` | the cross-repo issue board (every repo's issues; `all=true` includes closed, `automation=true` includes automation-class sessions' tracking issues, otherwise hidden) — what the loom Issues pane reads |
 | `GET PATCH DELETE /api/issues/{id}` | per-issue CRUD |
 | `PUT DELETE /api/issues/{id}/tags/{key}` | set (upsert) / clear a free-form issue label — quiet `(key, value)` pills, no loud `attention`/`triage` ladder |
 | `GET POST /api/repos/issues?repo_root=…` | repo-wide board (`scope=repo\|backlog`) / create a backlog item |
@@ -243,8 +252,12 @@ top-level (`id`, `status`, `work_dir`, `term_session`, `agent_kind`, `model`,
 `effort`, `pending_prompt`, `github_repo`, `last_activity_at`,
 `created_at`, `updated_at`, `parent_id`, `protocol` (`terminal` or `acp`),
 `acp_session_id`, `current_mode`, `usage` (`{used, size}` context window, from
-the journal's latest `usage` block), and — on the create response only —
-`tracking_issue`) plus a nested `branch: BranchView`
+the journal's latest `usage` block), `origin` (the channel that created it:
+`user`/`agent`/`github`/`slack`/`watch`/`actions`/`ops`), `class`
+(`interactive`/`automation`), `turn_count` (incremented on each `working`
+lifecycle edge), and `tracking_issue` (the weaver issue opened at create;
+populated on every read, not just the create response)) plus a nested
+`branch: BranchView`
 (`id`, `name`, `title`, `goal`, `description`, `tags`,
 `repo_root`, `branch`, `base_branch`, `created_at`, `updated_at`,
 `open_issue_count`, `github`).
@@ -485,6 +498,18 @@ once the terminal is gone (orphaned/done/archived), leaving the read-only log.
 Orphan detection is independent: if the session's supervisor is no longer alive,
 the session becomes `orphaned` and is eligible for `loom adopt`.
 
+**Automation lifecycle.** A `class = automation` session — every session not
+launched interactively by a human, excluding a watch's own warm sessions —
+carries a turn cap (`automation.turn_cap`, default `100`, `0` disables)
+counted by `sessions.turn_count`. Exceeding the cap raises a loud `blocked`
+attention tag and the ACP driver refuses to start a new turn. The monitor also
+reaps automation sessions: one is archived once its `tracking_issue_id`
+closes, or after `automation.idle_archive_secs` (default `28800`, `0`
+disables) of inactivity — both guarded by a no-live-turn check and a grace
+period, so a session mid-turn or only just gone quiet is never torn down out
+from under it. The `automation.*` settings live in
+`weaver-core::config::registry()` under the **Automation** group.
+
 ## GitHub integration
 
 When the `gh` CLI is installed and authenticated, loom keeps a per-branch
@@ -510,7 +535,7 @@ automatically — the same teardown as the Archive button (`web::archive`, share
 code): the terminal killed, worktree removed, branch and weaver history kept. The
 worktree is removed with `--force`, so any uncommitted work in it is discarded;
 a merged PR is taken to mean the workstream is done. Turn the behaviour off with
-`weaver config set github.archive_on_merge false` (or in the settings pane).
+`loom config set github.archive_on_merge false` (or in the settings pane).
 Both settings live in `weaver-core::config::registry()` under the **GitHub**
 group.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,7 +153,10 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
   - Loom tables (`crates/loom/src/db.rs`): `sessions` (`origin` — the channel
     it was created through: `user`/`agent`/`github`/`slack`/`watch`/`actions`/
     `ops`, stamped server-side at create; `class` — `interactive`/`automation`,
-    gating default-list visibility, see [Status & tags](#status--tags);
+    gating default-list visibility, see [Status & tags](#status--tags). A
+    request may set `class` explicitly; otherwise `watch`/`actions`/`ops`
+    origins default to `automation` while `github`/`slack` stay `interactive` —
+    a person asked for those sessions and expects to find them on the board;
     `turn_count` — incremented on each `working` lifecycle edge;
     `tracking_issue_id` — the weaver issue opened at create. One *active*
     session per branch is enforced by a partial unique index on `branch_id`

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -196,7 +196,7 @@ launches nothing.
   case-insensitively anywhere in a comment's prose, as a standalone mention
   ([step 4](#how-it-works)) — both `@loom rebase onto main` and `can you rebase
   this, @loom?` trigger. Settable in **Settings → GitHub** or
-  `weaver config set github.trigger_phrase "…"`.
+  `loom config set github.trigger_phrase "…"`.
 - `github.bot_login` (or `LOOM_GITHUB_BOT_LOGIN`) — a GitHub login whose own
   comments are ignored, so a bot account can post without re-triggering itself.
 

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -103,7 +103,7 @@ Two gates, both deny-by-default:
   installed workspace:
 
   ```sh
-  weaver config set slack.allowed_users "U0123ABCD U0456EFGH"
+  loom config set slack.allowed_users "U0123ABCD U0456EFGH"
   ```
 
   Also settable in **Settings → Slack**. Membership in a channel or workspace
@@ -123,7 +123,7 @@ Without a prefix, loom falls back to **`slack.default_repo`**, since a Slack
 conversation has no repo of its own the way a GitHub issue does:
 
 ```sh
-weaver config set slack.default_repo "acme/web"
+loom config set slack.default_repo "acme/web"
 ```
 
 With neither, the trigger replies asking for one rather than guessing.

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -1,15 +1,22 @@
-import { test as base, expect } from '@playwright/test';
-import { type ChildProcess, execFileSync, spawn } from 'child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { test as base, expect } from "@playwright/test";
+import { type ChildProcess, execFileSync, spawn } from "child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 // Repo layout: this file lives at <weaver>/e2e/fixtures/weaver.ts
-const WEAVER_ROOT = join(__dirname, '..', '..');
-const LOOM_BINARY = join(WEAVER_ROOT, 'target', 'debug', 'loom');
-const WEAVER_BINARY = join(WEAVER_ROOT, 'target', 'debug', 'weaver');
-const FRONTEND_DIR = join(WEAVER_ROOT, 'crates', 'loom', 'frontend');
-const DIST_INDEX = join(WEAVER_ROOT, 'crates', 'loom', 'static', 'dist', 'index.html');
+const WEAVER_ROOT = join(__dirname, "..", "..");
+const LOOM_BINARY = join(WEAVER_ROOT, "target", "debug", "loom");
+const WEAVER_BINARY = join(WEAVER_ROOT, "target", "debug", "weaver");
+const FRONTEND_DIR = join(WEAVER_ROOT, "crates", "loom", "frontend");
+const DIST_INDEX = join(
+  WEAVER_ROOT,
+  "crates",
+  "loom",
+  "static",
+  "dist",
+  "index.html",
+);
 
 /** One (key, value) annotation on a branch. The well-known loud keys are
  *  `attention` (the agent) and `triage` (a watch / `manual`); any other
@@ -120,7 +127,11 @@ export interface WeaverFixture {
   seedIssue(session: Session, title: string, body?: string): Promise<Issue>;
   /** Create an *unclaimed* backlog issue in a repo via `POST /api/repos/issues`
    *  — the kind the Issues pane offers a Launch button for. */
-  seedBacklogIssue(repoRoot: string, title: string, body?: string): Promise<Issue>;
+  seedBacklogIssue(
+    repoRoot: string,
+    title: string,
+    body?: string,
+  ): Promise<Issue>;
   /** Plant a normalized iris conversation log for a session so the Conversation
    *  tab has something to render. Points `session.log_dir` at a temp folder and
    *  writes the log where the endpoint's capture fallback reads it
@@ -139,7 +150,11 @@ export interface WeaverFixture {
   ): Promise<void>;
   /** Remove an artifact via `weaver artifact rm` — drops it and its whole
    *  history. `--repo` targets the repo-shared row when a branch copy shadows it. */
-  removeArtifact(session: Session, name: string, opts?: { repo?: boolean }): Promise<void>;
+  removeArtifact(
+    session: Session,
+    name: string,
+    opts?: { repo?: boolean },
+  ): Promise<void>;
   /** Set (upsert) a free-form label on an issue via `PUT …/issues/{id}/tags/{key}`. */
   tagIssue(id: number, key: string, value: string): Promise<Issue>;
   /** GET /api/issues (cross-repo board). */
@@ -152,13 +167,13 @@ export interface WeaverFixture {
    *  test can set up the archived state it wants to act on. */
   archiveSession(id: string): Promise<void>;
   /** Flip a session's status by writing a hook event row via `weaver hook`. */
-  hook(session: Session, event: 'working' | 'waiting' | 'idle'): Promise<void>;
+  hook(session: Session, event: "working" | "waiting" | "idle"): Promise<void>;
   /** Declare the agent's status (level + message) via `weaver status`. It
    *  writes the branch's `attention` tag (clearing it on `ok`) and the
    *  current-state message, recording a `tag` event the monitor re-broadcasts. */
   setStatus(
     session: Session,
-    level: 'ok' | 'attention' | 'blocked',
+    level: "ok" | "attention" | "blocked",
     message?: string,
   ): Promise<void>;
   /** Set (upsert) one tag on a session's branch via `PUT …/tags/{key}`. */
@@ -173,7 +188,7 @@ export interface WeaverFixture {
   /** Stamp a watch's `triage` mark — sugar over `setTag(triage, …)`. */
   mark(
     session: Session,
-    level: 'attention' | 'blocked',
+    level: "attention" | "blocked",
     opts?: { note?: string; by?: string },
   ): Promise<void>;
 }
@@ -188,9 +203,9 @@ export function ensureBuilt() {
   // into static/dist via build.rs). `rerun-if-changed` makes it a fast no-op when
   // nothing changed, but it rebuilds a stale bundle after a backend *or* frontend
   // edit — so the suite never tests an out-of-date or placeholder UI.
-  execFileSync('cargo', ['build'], {
+  execFileSync("cargo", ["build"], {
     cwd: WEAVER_ROOT,
-    stdio: 'inherit',
+    stdio: "inherit",
     env: process.env,
   });
   if (!existsSync(LOOM_BINARY)) {
@@ -202,9 +217,9 @@ export function ensureBuilt() {
   if (!existsSync(DIST_INDEX)) {
     // build.rs writes a placeholder when Node is unavailable; build the SPA
     // directly so the UI under test is the real one.
-    execFileSync('npx', ['rspack', 'build'], {
+    execFileSync("npx", ["rspack", "build"], {
       cwd: FRONTEND_DIR,
-      stdio: 'inherit',
+      stdio: "inherit",
       env: process.env,
     });
   }
@@ -214,38 +229,42 @@ export function ensureBuilt() {
 function makeRepo(dir: string) {
   mkdirSync(dir, { recursive: true });
   const git = (args: string[]) =>
-    execFileSync('git', args, { cwd: dir, stdio: 'pipe' });
-  git(['init', '-b', 'main']);
-  git(['config', 'user.name', 'Weaver E2E']);
-  git(['config', 'user.email', 'e2e@weaver.test']);
-  writeFileSync(join(dir, 'README.md'), '# weaver e2e fixture repo\n');
-  git(['add', '-A']);
-  git(['commit', '-m', 'initial commit']);
+    execFileSync("git", args, { cwd: dir, stdio: "pipe" });
+  git(["init", "-b", "main"]);
+  git(["config", "user.name", "Weaver E2E"]);
+  git(["config", "user.email", "e2e@weaver.test"]);
+  writeFileSync(join(dir, "README.md"), "# weaver e2e fixture repo\n");
+  git(["add", "-A"]);
+  git(["commit", "-m", "initial commit"]);
 }
 
 async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
   const res = await fetch(url, {
-    headers: { 'content-type': 'application/json' },
+    headers: { "content-type": "application/json" },
     ...init,
   });
   if (!res.ok) {
-    throw new Error(`${init?.method ?? 'GET'} ${url} → ${res.status}: ${await res.text()}`);
+    throw new Error(
+      `${init?.method ?? "GET"} ${url} → ${res.status}: ${await res.text()}`,
+    );
   }
   const text = await res.text();
   return text ? JSON.parse(text) : null;
 }
 
 /** Delete every session on a server (and its branch/worktree), best-effort.
- *  Includes archived sessions (`?archived=true`) — `/api/sessions` hides them by
- *  default, so without this an archived session survives the per-test wipe and
+ *  Includes archived and automation-class sessions (`?archived=true&automation=true`)
+ *  — `/api/sessions` hides both by default, so without this such a session survives the per-test wipe and
  *  leaks into the next test, breaking count-based assertions ("0 sessions"). */
 async function deleteAllSessions(baseUrl: string) {
   try {
-    const all = (await fetchJson(`${baseUrl}/api/sessions?archived=true`)) as Session[];
+    const all = (await fetchJson(
+      `${baseUrl}/api/sessions?archived=true&automation=true`,
+    )) as Session[];
     for (const s of all) {
       try {
         await fetch(`${baseUrl}/api/sessions/${s.id}?keep_branch=false`, {
-          method: 'DELETE',
+          method: "DELETE",
         });
       } catch {
         /* best effort */
@@ -263,7 +282,7 @@ async function deleteAllWatches(baseUrl: string) {
     const all = (await fetchJson(`${baseUrl}/api/watches`)) as { id: string }[];
     for (const o of all) {
       try {
-        await fetch(`${baseUrl}/api/watches/${o.id}`, { method: 'DELETE' });
+        await fetch(`${baseUrl}/api/watches/${o.id}`, { method: "DELETE" });
       } catch {
         /* best effort */
       }
@@ -279,10 +298,12 @@ async function deleteAllWatches(baseUrl: string) {
  *  count-based assertions ("0 issues") order-independent. */
 async function deleteAllIssues(baseUrl: string) {
   try {
-    const all = (await fetchJson(`${baseUrl}/api/issues?all=true`)) as { id: number }[];
+    const all = (await fetchJson(`${baseUrl}/api/issues?all=true`)) as {
+      id: number;
+    }[];
     for (const i of all) {
       try {
-        await fetch(`${baseUrl}/api/issues/${i.id}`, { method: 'DELETE' });
+        await fetch(`${baseUrl}/api/issues/${i.id}`, { method: "DELETE" });
       } catch {
         /* best effort */
       }
@@ -313,10 +334,10 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
   // parallel safely — see playwright.config.ts.
   server: [
     async ({}, use, workerInfo) => {
-      const tmpDir = mkdtempSync(join(tmpdir(), 'weaver-e2e-'));
-      const weaverHome = join(tmpDir, 'home');
-      const dbPath = join(tmpDir, 'db.sqlite');
-      const repoPath = join(tmpDir, 'repo');
+      const tmpDir = mkdtempSync(join(tmpdir(), "weaver-e2e-"));
+      const weaverHome = join(tmpDir, "home");
+      const dbPath = join(tmpDir, "db.sqlite");
+      const repoPath = join(tmpDir, "repo");
       mkdirSync(weaverHome, { recursive: true });
       makeRepo(repoPath);
 
@@ -330,25 +351,32 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
         ...process.env,
         WEAVER_HOME: weaverHome,
         WEAVER_DB: dbPath,
-        WEAVER_TAPESTRY_BIN: join(WEAVER_ROOT, 'target', 'debug', 'tapestry'),
-        RUST_LOG: 'loom=warn,weaver_core=warn',
+        WEAVER_TAPESTRY_BIN: join(WEAVER_ROOT, "target", "debug", "tapestry"),
+        RUST_LOG: "loom=warn,weaver_core=warn",
         // Seed an operator: loom refuses to boot with no owner configured, and
         // loopback trust authenticates every test request as this primary user
         // (so the page is signed in without an OAuth round-trip).
-        LOOM_OWNER_GITHUB: 'loom-e2e-owner',
+        LOOM_OWNER_GITHUB: "loom-e2e-owner",
       };
 
       // Bind to a random free port (0) and parse the actual port from stdout.
-      const server: ChildProcess = spawn(LOOM_BINARY, ['server', 'run', '--addr', '127.0.0.1:0'], {
-        env: childEnv,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
+      const server: ChildProcess = spawn(
+        LOOM_BINARY,
+        ["server", "run", "--addr", "127.0.0.1:0"],
+        {
+          env: childEnv,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
 
-      let baseUrl = '';
-      let serverLog = '';
+      let baseUrl = "";
+      let serverLog = "";
       await new Promise<void>((resolve, reject) => {
         const timer = setTimeout(
-          () => reject(new Error(`loom did not start in 20s. Output:\n${serverLog}`)),
+          () =>
+            reject(
+              new Error(`loom did not start in 20s. Output:\n${serverLog}`),
+            ),
           20_000,
         );
         const onData = (chunk: Buffer) => {
@@ -360,16 +388,20 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
             resolve();
           }
         };
-        server.stdout!.on('data', onData);
-        server.stderr!.on('data', onData);
-        server.on('error', (err) => {
+        server.stdout!.on("data", onData);
+        server.stderr!.on("data", onData);
+        server.on("error", (err) => {
           clearTimeout(timer);
           reject(err);
         });
-        server.on('exit', (code) => {
+        server.on("exit", (code) => {
           if (!baseUrl) {
             clearTimeout(timer);
-            reject(new Error(`loom exited with code ${code} before listening:\n${serverLog}`));
+            reject(
+              new Error(
+                `loom exited with code ${code} before listening:\n${serverLog}`,
+              ),
+            );
           }
         });
       });
@@ -388,7 +420,8 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
         }
         await new Promise((r) => setTimeout(r, 100));
       }
-      if (!healthy) throw new Error(`loom /api/health never returned ok:\n${serverLog}`);
+      if (!healthy)
+        throw new Error(`loom /api/health never returned ok:\n${serverLog}`);
 
       // Pin the `weaver`/`loom` CLI subprocesses (setStatus, seedConversation, the
       // artifact helpers) at THIS server. `childEnv` spreads `process.env`, so
@@ -402,14 +435,14 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
       // gives every test its cheap, deterministic no-op agent and must exist
       // before the `agent.default` patch below validates against it.
       await fetchJson(`${baseUrl}/api/agents/custom`, {
-        method: 'POST',
-        body: JSON.stringify({ name: 'shell', label: 'Shell' }),
+        method: "POST",
+        body: JSON.stringify({ name: "shell", label: "Shell" }),
       });
 
       // UI-created sessions should use a plain shell, never the real claude CLI.
       await fetchJson(`${baseUrl}/api/settings`, {
-        method: 'PATCH',
-        body: JSON.stringify({ 'agent.default': 'shell' }),
+        method: "PATCH",
+        body: JSON.stringify({ "agent.default": "shell" }),
       });
 
       await use({ baseUrl, repoPath, childEnv });
@@ -428,18 +461,18 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
           }
         };
         const force = setTimeout(() => {
-          server.kill('SIGKILL');
+          server.kill("SIGKILL");
           finish();
         }, 5_000);
-        server.on('exit', () => {
+        server.on("exit", () => {
           clearTimeout(force);
           finish();
         });
-        server.kill('SIGTERM');
+        server.kill("SIGTERM");
       });
       rmSync(tmpDir, { recursive: true, force: true });
     },
-    { scope: 'worker' },
+    { scope: "worker" },
   ],
 
   // Per-test handle on the worker's server. The server is reused; this fixture
@@ -455,12 +488,12 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
 
       async seedSession(opts) {
         return (await fetchJson(`${baseUrl}/api/sessions`, {
-          method: 'POST',
+          method: "POST",
           body: JSON.stringify({
             goal: opts.goal,
             title: opts.title ?? opts.name,
             cwd: repoPath,
-            agent: 'shell',
+            agent: "shell",
             name: opts.name,
             base: opts.base,
             parent_branch: opts.parent,
@@ -470,29 +503,36 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
 
       async seedWatch(opts) {
         return (await fetchJson(`${baseUrl}/api/watches`, {
-          method: 'POST',
+          method: "POST",
           body: JSON.stringify({
             name: opts.name,
             trigger: opts.trigger ?? {},
             scope: opts.scope ?? {},
-            program: opts.program ?? 'builtin:status',
+            program: opts.program ?? "builtin:status",
             params: opts.params ?? {},
-            capabilities: opts.capabilities ?? ['observe', 'mark', 'escalate'],
+            capabilities: opts.capabilities ?? ["observe", "mark", "escalate"],
           }),
         })) as Watch;
       },
 
       async seedIssue(session, title, body) {
-        return (await fetchJson(`${baseUrl}/api/branches/${session.branch.id}/issues`, {
-          method: 'POST',
-          body: JSON.stringify({ title, body: body ?? '' }),
-        })) as Issue;
+        return (await fetchJson(
+          `${baseUrl}/api/branches/${session.branch.id}/issues`,
+          {
+            method: "POST",
+            body: JSON.stringify({ title, body: body ?? "" }),
+          },
+        )) as Issue;
       },
 
       async seedBacklogIssue(repoRoot, title, body) {
         return (await fetchJson(`${baseUrl}/api/repos/issues`, {
-          method: 'POST',
-          body: JSON.stringify({ repo_root: repoRoot, title, body: body ?? '' }),
+          method: "POST",
+          body: JSON.stringify({
+            repo_root: repoRoot,
+            title,
+            body: body ?? "",
+          }),
         })) as Issue;
       },
 
@@ -503,50 +543,53 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
         // this worker's WEAVER_HOME (reaped in worker teardown, so no stray
         // /tmp/weaver-conv-* dirs leak across runs) and drop the log there,
         // slugging the branch the same way the server does.
-        const logRoot = mkdtempSync(join(childEnv.WEAVER_HOME!, 'conv-'));
+        const logRoot = mkdtempSync(join(childEnv.WEAVER_HOME!, "conv-"));
         await fetchJson(`${baseUrl}/api/settings`, {
-          method: 'PATCH',
-          body: JSON.stringify({ 'session.log_dir': logRoot }),
+          method: "PATCH",
+          body: JSON.stringify({ "session.log_dir": logRoot }),
         });
-        const slug = session.branch.branch.replace(/[^A-Za-z0-9._-]/g, '-');
+        const slug = session.branch.branch.replace(/[^A-Za-z0-9._-]/g, "-");
         mkdirSync(join(logRoot, slug), { recursive: true });
-        writeFileSync(join(logRoot, slug, 'chat.json'), JSON.stringify(log));
+        writeFileSync(join(logRoot, slug, "chat.json"), JSON.stringify(log));
       },
 
       async writeArtifact(session, name, content, opts) {
         // `weaver artifact write <name> -` reads content from stdin and appends
         // a revision to the branch resolved from $WEAVER_BRANCH (`--repo` makes
         // it repo-shared). The first write creates the envelope.
-        const args = ['artifact', 'write', name, '-'];
-        if (opts?.title) args.push('--title', opts.title);
-        if (opts?.kind) args.push('--kind', opts.kind);
-        if (opts?.repo) args.push('--repo');
+        const args = ["artifact", "write", name, "-"];
+        if (opts?.title) args.push("--title", opts.title);
+        if (opts?.kind) args.push("--kind", opts.kind);
+        if (opts?.repo) args.push("--repo");
         execFileSync(WEAVER_BINARY, args, {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
           input: content,
-          stdio: ['pipe', 'pipe', 'pipe'],
+          stdio: ["pipe", "pipe", "pipe"],
         });
       },
 
       async removeArtifact(session, name, opts) {
-        const args = ['artifact', 'rm', name];
-        if (opts?.repo) args.push('--repo');
+        const args = ["artifact", "rm", name];
+        if (opts?.repo) args.push("--repo");
         execFileSync(WEAVER_BINARY, args, {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
-          stdio: ['pipe', 'pipe', 'pipe'],
+          stdio: ["pipe", "pipe", "pipe"],
         });
       },
 
       async tagIssue(id, key, value) {
-        return (await fetchJson(`${baseUrl}/api/issues/${id}/tags/${encodeURIComponent(key)}`, {
-          method: 'PUT',
-          body: JSON.stringify({ value }),
-        })) as Issue;
+        return (await fetchJson(
+          `${baseUrl}/api/issues/${id}/tags/${encodeURIComponent(key)}`,
+          {
+            method: "PUT",
+            body: JSON.stringify({ value }),
+          },
+        )) as Issue;
       },
 
       async listIssues(all = false) {
         return (await fetchJson(
-          `${baseUrl}/api/issues${all ? '?all=true' : ''}`,
+          `${baseUrl}/api/issues${all ? "?all=true" : ""}`,
         )) as Issue[];
       },
 
@@ -559,15 +602,17 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
       },
 
       async archiveSession(id) {
-        await fetchJson(`${baseUrl}/api/sessions/${id}/archive`, { method: 'POST' });
+        await fetchJson(`${baseUrl}/api/sessions/${id}/archive`, {
+          method: "POST",
+        });
       },
 
       async hook(session, event) {
         // `weaver hook` writes an `events` row keyed on the branch resolved
         // from $WEAVER_BRANCH; the loom monitor consumes it on its next tick.
-        execFileSync(WEAVER_BINARY, ['hook', '--event', event], {
+        execFileSync(WEAVER_BINARY, ["hook", "--event", event], {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
-          stdio: 'pipe',
+          stdio: "pipe",
         });
       },
 
@@ -575,30 +620,30 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
         // `weaver status <level> [message]` writes the branch's `attention`
         // tag (clearing it on `ok`) and the current-state message, recording a
         // `tag` event the monitor re-broadcasts.
-        const args = ['status', level, ...(message ? [message] : [])];
+        const args = ["status", level, ...(message ? [message] : [])];
         execFileSync(WEAVER_BINARY, args, {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
-          stdio: 'pipe',
+          stdio: "pipe",
         });
       },
 
       async setTag(session, key, value, opts) {
         await fetchJson(`${baseUrl}/api/sessions/${session.id}/tags/${key}`, {
-          method: 'PUT',
+          method: "PUT",
           body: JSON.stringify({ value, note: opts?.note, by: opts?.by }),
         });
       },
 
       async clearTag(session, key) {
         await fetchJson(`${baseUrl}/api/sessions/${session.id}/tags/${key}`, {
-          method: 'DELETE',
+          method: "DELETE",
         });
       },
 
       async mark(session, level, opts) {
-        await fixture.setTag(session, 'triage', level, {
+        await fixture.setTag(session, "triage", level, {
           note: opts?.note,
-          by: opts?.by ?? 'manual',
+          by: opts?.by ?? "manual",
         });
       },
     };

--- a/e2e/tests/automation.spec.ts
+++ b/e2e/tests/automation.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "../fixtures/weaver";
+
+// Phase 1: automation session visibility. Sessions launched by a background
+// surface (a webhook, a watch, `/marinbot`, …) are stamped `class:
+// 'automation'` at create time and hidden from the fleet list by default — the
+// list is a person's workbench, not a log of every agent turn the server ever
+// ran. The Automation toggle (alongside the archived one) reveals them as
+// ordinary cards, with a quiet origin pill naming the surface that launched
+// them. See docs/loom-ui.md and crates/loom/frontend/src/views/SessionList.vue.
+//
+// `origin` is server-stamped and cannot be supplied by an API caller: a plain
+// create lands as `user`, and one carrying `parent_branch` as `agent` — the
+// only non-`user` origin reachable from a test, so that is what the pill
+// coverage uses.
+
+/** Create a session directly via the API with an explicit `class` —
+ *  `weaver.seedSession` always creates an ordinary interactive session, so an
+ *  automation-class row is seeded with a raw POST mirroring its request body. */
+async function seedAutomationSession(
+  baseUrl: string,
+  repoPath: string,
+  opts: { name: string; goal: string; parentBranch?: string },
+) {
+  const res = await fetch(`${baseUrl}/api/sessions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      goal: opts.goal,
+      title: opts.name,
+      cwd: repoPath,
+      agent: "shell",
+      name: opts.name,
+      class: "automation",
+      parent_branch: opts.parentBranch,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `seed automation session failed: ${res.status} ${await res.text()}`,
+    );
+  }
+  return res.json();
+}
+
+test.describe("automation session visibility", () => {
+  test("an automation-class session is hidden from the default session list", async ({
+    page,
+    weaver,
+  }) => {
+    await seedAutomationSession(weaver.baseUrl, weaver.repoPath, {
+      name: "watch-triggered",
+      goal: "Triggered by a watch round",
+    });
+
+    await page.goto(weaver.baseUrl);
+
+    // Hidden by default — the fleet reads as empty, not "1 session".
+    await expect(page.getByText("No sessions yet.")).toBeVisible();
+    await expect(page.getByTestId("session-card")).toHaveCount(0);
+  });
+
+  test("the Automation toggle reveals an automation-class session", async ({
+    page,
+    weaver,
+  }) => {
+    const parent = await weaver.seedSession({
+      goal: "Parent work",
+      name: "parent-task",
+    });
+    // A sub-session launch (`parent_branch`) is stamped `origin: 'agent'` —
+    // the pill under test.
+    const automation = await seedAutomationSession(
+      weaver.baseUrl,
+      weaver.repoPath,
+      {
+        name: "delegated-run",
+        goal: "Delegated by the parent session",
+        parentBranch: parent.branch.id,
+      },
+    );
+
+    await page.goto(weaver.baseUrl);
+    await expect(page.getByTestId("session-card")).toHaveCount(1);
+
+    const toggle = page.getByTestId("automation-toggle");
+    await expect(toggle).toContainText("Show 1 automation");
+    await toggle.click();
+
+    const card = page.locator(`[data-session-id="${automation.id}"]`);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText("delegated-run");
+    // A non-`user` origin renders as a quiet identity pill on the card.
+    await expect(card.getByTestId("origin-pill")).toHaveText("agent");
+
+    await expect(toggle).toContainText("Hide 1 automation");
+    await toggle.click();
+    await expect(page.getByTestId("session-card")).toHaveCount(1);
+  });
+
+  test("an ordinary session still appears by default alongside a hidden automation one", async ({
+    page,
+    weaver,
+  }) => {
+    const ordinary = await weaver.seedSession({
+      goal: "Regular work",
+      name: "ordinary-task",
+    });
+    await seedAutomationSession(weaver.baseUrl, weaver.repoPath, {
+      name: "ops-triggered",
+      goal: "Launched by an ops script",
+    });
+
+    await page.goto(weaver.baseUrl);
+
+    await expect(page.getByTestId("session-card")).toHaveCount(1);
+    const card = page.locator(`[data-session-id="${ordinary.id}"]`);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText("ordinary-task");
+    // A `user`-origin session (the default) carries no origin pill.
+    await expect(card.getByTestId("origin-pill")).toHaveCount(0);
+
+    await page.getByTestId("automation-toggle").click();
+    await expect(page.getByTestId("session-card")).toHaveCount(2);
+  });
+});


### PR DESCRIPTION
Phase 1 of the automation/workspace split ([design artifact](https://loom.rjp.io/s/wgshvdv8/artifacts/design)): loom can host non-user-driven sessions (webhooks, watches, Slack, future actions/ops) without churning the user's fleet view.

## What changed

**Session identity.** `sessions` gains four columns via `migrate_loom`: `origin` (`user|agent|github|slack|watch|actions|ops` — stamped server-side by the creating channel, never caller-supplied), `class` (`interactive|automation`), `turn_count`, and `tracking_issue_id`. Existing rows are backfilled (`managed_by` set → `watch`/`automation`; `parent_branch_id` set → `agent`).

**Automation visibility.** Automation-class sessions are hidden from the default session list and issues board behind a `?automation=true` param; the UI fetches the superset once and filters client-side with a toggle chip (symmetric with the archived toggle). Non-`user` origins render as a quiet pill on the card.

**Turn cap.** `automation.turn_cap` (default 100, 0 disables) bounds automation runs. Enforced actively in the ACP path (prompt refused, session tagged `blocked` with "turn cap (N) reached") and passively in the monitor for hook-driven sessions. Warm/`managed_by` sessions are exempt.

**Reaper.** Idle automation sessions are archived after `automation.idle_archive_secs` (default 8h) with a 15-minute no-live-turn grace; warm sessions are exempt. Archived sessions no longer occupy the one-active-session-per-branch slot (the partial unique index now excludes `archived`; adopt/recover return 409 when the slot is taken).

**`weaver config` narrows to read-only.** `set`/`rm` are removed (no backwards compat, per review decision); settings writes go through `loom config set`. Docs updated.

**ACP fix (pre-existing, exposed by this change).** `AcpRegistry::stop` removes a session's task handle but never aborts the future, so a superseded task could consume the durable prompt queue and lose the prompt against a dead relay. A generation guard (`is_current`) now makes stale tasks stand down before touching the queue. Root-caused from a ~20% flake in `handoff_recovers_without_a_live_task_and_preserves_the_queue`; stress-verified 12/12.

## Testing

- `scripts/pre-commit.sh` and `cargo test --workspace` green.
- e2e: 121 passed locally (CI has no Playwright job), including a new `automation.spec.ts` covering hidden-by-default, toggle reveal + origin pill, and mixed ordinary/automation lists.

Session: https://loom.rjp.io/s/1eftmppp
Fixes rjpower/weaver issue #566 (weaver-tracked).