### PR TITLE
chore(config): use the canonical Loom repository

### DIFF
--- a/deploy/gcp/bootstrap.py
+++ b/deploy/gcp/bootstrap.py
@@ -615,7 +615,7 @@ def wait_for_https(domain: str, timeout: int = 300) -> bool:
 @click.option(
     "--repo-url",
     envvar="REPO_URL",
-    default="https://github.com/rjpower/weaver.git",
+    default="https://github.com/marin-community/loom.git",
     show_default=True,
     help="Git URL the VM clones to get deploy/standalone.",
 )

--- a/deploy/pulumi/Pulumi.example.yaml
+++ b/deploy/pulumi/Pulumi.example.yaml
@@ -15,7 +15,7 @@ config:
   # Name of an existing, already-delegated Cloud DNS managed zone. Omit this
   # field when DNS is hosted elsewhere and create the exported A record there.
   loom-gcp:dnsManagedZone: example-com
-  loom-gcp:githubRepository: rjpower/weaver
+  loom-gcp:githubRepository: marin-community/loom
   loom-gcp:githubRef: refs/heads/main
   # Build locally on the VM for the first deployment. After the image workflow
   # has published an image, change to pull and add imageTag with its commit SHA.
@@ -74,7 +74,7 @@ config:
   loom-gcp:githubFederations:
     - name: weaver-issues
       repositoryId: "123456789"
-      workflowRef: rjpower/weaver/.github/workflows/loom-issue.yml@refs/heads/main
+      workflowRef: marin-community/loom/.github/workflows/loom-issue.yml@refs/heads/main
       event: issues
       ref: refs/heads/main
       serviceTag: weaver-actions

--- a/deploy/pulumi/infrastructure.py
+++ b/deploy/pulumi/infrastructure.py
@@ -178,11 +178,11 @@ class DeploymentConfig:
     machine_type: str = "e2-highmem-4"
     boot_disk_gb: int = 100
     data_disk_gb: int = 500
-    repo_url: str = "https://github.com/rjpower/weaver.git"
+    repo_url: str = "https://github.com/marin-community/loom.git"
     git_ref: str = "main"
     image_mode: str = "build"
     image_tag: str = "latest"
-    github_repository: str = "rjpower/weaver"
+    github_repository: str = "marin-community/loom"
     github_ref: str = "refs/heads/main"
     profiles: dict[str, dict[str, Any]] | None = None
     workloads: tuple[WorkloadIdentityConfig, ...] = ()
@@ -243,11 +243,11 @@ class DeploymentConfig:
                 config.get_int("dataDiskGb"), 500, "dataDiskGb"
             ),
             repo_url=config.get("repoUrl")
-            or "https://github.com/rjpower/weaver.git",
+            or "https://github.com/marin-community/loom.git",
             git_ref=config.get("gitRef") or "main",
             image_mode=config.get("imageMode") or "build",
             image_tag=config.get("imageTag") or "latest",
-            github_repository=config.get("githubRepository") or "rjpower/weaver",
+            github_repository=config.get("githubRepository") or "marin-community/loom",
             github_ref=config.get("githubRef") or "refs/heads/main",
             profiles=dict(config.get_object("profiles") or {}),
             workloads=tuple(

--- a/deploy/pulumi/tests/test_infrastructure.py
+++ b/deploy/pulumi/tests/test_infrastructure.py
@@ -247,7 +247,7 @@ def test_wif_is_repository_and_main_bound_with_least_privilege_iam():
         condition = field(
             provider.inputs, "attribute_condition", "attributeCondition"
         )
-        assert "rjpower/weaver" in condition
+        assert "marin-community/loom" in condition
         assert "refs/heads/main" in condition
 
         repository = by_name("loom-images")

--- a/docs/plans/watches.md
+++ b/docs/plans/watches.md
@@ -6,7 +6,7 @@ status: active
 # The Watch — periodic, triggered watch agents
 
 A weaver [plan](../structured-projects.md) (issue
-[#61](https://github.com/rjpower/weaver/issues/61)): the design surface and the
+[#61](https://github.com/marin-community/loom/issues/61)): the design surface and the
 task breakdown for one large effort. This file owns the *structure* — the
 problem, the architecture, the tasks and their dependencies; the issue ledger
 owns the *state* (which task is open / in-flight / done). Nothing here ships

--- a/docs/structured-projects.md
+++ b/docs/structured-projects.md
@@ -6,7 +6,7 @@
 > the slug rules, and the reconcile engine built around it do not.
 
 Status: **implemented** (issue
-[#14](https://github.com/rjpower/weaver/issues/14)). This doc surveys how the
+[#14](https://github.com/marin-community/loom/issues/14)). This doc surveys how the
 field handles spec-driven, multi-step agent work, then argues for a weaver-shaped
 answer; the design it argues for now ships. What landed:
 


### PR DESCRIPTION
Use marin-community/loom as the default source for GCE and Pulumi deployments, GitHub OIDC scoping, examples, and internal issue links. This removes stale owner-specific references after the repository transfer while preserving the existing binary and configuration names.