### PR TITLE
fix(loom): allow permissions during ACP adoption

### DIFF
--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -417,7 +417,7 @@ async fn start_inner(
     // From this point onward the detached relay exists. Any failure must tear it
     // down and clear partially-persisted provider state before returning, or the
     // caller gets a stuck row plus a relay name handoff cannot safely reuse.
-    let prepared: Result<Task> = async {
+    let prepared: Result<(Task, mpsc::Receiver<Command>)> = async {
         let stream = crate::backend::subscribe_relay(&relay_name, 0).await?;
         let mut task = Task::fresh(
             state,
@@ -427,14 +427,29 @@ async fn start_inner(
             events_tx.clone(),
         )
         .await?;
-        task.handshake(&launch, handoff).await?;
-        Ok(task)
+        // `session/load` may replay an unanswered permission request and wait
+        // for the client response before returning. Register the task before
+        // setup so the REST permission route can drive that request instead of
+        // deadlocking against a handshake that has not published its handle.
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(64);
+        task.generation = state.acp.register(
+            session_id,
+            AcpHandle {
+                cmd_tx,
+                events_tx: events_tx.clone(),
+                metadata: task.metadata.clone(),
+            },
+        );
+        if let Err(error) = task.handshake(&launch, handoff, &mut cmd_rx).await {
+            task.registry.remove_own(&task.session_id, task.generation);
+            return Err(error);
+        }
+        Ok((task, cmd_rx))
     }
     .await;
-    let mut task = match prepared {
-        Ok(task) => task,
+    let (task, cmd_rx) = match prepared {
+        Ok(prepared) => prepared,
         Err(error) => {
-            state.acp.stop(session_id);
             let latest = session::get(&state.db, session_id).await.ok().flatten();
             if let Some(turn) = latest.as_ref().and_then(session::acp_inflight_turn) {
                 let _ = chat::close_abandoned_turn(&state.db, session_id, turn).await;
@@ -449,15 +464,6 @@ async fn start_inner(
         }
     };
 
-    let (cmd_tx, cmd_rx) = mpsc::channel(64);
-    task.generation = state.acp.register(
-        session_id,
-        AcpHandle {
-            cmd_tx,
-            events_tx,
-            metadata: task.metadata.clone(),
-        },
-    );
     tokio::spawn(async move { task.run(cmd_rx).await });
     Ok(())
 }
@@ -948,7 +954,12 @@ impl Task {
 
     // -- handshake ----------------------------------------------------------
 
-    async fn handshake(&mut self, launch: &AcpLaunch, handoff: Option<Value>) -> Result<()> {
+    async fn handshake(
+        &mut self,
+        launch: &AcpLaunch,
+        handoff: Option<Value>,
+        cmd_rx: &mut mpsc::Receiver<Command>,
+    ) -> Result<()> {
         let id = self.next_id();
         self.stream
             .write(&wire::request_line(
@@ -958,7 +969,7 @@ impl Task {
             ))
             .await?;
         let (res, err) = self
-            .recv_until_response(id, method::INITIALIZE, launch.setup_timeout)
+            .recv_until_response(id, method::INITIALIZE, launch.setup_timeout, cmd_rx)
             .await?;
         let res = res.ok_or_else(|| anyhow!("initialize failed: {err:?}"))?;
         if let Ok(init) = serde_json::from_value::<wire::InitializeResult>(res) {
@@ -975,7 +986,7 @@ impl Task {
                     .write(&wire::request_line(id, method::SESSION_NEW, params))
                     .await?;
                 let (res, err) = self
-                    .recv_until_response(id, method::SESSION_NEW, launch.setup_timeout)
+                    .recv_until_response(id, method::SESSION_NEW, launch.setup_timeout, cmd_rx)
                     .await?;
                 let res = res.ok_or_else(|| anyhow!("session/new failed: {err:?}"))?;
                 let ns: wire::NewSessionResult = serde_json::from_value(res)?;
@@ -1012,7 +1023,7 @@ impl Task {
                 // History replays as `session/update` notifications during the call.
                 let load_timeout = launch.setup_timeout.saturating_mul(4);
                 let (res, err) = self
-                    .recv_until_response(id, method::SESSION_LOAD, load_timeout)
+                    .recv_until_response(id, method::SESSION_LOAD, load_timeout, cmd_rx)
                     .await?;
                 self.suppress_journal = false;
                 // Drop any consolidation the suppressed replay left half-open so it
@@ -1046,7 +1057,7 @@ impl Task {
                 ))
                 .await?;
             let (result, error) = self
-                .recv_until_response(id, method::SESSION_SET_MODE, launch.setup_timeout)
+                .recv_until_response(id, method::SESSION_SET_MODE, launch.setup_timeout, cmd_rx)
                 .await?;
             if result.is_none() {
                 bail!("session/set_mode failed: {error:?}");
@@ -1073,6 +1084,7 @@ impl Task {
         want: u64,
         method_name: &str,
         timeout: Duration,
+        cmd_rx: &mut mpsc::Receiver<Command>,
     ) -> Result<(Option<Value>, Option<Value>)> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
@@ -1080,34 +1092,73 @@ impl Task {
             if remaining.is_zero() {
                 bail!("timed out waiting for ACP {method_name} response after {timeout:?}");
             }
-            let event = tokio::time::timeout(remaining, self.stream.recv())
-                .await
-                .map_err(|_| {
-                    anyhow!("timed out waiting for ACP {method_name} response after {timeout:?}")
-                })?;
-            match event {
-                Some(RelayEvent::Frame { seq, payload }) => {
-                    self.highest_seq = seq;
-                    let inc: Incoming = match serde_json::from_slice(&payload) {
-                        Ok(i) => i,
-                        Err(_) => {
+            tokio::select! {
+                event = self.stream.recv() => match event {
+                    Some(RelayEvent::Frame { seq, payload }) => {
+                        self.highest_seq = seq;
+                        let inc: Incoming = match serde_json::from_slice(&payload) {
+                            Ok(i) => i,
+                            Err(_) => {
+                                self.maybe_ack().await?;
+                                continue;
+                            }
+                        };
+                        if inc.kind() == IncomingKind::Response
+                            && inc.id.as_ref().and_then(Value::as_u64) == Some(want)
+                        {
                             self.maybe_ack().await?;
-                            continue;
+                            return Ok((inc.result, inc.error));
                         }
-                    };
-                    if inc.kind() == IncomingKind::Response
-                        && inc.id.as_ref().and_then(Value::as_u64) == Some(want)
-                    {
+                        self.dispatch_frame(seq, inc).await;
                         self.maybe_ack().await?;
-                        return Ok((inc.result, inc.error));
                     }
-                    self.dispatch_frame(seq, inc).await;
-                    self.maybe_ack().await?;
+                    Some(RelayEvent::Exit { status }) => {
+                        bail!("agent exited during handshake (status {status:?})")
+                    }
+                    None => bail!("relay closed during handshake"),
+                },
+                cmd = cmd_rx.recv() => match cmd {
+                    Some(cmd) => self.on_setup_command(cmd).await,
+                    None => bail!("ACP session setup was stopped"),
+                },
+                _ = tokio::time::sleep_until(deadline) => {
+                    bail!("timed out waiting for ACP {method_name} response after {timeout:?}")
                 }
-                Some(RelayEvent::Exit { status }) => {
-                    bail!("agent exited during handshake (status {status:?})")
-                }
-                None => bail!("relay closed during handshake"),
+            }
+        }
+    }
+
+    /// During initialize/new/load only permission answers are safe to drive.
+    /// In particular, a replayed open permission can be a prerequisite for the
+    /// `session/load` response itself. Reject other controls promptly rather
+    /// than queueing an HTTP request behind setup or sending it with an empty
+    /// provider session id.
+    async fn on_setup_command(&mut self, cmd: Command) {
+        let setup_error = || anyhow!("ACP session setup is still in progress");
+        match cmd {
+            Command::AnswerPermission {
+                request_id,
+                option_id,
+                by,
+                reply,
+            } => {
+                let answer = self.answer_permission(&request_id, &option_id, &by).await;
+                let _ = reply.send(answer);
+            }
+            Command::Prompt { reply, .. } | Command::ForcePending { reply, .. } => {
+                let _ = reply.send(Err(setup_error()));
+            }
+            Command::RetractPending { reply } => {
+                let _ = reply.send(Err(setup_error()));
+            }
+            Command::Cancel { reply } | Command::SetMode { reply, .. } => {
+                let _ = reply.send(Err(setup_error()));
+            }
+            Command::SetConfigOption { reply, .. } => {
+                let _ = reply.send(Err(setup_error()));
+            }
+            Command::PrepareHandoff { reply } => {
+                let _ = reply.send(Err(setup_error()));
             }
         }
     }

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -34,6 +34,8 @@ let cancelled = false;
 const steeringSupported = process.env.FAKE_ACP_STEERING === "1";
 const forceSteeringNewTurn = process.env.FAKE_ACP_STEERING_FORCE_NEW_TURN === "1";
 const steeringDelayMs = Number(process.env.FAKE_ACP_STEERING_DELAY_MS || "0");
+const loadPermission = process.env.FAKE_ACP_LOAD_PERMISSION || "";
+const fixedPermissionId = Number(process.env.FAKE_ACP_PERMISSION_ID || "0");
 let promptActive = false;
 let promptResources = [];
 const steeringQueue = [];
@@ -140,7 +142,7 @@ function advertiseCommands() {
 }
 
 function askPermission(name) {
-  const reqId = 10000 + pending.size + Math.floor(Math.random() * 1000);
+  const reqId = fixedPermissionId || 10000 + pending.size + Math.floor(Math.random() * 1000);
   const toolCallId = "perm-tool-" + reqId;
   const toolCall = { toolCallId, title: "Edit " + name, kind: "edit", status: "pending" };
   const options = [
@@ -156,6 +158,21 @@ function askPermission(name) {
     params: { sessionId, toolCall, options },
   });
   return p;
+}
+
+async function handleLoad(id, params) {
+  sessionId = params.sessionId;
+  // Replay a tiny scripted history as the spec's load notifications.
+  notify({ sessionUpdate: "user_message_chunk", content: { type: "text", text: "earlier question" } });
+  notify({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "earlier answer" } });
+  // Some adapters replay an unanswered request and cannot complete load until
+  // the client answers it. Tests opt into that setup-time handshake shape.
+  if (loadPermission) await askPermission(loadPermission);
+  respond(id, {
+    modes: { currentModeId: currentMode, availableModes: MODES },
+    configOptions: configOptions(),
+  });
+  advertiseCommands();
 }
 
 async function runToken(tok) {
@@ -322,15 +339,7 @@ function handleMessage(msg) {
       advertiseCommands();
       break;
     case "session/load":
-      sessionId = msg.params.sessionId;
-      // Replay a tiny scripted history as the spec's load notifications.
-      notify({ sessionUpdate: "user_message_chunk", content: { type: "text", text: "earlier question" } });
-      notify({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "earlier answer" } });
-      respond(msg.id, {
-        modes: { currentModeId: currentMode, availableModes: MODES },
-        configOptions: configOptions(),
-      });
-      advertiseCommands();
+      void handleLoad(msg.id, msg.params);
       break;
     case "session/set_mode":
       currentMode = msg.params.modeId;

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1994,9 +1994,105 @@ async fn handoff_failure_cleans_up_the_replacement() {
     );
 }
 
-/// B. Adopt after a full crash (task + relay gone): the monitor orphans the row,
-///    `/adopt` respawns the relay and reopens via `session/load`, and the journal
-///    continues without duplicating the replayed history.
+/// A permission replayed during `session/load` is drivable before adoption
+/// completes, breaking the load → permission → load dependency cycle.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn adopt_can_answer_a_permission_replayed_during_load() {
+    let _permission_id = EnvVarSet::set("FAKE_ACP_PERMISSION_ID", "4242");
+    let _load_permission = EnvVarSet::set("FAKE_ACP_LOAD_PERMISSION", "resume-edit");
+    let ts = TestServer::start().await;
+    seed_acp_agent(&ts, "fakeacp-permission").await;
+
+    // Leave a durable open permission in the original conversation. A fresh
+    // adapter process will replay the same request while loading this session.
+    let created = rest_create(
+        &ts,
+        "fakeacp-permission",
+        "permission:resume-edit|say:after-permission",
+    )
+    .await;
+    let id = created["id"].as_str().unwrap().to_string();
+    let relay = created["term_session"].as_str().unwrap().to_string();
+    let chat = poll_chat(&ts, &id, Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "permission_request"
+                && block["payload"]["request_id"] == "4242"
+                && block["payload"]["outcome"].is_null()
+        })
+    })
+    .await;
+    assert_eq!(chat["live_turn"], 0);
+
+    assert!(ts.state.acp.stop(&id), "the original task was live");
+    backend::kill_session_and_wait(&relay).await.unwrap();
+    poll_view(&ts, &id, Duration::from_secs(15), |view| {
+        view["status"] == "orphaned"
+    })
+    .await;
+
+    // Adoption remains in `session/load` until this response arrives. Drive it
+    // through the public route concurrently, exactly as the dashboard does.
+    let adopt_client = weaver_api::Client::new(ts.client.base());
+    let adopt_id = id.clone();
+    let adopt = tokio::spawn(async move {
+        adopt_client
+            .post(&format!("/api/sessions/{adopt_id}/adopt"), json!({}))
+            .await
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while !ts.state.acp.is_live(&id) {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "adopting task was not registered during session/load"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    loop {
+        match ts
+            .client
+            .post(
+                &format!("/api/sessions/{id}/permissions/4242"),
+                json!({ "option_id": "allow-once" }),
+            )
+            .await
+        {
+            Ok(answer) => {
+                assert_eq!(answer["resolved"], true);
+                break;
+            }
+            Err(error)
+                if error.to_string().contains("404") && tokio::time::Instant::now() < deadline =>
+            {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(error) => panic!("setup-time permission was not drivable: {error}"),
+        }
+    }
+
+    adopt
+        .await
+        .expect("adopt task joins")
+        .expect("adopt completes after the permission answer");
+    assert!(ts.state.acp.is_live(&id));
+    let chat = ts
+        .client
+        .get(&format!("/api/sessions/{id}/chat"))
+        .await
+        .unwrap();
+    let permission = chat["blocks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|block| block["kind"] == "permission_request")
+        .unwrap();
+    assert_eq!(permission["payload"]["outcome"]["option_id"], "allow-once");
+    assert_eq!(permission["payload"]["outcome"]["by"], "manual");
+}
+
+/// B. Adopt after a full crash without an open permission: the ordinary load
+///    replay remains deduplicated and the journal continues on the next turn.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn adopt_reopens_via_load_without_duplicates() {


### PR DESCRIPTION
Register the ACP task command channel before the setup handshake so permissions replayed by session/load can be answered through the existing REST route. The setup loop services permission answers while rejecting other controls until initialization completes, and removes only its own registry generation if setup fails.\n\nAdd an integration regression that crashes an ACP session with an open permission, replays that request during adoption, answers it over REST, and verifies adoption completes with a live driver.