### PR TITLE
fix(deploy): install native codex with bwrap permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,8 @@ RUN set -eux; \
     # relaying network) and otherwise degrades to unsandboxed with a warning;
     # Codex prefers a system `bwrap` over the one it bundles. Both need the
     # unprivileged user namespaces this container already permits (the
-    # SYS_ADMIN + apparmor=unconfined grant in docker-compose.yml).
+    # SYS_ADMIN + apparmor=unconfined + seccomp=unconfined grants in
+    # docker-compose.yml).
     #
     # The remaining tools round out what a general coding agent expects to find:
     # sqlite3 (loom's own store is sqlite; agents inspect/seed .db files),
@@ -105,12 +106,11 @@ RUN set -eux; \
 # The agent runtimes loom's sessions launch — Claude Code (`claude`) and the
 # OpenAI Codex CLI (`codex`) — are deliberately NOT baked into the image. The
 # container runs as a non-root user, so a runtime installed into the read-only
-# system dirs (what a build-time `npm i -g` lands in) can neither self-update
-# (Claude reports it's "installed in a read-only location") nor be bumped live.
-# Instead loom-entrypoint (below) installs both at first boot into the app user's
-# $HOME on the persisted loom_home volume, where they are writable, update in
-# place (`claude` auto-updates; `codex update` on demand), and survive container
-# recreates. Pin either with CLAUDE_CODE_VERSION / CODEX_VERSION (see compose).
+# system dirs can neither self-update nor be bumped live. Instead
+# loom-entrypoint (below) installs both native CLIs at first boot into the app
+# user's $HOME on the persisted loom_home volume, where they are writable,
+# update in place, and survive container recreates. Claude can be pinned with
+# CLAUDE_CODE_VERSION (see compose).
 
 # code-server — the per-session embedded VS Code that `crate::ide` spawns and
 # reverse-proxies (one rooted at each worktree, behind loom's auth). The `.deb`
@@ -252,18 +252,18 @@ if [ "${1:-}" = loom ] && [ "${2:-}" = server ]; then
     [ -x "$HOME/.local/bin/claude" ] \
       || echo "loom: WARNING: Claude install failed (offline?); agents lack 'claude' until a later boot installs it" >&2
   fi
-  if ! command -v codex >/dev/null 2>&1; then
-    echo "loom: installing Codex CLI into $HOME/.npm-global ..." >&2
-    # The Codex runtime installs the same way client packages do: `npm i -g`
-    # lands `codex` in $HOME/.npm-global/bin (NPM_CONFIG_PREFIX, on the volume,
-    # early on PATH), so it persists across recreates and can be bumped live with
-    # `codex update`. Pin with CODEX_VERSION (an npm dist-tag or exact version;
-    # default `latest`). Non-fatal — like Claude, loom still boots and agents can
-    # add it on a later networked boot. Codex is useless without OpenAI auth
-    # (OPENAI_API_KEY, or `codex login`); installing the CLI needs neither.
-    npm install -g "@openai/codex@${CODEX_VERSION:-latest}" || true
-    command -v codex >/dev/null 2>&1 \
-      || echo "loom: WARNING: Codex install failed (offline?); the codex runtime is unavailable until a later boot installs it" >&2
+  if [ ! -x "$HOME/.local/bin/codex" ]; then
+    echo "loom: installing native Codex CLI into $HOME/.local ..." >&2
+    # Use OpenAI's native installer rather than the npm wrapper. It downloads the
+    # platform binary into the persisted, writable home volume, which is already
+    # early on PATH. CODEX_NON_INTERACTIVE prevents an entrypoint without a TTY
+    # from blocking on installer prompts. Non-fatal — like Claude, loom still
+    # boots and agents can add it on a later networked boot.
+    # Codex is useless without OpenAI auth (OPENAI_API_KEY, or `codex login`),
+    # but installing the CLI needs neither.
+    curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh || true
+    [ -x "$HOME/.local/bin/codex" ] \
+      || echo "loom: WARNING: native Codex install failed (offline?); the codex runtime is unavailable until a later boot installs it" >&2
   fi
   if ! command -v claude-agent-acp >/dev/null 2>&1 || ! command -v codex-acp >/dev/null 2>&1; then
     echo "loom: installing the ACP adapters into $HOME/.npm-global ..." >&2

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -156,15 +156,18 @@ database included). This is deliberate for a single-tenant host running the
 owner's own agents; do not carry it into a deploy that runs code you do not
 trust.
 
-The `loom` container also runs with `SYS_ADMIN` and an unconfined AppArmor
-profile. These exist for one purpose: at boot, `loom-cgroup-init` (root-only,
-via a single sudoers line) remounts the container's own cgroup-v2 tree
-read-write and delegates an `agents/` subtree to the app user, which is what
+The `loom` container also runs with `SYS_ADMIN`, an unconfined AppArmor profile,
+and an unconfined seccomp profile. The first two let `loom-cgroup-init`
+(root-only, via a single sudoers line) remount the container's own cgroup-v2
+tree read-write and delegate an `agents/` subtree to the app user, which is what
 lets loom confine **each session to its own memory cgroup** (the
 `session.memory_max_gb` setting, default 8 GiB). A runaway agent process is
 then OOM-killed inside its session instead of stalling the whole VM. Next to
-the docker.sock mount these grants add no real capability on this box; remove
-them and loom still runs, with sessions simply unlimited.
+the docker.sock mount these grants add no real capability on this box. The
+seccomp exception additionally lets bubblewrap create the namespaces that
+Codex and Claude use for command sandboxing. Remove the first two and loom
+still runs with sessions unlimited; remove the seccomp exception and their
+command sandboxes cannot start.
 
 Background on these knobs is in the repo
 [README "Authentication"](../README.md#authentication) and
@@ -346,28 +349,27 @@ The agent tooling the image ships splits by how it updates:
   runs as a non-root user, so a runtime installed into the read-only system dirs
   could neither self-update (Claude reports "installed in a read-only location")
   nor be bumped live. Instead, the first time the daemon starts it installs both
-  `claude` and `codex` into the persisted `loom_home` volume (`~/.local/bin` and
-  the home npm prefix `~/.npm-global/bin`), where updates land without a rebuild
-  and survive `up`/`down`/recreate. That first install needs network (the deploy
-  needs it anyway); if it fails loom still comes up and installs on a later boot.
+  native CLIs into the persisted `loom_home` volume (`~/.local/bin`), where
+  updates land without a rebuild and survive `up`/`down`/recreate. That first
+  install needs network (the deploy needs it anyway); if it fails loom still
+  comes up and installs on a later boot.
   - **Claude Code** auto-updates itself in place. Pin the tracked build with
     `CLAUDE_CODE_VERSION` (`stable` — the default — `latest`, or an exact version
     like `2.1.198`); force one live with
     `docker compose exec loom claude install <version> --force`.
-  - **Codex CLI** updates on demand rather than automatically. Pin with
-    `CODEX_VERSION` (an npm dist-tag or exact version; default `latest`); bump one
-    live with `docker compose exec loom codex update` (or reinstall with
-    `docker compose exec loom npm i -g @openai/codex@<version>`).
+  - **Codex CLI** updates on demand rather than automatically. Bump one live
+    with `docker compose exec loom codex update`, or remove
+    `~/.local/bin/codex` and restart the service to rerun the native installer.
 
-  Set either pin in the `loom` service's `environment:` in
+  Set the Claude pin in the `loom` service's `environment:` in
   [`docker-compose.yml`](standalone/docker-compose.yml).
 
 - **Command sandboxing.** The image ships `bubblewrap` + `socat`, the sandbox
   the runtimes reach for on Linux: Claude Code's sandboxed Bash runs commands
   under `bwrap` (falling back to unsandboxed with a warning if it can't), and
   Codex prefers a system `bwrap` over the one it bundles. Both rely on the
-  unprivileged user namespaces this container already permits via its
-  `SYS_ADMIN` + `apparmor=unconfined` grant (see
+  unprivileged user namespaces this container permits through its
+  `SYS_ADMIN` + `apparmor=unconfined` + `seccomp=unconfined` grants (see
   [Security posture](#security-posture)); a fresh `/proc` mount can still fail
   in this nested setting, so a runtime may need its weaker-nested-sandbox escape
   hatch (Codex `--no-proc`; Claude `enableWeakerNestedSandbox`) to sandbox at

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -79,14 +79,20 @@ services:
     # container's own cgroup-v2 tree read-write and delegates an agents/
     # subtree to the app user; each session then confines itself there and a
     # runaway agent OOMs alone instead of taking the VM down. The remount is
-    # what needs SYS_ADMIN and an unconfined AppArmor profile — a wider grant
-    # than default, but this container already holds the root-equivalent
-    # docker.sock (above), so it adds nothing on this single-tenant box. Without
-    # these the init script fails and sessions simply run unlimited.
+    # what needs SYS_ADMIN and an unconfined AppArmor profile. Bubblewrap also
+    # needs the unconfined seccomp profile below to create its sandbox namespaces.
+    # These are wider than default, but this container already holds the
+    # root-equivalent docker.sock (above), so they add nothing on this
+    # single-tenant box. Without the first two the init script fails and sessions
+    # simply run unlimited.
     cap_add:
       - SYS_ADMIN
     security_opt:
       - apparmor=unconfined
+      # Docker's default seccomp profile denies the namespace operations bwrap
+      # needs. Scope this exception to loom; the container is already the
+      # single-tenant trust boundary because it has the host Docker socket.
+      - seccomp=unconfined
     # The delegation dance assumes the container sees only its own cgroup
     # subtree; private is the cgroup-v2 default, pinned here because the limits
     # depend on it.


### PR DESCRIPTION
Install Codex with OpenAI's native installer in the persisted home volume, leaving npm for ACP adapters and optional Node tools.\n\nAllow bubblewrap's namespace setup in the standalone Docker deployment with its scoped seccomp exception, and document the required sandbox permissions.\n\nFixes #576