### PR TITLE
fix(loom): keep session GitHub associations accurate

### DIFF
--- a/crates/loom/frontend/src/components/GithubAssociations.vue
+++ b/crates/loom/frontend/src/components/GithubAssociations.vue
@@ -1,0 +1,238 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { Session } from '../types';
+import { clearSessionGithub, patchIssue, refreshSessionGithub, setSessionGithub } from '../api';
+
+// The two GitHub links a workstream accumulates: the issue it came from and the
+// PR it produces. Both pills remain visible when empty so association is a
+// discoverable operation rather than a setting hidden in the manage menu.
+const props = defineProps<{ ws: Session }>();
+const emit = defineEmits<{ reload: [] }>();
+
+const prOpen = ref(false);
+const prDraft = ref('');
+const prBusy = ref('');
+const prError = ref('');
+const prNumber = computed(() => props.ws.branch.github?.pr_number ?? props.ws.branch.github_pr);
+const prStateClass = computed(() => {
+  const state = props.ws.branch.github?.pr_state;
+  return (
+    { OPEN: 'text-ok', MERGED: 'text-agent', CLOSED: 'text-block' }[state ?? ''] ?? 'text-muted'
+  );
+});
+const prChecksClass = computed(() => {
+  const checks = props.ws.branch.github?.checks;
+  return (
+    { passing: 'text-ok', failing: 'text-block', pending: 'text-info' }[checks ?? ''] ??
+    'text-muted'
+  );
+});
+
+const issueOpen = ref(false);
+const issueDraft = ref('');
+const issueBusy = ref(false);
+const issueError = ref('');
+
+function togglePrEditor() {
+  prOpen.value = !prOpen.value;
+  issueOpen.value = false;
+  prError.value = '';
+  prDraft.value = String(props.ws.branch.github_pr ?? props.ws.branch.github?.pr_number ?? '');
+}
+
+async function updatePr(action: 'set' | 'auto' | 'refresh') {
+  if (prBusy.value) return;
+  const number = Number(prDraft.value);
+  if (action === 'set' && (!Number.isInteger(number) || number <= 0)) {
+    prError.value = 'Enter a positive PR number.';
+    return;
+  }
+  prBusy.value = action;
+  prError.value = '';
+  try {
+    if (action === 'set') await setSessionGithub(props.ws.id, number);
+    else if (action === 'auto') await clearSessionGithub(props.ws.id);
+    else await refreshSessionGithub(props.ws.id);
+    prOpen.value = false;
+    emit('reload');
+  } catch (e) {
+    prError.value = (e as Error).message;
+  } finally {
+    prBusy.value = '';
+  }
+}
+
+function toggleIssueEditor() {
+  issueOpen.value = !issueOpen.value;
+  prOpen.value = false;
+  issueError.value = '';
+  issueDraft.value = props.ws.github_issue
+    ? `${props.ws.github_issue.repo}#${props.ws.github_issue.number}`
+    : '';
+}
+
+async function updateIssue(clear = false) {
+  if (issueBusy.value) return;
+  if (!props.ws.tracking_issue) {
+    issueError.value = 'This session has no tracking issue to associate.';
+    return;
+  }
+  issueBusy.value = true;
+  issueError.value = '';
+  try {
+    await patchIssue(props.ws.tracking_issue, { github: clear ? '' : issueDraft.value.trim() });
+    issueOpen.value = false;
+    emit('reload');
+  } catch (e) {
+    issueError.value = (e as Error).message;
+  } finally {
+    issueBusy.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="relative shrink-0">
+    <button
+      type="button"
+      class="pill font-mono hover:border-accent hover:text-accent"
+      data-testid="pr-association-pill"
+      :aria-expanded="prOpen"
+      :title="prNumber ? 'Edit pull request association' : 'Associate a pull request'"
+      @click="togglePrEditor"
+    >
+      PR {{ prNumber ? `#${prNumber}` : '—' }}
+    </button>
+    <div
+      v-if="prOpen"
+      class="absolute left-0 top-full z-30 mt-1 w-64 rounded border border-line bg-surface p-3 shadow-lg"
+      data-testid="pr-mapping-popover"
+    >
+      <form class="space-y-2" data-testid="pr-mapping-form" @submit.prevent="updatePr('set')">
+        <div class="flex items-baseline justify-between gap-2">
+          <span class="text-2xs font-semibold uppercase tracking-wider text-muted"
+            >Pull request</span
+          >
+          <a
+            v-if="ws.branch.github"
+            :href="ws.branch.github.pr_url"
+            target="_blank"
+            rel="noopener"
+            class="text-2xs text-accent hover:underline"
+            >Open on GitHub ↗</a
+          >
+        </div>
+        <label class="block text-2xs text-muted">
+          PR number
+          <input
+            v-model="prDraft"
+            type="number"
+            min="1"
+            class="mt-1 block w-full rounded bg-input px-2 py-1.5 font-mono text-xs text-fg"
+          />
+        </label>
+        <p class="text-2xs text-faint">
+          {{ ws.branch.github_pr ? 'Pinned manually.' : 'Following the worktree branch.' }}
+        </p>
+        <p v-if="prError" class="text-xs text-block">{{ prError }}</p>
+        <div class="flex flex-wrap gap-1.5">
+          <button type="submit" class="btn-primary px-2 py-1 text-xs" :disabled="!!prBusy">
+            {{ prBusy === 'set' ? 'Saving…' : 'Pin PR' }}
+          </button>
+          <button
+            type="button"
+            class="btn-secondary px-2 py-1 text-xs"
+            :disabled="!!prBusy"
+            @click="updatePr('auto')"
+          >
+            Use current
+          </button>
+          <button
+            type="button"
+            class="btn-secondary px-2 py-1 text-xs"
+            :disabled="!!prBusy"
+            @click="updatePr('refresh')"
+          >
+            Refresh
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <template v-if="ws.branch.github">
+    <span :class="prStateClass" class="font-mono uppercase tracking-wide">
+      {{ ws.branch.github.pr_state.toLowerCase() }}
+    </span>
+    <span
+      v-if="ws.branch.github.checks"
+      :class="prChecksClass"
+      class="font-mono"
+      :title="`Checks ${ws.branch.github.checks}`"
+      >●</span
+    >
+  </template>
+
+  <div class="relative shrink-0">
+    <button
+      type="button"
+      class="pill font-mono hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-60"
+      data-testid="issue-association-pill"
+      :aria-expanded="issueOpen"
+      :disabled="!ws.tracking_issue"
+      :title="
+        ws.tracking_issue
+          ? ws.github_issue
+            ? 'Edit GitHub issue association'
+            : 'Associate a GitHub issue'
+          : 'This session has no tracking issue'
+      "
+      @click="toggleIssueEditor"
+    >
+      Issue {{ ws.github_issue ? `#${ws.github_issue.number}` : '—' }}
+    </button>
+    <div
+      v-if="issueOpen"
+      class="absolute left-0 top-full z-30 mt-1 w-72 rounded border border-line bg-surface p-3 shadow-lg"
+      data-testid="issue-mapping-popover"
+    >
+      <form class="space-y-2" data-testid="issue-mapping-form" @submit.prevent="updateIssue()">
+        <div class="flex items-baseline justify-between gap-2">
+          <span class="text-2xs font-semibold uppercase tracking-wider text-muted"
+            >GitHub issue</span
+          >
+          <a
+            v-if="ws.github_issue"
+            :href="`https://github.com/${ws.github_issue.repo}/issues/${ws.github_issue.number}`"
+            target="_blank"
+            rel="noopener"
+            class="text-2xs text-accent hover:underline"
+            >Open on GitHub ↗</a
+          >
+        </div>
+        <label class="block text-2xs text-muted">
+          owner/repo#number
+          <input
+            v-model="issueDraft"
+            placeholder="acme/widgets#123"
+            class="mt-1 block w-full rounded bg-input px-2 py-1.5 font-mono text-xs text-fg"
+          />
+        </label>
+        <p v-if="issueError" class="text-xs text-block">{{ issueError }}</p>
+        <div class="flex gap-1.5">
+          <button type="submit" class="btn-primary px-2 py-1 text-xs" :disabled="issueBusy">
+            {{ issueBusy ? 'Saving…' : 'Save' }}
+          </button>
+          <button
+            v-if="ws.github_issue"
+            type="button"
+            class="btn-secondary px-2 py-1 text-xs"
+            :disabled="issueBusy"
+            @click="updateIssue(true)"
+          >
+            Clear
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -2,13 +2,7 @@
 import { ref, computed, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import type { AgentMetadata, Session } from '../types';
-import {
-  handoffSession,
-  listAgents,
-  refreshSessionGithub,
-  setSessionGithub,
-  clearSessionGithub,
-} from '../api';
+import { handoffSession, listAgents } from '../api';
 import {
   messageOf,
   conversationState,
@@ -24,7 +18,7 @@ import SignalChip from './SignalChip.vue';
 import TagPill from './TagPill.vue';
 import SessionDetailsPopover from './SessionDetailsPopover.vue';
 import SessionRemedyButton from './SessionRemedyButton.vue';
-import GithubStatus from './GithubStatus.vue';
+import GithubAssociations from './GithubAssociations.vue';
 
 // The session page header — one compact chrome block shared by both the detail
 // view and the file browser, so the "where am I / what is this" context never
@@ -33,7 +27,7 @@ import GithubStatus from './GithubStatus.vue';
 //   row 1  ← all · title (inline rename) · [signal chips]ⁱ
 //           · lifecycle badge · ⌄ details menu
 //   row 2  the agent's current-state message as prose (the point of the page)
-//   row 3  repo/branch · agent · PR link · the quiet conversation-state + freshness
+//   row 3  repo/branch · agent · PR/issue links · quiet conversation-state + freshness
 //
 // The old full-width "▶ Working … last activity" strip is gone: when the session
 // is calm, its state is a quiet note on row 3; when a loud signal is raised it
@@ -187,41 +181,6 @@ async function submitHandoff() {
     handoffBusy.value = false;
   }
 }
-
-// PR association: automatic by default, with an explicit numeric override for
-// branches whose current work belongs to a different PR than GitHub infers.
-const prOpen = ref(false);
-const prDraft = ref('');
-const prBusy = ref('');
-const prError = ref('');
-
-function togglePrEditor() {
-  prOpen.value = !prOpen.value;
-  prError.value = '';
-  prDraft.value = String(props.ws.branch.github_pr ?? props.ws.branch.github?.pr_number ?? '');
-}
-
-async function updatePr(action: 'set' | 'auto' | 'refresh') {
-  if (prBusy.value) return;
-  const number = Number(prDraft.value);
-  if (action === 'set' && (!Number.isInteger(number) || number <= 0)) {
-    prError.value = 'Enter a positive PR number.';
-    return;
-  }
-  prBusy.value = action;
-  prError.value = '';
-  try {
-    if (action === 'set') await setSessionGithub(props.ws.id, number);
-    else if (action === 'auto') await clearSessionGithub(props.ws.id);
-    else await refreshSessionGithub(props.ws.id);
-    prOpen.value = false;
-    emit('reload');
-  } catch (e) {
-    prError.value = (e as Error).message;
-  } finally {
-    prBusy.value = '';
-  }
-}
 </script>
 
 <template>
@@ -291,65 +250,6 @@ async function updatePr(action: 'set' | 'auto' | 'refresh') {
           <SessionDetailsPopover :ws="ws" v-model:open="showDetails">
             <template #actions>
               <div class="space-y-1">
-                <button
-                  type="button"
-                  data-testid="action-pr-mapping"
-                  class="block w-full rounded px-2 py-1.5 text-left text-fg transition-colors hover:bg-subtle"
-                  @click="togglePrEditor"
-                >
-                  <span class="block text-xs font-medium">Pull request</span>
-                  <span class="block text-2xs text-faint">
-                    {{
-                      ws.branch.github_pr
-                        ? `Pinned to #${ws.branch.github_pr}`
-                        : ws.branch.github
-                          ? `Automatic · #${ws.branch.github.pr_number}`
-                          : 'Automatic · none found'
-                    }}
-                  </span>
-                </button>
-                <form
-                  v-if="prOpen"
-                  class="space-y-2 rounded border border-line bg-input p-2"
-                  data-testid="pr-mapping-form"
-                  @submit.prevent="updatePr('set')"
-                >
-                  <label class="block text-2xs font-semibold uppercase tracking-wider text-muted">
-                    PR number
-                    <input
-                      v-model="prDraft"
-                      type="number"
-                      min="1"
-                      class="mt-1 block w-full rounded bg-surface px-2 py-1.5 font-mono text-xs font-normal normal-case tracking-normal text-fg"
-                    />
-                  </label>
-                  <p v-if="prError" class="text-xs text-block">{{ prError }}</p>
-                  <div class="flex flex-wrap gap-1.5">
-                    <button
-                      type="submit"
-                      class="btn-primary px-2 py-1 text-xs"
-                      :disabled="!!prBusy"
-                    >
-                      {{ prBusy === 'set' ? 'Saving…' : 'Pin PR' }}
-                    </button>
-                    <button
-                      type="button"
-                      class="btn-secondary px-2 py-1 text-xs"
-                      :disabled="!!prBusy"
-                      @click="updatePr('auto')"
-                    >
-                      Use current
-                    </button>
-                    <button
-                      type="button"
-                      class="btn-secondary px-2 py-1 text-xs"
-                      :disabled="!!prBusy"
-                      @click="updatePr('refresh')"
-                    >
-                      Refresh
-                    </button>
-                  </div>
-                </form>
                 <button
                   v-if="canHandoff"
                   type="button"
@@ -475,13 +375,12 @@ async function updatePr(action: 'set' | 'auto' | 'refresh') {
           · <span :class="modelTint" class="font-medium">{{ ws.model }}</span></template
         >
       </span>
-      <!-- The branch's PR, surfaced inline as a small link — the one place you
-           already look — rather than buried in the Overview tab. Compact mode is
-           the same tight glyphline the dashboard list uses. -->
-      <template v-if="ws.branch.github">
-        <span class="text-faint">·</span>
-        <GithubStatus :gh="ws.branch.github" compact class="min-w-0" />
-      </template>
+      <span class="text-faint">·</span>
+
+      <!-- GitHub associations stay visible even when empty. Clicking either
+           pill opens its editor; the PR retains automatic discovery as a mode,
+           while the issue is the explicit link on this session's tracker. -->
+      <GithubAssociations :ws="ws" @reload="emit('reload')" />
       <div class="ml-auto flex shrink-0 items-center gap-1.5">
         <span v-if="!signals.length" data-testid="conversation-state" :class="toneClass">
           {{ conv.glyph }} {{ conv.label }}

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -80,6 +80,8 @@ export interface Session {
   /** Reasoning effort interpreted by the selected agent protocol. */
   effort: string;
   github_repo: string | null;
+  /** GitHub issue linked to this session's weaver tracking issue. */
+  github_issue: { repo: string; number: number } | null;
   last_activity_at: string;
   created_at: string;
   updated_at: string;

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -714,6 +714,30 @@ pub async fn clear_status(db: &Db, branch_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// The branch name GitHub should use for automatic PR discovery.
+///
+/// A session's [`Branch`] is its durable loom identity, but an agent is free to
+/// switch or rename the checked-out git branch after launch. Workflows such as
+/// Marin's `fix-issue` skill do exactly that before opening an `agent/...` PR.
+/// Prefer the worktree's live HEAD so the poller follows that PR; fall back to
+/// the stored name when the worktree is missing, detached, or unreadable.
+async fn discovery_branch(session: &Session, branch: &Branch) -> String {
+    match crate::git::current_branch(Path::new(&session.work_dir)).await {
+        Ok(current) if !current.trim().is_empty() && current != "HEAD" => {
+            if current != branch.branch {
+                tracing::debug!(
+                    session = %session.id,
+                    stored_branch = %branch.branch,
+                    worktree_branch = %current,
+                    "using worktree HEAD for GitHub PR discovery"
+                );
+            }
+            current
+        }
+        _ => branch.branch.clone(),
+    }
+}
+
 /// Persist (replacing) the snapshot for a branch.
 pub async fn upsert_status(db: &Db, branch_id: &str, s: &GithubStatus) -> Result<()> {
     sqlx::query(
@@ -768,7 +792,8 @@ pub async fn refresh(
         // treating yesterday's cached number as authoritative. Only when the
         // branch has no open PR do we revisit the previous number once, to
         // preserve its close/merge transition before the snapshot is cleared.
-        let current = fetch_open_pr(&repo_root, &branch.branch, token.as_deref()).await?;
+        let head = discovery_branch(session, branch).await;
+        let current = fetch_open_pr(&repo_root, &head, token.as_deref()).await?;
         if current.is_some() {
             current
         } else if previous.as_ref().is_some_and(|pr| pr.pr_state == "OPEN") {
@@ -1371,6 +1396,18 @@ mod tests {
 
         clear_mapping(&f.state.db, &f.branch.id).await.unwrap();
         assert_eq!(get_mapping(&f.state.db, &f.branch.id).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn automatic_discovery_follows_the_worktree_head_branch() {
+        let f = fixture().await;
+        git(&f.work_dir, &["switch", "-c", "agent/20260721-fix-7473"]);
+
+        assert_eq!(
+            discovery_branch(&f.session, &f.branch).await,
+            "agent/20260721-fix-7473"
+        );
+        assert_eq!(f.branch.branch, "weaver/feat", "loom identity stays stable");
     }
 
     #[tokio::test]

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -279,6 +279,16 @@ pub(crate) async fn session_view(
     branch: &Branch,
 ) -> ApiResult<SessionView> {
     let bv = branch_view(db, branch).await?;
+    let github_issue = if let Some(id) = session.tracking_issue_id {
+        weaver_core::issue::get(db, id).await?.and_then(|issue| {
+            match (issue.github_repo, issue.github_issue) {
+                (Some(repo), Some(number)) => Some(weaver_api::GithubIssueRef { repo, number }),
+                _ => None,
+            }
+        })
+    } else {
+        None
+    };
     // The latest usage block is a cheap indexed query; `None` for a terminal
     // session (or an ACP session before the agent reports usage).
     let usage = if session.protocol == "acp" {
@@ -298,6 +308,7 @@ pub(crate) async fn session_view(
         model: session.model.clone(),
         effort: session.effort.clone(),
         github_repo: session.github_repo.clone(),
+        github_issue,
         last_activity_at: session
             .last_activity_at
             .clone()

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -126,6 +126,11 @@ pub struct SessionView {
     pub model: String,
     pub effort: String,
     pub github_repo: Option<String>,
+    /// GitHub issue linked to this session's tracking issue, if any. This is
+    /// separate from `branch.github`, which is the pull request created by the
+    /// work. The tracking issue remains the source of truth for edits.
+    #[serde(default)]
+    pub github_issue: Option<GithubIssueRef>,
     pub last_activity_at: String,
     pub created_at: String,
     pub updated_at: String,
@@ -199,6 +204,13 @@ pub struct AcpUsage {
     pub size: u64,
     #[serde(default)]
     pub cost: Option<AcpCost>,
+}
+
+/// A GitHub issue association carried by a session's tracking issue.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GithubIssueRef {
+    pub repo: String,
+    pub number: i64,
 }
 
 fn default_protocol() -> String {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,7 +291,8 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 
 `SessionView` (`/api/sessions[/...]`) returns session-specific fields
 top-level (`id`, `status`, `work_dir`, `term_session`, `agent_kind`, `model`,
-`effort`, `pending_prompt`, `github_repo`, `last_activity_at`,
+`effort`, `pending_prompt`, `github_repo`, `github_issue` (the `repo` + `number`
+linked on the session's tracking issue), `last_activity_at`,
 `created_at`, `updated_at`, `parent_id`, `protocol` (`terminal` or `acp`),
 `acp_session_id`, `current_mode`, `usage` (`{used, size}` context window, from
 the journal's latest `usage` block), `origin` (the channel that created it:
@@ -557,8 +558,11 @@ from under it. The `automation.*` settings live in
 When the `gh` CLI is installed and authenticated, loom keeps a per-branch
 pull-request snapshot alongside the session. A second background loop
 (`github::poll`, sibling of the monitor, spawned in `server::serve`) ticks every
-30s and, for each active session, runs `gh pr view <branch> --json …` from the
-repo root. The result — PR number, URL, state (`OPEN`/`CLOSED`/`MERGED`), draft
+30s and, for each active session, runs `gh pr list --head <branch> …` from the
+repo root. `<branch>` is the worktree's live HEAD (falling back to loom's stored
+branch identity when the worktree cannot be read), so an agent that switches or
+renames its branch before opening a PR is still discovered. The result — PR
+number, URL, state (`OPEN`/`CLOSED`/`MERGED`), draft
 flag, `reviewDecision`, a rolled-up `checks` verdict (`passing`/`failing`/
 `pending`), and mergeability — is written to the loom-owned `branch_github`
 table (one row per branch, keyed `branch_id`) and served as `BranchView.github`.
@@ -570,6 +574,12 @@ while the `github.poll` setting is off, `gh` is missing (probed once, cached via
 `gh_available`), or the repo has no GitHub remote (a per-branch `gh` error that
 is logged at debug and skipped). So it is a no-op on non-GitHub repos rather
 than a failure.
+
+The session header always renders PR and issue association pills, including an
+empty state. The PR editor can pin an explicit number or return to live-branch
+discovery through `PUT` / `DELETE /api/sessions/{id}/github`; the issue editor
+patches the GitHub link on the session's weaver tracking issue, which remains
+the source of truth for that association.
 
 **Archive on merge.** When a poll finds a branch's PR has merged and
 `github.archive_on_merge` is on (the default), loom archives the session

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -59,11 +59,13 @@ export interface Session {
   agent_kind: string;
   pending_prompt: string;
   github_repo: string | null;
+  github_issue: { repo: string; number: number } | null;
   last_activity_at: string;
   created_at: string;
   updated_at: string;
   /** Branch id of the session that launched this one, or null at the top level. */
   parent_id: string | null;
+  tracking_issue: number | null;
   branch: Branch;
 }
 

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -45,7 +45,7 @@ test.describe('session detail view', () => {
     await expect(page).toHaveTitle('Weaver - Sessions');
   });
 
-  test('edits the session pull request mapping from the manage menu', async ({ page, weaver }) => {
+  test('edits pull request and issue associations from visible pills', async ({ page, weaver }) => {
     const s = await weaver.seedSession({ goal: 'Map my PR', name: 'pr-map' });
     let requestBody: unknown;
     await page.route(`**/api/sessions/${s.id}/github`, async (route) => {
@@ -57,14 +57,33 @@ test.describe('session detail view', () => {
     });
 
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);
-    await page.getByRole('button', { name: 'manage' }).click();
-    await page.getByTestId('action-pr-mapping').click();
+    const prPill = page.getByTestId('pr-association-pill');
+    const issuePill = page.getByTestId('issue-association-pill');
+    await expect(prPill).toHaveText('PR —');
+    await expect(issuePill).toHaveText('Issue —');
+
+    await prPill.click();
     const form = page.getByTestId('pr-mapping-form');
     await form.getByLabel('PR number').fill('37');
     await form.getByRole('button', { name: 'Pin PR' }).click();
 
     await expect.poll(() => requestBody).toEqual({ pr_number: 37 });
     await expect(form).toBeHidden();
+
+    await issuePill.click();
+    const issueForm = page.getByTestId('issue-mapping-form');
+    await issueForm.getByLabel('owner/repo#number').fill('acme/widgets#73');
+    await issueForm.getByRole('button', { name: 'Save' }).click();
+
+    await expect(issuePill).toHaveText('Issue #73');
+    await expect.poll(async () => (await weaver.getSession(s.id)).github_issue).toEqual({
+      repo: 'acme/widgets',
+      number: 73,
+    });
+
+    await issuePill.click();
+    await page.getByTestId('issue-mapping-form').getByRole('button', { name: 'Clear' }).click();
+    await expect(issuePill).toHaveText('Issue —');
   });
 
   test('clearing the attention chip marks the agent’s attention calm', async ({ page, weaver }) => {


### PR DESCRIPTION
Use the worktree's live HEAD branch for automatic pull-request discovery so workflows that rename or switch branches after launch still receive PR status and annotations. Fall back to the durable loom branch identity when the worktree is unavailable.

Expose the tracking issue's GitHub link in the session view and replace the hidden PR control with always-visible, editable PR and issue pills, including empty association states.

Session: https://loom.rjp.io/s/gqg9pmt3