### PR TITLE
feat(loom): provision workload identities and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,10 @@ grant). Set `LOOM_GITHUB_WEBHOOK_SECRET` and point a repo/org webhook at
 
 Loom serves a JSON API under `/api`; the Vue SPA is the primary consumer.
 
-- `GET /api/health`
+- `GET /api/health`, `GET /api/health/live` (process liveness), and
+  `GET /api/ready` (database + migration readiness)
+- `GET /metrics` (bounded-label OpenMetrics) and `GET /api/diagnostics`
+  (admin-only operational inventory used by Settings → Diagnostics)
 - `GET POST /api/sessions`, `GET PATCH DELETE /api/sessions/{id}`,
   `POST /api/sessions/{id}/{note,archive,adopt,github}`,
   `GET /api/sessions/{id}/{diff,log,events}`,

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -509,6 +509,9 @@ export const getLogs = (limit = 500) =>
 /** Build version, pid, and start time of the running server. */
 export const getServerStatus = () => get('/status') as Promise<import('./types').ServerStatus>;
 
+/** Redacted durable-state and capacity snapshot for approved operators. */
+export const getDiagnostics = () => get('/diagnostics') as Promise<import('./types').Diagnostics>;
+
 /** Recent detached background tasks (the `@loom` webhook launches that run off the
  *  request), newest first. Operator-only, like the log endpoints. */
 export const getTasks = () => get('/tasks') as Promise<import('./types').TaskRecord[]>;

--- a/crates/loom/frontend/src/components/LogsPanel.vue
+++ b/crates/loom/frontend/src/components/LogsPanel.vue
@@ -98,7 +98,9 @@ async function loadSnapshot() {
     const [snap, st, diag] = await Promise.all([
       api.getLogs(2000),
       api.getServerStatus(),
-      api.getDiagnostics(),
+      // Diagnostics require the admin grant. Keep the operator-visible log and
+      // status snapshot useful when that optional request is forbidden or down.
+      api.getDiagnostics().catch(() => null),
     ]);
     lines.value = snap;
     status.value = st;

--- a/crates/loom/frontend/src/components/LogsPanel.vue
+++ b/crates/loom/frontend/src/components/LogsPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue';
 import * as api from '../api';
-import type { LogLine, ServerStatus, TaskRecord } from '../types';
+import type { Diagnostics, LogLine, ServerStatus, TaskRecord } from '../types';
 
 // Live server logs, straight from the process's tracing output — the same lines
 // that go to stdout / `docker compose logs`, but readable from the browser so an
@@ -14,6 +14,7 @@ import type { LogLine, ServerStatus, TaskRecord } from '../types';
 const MAX_LINES = 5000;
 const lines = ref<LogLine[]>([]);
 const status = ref<ServerStatus | null>(null);
+const diagnostics = ref<Diagnostics | null>(null);
 const error = ref('');
 
 // Filters. `minLevel` is a severity floor (show this and louder).
@@ -94,9 +95,14 @@ function closeStream() {
 
 async function loadSnapshot() {
   try {
-    const [snap, st] = await Promise.all([api.getLogs(2000), api.getServerStatus()]);
+    const [snap, st, diag] = await Promise.all([
+      api.getLogs(2000),
+      api.getServerStatus(),
+      api.getDiagnostics(),
+    ]);
     lines.value = snap;
     status.value = st;
+    diagnostics.value = diag;
     error.value = '';
     await nextTick();
     scrollToBottom(true);
@@ -185,6 +191,13 @@ const uptime = computed(() => {
   return h ? `${h}h ${m}m` : m ? `${m}m ${s}s` : `${s}s`;
 });
 
+const currentSessionCount = computed(
+  () =>
+    diagnostics.value?.sessions
+      .filter((row) => row.status !== 'archived')
+      .reduce((total, row) => total + row.count, 0) ?? 0,
+);
+
 // --- Background tasks ------------------------------------------------------
 // The detached `@loom` webhook launches (clone → create → reply) that run off the
 // webhook request. Polled — low-frequency, so a few-second refresh is plenty; no
@@ -240,6 +253,180 @@ onUnmounted(() => {
       >
       <span :title="status.started_at">started {{ shortTime(status.started_at) }}</span>
     </div>
+
+    <!-- Durable operational state. The backend returns aggregates and mapping
+         metadata only: no session ids, paths, users, tokens, or raw failures. -->
+    <section v-if="diagnostics" class="mb-5 space-y-3" data-testid="diagnostics-overview">
+      <div class="flex flex-wrap items-center gap-2">
+        <h2 class="mr-1 text-2xs font-semibold uppercase tracking-wider text-muted">
+          Control plane
+        </h2>
+        <span class="rounded bg-input px-2 py-1 font-mono text-2xs text-fg">
+          {{ currentSessionCount }} non-archived sessions
+        </span>
+        <span
+          v-for="migration in diagnostics.migrations"
+          :key="migration.stream"
+          class="rounded px-2 py-1 font-mono text-2xs"
+          :class="migration.ready ? 'bg-ok/10 text-ok' : 'bg-block/10 text-block'"
+        >
+          {{ migration.stream }} schema {{ migration.current }}/{{ migration.expected }}
+        </span>
+      </div>
+
+      <div class="grid gap-3 xl:grid-cols-2">
+        <div class="overflow-x-auto rounded-md border border-line">
+          <table class="w-full border-collapse font-mono text-2xs">
+            <thead>
+              <tr class="bg-surface text-left text-faint">
+                <th class="px-2 py-1 font-medium">Profile</th>
+                <th class="px-2 py-1 font-medium">Revision</th>
+                <th class="px-2 py-1 font-medium">Used</th>
+                <th class="px-2 py-1 font-medium">Available</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="profile in diagnostics.profiles"
+                :key="profile.profile"
+                class="border-t border-line/40"
+              >
+                <td class="px-2 py-1 text-fg">{{ profile.profile }}</td>
+                <td class="px-2 py-1 text-muted">{{ profile.revision }}</td>
+                <td class="px-2 py-1 text-muted">
+                  {{ profile.active }} / {{ profile.maximum ?? '∞' }}
+                </td>
+                <td class="px-2 py-1" :class="profile.available === 0 ? 'text-block' : 'text-ok'">
+                  {{ profile.available ?? 'unlimited' }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="overflow-x-auto rounded-md border border-line">
+          <table class="w-full border-collapse font-mono text-2xs">
+            <thead>
+              <tr class="bg-surface text-left text-faint">
+                <th class="px-2 py-1 font-medium">Status</th>
+                <th class="px-2 py-1 font-medium">Profile</th>
+                <th class="px-2 py-1 font-medium">Class</th>
+                <th class="px-2 py-1 font-medium">Protocol</th>
+                <th class="px-2 py-1 text-right font-medium">Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-if="!diagnostics.sessions.length">
+                <td colspan="5" class="px-2 py-2 text-muted">No sessions.</td>
+              </tr>
+              <tr
+                v-for="row in diagnostics.sessions"
+                :key="`${row.status}:${row.profile}:${row.class}:${row.protocol}:${row.runner_pool}`"
+                class="border-t border-line/40"
+              >
+                <td
+                  class="px-2 py-1"
+                  :class="
+                    row.status === 'error'
+                      ? 'text-block'
+                      : row.status === 'orphaned'
+                        ? 'text-attn'
+                        : 'text-fg'
+                  "
+                >
+                  {{ row.status }}
+                </td>
+                <td class="px-2 py-1 text-muted">{{ row.profile }}</td>
+                <td class="px-2 py-1 text-muted">{{ row.class }}</td>
+                <td class="px-2 py-1 text-muted">{{ row.protocol }}</td>
+                <td class="px-2 py-1 text-right text-fg">{{ row.count }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="grid gap-3 xl:grid-cols-2">
+        <div class="rounded-md border border-line bg-surface px-3 py-2 text-xs">
+          <h3 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-muted">
+            Automation runs
+          </h3>
+          <p v-if="!diagnostics.automation_runs.counts.length" class="text-faint">No runs yet.</p>
+          <div v-else class="flex flex-wrap gap-1.5 font-mono text-2xs">
+            <span
+              v-for="run in diagnostics.automation_runs.counts"
+              :key="`${run.status}:${run.source}:${run.service_tag}:${run.profile}`"
+              class="rounded bg-input px-2 py-1"
+              :class="run.status === 'failed' ? 'text-block' : 'text-muted'"
+            >
+              {{ run.service_tag }}/{{ run.profile }} · {{ run.status }} {{ run.count }}
+            </span>
+          </div>
+          <p v-if="diagnostics.automation_runs.stale_creating" class="mt-2 text-2xs text-block">
+            {{ diagnostics.automation_runs.stale_creating }} creating for more than five minutes
+          </p>
+        </div>
+
+        <div class="rounded-md border border-line bg-surface px-3 py-2 text-xs">
+          <h3 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-muted">
+            Orphan / error inventory
+          </h3>
+          <p v-if="!diagnostics.problems.length" class="text-ok">No orphaned or error sessions.</p>
+          <div v-else class="space-y-1 font-mono text-2xs">
+            <p
+              v-for="problem in diagnostics.problems"
+              :key="`${problem.status}:${problem.profile}:${problem.protocol}`"
+            >
+              <span :class="problem.status === 'error' ? 'text-block' : 'text-attn'">
+                {{ problem.count }} {{ problem.status }}
+              </span>
+              <span class="text-muted">
+                · {{ problem.profile }} / {{ problem.class }} / {{ problem.protocol }} /
+                {{ problem.runner_pool }}
+              </span>
+              <span v-if="problem.latest_activity_at" class="text-faint">
+                · latest {{ shortTime(problem.latest_activity_at) }}
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <details
+        v-if="diagnostics.federations.length"
+        class="rounded-md border border-line bg-surface px-3 py-2"
+      >
+        <summary class="cursor-pointer text-2xs font-semibold uppercase tracking-wider text-muted">
+          Federation mappings ({{ diagnostics.federations.length }})
+        </summary>
+        <div class="mt-2 overflow-x-auto">
+          <table class="w-full border-collapse font-mono text-2xs">
+            <thead>
+              <tr class="text-left text-faint">
+                <th class="px-2 py-1 font-medium">Name</th>
+                <th class="px-2 py-1 font-medium">Provider / service</th>
+                <th class="px-2 py-1 font-medium">Audience</th>
+                <th class="px-2 py-1 font-medium">Profiles</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="mapping in diagnostics.federations"
+                :key="mapping.name"
+                class="border-t border-line/40"
+              >
+                <td class="px-2 py-1 text-fg">{{ mapping.name }}</td>
+                <td class="px-2 py-1 text-muted">
+                  {{ mapping.provider }} · {{ mapping.service_tag }}
+                </td>
+                <td class="px-2 py-1 break-all text-muted">{{ mapping.audience }}</td>
+                <td class="px-2 py-1 text-muted">{{ mapping.profiles.join(', ') }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </section>
 
     <!-- Background tasks: the detached @loom webhook launches. -->
     <section class="mb-5">

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -836,6 +836,8 @@ export interface Profile {
 
 export interface ProfileEnv {
   name: string;
+  source: 'literal' | 'gcp_secret';
+  secret_ref: string | null;
   updated_at: string;
 }
 
@@ -914,6 +916,80 @@ export interface ServerStatus {
   version: string;
   pid: number;
   started_at: string;
+}
+
+export interface MigrationStream {
+  stream: string;
+  current: number;
+  expected: number;
+  applied: number;
+  ready: boolean;
+}
+
+export interface DiagnosticSessionCount {
+  status: string;
+  class: string;
+  profile: string;
+  protocol: string;
+  runner_pool: string;
+  count: number;
+}
+
+export interface DiagnosticProfileCapacity {
+  profile: string;
+  revision: number;
+  active: number;
+  maximum: number | null;
+  available: number | null;
+}
+
+export interface DiagnosticRunCount {
+  status: string;
+  source: string;
+  service_tag: string;
+  profile: string;
+  count: number;
+}
+
+export interface DiagnosticRunFailure {
+  source: string;
+  profile: string;
+  outcome: string | null;
+  updated_at: string;
+}
+
+export interface DiagnosticProblemSummary {
+  status: string;
+  class: string;
+  profile: string;
+  protocol: string;
+  runner_pool: string;
+  count: number;
+  latest_activity_at: string | null;
+}
+
+export interface DiagnosticFederation {
+  name: string;
+  provider: string;
+  audience: string;
+  service_tag: string;
+  profiles: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+/** Redacted admin operational snapshot from `GET /api/diagnostics`. */
+export interface Diagnostics {
+  sessions: DiagnosticSessionCount[];
+  profiles: DiagnosticProfileCapacity[];
+  automation_runs: {
+    counts: DiagnosticRunCount[];
+    stale_creating: number;
+    recent_failures: DiagnosticRunFailure[];
+  };
+  problems: DiagnosticProblemSummary[];
+  migrations: MigrationStream[];
+  federations: DiagnosticFederation[];
 }
 
 /** One detached background task (a `@loom` webhook launch). Mirrors

--- a/crates/loom/migrations/0004_workload_federation.sql
+++ b/crates/loom/migrations/0004_workload_federation.sql
@@ -1,0 +1,55 @@
+ALTER TABLE profile_env ADD COLUMN source TEXT NOT NULL DEFAULT 'literal';
+ALTER TABLE profile_env ADD COLUMN secret_ref TEXT;
+ALTER TABLE profiles ADD COLUMN managed_by_deployment INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE automation_runs ADD COLUMN service_tag TEXT NOT NULL DEFAULT 'unknown';
+UPDATE automation_runs SET service_tag = source;
+
+ALTER TABLE federation_mappings RENAME TO federation_mappings_legacy;
+
+CREATE TABLE federation_mappings (
+    id                TEXT PRIMARY KEY,
+    name              TEXT NOT NULL UNIQUE,
+    provider          TEXT NOT NULL,
+    issuer            TEXT NOT NULL,
+    audience          TEXT NOT NULL,
+    subject           TEXT,
+    service_account   TEXT,
+    service_tag       TEXT NOT NULL,
+    repository_id     TEXT,
+    workflow_ref      TEXT,
+    event_name        TEXT,
+    ref_pattern       TEXT,
+    profiles_json     TEXT NOT NULL,
+    managed_by_deployment INTEGER NOT NULL DEFAULT 0,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL
+);
+
+INSERT INTO federation_mappings (
+    id, name, provider, issuer, audience, subject, service_account,
+    service_tag, repository_id, workflow_ref, event_name, ref_pattern,
+    profiles_json, managed_by_deployment, created_at, updated_at
+)
+SELECT
+    id,
+    'github-' || id,
+    'github',
+    issuer,
+    audience,
+    NULL,
+    NULL,
+    'github-actions',
+    repository_id,
+    workflow_ref,
+    event_name,
+    ref_pattern,
+    json_array(profile),
+    0,
+    created_at,
+    created_at
+FROM federation_mappings_legacy;
+
+DROP TABLE federation_mappings_legacy;
+
+CREATE INDEX idx_federation_lookup
+    ON federation_mappings(issuer, audience, provider);

--- a/crates/loom/src/auth.rs
+++ b/crates/loom/src/auth.rs
@@ -567,7 +567,7 @@ pub async fn lookup_token(db: &Db, token: &str) -> Result<Option<Principal>> {
                     subject: claims.sub.clone(),
                     profiles: claims.profiles.clone(),
                 },
-                automation_context: claims.github,
+                automation_context: claims.federation,
             }));
     }
     let hash = sha256_hex(token);

--- a/crates/loom/src/automation.rs
+++ b/crates/loom/src/automation.rs
@@ -1,4 +1,4 @@
-//! Short-lived automation credentials and GitHub Actions OIDC federation.
+//! Short-lived automation credentials and provider-backed OIDC federation.
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
@@ -24,7 +24,7 @@ const DEFAULT_AUDIENCE: &str = "loom";
 const MAX_TTL_SECS: i64 = 3600;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct FederationContext {
+pub struct GithubContext {
     pub repository_id: String,
     pub repository: String,
     pub workflow_ref: String,
@@ -33,6 +33,18 @@ pub struct FederationContext {
     pub git_ref: String,
     pub run_id: String,
     pub run_attempt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FederationContext {
+    pub provider: String,
+    pub issuer: String,
+    pub subject: String,
+    pub service_tag: String,
+    #[serde(default)]
+    pub service_account: Option<String>,
+    #[serde(default)]
+    pub github: Option<GithubContext>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,7 +59,11 @@ pub struct LoomClaims {
     pub exp: i64,
     pub jti: String,
     #[serde(default)]
-    pub github: Option<FederationContext>,
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub service_tag: Option<String>,
+    #[serde(default)]
+    pub federation: Option<FederationContext>,
 }
 
 fn key_path() -> PathBuf {
@@ -97,7 +113,7 @@ pub async fn mint(
     subject: &str,
     profiles: Vec<String>,
     ttl_secs: i64,
-    github: Option<FederationContext>,
+    federation: Option<FederationContext>,
 ) -> Result<AutomationTokenView> {
     let subject = subject.trim();
     if subject.is_empty() || profiles.is_empty() {
@@ -128,7 +144,11 @@ pub async fn mint(
         nbf: now - 5,
         exp: expires_at,
         jti: hex::encode(nonce),
-        github,
+        provider: federation.as_ref().map(|context| context.provider.clone()),
+        service_tag: federation
+            .as_ref()
+            .map(|context| context.service_tag.clone()),
+        federation,
     };
     let (encoding_key, _) = signing_keys()?;
     let token = encode(&Header::new(Algorithm::EdDSA), &claims, &encoding_key)?;
@@ -160,101 +180,234 @@ pub async fn verify(db: &Db, token: &str) -> Result<Option<LoomClaims>> {
 #[derive(Debug, Clone, FromRow)]
 struct FederationRow {
     id: String,
+    name: String,
+    provider: String,
     issuer: String,
     audience: String,
-    repository_id: String,
-    workflow_ref: String,
+    subject: Option<String>,
+    service_account: Option<String>,
+    service_tag: String,
+    repository_id: Option<String>,
+    workflow_ref: Option<String>,
     event_name: Option<String>,
     ref_pattern: Option<String>,
-    profile: String,
+    profiles_json: String,
     created_at: String,
+    updated_at: String,
 }
 
-impl From<FederationRow> for FederationView {
-    fn from(row: FederationRow) -> Self {
-        Self {
-            id: row.id,
-            issuer: row.issuer,
-            audience: row.audience,
-            repository_id: row.repository_id,
-            workflow_ref: row.workflow_ref,
-            event_name: row.event_name,
-            ref_pattern: row.ref_pattern,
-            profile: row.profile,
-            created_at: row.created_at,
-        }
+impl FederationRow {
+    fn profiles(&self) -> Result<Vec<String>> {
+        serde_json::from_str(&self.profiles_json).context("invalid federation profiles")
+    }
+
+    fn view(&self) -> Result<FederationView> {
+        Ok(FederationView {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            provider: self.provider.clone(),
+            issuer: self.issuer.clone(),
+            audience: self.audience.clone(),
+            subject: self.subject.clone(),
+            service_account: self.service_account.clone(),
+            service_tag: self.service_tag.clone(),
+            repository_id: self.repository_id.clone(),
+            workflow_ref: self.workflow_ref.clone(),
+            event_name: self.event_name.clone(),
+            ref_pattern: self.ref_pattern.clone(),
+            profiles: self.profiles()?,
+            created_at: self.created_at.clone(),
+            updated_at: self.updated_at.clone(),
+        })
     }
 }
 
 pub async fn federation_add(db: &Db, req: &FederationReq) -> Result<FederationView> {
-    let issuer = req.issuer.trim().trim_end_matches('/');
+    let name = req.name.trim();
+    crate::profile::validate_name(name).map_err(|error| anyhow!(error))?;
+    let provider = req.provider.trim().to_ascii_lowercase();
+    if !matches!(provider.as_str(), "github" | "google") {
+        bail!("federation provider must be 'github' or 'google'");
+    }
+    let issuer = req.issuer.trim();
     let audience = req.audience.trim();
-    if issuer.is_empty()
-        || audience.is_empty()
-        || req.repository_id.trim().is_empty()
-        || req.workflow_ref.trim().is_empty()
+    if issuer.is_empty() || audience.is_empty() {
+        bail!("issuer and audience are required");
+    }
+    if issuer.ends_with('/') || audience.ends_with('/') {
+        bail!("federation issuer and audience must not have a trailing slash");
+    }
+    let service_tag = req.service_tag.trim();
+    if service_tag.is_empty()
+        || service_tag.len() > 64
+        || !service_tag
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
     {
-        bail!("issuer, audience, repository_id, and workflow_ref are required");
+        bail!("service_tag must be 1-64 portable label characters");
     }
-    if audience.ends_with('/') {
-        bail!("federation audience must not have a trailing slash");
+    let mut profiles: Vec<String> = req
+        .profiles
+        .iter()
+        .map(|profile| profile.trim().to_string())
+        .collect();
+    profiles.sort();
+    profiles.dedup();
+    if profiles.is_empty() || profiles.iter().any(String::is_empty) {
+        bail!("at least one federation profile is required");
     }
-    let profile = crate::profile::get(db, req.profile.trim())
-        .await?
-        .ok_or_else(|| anyhow!("unknown profile '{}'", req.profile))?;
-    if !profile.is_automation_safe() {
-        bail!("federation profile must be automation-class, strict, and env-cleared");
+    for profile_name in &profiles {
+        let profile = crate::profile::get(db, profile_name)
+            .await?
+            .ok_or_else(|| anyhow!("unknown profile '{profile_name}'"))?;
+        if !profile.is_automation_safe() {
+            bail!("federation profiles must be automation-class, strict, and env-cleared");
+        }
+    }
+    let optional = |value: Option<&str>| {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    };
+    let subject = optional(req.subject.as_deref());
+    let service_account = optional(req.service_account.as_deref());
+    let repository_id = optional(req.repository_id.as_deref());
+    let workflow_ref = optional(req.workflow_ref.as_deref());
+    match provider.as_str() {
+        "github" => {
+            if repository_id.is_none() || workflow_ref.is_none() {
+                bail!("GitHub federation requires repository_id and workflow_ref");
+            }
+            if subject.is_some() || service_account.is_some() {
+                bail!("GitHub federation does not accept Google identity fields");
+            }
+        }
+        "google" => {
+            if issuer != "https://accounts.google.com" {
+                bail!("Google federation issuer must be https://accounts.google.com");
+            }
+            if !subject
+                .as_deref()
+                .is_some_and(|value| value.bytes().all(|byte| byte.is_ascii_digit()))
+                || !service_account
+                    .as_deref()
+                    .is_some_and(|value| value.ends_with(".iam.gserviceaccount.com"))
+            {
+                bail!("Google federation requires a numeric subject and service-account email");
+            }
+            if repository_id.is_some() || workflow_ref.is_some() {
+                bail!("Google federation does not accept GitHub identity fields");
+            }
+        }
+        _ => unreachable!(),
     }
     let id = hex::encode(rand::random::<[u8; 8]>());
+    let now = now_iso();
+    let profiles_json = serde_json::to_string(&profiles)?;
     sqlx::query(
         "INSERT INTO federation_mappings
-         (id, issuer, audience, repository_id, workflow_ref, event_name, ref_pattern, profile, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+         (id, name, provider, issuer, audience, subject, service_account,
+          service_tag, repository_id, workflow_ref, event_name, ref_pattern,
+          profiles_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(name) DO UPDATE SET
+          provider=excluded.provider, issuer=excluded.issuer,
+          audience=excluded.audience, subject=excluded.subject,
+          service_account=excluded.service_account,
+          service_tag=excluded.service_tag,
+          repository_id=excluded.repository_id,
+          workflow_ref=excluded.workflow_ref, event_name=excluded.event_name,
+          ref_pattern=excluded.ref_pattern, profiles_json=excluded.profiles_json,
+          updated_at=excluded.updated_at
+         WHERE provider IS NOT excluded.provider OR issuer IS NOT excluded.issuer
+            OR audience IS NOT excluded.audience OR subject IS NOT excluded.subject
+            OR service_account IS NOT excluded.service_account
+            OR service_tag IS NOT excluded.service_tag
+            OR repository_id IS NOT excluded.repository_id
+            OR workflow_ref IS NOT excluded.workflow_ref
+            OR event_name IS NOT excluded.event_name
+            OR ref_pattern IS NOT excluded.ref_pattern
+            OR profiles_json IS NOT excluded.profiles_json",
     )
     .bind(&id)
+    .bind(name)
+    .bind(&provider)
     .bind(issuer)
     .bind(audience)
-    .bind(req.repository_id.trim())
-    .bind(req.workflow_ref.trim())
-    .bind(req.event_name.as_deref().map(str::trim).filter(|v| !v.is_empty()))
-    .bind(req.ref_pattern.as_deref().map(str::trim).filter(|v| !v.is_empty()))
-    .bind(&profile.name)
-    .bind(now_iso())
+    .bind(subject)
+    .bind(service_account)
+    .bind(service_tag)
+    .bind(repository_id)
+    .bind(workflow_ref)
+    .bind(
+        req.event_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty()),
+    )
+    .bind(
+        req.ref_pattern
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty()),
+    )
+    .bind(profiles_json)
+    .bind(&now)
+    .bind(&now)
     .execute(db)
     .await?;
-    federation_get(db, &id)
+    federation_get(db, name)
         .await?
         .ok_or_else(|| anyhow!("mapping vanished"))
 }
 
 pub async fn federation_list(db: &Db) -> Result<Vec<FederationView>> {
-    Ok(sqlx::query_as::<_, FederationRow>(
-        "SELECT * FROM federation_mappings ORDER BY created_at DESC",
+    sqlx::query_as::<_, FederationRow>("SELECT * FROM federation_mappings ORDER BY created_at DESC")
+        .fetch_all(db)
+        .await?
+        .into_iter()
+        .map(|row| row.view())
+        .collect()
+}
+
+pub async fn federation_get(db: &Db, key: &str) -> Result<Option<FederationView>> {
+    sqlx::query_as::<_, FederationRow>("SELECT * FROM federation_mappings WHERE id = ? OR name = ?")
+        .bind(key)
+        .bind(key)
+        .fetch_optional(db)
+        .await?
+        .map(|row| row.view())
+        .transpose()
+}
+
+pub async fn federation_remove(db: &Db, key: &str) -> Result<bool> {
+    Ok(
+        sqlx::query("DELETE FROM federation_mappings WHERE id = ? OR name = ?")
+            .bind(key)
+            .bind(key)
+            .execute(db)
+            .await?
+            .rows_affected()
+            > 0,
+    )
+}
+
+pub async fn federation_mark_deployment_managed(db: &Db, name: &str) -> Result<()> {
+    sqlx::query("UPDATE federation_mappings SET managed_by_deployment = 1 WHERE name = ?")
+        .bind(name)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+pub async fn deployment_managed_federation_names(db: &Db) -> Result<Vec<String>> {
+    Ok(sqlx::query_scalar(
+        "SELECT name FROM federation_mappings
+         WHERE managed_by_deployment = 1 ORDER BY name",
     )
     .fetch_all(db)
-    .await?
-    .into_iter()
-    .map(Into::into)
-    .collect())
-}
-
-async fn federation_get(db: &Db, id: &str) -> Result<Option<FederationView>> {
-    Ok(
-        sqlx::query_as::<_, FederationRow>("SELECT * FROM federation_mappings WHERE id = ?")
-            .bind(id)
-            .fetch_optional(db)
-            .await?
-            .map(Into::into),
-    )
-}
-
-pub async fn federation_remove(db: &Db, id: &str) -> Result<bool> {
-    Ok(sqlx::query("DELETE FROM federation_mappings WHERE id = ?")
-        .bind(id)
-        .execute(db)
-        .await?
-        .rows_affected()
-        > 0)
+    .await?)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -292,12 +445,40 @@ struct GithubClaims {
     _exp: usize,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GoogleClaims {
+    iss: String,
+    aud: Audience,
+    sub: String,
+    email: String,
+    email_verified: bool,
+    #[serde(rename = "exp")]
+    _exp: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct OidcHint {
+    iss: String,
+    aud: Audience,
+    sub: String,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    repository_id: Option<String>,
+    #[serde(default)]
+    workflow_ref: Option<String>,
+    #[serde(default)]
+    event_name: Option<String>,
+    #[serde(default, rename = "ref")]
+    git_ref: Option<String>,
+}
+
 #[derive(Deserialize)]
 struct Discovery {
     jwks_uri: String,
 }
 
-fn unverified_claims(token: &str) -> Result<GithubClaims> {
+fn unverified_claims(token: &str) -> Result<OidcHint> {
     let payload = token
         .split('.')
         .nth(1)
@@ -318,31 +499,45 @@ fn ref_matches(pattern: Option<&str>, value: &str) -> bool {
 
 pub async fn federate(db: &Db, token: &str) -> Result<AutomationTokenView> {
     let hint = unverified_claims(token)?;
-    let rows = sqlx::query_as::<_, FederationRow>(
-        "SELECT * FROM federation_mappings
-         WHERE issuer = ? AND repository_id = ? AND workflow_ref = ?",
-    )
-    .bind(hint.iss.trim_end_matches('/'))
-    .bind(&hint.repository_id)
-    .bind(&hint.workflow_ref)
-    .fetch_all(db)
-    .await?;
-    let mapping = rows
+    let rows =
+        sqlx::query_as::<_, FederationRow>("SELECT * FROM federation_mappings WHERE issuer = ?")
+            .bind(&hint.iss)
+            .fetch_all(db)
+            .await?;
+    let mut matches = rows
         .into_iter()
-        .find(|mapping| {
-            hint.aud.contains(&mapping.audience)
-                && mapping
-                    .event_name
-                    .as_deref()
-                    .is_none_or(|event| event == hint.event_name)
-                && ref_matches(mapping.ref_pattern.as_deref(), &hint.git_ref)
+        .filter(|mapping| {
+            if !hint.aud.contains(&mapping.audience) {
+                return false;
+            }
+            match mapping.provider.as_str() {
+                "github" => {
+                    mapping.repository_id.as_deref() == hint.repository_id.as_deref()
+                        && mapping.workflow_ref.as_deref() == hint.workflow_ref.as_deref()
+                        && mapping
+                            .event_name
+                            .as_deref()
+                            .is_none_or(|event| Some(event) == hint.event_name.as_deref())
+                        && hint.git_ref.as_deref().is_some_and(|git_ref| {
+                            ref_matches(mapping.ref_pattern.as_deref(), git_ref)
+                        })
+                }
+                "google" => {
+                    mapping.subject.as_deref() == Some(hint.sub.as_str())
+                        && mapping.service_account.as_deref() == hint.email.as_deref()
+                }
+                _ => false,
+            }
         })
-        .ok_or_else(|| anyhow!("no federation mapping matches this workflow identity"))?;
+        .collect::<Vec<_>>();
+    if matches.len() > 1 {
+        bail!("multiple federation mappings match this workload identity");
+    }
+    let mapping = matches
+        .pop()
+        .ok_or_else(|| anyhow!("no federation mapping matches this workload identity"))?;
 
-    let discovery_url = format!(
-        "{}/.well-known/openid-configuration",
-        mapping.issuer.trim_end_matches('/')
-    );
+    let discovery_url = format!("{}/.well-known/openid-configuration", mapping.issuer);
     let http = reqwest::Client::new();
     let discovery = http
         .get(discovery_url)
@@ -359,6 +554,13 @@ pub async fn federate(db: &Db, token: &str) -> Result<AutomationTokenView> {
         .json::<jsonwebtoken::jwk::JwkSet>()
         .await?;
     let header = decode_header(token)?;
+    if !matches!(header.alg, Algorithm::RS256 | Algorithm::EdDSA)
+        || ((mapping.provider == "google"
+            || mapping.issuer == "https://token.actions.githubusercontent.com")
+            && header.alg != Algorithm::RS256)
+    {
+        bail!("OIDC signing algorithm is not allowed for this provider");
+    }
     let kid = header
         .kid
         .as_deref()
@@ -370,35 +572,66 @@ pub async fn federate(db: &Db, token: &str) -> Result<AutomationTokenView> {
     let mut validation = Validation::new(header.alg);
     validation.set_issuer(&[mapping.issuer.as_str()]);
     validation.set_audience(&[mapping.audience.as_str()]);
-    let verified = decode::<GithubClaims>(token, &key, &validation)?.claims;
-    if verified.repository_id != mapping.repository_id
-        || verified.workflow_ref != mapping.workflow_ref
-        || mapping
-            .event_name
-            .as_deref()
-            .is_some_and(|event| event != verified.event_name)
-        || !ref_matches(mapping.ref_pattern.as_deref(), &verified.git_ref)
-    {
-        bail!("verified OIDC claims do not match the federation mapping");
-    }
-    let context = FederationContext {
-        repository_id: verified.repository_id,
-        repository: verified.repository,
-        workflow_ref: verified.workflow_ref,
-        workflow_sha: verified.workflow_sha,
-        event_name: verified.event_name,
-        git_ref: verified.git_ref,
-        run_id: verified.run_id,
-        run_attempt: verified.run_attempt,
+    let profiles = mapping.profiles()?;
+    let (subject, context) = match mapping.provider.as_str() {
+        "github" => {
+            let verified = decode::<GithubClaims>(token, &key, &validation)?.claims;
+            if mapping.repository_id.as_deref() != Some(verified.repository_id.as_str())
+                || mapping.workflow_ref.as_deref() != Some(verified.workflow_ref.as_str())
+                || mapping
+                    .event_name
+                    .as_deref()
+                    .is_some_and(|event| event != verified.event_name)
+                || !ref_matches(mapping.ref_pattern.as_deref(), &verified.git_ref)
+            {
+                bail!("verified OIDC claims do not match the federation mapping");
+            }
+            let subject = format!(
+                "github:{}:{}:{}",
+                verified.repository_id, verified.workflow_ref, verified.sub
+            );
+            let github = GithubContext {
+                repository_id: verified.repository_id,
+                repository: verified.repository,
+                workflow_ref: verified.workflow_ref,
+                workflow_sha: verified.workflow_sha,
+                event_name: verified.event_name,
+                git_ref: verified.git_ref,
+                run_id: verified.run_id,
+                run_attempt: verified.run_attempt,
+            };
+            let context = FederationContext {
+                provider: mapping.provider.clone(),
+                issuer: mapping.issuer.clone(),
+                subject: subject.clone(),
+                service_tag: mapping.service_tag.clone(),
+                service_account: None,
+                github: Some(github),
+            };
+            (subject, context)
+        }
+        "google" => {
+            let verified = decode::<GoogleClaims>(token, &key, &validation)?.claims;
+            if !verified.email_verified
+                || mapping.subject.as_deref() != Some(verified.sub.as_str())
+                || mapping.service_account.as_deref() != Some(verified.email.as_str())
+            {
+                bail!("verified Google identity does not match the federation mapping");
+            }
+            let subject = format!("google:{}:{}", verified.sub, verified.email);
+            let context = FederationContext {
+                provider: mapping.provider.clone(),
+                issuer: verified.iss,
+                subject: subject.clone(),
+                service_tag: mapping.service_tag.clone(),
+                service_account: Some(verified.email),
+                github: None,
+            };
+            (subject, context)
+        }
+        _ => bail!("unsupported federation provider"),
     };
-    // The exact verified workflow identity is the automation subject. Keep the
-    // GitHub `sub` in it for audit while authorization remains keyed on stable
-    // repository_id + workflow_ref.
-    let subject = format!(
-        "github:{}:{}:{}",
-        mapping.repository_id, mapping.workflow_ref, verified.sub
-    );
-    mint(db, &subject, vec![mapping.profile], 600, Some(context)).await
+    mint(db, &subject, profiles, 600, Some(context)).await
 }
 
 #[cfg(test)]
@@ -463,6 +696,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn google_workload_mappings_are_exact_and_idempotent() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        automation_profile(&db).await;
+        let req = FederationReq {
+            name: "marin-ops".to_string(),
+            provider: "google".to_string(),
+            issuer: "https://accounts.google.com".to_string(),
+            audience: "https://loom.example.com".to_string(),
+            subject: Some("11223344556677889900".to_string()),
+            service_account: Some("loom-marin-ops@acme.iam.gserviceaccount.com".to_string()),
+            service_tag: "marin-ops".to_string(),
+            repository_id: None,
+            workflow_ref: None,
+            event_name: None,
+            ref_pattern: None,
+            profiles: vec!["actions".to_string()],
+        };
+
+        let created = federation_add(&db, &req).await.unwrap();
+        let unchanged = federation_add(&db, &req).await.unwrap();
+        assert_eq!(unchanged.id, created.id);
+        assert_eq!(unchanged.updated_at, created.updated_at);
+        assert_eq!(unchanged.subject.as_deref(), Some("11223344556677889900"));
+        assert_eq!(unchanged.profiles, vec!["actions"]);
+
+        let mut invalid = req;
+        invalid.name = "invalid-google".to_string();
+        invalid.subject = Some("service-account-name".to_string());
+        assert!(federation_add(&db, &invalid).await.is_err());
+    }
+
+    #[tokio::test]
     #[serial_test::serial]
     async fn github_oidc_signature_and_mapping_are_verified_before_context_is_copied() {
         let home = tempfile::tempdir().unwrap();
@@ -504,13 +769,20 @@ mod tests {
         federation_add(
             &db,
             &FederationReq {
+                name: "actions-main".to_string(),
+                provider: "github".to_string(),
                 issuer: issuer.clone(),
                 audience: "loom-test".to_string(),
-                repository_id: "123".to_string(),
-                workflow_ref: "acme/repo/.github/workflows/loom.yml@refs/heads/main".to_string(),
+                subject: None,
+                service_account: None,
+                service_tag: "github-actions".to_string(),
+                repository_id: Some("123".to_string()),
+                workflow_ref: Some(
+                    "acme/repo/.github/workflows/loom.yml@refs/heads/main".to_string(),
+                ),
                 event_name: Some("issues".to_string()),
                 ref_pattern: Some("refs/heads/main".to_string()),
-                profile: "actions".to_string(),
+                profiles: vec!["actions".to_string()],
             },
         )
         .await
@@ -540,7 +812,9 @@ mod tests {
         .unwrap();
         let exchanged = federate(&db, &oidc).await.unwrap();
         let loom = verify(&db, &exchanged.token).await.unwrap().unwrap();
-        let context = loom.github.unwrap();
+        let federation = loom.federation.unwrap();
+        assert_eq!(federation.service_tag, "github-actions");
+        let context = federation.github.unwrap();
         assert_eq!(context.repository, "acme/repo");
         assert_eq!(context.workflow_sha, "abc123");
         assert_eq!(context.run_attempt, "2");

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -100,6 +100,11 @@ enum Cmd {
         #[command(subcommand)]
         cmd: FederationCmd,
     },
+    /// Apply a declarative deployment manifest through Loom's REST API.
+    Deployment {
+        #[command(subcommand)]
+        cmd: DeploymentCmd,
+    },
     /// Show the repo's issue board (every issue across branches + backlog).
     Issue {
         #[command(subcommand)]
@@ -568,27 +573,48 @@ enum TokenCmd {
     },
 }
 
+#[derive(Args)]
+struct FederationAddArgs {
+    /// Stable mapping name. Omitted legacy calls derive one from identity fields.
+    name: Option<String>,
+    #[arg(long, default_value = "github")]
+    provider: String,
+    #[arg(long, default_value = "https://token.actions.githubusercontent.com")]
+    issuer: String,
+    #[arg(long)]
+    audience: String,
+    #[arg(long)]
+    subject: Option<String>,
+    #[arg(long)]
+    service_account: Option<String>,
+    #[arg(long, default_value = "github-actions")]
+    service_tag: String,
+    #[arg(long)]
+    repository_id: Option<String>,
+    #[arg(long)]
+    workflow_ref: Option<String>,
+    #[arg(long)]
+    event: Option<String>,
+    #[arg(long = "ref")]
+    git_ref: Option<String>,
+    #[arg(long = "profile", required = true)]
+    profiles: Vec<String>,
+}
+
 #[derive(Subcommand)]
 enum FederationCmd {
-    Add {
-        #[arg(long, default_value = "https://token.actions.githubusercontent.com")]
-        issuer: String,
-        #[arg(long)]
-        audience: String,
-        #[arg(long)]
-        repository_id: String,
-        #[arg(long)]
-        workflow_ref: String,
-        #[arg(long)]
-        event: Option<String>,
-        #[arg(long = "ref")]
-        git_ref: Option<String>,
-        #[arg(long)]
-        profile: String,
-    },
+    Add(Box<FederationAddArgs>),
     Ls,
-    Rm {
-        id: String,
+    Rm { id: String },
+}
+
+#[derive(Subcommand)]
+enum DeploymentCmd {
+    /// Reconcile profiles, secret references, and workload federation mappings.
+    Apply {
+        /// JSON manifest path, or `-` for stdin.
+        #[arg(long, default_value = "-")]
+        file: String,
     },
 }
 
@@ -647,6 +673,12 @@ enum ProfileEnvCmd {
         profile: String,
         name: String,
         value: String,
+    },
+    /// Set a write-only GCP Secret Manager version reference.
+    Secret {
+        profile: String,
+        name: String,
+        secret_ref: String,
     },
     /// Remove an environment value.
     Rm { profile: String, name: String },
@@ -784,6 +816,7 @@ async fn run() -> Result<()> {
         Cmd::Token { cmd } => run_token(cmd).await,
         Cmd::Profile { cmd } => run_profile(cmd).await,
         Cmd::Federation { cmd } => run_federation(cmd).await,
+        Cmd::Deployment { cmd } => run_deployment(cmd).await,
         Cmd::Setup { cmd } => run_setup(cmd).await,
         Cmd::Config { cmd } => run_config(cmd).await,
         Cmd::Launch(opts) => cmd_launch(opts.into()).await,
@@ -916,24 +949,47 @@ fn parse_ttl(value: &str) -> Result<i64> {
 async fn run_federation(cmd: FederationCmd) -> Result<()> {
     let client = client::default();
     match cmd {
-        FederationCmd::Add {
-            issuer,
-            audience,
-            repository_id,
-            workflow_ref,
-            event,
-            git_ref,
-            profile,
-        } => {
+        FederationCmd::Add(args) => {
+            let FederationAddArgs {
+                name,
+                provider,
+                issuer,
+                audience,
+                subject,
+                service_account,
+                service_tag,
+                repository_id,
+                workflow_ref,
+                event,
+                git_ref,
+                profiles,
+            } = *args;
+            let name = name.unwrap_or_else(|| {
+                use sha2::Digest as _;
+                let identity = format!(
+                    "{provider}:{}:{}:{}:{}",
+                    subject.as_deref().unwrap_or_default(),
+                    service_account.as_deref().unwrap_or_default(),
+                    repository_id.as_deref().unwrap_or_default(),
+                    workflow_ref.as_deref().unwrap_or_default(),
+                );
+                let digest = sha2::Sha256::digest(identity.as_bytes());
+                format!("federation-{}", hex::encode(&digest[..8]))
+            });
             let mapping = client
                 .add_federation(&weaver_api::FederationReq {
+                    name,
+                    provider,
                     issuer,
                     audience,
+                    subject,
+                    service_account,
+                    service_tag,
                     repository_id,
                     workflow_ref,
                     event_name: event,
                     ref_pattern: git_ref,
-                    profile,
+                    profiles,
                 })
                 .await?;
             println!("added federation mapping {}", mapping.id);
@@ -941,14 +997,44 @@ async fn run_federation(cmd: FederationCmd) -> Result<()> {
         FederationCmd::Ls => {
             for mapping in client.list_federations().await? {
                 println!(
-                    "{}  repo={}  workflow={}  profile={}",
-                    mapping.id, mapping.repository_id, mapping.workflow_ref, mapping.profile
+                    "{}  provider={}  service={}  profiles={}",
+                    mapping.name,
+                    mapping.provider,
+                    mapping.service_tag,
+                    mapping.profiles.join(",")
                 );
             }
         }
         FederationCmd::Rm { id } => {
             client.remove_federation(&id).await?;
             println!("removed federation mapping {id}");
+        }
+    }
+    Ok(())
+}
+
+async fn run_deployment(cmd: DeploymentCmd) -> Result<()> {
+    match cmd {
+        DeploymentCmd::Apply { file } => {
+            let contents = if file == "-" {
+                use std::io::Read as _;
+                let mut contents = String::new();
+                std::io::stdin()
+                    .read_to_string(&mut contents)
+                    .context("reading deployment manifest from stdin")?;
+                contents
+            } else {
+                std::fs::read_to_string(&file)
+                    .with_context(|| format!("reading deployment manifest {file}"))?
+            };
+            let request: weaver_api::DeploymentReq =
+                serde_json::from_str(&contents).context("decoding deployment manifest")?;
+            let result = client::default().reconcile_deployment(&request).await?;
+            println!(
+                "reconciled {} profiles and {} federation mappings",
+                result.profiles.len(),
+                result.federations.len()
+            );
         }
     }
     Ok(())
@@ -1011,6 +1097,16 @@ async fn run_profile(cmd: ProfileCmd) -> Result<()> {
             } => {
                 client.set_profile_env(&profile, &name, &value).await?;
                 println!("set {name} on profile {profile}");
+            }
+            ProfileEnvCmd::Secret {
+                profile,
+                name,
+                secret_ref,
+            } => {
+                client
+                    .set_profile_env_secret(&profile, &name, &secret_ref)
+                    .await?;
+                println!("set Secret Manager reference for {name} on profile {profile}");
             }
             ProfileEnvCmd::Rm { profile, name } => {
                 client.remove_profile_env(&profile, &name).await?;

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -25,9 +25,19 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "grants-runs",
         include_str!("../migrations/0003_grants_runs.sql"),
     ),
+    (
+        4,
+        "workload-federation",
+        include_str!("../migrations/0004_workload_federation.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
+
+/// Latest loom-owned schema version compiled into this binary.
+pub fn latest_migration_version() -> i64 {
+    LOOM_MIGRATIONS.last().map_or(0, |(version, _, _)| *version)
+}
 
 /// Open the shared database and apply loom's schema after the core schema.
 pub async fn connect(path: &Path) -> Result<Db> {
@@ -247,7 +257,7 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3]);
+        assert_eq!(versions, vec![1, 2, 3, 4]);
 
         let columns = table_columns(&db, "sessions").await.unwrap();
         for expected in [
@@ -331,7 +341,7 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1]);
+        assert_eq!(versions, vec![1, 2, 3, 4]);
         let index_sql: String = sqlx::query_scalar(
             "SELECT sql FROM sqlite_master
              WHERE type = 'index' AND name = 'idx_sessions_active_branch'",
@@ -405,7 +415,7 @@ mod tests {
             .fetch_one(&db)
             .await
             .unwrap();
-        assert_eq!(count, 3);
+        assert_eq!(count, 4);
 
         // Adoption replaced the historical index predicate: archived history
         // no longer prevents a new active session from claiming the branch.

--- a/crates/loom/src/profile.rs
+++ b/crates/loom/src/profile.rs
@@ -6,6 +6,7 @@
 //! rotatable and are loaded again on a real respawn.
 
 use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
 use crate::db::{now_iso, Db};
@@ -63,7 +64,7 @@ impl Profile {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProfileInput {
     pub name: String,
     #[serde(default)]
@@ -100,7 +101,17 @@ fn default_class() -> String {
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct ProfileEnvMeta {
     pub name: String,
+    pub source: String,
+    pub secret_ref: Option<String>,
     pub updated_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct ProfileEnvRow {
+    name: String,
+    value: String,
+    source: String,
+    secret_ref: Option<String>,
 }
 
 pub fn validate_name(name: &str) -> std::result::Result<(), String> {
@@ -192,14 +203,33 @@ pub async fn get(db: &Db, name: &str) -> Result<Option<Profile>> {
 pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
     let name = input.name.trim();
     let (protocol, mode) = validate_input(db, input).await?;
-    let ambient = serde_json::to_string(&input.ambient_allowlist)?;
+    let normalized = ProfileInput {
+        name: name.to_string(),
+        description: input.description.trim().to_string(),
+        agent_kind: input.agent_kind.trim().to_string(),
+        model: input.model.trim().to_string(),
+        effort: input.effort.trim().to_string(),
+        protocol,
+        mode,
+        class: input.class.trim().to_string(),
+        strict: input.strict,
+        env_clear: input.env_clear,
+        ambient_allowlist: input.ambient_allowlist.clone(),
+        idle_archive_secs: input.idle_archive_secs,
+        max_concurrent: input.max_concurrent,
+        turn_budget: input.turn_budget,
+    };
+    let ambient = serde_json::to_string(&normalized.ambient_allowlist)?;
     if let Some(existing) = get(db, name).await? {
+        if existing.as_input()? == normalized {
+            return Ok(existing);
+        }
         if existing.is_automation_safe()
             && has_automation_sessions(db, name).await?
-            && (!input.strict
-                || !input.env_clear
-                || input.class != "automation"
-                || widens_allowlist(&existing.ambient_names()?, &input.ambient_allowlist))
+            && (!normalized.strict
+                || !normalized.env_clear
+                || normalized.class != "automation"
+                || widens_allowlist(&existing.ambient_names()?, &normalized.ambient_allowlist))
         {
             bail!("cannot weaken a profile referenced by automation sessions");
         }
@@ -221,19 +251,19 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
           revision=profiles.revision + 1, updated_at=excluded.updated_at",
     )
     .bind(name)
-    .bind(input.description.trim())
-    .bind(input.agent_kind.trim())
-    .bind(input.model.trim())
-    .bind(input.effort.trim())
-    .bind(protocol)
-    .bind(mode)
-    .bind(input.class.trim())
-    .bind(input.strict)
-    .bind(input.env_clear)
+    .bind(&normalized.description)
+    .bind(&normalized.agent_kind)
+    .bind(&normalized.model)
+    .bind(&normalized.effort)
+    .bind(&normalized.protocol)
+    .bind(&normalized.mode)
+    .bind(&normalized.class)
+    .bind(normalized.strict)
+    .bind(normalized.env_clear)
     .bind(ambient)
-    .bind(input.idle_archive_secs)
-    .bind(input.max_concurrent)
-    .bind(input.turn_budget)
+    .bind(normalized.idle_archive_secs)
+    .bind(normalized.max_concurrent)
+    .bind(normalized.turn_budget)
     .bind(&now)
     .bind(&now)
     .execute(db)
@@ -278,7 +308,8 @@ pub async fn remove(db: &Db, name: &str) -> Result<bool> {
 
 pub async fn env_meta(db: &Db, profile: &str) -> Result<Vec<ProfileEnvMeta>> {
     Ok(sqlx::query_as::<_, ProfileEnvMeta>(
-        "SELECT name, updated_at FROM profile_env WHERE profile_name = ? ORDER BY name",
+        "SELECT name, source, secret_ref, updated_at
+         FROM profile_env WHERE profile_name = ? ORDER BY name",
     )
     .bind(profile)
     .fetch_all(db)
@@ -286,12 +317,31 @@ pub async fn env_meta(db: &Db, profile: &str) -> Result<Vec<ProfileEnvMeta>> {
 }
 
 pub async fn env_pairs(db: &Db, profile: &str) -> Result<Vec<(String, String)>> {
-    Ok(sqlx::query_as::<_, (String, String)>(
-        "SELECT name, value FROM profile_env WHERE profile_name = ? ORDER BY name",
+    let rows = sqlx::query_as::<_, ProfileEnvRow>(
+        "SELECT name, value, source, secret_ref
+         FROM profile_env WHERE profile_name = ? ORDER BY name",
     )
     .bind(profile)
     .fetch_all(db)
-    .await?)
+    .await?;
+    let mut values = Vec::with_capacity(rows.len());
+    for row in rows {
+        let value = match row.source.as_str() {
+            "literal" => row.value,
+            "gcp_secret" => {
+                let secret_ref = row
+                    .secret_ref
+                    .as_deref()
+                    .ok_or_else(|| anyhow!("profile environment secret reference is missing"))?;
+                resolve_gcp_secret(secret_ref).await.with_context(|| {
+                    format!("resolving profile environment variable {}", row.name)
+                })?
+            }
+            source => bail!("unsupported profile environment source '{source}'"),
+        };
+        values.push((row.name, value));
+    }
+    Ok(values)
 }
 
 pub async fn env_get(db: &Db, profile: &str, name: &str) -> Result<Option<String>> {
@@ -310,9 +360,12 @@ pub async fn env_set(db: &Db, profile: &str, name: &str, value: &str) -> Result<
         bail!("unknown profile '{profile}'");
     }
     sqlx::query(
-        "INSERT INTO profile_env (profile_name, name, value, updated_at) VALUES (?, ?, ?, ?)
+        "INSERT INTO profile_env
+         (profile_name, name, value, source, secret_ref, updated_at)
+         VALUES (?, ?, ?, 'literal', NULL, ?)
          ON CONFLICT(profile_name, name) DO UPDATE SET
-          value=excluded.value, updated_at=excluded.updated_at",
+          value=excluded.value, source='literal', secret_ref=NULL,
+          updated_at=excluded.updated_at",
     )
     .bind(profile)
     .bind(name)
@@ -321,6 +374,95 @@ pub async fn env_set(db: &Db, profile: &str, name: &str, value: &str) -> Result<
     .execute(db)
     .await?;
     Ok(())
+}
+
+pub async fn env_set_secret(db: &Db, profile: &str, name: &str, secret_ref: &str) -> Result<()> {
+    crate::agent_env::validate_name(name).map_err(|e| anyhow!(e))?;
+    if get(db, profile).await?.is_none() {
+        bail!("unknown profile '{profile}'");
+    }
+    validate_gcp_secret_ref(secret_ref)?;
+    sqlx::query(
+        "INSERT INTO profile_env
+         (profile_name, name, value, source, secret_ref, updated_at)
+         VALUES (?, ?, '', 'gcp_secret', ?, ?)
+         ON CONFLICT(profile_name, name) DO UPDATE SET
+          value='', source='gcp_secret', secret_ref=excluded.secret_ref,
+          updated_at=excluded.updated_at",
+    )
+    .bind(profile)
+    .bind(name)
+    .bind(secret_ref)
+    .bind(now_iso())
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+fn validate_gcp_secret_ref(secret_ref: &str) -> Result<()> {
+    let parts: Vec<&str> = secret_ref.split('/').collect();
+    if parts.len() != 6
+        || parts[0] != "projects"
+        || parts[2] != "secrets"
+        || parts[4] != "versions"
+        || parts[1].is_empty()
+        || parts[3].is_empty()
+        || parts[5].is_empty()
+        || !parts.iter().all(|part| {
+            part.bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        })
+        || (parts[5] != "latest" && !parts[5].bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        bail!("secret_ref must be projects/PROJECT/secrets/SECRET/versions/VERSION");
+    }
+    Ok(())
+}
+
+async fn resolve_gcp_secret(secret_ref: &str) -> Result<String> {
+    validate_gcp_secret_ref(secret_ref)?;
+    #[derive(Deserialize)]
+    struct MetadataToken {
+        access_token: String,
+    }
+    #[derive(Deserialize)]
+    struct SecretPayload {
+        data: String,
+    }
+    #[derive(Deserialize)]
+    struct SecretAccess {
+        payload: SecretPayload,
+    }
+
+    let http = reqwest::Client::new();
+    let token = http
+        .get("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+        .header("Metadata-Flavor", "Google")
+        .send()
+        .await
+        .context("requesting the VM workload access token")?
+        .error_for_status()
+        .context("the VM workload access token request was rejected")?
+        .json::<MetadataToken>()
+        .await
+        .context("decoding the VM workload access token")?;
+    let access = http
+        .get(format!(
+            "https://secretmanager.googleapis.com/v1/{secret_ref}:access"
+        ))
+        .bearer_auth(token.access_token)
+        .send()
+        .await
+        .context("requesting the Secret Manager value")?
+        .error_for_status()
+        .context("the Secret Manager value request was rejected")?
+        .json::<SecretAccess>()
+        .await
+        .context("decoding the Secret Manager response")?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(access.payload.data)
+        .context("decoding the Secret Manager payload")?;
+    String::from_utf8(bytes).context("Secret Manager value is not UTF-8")
 }
 
 pub async fn env_remove(db: &Db, profile: &str, name: &str) -> Result<bool> {
@@ -333,6 +475,22 @@ pub async fn env_remove(db: &Db, profile: &str, name: &str) -> Result<bool> {
             .rows_affected()
             > 0,
     )
+}
+
+pub async fn mark_deployment_managed(db: &Db, name: &str) -> Result<()> {
+    sqlx::query("UPDATE profiles SET managed_by_deployment = 1 WHERE name = ?")
+        .bind(name)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+pub async fn deployment_managed_names(db: &Db) -> Result<Vec<String>> {
+    Ok(sqlx::query_scalar(
+        "SELECT name FROM profiles WHERE managed_by_deployment = 1 ORDER BY name",
+    )
+    .fetch_all(db)
+    .await?)
 }
 
 /// Repair the one-time legacy seed through the same runtime metadata validators
@@ -405,5 +563,47 @@ mod tests {
                 .as_deref(),
             Some("secret")
         );
+    }
+
+    #[tokio::test]
+    async fn unchanged_profiles_do_not_advance_the_revision() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let existing = get(&db, DEFAULT_PROFILE).await.unwrap().unwrap();
+        let input = existing.as_input().unwrap();
+
+        let unchanged = upsert(&db, &input).await.unwrap();
+
+        assert_eq!(unchanged.revision, existing.revision);
+        assert_eq!(unchanged.updated_at, existing.updated_at);
+    }
+
+    #[tokio::test]
+    async fn secret_references_are_validated_and_values_stay_out_of_the_database() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let secret_ref = "projects/acme-prod/secrets/ops_token/versions/latest";
+
+        env_set_secret(&db, DEFAULT_PROFILE, "OPS_TOKEN", secret_ref)
+            .await
+            .unwrap();
+        let metadata = env_meta(&db, DEFAULT_PROFILE).await.unwrap();
+        assert_eq!(metadata[0].name, "OPS_TOKEN");
+        assert_eq!(metadata[0].source, "gcp_secret");
+        assert_eq!(metadata[0].secret_ref.as_deref(), Some(secret_ref));
+        assert_eq!(
+            env_get(&db, DEFAULT_PROFILE, "OPS_TOKEN")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("")
+        );
+
+        assert!(env_set_secret(
+            &db,
+            DEFAULT_PROFILE,
+            "OPS_TOKEN",
+            "projects/acme-prod/secrets/ops_token/versions/not-a-version"
+        )
+        .await
+        .is_err());
     }
 }

--- a/crates/loom/src/runs.rs
+++ b/crates/loom/src/runs.rs
@@ -11,6 +11,7 @@ pub struct Run {
     pub id: String,
     pub actor_subject: String,
     pub source: String,
+    pub service_tag: String,
     pub profile: String,
     pub idempotency_key: String,
     pub request_json: String,
@@ -28,6 +29,7 @@ impl From<Run> for RunView {
             id: run.id,
             actor_subject: run.actor_subject,
             source: run.source,
+            service_tag: run.service_tag,
             profile: run.profile,
             idempotency_key: run.idempotency_key,
             session_id: run.session_id,
@@ -49,6 +51,7 @@ pub async fn reserve(
     db: &Db,
     subject: &str,
     source: &str,
+    service_tag: &str,
     profile: &str,
     idempotency_key: &str,
     request_json: &str,
@@ -58,14 +61,15 @@ pub async fn reserve(
     let now = now_iso();
     let result = sqlx::query(
         "INSERT INTO automation_runs
-         (id, actor_subject, source, profile, idempotency_key, request_json,
+         (id, actor_subject, source, service_tag, profile, idempotency_key, request_json,
           session_id, status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, 'creating', ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'creating', ?, ?)
          ON CONFLICT(actor_subject, idempotency_key) DO NOTHING",
     )
     .bind(&id)
     .bind(subject)
     .bind(source)
+    .bind(service_tag)
     .bind(profile)
     .bind(idempotency_key)
     .bind(request_json)
@@ -170,9 +174,17 @@ mod tests {
     #[tokio::test]
     async fn reservation_is_idempotent_for_subject_and_key() {
         let db = crate::db::connect_in_memory().await.unwrap();
-        let first = reserve(&db, "subject", "actions", "default", "delivery", "{}")
-            .await
-            .unwrap();
+        let first = reserve(
+            &db,
+            "subject",
+            "actions",
+            "weaver-actions",
+            "default",
+            "delivery",
+            "{}",
+        )
+        .await
+        .unwrap();
         let (first_id, first_session_id) = match first {
             Reservation::Created(run) => (run.id, run.session_id),
             Reservation::Existing(_) => panic!("first reservation must be new"),
@@ -181,6 +193,7 @@ mod tests {
             &db,
             "subject",
             "actions",
+            "weaver-actions",
             "default",
             "delivery",
             "different",
@@ -200,9 +213,17 @@ mod tests {
     #[tokio::test]
     async fn only_a_stale_creating_run_can_be_reclaimed() {
         let db = crate::db::connect_in_memory().await.unwrap();
-        let run = match reserve(&db, "subject", "actions", "default", "key", "{}")
-            .await
-            .unwrap()
+        let run = match reserve(
+            &db,
+            "subject",
+            "actions",
+            "weaver-actions",
+            "default",
+            "key",
+            "{}",
+        )
+        .await
+        .unwrap()
         {
             Reservation::Created(run) => run,
             Reservation::Existing(_) => unreachable!(),

--- a/crates/loom/src/runtime.rs
+++ b/crates/loom/src/runtime.rs
@@ -20,6 +20,7 @@ enum ActorKind {
         subject: String,
     },
     Automation {
+        origin: String,
         subject: String,
         profiles: Vec<String>,
         run_id: Option<String>,
@@ -43,6 +44,7 @@ impl Actor {
                 delegated,
             }),
             Grant::Automation { subject, profiles } => Self(ActorKind::Automation {
+                origin: "automation".to_string(),
                 subject: subject.clone(),
                 profiles: profiles.clone(),
                 run_id: None,
@@ -71,12 +73,14 @@ impl Actor {
     }
 
     pub(crate) fn automation(
+        origin: impl Into<String>,
         subject: impl Into<String>,
         profiles: Vec<String>,
         run_id: impl Into<String>,
         session_id: impl Into<String>,
     ) -> Self {
         Self(ActorKind::Automation {
+            origin: origin.into(),
             subject: subject.into(),
             profiles,
             run_id: Some(run_id.into()),
@@ -92,7 +96,7 @@ impl Actor {
             | ActorKind::Session { .. } => "agent",
             ActorKind::Admin { .. } => "user",
             ActorKind::Producer { origin, .. } => origin,
-            ActorKind::Automation { .. } => "actions",
+            ActorKind::Automation { origin, .. } => origin,
         }
     }
 

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -26,8 +26,11 @@ use super::{ApiResult, AppError, AppState};
 // Three credentials resolve to one `auth::Principal`: an `Authorization: Bearer`
 // API token, a login session cookie, or a trusted-loopback request. The
 // `require_auth` middleware enforces this on every route except the public login
-// surface (`/auth/me`, `/auth/login`, `/auth/logout`, `/auth/github/*`) and
-// `/health`. The crypto and storage live in `crate::auth`; this is the HTTP glue.
+// surface (`/auth/me`, `/auth/login`, `/auth/logout`, `/auth/github/*`), the
+// cryptographically authenticated federation/webhook routes, and
+// health/readiness probes. The root `/metrics` route is outside this nested API
+// middleware entirely. The crypto and storage live in `crate::auth`; this is
+// the HTTP glue.
 // ===========================================================================
 
 /// The login cookie's `Max-Age` in seconds, derived from the stored-session TTL

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -96,16 +96,22 @@ pub(super) async fn create_run(
 ) -> ApiResult<Json<RunView>> {
     let profile = req.profile.trim().to_string();
     let (subject, profiles) = run_identity(&principal, &profile)?;
-    if req.source != "actions" {
+    if !matches!(req.source.as_str(), "actions" | "ops" | "grafana") {
         return Err(AppError::bad_request(
-            "only the 'actions' run source is supported",
+            "run source must be 'actions', 'ops', or 'grafana'",
         ));
     }
     req.session.profile = Some(profile.clone());
     req.session.class = None;
 
     let idempotency_key = match &principal.automation_context {
-        Some(context) => {
+        Some(context) if context.provider == "github" => {
+            let context = context.github.as_ref().ok_or_else(|| {
+                AppError::new(
+                    StatusCode::UNAUTHORIZED,
+                    "GitHub automation credential is missing workflow context",
+                )
+            })?;
             if let Some(repo) = req
                 .session
                 .repo
@@ -125,7 +131,7 @@ pub(super) async fn create_run(
                 context.repository_id, context.run_id, context.run_attempt
             )
         }
-        None => {
+        _ => {
             let key = req.idempotency_key.trim();
             if key.is_empty() {
                 return Err(AppError::bad_request("idempotency_key is required"));
@@ -134,10 +140,16 @@ pub(super) async fn create_run(
         }
     };
     let request_json = serde_json::to_string(&req)?;
+    let service_tag = principal
+        .automation_context
+        .as_ref()
+        .map(|context| context.service_tag.as_str())
+        .unwrap_or(req.source.as_str());
     let reservation = crate::runs::reserve(
         &st.db,
         &subject,
         &req.source,
+        service_tag,
         &profile,
         &idempotency_key,
         &request_json,
@@ -165,6 +177,7 @@ pub(super) async fn create_run(
         crate::runs::Reservation::Created(run) => run,
     };
     let actor = crate::runtime::Actor::automation(
+        req.source.clone(),
         subject,
         profiles,
         run.id.clone(),

--- a/crates/loom/src/web/deployment.rs
+++ b/crates/loom/src/web/deployment.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeSet;
+
+use axum::{extract::State, http::StatusCode, Extension, Json};
+use weaver_api::{DeploymentReq, DeploymentView};
+
+use crate::auth::Principal;
+
+use super::{profiles, ApiResult, AppError, AppState};
+
+/// Reconcile the runtime resources declared by a deployment stack. This is the
+/// API-first boundary Pulumi's startup generation calls through the local Loom
+/// CLI; the manifest contains references and policy, never secret values.
+pub(super) async fn reconcile_deployment(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Json(req): Json<DeploymentReq>,
+) -> ApiResult<Json<DeploymentView>> {
+    if !principal.is_admin() {
+        return Err(AppError::new(StatusCode::FORBIDDEN, "admin grant required"));
+    }
+
+    let mut profile_names = BTreeSet::new();
+    for declared in &req.profiles {
+        let name = declared.profile.name.trim();
+        if !profile_names.insert(name.to_string()) {
+            return Err(AppError::bad_request(format!(
+                "profile '{name}' is declared more than once"
+            )));
+        }
+        let mut env_names = BTreeSet::new();
+        for env in &declared.env {
+            if !env_names.insert(env.name.trim().to_string()) {
+                return Err(AppError::bad_request(format!(
+                    "profile '{name}' environment variable '{}' is declared more than once",
+                    env.name
+                )));
+            }
+        }
+    }
+    let mut federation_names = BTreeSet::new();
+    for mapping in &req.federations {
+        if !federation_names.insert(mapping.name.trim().to_string()) {
+            return Err(AppError::bad_request(format!(
+                "federation '{}' is declared more than once",
+                mapping.name
+            )));
+        }
+    }
+
+    for declared in &req.profiles {
+        let input = super::profiles::input(
+            declared.profile.clone(),
+            declared.profile.name.trim().to_string(),
+        );
+        let profile = crate::profile::upsert(&st.db, &input)
+            .await
+            .map_err(|error| AppError::bad_request(error.to_string()))?;
+        crate::profile::mark_deployment_managed(&st.db, &profile.name).await?;
+
+        let existing = crate::profile::env_meta(&st.db, &profile.name).await?;
+        let declared_names: BTreeSet<&str> =
+            declared.env.iter().map(|entry| entry.name.trim()).collect();
+        for env in &declared.env {
+            let name = env.name.trim();
+            let result = match (env.value.as_deref(), env.secret_ref.as_deref()) {
+                (Some(value), None) => {
+                    crate::profile::env_set(&st.db, &profile.name, name, value).await
+                }
+                (None, Some(secret_ref)) => {
+                    crate::profile::env_set_secret(&st.db, &profile.name, name, secret_ref).await
+                }
+                (None, None) if existing.iter().any(|current| current.name == name) => Ok(()),
+                (None, None) => Err(anyhow::anyhow!(
+                    "profile '{}' has no existing write-only value for '{name}'",
+                    profile.name
+                )),
+                (Some(_), Some(_)) => Err(anyhow::anyhow!(
+                    "profile '{}' environment '{name}' sets both value and secret_ref",
+                    profile.name
+                )),
+            };
+            result.map_err(|error| AppError::bad_request(error.to_string()))?;
+        }
+        for current in existing {
+            if !declared_names.contains(current.name.as_str()) {
+                crate::profile::env_remove(&st.db, &profile.name, &current.name).await?;
+            }
+        }
+    }
+
+    for mapping in &req.federations {
+        crate::automation::federation_add(&st.db, mapping)
+            .await
+            .map_err(|error| AppError::bad_request(error.to_string()))?;
+        crate::automation::federation_mark_deployment_managed(&st.db, &mapping.name).await?;
+    }
+
+    if req.prune {
+        for name in crate::automation::deployment_managed_federation_names(&st.db).await? {
+            if !federation_names.contains(&name) {
+                crate::automation::federation_remove(&st.db, &name).await?;
+            }
+        }
+        for name in crate::profile::deployment_managed_names(&st.db).await? {
+            if !profile_names.contains(&name) {
+                crate::profile::remove(&st.db, &name)
+                    .await
+                    .map_err(|error| AppError::bad_request(error.to_string()))?;
+            }
+        }
+    }
+
+    let mut profile_views = Vec::new();
+    for name in profile_names {
+        let profile = crate::profile::get(&st.db, &name)
+            .await?
+            .ok_or_else(|| AppError::not_found("profile"))?;
+        profile_views.push(profiles::view(&st, profile).await?);
+    }
+    let mappings = crate::automation::federation_list(&st.db)
+        .await?
+        .into_iter()
+        .filter(|mapping| federation_names.contains(&mapping.name))
+        .collect();
+    Ok(Json(DeploymentView {
+        profiles: profile_views,
+        federations: mappings,
+    }))
+}

--- a/crates/loom/src/web/diagnostics.rs
+++ b/crates/loom/src/web/diagnostics.rs
@@ -553,12 +553,6 @@ async fn render_metrics(db: &Db, view: &DiagnosticsView) -> Result<String> {
         "Durable automation runs by status, source, service, and profile.",
         "gauge",
     );
-    append_help(
-        &mut output,
-        "loom_automation_runs_total",
-        "Durable automation runs by source, service, profile, and outcome.",
-        "counter",
-    );
     for run in &view.automation_runs.counts {
         writeln!(
             output,
@@ -567,16 +561,6 @@ async fn render_metrics(db: &Db, view: &DiagnosticsView) -> Result<String> {
             label_value(&run.source),
             label_value(&run.service_tag),
             label_value(&run.profile),
-            run.count
-        )
-        .expect("writing a String cannot fail");
-        writeln!(
-            output,
-            "loom_automation_runs_total{{source=\"{}\",service=\"{}\",profile=\"{}\",outcome=\"{}\"}} {}",
-            label_value(&run.source),
-            label_value(&run.service_tag),
-            label_value(&run.profile),
-            label_value(&run.status),
             run.count
         )
         .expect("writing a String cannot fail");

--- a/crates/loom/src/web/diagnostics.rs
+++ b/crates/loom/src/web/diagnostics.rs
@@ -1,0 +1,672 @@
+//! Operational health, Prometheus metrics, and the admin diagnostics snapshot.
+//!
+//! Everything here is derived from durable control-plane state. Labels are
+//! restricted to bounded operational dimensions; identities, paths, branch and
+//! session keys, token identifiers, and raw error text never enter metrics or
+//! diagnostics payloads.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use anyhow::Result;
+use axum::{
+    extract::State,
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Extension, Json,
+};
+use sqlx::FromRow;
+use weaver_api::{
+    DiagnosticFederation, DiagnosticProblemSummary, DiagnosticProfileCapacity, DiagnosticRunCount,
+    DiagnosticRunFailure, DiagnosticRunSummary, DiagnosticSessionCount, DiagnosticsView,
+    MigrationStreamView, ReadinessView,
+};
+
+use crate::auth::Principal;
+use crate::db::Db;
+
+use super::{ApiResult, AppError, AppState};
+
+const LOCAL_RUNNER_POOL: &str = "local";
+const METRICS_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+
+#[derive(FromRow)]
+struct SessionCountRow {
+    status: String,
+    class: String,
+    profile: String,
+    protocol: String,
+    count: i64,
+}
+
+#[derive(FromRow)]
+struct ProfileCapacityRow {
+    profile: String,
+    revision: i64,
+    maximum: i64,
+    active: i64,
+}
+
+#[derive(FromRow)]
+struct RunCountRow {
+    status: String,
+    source: String,
+    service_tag: String,
+    profile: String,
+    count: i64,
+}
+
+#[derive(FromRow)]
+struct RunFailureRow {
+    source: String,
+    profile: String,
+    outcome: Option<String>,
+    updated_at: String,
+}
+
+#[derive(FromRow)]
+struct ProblemRow {
+    status: String,
+    class: String,
+    profile: String,
+    protocol: String,
+    count: i64,
+    latest_activity_at: Option<String>,
+}
+
+#[derive(FromRow)]
+struct FederationRow {
+    name: String,
+    provider: String,
+    audience: String,
+    service_tag: String,
+    profiles_json: String,
+    created_at: String,
+    updated_at: String,
+}
+
+fn bounded_status(value: &str) -> &str {
+    match value {
+        "created" | "launching" | "running" | "orphaned" | "done" | "error" | "archived" => value,
+        _ => "other",
+    }
+}
+
+fn bounded_class(value: &str) -> &str {
+    match value {
+        "interactive" | "automation" => value,
+        _ => "other",
+    }
+}
+
+fn bounded_protocol(value: &str) -> &str {
+    match value {
+        "terminal" | "acp" => value,
+        _ => "other",
+    }
+}
+
+fn bounded_run_status(value: &str) -> &str {
+    match value {
+        "creating" | "running" | "completed" | "failed" | "cancelled" => value,
+        _ => "other",
+    }
+}
+
+fn bounded_source(value: &str) -> &str {
+    match value {
+        "actions" | "ops" | "grafana" => value,
+        _ => "other",
+    }
+}
+
+fn label_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('"', "\\\"")
+}
+
+async fn migration_states(db: &Db) -> Result<Vec<MigrationStreamView>> {
+    let streams = [
+        (
+            "core",
+            "schema_migrations",
+            weaver_core::migrations::latest_version(),
+        ),
+        (
+            "loom",
+            "loom_schema_migrations",
+            crate::db::latest_migration_version(),
+        ),
+    ];
+    let mut states = Vec::with_capacity(streams.len());
+    for (stream, table, expected) in streams {
+        // Both identifiers are compile-time literals. SQLite cannot bind table
+        // names, so keep this list closed rather than accepting caller input.
+        let query = format!("SELECT COALESCE(MAX(version), 0), COUNT(*) FROM {table}");
+        let (current, applied): (i64, i64) = sqlx::query_as(&query).fetch_one(db).await?;
+        states.push(MigrationStreamView {
+            stream: stream.to_string(),
+            current,
+            expected,
+            applied,
+            ready: current == expected && applied == expected,
+        });
+    }
+    Ok(states)
+}
+
+async fn readiness_snapshot(db: &Db) -> Result<ReadinessView> {
+    let _: i64 = sqlx::query_scalar("SELECT 1").fetch_one(db).await?;
+    let migrations = migration_states(db).await?;
+    let ready = migrations.iter().all(|stream| stream.ready);
+    Ok(ReadinessView {
+        status: if ready { "ready" } else { "not_ready" }.to_string(),
+        database: true,
+        migrations,
+        degraded: Vec::new(),
+    })
+}
+
+/// Process-level liveness. Kept separate from database checks so a wedged DB
+/// does not cause the process supervisor to restart an otherwise diagnosable
+/// API in a loop.
+pub(super) async fn liveness() -> &'static str {
+    "ok"
+}
+
+/// Database + migration readiness. Optional remote runner capacity will be
+/// added to `degraded`, not folded into the top-level readiness decision.
+pub(super) async fn readiness(State(st): State<AppState>) -> Response {
+    match readiness_snapshot(&st.db).await {
+        Ok(view) => {
+            let status = if view.status == "ready" {
+                StatusCode::OK
+            } else {
+                StatusCode::SERVICE_UNAVAILABLE
+            };
+            (status, Json(view)).into_response()
+        }
+        Err(error) => {
+            tracing::error!(error = %format!("{error:?}"), "readiness database check failed");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ReadinessView {
+                    status: "not_ready".to_string(),
+                    database: false,
+                    migrations: Vec::new(),
+                    degraded: vec!["database unavailable".to_string()],
+                }),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn session_counts(db: &Db) -> Result<Vec<DiagnosticSessionCount>> {
+    let rows = sqlx::query_as::<_, SessionCountRow>(
+        "SELECT status, class, profile, protocol, COUNT(*) AS count
+         FROM sessions
+         GROUP BY status, class, profile, protocol
+         ORDER BY status, class, profile, protocol",
+    )
+    .fetch_all(db)
+    .await?;
+    let mut counts = BTreeMap::new();
+    for row in rows {
+        *counts
+            .entry((
+                bounded_status(&row.status).to_string(),
+                bounded_class(&row.class).to_string(),
+                row.profile,
+                bounded_protocol(&row.protocol).to_string(),
+            ))
+            .or_insert(0) += row.count;
+    }
+    Ok(counts
+        .into_iter()
+        .map(
+            |((status, class, profile, protocol), count)| DiagnosticSessionCount {
+                status,
+                class,
+                profile,
+                protocol,
+                runner_pool: LOCAL_RUNNER_POOL.to_string(),
+                count,
+            },
+        )
+        .collect())
+}
+
+async fn profile_capacity(db: &Db) -> Result<Vec<DiagnosticProfileCapacity>> {
+    let rows = sqlx::query_as::<_, ProfileCapacityRow>(
+        "SELECT p.name AS profile, p.revision, p.max_concurrent AS maximum,
+                COUNT(s.id) AS active
+         FROM profiles p
+         LEFT JOIN sessions s ON s.profile = p.name
+            AND s.status NOT IN ('done', 'error', 'archived')
+         GROUP BY p.name, p.revision, p.max_concurrent
+         ORDER BY p.name",
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            let maximum = (row.maximum > 0).then_some(row.maximum);
+            DiagnosticProfileCapacity {
+                profile: row.profile,
+                revision: row.revision,
+                active: row.active,
+                maximum,
+                available: maximum.map(|limit| (limit - row.active).max(0)),
+            }
+        })
+        .collect())
+}
+
+async fn automation_runs(db: &Db) -> Result<DiagnosticRunSummary> {
+    let rows = sqlx::query_as::<_, RunCountRow>(
+        "SELECT status, source, service_tag, profile, COUNT(*) AS count
+         FROM automation_runs
+         GROUP BY status, source, service_tag, profile
+         ORDER BY status, source, service_tag, profile",
+    )
+    .fetch_all(db)
+    .await?;
+    let mut grouped_counts = BTreeMap::new();
+    for row in rows {
+        *grouped_counts
+            .entry((
+                bounded_run_status(&row.status).to_string(),
+                bounded_source(&row.source).to_string(),
+                row.service_tag,
+                row.profile,
+            ))
+            .or_insert(0) += row.count;
+    }
+    let counts = grouped_counts
+        .into_iter()
+        .map(
+            |((status, source, service_tag, profile), count)| DiagnosticRunCount {
+                status,
+                source,
+                service_tag,
+                profile,
+                count,
+            },
+        )
+        .collect();
+    let stale_before = (chrono::Utc::now() - chrono::Duration::minutes(5))
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let stale_creating = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM automation_runs WHERE status = 'creating' AND updated_at <= ?",
+    )
+    .bind(stale_before)
+    .fetch_one(db)
+    .await?;
+    let recent_failures = sqlx::query_as::<_, RunFailureRow>(
+        "SELECT source, profile, outcome, updated_at
+         FROM automation_runs WHERE status = 'failed'
+         ORDER BY updated_at DESC LIMIT 20",
+    )
+    .fetch_all(db)
+    .await?
+    .into_iter()
+    .map(|row| DiagnosticRunFailure {
+        source: bounded_source(&row.source).to_string(),
+        profile: row.profile,
+        outcome: row
+            .outcome
+            .as_deref()
+            .map(bounded_run_status)
+            .map(str::to_string),
+        updated_at: row.updated_at,
+    })
+    .collect();
+    Ok(DiagnosticRunSummary {
+        counts,
+        stale_creating,
+        recent_failures,
+    })
+}
+
+async fn problems(db: &Db) -> Result<Vec<DiagnosticProblemSummary>> {
+    let rows = sqlx::query_as::<_, ProblemRow>(
+        "SELECT s.status, s.class, s.profile, s.protocol, COUNT(*) AS count,
+                MAX(COALESCE(s.last_activity_at, b.updated_at, s.created_at)) AS latest_activity_at
+         FROM sessions s
+         LEFT JOIN branches b ON b.id = s.branch_id
+         WHERE s.status IN ('orphaned', 'error')
+         GROUP BY s.status, s.class, s.profile, s.protocol
+         ORDER BY s.status, s.class, s.profile, s.protocol",
+    )
+    .fetch_all(db)
+    .await?;
+    let mut grouped = BTreeMap::new();
+    for row in rows {
+        let entry = grouped
+            .entry((
+                bounded_status(&row.status).to_string(),
+                bounded_class(&row.class).to_string(),
+                row.profile,
+                bounded_protocol(&row.protocol).to_string(),
+            ))
+            .or_insert((0, None::<String>));
+        entry.0 += row.count;
+        if row.latest_activity_at.as_ref() > entry.1.as_ref() {
+            entry.1 = row.latest_activity_at;
+        }
+    }
+    Ok(grouped
+        .into_iter()
+        .map(
+            |((status, class, profile, protocol), (count, latest_activity_at))| {
+                DiagnosticProblemSummary {
+                    status,
+                    class,
+                    profile,
+                    protocol,
+                    runner_pool: LOCAL_RUNNER_POOL.to_string(),
+                    count,
+                    latest_activity_at,
+                }
+            },
+        )
+        .collect())
+}
+
+async fn federations(db: &Db) -> Result<Vec<DiagnosticFederation>> {
+    let rows = sqlx::query_as::<_, FederationRow>(
+        "SELECT name, provider, audience, service_tag, profiles_json,
+                created_at, updated_at
+         FROM federation_mappings ORDER BY created_at DESC",
+    )
+    .fetch_all(db)
+    .await?;
+    rows.into_iter()
+        .map(|row| {
+            let profiles = serde_json::from_str(&row.profiles_json)?;
+            Ok(DiagnosticFederation {
+                name: row.name,
+                provider: row.provider,
+                audience: row.audience,
+                service_tag: row.service_tag,
+                profiles,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            })
+        })
+        .collect()
+}
+
+async fn snapshot(db: &Db) -> Result<DiagnosticsView> {
+    Ok(DiagnosticsView {
+        sessions: session_counts(db).await?,
+        profiles: profile_capacity(db).await?,
+        automation_runs: automation_runs(db).await?,
+        problems: problems(db).await?,
+        migrations: migration_states(db).await?,
+        federations: federations(db).await?,
+    })
+}
+
+async fn metric_snapshot(db: &Db) -> Result<DiagnosticsView> {
+    Ok(DiagnosticsView {
+        sessions: session_counts(db).await?,
+        profiles: profile_capacity(db).await?,
+        automation_runs: automation_runs(db).await?,
+        problems: Vec::new(),
+        migrations: migration_states(db).await?,
+        federations: Vec::new(),
+    })
+}
+
+pub(super) async fn diagnostics(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+) -> ApiResult<Json<DiagnosticsView>> {
+    if !principal.is_admin() {
+        return Err(AppError::new(StatusCode::FORBIDDEN, "admin grant required"));
+    }
+    Ok(Json(snapshot(&st.db).await?))
+}
+
+fn append_help(output: &mut String, name: &str, help: &str, metric_type: &str) {
+    writeln!(output, "# HELP {name} {help}").expect("writing a String cannot fail");
+    writeln!(output, "# TYPE {name} {metric_type}").expect("writing a String cannot fail");
+}
+
+async fn render_metrics(db: &Db, view: &DiagnosticsView) -> Result<String> {
+    let mut output = String::new();
+    append_help(
+        &mut output,
+        "loom_sessions_current",
+        "Current durable sessions by bounded control-plane dimensions.",
+        "gauge",
+    );
+    for row in &view.sessions {
+        if row.status == "archived" {
+            continue;
+        }
+        writeln!(
+            output,
+            "loom_sessions_current{{status=\"{}\",class=\"{}\",profile=\"{}\",protocol=\"{}\",runner_pool=\"{}\"}} {}",
+            label_value(&row.status),
+            label_value(&row.class),
+            label_value(&row.profile),
+            label_value(&row.protocol),
+            label_value(&row.runner_pool),
+            row.count
+        )
+        .expect("writing a String cannot fail");
+    }
+
+    append_help(
+        &mut output,
+        "loom_sessions_created_total",
+        "Durable session rows created, including archived history.",
+        "counter",
+    );
+    let mut created: BTreeMap<(&str, &str, &str), i64> = BTreeMap::new();
+    for row in &view.sessions {
+        *created
+            .entry((&row.profile, &row.class, &row.runner_pool))
+            .or_default() += row.count;
+    }
+    for ((profile, class, runner_pool), count) in created {
+        writeln!(
+            output,
+            "loom_sessions_created_total{{profile=\"{}\",class=\"{}\",runner_pool=\"{}\"}} {}",
+            label_value(profile),
+            label_value(class),
+            label_value(runner_pool),
+            count
+        )
+        .expect("writing a String cannot fail");
+    }
+
+    append_help(
+        &mut output,
+        "loom_session_turns_total",
+        "Completed agent turns retained in durable session state.",
+        "counter",
+    );
+    let turns: Vec<(String, i64)> = sqlx::query_as(
+        "SELECT profile, COALESCE(SUM(turn_count), 0) FROM sessions GROUP BY profile ORDER BY profile",
+    )
+    .fetch_all(db)
+    .await?;
+    for (profile, count) in turns {
+        writeln!(
+            output,
+            "loom_session_turns_total{{profile=\"{}\"}} {count}",
+            label_value(&profile)
+        )
+        .expect("writing a String cannot fail");
+    }
+
+    append_help(
+        &mut output,
+        "loom_profile_revision",
+        "Current revision of each configured launch profile.",
+        "gauge",
+    );
+    append_help(
+        &mut output,
+        "loom_profile_capacity",
+        "Profile capacity by used, limit, and available state; unlimited profiles omit limit and available.",
+        "gauge",
+    );
+    for profile in &view.profiles {
+        let name = label_value(&profile.profile);
+        writeln!(
+            output,
+            "loom_profile_revision{{profile=\"{name}\"}} {}",
+            profile.revision
+        )
+        .expect("writing a String cannot fail");
+        writeln!(
+            output,
+            "loom_profile_capacity{{profile=\"{name}\",state=\"used\"}} {}",
+            profile.active
+        )
+        .expect("writing a String cannot fail");
+        if let (Some(limit), Some(available)) = (profile.maximum, profile.available) {
+            writeln!(
+                output,
+                "loom_profile_capacity{{profile=\"{name}\",state=\"limit\"}} {limit}"
+            )
+            .expect("writing a String cannot fail");
+            writeln!(
+                output,
+                "loom_profile_capacity{{profile=\"{name}\",state=\"available\"}} {available}"
+            )
+            .expect("writing a String cannot fail");
+        }
+    }
+
+    append_help(
+        &mut output,
+        "loom_automation_runs_current",
+        "Durable automation runs by status, source, service, and profile.",
+        "gauge",
+    );
+    append_help(
+        &mut output,
+        "loom_automation_runs_total",
+        "Durable automation runs by source, service, profile, and outcome.",
+        "counter",
+    );
+    for run in &view.automation_runs.counts {
+        writeln!(
+            output,
+            "loom_automation_runs_current{{status=\"{}\",source=\"{}\",service=\"{}\",profile=\"{}\"}} {}",
+            label_value(&run.status),
+            label_value(&run.source),
+            label_value(&run.service_tag),
+            label_value(&run.profile),
+            run.count
+        )
+        .expect("writing a String cannot fail");
+        writeln!(
+            output,
+            "loom_automation_runs_total{{source=\"{}\",service=\"{}\",profile=\"{}\",outcome=\"{}\"}} {}",
+            label_value(&run.source),
+            label_value(&run.service_tag),
+            label_value(&run.profile),
+            label_value(&run.status),
+            run.count
+        )
+        .expect("writing a String cannot fail");
+    }
+    append_help(
+        &mut output,
+        "loom_automation_runs_stale_creating",
+        "Automation runs left in creating state for more than five minutes.",
+        "gauge",
+    );
+    writeln!(
+        output,
+        "loom_automation_runs_stale_creating {}",
+        view.automation_runs.stale_creating
+    )
+    .expect("writing a String cannot fail");
+
+    append_help(
+        &mut output,
+        "loom_migration_version",
+        "Applied and expected schema migration versions.",
+        "gauge",
+    );
+    append_help(
+        &mut output,
+        "loom_migration_ready",
+        "Whether a schema migration stream is at the version expected by this process.",
+        "gauge",
+    );
+    for migration in &view.migrations {
+        let stream = label_value(&migration.stream);
+        writeln!(
+            output,
+            "loom_migration_version{{stream=\"{stream}\",state=\"applied\"}} {}",
+            migration.current
+        )
+        .expect("writing a String cannot fail");
+        writeln!(
+            output,
+            "loom_migration_version{{stream=\"{stream}\",state=\"expected\"}} {}",
+            migration.expected
+        )
+        .expect("writing a String cannot fail");
+        writeln!(
+            output,
+            "loom_migration_ready{{stream=\"{stream}\"}} {}",
+            i32::from(migration.ready)
+        )
+        .expect("writing a String cannot fail");
+    }
+    output.push_str("# EOF\n");
+    Ok(output)
+}
+
+/// Public scrape surface. It contains aggregates only; the richer inventory is
+/// admin-gated at `/api/diagnostics`.
+pub(super) async fn metrics(State(st): State<AppState>) -> Response {
+    match metric_snapshot(&st.db).await {
+        Ok(view) => match render_metrics(&st.db, &view).await {
+            Ok(body) => (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, METRICS_CONTENT_TYPE)],
+                body,
+            )
+                .into_response(),
+            Err(error) => metrics_error(error),
+        },
+        Err(error) => metrics_error(error),
+    }
+}
+
+fn metrics_error(error: anyhow::Error) -> Response {
+    tracing::error!(error = %format!("{error:?}"), "metrics snapshot failed");
+    (StatusCode::SERVICE_UNAVAILABLE, "metrics unavailable\n").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prometheus_label_values_are_escaped() {
+        assert_eq!(label_value("a\\b\n\"c"), "a\\\\b\\n\\\"c");
+    }
+
+    #[test]
+    fn arbitrary_dimensions_collapse_to_other() {
+        assert_eq!(bounded_status("branch-name"), "other");
+        assert_eq!(bounded_class("user-name"), "other");
+        assert_eq!(bounded_protocol("token-id"), "other");
+        assert_eq!(bounded_source("repository-path"), "other");
+    }
+}

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -15,8 +15,10 @@
 //!   session). `/api/branches/{id}` — GET / PATCH (goal / title / description).
 //! * `/api/branches/{id}/issues` — list / POST issues for a branch.
 //! * `/api/issues/{id}` — GET / PATCH / DELETE an issue by id.
-//! * `/api/repos/recent`, `/api/repos/branches`, `/api/health`, `/api/settings`
-//!   — unchanged.
+//! * `/api/health` + `/api/health/live` are process-level liveness;
+//!   `/api/ready` checks the database and migration streams; `/metrics` exposes
+//!   bounded-label OpenMetrics; `/api/diagnostics` is the admin inventory.
+//! * `/api/repos/recent`, `/api/repos/branches`, `/api/settings` — unchanged.
 //!
 //! The `/api/hook` endpoint that used to exist is gone — agent hooks now go
 //! through `weaver hook --event …` which writes an `events` row consumed by
@@ -67,6 +69,8 @@ mod artifacts;
 mod auth;
 mod automation;
 mod branches;
+mod deployment;
+mod diagnostics;
 mod discussion;
 mod env;
 mod issues;
@@ -84,6 +88,8 @@ use artifacts::*;
 use auth::*;
 use automation::*;
 use branches::*;
+use deployment::*;
+use diagnostics::*;
 use discussion::*;
 use env::*;
 use issues::*;
@@ -539,7 +545,12 @@ pub fn router(state: AppState) -> Router {
     // middleware — these must work for an unauthenticated caller, since they are
     // how one *becomes* authenticated.
     let public = Router::new()
-        .route("/health", get(|| async { "ok" }))
+        // `/health` remains the compatibility liveness probe. `/health/live`
+        // names it explicitly; readiness checks DB + migration state.
+        .route("/health", get(liveness))
+        .route("/health/live", get(liveness))
+        .route("/ready", get(readiness))
+        .route("/health/ready", get(readiness))
         .route("/auth/me", get(auth_me))
         .route("/auth/login", post(auth_login))
         .route("/auth/logout", post(auth_logout))
@@ -731,6 +742,7 @@ pub fn router(state: AppState) -> Router {
             axum::routing::put(put_repo_env).delete(delete_repo_env),
         )
         .route("/settings", get(get_settings).patch(patch_settings))
+        .route("/deployment/reconcile", post(reconcile_deployment))
         .route("/profiles", get(list_profiles).post(create_profile))
         .route(
             "/profiles/{name}",
@@ -758,6 +770,7 @@ pub fn router(state: AppState) -> Router {
         .route("/logs/stream", get(logs_stream))
         .route("/status", get(server_status))
         .route("/tasks", get(tasks_snapshot))
+        .route("/diagnostics", get(diagnostics))
         // Watches — periodic / triggered watch programs over the fleet.
         .route("/watches", get(list_watches).post(create_watch))
         // The static segment wins over the `{id}` capture below, so a program
@@ -811,10 +824,13 @@ pub fn router(state: AppState) -> Router {
         // ETag/304 short-circuit for cacheable GETs — applied across the whole
         // API surface (public + protected) before the state is sealed in.
         .layer(axum::middleware::from_fn(api_etag_middleware))
-        .with_state(state);
+        .with_state(state.clone());
 
     let index = static_dir().join("index.html");
     Router::new()
+        // Conventional root scrape endpoint. The public edge may block it
+        // while a same-host metrics agent scrapes the loopback listener.
+        .route("/metrics", get(metrics))
         .nest("/api", api)
         .fallback_service(ServeDir::new(static_dir()).fallback(ServeFile::new(index)))
         .layer(axum::middleware::from_fn(static_cache_middleware))
@@ -823,6 +839,7 @@ pub fn router(state: AppState) -> Router {
         // Outermost, so it wraps auth and every other layer: tag each request's log
         // lines with its method + path (see `request_context_span`).
         .layer(axum::middleware::from_fn(request_context_span))
+        .with_state(state)
 }
 
 #[cfg(test)]

--- a/crates/loom/src/web/profiles.rs
+++ b/crates/loom/src/web/profiles.rs
@@ -9,7 +9,7 @@ use crate::profile::{self, Profile, ProfileInput};
 
 use super::{ApiResult, AppError, AppState};
 
-fn input(req: ProfileReq, name: String) -> ProfileInput {
+pub(super) fn input(req: ProfileReq, name: String) -> ProfileInput {
     ProfileInput {
         name,
         description: req.description,
@@ -28,7 +28,7 @@ fn input(req: ProfileReq, name: String) -> ProfileInput {
     }
 }
 
-async fn view(st: &AppState, profile: Profile) -> ApiResult<ProfileView> {
+pub(super) async fn view(st: &AppState, profile: Profile) -> ApiResult<ProfileView> {
     let ambient_allowlist = profile
         .ambient_names()
         .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -37,6 +37,8 @@ async fn view(st: &AppState, profile: Profile) -> ApiResult<ProfileView> {
         .into_iter()
         .map(|entry| ProfileEnvView {
             name: entry.name,
+            source: entry.source,
+            secret_ref: entry.secret_ref,
             updated_at: entry.updated_at,
         })
         .collect();
@@ -124,9 +126,16 @@ pub(super) async fn put_profile_env(
     Path((profile_name, name)): Path<(String, String)>,
     Json(req): Json<PutProfileEnvReq>,
 ) -> ApiResult<Json<ProfileView>> {
-    profile::env_set(&st.db, &profile_name, &name, &req.value)
-        .await
-        .map_err(|e| AppError::bad_request(e.to_string()))?;
+    match (req.value.as_deref(), req.secret_ref.as_deref()) {
+        (Some(value), None) => profile::env_set(&st.db, &profile_name, &name, value).await,
+        (None, Some(secret_ref)) => {
+            profile::env_set_secret(&st.db, &profile_name, &name, secret_ref).await
+        }
+        _ => Err(anyhow::anyhow!(
+            "exactly one of value and secret_ref is required"
+        )),
+    }
+    .map_err(|e| AppError::bad_request(e.to_string()))?;
     let item = profile::get(&st.db, &profile_name)
         .await?
         .ok_or_else(|| AppError::not_found("profile"))?;

--- a/crates/loom/tests/integration/diagnostics.rs
+++ b/crates/loom/tests/integration/diagnostics.rs
@@ -193,6 +193,7 @@ async fn health_readiness_and_metrics_are_public_and_label_safe() {
     assert!(metrics.contains("runner_pool=\"local\""));
     assert!(metrics.contains("loom_profile_capacity{profile=\"default\",state=\"available\"} 1"));
     assert!(metrics.contains("loom_automation_runs_current{"));
+    assert!(!metrics.contains("loom_automation_runs_total"));
     assert!(metrics.contains("loom_migration_ready{stream=\"loom\"} 1"));
     assert!(metrics.ends_with("# EOF\n"));
     for forbidden in [

--- a/crates/loom/tests/integration/diagnostics.rs
+++ b/crates/loom/tests/integration/diagnostics.rs
@@ -1,0 +1,233 @@
+//! Operational endpoints: public liveness/readiness/metrics and the admin-only,
+//! redacted diagnostics inventory.
+
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use serial_test::serial;
+
+use super::fixtures::TestServer;
+
+fn url(ts: &TestServer, path: &str) -> String {
+    format!("http://{}{}", ts.addr, path)
+}
+
+async fn seed_operational_state(ts: &TestServer) {
+    sqlx::query(
+        "INSERT INTO branches (id, repo_root, branch, updated_at)
+         VALUES ('diag-branch', '/sensitive/repository/path',
+                 'weaver/sensitive-branch-name', '2026-07-22T10:00:00.000Z')",
+    )
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+    sqlx::query("UPDATE profiles SET max_concurrent = 2, revision = 7 WHERE name = 'default'")
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO sessions
+         (id, branch_id, work_dir, term_session, agent_kind, status,
+          last_activity_at, class, protocol, profile, creator_subject)
+         VALUES ('sensitive-session-id', 'diag-branch', '/sensitive/worktree/path',
+                 'sensitive-terminal-id', 'shell', 'orphaned',
+                 '2026-07-22T10:01:00.000Z', 'automation', 'acp', 'default',
+                 'sensitive-user-name')",
+    )
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO automation_runs
+         (id, actor_subject, source, service_tag, profile, idempotency_key, request_json,
+          session_id, status, outcome, summary, created_at, updated_at)
+         VALUES ('sensitive-run-id', 'sensitive-actor', 'actions', 'weaver-actions', 'default',
+                 'sensitive-token-id', '{\"secret\":\"do-not-return\"}',
+                 'sensitive-session-id', 'failed', 'secret-outcome-text',
+                 'raw failure contains bearer-secret',
+                 '2026-07-22T09:00:00.000Z', '2026-07-22T10:02:00.000Z')",
+    )
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO federation_mappings
+         (id, name, provider, issuer, audience, subject, service_account,
+          service_tag, profiles_json, created_at, updated_at)
+         VALUES ('mapping-internal-id', 'ops-service', 'google',
+                 'https://accounts.google.com', 'loom-production', '12345',
+                 'ops@example.iam.gserviceaccount.com', 'ops', '[\"default\"]',
+                 '2026-07-22T09:00:00.000Z', '2026-07-22T09:00:00.000Z')",
+    )
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn diagnostics_are_correct_redacted_and_admin_only() {
+    let ts = TestServer::start().await;
+    seed_operational_state(&ts).await;
+    let http = reqwest::Client::new();
+
+    let typed = ts.client.diagnostics().await.unwrap();
+    assert_eq!(typed.profiles[0].active, 1);
+    assert_eq!(typed.automation_runs.recent_failures.len(), 1);
+
+    let response = http.get(url(&ts, "/api/diagnostics")).send().await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let diagnostics: Value = response.json().await.unwrap();
+    let orphan = diagnostics["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["status"] == "orphaned")
+        .unwrap();
+    assert_eq!(orphan["count"], 1);
+    assert_eq!(orphan["class"], "automation");
+    assert_eq!(orphan["profile"], "default");
+    assert_eq!(orphan["protocol"], "acp");
+    assert_eq!(orphan["runner_pool"], "local");
+    assert_eq!(diagnostics["profiles"][0]["active"], 1);
+    assert_eq!(diagnostics["profiles"][0]["maximum"], 2);
+    assert_eq!(diagnostics["profiles"][0]["available"], 1);
+    assert_eq!(
+        diagnostics["automation_runs"]["recent_failures"][0]["profile"],
+        "default"
+    );
+    assert_eq!(
+        diagnostics["automation_runs"]["counts"][0]["service_tag"],
+        "weaver-actions"
+    );
+    assert_eq!(
+        diagnostics["automation_runs"]["recent_failures"][0]["outcome"],
+        "other"
+    );
+    assert_eq!(diagnostics["problems"][0]["status"], "orphaned");
+    assert_eq!(diagnostics["federations"][0]["name"], "ops-service");
+    assert_eq!(diagnostics["federations"][0]["service_tag"], "ops");
+    assert_eq!(diagnostics["migrations"][0]["ready"], true);
+    assert_eq!(diagnostics["migrations"][1]["ready"], true);
+
+    let encoded = diagnostics.to_string();
+    for forbidden in [
+        "sensitive-session-id",
+        "sensitive-branch-name",
+        "/sensitive/repository/path",
+        "/sensitive/worktree/path",
+        "sensitive-terminal-id",
+        "sensitive-user-name",
+        "sensitive-actor",
+        "sensitive-token-id",
+        "do-not-return",
+        "bearer-secret",
+        "secret-outcome-text",
+        "mapping-internal-id",
+        "12345",
+        "ops@example.iam.gserviceaccount.com",
+    ] {
+        assert!(
+            !encoded.contains(forbidden),
+            "diagnostics leaked {forbidden}"
+        );
+    }
+
+    let session_token = loom::auth::create_session_token(
+        &ts.state.db,
+        Some("rjpower"),
+        "sensitive-session-id",
+        "diag-branch",
+    )
+    .await
+    .unwrap();
+    ts.client
+        .patch("/api/settings", json!({ "auth.trust_loopback": false }))
+        .await
+        .unwrap();
+
+    let unauthenticated = http.get(url(&ts, "/api/diagnostics")).send().await.unwrap();
+    assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+    let scoped = http
+        .get(url(&ts, "/api/diagnostics"))
+        .bearer_auth(session_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(scoped.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+#[serial]
+async fn health_readiness_and_metrics_are_public_and_label_safe() {
+    let ts = TestServer::start().await;
+    seed_operational_state(&ts).await;
+    ts.client
+        .patch("/api/settings", json!({ "auth.trust_loopback": false }))
+        .await
+        .unwrap();
+    let http = reqwest::Client::new();
+
+    for path in ["/api/health", "/api/health/live"] {
+        let response = http.get(url(&ts, path)).send().await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        assert_eq!(response.text().await.unwrap(), "ok");
+    }
+    let ready = http.get(url(&ts, "/api/ready")).send().await.unwrap();
+    assert_eq!(ready.status(), StatusCode::OK);
+    let ready: Value = ready.json().await.unwrap();
+    assert_eq!(ready["status"], "ready");
+    assert_eq!(ready["database"], true);
+    assert_eq!(ready["degraded"], json!([]));
+    assert_eq!(ts.client.readiness().await.unwrap().status, "ready");
+
+    let metrics = http.get(url(&ts, "/metrics")).send().await.unwrap();
+    assert_eq!(metrics.status(), StatusCode::OK);
+    assert_eq!(
+        metrics.headers()["content-type"],
+        "application/openmetrics-text; version=1.0.0; charset=utf-8"
+    );
+    let metrics = metrics.text().await.unwrap();
+    assert!(metrics.contains("loom_sessions_current{"));
+    assert!(metrics.contains("status=\"orphaned\""));
+    assert!(metrics.contains("profile=\"default\""));
+    assert!(metrics.contains("runner_pool=\"local\""));
+    assert!(metrics.contains("loom_profile_capacity{profile=\"default\",state=\"available\"} 1"));
+    assert!(metrics.contains("loom_automation_runs_current{"));
+    assert!(metrics.contains("loom_migration_ready{stream=\"loom\"} 1"));
+    assert!(metrics.ends_with("# EOF\n"));
+    for forbidden in [
+        "sensitive-session-id",
+        "sensitive-branch-name",
+        "/sensitive/repository/path",
+        "/sensitive/worktree/path",
+        "sensitive-user-name",
+        "sensitive-token-id",
+        "bearer-secret",
+    ] {
+        assert!(!metrics.contains(forbidden), "metrics leaked {forbidden}");
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn readiness_fails_when_a_migration_stream_is_incomplete() {
+    let ts = TestServer::start().await;
+    let latest = loom::db::latest_migration_version();
+    sqlx::query("DELETE FROM loom_schema_migrations WHERE version = ?")
+        .bind(latest)
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+
+    let response = reqwest::Client::new()
+        .get(url(&ts, "/api/ready"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["status"], "not_ready");
+    assert_eq!(body["database"], true);
+    assert_eq!(body["migrations"][1]["ready"], false);
+    assert_eq!(body["migrations"][1]["expected"], latest);
+}

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -15,6 +15,7 @@ mod auth;
 mod branches;
 mod conversation;
 mod custom_agents;
+mod diagnostics;
 mod env;
 mod ide;
 mod logs;

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -83,3 +83,77 @@ async fn strict_profile_crud_withholds_secrets_and_stamps_sessions() {
         .unwrap();
     assert_eq!(delete.status(), StatusCode::BAD_REQUEST);
 }
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deployment_manifest_reconciles_profiles_secret_refs_and_workload_identity() {
+    let ts = TestServer::start().await;
+    let manifest = json!({
+        "profiles": [{
+            "profile": {
+                "name": "ops",
+                "description": "operations automation",
+                "agent_kind": "shell",
+                "protocol": "terminal",
+                "mode": "plan",
+                "class": "automation",
+                "strict": true,
+                "env_clear": true,
+                "max_concurrent": 1,
+                "turn_budget": 20
+            },
+            "env": [{
+                "name": "KUBECONFIG",
+                "secret_ref": "projects/example/secrets/ops-kubeconfig/versions/latest"
+            }]
+        }],
+        "federations": [{
+            "name": "marin-ops",
+            "provider": "google",
+            "issuer": "https://accounts.google.com",
+            "audience": "https://loom.example.com",
+            "subject": "11223344556677889900",
+            "service_account": "loom-marin-ops@example.iam.gserviceaccount.com",
+            "service_tag": "marin-ops",
+            "profiles": ["ops"]
+        }],
+        "prune": true
+    });
+
+    let first = ts
+        .client
+        .post("/api/deployment/reconcile", manifest.clone())
+        .await
+        .unwrap();
+    assert_eq!(first["profiles"][0]["revision"], 1);
+    assert_eq!(first["profiles"][0]["env"][0]["source"], "gcp_secret");
+    assert_eq!(
+        first["profiles"][0]["env"][0]["secret_ref"],
+        "projects/example/secrets/ops-kubeconfig/versions/latest"
+    );
+    assert!(!first.to_string().contains("value"));
+    let mapping_id = first["federations"][0]["id"].clone();
+    assert_eq!(first["federations"][0]["service_tag"], "marin-ops");
+
+    let second = ts
+        .client
+        .post("/api/deployment/reconcile", manifest)
+        .await
+        .unwrap();
+    assert_eq!(second["profiles"][0]["revision"], 1);
+    assert_eq!(second["federations"][0]["id"], mapping_id);
+
+    ts.client
+        .post(
+            "/api/deployment/reconcile",
+            json!({ "profiles": [], "federations": [], "prune": true }),
+        )
+        .await
+        .unwrap();
+    let profile = reqwest::Client::new()
+        .get(format!("http://{}/api/profiles/ops", ts.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(profile.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -13,10 +13,11 @@ use serde_json::Value;
 use crate::dto::{
     AnchorDto, ArtifactMeta, ArtifactUpsertReq, ArtifactView, AutomationTokenReq,
     AutomationTokenView, BranchStatusReq, BranchView, CommentDto, CreateEventReq, CreateIssueReq,
-    CreateRepoIssueReq, CreateReq, CreateTokenReq, CreateWatchReq, CreatedTokenView, FederationReq,
-    FederationView, HandoffReq, IssueView, NewCommentBody, NewThreadBody, PatchIssueReq,
-    PatchSessionReq, PatchWatchReq, ProfileReq, ProfileView, PutProfileEnvReq, RunReq, RunView,
-    RunWatchReq, SendReq, SessionView, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
+    CreateRepoIssueReq, CreateReq, CreateTokenReq, CreateWatchReq, CreatedTokenView, DeploymentReq,
+    DeploymentView, DiagnosticsView, FederationReq, FederationView, HandoffReq, IssueView,
+    NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileReq,
+    ProfileView, PutProfileEnvReq, ReadinessView, RunReq, RunView, RunWatchReq, SendReq,
+    SessionView, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
 };
 
 /// A client for one loom server, identified by its base URL.
@@ -664,6 +665,16 @@ impl Client {
 
     // -- Settings -------------------------------------------------------------
 
+    /// Public database and migration readiness (`GET /api/ready`).
+    pub async fn readiness(&self) -> Result<ReadinessView> {
+        self.get_typed("/api/ready").await
+    }
+
+    /// Admin-only redacted operational inventory (`GET /api/diagnostics`).
+    pub async fn diagnostics(&self) -> Result<DiagnosticsView> {
+        self.get_typed("/api/diagnostics").await
+    }
+
     /// List named launch profiles. Secret environment values are withheld.
     pub async fn list_profiles(&self) -> Result<Vec<ProfileView>> {
         self.get_typed("/api/profiles").await
@@ -700,7 +711,30 @@ impl Client {
         value: &str,
     ) -> Result<ProfileView> {
         let req = PutProfileEnvReq {
-            value: value.to_string(),
+            value: Some(value.to_string()),
+            secret_ref: None,
+        };
+        self.send_typed(
+            Method::PUT,
+            &format!(
+                "/api/profiles/{}/env/{}",
+                Self::seg(profile),
+                Self::seg(name)
+            ),
+            Some(&req),
+        )
+        .await
+    }
+
+    pub async fn set_profile_env_secret(
+        &self,
+        profile: &str,
+        name: &str,
+        secret_ref: &str,
+    ) -> Result<ProfileView> {
+        let req = PutProfileEnvReq {
+            value: None,
+            secret_ref: Some(secret_ref.to_string()),
         };
         self.send_typed(
             Method::PUT,
@@ -800,6 +834,11 @@ impl Client {
 
     pub async fn remove_federation(&self, id: &str) -> Result<Value> {
         self.delete(&format!("/api/auth/federations/{}", Self::seg(id)))
+            .await
+    }
+
+    pub async fn reconcile_deployment(&self, req: &DeploymentReq) -> Result<DeploymentView> {
+        self.send_typed(Method::POST, "/api/deployment/reconcile", Some(req))
             .await
     }
 

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -262,6 +262,10 @@ pub struct ProfileView {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfileEnvView {
     pub name: String,
+    /// `literal` or `gcp_secret`. The value itself is never returned.
+    pub source: String,
+    #[serde(default)]
+    pub secret_ref: Option<String>,
     pub updated_at: String,
 }
 
@@ -298,7 +302,12 @@ pub struct ProfileReq {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PutProfileEnvReq {
-    pub value: String,
+    /// A write-only literal. Exactly one of `value` and `secret_ref` is required.
+    #[serde(default)]
+    pub value: Option<String>,
+    /// A GCP Secret Manager version resource, resolved only at launch/respawn.
+    #[serde(default)]
+    pub secret_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -321,16 +330,34 @@ pub struct FederateReq {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FederationReq {
+    /// Stable operator-owned identity used for idempotent reconciliation.
+    pub name: String,
+    #[serde(default = "github_provider")]
+    pub provider: String,
     #[serde(default = "github_oidc_issuer")]
     pub issuer: String,
     pub audience: String,
-    pub repository_id: String,
-    pub workflow_ref: String,
+    /// Exact numeric OIDC subject for Google workload identities.
+    #[serde(default)]
+    pub subject: Option<String>,
+    /// Exact verified Google service-account email.
+    #[serde(default)]
+    pub service_account: Option<String>,
+    /// Stable, bounded audit label copied into Loom automation credentials.
+    pub service_tag: String,
+    #[serde(default)]
+    pub repository_id: Option<String>,
+    #[serde(default)]
+    pub workflow_ref: Option<String>,
     #[serde(default)]
     pub event_name: Option<String>,
     #[serde(default)]
     pub ref_pattern: Option<String>,
-    pub profile: String,
+    pub profiles: Vec<String>,
+}
+
+fn github_provider() -> String {
+    "github".to_string()
 }
 
 fn github_oidc_issuer() -> String {
@@ -340,14 +367,56 @@ fn github_oidc_issuer() -> String {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FederationView {
     pub id: String,
+    pub name: String,
+    pub provider: String,
     pub issuer: String,
     pub audience: String,
-    pub repository_id: String,
-    pub workflow_ref: String,
+    pub subject: Option<String>,
+    pub service_account: Option<String>,
+    pub service_tag: String,
+    pub repository_id: Option<String>,
+    pub workflow_ref: Option<String>,
     pub event_name: Option<String>,
     pub ref_pattern: Option<String>,
-    pub profile: String,
+    pub profiles: Vec<String>,
     pub created_at: String,
+    pub updated_at: String,
+}
+
+/// One named profile and its authoritative write-only environment declaration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentProfileReq {
+    pub profile: ProfileReq,
+    #[serde(default)]
+    pub env: Vec<DeploymentProfileEnvReq>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentProfileEnvReq {
+    pub name: String,
+    /// Omit both fields to preserve an existing write-only value by name.
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub secret_ref: Option<String>,
+}
+
+/// Declarative runtime resources rendered by Pulumi and reconciled by name.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DeploymentReq {
+    #[serde(default)]
+    pub profiles: Vec<DeploymentProfileReq>,
+    #[serde(default)]
+    pub federations: Vec<FederationReq>,
+    /// Remove previously deployment-managed resources omitted from this request.
+    #[serde(default)]
+    pub prune: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentView {
+    pub profiles: Vec<ProfileView>,
+    pub federations: Vec<FederationView>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -368,6 +437,7 @@ pub struct RunView {
     pub id: String,
     pub actor_subject: String,
     pub source: String,
+    pub service_tag: String,
     pub profile: String,
     pub idempotency_key: String,
     pub session_id: String,
@@ -376,6 +446,113 @@ pub struct RunView {
     pub summary: String,
     pub created_at: String,
     pub updated_at: String,
+}
+
+/// One migration stream's observed and expected state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MigrationStreamView {
+    pub stream: String,
+    pub current: i64,
+    pub expected: i64,
+    pub applied: i64,
+    pub ready: bool,
+}
+
+/// Public readiness response. Liveness remains the process-only `/api/health`;
+/// this shape proves that the database and both migration streams are usable.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadinessView {
+    pub status: String,
+    pub database: bool,
+    pub migrations: Vec<MigrationStreamView>,
+    /// Optional facilities may report degraded here without taking the API out
+    /// of service. Empty until remote runner pools exist.
+    pub degraded: Vec<String>,
+}
+
+/// A session count across every bounded control-plane dimension available in
+/// the current schema. `runner_pool` is `local` until runner pools land.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiagnosticSessionCount {
+    pub status: String,
+    pub class: String,
+    pub profile: String,
+    pub protocol: String,
+    pub runner_pool: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiagnosticProfileCapacity {
+    pub profile: String,
+    pub revision: i64,
+    pub active: i64,
+    /// `None` means unlimited (`max_concurrent = 0`).
+    pub maximum: Option<i64>,
+    pub available: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiagnosticRunCount {
+    pub status: String,
+    pub source: String,
+    pub service_tag: String,
+    pub profile: String,
+    pub count: i64,
+}
+
+/// A redacted recent failed run. Deliberately excludes actor, idempotency key,
+/// session id, request body, and raw failure summary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiagnosticRunFailure {
+    pub source: String,
+    pub profile: String,
+    pub outcome: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiagnosticRunSummary {
+    pub counts: Vec<DiagnosticRunCount>,
+    pub stale_creating: i64,
+    pub recent_failures: Vec<DiagnosticRunFailure>,
+}
+
+/// Aggregated orphan/error inventory. No session, branch, path, principal, or
+/// error text crosses this diagnostics boundary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiagnosticProblemSummary {
+    pub status: String,
+    pub class: String,
+    pub profile: String,
+    pub protocol: String,
+    pub runner_pool: String,
+    pub count: i64,
+    pub latest_activity_at: Option<String>,
+}
+
+/// Non-secret federation mapping metadata useful for verifying deployment
+/// reconciliation. This never includes a bearer/OIDC token or signing key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiagnosticFederation {
+    pub name: String,
+    pub provider: String,
+    pub audience: String,
+    pub service_tag: String,
+    pub profiles: Vec<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Admin-only operational snapshot returned by `/api/diagnostics`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiagnosticsView {
+    pub sessions: Vec<DiagnosticSessionCount>,
+    pub profiles: Vec<DiagnosticProfileCapacity>,
+    pub automation_runs: DiagnosticRunSummary,
+    pub problems: Vec<DiagnosticProblemSummary>,
+    pub migrations: Vec<MigrationStreamView>,
+    pub federations: Vec<DiagnosticFederation>,
 }
 
 fn default_class() -> String {

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -90,6 +90,14 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
     ),
 ];
 
+/// Latest core schema version compiled into this binary.
+///
+/// Health and diagnostics callers use this to distinguish "the database
+/// answers" from "the database has every migration this process expects".
+pub fn latest_version() -> i64 {
+    MIGRATIONS.last().map_or(0, |(version, _, _)| *version)
+}
+
 /// weaver-core's own stream. Kept private: the tables it manages are this
 /// crate's to migrate, and callers only ever need [`run`].
 const STREAM: Stream = Stream::new("schema_migrations", MIGRATIONS);

--- a/deploy/gcp/startup-script.sh
+++ b/deploy/gcp/startup-script.sh
@@ -89,6 +89,16 @@ if ! command -v gcloud >/dev/null 2>&1; then
   apt-get install -y --no-install-recommends google-cloud-cli
 fi
 
+# ---- Google Cloud Ops Agent (Prometheus receiver) --------------------------
+if ! dpkg-query -W -f='${Status}' google-cloud-ops-agent 2>/dev/null | grep -q 'ok installed'; then
+  echo "== installing Google Cloud Ops Agent =="
+  OPS_AGENT_INSTALLER=/tmp/add-google-cloud-ops-agent-repo.sh
+  curl -fsSLo "$OPS_AGENT_INSTALLER" \
+    https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+  bash "$OPS_AGENT_INSTALLER" --also-install
+  rm -f "$OPS_AGENT_INSTALLER"
+fi
+
 # ---- git (to clone the repo) ----------------------------------------------
 # Installed in its own command-guarded block, NOT bundled into the gcloud
 # install above: on a reboot where gcloud is already present that block is
@@ -198,6 +208,40 @@ if [ "$IMAGE_MODE" = "pull" ] && [ -n "$AR_IMAGE" ]; then
 else
   echo "== building and starting the stack =="
   docker compose up -d --build
+fi
+
+# ---- reconcile Pulumi-owned runtime policy ---------------------------------
+# The manifest contains profile policy, Secret Manager references, and exact
+# workload identities — never secret values. Apply it through Loom's REST API
+# from inside the container, where the machine-local credential already exists.
+DEPLOYMENT_FILE=/run/loom-deployment.json
+if meta instance/attributes/loom-deployment >"$DEPLOYMENT_FILE" 2>/dev/null && [ -s "$DEPLOYMENT_FILE" ]; then
+  echo "== waiting for loom before deployment reconciliation =="
+  for _ in $(seq 1 60); do
+    if curl -fsS http://127.0.0.1:7878/api/health >/dev/null; then
+      break
+    fi
+    sleep 2
+  done
+  if ! curl -fsS http://127.0.0.1:7878/api/health >/dev/null; then
+    echo "loom startup-script: loom did not become healthy for reconciliation" >&2
+    exit 1
+  fi
+  docker compose exec -T loom loom deployment apply --file - <"$DEPLOYMENT_FILE"
+  rm -f "$DEPLOYMENT_FILE"
+fi
+
+# Pulumi renders the Ops Agent receiver as instance metadata. The receiver
+# scrapes Loom's loopback-only `/metrics`; its service account can only write
+# telemetry and read explicitly referenced profile secrets.
+OPS_AGENT_CONFIG=/etc/google-cloud-ops-agent/config.yaml
+OPS_AGENT_PENDING=/run/loom-ops-agent.yaml
+if meta instance/attributes/loom-ops-agent-config >"$OPS_AGENT_PENDING" 2>/dev/null && [ -s "$OPS_AGENT_PENDING" ]; then
+  install -o root -g root -m 0644 "$OPS_AGENT_PENDING" "$OPS_AGENT_CONFIG"
+  rm -f "$OPS_AGENT_PENDING"
+  systemctl restart google-cloud-ops-agent
+else
+  rm -f "$OPS_AGENT_PENDING"
 fi
 
 echo "== loom startup-script done =="

--- a/deploy/pulumi/IMPORT.md
+++ b/deploy/pulumi/IMPORT.md
@@ -56,7 +56,26 @@ only then attach it under Pulumi. Otherwise the new empty Docker data root makes
 the old boot-disk volumes appear to vanish. Do not import old secret versions:
 setting `loomDotenv` creates a fresh version while preserving history.
 The snapshot policy, backup bucket/timer, WIF provider, and CI service account
-are new and need no import.
+are new and need no import. The readiness uptime check, alert policy, dashboard,
+Ops Agent configuration, and metric/log writer bindings are also new.
+
+If a service account named in `loom-gcp:workloads` already exists, import it
+before the first preview. The Pulumi logical name is `loom-workload-<name>` and
+the provider ID uses the configured `serviceAccountId`:
+
+```sh
+export WORKLOAD_NAME=marin-ops WORKLOAD_SERVICE_ACCOUNT=loom-marin-ops
+pulumi import gcp:serviceaccount/account:Account \
+  "loom-workload-${WORKLOAD_NAME}" \
+  "projects/${PROJECT}/serviceAccounts/${WORKLOAD_SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com"
+```
+
+Do not substitute an email address or display name into Loom's federation
+manifest. After import, Pulumi reads the account's immutable numeric `uniqueId`
+and exact email and renders both into the mapping. A preview that replaces an
+existing workload account means its configured `serviceAccountId` or import ID
+does not match; fix that before updating or every token minted for the former
+numeric subject will stop matching.
 
 Before accepting the update:
 
@@ -74,6 +93,10 @@ Before accepting the update:
 5. The legacy script granted Secret Manager access at project scope. Once the
    new secret-level binding is verified, remove that old project-level binding
    so the VM retains access only to `LOOM_DOTENV`.
+6. Confirm every secret reference declared under `profiles.*.env` exists and
+   that preview adds a secret-level accessor binding for the Loom VM. A missing
+   secret version fails closed when a session launches; it does not fall back to
+   an ambient or stale value.
 
 Pulumi may propose IAM-member additions and metadata changes on the first
 managed update; those are expected. A persistent-disk, address, secret, or VM

--- a/deploy/pulumi/Pulumi.example.yaml
+++ b/deploy/pulumi/Pulumi.example.yaml
@@ -20,3 +20,45 @@ config:
   # Build locally on the VM for the first deployment. After the image workflow
   # has published an image, change to pull and add imageTag with its commit SHA.
   loom-gcp:imageMode: build
+  # Runtime policy is reconciled through Loom's REST API on every startup
+  # generation. Environment values are Secret Manager references, never raw
+  # values in Pulumi state or VM metadata.
+  loom-gcp:profiles:
+    ops:
+      description: Marin operations automation
+      class: automation
+      agent: codex
+      protocol: acp
+      mode: plan
+      strict: true
+      envClear: true
+      ambientAllowlist: []
+      maxConcurrent: 1
+      turnBudget: 20
+      idleArchiveSeconds: 1800
+      env:
+        KUBECONFIG:
+          secretRef: projects/my-project/secrets/ops-kubeconfig/versions/latest
+  # Pulumi creates these service accounts and exports the non-secret client
+  # configuration a Cloud Run service or Grafana gateway consumes. Import an
+  # existing account at the generated resource URN before the first update.
+  loom-gcp:workloads:
+    - name: marin-ops
+      serviceAccountId: loom-marin-ops
+      serviceTag: marin-ops
+      profile: ops
+    - name: grafana
+      serviceAccountId: loom-grafana
+      serviceTag: grafana
+      profile: ops
+  loom-gcp:githubFederations:
+    - name: weaver-issues
+      repositoryId: "123456789"
+      workflowRef: rjpower/weaver/.github/workflows/loom-issue.yml@refs/heads/main
+      event: issues
+      ref: refs/heads/main
+      serviceTag: weaver-actions
+      profile: ops
+  # Optional Cloud Monitoring email channels for the managed readiness alert.
+  loom-gcp:alertEmails:
+    - operator@example.com

--- a/deploy/pulumi/README.md
+++ b/deploy/pulumi/README.md
@@ -76,39 +76,105 @@ The protected address, data disk, secret, and backup bucket make an accidental
 during an explicitly planned teardown. The boot disk is disposable; the
 separately attached data disk is retained when the VM is replaced.
 
-## Actions automation bring-up
+## Runtime profiles and workload identities
 
 Use one canonical public URL with no trailing slash. It is both the API base
-and the exact OIDC audience, so `https://loom.example.com` and
-`https://loom.example.com/` are intentionally different and the latter is
-rejected by the workflow.
+and exact OIDC audience. Declare profiles, their Secret Manager references,
+and workload bindings in `Pulumi.<stack>.yaml`; see
+[`Pulumi.example.yaml`](Pulumi.example.yaml) for a complete `ops` profile with
+Marin, Grafana, and GitHub Actions callers. Raw profile secret values are not
+accepted by the stack. Pulumi grants the Loom VM access only to the named
+secrets and places a non-secret reconciliation manifest in VM metadata.
 
-Create a strict, environment-cleared profile and then bind the exact workflow
-identity to it:
-
-```sh
-export LOOM_URL=https://loom.example.com
-loom profile add github-actions \
-  --agent codex --class automation --strict --env-clear \
-  --mode auto --max-concurrent 2 --turn-budget 100 --idle-archive-secs 28800
-loom profile env set github-actions GH_TOKEN '<fine-grained token>'
-
-repo=rjpower/weaver
-repo_id=$(gh api "repos/$repo" --jq .id)
-loom federation add \
-  --audience "$LOOM_URL" \
-  --repository-id "$repo_id" \
-  --workflow-ref "$repo/.github/workflows/loom-issue.yml@refs/heads/main" \
-  --event issues --ref refs/heads/main --profile github-actions
+```mermaid
+flowchart LR
+    P[Pulumi stack] -->|profile policy + secret refs| M[VM metadata manifest]
+    P -->|secret-level accessor| SM[Secret Manager]
+    P -->|service account| W[Cloud Run / GCE workload]
+    M -->|local admin API on startup| L[Loom]
+    L -->|resolve at session launch| SM
+    W -->|Google audience-bound ID token| F[POST /api/auth/federate]
+    F -->|10 minute Loom JWT| W
+    W -->|profile-scoped run| L
 ```
 
-Set repository variable `LOOM_URL` to that same value and, if the profile is
-not named `github-actions`, set `LOOM_PROFILE`. The opt-in
+On every startup generation, the VM waits for Loom readiness and runs `loom
+deployment apply` against the local REST API. Reconciliation is idempotent and
+prunes only profiles and identity mappings previously managed by the deployment
+manifest; operator-created resources are left alone. A referenced secret is
+resolved when a session launches or respawns, so rotating its Secret Manager
+version does not require storing a value in SQLite or Pulumi state.
+
+Each `workloads` entry creates a Google service account. Its immutable numeric
+subject and exact email address are bound to one declared profile. Grant that
+service account to the Cloud Run service (or other GCP workload), then consume
+the non-secret `workloadClients` stack output. The stdlib-only Python helper
+renews both sides of the exchange:
+
+```python
+from weaver_loom import Client, WorkloadCredentials
+
+credentials = WorkloadCredentials("https://loom.example.com")
+loom = Client(
+    base="https://loom.example.com",
+    credentials=credentials,
+    capabilities=["launch"],
+)
+run = loom.run(
+    "ops",
+    idempotency_key="incident-2026-07-22",
+    session={
+        "repo": "marin-community/marin",
+        "goal": "Investigate the production alert and report findings",
+    },
+    source="ops",
+)
+```
+
+No long-lived Loom token is stored in the caller. The helper gets an
+audience-bound Google identity token from the metadata server, exchanges it for
+a ten-minute profile-scoped Loom JWT, refreshes before expiry with jitter, and
+retries once after a 401. Revocation is immediate at the next exchange: remove
+the workload mapping with `pulumi up`, or detach/disable its service account.
+
+GitHub mappings are declared in `githubFederations`; use the repository's
+numeric `repositoryId`, exact workflow ref, event, and branch ref. Set repository
+variable `LOOM_URL` to the canonical stack URL and, if needed, set
+`LOOM_PROFILE`. The opt-in
 [`loom-issue.yml`](../../.github/workflows/loom-issue.yml) workflow then starts
 one retry-safe run when the `loom` label is added to an issue. It requests only
 `contents: read` and `id-token: write`; no long-lived Loom credential is stored
-in GitHub. Run `loom federation ls` to audit mappings and `loom profile show
-github-actions` to verify that secret values remain withheld.
+in GitHub. Run `loom federation ls`, `loom profile show ops`, and `pulumi stack
+output workloadClients` to audit the effective non-secret configuration.
+
+## Operations and debugging
+
+The VM runs the Google Cloud Ops Agent and scrapes Loom's loopback-only
+OpenMetrics endpoint every 30 seconds. Caddy deliberately returns 404 for the
+public `/metrics` path. Pulumi also creates:
+
+- a public HTTPS readiness uptime check at `/api/ready`;
+- a two-minute readiness alert, with optional email channels from
+  `alertEmails`; and
+- a Cloud Monitoring dashboard for current sessions and automation runs,
+  partitioned only by bounded status, profile, source, and mapped service labels.
+
+Use `/api/health` for liveness and `/api/ready` for dependency readiness. An
+authenticated administrator can open Settings → Diagnostics or request
+`/api/diagnostics` for current session/run counts, database migration state,
+task health, and process/runtime details. Diagnostics and metrics never include
+branch names, paths, user IDs, workload subjects, tokens, or raw error text.
+
+Useful first checks after a bring-up are:
+
+```sh
+curl -fsS https://loom.example.com/api/health
+curl -fsS https://loom.example.com/api/ready
+gcloud compute ssh loom --zone=us-central1-a \
+  --command='sudo systemctl status google-cloud-ops-agent; journalctl -u google-cloud-ops-agent -n 100'
+gcloud compute ssh loom --zone=us-central1-a \
+  --command='curl -fsS http://127.0.0.1:7878/metrics | head'
+```
 
 ## Backups
 

--- a/deploy/pulumi/infrastructure.py
+++ b/deploy/pulumi/infrastructure.py
@@ -819,7 +819,7 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
             },
             sort_keys=True,
         ),
-        opts=api_options,
+        opts=pulumi.ResourceOptions(depends_on=[instance]),
     )
 
     pulumi.export("address", address.address)

--- a/deploy/pulumi/infrastructure.py
+++ b/deploy/pulumi/infrastructure.py
@@ -7,9 +7,12 @@ the stack entry point.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pulumi
 import pulumi_gcp as gcp
@@ -24,6 +27,137 @@ def _positive_config_int(value: int | None, default: int, name: str) -> int:
     if resolved <= 0:
         raise ValueError(f"{name} must be positive")
     return resolved
+
+
+SECRET_REF = re.compile(
+    r"^projects/(?P<project>[a-z0-9-]+)/secrets/(?P<secret>[A-Za-z0-9_-]+)/versions/(?:latest|[0-9]+)$"
+)
+
+
+@dataclass(frozen=True)
+class WorkloadIdentityConfig:
+    name: str
+    profile: str
+    service_tag: str
+    service_account_id: str
+
+    @classmethod
+    def parse(cls, value: dict[str, Any]) -> "WorkloadIdentityConfig":
+        name = str(value.get("name", "")).strip()
+        profile = str(value.get("profile", "")).strip()
+        service_tag = str(value.get("serviceTag", name)).strip()
+        account_id = str(value.get("serviceAccountId", f"loom-{name}")).strip()
+        if not re.fullmatch(r"[a-z][a-z0-9-]{4,28}[a-z0-9]", account_id):
+            raise ValueError(f"invalid serviceAccountId for workload {name!r}")
+        if not name or not profile or not service_tag:
+            raise ValueError("workloads require name, profile, and serviceTag")
+        if not re.fullmatch(r"[a-z](?:[a-z0-9-]{0,62}[a-z0-9])?", name):
+            raise ValueError(f"invalid workload name {name!r}")
+        if not re.fullmatch(r"[A-Za-z0-9_.:-]{1,64}", service_tag):
+            raise ValueError(f"invalid serviceTag for workload {name!r}")
+        return cls(name, profile, service_tag, account_id)
+
+
+def _profile_manifest(
+    profiles: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """Translate stack-friendly camelCase profiles into Loom's REST contract."""
+    result: list[dict[str, Any]] = []
+    secret_refs: list[tuple[str, str]] = []
+    for name, raw in sorted(profiles.items()):
+        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]{0,63}", name):
+            raise ValueError(f"invalid profile name {name!r}")
+        agent = str(raw.get("agent", "")).strip()
+        if not agent:
+            raise ValueError(f"profile {name!r} requires agent")
+        profile = {
+            "name": name,
+            "description": str(raw.get("description", "")),
+            "agent_kind": agent,
+            "model": str(raw.get("model", "")),
+            "effort": str(raw.get("effort", "")),
+            "protocol": str(raw.get("protocol", "")),
+            "mode": str(raw.get("mode", "auto")),
+            "class": str(raw.get("class", "interactive")),
+            "strict": bool(raw.get("strict", False)),
+            "env_clear": bool(raw.get("envClear", False)),
+            "ambient_allowlist": list(raw.get("ambientAllowlist", [])),
+            "idle_archive_secs": raw.get("idleArchiveSeconds"),
+            "max_concurrent": int(raw.get("maxConcurrent", 0)),
+            "turn_budget": raw.get("turnBudget"),
+        }
+        env = []
+        for env_name, env_value in sorted(dict(raw.get("env", {})).items()):
+            if (
+                not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", env_name)
+                or env_name.startswith(("LOOM_", "WEAVER_"))
+            ):
+                raise ValueError(
+                    f"profile {name!r} has invalid environment name {env_name!r}"
+                )
+            if not isinstance(env_value, dict):
+                raise ValueError(
+                    f"profile {name!r} env {env_name!r} must use a full secretRef"
+                )
+            secret_ref = str(env_value.get("secretRef", "")).strip()
+            match = SECRET_REF.fullmatch(secret_ref)
+            if not match:
+                raise ValueError(
+                    f"profile {name!r} env {env_name!r} must use a full secretRef"
+                )
+            env.append({"name": env_name, "secret_ref": secret_ref})
+            secret_refs.append((match.group("project"), match.group("secret")))
+        result.append({"profile": profile, "env": env})
+    return result, secret_refs
+
+
+def _github_federation_manifest(
+    mappings: list[dict[str, Any]], audience: str
+) -> list[dict[str, Any]]:
+    result = []
+    for raw in mappings:
+        name = str(raw.get("name", "")).strip()
+        repository_id = str(raw.get("repositoryId", "")).strip()
+        workflow_ref = str(raw.get("workflowRef", "")).strip()
+        profile = str(raw.get("profile", "")).strip()
+        if not all((name, repository_id, workflow_ref, profile)):
+            raise ValueError(
+                "githubFederations require name, repositoryId, workflowRef, and profile"
+            )
+        result.append(
+            {
+                "name": name,
+                "provider": "github",
+                "issuer": "https://token.actions.githubusercontent.com",
+                "audience": audience,
+                "service_tag": str(raw.get("serviceTag", "github-actions")),
+                "repository_id": repository_id,
+                "workflow_ref": workflow_ref,
+                "event_name": raw.get("event"),
+                "ref_pattern": raw.get("ref"),
+                "profiles": [profile],
+            }
+        )
+    return result
+
+
+def _google_federation_mapping(
+    workload: WorkloadIdentityConfig,
+    audience: str,
+    email: str,
+    subject: str,
+) -> dict[str, Any]:
+    """Render the exact two-claim Google identity binding Loom verifies."""
+    return {
+        "name": workload.name,
+        "provider": "google",
+        "issuer": "https://accounts.google.com",
+        "audience": audience,
+        "subject": str(subject),
+        "service_account": email,
+        "service_tag": workload.service_tag,
+        "profiles": [workload.profile],
+    }
 
 
 @dataclass(frozen=True)
@@ -47,6 +181,10 @@ class DeploymentConfig:
     image_tag: str = "latest"
     github_repository: str = "rjpower/weaver"
     github_ref: str = "refs/heads/main"
+    profiles: dict[str, dict[str, Any]] | None = None
+    workloads: tuple[WorkloadIdentityConfig, ...] = ()
+    github_federations: tuple[dict[str, Any], ...] = ()
+    alert_emails: tuple[str, ...] = ()
     snapshot_retention_days: int = 14
     backup_retention_days: int = 30
 
@@ -64,6 +202,16 @@ class DeploymentConfig:
             ("backupRetentionDays", self.backup_retention_days),
         ):
             _positive_config_int(value, value, name)
+        profile_names = set((self.profiles or {}).keys())
+        workload_names: set[str] = set()
+        for workload in self.workloads:
+            if workload.name in workload_names:
+                raise ValueError(f"duplicate workload name {workload.name!r}")
+            if workload.profile not in profile_names:
+                raise ValueError(
+                    f"workload {workload.name!r} references unknown profile {workload.profile!r}"
+                )
+            workload_names.add(workload.name)
 
     @classmethod
     def from_pulumi(cls) -> "DeploymentConfig":
@@ -98,6 +246,16 @@ class DeploymentConfig:
             image_tag=config.get("imageTag") or "latest",
             github_repository=config.get("githubRepository") or "rjpower/weaver",
             github_ref=config.get("githubRef") or "refs/heads/main",
+            profiles=dict(config.get_object("profiles") or {}),
+            workloads=tuple(
+                WorkloadIdentityConfig.parse(value)
+                for value in list(config.get_object("workloads") or [])
+            ),
+            github_federations=tuple(
+                dict(value)
+                for value in list(config.get_object("githubFederations") or [])
+            ),
+            alert_emails=tuple(config.get_object("alertEmails") or []),
             snapshot_retention_days=_positive_config_int(
                 config.get_int("snapshotRetentionDays"), 14, "snapshotRetentionDays"
             ),
@@ -114,6 +272,9 @@ class Infrastructure:
     artifact_repository: gcp.artifactregistry.Repository
     backup_bucket: gcp.storage.Bucket
     workload_identity_provider: gcp.iam.WorkloadIdentityPoolProvider
+    workload_accounts: tuple[gcp.serviceaccount.Account, ...]
+    uptime_check: gcp.monitoring.UptimeCheckConfig
+    dashboard: gcp.monitoring.Dashboard
 
 
 def _enable_apis(project: str) -> list[gcp.projects.Service]:
@@ -123,6 +284,8 @@ def _enable_apis(project: str) -> list[gcp.projects.Service]:
         "dns.googleapis.com",
         "iam.googleapis.com",
         "iamcredentials.googleapis.com",
+        "logging.googleapis.com",
+        "monitoring.googleapis.com",
         "secretmanager.googleapis.com",
         "sts.googleapis.com",
         "storage.googleapis.com",
@@ -157,6 +320,77 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
         display_name="GitHub Actions loom image publisher",
         opts=api_options,
     )
+
+    profile_manifest, profile_secret_refs = _profile_manifest(config.profiles or {})
+    audience = f"https://{config.domain.rstrip('/')}"
+    workload_accounts: list[gcp.serviceaccount.Account] = []
+    workload_mapping_outputs: list[pulumi.Output[dict[str, Any]]] = []
+    workload_client_outputs: list[pulumi.Output[dict[str, str]]] = []
+    for workload in config.workloads:
+        resource_name = re.sub(r"[^a-z0-9-]", "-", workload.name.lower())
+        account = gcp.serviceaccount.Account(
+            f"loom-workload-{resource_name}",
+            project=config.project,
+            account_id=workload.service_account_id,
+            display_name=f"Loom workload: {workload.name}",
+            opts=api_options,
+        )
+        workload_accounts.append(account)
+        workload_mapping_outputs.append(
+            pulumi.Output.all(account.email, account.unique_id).apply(
+                lambda values, workload=workload: _google_federation_mapping(
+                    workload, audience, values[0], values[1]
+                )
+            )
+        )
+        workload_client_outputs.append(
+            account.email.apply(
+                lambda email, workload=workload: {
+                    "name": workload.name,
+                    "serviceAccount": email,
+                    "loomUrl": audience,
+                    "tokenAudience": audience,
+                    "profile": workload.profile,
+                    "serviceTag": workload.service_tag,
+                }
+            )
+        )
+    github_mappings = _github_federation_manifest(
+        list(config.github_federations), audience
+    )
+    def render_deployment_manifest(workload_mappings: list[dict[str, Any]]) -> str:
+        return json.dumps(
+            {
+                "profiles": profile_manifest,
+                "federations": github_mappings + workload_mappings,
+                "prune": True,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    deployment_manifest: pulumi.Input[str]
+    if workload_mapping_outputs:
+        deployment_manifest = pulumi.Output.all(*workload_mapping_outputs).apply(
+            lambda workload_mappings: render_deployment_manifest(
+                list(workload_mappings)
+            )
+        )
+    else:
+        deployment_manifest = render_deployment_manifest([])
+    vm_observability_grants = [
+        gcp.projects.IAMMember(
+            f"loom-vm-{suffix}",
+            project=config.project,
+            role=role,
+            member=vm_account.email.apply(lambda email: f"serviceAccount:{email}"),
+            opts=api_options,
+        )
+        for suffix, role in (
+            ("metric-writer", "roles/monitoring.metricWriter"),
+            ("log-writer", "roles/logging.logWriter"),
+        )
+    ]
 
     artifact_repository = gcp.artifactregistry.Repository(
         "loom-images",
@@ -287,6 +521,23 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
         role="roles/secretmanager.secretAccessor",
         member=vm_account.email.apply(lambda email: f"serviceAccount:{email}"),
     )
+    profile_secret_readers = []
+    for secret_project, secret_name in sorted(set(profile_secret_refs)):
+        suffix = hashlib.sha256(
+            f"{secret_project}/{secret_name}".encode()
+        ).hexdigest()[:10]
+        profile_secret_readers.append(
+            gcp.secretmanager.SecretIamMember(
+                f"loom-profile-secret-{suffix}",
+                project=secret_project,
+                secret_id=secret_name,
+                role="roles/secretmanager.secretAccessor",
+                member=vm_account.email.apply(
+                    lambda email: f"serviceAccount:{email}"
+                ),
+                opts=api_options,
+            )
+        )
 
     backup_bucket = gcp.storage.Bucket(
         "loom-backups",
@@ -362,6 +613,22 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
         "image-mode": config.image_mode,
         "ar-image": image,
         "backup-bucket": backup_bucket.name,
+        "loom-deployment": deployment_manifest,
+        "loom-ops-agent-config": """metrics:
+  receivers:
+    loom:
+      type: prometheus
+      config:
+        scrape_configs:
+          - job_name: loom
+            scrape_interval: 30s
+            static_configs:
+              - targets: [\"127.0.0.1:7878\"]
+  service:
+    pipelines:
+      loom:
+        receivers: [loom]
+""",
     }
     dependencies: list[pulumi.Resource] = [
         web_firewall,
@@ -374,6 +641,8 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
         backup_bucket,
         vm_backup_writer,
         snapshot_attachment,
+        *profile_secret_readers,
+        *vm_observability_grants,
     ]
     if dns_record:
         dependencies.append(dns_record)
@@ -417,6 +686,142 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
         opts=pulumi.ResourceOptions(depends_on=dependencies),
     )
 
+    uptime_check = gcp.monitoring.UptimeCheckConfig(
+        "loom-readiness",
+        project=config.project,
+        display_name="Loom readiness",
+        period="60s",
+        timeout="10s",
+        log_check_failures=True,
+        http_check={
+            "path": "/api/ready",
+            "port": 443,
+            "request_method": "GET",
+            "use_ssl": True,
+            "validate_ssl": True,
+        },
+        monitored_resource={
+            "type": "uptime_url",
+            "labels": {"project_id": config.project, "host": config.domain},
+        },
+        opts=pulumi.ResourceOptions(depends_on=[instance]),
+    )
+    notification_channels = [
+        gcp.monitoring.NotificationChannel(
+            f"loom-alert-email-{index}",
+            project=config.project,
+            display_name=f"Loom operator {email}",
+            type="email",
+            labels={"email_address": email},
+            opts=api_options,
+        )
+        for index, email in enumerate(config.alert_emails)
+    ]
+    gcp.monitoring.AlertPolicy(
+        "loom-readiness-failed",
+        project=config.project,
+        display_name="Loom is not ready",
+        combiner="OR",
+        notification_channels=[channel.name for channel in notification_channels],
+        conditions=[
+            {
+                "display_name": "Public readiness probes are failing",
+                "condition_threshold": {
+                    "filter": (
+                        'metric.type="monitoring.googleapis.com/uptime_check/check_passed" '
+                        'AND resource.type="uptime_url" '
+                        f'AND resource.label.host="{config.domain}"'
+                    ),
+                    "duration": "120s",
+                    "comparison": "COMPARISON_LT",
+                    "threshold_value": 1,
+                    "aggregations": [
+                        {
+                            "alignment_period": "120s",
+                            "per_series_aligner": "ALIGN_NEXT_OLDER",
+                            "cross_series_reducer": "REDUCE_COUNT_TRUE",
+                            "group_by_fields": ["resource.label.host"],
+                        }
+                    ],
+                    "evaluation_missing_data": "EVALUATION_MISSING_DATA_ACTIVE",
+                },
+            }
+        ],
+        alert_strategy={"auto_close": "1800s"},
+        documentation={
+            "content": (
+                f"Loom readiness at {audience}/api/ready has failed for two minutes. "
+                "Inspect /api/diagnostics and the loom startup journal."
+            ),
+            "mime_type": "text/markdown",
+        },
+        opts=pulumi.ResourceOptions(depends_on=[uptime_check]),
+    )
+    dashboard = gcp.monitoring.Dashboard(
+        "loom-operations",
+        project=config.project,
+        dashboard_json=json.dumps(
+            {
+                "displayName": "Loom operations",
+                "mosaicLayout": {
+                    "columns": 12,
+                    "tiles": [
+                        {
+                            "xPos": 0,
+                            "yPos": 0,
+                            "width": 6,
+                            "height": 4,
+                            "widget": {
+                                "title": "Current sessions by state",
+                                "xyChart": {
+                                    "dataSets": [
+                                        {
+                                            "plotType": "LINE",
+                                            "targetAxis": "Y1",
+                                            "timeSeriesQuery": {
+                                                "prometheusQuery": (
+                                                    "sum by (status, profile) "
+                                                    "(loom_sessions_current)"
+                                                )
+                                            },
+                                        }
+                                    ],
+                                    "yAxis": {"label": "sessions", "scale": "LINEAR"},
+                                },
+                            },
+                        },
+                        {
+                            "xPos": 6,
+                            "yPos": 0,
+                            "width": 6,
+                            "height": 4,
+                            "widget": {
+                                "title": "Automation runs by state",
+                                "xyChart": {
+                                    "dataSets": [
+                                        {
+                                            "plotType": "STACKED_BAR",
+                                            "targetAxis": "Y1",
+                                            "timeSeriesQuery": {
+                                                "prometheusQuery": (
+                                                    "sum by (status, source, service, profile) "
+                                                    "(loom_automation_runs_current)"
+                                                )
+                                            },
+                                        }
+                                    ],
+                                    "yAxis": {"label": "runs", "scale": "LINEAR"},
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+            sort_keys=True,
+        ),
+        opts=api_options,
+    )
+
     pulumi.export("address", address.address)
     pulumi.export("url", f"https://{config.domain}/")
     pulumi.export("instanceName", instance.name)
@@ -425,6 +830,15 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
     pulumi.export("backupBucket", backup_bucket.url)
     pulumi.export("githubWorkloadIdentityProvider", workload_provider.name)
     pulumi.export("githubServiceAccount", ci_account.email)
+    pulumi.export("tokenAudience", audience)
+    pulumi.export("profileNames", sorted((config.profiles or {}).keys()))
+    pulumi.export(
+        "workloadClients",
+        pulumi.Output.all(*workload_client_outputs)
+        if workload_client_outputs
+        else [],
+    )
+    pulumi.export("monitoringDashboard", dashboard.id)
     if not config.dns_managed_zone:
         pulumi.log.warn(
             "dnsManagedZone is unset: create the exported address's A record "
@@ -437,4 +851,7 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
         artifact_repository=artifact_repository,
         backup_bucket=backup_bucket,
         workload_identity_provider=workload_provider,
+        workload_accounts=tuple(workload_accounts),
+        uptime_check=uptime_check,
+        dashboard=dashboard,
     )

--- a/deploy/pulumi/infrastructure.py
+++ b/deploy/pulumi/infrastructure.py
@@ -717,7 +717,7 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
         )
         for index, email in enumerate(config.alert_emails)
     ]
-    gcp.monitoring.AlertPolicy(
+    readiness_alert = gcp.monitoring.AlertPolicy(
         "loom-readiness-failed",
         project=config.project,
         display_name="Loom is not ready",
@@ -819,7 +819,7 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
             },
             sort_keys=True,
         ),
-        opts=pulumi.ResourceOptions(depends_on=[instance]),
+        opts=pulumi.ResourceOptions(depends_on=[instance, readiness_alert]),
     )
 
     pulumi.export("address", address.address)

--- a/deploy/pulumi/tests/test_infrastructure.py
+++ b/deploy/pulumi/tests/test_infrastructure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 import re
 
 import pulumi
@@ -20,6 +21,8 @@ class RecordingMocks(Mocks):
             outputs["address"] = "203.0.113.10"
         if args.typ == "gcp:serviceaccount/account:Account":
             outputs["email"] = f"{args.name}@example.iam.gserviceaccount.com"
+            outputs["uniqueId"] = "11223344556677889900"
+            outputs["unique_id"] = "11223344556677889900"
         if args.typ == "gcp:storage/bucket:Bucket":
             outputs["url"] = f"gs://{args.name}"
         return f"{args.name}_id", outputs
@@ -33,7 +36,10 @@ pulumi.runtime.set_mocks(mocks, project="loom-gcp", stack="test", preview=False)
 
 from infrastructure import (  # noqa: E402
     DeploymentConfig,
+    WorkloadIdentityConfig,
+    _google_federation_mapping,
     _positive_config_int,
+    _profile_manifest,
     create_infrastructure,
 )
 
@@ -51,6 +57,32 @@ def make_infrastructure():
             dns_managed_zone="example-zone",
             image_mode="pull",
             image_tag="0123456789abcdef0123456789abcdef01234567",
+            profiles={
+                "ops": {
+                    "agent": "codex",
+                    "protocol": "acp",
+                    "mode": "plan",
+                    "class": "automation",
+                    "strict": True,
+                    "envClear": True,
+                    "maxConcurrent": 1,
+                    "env": {
+                        "KUBECONFIG": {
+                            "secretRef": "projects/example/secrets/ops-kubeconfig/versions/latest"
+                        }
+                    },
+                }
+            },
+            workloads=(
+                WorkloadIdentityConfig.parse(
+                    {
+                        "name": "marin-ops",
+                        "profile": "ops",
+                        "serviceTag": "marin-ops",
+                        "serviceAccountId": "loom-marin-ops",
+                    }
+                ),
+            ),
         )
     )
 
@@ -74,6 +106,66 @@ def test_pull_mode_requires_a_commit_sha() -> None:
             loom_dotenv="LOOM_DOMAIN=loom.example.com\n",
             image_mode="pull",
             image_tag="latest",
+        )
+
+
+def test_profile_manifest_accepts_references_but_not_secret_values() -> None:
+    profiles, references = _profile_manifest(
+        {
+            "ops": {
+                "agent": "codex",
+                "strict": True,
+                "envClear": True,
+                "env": {
+                    "OPS_TOKEN": {
+                        "secretRef": "projects/example/secrets/ops-token/versions/7"
+                    }
+                },
+            }
+        }
+    )
+    assert profiles[0]["env"] == [
+        {
+            "name": "OPS_TOKEN",
+            "secret_ref": "projects/example/secrets/ops-token/versions/7",
+        }
+    ]
+    assert references == [("example", "ops-token")]
+    with pytest.raises(ValueError, match="full secretRef"):
+        _profile_manifest(
+            {"ops": {"agent": "codex", "env": {"OPS_TOKEN": "plaintext"}}}
+        )
+
+
+def test_google_mapping_binds_numeric_subject_email_and_profile() -> None:
+    workload = WorkloadIdentityConfig.parse(
+        {
+            "name": "marin-ops",
+            "profile": "ops",
+            "serviceTag": "marin-ops",
+            "serviceAccountId": "loom-marin-ops",
+        }
+    )
+    mapping = _google_federation_mapping(
+        workload,
+        "https://loom.example.com",
+        "loom-marin-ops@example.iam.gserviceaccount.com",
+        "11223344556677889900",
+    )
+    assert mapping["subject"] == "11223344556677889900"
+    assert mapping["service_account"].endswith(".iam.gserviceaccount.com")
+    assert mapping["profiles"] == ["ops"]
+
+
+@pytest.mark.parametrize("account_id", ["short", "a" * 31, "Upper-case"])
+def test_workload_service_account_ids_follow_gcp_limits(account_id: str) -> None:
+    with pytest.raises(ValueError, match="serviceAccountId"):
+        WorkloadIdentityConfig.parse(
+            {
+                "name": "marin-ops",
+                "profile": "ops",
+                "serviceAccountId": account_id,
+            }
         )
 
 
@@ -136,12 +228,14 @@ def test_wif_is_repository_and_main_bound_with_least_privilege_iam():
 
 def test_iam_roles_are_narrow() -> None:
     source = inspect.getsource(create_infrastructure)
-    assert set(re.findall(r'role="([^"]+)"', source)) == {
+    assert set(re.findall(r'"(roles/[^"]+)"', source)) == {
         "roles/iam.workloadIdentityUser",
         "roles/artifactregistry.writer",
         "roles/artifactregistry.reader",
         "roles/secretmanager.secretAccessor",
         "roles/storage.objectCreator",
+        "roles/monitoring.metricWriter",
+        "roles/logging.logWriter",
     }
 
 
@@ -157,6 +251,36 @@ def test_backup_bucket_enforces_public_access_prevention():
         assert prevention == "enforced"
 
     return infrastructure.instance.id.apply(check)
+
+
+@pulumi.runtime.test
+def test_profiles_workload_identity_and_monitoring_are_declarative():
+    infrastructure = make_infrastructure()
+
+    def check(_: object) -> None:
+        names = [resource.name for resource in mocks.resources]
+        assert "loom-workload-marin-ops" in names
+        assert "loom-profile-secret-" in " ".join(names)
+        assert "loom-readiness" in names
+        assert "loom-operations" in names
+        assert "loom-readiness-failed" in names
+
+        vm = by_name("loom")
+        manifest = json.loads(vm.inputs["metadata"]["loom-deployment"])
+        assert manifest["prune"] is True
+        assert manifest["profiles"][0]["profile"]["name"] == "ops"
+        env = manifest["profiles"][0]["env"][0]
+        assert env == {
+            "name": "KUBECONFIG",
+            "secret_ref": "projects/example/secrets/ops-kubeconfig/versions/latest",
+        }
+        mapping = manifest["federations"][0]
+        assert mapping["provider"] == "google"
+        assert mapping["subject"] == "11223344556677889900"
+        assert mapping["service_account"].endswith(".iam.gserviceaccount.com")
+        assert mapping["profiles"] == ["ops"]
+
+    return infrastructure.dashboard.id.apply(check)
 
 
 @pulumi.runtime.test

--- a/deploy/pulumi/tests/test_static_contract.py
+++ b/deploy/pulumi/tests/test_static_contract.py
@@ -34,6 +34,9 @@ class InfrastructureSourceContract(unittest.TestCase):
                 "gcp.artifactregistry.Repository",
                 "gcp.iam.WorkloadIdentityPool",
                 "gcp.iam.WorkloadIdentityPoolProvider",
+                "gcp.monitoring.UptimeCheckConfig",
+                "gcp.monitoring.AlertPolicy",
+                "gcp.monitoring.Dashboard",
             }.issubset(calls)
         )
 

--- a/deploy/standalone/Caddyfile
+++ b/deploy/standalone/Caddyfile
@@ -15,6 +15,11 @@
 # }
 
 {$LOOM_DOMAIN} {
+	# Prometheus metrics are scraped over the VM's loopback-only compose port.
+	# Profile names and fleet counts are operational metadata, not a public API.
+	@metrics path /metrics
+	respond @metrics 404
+
 	# A single upstream: the loom daemon, reached by its compose service name.
 	# Caddy's reverse_proxy is all loom needs from a front-door:
 	#

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -59,6 +59,10 @@ services:
         condition: service_completed_successfully
     expose:
       - "7878" # internal to the compose network only — never published
+    ports:
+      # Loopback-only scrape/debug path for the host's Ops Agent. Caddy remains
+      # the sole public listener and explicitly blocks `/metrics`.
+      - "127.0.0.1:7878:7878"
     # Docker-out-of-Docker: a session's `docker build`/`docker compose` talks to
     # the HOST's Docker daemon over its bind-mounted socket (volumes, below), so
     # builds run on the host — reusing its layer cache and writing images/layers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -245,11 +245,15 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 
 | Method + path | What it does |
 |---|---|
-| `GET /api/health` | liveness probe |
+| `GET /api/health` / `GET /api/health/live` | public, process-only liveness probes (`/api/health` is the compatibility alias) |
+| `GET /api/ready` | public structured readiness: database access plus core and loom migration versions; optional future remote runner degradation will be reported without failing the whole API |
+| `GET /metrics` | public OpenMetrics scrape derived from durable session/profile/run/migration state; labels are bounded operational dimensions and never contain session/branch/path/user/token/error values (deployments normally restrict this at the public edge) |
+| `GET /api/diagnostics` | admin-only redacted counts, profile capacity, automation failures/staleness, orphan/error inventory, migration state, and non-secret federation metadata; backs Settings → Diagnostics |
 | `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false` — and `automation` — default `false`; create resolves `profile` or `default`, permits launch selectors only when the profile is non-strict, stamps the resolved profile revision/policy, opens a tracking issue, and returns its id as `tracking_issue`) |
 | `GET POST /api/profiles`; `GET PUT DELETE /api/profiles/{name}` | named launch-policy CRUD; profile secret values are never returned |
-| `PUT DELETE /api/profiles/{profile}/env/{name}` | write-only profile environment management |
-| `POST /api/auth/federate` | exchange a mapped, verified OIDC identity for a short-lived Ed25519-signed Loom automation token |
+| `PUT DELETE /api/profiles/{profile}/env/{name}` | write-only profile environment management; a write supplies exactly one literal `value` or a full GCP Secret Manager `secret_ref`, and reads expose only source/reference metadata |
+| `POST /api/deployment/reconcile` | admin-only idempotent reconciliation of deployment-managed profiles, environment references, and federation mappings; pruning never touches operator-managed rows |
+| `POST /api/auth/federate` | exchange an exact mapped, signature-verified GitHub or Google OIDC identity for a ten-minute Ed25519-signed, profile-scoped Loom automation token |
 | `GET POST /api/runs`; `GET /api/runs/{id}` | durable, subject-scoped automation runs with idempotency reservation |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear a branch tag — the well-known `attention` and `triage` keys plus any free-form key |
@@ -628,9 +632,14 @@ while gating who may drive the fleet. The core (crypto, the tables, the
 GitHub OAuth calls) lives in `crate::auth`, deliberately `axum`-free; the HTTP
 glue (the middleware, cookie handling, route handlers) lives in `crate::web`.
 
-Every `/api` route except the public login surface (`/api/health`,
-`/api/auth/me`, `/api/auth/login`, `/api/auth/logout`, `/api/auth/github/*`) and
-the static SPA passes through the `require_auth` middleware, which resolves the
+Every `/api` route except the public health surface (`/api/health`,
+`/api/health/live`, `/api/health/ready`, `/api/ready`), the public login surface
+(`/api/auth/me`, `/api/auth/login`, `/api/auth/logout`, `/api/auth/github/*`),
+the OIDC-authenticated `/api/auth/federate`, and the HMAC-authenticated GitHub
+webhook passes through the `require_auth` middleware. The root `/metrics`
+aggregate scrape is also public (and intended
+to be restricted to the host metrics agent at the deployment edge). The static
+SPA needs no API principal. Protected requests resolve the
 request to a `Principal` three ways, in order:
 
 - **API token** — an `Authorization: Bearer loom_…` header. This is the
@@ -676,6 +685,22 @@ behind a **same-host reverse proxy** (where forwarded requests look like
 loopback and so trust must be off) local automation still authenticates via this
 token, while remote callers must present their own. The local token is hidden
 from the token list and is not revocable from the UI.
+
+**Workload federation.** An admin-managed federation mapping fixes the provider,
+issuer, exact audience, identity, service tag, and allowed strict automation
+profiles. GitHub mappings bind the numeric repository id plus exact workflow
+ref, with optional event/ref restrictions. Google mappings bind both the
+service account's immutable numeric `sub` and exact `email`; the verified token
+must also carry `email_verified = true`. Loom selects a candidate mapping only
+to discover its configured JWKS endpoint, then verifies signature, issuer,
+audience, algorithm, and all identity claims before minting. Google and the
+production GitHub issuer require RS256. The resulting token has only the
+`automation` grant and mapped profiles, carries non-secret provider/service-tag
+audit context, and expires after ten minutes. A caller obtains a new Google ID
+token and exchanges again; no refresh token or service-account key is stored by
+Loom. Automation run records and metrics persist the mapping's bounded service
+tag, so operators can distinguish Marin, Grafana, and Actions traffic without
+using the workload subject as an observability label.
 
 **Cookies** are `HttpOnly; SameSite=Lax; Path=/`; the `Secure` attribute is
 added when `auth.cookie_secure` is on (set it when loom is reached over HTTPS).

--- a/python/weaver-loom/README.md
+++ b/python/weaver-loom/README.md
@@ -23,3 +23,36 @@ rnd.finish(f"surveyed {rnd.surveyed}, {len(rnd.actions)} findings")
 
 The builtin programs under `crates/loom/watches/` are working examples;
 the program contract is documented in `docs/ARCHITECTURE.md` (Watches).
+
+## Google workload credentials
+
+Cloud Run, GCE, and other metadata-enabled Google workloads can authenticate
+without a stored Loom token. Pulumi binds the workload service account's exact
+numeric subject and email to a strict automation profile; `WorkloadCredentials`
+retrieves an audience-bound Google identity token and exchanges it for a
+short-lived, profile-scoped Loom JWT.
+
+```python
+from weaver_loom import Client, WorkloadCredentials
+
+base = "https://loom.example.com"
+client = Client(
+    base=base,
+    credentials=WorkloadCredentials(base),
+    capabilities=["launch"],
+)
+run = client.run(
+    "ops",
+    idempotency_key="dashboard-alert-1842",
+    session={
+        "repo": "marin-community/marin",
+        "goal": "Investigate alert 1842 and summarize the result",
+    },
+    source="ops",
+)
+```
+
+Credentials are cached only in memory, refreshed early with jitter, and
+invalidated for one retry after a 401. The helper never logs either upstream or
+Loom tokens. The caller still needs the `launch` capability in its client
+capability set if it constructs `Client` with an explicit restricted set.

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -48,7 +48,10 @@ from the weaver repo with ``uv pip install -e python/weaver-loom``.
 
 import json
 import os
+import random
 import subprocess
+import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -165,6 +168,98 @@ class CapabilityDenied(WeaverError):
     """A mutating call attempted without the capability it requires."""
 
 
+class WorkloadCredentials:
+    """Renewable Loom credentials backed by a Google workload identity.
+
+    The Google token is audience-bound and exchanged immediately; neither it
+    nor the short-lived Loom JWT is logged or persisted. This stdlib-only helper
+    works in Cloud Run, GCE, and any workload with the Compute metadata server.
+    """
+
+    METADATA_IDENTITY_URL = (
+        "http://metadata.google.internal/computeMetadata/v1/instance/"
+        "service-accounts/default/identity"
+    )
+
+    def __init__(
+        self,
+        loom_url,
+        audience=None,
+        refresh_margin=90,
+        clock=time.time,
+        metadata_url=None,
+    ):
+        self.loom_url = _base_url(loom_url)
+        self.audience = (audience or self.loom_url).rstrip("/")
+        self.refresh_margin = refresh_margin
+        self._clock = clock
+        self._metadata_url = metadata_url or self.METADATA_IDENTITY_URL
+        self._token = None
+        self._expires_at = 0
+        self._refresh_jitter = 0
+        self._lock = threading.Lock()
+
+    def invalidate(self):
+        """Force the next request to perform a fresh identity exchange."""
+        with self._lock:
+            self._token = None
+            self._expires_at = 0
+
+    def token(self):
+        """Return a cached Loom JWT, refreshing before expiry with jitter."""
+        with self._lock:
+            now = self._clock()
+            if self._token and now < (
+                self._expires_at - self.refresh_margin - self._refresh_jitter
+            ):
+                return self._token
+            google_token = self._google_identity_token()
+            request = urllib.request.Request(
+                self.loom_url + "/api/auth/federate",
+                data=json.dumps({"token": google_token}).encode(),
+                method="POST",
+                headers={"Content-Type": "application/json"},
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=15) as response:
+                    exchanged = json.loads(response.read())
+            except urllib.error.HTTPError as error:
+                # Deliberately exclude the response body: an upstream must not
+                # trick a service into reflecting either credential into logs.
+                raise WeaverError(
+                    f"POST /auth/federate: HTTP {error.code}"
+                ) from None
+            except urllib.error.URLError as error:
+                raise WeaverError(f"POST /auth/federate: {error.reason}") from None
+            token = exchanged.get("token")
+            expires_at = exchanged.get("expires_at")
+            if not token or not isinstance(expires_at, int):
+                raise WeaverError("POST /auth/federate: invalid credential response")
+            self._token = token
+            self._expires_at = expires_at
+            self._refresh_jitter = random.uniform(0, 30)
+            return token
+
+    def _google_identity_token(self):
+        query = urllib.parse.urlencode(
+            {"audience": self.audience, "format": "full"}
+        )
+        request = urllib.request.Request(
+            self._metadata_url + "?" + query,
+            headers={"Metadata-Flavor": "Google"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                token = response.read().decode().strip()
+        except urllib.error.HTTPError as error:
+            raise WeaverError(f"Google identity token: HTTP {error.code}") from None
+        except urllib.error.URLError as error:
+            raise WeaverError(f"Google identity token: {error.reason}") from None
+        if token.count(".") != 2:
+            raise WeaverError("Google identity token: invalid response")
+        return token
+
+
 def gh_json(args, cwd=None, timeout=30):
     """Run ``gh <args>`` and parse its stdout as JSON.
 
@@ -215,9 +310,10 @@ class Client:
     construction. Sessions and branches cross as plain dicts.
     """
 
-    def __init__(self, base=None, capabilities=None):
+    def __init__(self, base=None, capabilities=None, credentials=None):
         self.base = _base_url(base)
         self.capabilities = list(capabilities or [])
+        self.credentials = credentials
 
     def can(self, cap):
         """Whether this client holds ``cap`` (``observe`` is always held)."""
@@ -235,18 +331,28 @@ class Client:
         headers = {"Content-Type": "application/json"} if data else {}
         # The engine injects $LOOM_TOKEN (the machine-local token); present it so
         # the round authenticates even when loopback trust is off.
-        token = (os.environ.get("LOOM_TOKEN") or "").strip()
+        token = (
+            self.credentials.token()
+            if self.credentials is not None
+            else (os.environ.get("LOOM_TOKEN") or "").strip()
+        )
         if token:
             headers["Authorization"] = "Bearer " + token
-        req = urllib.request.Request(url, data=data, method=method, headers=headers)
-        try:
-            with urllib.request.urlopen(req) as resp:
-                raw = resp.read()
-        except urllib.error.HTTPError as e:
-            detail = e.read().decode("utf-8", errors="replace").strip()
-            raise WeaverError(f"{method} {path}: HTTP {e.code}: {detail}") from None
-        except urllib.error.URLError as e:
-            raise WeaverError(f"{method} {path}: {e.reason}") from None
+        for attempt in range(2):
+            req = urllib.request.Request(url, data=data, method=method, headers=headers)
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    raw = resp.read()
+                break
+            except urllib.error.HTTPError as e:
+                if e.code == 401 and self.credentials is not None and attempt == 0:
+                    self.credentials.invalidate()
+                    headers["Authorization"] = "Bearer " + self.credentials.token()
+                    continue
+                detail = e.read().decode("utf-8", errors="replace").strip()
+                raise WeaverError(f"{method} {path}: HTTP {e.code}: {detail}") from None
+            except urllib.error.URLError as e:
+                raise WeaverError(f"{method} {path}: {e.reason}") from None
         return json.loads(raw) if raw else None
 
     # -- Reads (observe) ----------------------------------------------------
@@ -283,6 +389,20 @@ class Client:
             {"prompt": prompt, "model": model or "", "effort": effort or ""},
         )
         return (reply or {}).get("output")
+
+    def run(self, profile, idempotency_key, session, source="ops"):
+        """Create an idempotent profile-scoped automation run; needs ``launch``."""
+        self._gate("launch")
+        return self._request(
+            "POST",
+            "/runs",
+            {
+                "profile": profile,
+                "idempotency_key": idempotency_key,
+                "source": source,
+                "session": session,
+            },
+        )
 
     # -- Writes (capability-gated) --------------------------------------------
 

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -9,7 +9,10 @@ builtin scripts against a real loom.
 """
 
 import json
+import io
 import subprocess
+import urllib.error
+import urllib.request
 
 import pytest
 from weaver_loom import (
@@ -18,10 +21,80 @@ from weaver_loom import (
     Client,
     Round,
     WeaverError,
+    WorkloadCredentials,
     gh_json,
     parse_judgement,
     parse_tag_recommendations,
 )
+
+
+class Response:
+    def __init__(self, body):
+        self.body = body.encode() if isinstance(body, str) else body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self.body
+
+
+def test_workload_credentials_exchange_once_and_cache(monkeypatch):
+    requests = []
+
+    def urlopen(request, timeout=None):
+        requests.append(request)
+        if "metadata" in request.full_url:
+            return Response("header.payload.signature")
+        return Response('{"token":"loom-jwt","expires_at":2000}')
+
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+    credentials = WorkloadCredentials(
+        "https://loom.example.com", clock=lambda: 1000
+    )
+    assert credentials.token() == "loom-jwt"
+    assert credentials.token() == "loom-jwt"
+    assert len(requests) == 2
+    assert "audience=https%3A%2F%2Floom.example.com" in requests[0].full_url
+    assert requests[0].headers["Metadata-flavor"] == "Google"
+    assert json.loads(requests[1].data) == {"token": "header.payload.signature"}
+
+
+def test_client_retries_one_unauthorized_request_with_refreshed_workload_token(
+    monkeypatch,
+):
+    class Credentials:
+        def __init__(self):
+            self.generation = 1
+            self.invalidations = 0
+
+        def token(self):
+            return f"token-{self.generation}"
+
+        def invalidate(self):
+            self.invalidations += 1
+            self.generation += 1
+
+    credentials = Credentials()
+    requests = []
+
+    def urlopen(request):
+        requests.append(request)
+        if len(requests) == 1:
+            raise urllib.error.HTTPError(
+                request.full_url, 401, "expired", {}, io.BytesIO(b"")
+            )
+        return Response("[]")
+
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+    client = Client(base="https://loom.example.com", credentials=credentials)
+    assert client.sessions() == []
+    assert credentials.invalidations == 1
+    assert requests[0].headers["Authorization"] == "Bearer token-1"
+    assert requests[1].headers["Authorization"] == "Bearer token-2"
 
 
 class StubClient(Client):
@@ -35,6 +108,32 @@ class StubClient(Client):
     def _request(self, method, path, body=None):
         self.requests.append((method, path, body))
         return self.replies.get(path)
+
+
+def test_profile_scoped_run_is_capability_gated_and_preserves_idempotency():
+    session_request = {
+        "repo": "marin-community/marin",
+        "goal": "investigate the alert",
+    }
+    client = StubClient(capabilities=["launch"], replies={"/runs": {"id": "r1"}})
+
+    assert client.run("ops", "alert-1842", session_request, source="ops") == {
+        "id": "r1"
+    }
+    assert client.requests == [
+        (
+            "POST",
+            "/runs",
+            {
+                "profile": "ops",
+                "idempotency_key": "alert-1842",
+                "source": "ops",
+                "session": session_request,
+            },
+        )
+    ]
+    with pytest.raises(CapabilityDenied):
+        StubClient().run("ops", "alert-1842", session_request)
 
 
 def session(id, status="running", tags=None, repo_root="/repo"):


### PR DESCRIPTION
## Runtime bring-up

Make the GCP Pulumi stack authoritative for Loom runtime policy as well as infrastructure. Profiles, Secret Manager references, GitHub mappings, and Google workload identities are rendered into a non-secret manifest and reconciled idempotently through the local REST API on every startup generation. The VM receives only secret-level accessor grants, while workload callers receive service accounts and exported client configuration.

Generalize OIDC federation to verify exact Google service-account subjects and emails alongside GitHub workflows. Minted ten-minute tokens are profile-scoped and carry bounded service tags; the Python client renews Google and Loom credentials in memory, retries once after expiration, and creates idempotent automation runs. Service tags persist into run records and metrics without using workload identities as labels.

## Operations

Add public liveness/readiness, loopback-only OpenMetrics, and an admin diagnostics view with redacted fleet, capacity, migration, federation, and failure summaries. Pulumi installs the Ops Agent, creates the readiness uptime check and alert, and publishes a Cloud Monitoring dashboard for sessions and workload-tagged runs. Caddy blocks public metric scraping while the host agent uses the loopback Compose port.

Document declarative bring-up, workload consumption, imports, secret rotation, revocation, and first-response debugging.

Part of #174