### PR TITLE
feat(deploy): add Pulumi and storage backend seams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,22 @@ jobs:
       - run: maturin build --release --manifest-path crates/weaver-py/Cargo.toml --out dist
       - run: pip install --find-links dist weaver-py
       - run: pytest crates/weaver-py/tests python/weaver-loom/tests -v
+
+  infrastructure:
+    name: infrastructure
+    runs-on: ubuntu-latest
+    # Pulumi's runtime mocks validate the GCP resource graph without cloud
+    # credentials or a backend. ShellCheck covers the boot/backup path that
+    # runs as root on the VM; neither step contacts or changes GCP.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: deploy/pulumi/requirements-dev.txt
+      - run: pip install -r deploy/pulumi/requirements-dev.txt
+      - run: python -m compileall -q deploy/pulumi
+      - run: python -m pytest -q tests
+        working-directory: deploy/pulumi
+      - run: shellcheck deploy/gcp/startup-script.sh deploy/gcp/backup-sqlite.sh

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,54 @@
+name: Publish deployment image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deployment-image-${{ github.ref }}
+  cancel-in-progress: true
+
+# The GCP provider also restricts the assertion to this repository and main.
+# No long-lived service-account key is stored in GitHub.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # Credential-bearing workflow: pin every third-party action to a reviewed
+      # commit, keeping the release tag only as a human-readable comment.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - id: auth
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ vars.LOOM_GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.LOOM_GCP_IMAGE_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Configure Artifact Registry authentication
+        run: gcloud auth configure-docker "${LOOM_GCP_REGION}-docker.pkg.dev" --quiet
+        env:
+          LOOM_GCP_REGION: ${{ vars.LOOM_GCP_REGION }}
+      - id: image
+        name: Resolve immutable image name
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${region}-docker.pkg.dev/${project}/loom/loom:${GITHUB_SHA}"
+          echo "name=${image}" >>"${GITHUB_OUTPUT}"
+        env:
+          region: ${{ vars.LOOM_GCP_REGION }}
+          project: ${{ vars.LOOM_GCP_PROJECT }}
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          build-args: CARGO_PROFILE=release
+          tags: ${{ steps.image.outputs.name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -40,10 +40,17 @@ jobs:
           set -euo pipefail
           image="${region}-docker.pkg.dev/${project}/loom/loom:${GITHUB_SHA}"
           echo "name=${image}" >>"${GITHUB_OUTPUT}"
+          if gcloud artifacts docker images describe "${image}" >/dev/null 2>&1; then
+            echo "exists=true" >>"${GITHUB_OUTPUT}"
+            echo "${image} is already published; keeping its immutable digest"
+          else
+            echo "exists=false" >>"${GITHUB_OUTPUT}"
+          fi
         env:
           region: ${{ vars.LOOM_GCP_REGION }}
           project: ${{ vars.LOOM_GCP_PROJECT }}
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        if: steps.image.outputs.exists != 'true'
         with:
           context: .
           platforms: linux/amd64

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ python/weaver-loom/dist/
 __pycache__/
 python/weaver-loom/.venv/
 python/weaver-loom/uv.lock
+deploy/pulumi/.venv/
+
+# Local Pulumi stack files contain encrypted secret material and deployment-
+# specific config. The checked-in example is documentation, not a live stack.
+deploy/pulumi/Pulumi.*.yaml
+!deploy/pulumi/Pulumi.example.yaml
 
 # Local-only container env, rendered from loom.toml by `loom config render-env`
 # (deploy/standalone/.env — holds GH_TOKEN etc.). Never commit it: host secrets.

--- a/crates/loom/migrations/0001_baseline.sql
+++ b/crates/loom/migrations/0001_baseline.sql
@@ -1,0 +1,146 @@
+-- Loom-owned schema at the point its independent migration stream was
+-- introduced. Existing unversioned databases are brought to this shape by the
+-- adoption code in db.rs and then stamped at version 1; fresh databases run
+-- this file normally.
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id                 TEXT PRIMARY KEY,
+    branch_id          TEXT NOT NULL REFERENCES branches(id) ON DELETE CASCADE,
+    work_dir           TEXT NOT NULL,
+    term_session       TEXT NOT NULL,
+    agent_kind         TEXT NOT NULL DEFAULT 'claude',
+    model              TEXT NOT NULL DEFAULT '',
+    effort             TEXT NOT NULL DEFAULT '',
+    status             TEXT NOT NULL,
+    github_repo        TEXT,
+    last_activity_at   TEXT,
+    parent_branch_id   TEXT,
+    managed_by         TEXT,
+    created_by         TEXT,
+    park               TEXT,
+    sort_order         REAL,
+    protocol           TEXT NOT NULL DEFAULT 'terminal',
+    acp_session_id     TEXT,
+    acp_ack_seq        INTEGER NOT NULL DEFAULT 0,
+    acp_inflight       TEXT,
+    current_mode       TEXT,
+    pending_prompt     TEXT NOT NULL DEFAULT '',
+    origin             TEXT NOT NULL DEFAULT 'user',
+    class              TEXT NOT NULL DEFAULT 'interactive',
+    turn_count         INTEGER NOT NULL DEFAULT 0,
+    tracking_issue_id  INTEGER,
+    created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_active_branch
+    ON sessions(branch_id) WHERE status NOT IN ('done', 'error', 'archived');
+
+CREATE TABLE IF NOT EXISTS recent_repos (
+    repo_root    TEXT PRIMARY KEY,
+    last_used_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE TABLE IF NOT EXISTS repos (
+    slug       TEXT PRIMARY KEY,
+    remote_url TEXT NOT NULL,
+    path       TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE TABLE IF NOT EXISTS processed_deliveries (
+    delivery_id TEXT PRIMARY KEY,
+    received_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE TABLE IF NOT EXISTS branch_github (
+    branch_id        TEXT PRIMARY KEY REFERENCES branches(id) ON DELETE CASCADE,
+    pr_number        INTEGER,
+    pr_url           TEXT,
+    pr_state         TEXT,
+    pr_title         TEXT,
+    is_draft         INTEGER NOT NULL DEFAULT 0,
+    review_decision  TEXT,
+    checks           TEXT,
+    mergeable        TEXT,
+    merged_at        TEXT,
+    fetched_at       TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS branch_github_mapping (
+    branch_id  TEXT PRIMARY KEY REFERENCES branches(id) ON DELETE CASCADE,
+    pr_number  INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    username       TEXT PRIMARY KEY,
+    github_login   TEXT UNIQUE,
+    password_hash  TEXT,
+    github_user_id INTEGER,
+    display_name   TEXT,
+    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id           TEXT PRIMARY KEY,
+    username     TEXT NOT NULL REFERENCES users(username) ON DELETE CASCADE,
+    name         TEXT NOT NULL,
+    token_hash   TEXT NOT NULL UNIQUE,
+    prefix       TEXT NOT NULL,
+    kind         TEXT NOT NULL DEFAULT 'pat',
+    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    last_used_at TEXT,
+    expires_at   TEXT
+);
+
+CREATE TABLE IF NOT EXISTS agent_env (
+    name       TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE TABLE IF NOT EXISTS repo_env (
+    repo_root  TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (repo_root, name)
+);
+
+CREATE TABLE IF NOT EXISTS auth_sessions (
+    token_hash TEXT PRIMARY KEY,
+    username   TEXT NOT NULL REFERENCES users(username) ON DELETE CASCADE,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    expires_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user_github_tokens (
+    username   TEXT PRIMARY KEY REFERENCES users(username) ON DELETE CASCADE,
+    token      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE TABLE IF NOT EXISTS custom_agents (
+    name           TEXT PRIMARY KEY,
+    label          TEXT NOT NULL,
+    setup          TEXT NOT NULL DEFAULT '',
+    launch         TEXT NOT NULL DEFAULT '',
+    resume         TEXT NOT NULL DEFAULT '',
+    reports_status INTEGER NOT NULL DEFAULT 0,
+    protocol       TEXT NOT NULL DEFAULT 'terminal',
+    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE TABLE IF NOT EXISTS chat_blocks (
+    id         INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    turn       INTEGER NOT NULL,
+    seq        INTEGER NOT NULL,
+    kind       TEXT NOT NULL,
+    payload    TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(session_id, turn, seq)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_blocks_session
+    ON chat_blocks(session_id, turn, seq);

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -39,7 +39,7 @@
 //! the sqlite write for any block that frame *completed* has committed: the ack
 //! watermark is held back to just before the earliest frame still feeding an open
 //! consolidation buffer, a live tool call, or an unanswered permission request
-//! (block-boundary acking). Journal writes are idempotent (`INSERT OR IGNORE` on
+//! (block-boundary acking). Journal writes are idempotent (conflicts ignored on
 //! `(session_id, turn, seq)`, plus upstream-id guards for tool calls and turn
 //! ends), so a replay after a loom restart re-ingests without duplicating.
 

--- a/crates/loom/src/auth.rs
+++ b/crates/loom/src/auth.rs
@@ -32,8 +32,9 @@ use base64::Engine as _;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use sqlx::Row;
+use weaver_core::db::iso_in_days;
 
-use crate::db::{weaver_home, Db};
+use crate::db::{now_iso, weaver_home, Db};
 
 /// Prefix on every loom API token, so a leaked secret is recognisable and
 /// greppable. A token looks like `loom_<43 url-safe base64 chars>`.
@@ -48,9 +49,10 @@ pub const SESSION_TTL_DAYS: i64 = 30;
 pub const SESSION_COOKIE: &str = "loom_session";
 /// The reserved [`TokenKind::Local`] token name.
 const LOCAL_TOKEN_NAME: &str = "this machine";
-/// SQLite expression for the current instant in our stored ISO format — the one
-/// `weaver-core` writes, so string comparisons against `*_at` columns are sound.
-const SQL_NOW: &str = "strftime('%Y-%m-%dT%H:%M:%fZ','now')";
+
+// Instants and expiries are computed app-side ([`now_iso`] / [`iso_in_days`])
+// and bound as parameters — the stored ISO format orders lexicographically, so
+// the `*_at` comparisons below need no SQL date functions.
 
 // ---------------------------------------------------------------------------
 // Principal
@@ -153,7 +155,7 @@ fn verify_password(password: &str, stored: &str) -> bool {
 // ---------------------------------------------------------------------------
 
 /// One approved operator.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct User {
     pub username: String,
     pub github_login: Option<String>,
@@ -168,37 +170,28 @@ impl User {
     }
 }
 
-fn user_from_row(r: &sqlx::sqlite::SqliteRow) -> User {
-    User {
-        username: r.get("username"),
-        github_login: r.get("github_login"),
-        password_hash: r.get("password_hash"),
-        created_at: r.get("created_at"),
-    }
-}
-
 pub async fn get_user(db: &Db, username: &str) -> Result<Option<User>> {
-    let row = sqlx::query(
+    let row = sqlx::query_as::<_, User>(
         "SELECT username, github_login, password_hash, created_at FROM users WHERE username = ?",
     )
     .bind(username)
     .fetch_optional(db)
     .await?;
-    Ok(row.as_ref().map(user_from_row))
+    Ok(row)
 }
 
 /// The approved user whose `github_login` matches (case-insensitively — GitHub
 /// logins are case-insensitive), if any. This is the allowlist check the OAuth
 /// callback runs: an unknown GitHub identity has no row and is rejected.
 pub async fn user_by_github(db: &Db, login: &str) -> Result<Option<User>> {
-    let row = sqlx::query(
+    let row = sqlx::query_as::<_, User>(
         "SELECT username, github_login, password_hash, created_at FROM users
          WHERE github_login IS NOT NULL AND lower(github_login) = lower(?)",
     )
     .bind(login)
     .fetch_optional(db)
     .await?;
-    Ok(row.as_ref().map(user_from_row))
+    Ok(row)
 }
 
 /// Record the GitHub profile (numeric id + display name) captured at sign-in,
@@ -261,12 +254,12 @@ pub async fn commit_identity(db: &Db, username: &str) -> Result<Option<CommitIde
 }
 
 pub async fn list_users(db: &Db) -> Result<Vec<User>> {
-    let rows = sqlx::query(
+    let rows = sqlx::query_as::<_, User>(
         "SELECT username, github_login, password_hash, created_at FROM users ORDER BY created_at, username",
     )
     .fetch_all(db)
     .await?;
-    Ok(rows.iter().map(user_from_row).collect())
+    Ok(rows)
 }
 
 /// The primary (owner) user: the earliest-created row. Loopback requests and the
@@ -376,13 +369,12 @@ pub async fn loopback_principal(db: &Db) -> Result<Option<Principal>> {
 /// Open a browser session for `username`, returning the opaque cookie value.
 pub async fn create_session(db: &Db, username: &str) -> Result<String> {
     let (plain, hash, _) = mint_token();
-    let sql = format!(
-        "INSERT INTO auth_sessions (token_hash, username, expires_at)
-         VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now','+{SESSION_TTL_DAYS} days'))"
-    );
-    sqlx::query(&sql)
+    let expires_at = iso_in_days(SESSION_TTL_DAYS)
+        .ok_or_else(|| anyhow!("browser session expiry is outside the supported range"))?;
+    sqlx::query("INSERT INTO auth_sessions (token_hash, username, expires_at) VALUES (?, ?, ?)")
         .bind(&hash)
         .bind(username)
+        .bind(expires_at)
         .execute(db)
         .await?;
     Ok(plain)
@@ -392,12 +384,13 @@ pub async fn create_session(db: &Db, username: &str) -> Result<String> {
 /// or its user has since been removed.
 pub async fn lookup_session(db: &Db, cookie: &str) -> Result<Option<Principal>> {
     let hash = sha256_hex(cookie);
-    let row = sqlx::query(&format!(
+    let row = sqlx::query(
         "SELECT s.username AS username, u.github_login AS github_login
          FROM auth_sessions s JOIN users u ON u.username = s.username
-         WHERE s.token_hash = ? AND s.expires_at > {SQL_NOW}"
-    ))
+         WHERE s.token_hash = ? AND s.expires_at > ?",
+    )
     .bind(&hash)
+    .bind(now_iso())
     .fetch_optional(db)
     .await?;
     Ok(row.map(|r| Principal {
@@ -438,7 +431,7 @@ impl TokenKind {
 }
 
 /// A token's non-secret metadata, for the token list.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct TokenInfo {
     pub id: String,
     pub name: String,
@@ -446,17 +439,6 @@ pub struct TokenInfo {
     pub created_at: String,
     pub last_used_at: Option<String>,
     pub expires_at: Option<String>,
-}
-
-fn token_info_from_row(r: &sqlx::sqlite::SqliteRow) -> TokenInfo {
-    TokenInfo {
-        id: r.get("id"),
-        name: r.get("name"),
-        prefix: r.get("prefix"),
-        created_at: r.get("created_at"),
-        last_used_at: r.get("last_used_at"),
-        expires_at: r.get("expires_at"),
-    }
 }
 
 /// Mint a personal access token owned by `username`. Returns the one-time
@@ -479,26 +461,28 @@ async fn create_token_kind(
 ) -> Result<(String, TokenInfo)> {
     let (plain, hash, prefix) = mint_token();
     let id = random_id();
-    // Expiry is computed in SQL so it shares the exact stored format; a positive
-    // `expires_in_days` sets it, anything else leaves the token non-expiring.
-    let expires_sql = match expires_in_days {
-        Some(d) if d > 0 => format!("strftime('%Y-%m-%dT%H:%M:%fZ','now','+{d} days')"),
-        _ => "NULL".to_string(),
+    // A positive `expires_in_days` sets the expiry; anything else leaves the
+    // token non-expiring.
+    let expires_at = match expires_in_days {
+        Some(d) if d > 0 => Some(
+            iso_in_days(d).ok_or_else(|| anyhow!("token expiry is outside the supported range"))?,
+        ),
+        _ => None,
     };
-    let sql = format!(
+    sqlx::query(
         "INSERT INTO api_tokens (id, username, name, token_hash, prefix, kind, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, {expires_sql})"
-    );
-    sqlx::query(&sql)
-        .bind(&id)
-        .bind(username)
-        .bind(name)
-        .bind(&hash)
-        .bind(&prefix)
-        .bind(kind.as_str())
-        .execute(db)
-        .await
-        .context("creating token")?;
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(username)
+    .bind(name)
+    .bind(&hash)
+    .bind(&prefix)
+    .bind(kind.as_str())
+    .bind(&expires_at)
+    .execute(db)
+    .await
+    .context("creating token")?;
     let info = get_token(db, &id)
         .await?
         .ok_or_else(|| anyhow!("token vanished after insert"))?;
@@ -506,25 +490,25 @@ async fn create_token_kind(
 }
 
 async fn get_token(db: &Db, id: &str) -> Result<Option<TokenInfo>> {
-    let row = sqlx::query(
+    let row = sqlx::query_as::<_, TokenInfo>(
         "SELECT id, name, prefix, created_at, last_used_at, expires_at FROM api_tokens WHERE id = ?",
     )
     .bind(id)
     .fetch_optional(db)
     .await?;
-    Ok(row.as_ref().map(token_info_from_row))
+    Ok(row)
 }
 
 /// Every user-managed token (the machine 'local' token is infrastructure and is
 /// omitted), newest first.
 pub async fn list_tokens(db: &Db) -> Result<Vec<TokenInfo>> {
-    let rows = sqlx::query(
+    let rows = sqlx::query_as::<_, TokenInfo>(
         "SELECT id, name, prefix, created_at, last_used_at, expires_at FROM api_tokens
          WHERE kind = 'pat' ORDER BY created_at DESC",
     )
     .fetch_all(db)
     .await?;
-    Ok(rows.iter().map(token_info_from_row).collect())
+    Ok(rows)
 }
 
 /// Revoke a token by id. Refuses the machine 'local' token. Returns whether a
@@ -545,24 +529,24 @@ pub async fn lookup_token(db: &Db, token: &str) -> Result<Option<Principal>> {
         return Ok(None);
     }
     let hash = sha256_hex(token);
-    let row = sqlx::query(&format!(
+    let row = sqlx::query(
         "SELECT t.id AS id, t.username AS username, u.github_login AS github_login
          FROM api_tokens t JOIN users u ON u.username = t.username
-         WHERE t.token_hash = ? AND (t.expires_at IS NULL OR t.expires_at > {SQL_NOW})"
-    ))
+         WHERE t.token_hash = ? AND (t.expires_at IS NULL OR t.expires_at > ?)",
+    )
     .bind(&hash)
+    .bind(now_iso())
     .fetch_optional(db)
     .await?;
     let Some(row) = row else {
         return Ok(None);
     };
     let id: String = row.get("id");
-    let _ = sqlx::query(&format!(
-        "UPDATE api_tokens SET last_used_at = {SQL_NOW} WHERE id = ?"
-    ))
-    .bind(&id)
-    .execute(db)
-    .await;
+    let _ = sqlx::query("UPDATE api_tokens SET last_used_at = ? WHERE id = ?")
+        .bind(now_iso())
+        .bind(&id)
+        .execute(db)
+        .await;
     Ok(Some(Principal {
         username: row.get("username"),
         github_login: row.get("github_login"),
@@ -619,8 +603,9 @@ async fn register_local_token(db: &Db, plain: &str) -> Result<()> {
     let hash = sha256_hex(plain);
     let prefix: String = plain.chars().take(PREFIX_KEEP).collect();
     sqlx::query(
-        "INSERT OR IGNORE INTO api_tokens (id, username, name, token_hash, prefix, kind)
-         VALUES (?, ?, ?, ?, ?, 'local')",
+        "INSERT INTO api_tokens (id, username, name, token_hash, prefix, kind)
+         VALUES (?, ?, ?, ?, ?, 'local')
+         ON CONFLICT DO NOTHING",
     )
     .bind(random_id())
     .bind(&owner)
@@ -1044,7 +1029,7 @@ mod tests {
     async fn register_then_lookup(db: &Db) -> Principal {
         let (plain, _, _) = mint_token();
         register_local_token(db, &plain).await.unwrap();
-        // Re-registering the same plaintext is a no-op (INSERT OR IGNORE).
+        // Re-registering the same plaintext is a no-op (conflict ignored).
         register_local_token(db, &plain).await.unwrap();
         lookup_token(db, &plain).await.unwrap().unwrap()
     }

--- a/crates/loom/src/chat.rs
+++ b/crates/loom/src/chat.rs
@@ -4,11 +4,11 @@
 //!
 //! One row per consolidated *block*, addressed by `(session_id, turn, seq)`:
 //! `turn` is the 0-based prompt cycle, `seq` the 0-based position within it.
-//! Every write is idempotent — `INSERT OR IGNORE` on that key — so a relay spool
-//! replay after a loom restart re-ingests the same frames without duplicating a
-//! block. The one mutable block is `permission_request`: inserted open, then
-//! `UPDATE`d in place with its outcome when resolved (keyed by the upstream
-//! request id inside the payload).
+//! Every write is idempotent — conflicts on that key are ignored — so a relay
+//! spool replay after a loom restart re-ingests the same frames without
+//! duplicating a block. The one mutable block is `permission_request`: inserted
+//! open, then `UPDATE`d in place with its outcome when resolved (keyed by the
+//! upstream request id inside the payload).
 //!
 //! `payload` is opaque JSON here; its shape is keyed by `kind` (see the block
 //! kinds documented on [`crate::acp`]). This module only stores and reads it.
@@ -109,8 +109,9 @@ pub async fn insert(
     payload: &Value,
 ) -> Result<bool> {
     let res = sqlx::query(
-        "INSERT OR IGNORE INTO chat_blocks (session_id, turn, seq, kind, payload, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO chat_blocks (session_id, turn, seq, kind, payload, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT DO NOTHING",
     )
     .bind(session_id)
     .bind(turn)
@@ -126,23 +127,34 @@ pub async fn insert(
 /// Every block for a session, in `(turn, seq)` order — the transcript snapshot
 /// the client fetches before tailing the SSE stream.
 pub async fn list(db: &Db, session_id: &str) -> Result<Vec<ChatBlockView>> {
-    let rows = sqlx::query(
+    let rows = sqlx::query_as::<_, ChatBlockRow>(
         "SELECT turn, seq, kind, payload, created_at FROM chat_blocks
          WHERE session_id = ? ORDER BY turn ASC, seq ASC",
     )
     .bind(session_id)
     .fetch_all(db)
     .await?;
-    Ok(rows.into_iter().map(row_to_view).collect())
+    Ok(rows.into_iter().map(ChatBlockView::from).collect())
 }
 
-fn row_to_view(r: sqlx::sqlite::SqliteRow) -> ChatBlockView {
-    ChatBlockView {
-        turn: r.get("turn"),
-        seq: r.get("seq"),
-        kind: r.get("kind"),
-        payload: serde_json::from_str(&r.get::<String, _>("payload")).unwrap_or(Value::Null),
-        created_at: r.get("created_at"),
+#[derive(sqlx::FromRow)]
+struct ChatBlockRow {
+    turn: i64,
+    seq: i64,
+    kind: String,
+    payload: String,
+    created_at: String,
+}
+
+impl From<ChatBlockRow> for ChatBlockView {
+    fn from(row: ChatBlockRow) -> Self {
+        Self {
+            turn: row.turn,
+            seq: row.seq,
+            kind: row.kind,
+            payload: serde_json::from_str(&row.payload).unwrap_or(Value::Null),
+            created_at: row.created_at,
+        }
     }
 }
 
@@ -165,7 +177,7 @@ pub async fn max_turn_seq(db: &Db, session_id: &str) -> Result<Option<(i64, i64)
 /// [`crate::acp`] reloads these so a REST answer can still resolve one; the
 /// matching un-acked frame replays the JSON-RPC id.
 pub async fn open_permissions(db: &Db, session_id: &str) -> Result<Vec<ChatBlockView>> {
-    let rows = sqlx::query(
+    let rows = sqlx::query_as::<_, ChatBlockRow>(
         "SELECT turn, seq, kind, payload, created_at FROM chat_blocks
          WHERE session_id = ? AND kind = ? ORDER BY turn ASC, seq ASC",
     )
@@ -175,7 +187,7 @@ pub async fn open_permissions(db: &Db, session_id: &str) -> Result<Vec<ChatBlock
     .await?;
     Ok(rows
         .into_iter()
-        .map(row_to_view)
+        .map(ChatBlockView::from)
         .filter(|v| v.payload.get("outcome").map(Value::is_null).unwrap_or(true))
         .collect())
 }
@@ -233,7 +245,7 @@ pub async fn resolve_permission(
     option_id: &str,
     by: &str,
 ) -> Result<Option<ChatBlockView>> {
-    let rows = sqlx::query(
+    let rows = sqlx::query_as::<_, ChatBlockRow>(
         "SELECT turn, seq, kind, payload, created_at FROM chat_blocks
          WHERE session_id = ? AND kind = ?",
     )
@@ -241,8 +253,8 @@ pub async fn resolve_permission(
     .bind(kind::PERMISSION_REQUEST)
     .fetch_all(db)
     .await?;
-    for r in rows {
-        let mut view = row_to_view(r);
+    for row in rows {
+        let mut view = ChatBlockView::from(row);
         if view.payload.get("request_id").and_then(Value::as_str) != Some(request_id) {
             continue;
         }

--- a/crates/loom/src/custom_agents.rs
+++ b/crates/loom/src/custom_agents.rs
@@ -20,7 +20,6 @@
 
 use anyhow::Result;
 use serde::Serialize;
-use sqlx::Row;
 
 use crate::db::{now_iso, Db};
 
@@ -38,7 +37,7 @@ pub const PROTOCOLS: &[&str] = &["terminal", "acp"];
 /// One custom agent definition — a row of the `custom_agents` table and the shape
 /// the API returns for the editor. Every field is operator-supplied except the
 /// timestamps.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, sqlx::FromRow)]
 pub struct CustomAgent {
     /// The id referenced by the agent list and a session's `agent_kind`.
     pub name: String,
@@ -113,25 +112,11 @@ pub fn validate_fields(agent: &CustomAgent) -> std::result::Result<(), String> {
     Ok(())
 }
 
-fn row_to_agent(r: &sqlx::sqlite::SqliteRow) -> CustomAgent {
-    CustomAgent {
-        name: r.get::<String, _>("name"),
-        label: r.get::<String, _>("label"),
-        setup: r.get::<String, _>("setup"),
-        launch: r.get::<String, _>("launch"),
-        resume: r.get::<String, _>("resume"),
-        reports_status: r.get::<i64, _>("reports_status") != 0,
-        protocol: {
-            let p = r.get::<String, _>("protocol");
-            if p.is_empty() {
-                "terminal".to_string()
-            } else {
-                p
-            }
-        },
-        created_at: r.get::<String, _>("created_at"),
-        updated_at: r.get::<String, _>("updated_at"),
+fn normalize_protocol(mut agent: CustomAgent) -> CustomAgent {
+    if agent.protocol.is_empty() {
+        agent.protocol = "terminal".to_string();
     }
+    agent
 }
 
 const COLUMNS: &str =
@@ -140,15 +125,18 @@ const COLUMNS: &str =
 /// Every custom agent, ordered by name.
 pub async fn list(db: &Db) -> Result<Vec<CustomAgent>> {
     let sql = format!("SELECT {COLUMNS} FROM custom_agents ORDER BY name");
-    let rows = sqlx::query(&sql).fetch_all(db).await?;
-    Ok(rows.iter().map(row_to_agent).collect())
+    let rows = sqlx::query_as::<_, CustomAgent>(&sql).fetch_all(db).await?;
+    Ok(rows.into_iter().map(normalize_protocol).collect())
 }
 
 /// One custom agent by name, or `None` when it isn't defined.
 pub async fn get(db: &Db, name: &str) -> Result<Option<CustomAgent>> {
     let sql = format!("SELECT {COLUMNS} FROM custom_agents WHERE name = ?");
-    let row = sqlx::query(&sql).bind(name).fetch_optional(db).await?;
-    Ok(row.as_ref().map(row_to_agent))
+    let row = sqlx::query_as::<_, CustomAgent>(&sql)
+        .bind(name)
+        .fetch_optional(db)
+        .await?;
+    Ok(row.map(normalize_protocol))
 }
 
 /// Whether a custom agent by this name exists.
@@ -185,7 +173,7 @@ pub async fn set(db: &Db, agent: &CustomAgent) -> Result<()> {
     .bind(&agent.setup)
     .bind(&agent.launch)
     .bind(&agent.resume)
-    .bind(i64::from(agent.reports_status))
+    .bind(agent.reports_status)
     .bind(protocol)
     .bind(&now)
     .bind(&now)

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -1,6 +1,5 @@
-//! Loom database setup: opens the shared `~/.weaver/weaver.db` via
-//! `weaver-core`, then adds loom-owned tables (`sessions`, `recent_repos`) on
-//! top.
+//! Loom database setup: opens the shared database through `weaver-core`, then
+//! applies loom's independently versioned, loom-owned schema.
 
 use anyhow::{Context, Result};
 use std::path::Path;
@@ -8,266 +7,20 @@ use std::path::Path;
 pub use weaver_core::db::{
     connect_in_memory as core_connect_in_memory, default_db_path, now_iso, run_dir, weaver_home, Db,
 };
+use weaver_core::migrations::{add_column_if_missing, split_statements, table_columns, Stream};
 
-const LOOM_SCHEMA: &str = r#"
--- One *active* session per branch, enforced by the partial unique index
--- below; terminal sessions stay in the table for history.
-CREATE TABLE IF NOT EXISTS sessions (
-    id                 TEXT PRIMARY KEY,
-    branch_id          TEXT NOT NULL REFERENCES branches(id) ON DELETE CASCADE,
-    work_dir           TEXT NOT NULL,
-    term_session       TEXT NOT NULL,
-    agent_kind         TEXT NOT NULL DEFAULT 'claude',
-    -- Per-session model selector and reasoning effort, interpreted by the
-    -- selected agent type. Empty uses the runtime's own default.
-    model              TEXT NOT NULL DEFAULT '',
-    effort             TEXT NOT NULL DEFAULT '',
-    status             TEXT NOT NULL,
-    github_repo        TEXT,
-    last_activity_at   TEXT,
-    -- The watch id that owns this session when it is engine-managed
-    -- infrastructure — a warm session a watcher keeps for its across-round
-    -- memory. NULL for an ordinary fleet session. A managed session is hidden
-    -- from the fleet listing and the survey scope, and its restart adoption is
-    -- governed by `watch.adopt_warm`, independent of `server.auto_adopt`.
-    managed_by         TEXT,
-    -- The principal (username) that launched this session — attribution for the
-    -- shared team board. NULL for engine-created sessions (warm watch
-    -- sessions) and rows that predate the column. A tracking/UX field, never a
-    -- security boundary: the fleet stays co-owned, this just records who/what
-    -- launched each session.
-    created_by         TEXT,
-    -- Park state — the fleet-list resting shelf, a tier above archived: the
-    -- session keeps its terminal + worktree and stays resumable, it's just
-    -- collapsed out of the live list. Tri-state: NULL = auto (parked-in-view
-    -- once idle past the threshold, live otherwise), 'parked' = pinned to the
-    -- shelf by hand, 'active' = kept live by hand even when idle. Set by
-    -- dragging a row into/out of the Parked region.
-    park               TEXT,
-    -- Manual sort key for the fleet list. NULL = follow the automatic
-    -- urgency-then-recency order; a number places the row exactly (assigned as
-    -- the midpoint of its neighbours on drag). Shares one numeric axis with the
-    -- derived auto-order so manually-placed and untouched rows interleave.
-    sort_order         REAL,
-    -- How this session came to exist: 'user' (hand-launched), 'agent'
-    -- (delegated by another session), 'github' / 'slack' (chat triggers),
-    -- 'watch' (engine infrastructure). Stamped once at create.
-    origin             TEXT NOT NULL DEFAULT 'user',
-    -- Presentation tier: 'interactive' fleet work or 'automation' machinery,
-    -- which the fleet listing hides unless asked. Derived from origin at create
-    -- (watch/actions/ops -> automation), overridable per request.
-    class              TEXT NOT NULL DEFAULT 'interactive',
-    -- Completed agent turns on this session, incremented at each turn boundary.
-    turn_count         INTEGER NOT NULL DEFAULT 0,
-    -- The weaver issue opened (or claimed) as this session's tracker at launch,
-    -- or NULL when the launch tracked nothing.
-    tracking_issue_id  INTEGER,
-    created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
--- Archived counts as terminal here: an archived session keeps its history row
--- but no longer occupies the branch slot, so a fresh session can attach to the
--- same branch.
-CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_active_branch
-    ON sessions(branch_id) WHERE status NOT IN ('done', 'error', 'archived');
+const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[(
+    1,
+    "baseline",
+    include_str!("../migrations/0001_baseline.sql"),
+)];
 
-CREATE TABLE IF NOT EXISTS recent_repos (
-    repo_root    TEXT PRIMARY KEY,
-    last_used_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
+const LOOM_STREAM: Stream = Stream {
+    indicator_table: "loom_schema_migrations",
+    migrations: LOOM_MIGRATIONS,
+};
 
--- Managed repositories: GitHub repos loom has cloned (or may clone) into the
--- container-owned repo root (WEAVER_REPOS_DIR), laid out <owner>/<name>. The
--- slug -> (remote_url, path) mapping doubles as the clone allowlist: only a repo
--- registered here may be resolved and cloned for a session, the boundary the
--- GitHub trigger relies on. Distinct from `recent_repos`, which only records
--- bind-mounted local paths a session has used.
-CREATE TABLE IF NOT EXISTS repos (
-    slug       TEXT PRIMARY KEY,
-    remote_url TEXT NOT NULL,
-    path       TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-
--- Processed GitHub webhook deliveries, keyed on the `X-GitHub-Delivery` GUID.
--- The receiver records each delivery before acting on it and treats a repeat as
--- a no-op, so a replayed (or GitHub-retried) delivery never launches a second
--- session. Append-only; rows are cheap and can be pruned by age later.
-CREATE TABLE IF NOT EXISTS processed_deliveries (
-    delivery_id TEXT PRIMARY KEY,
-    received_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-
--- The latest GitHub snapshot for a branch: the pull request loom found for it
--- (via the `gh` CLI) plus its review/check rollup. One row per branch, replaced
--- on each poll; it is optional context, gone the moment the branch row is.
-CREATE TABLE IF NOT EXISTS branch_github (
-    branch_id        TEXT PRIMARY KEY REFERENCES branches(id) ON DELETE CASCADE,
-    pr_number        INTEGER,
-    pr_url           TEXT,
-    -- 'OPEN' | 'CLOSED' | 'MERGED'.
-    pr_state         TEXT,
-    pr_title         TEXT,
-    is_draft         INTEGER NOT NULL DEFAULT 0,
-    -- 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | NULL.
-    review_decision  TEXT,
-    -- Rolled-up checks: 'passing' | 'failing' | 'pending' | NULL (no checks).
-    checks           TEXT,
-    -- 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | NULL.
-    mergeable        TEXT,
-    merged_at        TEXT,
-    fetched_at       TEXT NOT NULL
-);
-
--- An optional user-selected PR for a branch. Without a row, loom discovers the
--- branch's current open PR automatically. Kept separate from branch_github: the
--- latter is only a disposable status snapshot and must be clearable when an
--- auto-discovered PR is no longer current.
-CREATE TABLE IF NOT EXISTS branch_github_mapping (
-    branch_id  TEXT PRIMARY KEY REFERENCES branches(id) ON DELETE CASCADE,
-    pr_number  INTEGER NOT NULL
-);
-
--- Authentication (loom-only; the daemon-less `weaver` CLI never serves HTTP, so
--- it has no notion of users). An *approved* operator: a row here is the
--- allowlist. `github_login` matches the GitHub OAuth identity; `password_hash`
--- (argon2) backs username/password login. Either may be NULL — a GitHub-only
--- user has no password until they set one, and vice versa.
-CREATE TABLE IF NOT EXISTS users (
-    username       TEXT PRIMARY KEY,
-    github_login   TEXT UNIQUE,
-    password_hash  TEXT,
-    -- Captured at GitHub sign-in for commit attribution (design §6.3, Level A).
-    -- `github_user_id` yields the stable `<id>+<login>@users.noreply.github.com`
-    -- commit email that links a commit to the GitHub account; `display_name` is
-    -- the profile name used for the git author name. Both NULL until the user has
-    -- signed in via GitHub since these columns existed.
-    github_user_id INTEGER,
-    display_name   TEXT,
-    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-
--- API tokens (personal access tokens) for automation — the `LOOM_TOKEN` a CI
--- job or the `loom` CLI presents as `Authorization: Bearer`. Only the SHA-256
--- `token_hash` is stored; the plaintext is shown once at creation. `prefix` is
--- the leading, non-secret slice kept for display ("loom_AbCd…"). `kind` is
--- 'pat' for a user token or 'local' for the machine token loom mints for its own
--- same-host subprocesses (hidden from the token list, not revocable from the UI).
-CREATE TABLE IF NOT EXISTS api_tokens (
-    id           TEXT PRIMARY KEY,
-    username     TEXT NOT NULL REFERENCES users(username) ON DELETE CASCADE,
-    name         TEXT NOT NULL,
-    token_hash   TEXT NOT NULL UNIQUE,
-    prefix       TEXT NOT NULL,
-    kind         TEXT NOT NULL DEFAULT 'pat',
-    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-    last_used_at TEXT,
-    expires_at   TEXT
-);
-
--- Operator-managed environment variables exported into every interactive agent
--- session loom launches (alongside loom's own WEAVER_* / LOOM_TOKEN). A plain
--- name/value store edited at runtime from the settings pane, so secrets and
--- tool config (e.g. a registry token, GH_HOST) can be added without rebuilding
--- the image or editing the deploy env file. NOT applied to the env-stripped
--- one-shot judgement agent.
-CREATE TABLE IF NOT EXISTS agent_env (
-    name       TEXT PRIMARY KEY,
-    value      TEXT NOT NULL,
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-
--- Per-repo environment variables, layered into a session's agent terminal above
--- the global `agent_env` (global < per-repo < the repo's own .weaver/config.toml
--- [env]). Keyed by the canonical `repo_root` path, like `branches`/`issues`, so a
--- launch (which has the resolved repo root) can look them up directly. Values are
--- write-only: the API returns names + timestamps, never the value, since these
--- hold per-repo secrets (registry tokens, database URLs). Blast-radius reduction,
--- not isolation — in the single shared container any agent can still read the
--- exported env (see the shared-loom design §6.4).
-CREATE TABLE IF NOT EXISTS repo_env (
-    repo_root  TEXT NOT NULL,
-    name       TEXT NOT NULL,
-    value      TEXT NOT NULL,
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-    PRIMARY KEY (repo_root, name)
-);
-
--- Browser login sessions: the opaque cookie a successful GitHub/password login
--- sets. Stored hashed like a token; named `auth_sessions` to stay clear of the
--- agent `sessions` table above. A row is dropped on logout or once `expires_at`
--- passes.
-CREATE TABLE IF NOT EXISTS auth_sessions (
-    token_hash TEXT PRIMARY KEY,
-    username   TEXT NOT NULL REFERENCES users(username) ON DELETE CASCADE,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-    expires_at TEXT NOT NULL
-);
-
--- A user's own GitHub token (a fine-grained PAT they paste into their account
--- pane), injected as GH_TOKEN into the interactive sessions that user launches
--- so an agent's `git push` / `gh` acts as *them* rather than as the shared
--- ambient GH_TOKEN from the deploy env. Write-only over the API (status +
--- timestamp, never the token), like `repo_env` — blast-radius reduction, not
--- isolation (any agent in the shared container can still read the exported
--- GH_TOKEN; see the shared-loom design §6.4). One row per user; dropped with the
--- user via ON DELETE CASCADE.
-CREATE TABLE IF NOT EXISTS user_github_tokens (
-    username   TEXT PRIMARY KEY REFERENCES users(username) ON DELETE CASCADE,
-    token      TEXT NOT NULL,
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-
--- Operator-defined custom agents: a coding agent the user wires up by naming the
--- shell commands loom runs at each launch stage, so it shows up in the agent list
--- beside the builtin `claude`/`codex` without a code change. `name` is the id the
--- agent list and a session's `agent_kind` reference; the builtin names are
--- reserved (see `custom_agents::validate_name`). Each stage is a shell fragment:
---   * `setup`  — run in the worktree before launch (e.g. installing status hooks);
---   * `launch` — the fresh-session command, with the goal appended as an argument;
---   * `resume` — the adopt/resume command (blank falls back to `launch`).
--- `reports_status` records whether the agent fires weaver's lifecycle hooks, which
--- drive the idle/attention signals (a fresh session is `running` immediately).
--- `protocol` is the execution backend loom drives this agent through: 'terminal'
--- (a PTY supervisor running an interactive command — the default) or 'acp' (a
--- headless adapter under a relay supervisor, whose `launch` command is the ACP
--- adapter spoken to over stdio). See `custom_agents::Protocol`.
-CREATE TABLE IF NOT EXISTS custom_agents (
-    name           TEXT PRIMARY KEY,
-    label          TEXT NOT NULL,
-    setup          TEXT NOT NULL DEFAULT '',
-    launch         TEXT NOT NULL DEFAULT '',
-    resume         TEXT NOT NULL DEFAULT '',
-    reports_status INTEGER NOT NULL DEFAULT 0,
-    protocol       TEXT NOT NULL DEFAULT 'terminal',
-    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-    updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-
--- The chat journal for ACP (protocol='acp') sessions: one row per consolidated
--- *block* of a session's conversation, in the order it reached a terminal state.
--- Loom's ACP client (crate::acp) accumulates streaming chunk deltas in memory and
--- writes a row here per block (a whole agent/user message, a tool call reaching a
--- terminal status, a plan, a permission resolution, a turn end). Every write is
--- idempotent — `INSERT OR IGNORE` on the (session_id, turn, seq) key — so a relay
--- replay after a loom restart re-ingests without duplicating. `payload` is the
--- block's JSON body (its shape keyed by `kind`; see crate::chat). `session_id`
--- is TEXT to match the string `sessions.id` it references.
-CREATE TABLE IF NOT EXISTS chat_blocks (
-    id         INTEGER PRIMARY KEY,
-    session_id TEXT    NOT NULL,
-    turn       INTEGER NOT NULL,
-    seq        INTEGER NOT NULL,
-    kind       TEXT    NOT NULL,
-    payload    TEXT    NOT NULL,
-    created_at TEXT    NOT NULL,
-    UNIQUE(session_id, turn, seq)
-);
-CREATE INDEX IF NOT EXISTS idx_chat_blocks_session
-    ON chat_blocks(session_id, turn, seq);
-"#;
-
-/// Open the shared database and apply loom's additional tables on top of the
-/// core schema.
+/// Open the shared database and apply loom's schema after the core schema.
 pub async fn connect(path: &Path) -> Result<Db> {
     let pool = weaver_core::db::connect(path).await?;
     migrate_loom(&pool).await?;
@@ -282,155 +35,79 @@ pub async fn connect_in_memory() -> Result<Db> {
 }
 
 async fn migrate_loom(pool: &Db) -> Result<()> {
-    let stripped: String = LOOM_SCHEMA
-        .lines()
-        .map(|line| match line.find("--") {
-            Some(idx) => &line[..idx],
-            None => line,
-        })
-        .collect::<Vec<&str>>()
-        .join("\n");
-    let statements: Vec<String> = stripped
-        .split(';')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
-    tracing::info!(statements = statements.len(), "applying loom schema");
-    for trimmed in &statements {
-        tracing::debug!(statement = %trimmed, "running loom migration");
-        sqlx::query(trimmed.as_str())
+    let indicator_exists = LOOM_STREAM.indicator_exists(pool).await?;
+    let baseline_recorded = if indicator_exists {
+        sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS(SELECT 1 FROM loom_schema_migrations WHERE version = 1)",
+        )
+        .fetch_one(pool)
+        .await
+        .context("checking loom baseline version")?
+    } else {
+        false
+    };
+
+    // Loom tables predate their migration stream. If an unversioned sessions
+    // table is present, bring every supported historical shape to the baseline
+    // end state and stamp it rather than replaying baseline DDL against it. Test
+    // the version, not just the indicator table: a crash after creating the
+    // indicator but before stamping must resume adoption on the next start.
+    if !baseline_recorded && !table_columns(pool, "sessions").await?.is_empty() {
+        adopt_unversioned_schema(pool).await?;
+        LOOM_STREAM.ensure_indicator(pool).await?;
+        LOOM_STREAM.stamp(pool, 1, "baseline").await?;
+    }
+
+    LOOM_STREAM.ensure_indicator(pool).await?;
+    LOOM_STREAM.apply_pending(pool).await?;
+
+    // Configuration-dependent seeding is intentionally not a migration. If the
+    // first start has no owner configured, a later restart must retry it.
+    seed_owner(pool).await?;
+    Ok(())
+}
+
+/// Adopt a database built by the pre-stream `LOOM_SCHEMA` runner.
+///
+/// Every operation is presence-gated or idempotent. The function can therefore
+/// resume after any interrupted statement, and it never compares an existing
+/// column's exact declaration: deployed databases legitimately carry stricter
+/// declarations than some historical source revisions.
+async fn adopt_unversioned_schema(pool: &Db) -> Result<()> {
+    tracing::info!("adopting unversioned loom schema");
+
+    // Create any loom tables that were introduced after this database was
+    // first deployed. Existing tables are left untouched and reconciled below.
+    for stmt in split_statements(LOOM_MIGRATIONS[0].2) {
+        sqlx::query(&stmt)
             .execute(pool)
             .await
-            .with_context(|| format!("running loom migration: {trimmed}"))?;
+            .with_context(|| format!("adopting loom baseline: {stmt}"))?;
     }
-    // Rename for databases created when the column was `tmux_session` (loom
-    // backed sessions with tmux before the native terminal supervisor). The
-    // `CREATE TABLE IF NOT EXISTS` above is a no-op on such DBs, so rename the
-    // existing column; a fresh DB already has `term_session`, so the rename finds
-    // nothing and is ignored.
-    rename_column_if_present(pool, "sessions", "tmux_session", "term_session").await?;
-    // Additive column migrations for databases created before the column
-    // existed. `CREATE TABLE IF NOT EXISTS` above is a no-op on such DBs, so we
-    // add the column explicitly and ignore the "duplicate column" error.
-    add_column_if_missing(pool, "sessions", "model", "TEXT NOT NULL DEFAULT ''").await?;
-    add_column_if_missing(pool, "sessions", "effort", "TEXT NOT NULL DEFAULT ''").await?;
-    // The branch id of the session that launched this one — its parent in the
-    // dashboard's session tree. Set once at create time from the known launcher;
-    // NULL for a top-level session. Sessions predating the column stay NULL (they
-    // render flat, as they did before threading existed).
-    add_column_if_missing(pool, "sessions", "parent_branch_id", "TEXT").await?;
-    // The owning watch id for an engine-managed (warm) session; NULL for an
-    // ordinary fleet session. Sessions predating the column stay NULL (they are
-    // all ordinary fleet sessions, as they were before warm sessions existed).
-    add_column_if_missing(pool, "sessions", "managed_by", "TEXT").await?;
-    // The principal (username) that launched this session — attribution for the
-    // shared team board. NULL for engine-created sessions and rows predating the
-    // column. (The `sessions` table is created here in `migrate_loom`, after the
-    // weaver-core numbered migrations have already run, so a `sessions` column is
-    // added here rather than as a numbered migration in weaver-core/migrations —
-    // matching `model`/`effort`/`parent_branch_id`/`managed_by` above.)
-    add_column_if_missing(pool, "sessions", "created_by", "TEXT").await?;
-    add_column_if_missing(pool, "sessions", "park", "TEXT").await?;
-    add_column_if_missing(pool, "sessions", "sort_order", "REAL").await?;
-    // The execution backend for this session: 'terminal' (a PTY supervisor
-    // driving an interactive TUI — the historical path) or 'acp' (a headless
-    // adapter under a relay supervisor, driven by crate::acp over the Agent
-    // Client Protocol). Sessions predating the column are all terminal.
-    add_column_if_missing(
-        pool,
-        "sessions",
-        "protocol",
-        "TEXT NOT NULL DEFAULT 'terminal'",
-    )
-    .await?;
-    // The agent's own on-disk session id for an ACP session (the `session/new`
-    // /`session/load` id), NULL for a terminal session or before setup completes.
-    add_column_if_missing(pool, "sessions", "acp_session_id", "TEXT").await?;
-    // The relay spool cursor: the highest frame seq loom has durably journaled a
-    // block boundary for. crate::acp subscribes from this on (re)attach so an
-    // un-acked frame replays exactly-once.
-    add_column_if_missing(
-        pool,
-        "sessions",
-        "acp_ack_seq",
-        "INTEGER NOT NULL DEFAULT 0",
-    )
-    .await?;
-    // Outstanding client->agent request state that does not survive loom's
-    // process — the in-flight `session/prompt` request id + its turn — as JSON
-    // (e.g. `{"prompt_id":7,"turn":3}`), re-adopted on attach so the eventual
-    // turn-end response is recognized. NULL when no turn is in flight.
-    add_column_if_missing(pool, "sessions", "acp_inflight", "TEXT").await?;
-    // The session's current ACP mode id (the gating posture: `bypassPermissions`,
-    // `acceptEdits`, `default`, `plan`, …). NULL until the agent reports one.
-    add_column_if_missing(pool, "sessions", "current_mode", "TEXT").await?;
-    // The durable prompt queue: a paragraph-appended user message accumulated
-    // while a turn is in flight, dispatched as one `session/prompt` at the next
-    // turn boundary. Canonically the empty string when nothing is queued — never
-    // NULL. Declared `NOT NULL DEFAULT ''` so a fresh database matches the shape
-    // long-lived databases already carry (older schemas created the column inside
-    // `CREATE TABLE sessions` as `TEXT NOT NULL DEFAULT ''`; `CREATE TABLE IF NOT
-    // EXISTS` is then a no-op and this additive migration is swallowed as a
-    // duplicate). Keeping every database on one shape means the queue-clearing
-    // writes below can never trip a `NOT NULL` constraint on one database while
-    // passing on another — see `session::take_pending_prompt`.
-    add_column_if_missing(
-        pool,
-        "sessions",
-        "pending_prompt",
-        "TEXT NOT NULL DEFAULT ''",
-    )
-    .await?;
-    // Session provenance + class (see the `sessions` schema above). Backfilled
-    // only when the column was freshly added — the rows predating it are the
-    // ones whose origin must be reconstructed from the old heuristics: an
-    // engine-managed (warm) session is watch machinery, and a session with a
-    // recorded launcher was delegated by an agent.
-    let origin_added =
-        add_column_if_missing(pool, "sessions", "origin", "TEXT NOT NULL DEFAULT 'user'").await?;
-    add_column_if_missing(
-        pool,
-        "sessions",
-        "class",
-        "TEXT NOT NULL DEFAULT 'interactive'",
-    )
-    .await?;
-    add_column_if_missing(pool, "sessions", "turn_count", "INTEGER NOT NULL DEFAULT 0").await?;
-    add_column_if_missing(pool, "sessions", "tracking_issue_id", "INTEGER").await?;
-    if origin_added {
-        sqlx::query(
-            "UPDATE sessions SET origin = 'watch', class = 'automation'
-             WHERE managed_by IS NOT NULL",
-        )
-        .execute(pool)
-        .await
-        .context("backfilling watch session origin")?;
-        sqlx::query(
-            "UPDATE sessions SET origin = 'agent'
-             WHERE origin = 'user' AND parent_branch_id IS NOT NULL",
-        )
-        .execute(pool)
-        .await
-        .context("backfilling agent session origin")?;
+
+    rename_session_terminal_column(pool).await?;
+    for (column, declaration) in [
+        ("model", "TEXT NOT NULL DEFAULT ''"),
+        ("effort", "TEXT NOT NULL DEFAULT ''"),
+        ("parent_branch_id", "TEXT"),
+        ("managed_by", "TEXT"),
+        ("created_by", "TEXT"),
+        ("park", "TEXT"),
+        ("sort_order", "REAL"),
+        ("protocol", "TEXT NOT NULL DEFAULT 'terminal'"),
+        ("acp_session_id", "TEXT"),
+        ("acp_ack_seq", "INTEGER NOT NULL DEFAULT 0"),
+        ("acp_inflight", "TEXT"),
+        ("current_mode", "TEXT"),
+        ("pending_prompt", "TEXT NOT NULL DEFAULT ''"),
+        ("origin", "TEXT NOT NULL DEFAULT 'user'"),
+        ("class", "TEXT NOT NULL DEFAULT 'interactive'"),
+        ("turn_count", "INTEGER NOT NULL DEFAULT 0"),
+        ("tracking_issue_id", "INTEGER"),
+    ] {
+        add_column_if_missing(pool, "sessions", column, declaration).await?;
     }
-    // Recreate the one-active-session-per-branch index under its current
-    // predicate (archived no longer occupies the branch slot). `CREATE INDEX IF
-    // NOT EXISTS` above silently keeps an old definition, so drop first; the
-    // predicate indexes strictly fewer rows than any prior one, so recreation
-    // cannot conflict on existing data.
-    sqlx::query("DROP INDEX IF EXISTS idx_sessions_active_branch")
-        .execute(pool)
-        .await?;
-    sqlx::query(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_active_branch
-         ON sessions(branch_id) WHERE status NOT IN ('done', 'error', 'archived')",
-    )
-    .execute(pool)
-    .await?;
-    // The custom agent's execution backend: 'terminal' (a PTY running its launch
-    // command) or 'acp' (its launch command is an ACP adapter driven over stdio).
-    // Added here for databases created before the column; a fresh DB has it from
-    // the `CREATE TABLE` above and this is a no-op.
+
     add_column_if_missing(
         pool,
         "custom_agents",
@@ -438,28 +115,78 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
         "TEXT NOT NULL DEFAULT 'terminal'",
     )
     .await?;
-    // GitHub profile captured at sign-in for commit attribution (see the `users`
-    // schema above). Added here for databases predating the columns; a fresh DB
-    // already has them from the `CREATE TABLE` and these are no-ops.
     add_column_if_missing(pool, "users", "github_user_id", "INTEGER").await?;
     add_column_if_missing(pool, "users", "display_name", "TEXT").await?;
-    seed_owner(pool).await?;
+
+    // These are safe to repeat. In particular, repeating them repairs a crash
+    // after `origin` or `class` was added but before the old one-shot backfill.
+    sqlx::query(
+        "UPDATE sessions SET origin = 'watch', class = 'automation'
+         WHERE managed_by IS NOT NULL",
+    )
+    .execute(pool)
+    .await
+    .context("backfilling watch session provenance")?;
+    sqlx::query(
+        "UPDATE sessions SET origin = 'agent'
+         WHERE origin = 'user' AND parent_branch_id IS NOT NULL",
+    )
+    .execute(pool)
+    .await
+    .context("backfilling delegated session provenance")?;
+
+    // `CREATE INDEX IF NOT EXISTS` retains an older predicate. Rebuild it after
+    // session adoption so archived history no longer occupies the branch slot.
+    sqlx::query("DROP INDEX IF EXISTS idx_sessions_active_branch")
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "CREATE UNIQUE INDEX idx_sessions_active_branch
+         ON sessions(branch_id) WHERE status NOT IN ('done', 'error', 'archived')",
+    )
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
-/// Seed the approved-user allowlist with the deploy owner named by
-/// `LOOM_OWNER_GITHUB`, so a fresh database is usable immediately: GitHub login
-/// works for exactly this one identity until more users are added.
-/// `INSERT OR IGNORE` makes this a no-op once the row (or any same-username
-/// row) exists, so it never clobbers later edits — including a password the
-/// owner has set.
-///
-/// Fails closed: with `LOOM_OWNER_GITHUB` unset or empty, no owner is seeded at
-/// all — a warning is logged and GitHub/loopback login simply has no `users`
-/// row to resolve to until the operator sets it (see [`crate::auth::primary_user`]
-/// returning `None`). This never falls back to a real login (e.g. the
-/// maintainer's own), which would hand an internet-facing deploy's sole owner
-/// slot to someone other than its operator.
+/// Reconcile the one historical rename without inspecting error strings.
+async fn rename_session_terminal_column(pool: &Db) -> Result<()> {
+    let columns = table_columns(pool, "sessions").await?;
+    let has_old = columns.iter().any(|column| column == "tmux_session");
+    let has_new = columns.iter().any(|column| column == "term_session");
+    match (has_old, has_new) {
+        (true, false) => {
+            sqlx::query("ALTER TABLE sessions RENAME COLUMN tmux_session TO term_session")
+                .execute(pool)
+                .await
+                .context("renaming sessions.tmux_session to term_session")?;
+        }
+        // A partially/manual-upgraded database can contain both. Preserve the
+        // new column as authoritative, fill only empty values from the old,
+        // then remove the legacy NOT NULL column: leaving it behind would make
+        // every later insert that supplies only `term_session` fail.
+        (true, true) => {
+            sqlx::query(
+                "UPDATE sessions SET term_session = tmux_session
+                 WHERE term_session IS NULL OR term_session = ''",
+            )
+            .execute(pool)
+            .await
+            .context("reconciling sessions terminal columns")?;
+            sqlx::query("ALTER TABLE sessions DROP COLUMN tmux_session")
+                .execute(pool)
+                .await
+                .context("dropping legacy sessions.tmux_session column")?;
+        }
+        (false, true) => {}
+        (false, false) => {
+            anyhow::bail!("unversioned sessions table has neither term_session nor tmux_session")
+        }
+    }
+    Ok(())
+}
+
+/// Seed the approved-user allowlist with the configured deploy owner.
 async fn seed_owner(pool: &Db) -> Result<()> {
     let owner = std::env::var("LOOM_OWNER_GITHUB")
         .ok()
@@ -473,71 +200,238 @@ async fn seed_owner(pool: &Db) -> Result<()> {
         );
         return Ok(());
     };
-    sqlx::query("INSERT OR IGNORE INTO users (username, github_login) VALUES (?, ?)")
-        .bind(&owner)
-        .bind(&owner)
-        .execute(pool)
-        .await
-        .with_context(|| format!("seeding owner user '{owner}'"))?;
+    sqlx::query(
+        "INSERT INTO users (username, github_login) VALUES (?, ?)
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(&owner)
+    .bind(&owner)
+    .execute(pool)
+    .await
+    .with_context(|| format!("seeding owner user '{owner}'"))?;
     Ok(())
-}
-
-/// Run `ALTER TABLE … RENAME COLUMN from TO to`, treating a missing source
-/// column as success (a fresh DB already has the new name, so there is nothing
-/// to rename).
-async fn rename_column_if_present(pool: &Db, table: &str, from: &str, to: &str) -> Result<()> {
-    let sql = format!("ALTER TABLE {table} RENAME COLUMN {from} TO {to}");
-    match sqlx::query(&sql).execute(pool).await {
-        Ok(_) => {
-            tracing::info!(%table, %from, %to, "renamed column");
-            Ok(())
-        }
-        // SQLite: "no such column: <from>" once already renamed / fresh schema.
-        Err(e) if e.to_string().contains("no such column") => Ok(()),
-        Err(e) => Err(e).with_context(|| format!("renaming column {table}.{from} -> {to}")),
-    }
-}
-
-/// Run `ALTER TABLE … ADD COLUMN`, treating an already-present column as
-/// success. Returns whether the column was freshly added (`false` when it
-/// already existed) so a caller can gate a one-time backfill on it.
-async fn add_column_if_missing(pool: &Db, table: &str, column: &str, decl: &str) -> Result<bool> {
-    let sql = format!("ALTER TABLE {table} ADD COLUMN {column} {decl}");
-    match sqlx::query(&sql).execute(pool).await {
-        Ok(_) => {
-            tracing::info!(%table, %column, "added column");
-            Ok(true)
-        }
-        Err(e) if e.to_string().contains("duplicate column name") => Ok(false),
-        Err(e) => Err(e).with_context(|| format!("adding column {table}.{column}")),
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::Row;
 
-    #[tokio::test]
-    async fn in_memory_schema_works() {
-        let db = connect_in_memory().await.unwrap();
+    async fn insert_branch(db: &Db, id: &str) {
         sqlx::query(
             "INSERT INTO branches (id, repo_root, branch, created_at, updated_at)
-             VALUES ('t1', '/r', 'main', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')",
+             VALUES (?, '/r', ?, '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')",
+        )
+        .bind(id)
+        .bind(id)
+        .execute(db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn fresh_schema_records_baseline_and_has_final_shape() {
+        let db = connect_in_memory().await.unwrap();
+        let versions: Vec<i64> =
+            sqlx::query_scalar("SELECT version FROM loom_schema_migrations ORDER BY version")
+                .fetch_all(&db)
+                .await
+                .unwrap();
+        assert_eq!(versions, vec![1]);
+
+        let columns = table_columns(&db, "sessions").await.unwrap();
+        for expected in [
+            "term_session",
+            "parent_branch_id",
+            "protocol",
+            "pending_prompt",
+            "origin",
+            "class",
+            "turn_count",
+            "tracking_issue_id",
+        ] {
+            assert!(
+                columns.iter().any(|column| column == expected),
+                "{expected}"
+            );
+        }
+
+        insert_branch(&db, "t1").await;
+        sqlx::query(
+            "INSERT INTO sessions (id, branch_id, work_dir, term_session, status)
+             VALUES ('archived', 't1', '/w1', 'term-1', 'archived'),
+                    ('active', 't1', '/w2', 'term-2', 'running')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn adopts_old_terminal_name_and_preserves_rows() {
+        let db = core_connect_in_memory().await.unwrap();
+        insert_branch(&db, "b1").await;
+        sqlx::query(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                branch_id TEXT NOT NULL,
+                work_dir TEXT NOT NULL,
+                tmux_session TEXT NOT NULL,
+                agent_kind TEXT NOT NULL DEFAULT 'claude',
+                status TEXT NOT NULL,
+                github_repo TEXT,
+                last_activity_at TEXT,
+                created_at TEXT NOT NULL DEFAULT ''
+             )",
         )
         .execute(&db)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO sessions (id, branch_id, work_dir, term_session, status)
-             VALUES ('s1', 't1', '/w', 'weaver-s1', 'running')",
+            "INSERT INTO sessions
+             (id, branch_id, work_dir, tmux_session, status, created_at)
+             VALUES ('s1', 'b1', '/w', 'legacy-term', 'running', '2026-01-01')",
         )
         .execute(&db)
         .await
         .unwrap();
-        let (n,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM sessions")
+
+        migrate_loom(&db).await.unwrap();
+        migrate_loom(&db).await.unwrap();
+
+        let columns = table_columns(&db, "sessions").await.unwrap();
+        assert!(columns.iter().any(|column| column == "term_session"));
+        assert!(!columns.iter().any(|column| column == "tmux_session"));
+        let row = sqlx::query("SELECT term_session, protocol, origin, class FROM sessions")
             .fetch_one(&db)
             .await
             .unwrap();
-        assert_eq!(n, 1);
+        assert_eq!(row.get::<String, _>("term_session"), "legacy-term");
+        assert_eq!(row.get::<String, _>("protocol"), "terminal");
+        assert_eq!(row.get::<String, _>("origin"), "user");
+        assert_eq!(row.get::<String, _>("class"), "interactive");
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM loom_schema_migrations")
+            .fetch_one(&db)
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+
+        // Adoption replaced the historical index predicate: archived history
+        // no longer prevents a new active session from claiming the branch.
+        sqlx::query("UPDATE sessions SET status = 'archived' WHERE id = 's1'")
+            .execute(&db)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions (id, branch_id, work_dir, term_session, status)
+             VALUES ('s2', 'b1', '/w2', 'new-term', 'running')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn partial_provenance_upgrade_is_repaired_idempotently() {
+        let db = core_connect_in_memory().await.unwrap();
+        insert_branch(&db, "watch-branch").await;
+        insert_branch(&db, "agent-branch").await;
+        sqlx::query(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                branch_id TEXT NOT NULL,
+                work_dir TEXT NOT NULL,
+                term_session TEXT NOT NULL,
+                agent_kind TEXT NOT NULL DEFAULT 'claude',
+                status TEXT NOT NULL,
+                github_repo TEXT,
+                last_activity_at TEXT,
+                parent_branch_id TEXT,
+                managed_by TEXT,
+                origin TEXT NOT NULL DEFAULT 'user',
+                created_at TEXT NOT NULL DEFAULT ''
+             )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions
+             (id, branch_id, work_dir, term_session, status, managed_by, created_at)
+             VALUES ('watch', 'watch-branch', '/w', 't1', 'running', 'watch-1', '2026-01-01')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions
+             (id, branch_id, work_dir, term_session, status, parent_branch_id, created_at)
+             VALUES ('agent', 'agent-branch', '/a', 't2', 'running', 'parent', '2026-01-01')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        // Model a crash after the indicator table was created but before the
+        // legacy baseline was stamped.
+        LOOM_STREAM.ensure_indicator(&db).await.unwrap();
+        migrate_loom(&db).await.unwrap();
+        migrate_loom(&db).await.unwrap();
+
+        let rows: Vec<(String, String, String)> =
+            sqlx::query_as("SELECT id, origin, class FROM sessions ORDER BY id")
+                .fetch_all(&db)
+                .await
+                .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("agent".into(), "agent".into(), "interactive".into()),
+                ("watch".into(), "watch".into(), "automation".into()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn adoption_reconciles_both_terminal_columns() {
+        let db = core_connect_in_memory().await.unwrap();
+        insert_branch(&db, "b1").await;
+        sqlx::query(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, branch_id TEXT NOT NULL, work_dir TEXT NOT NULL,
+                tmux_session TEXT NOT NULL, term_session TEXT,
+                agent_kind TEXT NOT NULL DEFAULT 'claude', status TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT ''
+             )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions
+             (id, branch_id, work_dir, tmux_session, term_session, status)
+             VALUES ('s1', 'b1', '/w', 'old-value', '', 'running')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        migrate_loom(&db).await.unwrap();
+        let value: String = sqlx::query_scalar("SELECT term_session FROM sessions WHERE id = 's1'")
+            .fetch_one(&db)
+            .await
+            .unwrap();
+        assert_eq!(value, "old-value");
+
+        let columns = table_columns(&db, "sessions").await.unwrap();
+        assert!(!columns.iter().any(|column| column == "tmux_session"));
+        insert_branch(&db, "b2").await;
+        sqlx::query(
+            "INSERT INTO sessions (id, branch_id, work_dir, term_session, status)
+             VALUES ('s2', 'b2', '/w2', 'new-value', 'running')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
     }
 }

--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -344,11 +344,13 @@ impl IssueCommentEvent {
 /// A repeat (a replay, or a GitHub retry of a delivery we already handled)
 /// returns `false`, so the caller treats it as a no-op.
 pub async fn record_delivery(db: &Db, delivery_id: &str) -> Result<bool> {
-    let res = sqlx::query("INSERT OR IGNORE INTO processed_deliveries (delivery_id) VALUES (?)")
-        .bind(delivery_id)
-        .execute(db)
-        .await
-        .context("recording webhook delivery")?;
+    let res = sqlx::query(
+        "INSERT INTO processed_deliveries (delivery_id) VALUES (?) ON CONFLICT DO NOTHING",
+    )
+    .bind(delivery_id)
+    .execute(db)
+    .await
+    .context("recording webhook delivery")?;
     Ok(res.rows_affected() > 0)
 }
 

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -364,6 +364,14 @@ pub(super) async fn create_token(
     if name.is_empty() {
         return Err(AppError::bad_request("a token name is required"));
     }
+    if body
+        .expires_in_days
+        .is_some_and(|days| days > 0 && weaver_core::db::iso_in_days(days).is_none())
+    {
+        return Err(AppError::bad_request(
+            "token expiry is outside the supported range",
+        ));
+    }
     let (token, info) =
         auth::create_token(&st.db, &principal.username, name, body.expires_in_days).await?;
     tracing::info!(username = %principal.username, id = %info.id, name = %info.name, "api token created");

--- a/crates/loom/tests/integration/auth.rs
+++ b/crates/loom/tests/integration/auth.rs
@@ -152,6 +152,19 @@ async fn loopback_trust_then_token_local_and_cookie_gate_access() {
 
 #[tokio::test]
 #[serial]
+async fn absurd_token_expiry_is_a_bad_request_not_a_panic() {
+    let ts = TestServer::start().await;
+    let response = reqwest::Client::new()
+        .post(url(&ts, "/api/auth/tokens"))
+        .json(&json!({ "name": "too-long", "expires_in_days": i64::MAX }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[serial]
 async fn health_is_public_but_protected_routes_are_not() {
     let ts = TestServer::start().await;
     let http = reqwest::Client::new();

--- a/crates/weaver-core/src/artifact.rs
+++ b/crates/weaver-core/src/artifact.rs
@@ -328,8 +328,8 @@ mod tests {
     /// write satisfies the `artifacts.branch_id` foreign key. Idempotent.
     async fn ensure_branch(db: &Db, id: &str) {
         sqlx::query(
-            "INSERT OR IGNORE INTO branches (id, repo_root, branch, base_branch)
-             VALUES (?, '/r', ?, 'main')",
+            "INSERT INTO branches (id, repo_root, branch, base_branch)
+             VALUES (?, '/r', ?, 'main') ON CONFLICT DO NOTHING",
         )
         .bind(id)
         .bind(id)

--- a/crates/weaver-core/src/db.rs
+++ b/crates/weaver-core/src/db.rs
@@ -48,6 +48,9 @@ impl ImmediateTransaction<'_> {
     }
 }
 
+/// A write transaction on [`Db`]. Callers hold this alias rather than naming
+/// the backend's transaction type themselves.
+pub type DbTransaction<'a> = ImmediateTransaction<'a>;
 /// Root directory for all weaver state on this machine.
 pub fn weaver_home() -> PathBuf {
     if let Ok(p) = std::env::var("WEAVER_HOME") {
@@ -110,6 +113,23 @@ pub fn now_iso() -> String {
         .to_string()
 }
 
+/// The instant `days` days from now, in the same stored format as [`now_iso`].
+/// Expiries are computed app-side and bound as parameters so queries carry no
+/// backend-specific date arithmetic; the format orders lexicographically, so
+/// string comparison against `*_at` columns is sound. Returns `None` when the
+/// requested interval or resulting instant is outside chrono's range.
+pub fn iso_in_days(days: i64) -> Option<String> {
+    let delta = chrono::TimeDelta::try_days(days)?;
+    chrono::Utc::now()
+        .checked_add_signed(delta)
+        .map(|instant| instant.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+}
+
+/// Open (creating if missing) and migrate the on-disk database.
+///
+/// Backend-specific surface, kept here and in [`begin_immediate`]: the
+/// `sqlite:` DSN string, the WAL journal mode, the `busy_timeout`, and the
+/// migrate-then-reopen connection dance below.
 pub async fn connect(path: &Path) -> Result<Db> {
     tracing::info!(path = %path.display(), "opening database");
     if let Some(parent) = path.parent() {
@@ -173,7 +193,10 @@ pub async fn connect_in_memory() -> Result<Db> {
 ///
 /// Contenders queue on [`WRITE_LOCK`] before acquiring a pool connection. This
 /// preserves read capacity while writes wait for SQLite's single writer slot.
-pub async fn begin_immediate(db: &Db) -> sqlx::Result<ImmediateTransaction<'static>> {
+///
+/// Backend-specific surface (with [`connect`]): the lock-upgrade behaviour and
+/// the `BEGIN IMMEDIATE` statement are SQLite's.
+pub async fn begin_immediate(db: &Db) -> sqlx::Result<DbTransaction<'static>> {
     let writer = WRITE_LOCK.lock().await;
     let tx = db.begin_with("BEGIN IMMEDIATE").await?;
     Ok(ImmediateTransaction {
@@ -193,6 +216,31 @@ mod tests {
     use super::*;
     use std::future::Future;
     use std::task::Poll;
+
+    #[test]
+    fn iso_in_days_uses_the_shared_sortable_timestamp_format() {
+        let before = chrono::Utc::now();
+        let encoded = iso_in_days(2).unwrap();
+        let after = chrono::Utc::now();
+        let parsed = chrono::DateTime::parse_from_rfc3339(&encoded)
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        // Formatting truncates sub-millisecond precision, hence the small
+        // tolerance around the time spent inside `iso_in_days`.
+        assert!(parsed >= before + chrono::Duration::days(2) - chrono::Duration::milliseconds(2));
+        assert!(parsed <= after + chrono::Duration::days(2) + chrono::Duration::milliseconds(2));
+        assert_eq!(encoded.len(), "2026-01-01T00:00:00.000Z".len());
+        assert!(encoded.ends_with('Z'));
+        assert!(iso_in_days(i64::MAX).is_none());
+    }
+
+    #[tokio::test]
+    async fn immediate_transactions_use_the_facade_alias() {
+        let db = connect_in_memory().await.unwrap();
+        let tx: DbTransaction<'_> = begin_immediate(&db).await.unwrap();
+        tx.rollback().await.unwrap();
+    }
 
     /// Regression: the on-disk pool must serve a fully-migrated schema on every
     /// connection. A schema-changing migration once left some pooled connections

--- a/crates/weaver-core/src/discussion.rs
+++ b/crates/weaver-core/src/discussion.rs
@@ -312,8 +312,8 @@ mod tests {
     /// realistic `base_rev`) is satisfied.
     async fn seed_artifact(db: &Db) -> i64 {
         sqlx::query(
-            "INSERT OR IGNORE INTO branches (id, repo_root, branch, base_branch)
-             VALUES ('b1', '/r', 'b1', 'main')",
+            "INSERT INTO branches (id, repo_root, branch, base_branch)
+             VALUES ('b1', '/r', 'b1', 'main') ON CONFLICT DO NOTHING",
         )
         .execute(db)
         .await

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -16,6 +16,12 @@
 //! pre-repo-scope `issues` table, backfill additive columns) to bring it to the
 //! point where the baseline migration applies cleanly, then records every
 //! migration as it runs.
+//!
+//! The engine itself is a [`Stream`]: an ordered migration set plus the
+//! indicator table recording it. weaver-core's own stream is private to
+//! [`run`]; loom runs a second stream over the same database for its tables,
+//! which are created *after* these migrations run and so can never join this
+//! numbered set.
 
 use anyhow::{Context, Result};
 use sqlx::Row;
@@ -84,96 +90,148 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
     ),
 ];
 
+/// weaver-core's own stream. Kept private: the tables it manages are this
+/// crate's to migrate, and callers only ever need [`run`].
+const STREAM: Stream = Stream {
+    indicator_table: "schema_migrations",
+    migrations: MIGRATIONS,
+};
+
 /// Apply every pending migration, bringing the database up to the latest schema.
 pub async fn run(pool: &Db) -> Result<()> {
     // A database without the indicator table is either brand-new or predates
     // the framework; bootstrap it once before the ordered migrations run.
-    if !indicator_exists(pool).await? {
+    if !STREAM.indicator_exists(pool).await? {
         legacy_bootstrap(pool).await?;
     }
-    ensure_indicator(pool).await?;
-    apply_pending(pool).await?;
+    STREAM.ensure_indicator(pool).await?;
+    STREAM.apply_pending(pool).await?;
     Ok(())
 }
 
-/// Does the `schema_migrations` indicator table exist yet?
-async fn indicator_exists(pool: &Db) -> Result<bool> {
-    let name: Option<String> = sqlx::query_scalar(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'",
-    )
-    .fetch_optional(pool)
-    .await?;
-    Ok(name.is_some())
+/// A versioned migration stream: an ordered `(version, name, sql)` set recorded
+/// in its own indicator table. Two streams over one database never interact —
+/// each tracks its versions in its own table — which is what lets loom version
+/// its tables (created after weaver-core's migrations run) separately.
+pub struct Stream {
+    /// The table recording applied versions, e.g. `schema_migrations`. Must be
+    /// a trusted literal: it is interpolated into SQL, never bound.
+    pub indicator_table: &'static str,
+    /// The ordered migration set. Versions are dense and strictly increasing;
+    /// the runner applies any not yet recorded, in order.
+    pub migrations: &'static [(i64, &'static str, &'static str)],
 }
 
-/// Create the indicator table that records which migrations have been applied.
-async fn ensure_indicator(pool: &Db) -> Result<()> {
-    sqlx::query(
-        "CREATE TABLE IF NOT EXISTS schema_migrations (
-            version    INTEGER PRIMARY KEY,
-            name       TEXT NOT NULL,
-            applied_at TEXT NOT NULL
-        )",
-    )
-    .execute(pool)
-    .await
-    .context("creating schema_migrations table")?;
-    Ok(())
-}
-
-/// Run every migration whose version is not yet recorded, each in its own
-/// transaction, recording it on success.
-///
-/// Safe to run from two processes at once (e.g. `loom` and a `weaver` CLI
-/// invocation both first-opening a fresh database): each migration *claims* its
-/// version with `INSERT OR IGNORE` as the transaction's first write, which takes
-/// the write lock atomically. The claimer (rows affected = 1) runs the SQL and
-/// commits the claim and the change together; a concurrent runner that finds the
-/// version already claimed (rows affected = 0) skips it rather than re-applying
-/// and colliding on the primary key.
-async fn apply_pending(pool: &Db) -> Result<()> {
-    let applied: Vec<i64> = sqlx::query_scalar("SELECT version FROM schema_migrations")
-        .fetch_all(pool)
-        .await
-        .context("reading schema_migrations")?;
-    for (version, name, sql) in MIGRATIONS {
-        // Fast path: a plain read, no lock. The claim below is the real guard.
-        if applied.contains(version) {
-            continue;
-        }
-        let mut tx = pool.begin().await?;
-        // Claim first, before any read in this transaction, so the INSERT (not a
-        // stale-snapshot read) is what acquires the write lock.
-        let claimed = sqlx::query(
-            "INSERT OR IGNORE INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)",
-        )
-        .bind(version)
-        .bind(*name)
-        .bind(now_iso())
-        .execute(&mut *tx)
-        .await?
-        .rows_affected();
-        if claimed == 0 {
-            // Another runner has this version in hand; leave it to them.
-            tx.rollback().await?;
-            continue;
-        }
-        tracing::info!(version, name, "applying migration");
-        for stmt in split_statements(sql) {
-            sqlx::query(&stmt)
-                .execute(&mut *tx)
-                .await
-                .with_context(|| format!("migration {version} ({name}): {stmt}"))?;
-        }
-        tx.commit().await?;
+impl Stream {
+    /// Does the indicator table exist yet?
+    pub async fn indicator_exists(&self, pool: &Db) -> Result<bool> {
+        let name: Option<String> =
+            sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+                .bind(self.indicator_table)
+                .fetch_optional(pool)
+                .await?;
+        Ok(name.is_some())
     }
-    Ok(())
+
+    /// Create the indicator table that records which migrations have been applied.
+    pub async fn ensure_indicator(&self, pool: &Db) -> Result<()> {
+        sqlx::query(&format!(
+            "CREATE TABLE IF NOT EXISTS {} (
+                version    INTEGER PRIMARY KEY,
+                name       TEXT NOT NULL,
+                applied_at TEXT NOT NULL
+            )",
+            self.indicator_table
+        ))
+        .execute(pool)
+        .await
+        .with_context(|| format!("creating {} table", self.indicator_table))?;
+        Ok(())
+    }
+
+    /// Record `version` as applied without running its SQL. The adoption path
+    /// for a database whose schema was built before its stream existed: a
+    /// bootstrap brings the schema to the migration's end state by hand, then
+    /// stamps it so the stream never re-applies it. A no-op when the version is
+    /// already recorded.
+    pub async fn stamp(&self, pool: &Db, version: i64, name: &str) -> Result<()> {
+        sqlx::query(&format!(
+            "INSERT INTO {} (version, name, applied_at) VALUES (?, ?, ?)
+             ON CONFLICT DO NOTHING",
+            self.indicator_table
+        ))
+        .bind(version)
+        .bind(name)
+        .bind(now_iso())
+        .execute(pool)
+        .await
+        .with_context(|| format!("stamping {} version {version}", self.indicator_table))?;
+        Ok(())
+    }
+
+    /// Run every migration whose version is not yet recorded, each in its own
+    /// transaction, recording it on success.
+    ///
+    /// Safe to run from two processes at once (e.g. `loom` and a `weaver` CLI
+    /// invocation both first-opening a fresh database): each migration *claims*
+    /// its version with an `ON CONFLICT DO NOTHING` insert as the transaction's
+    /// first write, which takes the write lock atomically. The claimer (rows
+    /// affected = 1) runs the SQL and commits the claim and the change together;
+    /// a concurrent runner that finds the version already claimed (rows
+    /// affected = 0) skips it rather than re-applying and colliding on the
+    /// primary key.
+    pub async fn apply_pending(&self, pool: &Db) -> Result<()> {
+        let applied: Vec<i64> =
+            sqlx::query_scalar(&format!("SELECT version FROM {}", self.indicator_table))
+                .fetch_all(pool)
+                .await
+                .with_context(|| format!("reading {}", self.indicator_table))?;
+        for (version, name, sql) in self.migrations {
+            // Fast path: a plain read, no lock. The claim below is the real guard.
+            if applied.contains(version) {
+                continue;
+            }
+            let mut tx = pool.begin().await?;
+            // Claim first, before any read in this transaction, so the INSERT
+            // (not a stale-snapshot read) is what acquires the write lock.
+            let claimed = sqlx::query(&format!(
+                "INSERT INTO {} (version, name, applied_at) VALUES (?, ?, ?)
+                 ON CONFLICT DO NOTHING",
+                self.indicator_table
+            ))
+            .bind(version)
+            .bind(*name)
+            .bind(now_iso())
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+            if claimed == 0 {
+                // Another runner has this version in hand; leave it to them.
+                tx.rollback().await?;
+                continue;
+            }
+            tracing::info!(
+                version,
+                name,
+                stream = self.indicator_table,
+                "applying migration"
+            );
+            for stmt in split_statements(sql) {
+                sqlx::query(&stmt)
+                    .execute(&mut *tx)
+                    .await
+                    .with_context(|| format!("migration {version} ({name}): {stmt}"))?;
+            }
+            tx.commit().await?;
+        }
+        Ok(())
+    }
 }
 
 /// Split a migration file into individual statements. Strips `--` line comments
 /// first so semicolons inside them don't truncate a statement, then splits on
 /// `;` and drops empty fragments.
-fn split_statements(sql: &str) -> Vec<String> {
+pub fn split_statements(sql: &str) -> Vec<String> {
     let stripped: String = sql
         .lines()
         .map(|line| match line.find("--") {
@@ -293,11 +351,20 @@ async fn migrate_issues_to_repo_scope(pool: &Db) -> Result<()> {
 }
 
 /// Run `ALTER TABLE … ADD COLUMN` when the column is missing. A no-op when the
-/// column already exists or the table doesn't exist yet.
-async fn add_column_if_missing(pool: &Db, table: &str, column: &str, decl: &str) -> Result<()> {
+/// column already exists or the table doesn't exist yet. Returns whether the
+/// column was freshly added, so a caller can gate a one-time backfill on it.
+/// Introspection-gated on presence only — a legacy bootstrap can never assume
+/// an existing column's exact declaration, since deployed databases carry
+/// shapes stricter than any one source revision.
+pub async fn add_column_if_missing(
+    pool: &Db,
+    table: &str,
+    column: &str,
+    decl: &str,
+) -> Result<bool> {
     let cols = table_columns(pool, table).await?;
     if cols.is_empty() || cols.iter().any(|c| c == column) {
-        return Ok(());
+        return Ok(false);
     }
     let sql = format!("ALTER TABLE {table} ADD COLUMN {column} {decl}");
     sqlx::query(&sql)
@@ -305,11 +372,11 @@ async fn add_column_if_missing(pool: &Db, table: &str, column: &str, decl: &str)
         .await
         .with_context(|| format!("adding column {table}.{column}"))?;
     tracing::info!(%table, %column, "added column");
-    Ok(())
+    Ok(true)
 }
 
 /// Column names of `table`, or empty if it doesn't exist.
-async fn table_columns(pool: &Db, table: &str) -> Result<Vec<String>> {
+pub async fn table_columns(pool: &Db, table: &str) -> Result<Vec<String>> {
     // `table` is always a hardcoded literal here, so the format! is safe.
     let rows = sqlx::query(&format!("PRAGMA table_info({table})"))
         .fetch_all(pool)
@@ -374,13 +441,56 @@ mod tests {
         assert_eq!(count, MIGRATIONS.len() as i64);
     }
 
+    #[tokio::test]
+    async fn independent_streams_keep_separate_versions() {
+        const FIRST_MIGRATIONS: &[(i64, &str, &str)] =
+            &[(1, "first", "CREATE TABLE first_owned (id INTEGER)")];
+        const SECOND_MIGRATIONS: &[(i64, &str, &str)] =
+            &[(1, "second", "CREATE TABLE second_owned (id INTEGER)")];
+        const FIRST: Stream = Stream {
+            indicator_table: "first_schema_migrations",
+            migrations: FIRST_MIGRATIONS,
+        };
+        const SECOND: Stream = Stream {
+            indicator_table: "second_schema_migrations",
+            migrations: SECOND_MIGRATIONS,
+        };
+
+        let pool = empty_pool().await;
+        FIRST.ensure_indicator(&pool).await.unwrap();
+        SECOND.ensure_indicator(&pool).await.unwrap();
+        FIRST.apply_pending(&pool).await.unwrap();
+        SECOND.apply_pending(&pool).await.unwrap();
+        // Stamping an existing version is idempotent and confined to its stream.
+        FIRST.stamp(&pool, 1, "first").await.unwrap();
+
+        let first: Vec<i64> = sqlx::query_scalar("SELECT version FROM first_schema_migrations")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        let second: Vec<i64> = sqlx::query_scalar("SELECT version FROM second_schema_migrations")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(first, vec![1]);
+        assert_eq!(second, vec![1]);
+        assert!(!table_columns(&pool, "first_owned")
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(!table_columns(&pool, "second_owned")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
     /// A version already recorded — as if a concurrent runner claimed and applied
-    /// it — is skipped (the `INSERT OR IGNORE` claim affects 0 rows, no PK
+    /// it — is skipped (the conflict-safe claim affects 0 rows, no PK
     /// conflict), while the remaining migrations still apply.
     #[tokio::test]
     async fn already_claimed_versions_are_skipped() {
         let pool = empty_pool().await;
-        ensure_indicator(&pool).await.unwrap();
+        STREAM.ensure_indicator(&pool).await.unwrap();
         // Stand up the baseline and record it, mimicking another process having
         // applied migration 1 already.
         for stmt in split_statements(MIGRATIONS[0].2) {
@@ -451,7 +561,7 @@ mod tests {
         let pool = empty_pool().await;
         // Stand up the schema through 0004 only, then seed marks on the old
         // columns as a pre-0005 database would carry them.
-        ensure_indicator(&pool).await.unwrap();
+        STREAM.ensure_indicator(&pool).await.unwrap();
         for (version, name, sql) in MIGRATIONS.iter().take_while(|(v, _, _)| *v < 5) {
             for stmt in split_statements(sql) {
                 sqlx::query(&stmt).execute(&pool).await.unwrap();
@@ -605,7 +715,7 @@ mod tests {
     #[tokio::test]
     async fn goal_artifact_migration_backfills_existing_goals() {
         let pool = empty_pool().await;
-        ensure_indicator(&pool).await.unwrap();
+        STREAM.ensure_indicator(&pool).await.unwrap();
         // Stand up the schema through 0011, then seed branches as a pre-0012
         // database would carry them — a goal in the column, no `goal` artifact.
         for (version, name, sql) in MIGRATIONS.iter().take_while(|(v, _, _)| *v < 12) {

--- a/crates/weaver-core/src/watch.rs
+++ b/crates/weaver-core/src/watch.rs
@@ -374,7 +374,8 @@ pub async fn list(db: &Db) -> Result<Vec<Watch>> {
 
 pub async fn list_enabled(db: &Db) -> Result<Vec<Watch>> {
     Ok(
-        sqlx::query_as::<_, Watch>("SELECT * FROM watches WHERE enabled = 1 ORDER BY name ASC")
+        sqlx::query_as::<_, Watch>("SELECT * FROM watches WHERE enabled = ? ORDER BY name ASC")
+            .bind(true)
             .fetch_all(db)
             .await?,
     )

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,7 +6,8 @@ a TLS front-door in front of it is the choice this directory captures.
 | Path | Front-door | Use it when |
 |---|---|---|
 | **[`standalone/`](standalone/)** | **bundled** (Caddy, automatic HTTPS) | You want one self-contained, internet-facing host. **Start here.** |
-| [`gcp/`](gcp/) | bundled (runs `standalone/` unmodified) | You want scripted provisioning of a single GCE VM to run the standalone stack on, instead of bringing your own host. |
+| [`pulumi/`](pulumi/) | bundled (runs `standalone/` unmodified) | You want a production single-VM GCP deployment described as IaC, with snapshots, backups, DNS, and keyless image publishing. |
+| [`gcp/`](gcp/) | bundled (runs `standalone/` unmodified) | Legacy imperative provisioning for an existing GCE install; migrate it to Pulumi. |
 | cloud / cluster | — | Future work — see [below](#future-cloud--cluster). |
 
 The rest of this README documents the **standalone** stack. It exposes loom to

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,6 +1,13 @@
-# Deploying loom to a single GCE VM
+# Legacy scripted GCE deployment
 
-Script-based (no Terraform) provisioning of one Google Compute Engine VM that
+This imperative path is retained for existing installations. New deployments
+should use the [Pulumi stack](../pulumi), which adds declarative state,
+protected resources, scheduled snapshots and backups, Cloud DNS records, and
+keyless image publishing. Follow its [import plan](../pulumi/IMPORT.md) before
+letting Pulumi manage resources created here; never run both provisioners over
+the same resources independently.
+
+Script-based provisioning of one Google Compute Engine VM that
 runs the [standalone stack](../standalone) — loom + its bundled Caddy
 front-door — and fronts it with your domain's TLS. This is Model 1 (a single
 host with Docker on 80/443); see [`../README.md`](../README.md#future-cloud--cluster)

--- a/deploy/gcp/backup-sqlite.sh
+++ b/deploy/gcp/backup-sqlite.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Create a transactionally consistent loom SQLite backup and upload it to the
+# instance's configured GCS bucket. Installed by startup-script.sh and invoked
+# by loom-backup.timer; it is also safe to run by hand.
+set -euo pipefail
+
+META="http://metadata.google.internal/computeMetadata/v1"
+metadata() { curl -fsS -H "Metadata-Flavor: Google" "${META}/$1"; }
+
+PROJECT="$(metadata project/project-id)"
+BUCKET="$(metadata instance/attributes/backup-bucket)"
+REPO_DIR=/opt/loom
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_NAME="weaver-${STAMP}.sqlite"
+CONTAINER_PATH="/tmp/${BACKUP_NAME}"
+TMP_DIR="$(mktemp -d /tmp/loom-backup.XXXXXX)"
+HOST_PATH="${TMP_DIR}/${BACKUP_NAME}"
+
+cleanup() {
+  docker compose -f "${REPO_DIR}/deploy/standalone/docker-compose.yml" \
+    exec -T loom rm -f "$CONTAINER_PATH" >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cd "${REPO_DIR}/deploy/standalone"
+
+# Never copy the live database files directly: WAL state may not be reflected
+# in the main file. SQLite's online backup API takes a consistent snapshot while
+# loom continues to serve traffic.
+docker compose exec -T loom sqlite3 /home/app/.weaver/weaver.db \
+  ".timeout 30000" ".backup '${CONTAINER_PATH}'"
+
+check="$(docker compose exec -T loom sqlite3 "$CONTAINER_PATH" \
+  "PRAGMA quick_check;" | tr -d '\r')"
+if [ "$check" != "ok" ]; then
+  echo "loom backup failed integrity check: ${check}" >&2
+  exit 1
+fi
+
+docker compose cp "loom:${CONTAINER_PATH}" "$HOST_PATH"
+gzip "$HOST_PATH"
+gcloud storage cp "${HOST_PATH}.gz" \
+  "gs://${BUCKET}/sqlite/${PROJECT}/${BACKUP_NAME}.gz"
+

--- a/deploy/gcp/backup-sqlite.sh
+++ b/deploy/gcp/backup-sqlite.sh
@@ -42,4 +42,3 @@ docker compose cp "loom:${CONTAINER_PATH}" "$HOST_PATH"
 gzip "$HOST_PATH"
 gcloud storage cp "${HOST_PATH}.gz" \
   "gs://${BUCKET}/sqlite/${PROJECT}/${BACKUP_NAME}.gz"
-

--- a/deploy/gcp/bootstrap.py
+++ b/deploy/gcp/bootstrap.py
@@ -3,7 +3,13 @@
 # requires-python = ">=3.11"
 # dependencies = ["click>=8.1"]
 # ///
-"""Provisions a single GCE VM that runs the standalone loom stack
+"""Legacy provisioner for the single-VM GCP deployment.
+
+New deployments use ``deploy/pulumi``. This script remains as a transition for
+existing installations; import its resources before allowing Pulumi to manage
+them, and never run both provisioners independently against the same names.
+
+Provisions a single GCE VM that runs the standalone loom stack
 (../standalone/docker-compose.yml) behind its bundled Caddy front-door. Run
 this from your workstation, not the VM. See ./README.md for the full runbook
 and the required run order.

--- a/deploy/gcp/loom-backup.service
+++ b/deploy/gcp/loom-backup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Back up loom's SQLite database to GCS
+After=docker.service google-startup-scripts.service
+Wants=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/loom-backup-sqlite
+

--- a/deploy/gcp/loom-backup.service
+++ b/deploy/gcp/loom-backup.service
@@ -6,4 +6,3 @@ Wants=docker.service
 [Service]
 Type=oneshot
 ExecStart=/usr/local/sbin/loom-backup-sqlite
-

--- a/deploy/gcp/loom-backup.timer
+++ b/deploy/gcp/loom-backup.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Nightly loom SQLite backup
+
+[Timer]
+OnCalendar=*-*-* 03:00:00 UTC
+RandomizedDelaySec=45m
+Persistent=true
+Unit=loom-backup.service
+
+[Install]
+WantedBy=timers.target
+

--- a/deploy/gcp/loom-backup.timer
+++ b/deploy/gcp/loom-backup.timer
@@ -9,4 +9,3 @@ Unit=loom-backup.service
 
 [Install]
 WantedBy=timers.target
-

--- a/deploy/gcp/startup-script.sh
+++ b/deploy/gcp/startup-script.sh
@@ -31,12 +31,31 @@ REPO_URL="$(meta instance/attributes/repo-url)"
 GIT_REF="$(meta instance/attributes/git-ref)"
 IMAGE_MODE="$(meta instance/attributes/image-mode)"
 AR_IMAGE="$(meta instance/attributes/ar-image 2>/dev/null || true)"
+BACKUP_BUCKET="$(meta instance/attributes/backup-bucket 2>/dev/null || true)"
 
 REPO_DIR=/opt/loom
 DATA_DISK_DEVICE=/dev/disk/by-id/google-loom-data
 DATA_MOUNT=/mnt/loom-data
 
 echo "== loom startup-script: domain=${LOOM_DOMAIN} image-mode=${IMAGE_MODE} =="
+
+# Caddy requests a public certificate as soon as the stack starts. A newly
+# managed Cloud DNS record (or a zone delegation) can lag the VM creation, so
+# hold the workload until public DNS points at this VM. This guard makes a
+# single Pulumi update safe even though infrastructure creation is concurrent.
+EXTERNAL_IP="$(meta instance/network-interfaces/0/access-configs/0/external-ip)"
+for _ in $(seq 1 80); do
+  if getent ahostsv4 "$LOOM_DOMAIN" | awk '{print $1}' | grep -Fxq "$EXTERNAL_IP"; then
+    echo "== ${LOOM_DOMAIN} resolves to ${EXTERNAL_IP} =="
+    break
+  fi
+  echo "== waiting for ${LOOM_DOMAIN} to resolve to ${EXTERNAL_IP} =="
+  sleep 15
+done
+if ! getent ahostsv4 "$LOOM_DOMAIN" | awk '{print $1}' | grep -Fxq "$EXTERNAL_IP"; then
+  echo "loom startup-script: refusing to start Caddy before DNS is ready" >&2
+  exit 1
+fi
 
 # ---- Docker + compose plugin ----------------------------------------------
 # Docker's signed apt repo, not `curl | sh` — this is a long-lived
@@ -151,6 +170,21 @@ if [ -n "$DOCKER_GID" ]; then
   echo "DOCKER_GID=${DOCKER_GID}" >>"$ENV_FILE"
 fi
 chmod 600 "$ENV_FILE"
+
+# ---- nightly, online SQLite backup -----------------------------------------
+# Pulumi supplies the bucket in instance metadata and grants this VM's service
+# account objectCreator on it. The script uses SQLite's `.backup` API inside the
+# running container, so an active WAL cannot produce a torn copy.
+if [ -n "$BACKUP_BUCKET" ]; then
+  install -m 0755 "${REPO_DIR}/deploy/gcp/backup-sqlite.sh" \
+    /usr/local/sbin/loom-backup-sqlite
+  install -m 0644 "${REPO_DIR}/deploy/gcp/loom-backup.service" \
+    /etc/systemd/system/loom-backup.service
+  install -m 0644 "${REPO_DIR}/deploy/gcp/loom-backup.timer" \
+    /etc/systemd/system/loom-backup.timer
+  systemctl daemon-reload
+  systemctl enable --now loom-backup.timer
+fi
 
 # ---- bring up the stack -----------------------------------------------------
 cd "${REPO_DIR}/deploy/standalone"

--- a/deploy/pulumi/IMPORT.md
+++ b/deploy/pulumi/IMPORT.md
@@ -1,0 +1,77 @@
+# Importing an existing scripted deployment
+
+Import every existing resource before the first `pulumi up`. Imports only adopt
+state; they do not restart the VM. Substitute the names used with
+`bootstrap.py` (the defaults below assume instance `loom`, service account
+`loom-vm`, repository `loom`, and secret `LOOM_DOTENV`).
+
+```sh
+export PROJECT=my-project REGION=us-central1 ZONE=us-central1-a
+export VM_SERVICE_ACCOUNT=loom-vm
+cd deploy/pulumi
+
+pulumi import gcp:serviceaccount/account:Account loom-vm \
+  "projects/${PROJECT}/serviceAccounts/${VM_SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com"
+pulumi import gcp:compute/firewall:Firewall loom-web \
+  "projects/${PROJECT}/global/firewalls/loom-allow-web"
+pulumi import gcp:compute/firewall:Firewall loom-ssh \
+  "projects/${PROJECT}/global/firewalls/loom-allow-ssh"
+pulumi import gcp:compute/address:Address loom-address \
+  "projects/${PROJECT}/regions/${REGION}/addresses/loom-ip"
+pulumi import gcp:compute/disk:Disk loom-data \
+  "projects/${PROJECT}/zones/${ZONE}/disks/loom-data"
+pulumi import gcp:secretmanager/secret:Secret loom-dotenv \
+  "projects/${PROJECT}/secrets/LOOM_DOTENV"
+pulumi import gcp:artifactregistry/repository:Repository loom-images \
+  "projects/${PROJECT}/locations/${REGION}/repositories/loom"
+pulumi import gcp:compute/instance:Instance loom \
+  "projects/${PROJECT}/zones/${ZONE}/instances/loom"
+```
+
+Set `loom-gcp:vmServiceAccountName` to `VM_SERVICE_ACCOUNT` before previewing;
+the setting exists specifically so a deployment created with
+`bootstrap.py --service-account-name` can be adopted without replacement.
+
+If `dnsManagedZone` names a Cloud DNS zone that already contains the live A
+record, import that record too. The record name is fully qualified and ends in
+a dot:
+
+```sh
+export DNS_ZONE=example-com DOMAIN=loom.example.com
+pulumi import gcp:dns/recordSet:RecordSet loom-dns-address \
+  "projects/${PROJECT}/managedZones/${DNS_ZONE}/rrsets/${DOMAIN}./A"
+```
+
+When DNS is hosted outside Cloud DNS, leave `dnsManagedZone` unset and there is
+no DNS resource to import.
+
+If Artifact Registry was never enabled, omit that import and let Pulumi create
+it. A legacy installation with `DATA_DISK_SIZE=0` needs a migration, not a bare
+update: take an online database backup, create the data disk, stop the stack,
+move Docker's data root (or restore the database and other durable volumes), and
+only then attach it under Pulumi. Otherwise the new empty Docker data root makes
+the old boot-disk volumes appear to vanish. Do not import old secret versions:
+setting `loomDotenv` creates a fresh version while preserving history.
+The snapshot policy, backup bucket/timer, WIF provider, and CI service account
+are new and need no import.
+
+Before accepting the update:
+
+1. Run `pulumi preview --diff` and require **zero replacements** of the address,
+   data disk, secret, and VM. Reconcile names/config or add any omitted imports
+   before proceeding.
+2. If using Cloud DNS, move the zone and delegate its nameservers before setting
+   `dnsManagedZone`. Otherwise leave it unset and retain the current provider's
+   A record.
+3. Run `pulumi up`, then `post-up.py`. The driver waits for public DNS, triggers
+   one new startup generation, streams only that generation's journal, and
+   checks HTTPS.
+4. After a verified backup and successful restore drill, retire the legacy
+   imperative state file `deploy/gcp/deploy.toml`.
+5. The legacy script granted Secret Manager access at project scope. Once the
+   new secret-level binding is verified, remove that old project-level binding
+   so the VM retains access only to `LOOM_DOTENV`.
+
+Pulumi may propose IAM-member additions and metadata changes on the first
+managed update; those are expected. A persistent-disk, address, secret, or VM
+replacement is not.

--- a/deploy/pulumi/IMPORT.md
+++ b/deploy/pulumi/IMPORT.md
@@ -31,6 +31,9 @@ pulumi import gcp:compute/instance:Instance loom \
 Set `loom-gcp:vmServiceAccountName` to `VM_SERVICE_ACCOUNT` before previewing;
 the setting exists specifically so a deployment created with
 `bootstrap.py --service-account-name` can be adopted without replacement.
+Set `loom-gcp:network` to the VM's existing VPC name before previewing. The
+stack adds its own tagged rules but deliberately leaves unrelated operator-owned
+firewall policy alone.
 
 If `dnsManagedZone` names a Cloud DNS zone that already contains the live A
 record, import that record too. The record name is fully qualified and ends in

--- a/deploy/pulumi/Pulumi.example.yaml
+++ b/deploy/pulumi/Pulumi.example.yaml
@@ -1,0 +1,19 @@
+# Copy to Pulumi.<stack>.yaml, then set loomDotenv with `pulumi config set
+# --secret`; never put its plaintext value in this file.
+config:
+  gcp:project: my-project
+  loom-gcp:region: us-central1
+  loom-gcp:zone: us-central1-a
+  loom-gcp:domain: loom.example.com
+  loom-gcp:operatorCidr: 203.0.113.7/32
+  # Set this to bootstrap.py's --service-account-name before importing a
+  # non-default legacy deployment.
+  loom-gcp:vmServiceAccountName: loom-vm
+  # Name of an existing, already-delegated Cloud DNS managed zone. Omit this
+  # field when DNS is hosted elsewhere and create the exported A record there.
+  loom-gcp:dnsManagedZone: example-com
+  loom-gcp:githubRepository: rjpower/weaver
+  loom-gcp:githubRef: refs/heads/main
+  # Build locally on the VM for the first deployment. After the image workflow
+  # has published an image, change to pull and add imageTag with its commit SHA.
+  loom-gcp:imageMode: build

--- a/deploy/pulumi/Pulumi.example.yaml
+++ b/deploy/pulumi/Pulumi.example.yaml
@@ -6,6 +6,9 @@ config:
   loom-gcp:zone: us-central1-a
   loom-gcp:domain: loom.example.com
   loom-gcp:operatorCidr: 203.0.113.7/32
+  # Existing VPC name. The stack adds Loom's tagged web and SSH rules but does
+  # not modify or second-guess unrelated rules managed by the operator.
+  loom-gcp:network: default
   # Set this to bootstrap.py's --service-account-name before importing a
   # non-default legacy deployment.
   loom-gcp:vmServiceAccountName: loom-vm

--- a/deploy/pulumi/Pulumi.yaml
+++ b/deploy/pulumi/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: loom-gcp
+runtime:
+  name: python
+  options:
+    virtualenv: .venv
+description: Single-host loom deployment on Google Cloud
+

--- a/deploy/pulumi/Pulumi.yaml
+++ b/deploy/pulumi/Pulumi.yaml
@@ -4,4 +4,3 @@ runtime:
   options:
     virtualenv: .venv
 description: Single-host loom deployment on Google Cloud
-

--- a/deploy/pulumi/README.md
+++ b/deploy/pulumi/README.md
@@ -1,0 +1,159 @@
+# Provisioning loom with Pulumi
+
+This stack is the authoritative description of a single-host GCP loom. It
+creates the VM and its supporting identity, network, storage, backup, image,
+and GitHub Actions resources; [`post-up.py`](post-up.py) performs the few
+bring-up checks that are observations rather than infrastructure.
+
+The legacy [`../gcp/bootstrap.py`](../gcp/bootstrap.py) remains temporarily for
+existing installations. Do not run it and Pulumi against the same resources
+until those resources have been [imported](IMPORT.md).
+
+## One-time state backend
+
+Pulumi cannot create the bucket that contains the state of the update creating
+that bucket. Bootstrap a dedicated versioned state bucket once (separate from
+the runtime backup bucket), then use it for every operator and CI invocation:
+
+```sh
+export PROJECT=my-project
+export STATE_BUCKET="${PROJECT}-loom-pulumi-state"
+gcloud storage buckets create "gs://${STATE_BUCKET}" \
+  --project="${PROJECT}" --location=us-central1 --uniform-bucket-level-access
+gcloud storage buckets update "gs://${STATE_BUCKET}" --versioning
+pulumi login "gs://${STATE_BUCKET}"
+```
+
+Restrict bucket IAM to loom infrastructure operators and enable an organization
+retention policy appropriate for your recovery requirements. This state holds
+encrypted secrets and resource identifiers; the separate `<project>-loom-backups`
+bucket holds database backups and is writable only by the VM service account.
+
+## Configure and create
+
+```sh
+cd deploy/pulumi
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+pulumi stack init production \
+  --secrets-provider='gcpkms://projects/<project>/locations/<location>/keyRings/<ring>/cryptoKeys/<key>'
+pulumi config set gcp:project my-project
+pulumi config set region us-central1
+pulumi config set domain loom.example.com
+pulumi config set operatorCidr 203.0.113.7/32
+# See Pulumi.example.yaml for the optional settings.
+
+# The complete rendered dotenv is stored as an encrypted Pulumi configuration
+# value, then written as a new Secret Manager version by the stack.
+pulumi config set --secret loomDotenv "$(loom config render-env --out -)"
+pulumi up
+./post-up.py --stack production
+```
+
+The KMS key in that command must already exist; the GCS state bucket stores only
+ciphertext. Grant decrypt permission only to infrastructure operators. If using
+the passphrase provider instead, keep `PULUMI_CONFIG_PASSPHRASE` in an access-
+controlled secrets manager and test recovery from a fresh workstation. Losing
+either the KMS key or passphrase makes the encrypted stack configuration
+unrecoverable.
+
+Set `dnsManagedZone` only to the name of an **existing Cloud DNS managed zone
+whose nameservers are already delegated at the registrar**. Pulumi manages the
+A record but deliberately does not create or delegate a DNS zone. When DNS is
+hosted elsewhere, omit the setting, create an A record for the exported
+`address`, and only then run `post-up.py`. Both the startup script and post-up
+driver refuse to start Caddy until public DNS resolves to the reserved address,
+preventing repeated failed ACME challenges.
+
+The protected address, data disk, secret, and backup bucket make an accidental
+`pulumi destroy` fail rather than erase durable state. Remove protection only
+during an explicitly planned teardown. The boot disk is disposable; the
+separately attached data disk is retained when the VM is replaced.
+
+## Backups
+
+Two independent recovery mechanisms are installed:
+
+- A daily Compute Engine snapshot policy retains data-disk snapshots for 14
+  days by default.
+- `loom-backup.timer` runs nightly on the VM. It invokes SQLite's online
+  `.backup` API inside the loom container, runs `PRAGMA quick_check`, compresses
+  the result, and uploads it to the versioned backup bucket. Objects expire
+  after 30 days by default.
+
+Inspect or run the portable backup manually with:
+
+```sh
+gcloud compute ssh loom --zone=us-central1-a \
+  --command='systemctl status loom-backup.timer; sudo systemctl start loom-backup.service'
+```
+
+Restore only with the stack fully stopped. After downloading and decompressing
+a selected object on the VM, validate it first, then use the loom image as root
+so the named volume, configured app UID/GID, and file mode are handled
+correctly:
+
+```sh
+cd /opt/loom/deploy/standalone
+docker compose run --rm --no-deps --user root --entrypoint sqlite3 \
+  -v /path/to/restored.sqlite:/restore/weaver.db:ro loom \
+  /restore/weaver.db 'PRAGMA quick_check;'  # must print: ok
+docker compose down
+docker compose run --rm --no-deps --user root --entrypoint sh \
+  -v /path/to/restored.sqlite:/restore/weaver.db:ro loom -ceu '
+    state=/home/app/.weaver
+    saved="$state/pre-restore-$(date -u +%Y%m%dT%H%M%SZ)"
+    mkdir -p "$saved"
+    for file in weaver.db weaver.db-wal weaver.db-shm; do
+      if [ -e "$state/$file" ]; then mv "$state/$file" "$saved/$file"; fi
+    done
+    install -o app -g app -m 0600 /restore/weaver.db "$state/weaver.db"
+  '
+docker compose up -d
+LOOM_DOMAIN="$(curl -fsS -H 'Metadata-Flavor: Google' \
+  http://metadata.google.internal/computeMetadata/v1/instance/attributes/loom-domain)"
+curl -fsS "https://${LOOM_DOMAIN}/api/health"  # must print: ok
+```
+
+Moving the old DB and its WAL/SHM sidecars together prevents stale WAL pages
+from being replayed into the restored database and keeps a rollback copy in the
+volume. Do not restore over a running server.
+
+## Deployment images
+
+Pulumi creates a repository-scoped Workload Identity Federation provider and a
+service account that can only write Artifact Registry images. Configure these
+GitHub repository variables from `pulumi stack output`:
+
+| Variable | Value |
+|---|---|
+| `LOOM_GCP_PROJECT` | GCP project id |
+| `LOOM_GCP_REGION` | stack region |
+| `LOOM_GCP_WIF_PROVIDER` | `githubWorkloadIdentityProvider` output |
+| `LOOM_GCP_IMAGE_SERVICE_ACCOUNT` | `githubServiceAccount` output |
+
+On pushes to `main`, [the image workflow](../../.github/workflows/image.yml)
+uses GitHub OIDC—no JSON key—to publish an immutable commit-SHA tag. The
+repository rejects tag replacement and deliberately has no mutable `latest`.
+Set `imageMode: pull`, pin `imageTag` to that SHA, and run `pulumi up` for a
+reproducible rollout; then run `post-up.py` to stream the new startup
+generation.
+
+The example stack uses `imageMode: build` so the first deployment is
+self-contained. Once that `pulumi up` has created WIF and Artifact Registry,
+set the four repository variables, manually dispatch **Publish deployment
+image**, and wait for it to finish. Then change `imageMode` to `pull`, set
+`imageTag` to the published commit SHA, run `pulumi up`, and run `post-up.py`.
+If a pull-mode VM boots before its selected image exists it fails safely and
+the post-up retrigger completes it after the image is published.
+
+## Validation
+
+```sh
+python3 -m compileall -q infrastructure.py post-up.py tests
+shellcheck ../gcp/startup-script.sh ../gcp/backup-sqlite.sh
+actionlint ../../.github/workflows/image.yml
+.venv/bin/pip install -r requirements-dev.txt
+.venv/bin/python -m pytest -q tests  # Pulumi mocks; no cloud credentials
+pulumi preview                       # final provider/schema check
+```

--- a/deploy/pulumi/README.md
+++ b/deploy/pulumi/README.md
@@ -20,7 +20,8 @@ export PROJECT=my-project
 export STATE_BUCKET="${PROJECT}-loom-pulumi-state"
 gcloud storage buckets create "gs://${STATE_BUCKET}" \
   --project="${PROJECT}" --location=us-central1 --uniform-bucket-level-access
-gcloud storage buckets update "gs://${STATE_BUCKET}" --versioning
+gcloud storage buckets update "gs://${STATE_BUCKET}" \
+  --versioning --public-access-prevention
 pulumi login "gs://${STATE_BUCKET}"
 ```
 
@@ -64,6 +65,11 @@ hosted elsewhere, omit the setting, create an A record for the exported
 `address`, and only then run `post-up.py`. Both the startup script and post-up
 driver refuse to start Caddy until public DNS resolves to the reserved address,
 preventing repeated failed ACME challenges.
+
+The stack uses the configured existing VPC (`default` unless `network` is set).
+It adds tagged Loom web and SSH rules, with Loom's SSH rule scoped to
+`operatorCidr`; it deliberately does not inspect, remove, or override unrelated
+firewall rules owned by the operator.
 
 The protected address, data disk, secret, and backup bucket make an accidental
 `pulumi destroy` fail rather than erase durable state. Remove protection only
@@ -135,6 +141,8 @@ GitHub repository variables from `pulumi stack output`:
 On pushes to `main`, [the image workflow](../../.github/workflows/image.yml)
 uses GitHub OIDC—no JSON key—to publish an immutable commit-SHA tag. The
 repository rejects tag replacement and deliberately has no mutable `latest`.
+Rerunning the workflow for an already-published commit detects the existing tag
+and exits successfully without rebuilding or moving it.
 Set `imageMode: pull`, pin `imageTag` to that SHA, and run `pulumi up` for a
 reproducible rollout; then run `post-up.py` to stream the new startup
 generation.

--- a/deploy/pulumi/__main__.py
+++ b/deploy/pulumi/__main__.py
@@ -1,0 +1,5 @@
+from infrastructure import DeploymentConfig, create_infrastructure
+
+
+create_infrastructure(DeploymentConfig.from_pulumi())
+

--- a/deploy/pulumi/__main__.py
+++ b/deploy/pulumi/__main__.py
@@ -2,4 +2,3 @@ from infrastructure import DeploymentConfig, create_infrastructure
 
 
 create_infrastructure(DeploymentConfig.from_pulumi())
-

--- a/deploy/pulumi/infrastructure.py
+++ b/deploy/pulumi/infrastructure.py
@@ -1,0 +1,416 @@
+"""Declarative Google Cloud resources for a single-host loom deployment.
+
+Keep the resource graph in ``create_infrastructure``: tests can run it under
+Pulumi mocks without credentials, while ``__main__.py`` is intentionally only
+the stack entry point.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pulumi
+import pulumi_gcp as gcp
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class DeploymentConfig:
+    project: str
+    region: str
+    zone: str
+    domain: str
+    operator_cidr: str
+    loom_dotenv: pulumi.Input[str]
+    dns_managed_zone: str | None = None
+    network: str = "default"
+    instance_name: str = "loom"
+    vm_service_account_name: str = "loom-vm"
+    machine_type: str = "e2-highmem-4"
+    boot_disk_gb: int = 100
+    data_disk_gb: int = 500
+    repo_url: str = "https://github.com/rjpower/weaver.git"
+    git_ref: str = "main"
+    image_mode: str = "build"
+    image_tag: str = "latest"
+    github_repository: str = "rjpower/weaver"
+    github_ref: str = "refs/heads/main"
+    snapshot_retention_days: int = 14
+    backup_retention_days: int = 30
+
+    def __post_init__(self) -> None:
+        if self.image_mode not in {"build", "pull"}:
+            raise ValueError("imageMode must be 'build' or 'pull'")
+        if self.image_mode == "pull" and not re.fullmatch(
+            r"[0-9a-f]{40}", self.image_tag
+        ):
+            raise ValueError("pull mode requires an immutable commit-SHA imageTag")
+
+    @classmethod
+    def from_pulumi(cls) -> "DeploymentConfig":
+        config = pulumi.Config()
+        gcp_config = pulumi.Config("gcp")
+        project = gcp_config.require("project")
+        region = config.get("region") or "us-central1"
+        return cls(
+            project=project,
+            region=region,
+            zone=config.get("zone") or f"{region}-a",
+            domain=config.require("domain"),
+            operator_cidr=config.require("operatorCidr"),
+            # Pulumi encrypts this in stack state. Render it with
+            # `loom config render-env --out -` and set it with --secret.
+            loom_dotenv=config.require_secret("loomDotenv"),
+            dns_managed_zone=config.get("dnsManagedZone"),
+            network=config.get("network") or "default",
+            instance_name=config.get("instanceName") or "loom",
+            vm_service_account_name=config.get("vmServiceAccountName") or "loom-vm",
+            machine_type=config.get("machineType") or "e2-highmem-4",
+            boot_disk_gb=config.get_int("bootDiskGb") or 100,
+            data_disk_gb=config.get_int("dataDiskGb") or 500,
+            repo_url=config.get("repoUrl")
+            or "https://github.com/rjpower/weaver.git",
+            git_ref=config.get("gitRef") or "main",
+            image_mode=config.get("imageMode") or "build",
+            image_tag=config.get("imageTag") or "latest",
+            github_repository=config.get("githubRepository") or "rjpower/weaver",
+            github_ref=config.get("githubRef") or "refs/heads/main",
+            snapshot_retention_days=config.get_int("snapshotRetentionDays") or 14,
+            backup_retention_days=config.get_int("backupRetentionDays") or 30,
+        )
+
+
+@dataclass(frozen=True)
+class Infrastructure:
+    address: gcp.compute.Address
+    instance: gcp.compute.Instance
+    artifact_repository: gcp.artifactregistry.Repository
+    backup_bucket: gcp.storage.Bucket
+    workload_identity_provider: gcp.iam.WorkloadIdentityPoolProvider
+
+
+def _enable_apis(project: str) -> list[gcp.projects.Service]:
+    services = (
+        "artifactregistry.googleapis.com",
+        "compute.googleapis.com",
+        "dns.googleapis.com",
+        "iam.googleapis.com",
+        "iamcredentials.googleapis.com",
+        "secretmanager.googleapis.com",
+        "sts.googleapis.com",
+        "storage.googleapis.com",
+    )
+    return [
+        gcp.projects.Service(
+            f"api-{service.split('.')[0]}",
+            project=project,
+            service=service,
+            disable_on_destroy=False,
+        )
+        for service in services
+    ]
+
+
+def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
+    """Create loom's GCP resource graph and export its operator-facing values."""
+    apis = _enable_apis(config.project)
+    api_options = pulumi.ResourceOptions(depends_on=apis)
+
+    vm_account = gcp.serviceaccount.Account(
+        "loom-vm",
+        project=config.project,
+        account_id=config.vm_service_account_name,
+        display_name="loom standalone VM",
+        opts=api_options,
+    )
+    ci_account = gcp.serviceaccount.Account(
+        "loom-image-ci",
+        project=config.project,
+        account_id="loom-image-ci",
+        display_name="GitHub Actions loom image publisher",
+        opts=api_options,
+    )
+
+    artifact_repository = gcp.artifactregistry.Repository(
+        "loom-images",
+        project=config.project,
+        location=config.region,
+        repository_id="loom",
+        format="DOCKER",
+        docker_config={"immutable_tags": True},
+        description="Immutable loom deployment images",
+        opts=api_options,
+    )
+    vm_image_reader = gcp.artifactregistry.RepositoryIamMember(
+        "loom-vm-image-reader",
+        project=config.project,
+        location=artifact_repository.location,
+        repository=artifact_repository.repository_id,
+        role="roles/artifactregistry.reader",
+        member=vm_account.email.apply(lambda email: f"serviceAccount:{email}"),
+    )
+    gcp.artifactregistry.RepositoryIamMember(
+        "loom-ci-image-writer",
+        project=config.project,
+        location=artifact_repository.location,
+        repository=artifact_repository.repository_id,
+        role="roles/artifactregistry.writer",
+        member=ci_account.email.apply(lambda email: f"serviceAccount:{email}"),
+    )
+
+    web_firewall = gcp.compute.Firewall(
+        "loom-web",
+        project=config.project,
+        network=config.network,
+        name=f"{config.instance_name}-allow-web",
+        direction="INGRESS",
+        source_ranges=["0.0.0.0/0"],
+        target_tags=["loom-web"],
+        allows=[
+            {"protocol": "tcp", "ports": ["80", "443"]},
+            {"protocol": "udp", "ports": ["443"]},
+        ],
+        opts=api_options,
+    )
+    ssh_firewall = gcp.compute.Firewall(
+        "loom-ssh",
+        project=config.project,
+        network=config.network,
+        name=f"{config.instance_name}-allow-ssh",
+        direction="INGRESS",
+        source_ranges=[config.operator_cidr],
+        target_tags=["loom-ssh"],
+        allows=[{"protocol": "tcp", "ports": ["22"]}],
+        opts=api_options,
+    )
+    address = gcp.compute.Address(
+        "loom-address",
+        project=config.project,
+        region=config.region,
+        name=f"{config.instance_name}-ip",
+        opts=pulumi.ResourceOptions(depends_on=apis, protect=True),
+    )
+
+    dns_record: gcp.dns.RecordSet | None = None
+    if config.dns_managed_zone:
+        dns_record = gcp.dns.RecordSet(
+            "loom-dns-address",
+            project=config.project,
+            managed_zone=config.dns_managed_zone,
+            name=f"{config.domain.rstrip('.')}.",
+            type="A",
+            ttl=300,
+            rrdatas=[address.address],
+            opts=api_options,
+        )
+
+    data_disk = gcp.compute.Disk(
+        "loom-data",
+        project=config.project,
+        zone=config.zone,
+        name=f"{config.instance_name}-data",
+        type="pd-balanced",
+        size=config.data_disk_gb,
+        opts=pulumi.ResourceOptions(depends_on=apis, protect=True),
+    )
+    snapshot_policy = gcp.compute.ResourcePolicy(
+        "loom-data-snapshots",
+        project=config.project,
+        region=config.region,
+        name=f"{config.instance_name}-data-daily",
+        snapshot_schedule_policy={
+            "schedule": {
+                "daily_schedule": {"days_in_cycle": 1, "start_time": "04:00"}
+            },
+            "retention_policy": {
+                "max_retention_days": config.snapshot_retention_days,
+                "on_source_disk_delete": "KEEP_AUTO_SNAPSHOTS",
+            },
+            "snapshot_properties": {"storage_locations": config.region},
+        },
+        opts=api_options,
+    )
+    snapshot_attachment = gcp.compute.DiskResourcePolicyAttachment(
+        "loom-data-snapshot-policy",
+        project=config.project,
+        zone=config.zone,
+        disk=data_disk.name,
+        name=snapshot_policy.name,
+    )
+
+    dotenv_secret = gcp.secretmanager.Secret(
+        "loom-dotenv",
+        project=config.project,
+        secret_id="LOOM_DOTENV",
+        replication={"auto": {}},
+        opts=pulumi.ResourceOptions(depends_on=apis, protect=True),
+    )
+    secret_version = gcp.secretmanager.SecretVersion(
+        "loom-dotenv-current",
+        secret=dotenv_secret.id,
+        secret_data=config.loom_dotenv,
+        # Secret data changes create a fresh version. Retain superseded versions
+        # for rollback without making ordinary rotation fight `protect`.
+        opts=pulumi.ResourceOptions(retain_on_delete=True),
+    )
+    vm_secret_reader = gcp.secretmanager.SecretIamMember(
+        "loom-vm-secret-reader",
+        project=config.project,
+        secret_id=dotenv_secret.secret_id,
+        role="roles/secretmanager.secretAccessor",
+        member=vm_account.email.apply(lambda email: f"serviceAccount:{email}"),
+    )
+
+    backup_bucket = gcp.storage.Bucket(
+        "loom-backups",
+        project=config.project,
+        location=config.region,
+        name=pulumi.Output.format(
+            "{}-{}-backups", config.project, config.instance_name
+        ),
+        uniform_bucket_level_access=True,
+        versioning={"enabled": True},
+        lifecycle_rules=[
+            {
+                "action": {"type": "Delete"},
+                "condition": {"age": config.backup_retention_days},
+            }
+        ],
+        opts=pulumi.ResourceOptions(depends_on=apis, protect=True),
+    )
+    vm_backup_writer = gcp.storage.BucketIAMMember(
+        "loom-vm-backup-writer",
+        bucket=backup_bucket.name,
+        role="roles/storage.objectCreator",
+        member=vm_account.email.apply(lambda email: f"serviceAccount:{email}"),
+    )
+
+    workload_pool = gcp.iam.WorkloadIdentityPool(
+        "loom-github",
+        project=config.project,
+        workload_identity_pool_id="loom-github",
+        display_name="loom GitHub Actions",
+        opts=api_options,
+    )
+    workload_provider = gcp.iam.WorkloadIdentityPoolProvider(
+        "loom-github-provider",
+        project=config.project,
+        workload_identity_pool_id=workload_pool.workload_identity_pool_id,
+        workload_identity_pool_provider_id="github",
+        display_name="loom GitHub repository",
+        attribute_mapping={
+            "google.subject": "assertion.sub",
+            "attribute.repository": "assertion.repository",
+            "attribute.ref": "assertion.ref",
+        },
+        attribute_condition=(
+            f"assertion.repository == '{config.github_repository}' && "
+            f"assertion.ref == '{config.github_ref}'"
+        ),
+        oidc={"issuer_uri": "https://token.actions.githubusercontent.com"},
+        opts=api_options,
+    )
+    principal = workload_pool.name.apply(
+        lambda name: (
+            f"principalSet://iam.googleapis.com/{name}/attribute.repository/"
+            f"{config.github_repository}"
+        )
+    )
+    gcp.serviceaccount.IAMMember(
+        "loom-ci-workload-identity",
+        service_account_id=ci_account.name,
+        role="roles/iam.workloadIdentityUser",
+        member=principal,
+    )
+
+    image = (
+        f"{config.region}-docker.pkg.dev/{config.project}/loom/loom:"
+        f"{config.image_tag}"
+    )
+    metadata = {
+        "loom-domain": config.domain,
+        "repo-url": config.repo_url,
+        "git-ref": config.git_ref,
+        "image-mode": config.image_mode,
+        "ar-image": image,
+        "backup-bucket": backup_bucket.name,
+    }
+    dependencies: list[pulumi.Resource] = [
+        web_firewall,
+        ssh_firewall,
+        data_disk,
+        dotenv_secret,
+        secret_version,
+        vm_secret_reader,
+        vm_image_reader,
+        backup_bucket,
+        vm_backup_writer,
+        snapshot_attachment,
+    ]
+    if dns_record:
+        dependencies.append(dns_record)
+    instance = gcp.compute.Instance(
+        "loom",
+        project=config.project,
+        zone=config.zone,
+        name=config.instance_name,
+        machine_type=config.machine_type,
+        tags=["loom-web", "loom-ssh"],
+        boot_disk={
+            "auto_delete": True,
+            "initialize_params": {
+                "image": "debian-cloud/debian-12",
+                "size": config.boot_disk_gb,
+                "type": "pd-balanced",
+            },
+        },
+        attached_disks=[
+            # GCE preserves separately attached persistent disks when an
+            # instance is deleted; the disk resource is protected as well.
+            {
+                "source": data_disk.id,
+                "device_name": "loom-data",
+                "mode": "READ_WRITE",
+            }
+        ],
+        network_interfaces=[
+            {
+                "network": config.network,
+                "access_configs": [{"nat_ip": address.address}],
+            }
+        ],
+        metadata=metadata,
+        metadata_startup_script=(ROOT / "deploy/gcp/startup-script.sh").read_text(),
+        service_account={
+            "email": vm_account.email,
+            "scopes": ["cloud-platform"],
+        },
+        allow_stopping_for_update=True,
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
+
+    pulumi.export("address", address.address)
+    pulumi.export("url", f"https://{config.domain}/")
+    pulumi.export("instanceName", instance.name)
+    pulumi.export("zone", config.zone)
+    pulumi.export("artifactImage", image)
+    pulumi.export("backupBucket", backup_bucket.url)
+    pulumi.export("githubWorkloadIdentityProvider", workload_provider.name)
+    pulumi.export("githubServiceAccount", ci_account.email)
+    if not config.dns_managed_zone:
+        pulumi.log.warn(
+            "dnsManagedZone is unset: create the exported address's A record "
+            "before running post-up.py"
+        )
+
+    return Infrastructure(
+        address=address,
+        instance=instance,
+        artifact_repository=artifact_repository,
+        backup_bucket=backup_bucket,
+        workload_identity_provider=workload_provider,
+    )

--- a/deploy/pulumi/infrastructure.py
+++ b/deploy/pulumi/infrastructure.py
@@ -273,6 +273,7 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
             "{}-{}-backups", config.project, config.instance_name
         ),
         uniform_bucket_level_access=True,
+        public_access_prevention="enforced",
         versioning={"enabled": True},
         lifecycle_rules=[
             {

--- a/deploy/pulumi/post-up.py
+++ b/deploy/pulumi/post-up.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["click>=8.1"]
+# ///
+"""Verify and activate a loom VM after ``pulumi up``.
+
+Pulumi owns durable resources. This small imperative tail deliberately owns the
+checks that are observations rather than resources: public DNS propagation,
+SSH readiness, the current startup-script journal run, and HTTPS health.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import click
+
+
+PULUMI_DIR = Path(__file__).resolve().parent
+STARTUP_UNIT = "google-startup-scripts"
+STARTUP_BANNER = "loom startup-script:"
+STARTUP_DONE = "loom startup-script done"
+STARTUP_FAILURES = ("failed with error", "Failed with result")
+
+
+def log(message: str) -> None:
+    click.echo(f"▶ {message}", err=True)
+
+
+def fail(message: str) -> None:
+    raise click.ClickException(message)
+
+
+def stack_outputs(stack: str | None) -> dict[str, str]:
+    command = ["pulumi", "stack", "output", "--json", "--cwd", str(PULUMI_DIR)]
+    if stack:
+        command.extend(["--stack", stack])
+    result = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    return json.loads(result.stdout)
+
+
+def resolved_ipv4(domain: str) -> set[str]:
+    try:
+        return {
+            item[4][0]
+            for item in socket.getaddrinfo(domain, 443, socket.AF_INET)
+        }
+    except OSError:
+        return set()
+
+
+def wait_for_dns(domain: str, address: str, timeout: int) -> None:
+    log(f"waiting for {domain} to resolve publicly to {address}")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if address in resolved_ipv4(domain):
+            return
+        time.sleep(15)
+    fail(
+        f"{domain} does not resolve to {address}; delegate the configured Cloud "
+        "DNS zone (or create the A record) before activating loom"
+    )
+
+
+def ssh(
+    project: str, zone: str, instance: str, command: str, timeout: int = 120
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "gcloud",
+            f"--project={project}",
+            "compute",
+            "ssh",
+            instance,
+            f"--zone={zone}",
+            "--quiet",
+            f"--command={command}",
+        ],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        timeout=timeout,
+    )
+
+
+def wait_for_ssh(project: str, zone: str, instance: str, timeout: int) -> None:
+    log("waiting for SSH")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if ssh(project, zone, instance, "true", timeout=60).returncode == 0:
+                return
+        except subprocess.TimeoutExpired:
+            pass
+        time.sleep(10)
+    fail("SSH never became reachable; check the operator CIDR firewall rule")
+
+
+def journal(project: str, zone: str, instance: str) -> list[str]:
+    result = ssh(
+        project,
+        zone,
+        instance,
+        f"sudo journalctl -u {STARTUP_UNIT} --no-pager -o cat 2>/dev/null",
+    )
+    return result.stdout.splitlines()
+
+
+def activate_and_monitor(
+    project: str, zone: str, instance: str, timeout: int
+) -> None:
+    # Anchor monitoring to a newly-triggered generation. Old failure text in the
+    # persistent journal must never make this deployment look failed.
+    prior = sum(STARTUP_BANNER in line for line in journal(project, zone, instance))
+    log("triggering the current startup script")
+    result = ssh(
+        project,
+        zone,
+        instance,
+        f"sudo systemctl restart --no-block {STARTUP_UNIT}.service",
+    )
+    if result.returncode:
+        fail(f"could not trigger startup script: {result.stderr.strip()}")
+
+    log("streaming the current startup-script generation")
+    deadline = time.monotonic() + timeout
+    printed = 0
+    while time.monotonic() < deadline:
+        lines = journal(project, zone, instance)
+        banners = [index for index, line in enumerate(lines) if STARTUP_BANNER in line]
+        if len(banners) <= prior:
+            time.sleep(15)
+            continue
+        boundary = banners[prior]
+        start = max(boundary, printed)
+        for line in lines[start:]:
+            click.echo(f"  {line}", err=True)
+        printed = len(lines)
+        window = "\n".join(lines[boundary:])
+        if STARTUP_DONE in window:
+            return
+        if any(marker in window for marker in STARTUP_FAILURES):
+            fail("startup script failed; inspect the journal output above")
+        time.sleep(15)
+    fail("startup script did not finish before the timeout")
+
+
+def health_is_ready(domain: str) -> bool:
+    """Return whether loom's exact public liveness contract is healthy once."""
+    try:
+        with urllib.request.urlopen(
+            f"https://{domain}/api/health", timeout=10
+        ) as response:
+            return response.status == 200 and response.read().strip() == b"ok"
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError):
+        # Caddy may already answer while its loom upstream is still starting;
+        # 401/404/5xx are not success for this exact public endpoint.
+        return False
+
+
+def wait_for_health(domain: str, timeout: int) -> None:
+    log(f"checking https://{domain}/api/health")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if health_is_ready(domain):
+            log("loom health check responded 200 ok")
+            return
+        time.sleep(15)
+    fail("the startup script succeeded, but loom's HTTPS health check is not ready")
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--stack", help="Pulumi stack name. Default: current stack.")
+@click.option("--dns-timeout", default=1200, show_default=True)
+@click.option("--ssh-timeout", default=300, show_default=True)
+@click.option("--startup-timeout", default=2400, show_default=True)
+@click.option("--https-timeout", default=300, show_default=True)
+def main(
+    stack: str | None,
+    dns_timeout: int,
+    ssh_timeout: int,
+    startup_timeout: int,
+    https_timeout: int,
+) -> None:
+    outputs = stack_outputs(stack)
+    try:
+        project = subprocess.run(
+            [
+                "pulumi",
+                "config",
+                "get",
+                "gcp:project",
+                "--cwd",
+                str(PULUMI_DIR),
+                *(["--stack", stack] if stack else []),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+        ).stdout.strip()
+        address = outputs["address"]
+        instance = outputs["instanceName"]
+        zone = outputs["zone"]
+        domain = outputs["url"].removeprefix("https://").rstrip("/")
+    except (KeyError, subprocess.CalledProcessError) as error:
+        fail(f"could not read the Pulumi stack outputs: {error}")
+
+    wait_for_dns(domain, address, dns_timeout)
+    wait_for_ssh(project, zone, instance, ssh_timeout)
+    activate_and_monitor(project, zone, instance, startup_timeout)
+    wait_for_health(domain, https_timeout)
+    log(f"loom is live: https://{domain}/")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as error:
+        click.echo(error.stderr or str(error), err=True)
+        sys.exit(error.returncode)

--- a/deploy/pulumi/requirements-dev.txt
+++ b/deploy/pulumi/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+click==8.2.1
+pytest==8.4.2

--- a/deploy/pulumi/requirements.txt
+++ b/deploy/pulumi/requirements.txt
@@ -1,0 +1,2 @@
+pulumi==3.253.0
+pulumi-gcp==9.23.0

--- a/deploy/pulumi/tests/test_infrastructure.py
+++ b/deploy/pulumi/tests/test_infrastructure.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import inspect
+
+import pulumi
+import pytest
+from pulumi.runtime import MockCallArgs, MockResourceArgs, Mocks
+
+
+class RecordingMocks(Mocks):
+    def __init__(self) -> None:
+        self.resources: list[MockResourceArgs] = []
+
+    def new_resource(self, args: MockResourceArgs):
+        self.resources.append(args)
+        outputs = dict(args.inputs)
+        outputs.setdefault("name", args.name)
+        if args.typ == "gcp:compute/address:Address":
+            outputs["address"] = "203.0.113.10"
+        if args.typ == "gcp:serviceaccount/account:Account":
+            outputs["email"] = f"{args.name}@example.iam.gserviceaccount.com"
+        if args.typ == "gcp:storage/bucket:Bucket":
+            outputs["url"] = f"gs://{args.name}"
+        return f"{args.name}_id", outputs
+
+    def call(self, args: MockCallArgs):
+        return args.args
+
+
+mocks = RecordingMocks()
+pulumi.runtime.set_mocks(mocks, project="loom-gcp", stack="test", preview=False)
+
+from infrastructure import DeploymentConfig, create_infrastructure  # noqa: E402
+
+
+def make_infrastructure():
+    mocks.resources.clear()
+    return create_infrastructure(
+        DeploymentConfig(
+            project="example",
+            region="us-central1",
+            zone="us-central1-a",
+            domain="loom.example.com",
+            operator_cidr="203.0.113.7/32",
+            loom_dotenv=pulumi.Output.secret("LOOM_DOMAIN=loom.example.com\n"),
+            dns_managed_zone="example-zone",
+            image_mode="pull",
+            image_tag="0123456789abcdef0123456789abcdef01234567",
+        )
+    )
+
+
+def by_name(name: str) -> MockResourceArgs:
+    return next(resource for resource in mocks.resources if resource.name == name)
+
+
+def field(inputs: dict, snake: str, camel: str):
+    return inputs.get(snake, inputs.get(camel))
+
+
+def test_pull_mode_requires_a_commit_sha() -> None:
+    with pytest.raises(ValueError, match="commit-SHA"):
+        DeploymentConfig(
+            project="example",
+            region="us-central1",
+            zone="us-central1-a",
+            domain="loom.example.com",
+            operator_cidr="203.0.113.7/32",
+            loom_dotenv="LOOM_DOMAIN=loom.example.com\n",
+            image_mode="pull",
+            image_tag="latest",
+        )
+
+
+@pulumi.runtime.test
+def test_vm_keeps_data_disk_and_installs_backup_metadata():
+    infrastructure = make_infrastructure()
+
+    def check(_: object) -> None:
+        vm = by_name("loom")
+        attached = field(vm.inputs, "attached_disks", "attachedDisks")
+        assert len(attached) == 1
+        assert field(attached[0], "device_name", "deviceName") == "loom-data"
+        # An attached persistent disk is not auto-deleted with a GCE instance;
+        # the source Disk also has a Pulumi protect option in the source below.
+        assert field(attached[0], "auto_delete", "autoDelete") is not True
+        metadata = vm.inputs["metadata"]
+        assert field(metadata, "backup-bucket", "backup-bucket")
+        assert metadata["image-mode"] == "pull"
+
+    return infrastructure.instance.id.apply(check)
+
+
+@pulumi.runtime.test
+def test_wif_is_repository_and_main_bound_with_least_privilege_iam():
+    infrastructure = make_infrastructure()
+
+    def check(_: object) -> None:
+        provider = by_name("loom-github-provider")
+        condition = field(
+            provider.inputs, "attribute_condition", "attributeCondition"
+        )
+        assert "rjpower/weaver" in condition
+        assert "refs/heads/main" in condition
+
+        repository = by_name("loom-images")
+        docker_config = field(repository.inputs, "docker_config", "dockerConfig")
+        assert field(docker_config, "immutable_tags", "immutableTags") is True
+
+        roles = {
+            resource.inputs.get("role")
+            for resource in mocks.resources
+            if resource.name
+            in {
+                "loom-ci-workload-identity",
+                "loom-ci-image-writer",
+                "loom-vm-image-reader",
+                "loom-vm-secret-reader",
+                "loom-vm-backup-writer",
+            }
+        }
+        assert roles == {
+            "roles/iam.workloadIdentityUser",
+            "roles/artifactregistry.writer",
+            "roles/artifactregistry.reader",
+            "roles/secretmanager.secretAccessor",
+            "roles/storage.objectCreator",
+        }
+
+    return infrastructure.workload_identity_provider.id.apply(check)
+
+
+@pulumi.runtime.test
+def test_secret_version_is_bound_to_managed_secret():
+    infrastructure = make_infrastructure()
+
+    def check(_: object) -> None:
+        secret = by_name("loom-dotenv")
+        version = by_name("loom-dotenv-current")
+        managed_secret = field(version.inputs, "secret", "secret")
+        assert managed_secret == f"{secret.name}_id"
+        assert field(version.inputs, "secret_data", "secretData")
+
+    return infrastructure.instance.id.apply(check)
+
+
+@pulumi.runtime.test
+def test_vm_waits_for_seeded_secret_and_all_runtime_grants():
+    infrastructure = make_infrastructure()
+
+    def check(_: object) -> None:
+        names = [resource.name for resource in mocks.resources]
+        vm_index = names.index("loom")
+        for prerequisite in (
+            "loom-dotenv-current",
+            "loom-vm-secret-reader",
+            "loom-vm-image-reader",
+            "loom-vm-backup-writer",
+            "loom-data-snapshot-policy",
+        ):
+            assert names.index(prerequisite) < vm_index
+
+        source = inspect.getsource(create_infrastructure)
+        dependencies = source[source.index("dependencies:") : source.index("instance =")]
+        for variable in (
+            "secret_version",
+            "vm_secret_reader",
+            "vm_image_reader",
+            "vm_backup_writer",
+            "snapshot_attachment",
+        ):
+            assert variable in dependencies
+
+    return infrastructure.instance.id.apply(check)
+
+
+def test_stateful_resources_are_source_protected():
+    source = inspect.getsource(create_infrastructure)
+    for declaration in (
+        '"loom-address"',
+        '"loom-data"',
+        '"loom-dotenv"',
+        '"loom-backups"',
+    ):
+        start = source.index(declaration)
+        assert "protect=True" in source[start : start + 700]
+    version = source[source.index('"loom-dotenv-current"') :]
+    assert "retain_on_delete=True" in version[:500]

--- a/deploy/pulumi/tests/test_infrastructure.py
+++ b/deploy/pulumi/tests/test_infrastructure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import re
 
 import pulumi
 import pytest
@@ -107,27 +108,32 @@ def test_wif_is_repository_and_main_bound_with_least_privilege_iam():
         docker_config = field(repository.inputs, "docker_config", "dockerConfig")
         assert field(docker_config, "immutable_tags", "immutableTags") is True
 
-        roles = {
-            resource.inputs.get("role")
-            for resource in mocks.resources
-            if resource.name
-            in {
-                "loom-ci-workload-identity",
-                "loom-ci-image-writer",
-                "loom-vm-image-reader",
-                "loom-vm-secret-reader",
-                "loom-vm-backup-writer",
-            }
-        }
-        assert roles == {
-            "roles/iam.workloadIdentityUser",
-            "roles/artifactregistry.writer",
-            "roles/artifactregistry.reader",
-            "roles/secretmanager.secretAccessor",
-            "roles/storage.objectCreator",
-        }
-
     return infrastructure.workload_identity_provider.id.apply(check)
+
+
+def test_iam_roles_are_narrow() -> None:
+    source = inspect.getsource(create_infrastructure)
+    assert set(re.findall(r'role="([^"]+)"', source)) == {
+        "roles/iam.workloadIdentityUser",
+        "roles/artifactregistry.writer",
+        "roles/artifactregistry.reader",
+        "roles/secretmanager.secretAccessor",
+        "roles/storage.objectCreator",
+    }
+
+
+@pulumi.runtime.test
+def test_backup_bucket_enforces_public_access_prevention():
+    infrastructure = make_infrastructure()
+
+    def check(_: object) -> None:
+        bucket = by_name("loom-backups")
+        prevention = field(
+            bucket.inputs, "public_access_prevention", "publicAccessPrevention"
+        )
+        assert prevention == "enforced"
+
+    return infrastructure.instance.id.apply(check)
 
 
 @pulumi.runtime.test

--- a/deploy/pulumi/tests/test_post_up.py
+++ b/deploy/pulumi/tests/test_post_up.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib.util
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "post-up.py"
+SPEC = importlib.util.spec_from_file_location("loom_post_up", MODULE_PATH)
+assert SPEC and SPEC.loader
+post_up = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(post_up)
+
+
+class Response:
+    def __init__(self, status: int, body: bytes):
+        self.status = status
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def test_health_requires_exact_200_ok_response() -> None:
+    with patch.object(post_up.urllib.request, "urlopen", return_value=Response(200, b"ok\n")):
+        assert post_up.health_is_ready("loom.example.com")
+
+    for status, body in [(200, b"login"), (204, b""), (404, b"not found")]:
+        with patch.object(
+            post_up.urllib.request, "urlopen", return_value=Response(status, body)
+        ):
+            assert not post_up.health_is_ready("loom.example.com")
+
+
+def test_health_rejects_caddy_upstream_errors() -> None:
+    error = urllib.error.HTTPError(
+        "https://loom.example.com/api/health", 502, "bad gateway", {}, None
+    )
+    with patch.object(post_up.urllib.request, "urlopen", side_effect=error):
+        assert not post_up.health_is_ready("loom.example.com")

--- a/deploy/pulumi/tests/test_static_contract.py
+++ b/deploy/pulumi/tests/test_static_contract.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import ast
+import re
+import unittest
+from pathlib import Path
+
+
+PULUMI_DIR = Path(__file__).resolve().parents[1]
+ROOT = PULUMI_DIR.parents[1]
+SOURCE = (PULUMI_DIR / "infrastructure.py").read_text()
+
+
+class InfrastructureSourceContract(unittest.TestCase):
+    def test_required_resource_types_are_declared(self) -> None:
+        tree = ast.parse(SOURCE)
+        calls = {
+            ast.unparse(node.func)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+        }
+        self.assertTrue(
+            {
+                "gcp.compute.Instance",
+                "gcp.compute.Disk",
+                "gcp.compute.ResourcePolicy",
+                "gcp.compute.DiskResourcePolicyAttachment",
+                "gcp.compute.Address",
+                "gcp.compute.Firewall",
+                "gcp.dns.RecordSet",
+                "gcp.secretmanager.Secret",
+                "gcp.secretmanager.SecretVersion",
+                "gcp.storage.Bucket",
+                "gcp.artifactregistry.Repository",
+                "gcp.iam.WorkloadIdentityPool",
+                "gcp.iam.WorkloadIdentityPoolProvider",
+            }.issubset(calls)
+        )
+
+    def test_vm_dependency_block_contains_runtime_prerequisites(self) -> None:
+        dependencies = SOURCE[
+            SOURCE.index("dependencies:") : SOURCE.index("instance =")
+        ]
+        for name in (
+            "secret_version",
+            "vm_secret_reader",
+            "vm_image_reader",
+            "vm_backup_writer",
+            "snapshot_attachment",
+        ):
+            self.assertIn(name, dependencies)
+
+    def test_backup_uses_sqlite_online_api_and_integrity_check(self) -> None:
+        backup = (ROOT / "deploy/gcp/backup-sqlite.sh").read_text()
+        self.assertIn(".backup", backup)
+        self.assertIn("PRAGMA quick_check", backup)
+        self.assertIn("gcloud storage cp", backup)
+
+    def test_image_workflow_is_keyless_and_immutable(self) -> None:
+        workflow = (ROOT / ".github/workflows/image.yml").read_text()
+        self.assertIn("id-token: write", workflow)
+        self.assertIn("google-github-actions/auth@", workflow)
+        self.assertIn("${GITHUB_SHA}", workflow)
+        self.assertNotIn("loom:latest", workflow)
+        self.assertNotIn("credentials_json", workflow)
+        self.assertIn('docker_config={"immutable_tags": True}', SOURCE)
+        action_refs = re.findall(r"uses:\s+[^@\s]+@([^\s#]+)", workflow)
+        self.assertTrue(action_refs)
+        self.assertTrue(all(re.fullmatch(r"[0-9a-f]{40}", ref) for ref in action_refs))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/pulumi/tests/test_static_contract.py
+++ b/deploy/pulumi/tests/test_static_contract.py
@@ -61,6 +61,8 @@ class InfrastructureSourceContract(unittest.TestCase):
         self.assertIn("id-token: write", workflow)
         self.assertIn("google-github-actions/auth@", workflow)
         self.assertIn("${GITHUB_SHA}", workflow)
+        self.assertIn("gcloud artifacts docker images describe", workflow)
+        self.assertIn("steps.image.outputs.exists != 'true'", workflow)
         self.assertNotIn("loom:latest", workflow)
         self.assertNotIn("credentials_json", workflow)
         self.assertIn('docker_config={"immutable_tags": True}', SOURCE)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,9 +168,12 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
     and the auth tables `users` (the approved-operator allowlist, seeded with
     the owner), `api_tokens` (hashed bearer tokens), and `auth_sessions`
     (hashed login cookies). See [Authentication](#authentication). Loom-owned
-    tables migrate via `add_column_if_missing` / `CREATE ... IF NOT EXISTS` in
-    `migrate_loom`, not the numbered core migrations below (those run before
-    loom creates its tables).
+    tables have their own ordered migration stream under
+    `crates/loom/migrations/`, recorded in `loom_schema_migrations`. This is a
+    separate stream because the core migrations run before loom creates its
+    tables. A pre-stream loom database is adopted once by presence-based
+    introspection, then stamped at the baseline version; do not add more
+    error-message-driven `ALTER TABLE` probes.
   - **Schema migrations** (`weaver-core/src/migrations.rs`): ordered SQL files
     under `crates/weaver-core/migrations/` (`NNNN_name.sql`, embedded with
     `include_str!`), applied at startup and recorded in a `schema_migrations`
@@ -178,6 +181,42 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
     a row in `MIGRATIONS`; never edit one that has shipped. A pre-framework
     database is brought to the baseline by a one-time `legacy_bootstrap` on
     first run.
+
+### Database ownership and the PostgreSQL seam
+
+The schema has two owners even though both currently share one SQLite file:
+
+- `weaver-core` owns the durable work ledger (`branches`, issues, tags,
+  events, artifacts, discussions, watches) and `schema_migrations`. Its
+  original baseline also physically creates `settings`; operator config is a
+  loom concern, but moving that table is still future boundary work.
+- `loom` owns host-local runtime, identity, integration, and agent-config
+  tables (`sessions`, chat, users/tokens, repos, agent config) and
+  `loom_schema_migrations`.
+
+The target rule is to keep cross-owner links as identifiers in application
+code. Two existing exceptions remain explicit split prerequisites: the
+`sessions.branch_id` schema has a physical foreign key to `branches`, and the
+issue-list view joins sessions to branches to apply automation visibility.
+Remove those before putting the owners in different databases, and do not add
+new cross-owner joins in the meantime.
+
+`weaver-core::db` is the backend seam: callers use its `Db` and
+`DbTransaction` aliases, time values are computed by Rust and bound, row
+decoding uses `FromRow`, and new conflict clauses should use portable
+`ON CONFLICT` forms. The implementation is still deliberately SQLite:
+`Db = SqlitePool`, connection setup uses WAL/`BEGIN IMMEDIATE`, migrations use
+SQLite introspection, and runtime queries use SQLite placeholders. These
+changes make a future backend explicit; they do not claim PostgreSQL support.
+
+The first useful shared-PostgreSQL move is the durable ledger, not host-local
+sessions. Its main data-model gate is a logical repository identity: today
+ledger rows key repos by absolute checkout paths, so two hosts would otherwise
+create two unrelated histories for the same repository. After that change —
+and after removing the FK/join and relocating `settings` noted above — a
+PostgreSQL implementation of the database seam and a real PostgreSQL CI lane
+can move the ledger while each runtime host keeps its sessions and chat in
+local SQLite.
 - **`server.json`** in `$WEAVER_HOME`: pid + bound addr, written when `loom`
   comes up. The `loom` CLI uses it to find the daemon when `WEAVER_API` is
   unset.


### PR DESCRIPTION
Builds the infrastructure and storage-preparation bundle on top of #169.

## Provisioning

Adds an authoritative Python Pulumi stack for the single-host GCP deployment: service identities and least-privilege IAM, existing-VPC firewall rules, protected address/disk/secret/backup resources, snapshot policy, optional Cloud DNS record, Artifact Registry, and repository-scoped GitHub OIDC for immutable image publication. The existing network remains operator-owned and configurable; Pulumi does not create a VPC or alter unrelated firewall policy.

The legacy imperative provisioner now has an explicit import plan. A post-up driver handles DNS, SSH, startup-journal, and exact HTTPS health checks. Nightly online SQLite backups are integrity-checked and uploaded to a private, versioned GCS bucket, alongside disk snapshots and a documented safe restore flow.

## Storage boundary

Gives Loom-owned tables an independent versioned migration stream with crash-resumable adoption of legacy database shapes. It replaces error-string migration probes with schema-presence checks, narrows concrete SQLite row and transaction types behind shared seams, moves time arithmetic to bound application values, and normalizes portable conflict/boolean forms.

SQLite remains the only implemented backend. The architecture guide records the remaining PostgreSQL gates: logical repository identity, the session-to-ledger foreign key, the issue visibility join, settings ownership, SQL placeholders, and backend-specific migration/introspection behavior.

This PR is stacked on #169 so its review contains only the provisioning and storage-boundary work; retarget it to main after #169 lands.