### PR TITLE
fix(loom): release issue ownership on archive

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -226,10 +226,14 @@ export const launchSessionForIssue = (repoRoot: string, issueId: number) =>
 export const createRepoIssue = (repoRoot: string, title: string, body = '') =>
   post('/repos/issues', { repo_root: repoRoot, title, body }) as Promise<Issue>;
 
-/** Patch an issue's editable fields. `github` is `owner/name#number`; blank clears it. */
+/** Patch an issue's editable fields. Blank `github` unlinks it;
+ *  `claimed_branch: null` returns it to the unclaimed backlog. */
 export const patchIssue = (
   id: number,
-  body: Partial<Pick<Issue, 'title' | 'body' | 'status'>> & { github?: string },
+  body: Partial<Pick<Issue, 'title' | 'body' | 'status'>> & {
+    github?: string;
+    claimed_branch?: null;
+  },
 ) => patch(`/issues/${id}`, body) as Promise<Issue>;
 
 /** Refresh, pin, or clear a session's PR association. */

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -225,16 +225,15 @@ const sessionsByBranch = computed(() => {
 });
 
 // An issue is automation-claimed when the session *currently* working its
-// branch (`claimed_branch`) is automation-class — the branch's active session
-// if one exists, else its most recently created. Archiving frees the branch
-// slot, so an archived automation run must not hide an issue a person has
-// since picked up on the re-let branch. Mirrors the server's own default-hide
-// rule (`GET /api/issues`).
+// branch (`claimed_branch`) is automation-class. Archived sessions never own
+// work, including historical rows whose claims predate archive cleanup. Mirrors
+// the server's own default-hide rule (`GET /api/issues`).
 function isAutomationClaimed(i: Issue): boolean {
   if (!i.claimed_branch) return false;
   const held = sessionsByBranch.value.get(`${i.repo_root}\0${i.claimed_branch}`) ?? [];
-  const active = (s: Session) => !['done', 'error', 'archived'].includes(s.status);
-  const holder = [...held].sort(
+  const eligible = held.filter((s) => s.status !== 'archived');
+  const active = (s: Session) => !['done', 'error'].includes(s.status);
+  const holder = eligible.sort(
     (a, b) => Number(active(b)) - Number(active(a)) || b.created_at.localeCompare(a.created_at),
   )[0];
   return holder?.class === 'automation';
@@ -287,6 +286,12 @@ async function withBusy<T>(id: number, fn: () => Promise<T>): Promise<T | undefi
 
 async function setStatus(i: Issue, status: 'open' | 'closed') {
   await withBusy(i.id, async () => replaceIssue((await patchIssue(i.id, { status })) as Issue));
+}
+
+async function unclaim(i: Issue) {
+  await withBusy(i.id, async () =>
+    replaceIssue((await patchIssue(i.id, { claimed_branch: null })) as Issue),
+  );
 }
 
 // Launch a fresh loom session that picks up an unclaimed backlog issue: the
@@ -643,6 +648,17 @@ async function removeTag(i: Issue, key: string) {
               @click="setStatus(i, 'open')"
             >
               Reopen
+            </button>
+            <button
+              v-if="i.claimed_branch"
+              type="button"
+              class="rounded px-1.5 py-0.5 text-2xs text-muted hover:bg-subtle hover:text-fg"
+              data-testid="issue-unclaim"
+              :disabled="busy[i.id]"
+              :title="`Return issue #${i.id} to the unclaimed backlog`"
+              @click="unclaim(i)"
+            >
+              Unclaim
             </button>
             <button
               type="button"

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -912,6 +912,10 @@ pub(crate) async fn apply_snapshot(
         && !session_mod::is_terminal(&session.status)
         && !recovered
     {
+        // Archive releases the branch's issue claims back to the backlog. Close
+        // the shipped work first so the existing merge lifecycle still finds
+        // those issues; archive then clears ownership from the closed rows too.
+        close_claimed_issues(state, branch, snap.pr_number).await;
         // The merge is already on the record as a `github` event (above) and the
         // archive records a `status` event, so no extra log line is needed.
         match crate::web::archive(state, session, branch).await {
@@ -921,7 +925,6 @@ pub(crate) async fn apply_snapshot(
                     pr = snap.pr_number,
                     "archived session after PR merge"
                 );
-                close_claimed_issues(state, branch, snap.pr_number).await;
             }
             Err(e) => tracing::warn!(
                 branch = %branch.branch,
@@ -1006,9 +1009,9 @@ async fn maybe_post_backlink(
 /// closure to its activity feed. The session is being torn down because its PR
 /// shipped, so the tracking issues it claimed close out with it — emitting the
 /// same `issue_closed` event `weaver issue close` records, so the dashboard
-/// reacts identically whether a person or the merge closed them. Best-effort:
-/// the archive has already happened, so a hiccup here only loses the auto-close,
-/// it must not surface as an error.
+/// reacts identically whether a person or the merge closed them. Best-effort: a
+/// hiccup here only loses the auto-close and must not prevent the session
+/// archive that follows.
 async fn close_claimed_issues(state: &AppState, branch: &Branch, pr: i64) {
     let closed = match weaver_core::issue::close_for_branch(
         &state.db,
@@ -1525,6 +1528,10 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(closed.status, "closed");
+        assert_eq!(
+            closed.claimed_branch, None,
+            "the archived session no longer owns the closed issue"
+        );
         // …and the closure lands on the activity feed as an `issue_closed` event,
         // just as `weaver issue close` would have recorded it.
         let logged = events::history(&f.state.db, &f.branch.id, 50)

--- a/crates/loom/src/web/issues.rs
+++ b/crates/loom/src/web/issues.rs
@@ -62,21 +62,20 @@ pub(super) async fn list_all_issues(
 ) -> ApiResult<Json<Vec<IssueView>>> {
     let mut issues = weaver_core::issue::list_all(&st.db, q.all).await?;
     if !q.automation {
-        // Branches whose *current* claim-holder is an automation-class session,
+        // Branches whose current claim-holder is an automation-class session,
         // as (repo_root, branch) pairs — issues key their claim by branch name,
-        // not branch id. The holder is the branch's active session if one
-        // exists, else its most recently created: archiving frees the branch
-        // slot, so an archived automation run must not hide an issue a person
-        // has since picked up on the re-let branch, while a reaped run with no
-        // successor keeps its issue off the default board.
+        // not branch id. Archived sessions never own work, including historical
+        // rows whose claims predate archive cleanup.
         let rows: Vec<(String, String)> = sqlx::query_as(
             "SELECT b.repo_root, b.branch FROM sessions s
              JOIN branches b ON b.id = s.branch_id
              WHERE s.class = 'automation'
+               AND s.status != 'archived'
                AND s.id = (
                    SELECT s2.id FROM sessions s2
                    WHERE s2.branch_id = s.branch_id
-                   ORDER BY (s2.status NOT IN ('done', 'error', 'archived')) DESC,
+                     AND s2.status != 'archived'
+                   ORDER BY (s2.status NOT IN ('done', 'error')) DESC,
                             s2.created_at DESC
                    LIMIT 1
                )",
@@ -195,6 +194,16 @@ pub(super) async fn patch_issue(
     let existing = weaver_core::issue::get(&st.db, id)
         .await?
         .ok_or_else(|| AppError::not_found("issue"))?;
+    if req
+        .claimed_branch
+        .as_ref()
+        .and_then(|branch| branch.as_deref())
+        .is_some_and(|branch| !branch.trim().is_empty())
+    {
+        return Err(AppError::bad_request(
+            "claimed_branch can only be cleared; launch a session to claim an issue",
+        ));
+    }
     if let Some(status) = req.status.as_deref() {
         match status {
             "open" => weaver_core::issue::reopen(&st.db, id).await?,
@@ -253,6 +262,9 @@ pub(super) async fn patch_issue(
         .execute(&st.db)
         .await?;
         tracing::info!(issue = id, github = mapping, "issue GitHub mapping changed");
+    }
+    if req.claimed_branch.is_some() {
+        weaver_core::issue::set_claim(&st.db, id, None).await?;
     }
     let issue = weaver_core::issue::get(&st.db, id)
         .await?
@@ -532,5 +544,47 @@ mod tests {
         .0;
         assert_eq!(cleared.github_repo, None);
         assert_eq!(cleared.github_issue, None);
+    }
+
+    #[tokio::test]
+    async fn patch_issue_clears_claim_but_cannot_assign_one() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let st = test_state(db.clone());
+        let issue = weaver_core::issue::add(
+            &db,
+            &weaver_core::issue::NewIssue {
+                repo_root: "/r".to_string(),
+                claimed_branch: Some("weaver/worker".to_string()),
+                title: "claimed".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let cleared = patch_issue(
+            State(st.clone()),
+            Path(issue.id),
+            Json(PatchIssueReq {
+                claimed_branch: Some(None),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        assert_eq!(cleared.claimed_branch, None);
+
+        let err = patch_issue(
+            State(st),
+            Path(issue.id),
+            Json(PatchIssueReq {
+                claimed_branch: Some(Some("weaver/other".to_string())),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1778,6 +1778,10 @@ pub(crate) async fn archive(
         }
     }
     session_mod::set_status(&st.db, &session.id, "archived").await?;
+    // A torn-down session cannot keep owning work. Return every issue it held
+    // to the repo backlog while preserving source-branch provenance and issue
+    // status, just as full session deletion does.
+    weaver_core::issue::unclaim_branch(&st.db, &branch.repo_root, &branch.branch).await?;
     // An archived session is finished with: its agent is gone, so it can no
     // longer "need me" — nor is it "resting". Clear every loud tag — the agent's
     // own `attention` and any watch's typed marks (loudness is value-driven, so

--- a/crates/loom/tests/integration/archive.rs
+++ b/crates/loom/tests/integration/archive.rs
@@ -99,7 +99,7 @@ async fn archive_keeps_branch_and_history() {
         .await
         .unwrap();
     let arch_id = arch["id"].as_str().unwrap().to_string();
-    let claimed_branch = arch["branch"]["branch"].as_str().unwrap().to_string();
+    let tracking_issue = arch["tracking_issue"].as_i64().unwrap();
     let arch_session = arch["term_session"].as_str().unwrap().to_string();
     let arch_work_dir = arch["work_dir"].as_str().unwrap().to_string();
     assert!(
@@ -170,12 +170,14 @@ async fn archive_keeps_branch_and_history() {
         .unwrap();
     assert_eq!(view["status"], "archived");
     let issues = client.get("/api/issues?automation=true").await.unwrap();
+    let issue = issues
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|issue| issue["id"].as_i64() == Some(tracking_issue))
+        .expect("the archived session's tracking issue survives");
     assert!(
-        issues
-            .as_array()
-            .unwrap()
-            .iter()
-            .all(|issue| issue["claimed_branch"] != claimed_branch),
+        issue["claimed_branch"].is_null(),
         "an archived session must not own any issues"
     );
     // Archiving cleared the attention tag so the dashboard stops flagging it

--- a/crates/loom/tests/integration/archive.rs
+++ b/crates/loom/tests/integration/archive.rs
@@ -99,6 +99,7 @@ async fn archive_keeps_branch_and_history() {
         .await
         .unwrap();
     let arch_id = arch["id"].as_str().unwrap().to_string();
+    let claimed_branch = arch["branch"]["branch"].as_str().unwrap().to_string();
     let arch_session = arch["term_session"].as_str().unwrap().to_string();
     let arch_work_dir = arch["work_dir"].as_str().unwrap().to_string();
     assert!(
@@ -168,6 +169,15 @@ async fn archive_keeps_branch_and_history() {
         .await
         .unwrap();
     assert_eq!(view["status"], "archived");
+    let issues = client.get("/api/issues?automation=true").await.unwrap();
+    assert!(
+        issues
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|issue| issue["claimed_branch"] != claimed_branch),
+        "an archived session must not own any issues"
+    );
     // Archiving cleared the attention tag so the dashboard stops flagging it
     // (absence is the calm state). The message (description) is kept as history.
     assert!(

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -753,10 +753,8 @@ async fn archive_frees_the_branch_for_a_new_session() {
 }
 
 /// The issue board hides an issue only while its branch's *current* claim-holder
-/// is automation-class. An archived automation run with no successor keeps its
-/// issue off the default board, but once a person re-lets the branch with an
-/// interactive session (archiving freed the slot), the issue surfaces again —
-/// historical automation tenancy must not hide live interactive work.
+/// is automation-class. Archiving releases the issue to the visible backlog;
+/// historical automation tenancy must not hide work that no session owns.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn issue_hiding_follows_the_branch_current_claim_holder() {
@@ -800,8 +798,8 @@ async fn issue_hiding_follows_the_branch_current_claim_holder() {
         .unwrap();
     let board = client.get("/api/issues").await.unwrap();
     assert!(
-        !on_board(board),
-        "an archived automation run with no successor keeps its issue hidden"
+        on_board(board),
+        "an archived automation run releases its issue to the visible backlog"
     );
 
     // A person picks the branch back up: the freed slot is re-let interactively.

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -1159,6 +1159,26 @@ pub struct PatchIssueReq {
     /// mapping; absent leaves it unchanged.
     #[serde(default)]
     pub github: Option<String>,
+    /// The branch currently working the issue. `null` clears the claim; absent
+    /// leaves it unchanged. Claims are created through session launch, so this
+    /// patch field deliberately supports clearing only.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_present_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub claimed_branch: Option<Option<String>>,
+}
+
+/// Preserve the PATCH distinction between an absent field and an explicit
+/// JSON `null`: serde's ordinary `Option<Option<T>>` handling maps both to the
+/// outer `None`.
+fn deserialize_present_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(deserializer)?))
 }
 
 /// Body for `POST /api/repos/issues`: create an unclaimed repo-level backlog

--- a/e2e/tests/issues.spec.ts
+++ b/e2e/tests/issues.spec.ts
@@ -72,6 +72,20 @@ test.describe('issues pane', () => {
     expect(persisted.find((i) => i.id === issue.id)?.title).toBe('new shiny title');
   });
 
+  test('returns a claimed issue to the backlog', async ({ page, weaver }) => {
+    const session = await weaver.seedSession({ goal: 'g', name: 'feature' });
+    const issue = await weaver.seedIssue(session, 'release me');
+
+    await page.goto(`${weaver.baseUrl}/issues`);
+    const row = page.locator(`[data-issue-id="${issue.id}"]`);
+    await row.getByTestId('issue-unclaim').click();
+
+    await expect(row.getByTestId('issue-unclaim')).toHaveCount(0);
+    await expect(row.getByTestId('issue-launch')).toBeVisible();
+    const persisted = (await weaver.listIssues()).find((candidate) => candidate.id === issue.id);
+    expect(persisted?.claimed_branch).toBeNull();
+  });
+
   test('changes and clears an issue GitHub mapping through the inline editor', async ({ page, weaver }) => {
     const session = await weaver.seedSession({ goal: 'g', name: 'feature' });
     const issue = await weaver.seedIssue(session, 'remappable');


### PR DESCRIPTION
Allow issue ownership to be cleared through PATCH /api/issues/{id} by sending claimed_branch: null, and expose the action as Unclaim on the Issues board.

Release every branch claim when a session is archived so open work returns to the repo backlog. Keep archive-on-merge behavior intact by closing shipped issues before archive clears their ownership, and ensure archived automation sessions no longer hide backlog work.

Add backend, integration, and Playwright coverage for manual unclaiming and archive ownership cleanup.