### PR TITLE
feat(loom): add named CLI login contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,11 +301,37 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the shape of `SessionView`.
 
 ## Server address
 
-`loom server run` binds `127.0.0.1:7878` by default. Set `WEAVER_API` (e.g.
-`WEAVER_API=http://127.0.0.1:9000`) to point loom *and* the `loom` CLI at a
-different address. `loom server run --addr <host:port>` overrides `WEAVER_API`.
-The running daemon records the address it bound in `~/.weaver/server.json`,
-so the `loom` CLI finds it with no configuration in the common case.
+`loom server run` binds `127.0.0.1:7878` by default. The running daemon records
+the address it bound in `~/.weaver/server.json`, so the `loom` CLI finds a local
+server with no configuration. Named contexts make switching between local and
+remote servers explicit:
+
+```sh
+loom context add local --url http://127.0.0.1:7878
+loom login production --url https://loom.oa.dev
+loom context ls
+loom context use production
+loom --context local session ls
+```
+
+`loom login` validates a personal API token before storing it. The prompt is
+hidden; use `--token-stdin` when a password manager supplies the token. Context
+endpoints live in `$XDG_CONFIG_HOME/loom/config.toml` (normally
+`~/.config/loom/config.toml`) and tokens live separately in
+`credentials.toml`, which is mode 0600. A repository may select one of the
+user's contexts by committing `.loom/client.toml`:
+
+```toml
+context = "production"
+```
+
+Repository configuration names a context but cannot provide an endpoint or
+credential. Selection order is `--context`, `WEAVER_API`, `LOOM_CONTEXT`, the
+repository selector, the user's default context, then the recorded local
+server. `LOOM_TOKEN` overrides a saved context credential unless `--context`
+selects a different endpoint than `WEAVER_API`; this prevents an injected local
+machine token from being sent to a remote server. `loom context current` shows
+what the current directory selects.
 
 ## Authentication
 
@@ -324,25 +350,37 @@ TLS-terminating reverse proxy. Access is then gated three ways:
   no owner is seeded, so GitHub sign-in won't work until it's set. Add more
   users, set your password, and configure GitHub sign-in under **Settings →
   Account**.
-- **API tokens** for automation — the `LOOM_TOKEN` a CI job or a remote `loom`
-  CLI presents as a bearer. Mint one under **Settings → Tokens** or:
+- **Personal API tokens** for remote CLIs and other trusted clients. Mint one
+  under **Settings → Tokens** or from a locally authenticated CLI:
 
   ```sh
-  loom token add github-actions     # prints the secret once — store it now
+  loom token add laptop --expires-days 30  # prints the secret once
   ```
 
-  Then, from anywhere (e.g. a GitHub Actions step that kicks off a session in
-  response to a comment):
+  Then sign in once from the remote machine:
+
+  ```sh
+  loom login production --url https://loom.example.com
+  loom session launch "Investigate the failing test in #123"
+  ```
+
+  For an ephemeral environment, the environment-variable form remains
+  available:
 
   ```sh
   export WEAVER_API=https://loom.example.com
   export LOOM_TOKEN=loom_xxxxxxxx
-  loom session launch "Investigate the failing test in #123"
-  # or hit the API directly:
   curl -H "Authorization: Bearer $LOOM_TOKEN" \
        -H 'content-type: application/json' \
        "$WEAVER_API/api/sessions" -d '{"cwd":"/srv/repo","goal":"..."}'
   ```
+
+- **Federated workflow tokens** for GitHub Actions and Google workloads. Loom
+  verifies the workload's OIDC identity and returns an automation-scoped token
+  with a fixed ten-minute lifetime. The workflow exchanges again for each run;
+  it does not store a personal token or choose one of the day-based lifetimes
+  shown on the personal-token page. See
+  [Restricted sessions](docs/restricted-sessions.md).
 
 To configure **GitHub sign-in**: register an OAuth app on GitHub with the
 callback `https://loom.example.com/api/auth/github/callback`, then paste its
@@ -429,10 +467,15 @@ placeholder page), `cargo test --workspace` runs the backend suites, and `cd e2e
 
 - `WEAVER_HOME` — state directory (default `~/.weaver`)
 - `WEAVER_DB` — database path (default `$WEAVER_HOME/weaver.db`)
-- `WEAVER_API` — loom URL the `loom` CLI talks to (default `http://127.0.0.1:7878`)
-- `WEAVER_BRANCH` — override the branch resolver (set by `loom session launch` in the worktree)
-- `LOOM_TOKEN` — bearer token the `loom` CLI / automation sends (see [Authentication](#authentication))
-- `LOOM_OWNER_GITHUB` — GitHub login seeded as the owner on a fresh database. No default; leave it unset and no owner is seeded (GitHub sign-in won't work until it's set).
+- `WEAVER_API` — explicit loom URL; overrides automatic named-context selection
+- `LOOM_CONTEXT` — named context to use when `--context` and `WEAVER_API` are unset
+- `WEAVER_BRANCH` — override the branch resolver (set by `loom session launch`
+  in the worktree)
+- `LOOM_TOKEN` — explicit bearer token for CLI clients and automation; normally
+  overrides saved context credentials (see [Authentication](#authentication))
+- `LOOM_OWNER_GITHUB` — GitHub login seeded as the owner on a fresh database.
+  No default; leave it unset and no owner is seeded (GitHub sign-in won't work
+  until it is set).
 - `LOOM_GITHUB_CLIENT_ID` / `LOOM_GITHUB_CLIENT_SECRET` — GitHub OAuth app credentials
 - `LOOM_GITHUB_WEBHOOK_SECRET` — shared secret for the inbound GitHub trigger; until set, the webhook rejects every delivery ([docs/github-trigger.md](docs/github-trigger.md))
 - `WEAVER_REPOS_DIR` — managed repo store root (default `$WEAVER_HOME/repos`)

--- a/crates/loom/frontend/src/components/TokensPanel.vue
+++ b/crates/loom/frontend/src/components/TokensPanel.vue
@@ -10,10 +10,10 @@ const tokens = ref<Token[]>([]);
 const error = ref('');
 const busy = ref(false);
 const name = ref('');
-const expiresDays = ref('');
+const expiresDays = ref('30');
 const created = ref<CreatedToken | null>(null);
 const copied = ref(false);
-const expiryPresets = ['7', '30', '90'];
+const serverOrigin = window.location.origin;
 
 async function load() {
   try {
@@ -33,7 +33,7 @@ async function create() {
     const days = expiresDays.value.trim() ? Number(expiresDays.value) : null;
     created.value = await api.createToken(name.value.trim(), days);
     name.value = '';
-    expiresDays.value = '';
+    expiresDays.value = '30';
     copied.value = false;
     await load();
   } catch (e) {
@@ -69,19 +69,17 @@ async function copy() {
 
 const fmt = (ts: string | null) => (ts ? new Date(ts).toLocaleString() : '—');
 
-function setExpiry(days: string) {
-  expiresDays.value = days;
-}
-
 onMounted(load);
 </script>
 
 <template>
   <div>
-    <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">API tokens</h2>
+    <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
+      Personal API tokens
+    </h2>
     <p class="mb-3 text-xs text-faint">
-      Tokens authenticate automation and remote CLIs. Use them as a bearer token or set
-      <code>LOOM_TOKEN</code>.
+      Sign in from <code>loom login</code> or another trusted client. A personal token has your
+      account's access, so store it like a password.
     </p>
 
     <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
@@ -104,6 +102,11 @@ onMounted(load);
           {{ copied ? 'Copied' : 'Copy' }}
         </button>
       </div>
+      <p class="mt-2 text-2xs text-muted">
+        Then run
+        <code class="select-all">loom login production --url {{ serverOrigin }}</code>
+        and paste the token when prompted.
+      </p>
     </div>
 
     <!-- Create form. -->
@@ -115,41 +118,24 @@ onMounted(load);
           <span class="text-2xs text-muted">Name</span>
           <input
             v-model="name"
-            placeholder="e.g. github-actions"
+            placeholder="e.g. laptop"
             data-testid="token-name"
             class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
             @keyup.enter="create"
           />
         </label>
         <label class="flex flex-col gap-1 md:min-w-0">
-          <span class="text-2xs text-muted">Expires</span>
-          <input
+          <span class="text-2xs text-muted">Lifetime</span>
+          <select
             v-model="expiresDays"
-            type="number"
-            min="1"
-            placeholder="never"
+            data-testid="token-lifetime"
             class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
-          />
-          <div class="flex flex-wrap gap-1">
-            <button
-              v-for="preset in expiryPresets"
-              :key="preset"
-              type="button"
-              class="rounded border border-line bg-input px-2 py-0.5 text-2xs text-muted transition-colors hover:text-fg"
-              :class="expiresDays === preset ? 'border-accent text-fg' : ''"
-              @click="setExpiry(preset)"
-            >
-              {{ preset }}d
-            </button>
-            <button
-              type="button"
-              class="rounded border border-line bg-input px-2 py-0.5 text-2xs text-muted transition-colors hover:text-fg"
-              :class="!expiresDays ? 'border-accent text-fg' : ''"
-              @click="setExpiry('')"
-            >
-              Never
-            </button>
-          </div>
+          >
+            <option value="7">7 days</option>
+            <option value="30">30 days (recommended)</option>
+            <option value="90">90 days</option>
+            <option value="">Never expires</option>
+          </select>
         </label>
         <div class="flex items-center md:justify-end">
           <button
@@ -162,6 +148,15 @@ onMounted(load);
           </button>
         </div>
       </div>
+    </div>
+
+    <div class="mb-4 rounded-md border border-line bg-surface px-3 py-2.5">
+      <p class="text-xs font-medium text-fg">Workflow credentials</p>
+      <p class="mt-1 text-2xs text-faint">
+        GitHub Actions and Google workloads should use workload federation when available. Loom
+        exchanges a verified OIDC identity for a fixed 10-minute token automatically; that lifetime
+        is separate from the personal-token choices above.
+      </p>
     </div>
 
     <!-- Existing tokens. -->

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1023,8 +1023,10 @@ async fn cmd_login(name: String, url: Option<String>, token_stdin: bool) -> Resu
 
     let remote = Client::new(url.clone()).with_token(Some(token.to_string()));
     let me = remote.get("/api/auth/me").await?;
-    if me.get("authenticated").and_then(Value::as_bool) != Some(true) {
-        bail!("Loom rejected the API token");
+    if me.get("authenticated").and_then(Value::as_bool) != Some(true)
+        || me.get("via").and_then(Value::as_str) != Some("token")
+    {
+        bail!("Loom rejected the personal API token");
     }
     remote
         .list_tokens()

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -20,6 +20,9 @@ use weaver_core::db::Db;
     about = "Orchestrate concurrent agent workstreams"
 )]
 struct Cli {
+    /// Select a named client context for this command.
+    #[arg(long, global = true)]
+    context: Option<String>,
     #[command(subcommand)]
     cmd: Cmd,
 }
@@ -92,6 +95,28 @@ enum Cmd {
     Token {
         #[command(subcommand)]
         cmd: TokenCmd,
+    },
+    /// Authenticate this CLI and save a named client context.
+    Login {
+        /// Context name to create or replace.
+        #[arg(default_value = "default")]
+        name: String,
+        /// Loom server URL. Omit to enter it interactively.
+        #[arg(long)]
+        url: Option<String>,
+        /// Read the API token from stdin instead of a hidden prompt.
+        #[arg(long)]
+        token_stdin: bool,
+    },
+    /// Remove the saved credential for a client context.
+    Logout {
+        #[arg(default_value = "default")]
+        name: String,
+    },
+    /// Manage named local and remote Loom client contexts.
+    Context {
+        #[command(subcommand)]
+        cmd: ClientContextCmd,
     },
     /// Manage named session launch profiles and their secret environment.
     Profile {
@@ -575,6 +600,27 @@ enum TokenCmd {
     },
 }
 
+#[derive(Subcommand)]
+enum ClientContextCmd {
+    /// List configured contexts without exposing their credentials.
+    Ls,
+    /// Set the default context.
+    Use { name: String },
+    /// Add or update an endpoint without storing a credential.
+    Add {
+        name: String,
+        #[arg(long)]
+        url: String,
+        /// Also make this the default context.
+        #[arg(long = "use")]
+        use_context: bool,
+    },
+    /// Show the context selected for the current directory.
+    Current,
+    /// Remove a context and its saved credential.
+    Rm { name: String },
+}
+
 #[derive(Args)]
 struct FederationAddArgs {
     /// Stable mapping name. Omitted legacy calls derive one from identity fields.
@@ -818,14 +864,22 @@ async fn main() {
 }
 
 async fn run() -> Result<()> {
-    let cli = Cli::parse();
-    match cli.cmd {
+    let Cli { context, cmd } = Cli::parse();
+    client::set_context_override(context.as_deref())?;
+    match cmd {
         Cmd::Mcp { adapter } => loom::mcp::serve(&adapter).await,
         Cmd::Server { cmd } => run_server(cmd).await,
         Cmd::Session { cmd } => run_session(cmd).await,
         Cmd::Issue { cmd } => run_issue(cmd).await,
         Cmd::Watch { cmd } => run_watch(cmd).await,
         Cmd::Token { cmd } => run_token(cmd).await,
+        Cmd::Login {
+            name,
+            url,
+            token_stdin,
+        } => cmd_login(name, url, token_stdin).await,
+        Cmd::Logout { name } => cmd_logout(name),
+        Cmd::Context { cmd } => run_client_context(cmd, context.as_deref()),
         Cmd::Profile { cmd } => run_profile(cmd).await,
         Cmd::Federation { cmd } => run_federation(cmd).await,
         Cmd::Deployment { cmd } => run_deployment(cmd).await,
@@ -931,7 +985,7 @@ async fn run_token(cmd: TokenCmd) -> Result<()> {
             profiles,
             ttl,
         } => {
-            let minted = client::default()
+            let minted = client::default()?
                 .mint_automation_token(&weaver_api::AutomationTokenReq {
                     subject,
                     profiles,
@@ -939,6 +993,127 @@ async fn run_token(cmd: TokenCmd) -> Result<()> {
                 })
                 .await?;
             println!("{}", minted.token);
+            Ok(())
+        }
+    }
+}
+
+async fn cmd_login(name: String, url: Option<String>, token_stdin: bool) -> Result<()> {
+    let paths = loom::client_context::ClientPaths::discover()?;
+    let existing_url = loom::client_context::context_url(&paths, &name)?;
+    let url = match url {
+        Some(url) => url,
+        None => prompt_line("Server URL", existing_url.as_deref())?,
+    };
+    let url = loom::client_context::normalize_url(&url)?;
+    let token = if token_stdin {
+        use std::io::Read as _;
+        let mut token = String::new();
+        std::io::stdin()
+            .read_to_string(&mut token)
+            .context("reading API token from stdin")?;
+        token
+    } else {
+        rpassword::prompt_password("API token: ").context("reading API token")?
+    };
+    let token = token.trim();
+    if token.is_empty() {
+        bail!("API token must not be empty");
+    }
+
+    let remote = Client::new(url.clone()).with_token(Some(token.to_string()));
+    let me = remote.get("/api/auth/me").await?;
+    if me.get("authenticated").and_then(Value::as_bool) != Some(true) {
+        bail!("Loom rejected the API token");
+    }
+    remote
+        .list_tokens()
+        .await
+        .context("credential is authenticated but is not a user API token")?;
+    loom::client_context::save_login(&paths, &name, &url, token)?;
+    let username = me
+        .get("username")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown user");
+    println!("logged in to {url} as {username}");
+    println!("current context: {name}");
+    Ok(())
+}
+
+fn cmd_logout(name: String) -> Result<()> {
+    let paths = loom::client_context::ClientPaths::discover()?;
+    if loom::client_context::remove_login(&paths, &name)? {
+        println!("removed saved credential for {name}");
+    } else {
+        println!("no saved credential for {name}");
+    }
+    Ok(())
+}
+
+fn run_client_context(cmd: ClientContextCmd, explicit: Option<&str>) -> Result<()> {
+    let paths = loom::client_context::ClientPaths::discover()?;
+    match cmd {
+        ClientContextCmd::Ls => {
+            let contexts = loom::client_context::list_contexts(&paths)?;
+            if contexts.is_empty() {
+                println!("no contexts — add one with `loom context add <name> --url <url>`");
+                return Ok(());
+            }
+            for context in contexts {
+                let current = if context.is_default { "*" } else { " " };
+                let auth = if context.authenticated {
+                    "authenticated"
+                } else {
+                    "no credential"
+                };
+                println!("{current} {}  {}  {auth}", context.name, context.url);
+            }
+            Ok(())
+        }
+        ClientContextCmd::Use { name } => {
+            loom::client_context::use_context(&paths, &name)?;
+            println!("current context: {name}");
+            Ok(())
+        }
+        ClientContextCmd::Add {
+            name,
+            url,
+            use_context,
+        } => {
+            loom::client_context::save_context(&paths, &name, &url, use_context)?;
+            println!("saved context {name}");
+            Ok(())
+        }
+        ClientContextCmd::Current => {
+            if explicit.is_none()
+                && std::env::var("WEAVER_API").is_ok_and(|url| !url.trim().is_empty())
+            {
+                println!("WEAVER_API  {}", loom::endpoint::base_url());
+                return Ok(());
+            }
+            match loom::client_context::resolve(explicit)? {
+                Some(context) => {
+                    let source = match context.source {
+                        loom::client_context::ContextSource::Explicit => "--context",
+                        loom::client_context::ContextSource::Environment => "LOOM_CONTEXT",
+                        loom::client_context::ContextSource::Repository(ref path) => {
+                            println!("selector: {}", path.display());
+                            "repository"
+                        }
+                        loom::client_context::ContextSource::Default => "default",
+                    };
+                    println!("{}  {}  {source}", context.name, context.url);
+                }
+                None => println!("local  {}  implicit", loom::endpoint::base_url()),
+            }
+            Ok(())
+        }
+        ClientContextCmd::Rm { name } => {
+            if loom::client_context::remove_context(&paths, &name)? {
+                println!("removed context {name}");
+            } else {
+                println!("unknown context {name}");
+            }
             Ok(())
         }
     }
@@ -959,7 +1134,7 @@ fn parse_ttl(value: &str) -> Result<i64> {
 }
 
 async fn run_federation(cmd: FederationCmd) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     match cmd {
         FederationCmd::Add(args) => {
             let FederationAddArgs {
@@ -1041,7 +1216,7 @@ async fn run_deployment(cmd: DeploymentCmd) -> Result<()> {
             };
             let request: weaver_api::DeploymentReq =
                 serde_json::from_str(&contents).context("decoding deployment manifest")?;
-            let result = client::default().reconcile_deployment(&request).await?;
+            let result = client::default()?.reconcile_deployment(&request).await?;
             println!(
                 "reconciled {} profiles and {} federation mappings",
                 result.profiles.len(),
@@ -1053,7 +1228,7 @@ async fn run_deployment(cmd: DeploymentCmd) -> Result<()> {
 }
 
 async fn run_profile(cmd: ProfileCmd) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     match cmd {
         ProfileCmd::Add(opts) => {
             let profile = client
@@ -1133,7 +1308,7 @@ async fn run_profile(cmd: ProfileCmd) -> Result<()> {
 }
 
 async fn cmd_token_create(name: String, expires_days: Option<i64>) -> Result<()> {
-    let created = client::default()
+    let created = client::default()?
         .create_token(&weaver_api::CreateTokenReq {
             name,
             expires_in_days: expires_days,
@@ -1155,7 +1330,7 @@ async fn cmd_token_create(name: String, expires_days: Option<i64>) -> Result<()>
 }
 
 async fn cmd_token_ls() -> Result<()> {
-    let tokens = client::default().list_tokens().await?;
+    let tokens = client::default()?.list_tokens().await?;
     if tokens.is_empty() {
         println!("no tokens — create one with `loom token add <name>`");
         return Ok(());
@@ -1174,7 +1349,7 @@ async fn cmd_token_ls() -> Result<()> {
 }
 
 async fn cmd_token_rm(id: String) -> Result<()> {
-    client::default().revoke_token(&id).await?;
+    client::default()?.revoke_token(&id).await?;
     println!("revoked token {id}");
     Ok(())
 }
@@ -2455,7 +2630,7 @@ async fn cmd_launch(a: LaunchArgs) -> Result<()> {
         protocol,
         mode,
     } = a;
-    let client = client::default();
+    let client = client::default()?;
     let target = resolve_repo_target(repo.as_deref())?;
     // A managed repo travels as `repo` (the server registers it and clones it if
     // this is its first use); a local checkout travels as `cwd`. Exactly one is
@@ -2583,7 +2758,7 @@ async fn cmd_session_url(key: Option<String>) -> Result<()> {
                  pass a session key explicitly: loom session url <session>",
             )?,
     };
-    let client = client::default();
+    let client = client::default()?;
     let res: Value = client
         .get(&format!("/api/sessions/{}/url", enc_key(&key)))
         .await
@@ -2598,7 +2773,7 @@ async fn cmd_session_url(key: Option<String>) -> Result<()> {
 
 /// `loom session poll` — a one-shot status read: lifecycle + attention.
 async fn cmd_session_poll(key: String) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let ws = fetch_session(&client, &key).await?;
     println!(
         "session {}  ({})",
@@ -2622,7 +2797,7 @@ async fn cmd_session_wait(
     interval: u64,
     lifecycle_only: bool,
 ) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     // Short-circuit if the session is already in a wake state at call time.
     let ws = fetch_session(&client, &key).await?;
     if let Some(reason) = wake_reason(&ws, &key, lifecycle_only) {
@@ -2700,7 +2875,7 @@ async fn cmd_session_send(key: String, message: String, submit: bool) -> Result<
     if message.trim().is_empty() {
         bail!("nothing to send — provide a message");
     }
-    let client = client::default();
+    let client = client::default()?;
     client
         .post(
             &format!("/api/sessions/{}/send", enc_key(&key)),
@@ -2716,7 +2891,7 @@ async fn cmd_session_send(key: String, message: String, submit: bool) -> Result<
 
 /// `loom session break` — send Escape to interrupt the agent's current turn.
 async fn cmd_session_break(key: String) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     client
         .post(
             &format!("/api/sessions/{}/interrupt", enc_key(&key)),
@@ -2729,7 +2904,7 @@ async fn cmd_session_break(key: String) -> Result<()> {
 
 /// `loom session preview` — print the session's recent terminal screen.
 async fn cmd_session_preview(key: String, lines: usize) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let res = client
         .get(&format!(
             "/api/sessions/{}/preview?lines={lines}",
@@ -2743,7 +2918,7 @@ async fn cmd_session_preview(key: String, lines: usize) -> Result<()> {
 }
 
 async fn cmd_ps(archived: bool, search: Option<String>) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     // Hide archived sessions by default; `--search` narrows by substring. Both
     // ride the same query the dashboard uses, so the CLI and UI stay one surface.
     let mut query = Vec::new();
@@ -2786,7 +2961,7 @@ async fn cmd_ps(archived: bool, search: Option<String>) -> Result<()> {
 }
 
 async fn cmd_issues(all: bool, backlog: bool) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let cwd = std::env::current_dir()?;
     let scope = if backlog { "backlog" } else { "repo" };
     let path = format!(
@@ -2828,7 +3003,7 @@ async fn cmd_issues(all: bool, backlog: bool) -> Result<()> {
 }
 
 async fn cmd_show(key: String) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let ws = client
         .get(&format!("/api/sessions/{}", enc_key(&key)))
         .await?;
@@ -2844,7 +3019,7 @@ async fn cmd_session_rename(key: String, title: String) -> Result<()> {
     if title.is_empty() {
         bail!("nothing to rename to — provide a new title");
     }
-    let client = client::default();
+    let client = client::default()?;
     let ws = client
         .patch(
             &format!("/api/sessions/{}", enc_key(&key)),
@@ -2929,7 +3104,7 @@ fn print_session(ws: &Value) {
 
 async fn cmd_attach(key: String) -> Result<()> {
     use std::os::unix::process::CommandExt;
-    let client = client::default();
+    let client = client::default()?;
     let ws = client
         .get(&format!("/api/sessions/{}", enc_key(&key)))
         .await?;
@@ -2954,7 +3129,7 @@ async fn cmd_attach(key: String) -> Result<()> {
 }
 
 async fn cmd_archive(key: String) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let res = client
         .post(
             &format!("/api/sessions/{}/archive", enc_key(&key)),
@@ -2976,7 +3151,7 @@ async fn cmd_archive(key: String) -> Result<()> {
 }
 
 async fn cmd_adopt(key: String) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let ws = client
         .post(&format!("/api/sessions/{}/adopt", enc_key(&key)), json!({}))
         .await?;
@@ -2992,7 +3167,7 @@ async fn cmd_adopt(key: String) -> Result<()> {
 }
 
 async fn cmd_recover(key: String) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let ws = client
         .post(
             &format!("/api/sessions/{}/recover", enc_key(&key)),
@@ -3017,7 +3192,7 @@ async fn cmd_handoff(
     effort: Option<String>,
     mode: Option<String>,
 ) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let ws = client
         .handoff_session(
             &key,
@@ -3041,7 +3216,7 @@ async fn cmd_handoff(
 }
 
 async fn cmd_rm(key: String, keep_branch: bool) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let path = format!("/api/sessions/{}?keep_branch={keep_branch}", enc_key(&key));
     let res = client.delete(&path).await?;
     println!("removed session {key}");
@@ -3056,7 +3231,7 @@ async fn cmd_rm(key: String, keep_branch: bool) -> Result<()> {
 }
 
 async fn cmd_open() -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let url = client.base().to_string();
     println!("opening {url}");
     if std::process::Command::new("xdg-open")
@@ -3154,7 +3329,7 @@ async fn cmd_watch_new(name: String) -> Result<()> {
 /// (the registry the panel offers), or print one program's script source with
 /// `--source` as a working example to start a custom program from.
 async fn cmd_watch_programs(source: Option<String>) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let rows = client
         .get("/api/watches/programs")
         .await?
@@ -3221,7 +3396,7 @@ fn build_scope(opts: &AddOpts) -> Result<Value> {
 
 /// `loom watch add` — register a watch via POST /api/watches.
 async fn cmd_watch_add(opts: AddOpts) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let trigger = build_trigger(&opts);
     let scope = build_scope(&opts)?;
     let params = opts
@@ -3269,7 +3444,7 @@ async fn cmd_watch_add(opts: AddOpts) -> Result<()> {
 
 /// `loom watch rm` — delete a watch.
 async fn cmd_watch_rm(name: String) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     client.delete(&format!("/api/watches/{name}")).await?;
     println!("removed watch {name}");
     Ok(())
@@ -3277,7 +3452,7 @@ async fn cmd_watch_rm(name: String) -> Result<()> {
 
 /// `loom watch enable|disable` — PATCH the `enabled` toggle.
 async fn cmd_watch_set_enabled(name: String, enabled: bool) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let o = client
         .patch(
             &format!("/api/watches/{name}"),
@@ -3294,7 +3469,7 @@ async fn cmd_watch_set_enabled(name: String, enabled: bool) -> Result<()> {
 
 /// `loom watch ls` — a table of every watch.
 async fn cmd_watch_ls() -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let rows = client
         .get("/api/watches")
         .await?
@@ -3330,7 +3505,7 @@ async fn cmd_watch_ls() -> Result<()> {
 
 /// `loom watch run` — fire a round now and print outcome + summary.
 async fn cmd_watch_run(name: String, dry_run: bool) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let res = client
         .post(
             &format!("/api/watches/{name}/run"),
@@ -3350,7 +3525,7 @@ async fn cmd_watch_run(name: String, dry_run: bool) -> Result<()> {
 /// `loom watch runs` / `logs` — the round history. `verbose` (the `logs`
 /// alias) also prints each round's actions.
 async fn cmd_watch_runs(name: String, limit: i64, verbose: bool) -> Result<()> {
-    let client = client::default();
+    let client = client::default()?;
     let rows = client
         .get(&format!("/api/watches/{name}/runs?limit={limit}"))
         .await?
@@ -3466,6 +3641,35 @@ fn capabilities_summary(o: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn client_context_commands_parse() {
+        let Cli { context, cmd } =
+            Cli::try_parse_from(["loom", "--context", "local", "session", "ls"]).unwrap();
+        assert_eq!(context.as_deref(), Some("local"));
+        assert!(matches!(cmd, Cmd::Session { .. }));
+
+        let Cli { cmd, .. } = Cli::try_parse_from([
+            "loom",
+            "context",
+            "add",
+            "production",
+            "--url",
+            "https://loom.example.com",
+            "--use",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cmd,
+            Cmd::Context {
+                cmd: ClientContextCmd::Add {
+                    name,
+                    use_context: true,
+                    ..
+                }
+            } if name == "production"
+        ));
+    }
 
     #[test]
     fn format_uptime_picks_a_sensible_granularity() {

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -879,7 +879,7 @@ async fn run() -> Result<()> {
             token_stdin,
         } => cmd_login(name, url, token_stdin).await,
         Cmd::Logout { name } => cmd_logout(name),
-        Cmd::Context { cmd } => run_client_context(cmd, context.as_deref()),
+        Cmd::Context { cmd } => run_client_context(cmd),
         Cmd::Profile { cmd } => run_profile(cmd).await,
         Cmd::Federation { cmd } => run_federation(cmd).await,
         Cmd::Deployment { cmd } => run_deployment(cmd).await,
@@ -1050,7 +1050,7 @@ fn cmd_logout(name: String) -> Result<()> {
     Ok(())
 }
 
-fn run_client_context(cmd: ClientContextCmd, explicit: Option<&str>) -> Result<()> {
+fn run_client_context(cmd: ClientContextCmd) -> Result<()> {
     let paths = loom::client_context::ClientPaths::discover()?;
     match cmd {
         ClientContextCmd::Ls => {
@@ -1085,26 +1085,26 @@ fn run_client_context(cmd: ClientContextCmd, explicit: Option<&str>) -> Result<(
             Ok(())
         }
         ClientContextCmd::Current => {
-            if explicit.is_none()
-                && std::env::var("WEAVER_API").is_ok_and(|url| !url.trim().is_empty())
-            {
-                println!("WEAVER_API  {}", loom::endpoint::base_url());
-                return Ok(());
-            }
-            match loom::client_context::resolve(explicit)? {
-                Some(context) => {
-                    let source = match context.source {
+            let selection = client::current_selection()?;
+            match selection.source {
+                client::ClientSelectionSource::Context { name, source } => {
+                    let source_name = match source {
                         loom::client_context::ContextSource::Explicit => "--context",
                         loom::client_context::ContextSource::Environment => "LOOM_CONTEXT",
-                        loom::client_context::ContextSource::Repository(ref path) => {
+                        loom::client_context::ContextSource::Repository(path) => {
                             println!("selector: {}", path.display());
                             "repository"
                         }
                         loom::client_context::ContextSource::Default => "default",
                     };
-                    println!("{}  {}  {source}", context.name, context.url);
+                    println!("{name}  {}  {source_name}", selection.base);
                 }
-                None => println!("local  {}  implicit", loom::endpoint::base_url()),
+                client::ClientSelectionSource::Environment => {
+                    println!("WEAVER_API  {}", selection.base)
+                }
+                client::ClientSelectionSource::Local => {
+                    println!("local  {}  implicit", selection.base)
+                }
             }
             Ok(())
         }

--- a/crates/loom/src/client.rs
+++ b/crates/loom/src/client.rs
@@ -3,33 +3,94 @@
 //! The client itself — typed methods and untyped JSON transport — lives in
 //! [`weaver_api::Client`], shared with the Python binding and any other
 //! out-of-process consumer. This module re-exports it and supplies the default
-//! base URL from [`crate::endpoint`], so loom's callers get a client pointed at
-//! the running daemon with no configuration.
+//! base URL from the selected [`crate::client_context`], falling back to local
+//! daemon discovery from [`crate::endpoint`].
+
+use std::sync::OnceLock;
+
+use anyhow::{bail, Result};
 
 pub use weaver_api::Client;
 
-/// A client pointed at the running daemon — the base URL resolved from
-/// `$WEAVER_API`, the recorded server address, then the default
-/// (see [`crate::endpoint::base_url`]).
-///
-/// The bearer token is resolved from `$LOOM_TOKEN`, falling back to the
-/// machine-local token file ([`crate::auth::local_token_path`]) so a same-host
-/// CLI works even when loopback trust is off and the user set no env var. A
-/// remote CLI (talking to a server on another host) has no local file, so it
-/// relies on `$LOOM_TOKEN` being set — as it must, since loopback trust can't
-/// apply across the network.
-pub fn default() -> Client {
-    Client::new(crate::endpoint::base_url()).with_token(resolve_token())
+static CONTEXT_OVERRIDE: OnceLock<String> = OnceLock::new();
+
+pub fn set_context_override(name: Option<&str>) -> Result<()> {
+    let Some(name) = name else {
+        return Ok(());
+    };
+    let name = crate::client_context::validate_name(name)?.to_string();
+    if let Some(current) = CONTEXT_OVERRIDE.get() {
+        if current != &name {
+            bail!("Loom context is already set to '{current}'");
+        }
+        return Ok(());
+    }
+    CONTEXT_OVERRIDE
+        .set(name)
+        .map_err(|_| anyhow::anyhow!("could not set Loom context"))
 }
 
-/// The bearer token a local CLI should present: `$LOOM_TOKEN`, else the
-/// persisted machine-local token, else none.
-fn resolve_token() -> Option<String> {
-    if let Ok(t) = std::env::var("LOOM_TOKEN") {
+/// A client pointed at the selected Loom server.
+///
+/// `$WEAVER_API` wins over named contexts. Authentication resolves from an
+/// explicit `$LOOM_TOKEN`, the selected context's credential, then the
+/// machine-local bearer for loopback endpoints only.
+pub fn default() -> Result<Client> {
+    let context_override = CONTEXT_OVERRIDE.get().map(String::as_str);
+    let explicit_endpoint = std::env::var("WEAVER_API")
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty());
+    let context = if context_override.is_some() {
+        crate::client_context::resolve(context_override)?
+    } else if explicit_endpoint {
+        None
+    } else {
+        crate::client_context::resolve(None)?
+    };
+    let base = context
+        .as_ref()
+        .map(|context| context.url.clone())
+        .unwrap_or_else(crate::endpoint::base_url);
+    let use_environment_token =
+        !explicit_endpoint || same_endpoint(&base, &crate::endpoint::base_url());
+    let token = resolve_token(
+        context.and_then(|context| context.token),
+        &base,
+        use_environment_token,
+    );
+    Ok(Client::new(base).with_token(token))
+}
+
+/// Resolve a bearer without ever sending the machine-local token to a remote
+/// host.
+fn resolve_token(
+    context_token: Option<String>,
+    base: &str,
+    use_environment_token: bool,
+) -> Option<String> {
+    if let Some(t) = std::env::var("LOOM_TOKEN")
+        .ok()
+        .filter(|_| use_environment_token)
+    {
         let t = t.trim().to_string();
         if !t.is_empty() {
             return Some(t);
         }
     }
-    crate::agent::read_local_token()
+    context_token.or_else(|| {
+        is_loopback(base)
+            .then(crate::agent::read_local_token)
+            .flatten()
+    })
+}
+
+fn same_endpoint(left: &str, right: &str) -> bool {
+    reqwest::Url::parse(left).ok() == reqwest::Url::parse(right).ok()
+}
+
+fn is_loopback(base: &str) -> bool {
+    reqwest::Url::parse(base)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_string))
+        .is_some_and(|host| matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1"))
 }

--- a/crates/loom/src/client.rs
+++ b/crates/loom/src/client.rs
@@ -12,8 +12,39 @@ use anyhow::{bail, Result};
 
 pub use weaver_api::Client;
 
+// The binary parses this once before dispatch. A write-once process value keeps
+// the cross-cutting CLI option out of every subcommand signature without
+// allowing it to change while an operation is running.
 static CONTEXT_OVERRIDE: OnceLock<String> = OnceLock::new();
 
+/// The endpoint selected for this CLI process and why it was selected.
+pub struct ClientSelection {
+    /// Normalized Loom server URL.
+    pub base: String,
+    /// Configuration source that selected the endpoint.
+    pub source: ClientSelectionSource,
+}
+
+/// The source of a selected CLI endpoint.
+pub enum ClientSelectionSource {
+    /// A named user context selected by a flag, environment, repository, or default.
+    Context {
+        name: String,
+        source: crate::client_context::ContextSource,
+    },
+    /// The legacy `WEAVER_API` endpoint override.
+    Environment,
+    /// The recorded or implicit local server.
+    Local,
+}
+
+struct ResolvedClient {
+    selection: ClientSelection,
+    context_token: Option<String>,
+    use_environment_token: bool,
+}
+
+/// Set the global `--context` value once, before CLI dispatch.
 pub fn set_context_override(name: Option<&str>) -> Result<()> {
     let Some(name) = name else {
         return Ok(());
@@ -32,10 +63,28 @@ pub fn set_context_override(name: Option<&str>) -> Result<()> {
 
 /// A client pointed at the selected Loom server.
 ///
-/// `$WEAVER_API` wins over named contexts. Authentication resolves from an
-/// explicit `$LOOM_TOKEN`, the selected context's credential, then the
-/// machine-local bearer for loopback endpoints only.
+/// An explicit `--context` wins over `$WEAVER_API`; otherwise the environment
+/// endpoint wins over automatic context selection. Authentication normally
+/// resolves from `$LOOM_TOKEN`, the selected context's credential, then the
+/// machine-local bearer for loopback endpoints. When `--context` selects a
+/// different endpoint than `$WEAVER_API`, the paired environment token is not
+/// sent to that server.
 pub fn default() -> Result<Client> {
+    let resolved = resolve_client()?;
+    let token = resolve_token(
+        resolved.context_token,
+        &resolved.selection.base,
+        resolved.use_environment_token,
+    );
+    Ok(Client::new(resolved.selection.base).with_token(token))
+}
+
+/// Resolve the endpoint selection without constructing an HTTP client.
+pub fn current_selection() -> Result<ClientSelection> {
+    Ok(resolve_client()?.selection)
+}
+
+fn resolve_client() -> Result<ResolvedClient> {
     let context_override = CONTEXT_OVERRIDE.get().map(String::as_str);
     let explicit_endpoint = std::env::var("WEAVER_API")
         .ok()
@@ -47,18 +96,34 @@ pub fn default() -> Result<Client> {
     } else {
         crate::client_context::resolve(None)?
     };
-    let base = context
-        .as_ref()
-        .map(|context| context.url.clone())
-        .unwrap_or_else(crate::endpoint::base_url);
-    let use_environment_token =
-        !explicit_endpoint || same_endpoint(&base, &crate::endpoint::base_url());
-    let token = resolve_token(
-        context.and_then(|context| context.token),
-        &base,
-        use_environment_token,
+    let environment_base = explicit_endpoint.then(crate::endpoint::base_url);
+    let base = context.as_ref().map_or_else(
+        || {
+            environment_base
+                .clone()
+                .unwrap_or_else(crate::endpoint::base_url)
+        },
+        |context| context.url.clone(),
     );
-    Ok(Client::new(base).with_token(token))
+    let use_environment_token = environment_base
+        .as_deref()
+        .is_none_or(|environment| same_endpoint(&base, environment));
+    let (source, context_token) = match context {
+        Some(context) => (
+            ClientSelectionSource::Context {
+                name: context.name,
+                source: context.source,
+            },
+            context.token,
+        ),
+        None if explicit_endpoint => (ClientSelectionSource::Environment, None),
+        None => (ClientSelectionSource::Local, None),
+    };
+    Ok(ResolvedClient {
+        selection: ClientSelection { base, source },
+        context_token,
+        use_environment_token,
+    })
 }
 
 /// Resolve a bearer without ever sending the machine-local token to a remote

--- a/crates/loom/src/client_context.rs
+++ b/crates/loom/src/client_context.rs
@@ -248,7 +248,7 @@ pub fn resolve(explicit: Option<&str>) -> Result<Option<ResolvedContext>> {
     resolve_from(&paths, explicit, environment.as_deref(), &cwd)
 }
 
-/// Resolve a named context from explicit inputs, used by the CLI and tests.
+/// Resolve a named context from supplied paths, selectors, and working directory.
 pub fn resolve_from(
     paths: &ClientPaths,
     explicit: Option<&str>,

--- a/crates/loom/src/client_context.rs
+++ b/crates/loom/src/client_context.rs
@@ -1,0 +1,409 @@
+//! Named remote-client contexts for the `loom` CLI.
+//!
+//! Server URLs live in the user's XDG config directory. Bearer tokens use a
+//! separate owner-only file, while a repository may select a context by name
+//! without supplying an endpoint or credential.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+const CONFIG_FILE: &str = "config.toml";
+const CREDENTIALS_FILE: &str = "credentials.toml";
+const REPO_CONFIG: &str = ".loom/client.toml";
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct ClientConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_context: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub contexts: BTreeMap<String, ContextConfig>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ContextConfig {
+    pub url: String,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct Credentials {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    contexts: BTreeMap<String, ContextCredential>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ContextCredential {
+    token: String,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RepoConfig {
+    context: String,
+}
+
+#[derive(Clone)]
+pub struct ClientPaths {
+    pub config: PathBuf,
+    pub credentials: PathBuf,
+}
+
+#[derive(Clone)]
+pub struct ResolvedContext {
+    pub name: String,
+    pub url: String,
+    pub token: Option<String>,
+    pub source: ContextSource,
+}
+
+#[derive(Clone)]
+pub enum ContextSource {
+    Explicit,
+    Environment,
+    Repository(PathBuf),
+    Default,
+}
+
+pub struct ContextSummary {
+    pub name: String,
+    pub url: String,
+    pub authenticated: bool,
+    pub is_default: bool,
+}
+
+impl ClientPaths {
+    pub fn discover() -> Result<Self> {
+        let root = match std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
+            Some(path) => PathBuf::from(path).join("loom"),
+            None => PathBuf::from(
+                std::env::var_os("HOME")
+                    .context("HOME is required to locate Loom client configuration")?,
+            )
+            .join(".config/loom"),
+        };
+        Ok(Self {
+            config: root.join(CONFIG_FILE),
+            credentials: root.join(CREDENTIALS_FILE),
+        })
+    }
+}
+
+pub fn normalize_url(value: &str) -> Result<String> {
+    let value = value.trim().trim_end_matches('/');
+    let parsed =
+        reqwest::Url::parse(value).context("server URL must include http:// or https://")?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        bail!("server URL must use http or https and include a host");
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        bail!("server URL must not contain credentials");
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() || !matches!(parsed.path(), "" | "/")
+    {
+        bail!("server URL must not contain a path, query, or fragment");
+    }
+    Ok(value.to_string())
+}
+
+pub fn validate_name(name: &str) -> Result<&str> {
+    let name = name.trim();
+    if name.is_empty()
+        || name.len() > 64
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        bail!("context names use 1-64 ASCII letters, digits, '.', '_', or '-'");
+    }
+    Ok(name)
+}
+
+pub fn load_config(paths: &ClientPaths) -> Result<ClientConfig> {
+    load_toml(&paths.config, "Loom client config")
+}
+
+pub fn context_url(paths: &ClientPaths, name: &str) -> Result<Option<String>> {
+    let name = validate_name(name)?;
+    Ok(load_config(paths)?
+        .contexts
+        .get(name)
+        .map(|context| context.url.clone()))
+}
+
+pub fn save_context(paths: &ClientPaths, name: &str, url: &str, make_default: bool) -> Result<()> {
+    let name = validate_name(name)?.to_string();
+    let url = normalize_url(url)?;
+    let mut config = load_config(paths)?;
+    config.contexts.insert(name.clone(), ContextConfig { url });
+    if make_default || config.default_context.is_none() {
+        config.default_context = Some(name);
+    }
+    save_config(paths, &config)
+}
+
+pub fn save_login(paths: &ClientPaths, name: &str, url: &str, token: &str) -> Result<()> {
+    let name = validate_name(name)?.to_string();
+    let token = token.trim();
+    if token.is_empty() {
+        bail!("token must not be empty");
+    }
+    save_context(paths, &name, url, true)?;
+    let mut credentials = load_credentials(paths)?;
+    credentials.contexts.insert(
+        name,
+        ContextCredential {
+            token: token.to_string(),
+        },
+    );
+    save_credentials(paths, &credentials)
+}
+
+pub fn use_context(paths: &ClientPaths, name: &str) -> Result<()> {
+    let name = validate_name(name)?;
+    let mut config = load_config(paths)?;
+    if !config.contexts.contains_key(name) {
+        bail!("unknown Loom context '{name}'");
+    }
+    config.default_context = Some(name.to_string());
+    save_config(paths, &config)
+}
+
+pub fn remove_login(paths: &ClientPaths, name: &str) -> Result<bool> {
+    let name = validate_name(name)?;
+    let mut credentials = load_credentials(paths)?;
+    let removed = credentials.contexts.remove(name).is_some();
+    if removed {
+        save_credentials(paths, &credentials)?;
+    }
+    Ok(removed)
+}
+
+pub fn remove_context(paths: &ClientPaths, name: &str) -> Result<bool> {
+    let name = validate_name(name)?;
+    let mut config = load_config(paths)?;
+    let removed = config.contexts.remove(name).is_some();
+    if !removed {
+        return Ok(false);
+    }
+    if config.default_context.as_deref() == Some(name) {
+        config.default_context = None;
+    }
+    save_config(paths, &config)?;
+    let _ = remove_login(paths, name)?;
+    Ok(true)
+}
+
+pub fn list_contexts(paths: &ClientPaths) -> Result<Vec<ContextSummary>> {
+    let config = load_config(paths)?;
+    let credentials = load_credentials(paths)?;
+    Ok(config
+        .contexts
+        .into_iter()
+        .map(|(name, context)| ContextSummary {
+            authenticated: credentials.contexts.contains_key(&name),
+            is_default: config.default_context.as_deref() == Some(name.as_str()),
+            name,
+            url: context.url,
+        })
+        .collect())
+}
+
+pub fn resolve(explicit: Option<&str>) -> Result<Option<ResolvedContext>> {
+    let paths = ClientPaths::discover()?;
+    let cwd = std::env::current_dir().context("resolving current directory")?;
+    resolve_from(
+        &paths,
+        explicit,
+        std::env::var("LOOM_CONTEXT").ok().as_deref(),
+        &cwd,
+    )
+}
+
+pub fn resolve_from(
+    paths: &ClientPaths,
+    explicit: Option<&str>,
+    environment: Option<&str>,
+    cwd: &Path,
+) -> Result<Option<ResolvedContext>> {
+    let config = load_config(paths)?;
+    let selected = if let Some(name) = explicit.filter(|name| !name.trim().is_empty()) {
+        Some((name.to_string(), ContextSource::Explicit))
+    } else if let Some(name) = environment.filter(|name| !name.trim().is_empty()) {
+        Some((name.to_string(), ContextSource::Environment))
+    } else if let Some((name, path)) = repo_context(cwd)? {
+        Some((name, ContextSource::Repository(path)))
+    } else {
+        config
+            .default_context
+            .clone()
+            .map(|name| (name, ContextSource::Default))
+    };
+    let Some((name, source)) = selected else {
+        return Ok(None);
+    };
+    let name = validate_name(&name)?.to_string();
+    let context = config.contexts.get(&name).with_context(|| {
+        format!(
+            "Loom context '{name}' is not defined in {}",
+            paths.config.display()
+        )
+    })?;
+    let credentials = load_credentials(paths)?;
+    let token = credentials
+        .contexts
+        .get(&name)
+        .map(|credential| credential.token.clone());
+    Ok(Some(ResolvedContext {
+        name,
+        url: normalize_url(&context.url)?,
+        token,
+        source,
+    }))
+}
+
+fn repo_context(cwd: &Path) -> Result<Option<(String, PathBuf)>> {
+    for directory in cwd.ancestors() {
+        let path = directory.join(REPO_CONFIG);
+        if path.is_file() {
+            let config: RepoConfig = load_toml(&path, "repository Loom client config")?;
+            return Ok(Some((validate_name(&config.context)?.to_string(), path)));
+        }
+        if directory.join(".git").exists() {
+            break;
+        }
+    }
+    Ok(None)
+}
+
+fn load_toml<T: Default + for<'de> Deserialize<'de>>(path: &Path, description: &str) -> Result<T> {
+    if !path.exists() {
+        return Ok(T::default());
+    }
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    toml::from_str(&text).with_context(|| format!("parsing {description} at {}", path.display()))
+}
+
+fn load_credentials(paths: &ClientPaths) -> Result<Credentials> {
+    if !paths.credentials.exists() {
+        return Ok(Credentials::default());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&paths.credentials)
+            .with_context(|| format!("reading metadata for {}", paths.credentials.display()))?
+            .permissions()
+            .mode();
+        if mode & 0o077 != 0 {
+            bail!(
+                "{} contains Loom credentials and must have mode 0600",
+                paths.credentials.display()
+            );
+        }
+    }
+    load_toml(&paths.credentials, "Loom client credentials")
+}
+
+fn save_config(paths: &ClientPaths, config: &ClientConfig) -> Result<()> {
+    let text = toml::to_string_pretty(config).context("serializing Loom client config")?;
+    if let Some(parent) = paths.config.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    std::fs::write(&paths.config, text)
+        .with_context(|| format!("writing {}", paths.config.display()))
+}
+
+fn save_credentials(paths: &ClientPaths, credentials: &Credentials) -> Result<()> {
+    let text =
+        toml::to_string_pretty(credentials).context("serializing Loom client credentials")?;
+    crate::envfile::write_private(&paths.credentials, &text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(root: &Path) -> ClientPaths {
+        ClientPaths {
+            config: root.join("config.toml"),
+            credentials: root.join("credentials.toml"),
+        }
+    }
+
+    #[test]
+    fn login_separates_endpoint_and_private_credentials() {
+        let directory = tempfile::tempdir().unwrap();
+        let paths = paths(directory.path());
+        save_login(
+            &paths,
+            "production",
+            "https://loom.example.com/",
+            "loom_secret",
+        )
+        .unwrap();
+
+        let config = std::fs::read_to_string(&paths.config).unwrap();
+        let credentials = std::fs::read_to_string(&paths.credentials).unwrap();
+        assert!(config.contains("https://loom.example.com"));
+        assert!(!config.contains("loom_secret"));
+        assert!(credentials.contains("loom_secret"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&paths.credentials)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_context_precedes_repository_and_default_contexts() {
+        let directory = tempfile::tempdir().unwrap();
+        let paths = paths(directory.path());
+        save_context(&paths, "local", "http://127.0.0.1:7878", true).unwrap();
+        save_login(
+            &paths,
+            "production",
+            "https://loom.example.com",
+            "loom_secret",
+        )
+        .unwrap();
+        use_context(&paths, "local").unwrap();
+        let repo = directory.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        std::fs::create_dir_all(repo.join(".loom")).unwrap();
+        std::fs::write(repo.join(REPO_CONFIG), "context = \"production\"\n").unwrap();
+
+        let repository = resolve_from(&paths, None, None, &repo).unwrap().unwrap();
+        assert_eq!(repository.name, "production");
+        assert_eq!(repository.token.as_deref(), Some("loom_secret"));
+        assert!(matches!(repository.source, ContextSource::Repository(_)));
+
+        let explicit = resolve_from(&paths, Some("local"), Some("production"), &repo)
+            .unwrap()
+            .unwrap();
+        assert_eq!(explicit.name, "local");
+        assert!(matches!(explicit.source, ContextSource::Explicit));
+    }
+
+    #[test]
+    fn urls_and_context_names_reject_credential_injection() {
+        assert!(normalize_url("https://user:secret@example.com").is_err());
+        assert!(normalize_url("https://example.com/api").is_err());
+        assert!(normalize_url("example.com").is_err());
+        assert!(validate_name("../../credentials").is_err());
+        assert_eq!(
+            normalize_url("http://127.0.0.1:7878/").unwrap(),
+            "http://127.0.0.1:7878"
+        );
+    }
+}

--- a/crates/loom/src/client_context.rs
+++ b/crates/loom/src/client_context.rs
@@ -15,6 +15,7 @@ const CREDENTIALS_FILE: &str = "credentials.toml";
 const REPO_CONFIG: &str = ".loom/client.toml";
 
 #[derive(Clone, Default, Serialize, Deserialize)]
+/// Public endpoint configuration stored in the user's XDG config directory.
 pub struct ClientConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_context: Option<String>,
@@ -23,6 +24,7 @@ pub struct ClientConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+/// One named Loom server endpoint.
 pub struct ContextConfig {
     pub url: String,
 }
@@ -45,12 +47,14 @@ struct RepoConfig {
 }
 
 #[derive(Clone)]
+/// Paths to the public endpoint config and private credential store.
 pub struct ClientPaths {
     pub config: PathBuf,
     pub credentials: PathBuf,
 }
 
 #[derive(Clone)]
+/// A named context resolved for the current invocation.
 pub struct ResolvedContext {
     pub name: String,
     pub url: String,
@@ -59,6 +63,7 @@ pub struct ResolvedContext {
 }
 
 #[derive(Clone)]
+/// The selector that chose a named context.
 pub enum ContextSource {
     Explicit,
     Environment,
@@ -66,6 +71,7 @@ pub enum ContextSource {
     Default,
 }
 
+/// Non-secret context metadata displayed by `loom context ls`.
 pub struct ContextSummary {
     pub name: String,
     pub url: String,
@@ -74,6 +80,7 @@ pub struct ContextSummary {
 }
 
 impl ClientPaths {
+    /// Locate Loom client files using `XDG_CONFIG_HOME` or `~/.config`.
     pub fn discover() -> Result<Self> {
         let root = match std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
             Some(path) => PathBuf::from(path).join("loom"),
@@ -90,6 +97,7 @@ impl ClientPaths {
     }
 }
 
+/// Validate and normalize a root HTTP(S) Loom server URL.
 pub fn normalize_url(value: &str) -> Result<String> {
     let value = value.trim().trim_end_matches('/');
     let parsed =
@@ -107,6 +115,7 @@ pub fn normalize_url(value: &str) -> Result<String> {
     Ok(value.to_string())
 }
 
+/// Validate a portable context name and return its trimmed form.
 pub fn validate_name(name: &str) -> Result<&str> {
     let name = name.trim();
     if name.is_empty()
@@ -120,10 +129,12 @@ pub fn validate_name(name: &str) -> Result<&str> {
     Ok(name)
 }
 
+/// Load the public context configuration, or an empty configuration if absent.
 pub fn load_config(paths: &ClientPaths) -> Result<ClientConfig> {
     load_toml(&paths.config, "Loom client config")
 }
 
+/// Return the configured URL for a named context.
 pub fn context_url(paths: &ClientPaths, name: &str) -> Result<Option<String>> {
     let name = validate_name(name)?;
     Ok(load_config(paths)?
@@ -132,6 +143,7 @@ pub fn context_url(paths: &ClientPaths, name: &str) -> Result<Option<String>> {
         .map(|context| context.url.clone()))
 }
 
+/// Add or update a context endpoint without changing its credential.
 pub fn save_context(paths: &ClientPaths, name: &str, url: &str, make_default: bool) -> Result<()> {
     let name = validate_name(name)?.to_string();
     let url = normalize_url(url)?;
@@ -143,6 +155,7 @@ pub fn save_context(paths: &ClientPaths, name: &str, url: &str, make_default: bo
     save_config(paths, &config)
 }
 
+/// Save a validated endpoint and its personal API token in separate files.
 pub fn save_login(paths: &ClientPaths, name: &str, url: &str, token: &str) -> Result<()> {
     let name = validate_name(name)?.to_string();
     let token = token.trim();
@@ -160,6 +173,7 @@ pub fn save_login(paths: &ClientPaths, name: &str, url: &str, token: &str) -> Re
     save_credentials(paths, &credentials)
 }
 
+/// Make an existing named context the user default.
 pub fn use_context(paths: &ClientPaths, name: &str) -> Result<()> {
     let name = validate_name(name)?;
     let mut config = load_config(paths)?;
@@ -170,6 +184,7 @@ pub fn use_context(paths: &ClientPaths, name: &str) -> Result<()> {
     save_config(paths, &config)
 }
 
+/// Remove a locally saved credential without revoking the server-side token.
 pub fn remove_login(paths: &ClientPaths, name: &str) -> Result<bool> {
     let name = validate_name(name)?;
     let mut credentials = load_credentials(paths)?;
@@ -180,6 +195,7 @@ pub fn remove_login(paths: &ClientPaths, name: &str) -> Result<bool> {
     Ok(removed)
 }
 
+/// Remove a context and its locally saved credential.
 pub fn remove_context(paths: &ClientPaths, name: &str) -> Result<bool> {
     let name = validate_name(name)?;
     let mut config = load_config(paths)?;
@@ -195,6 +211,7 @@ pub fn remove_context(paths: &ClientPaths, name: &str) -> Result<bool> {
     Ok(true)
 }
 
+/// List contexts with credential presence but never credential values.
 pub fn list_contexts(paths: &ClientPaths) -> Result<Vec<ContextSummary>> {
     let config = load_config(paths)?;
     let credentials = load_credentials(paths)?;
@@ -210,17 +227,28 @@ pub fn list_contexts(paths: &ClientPaths) -> Result<Vec<ContextSummary>> {
         .collect())
 }
 
+/// Resolve a named context for the current process and working directory.
 pub fn resolve(explicit: Option<&str>) -> Result<Option<ResolvedContext>> {
-    let paths = ClientPaths::discover()?;
     let cwd = std::env::current_dir().context("resolving current directory")?;
-    resolve_from(
-        &paths,
-        explicit,
-        std::env::var("LOOM_CONTEXT").ok().as_deref(),
-        &cwd,
-    )
+    let environment = std::env::var("LOOM_CONTEXT").ok();
+    let paths = match ClientPaths::discover() {
+        Ok(paths) => paths,
+        Err(error) => {
+            let named_context_requested = explicit.is_some_and(|name| !name.trim().is_empty())
+                || environment
+                    .as_deref()
+                    .is_some_and(|name| !name.trim().is_empty())
+                || repo_context(&cwd)?.is_some();
+            if named_context_requested {
+                return Err(error);
+            }
+            return Ok(None);
+        }
+    };
+    resolve_from(&paths, explicit, environment.as_deref(), &cwd)
 }
 
+/// Resolve a named context from explicit inputs, used by the CLI and tests.
 pub fn resolve_from(
     paths: &ClientPaths,
     explicit: Option<&str>,

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -15,6 +15,7 @@ pub mod builtins;
 pub mod chat;
 pub mod chatlog;
 pub mod client;
+pub mod client_context;
 pub mod custom_agents;
 pub mod db;
 pub mod endpoint;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,7 @@ other `weaver` subcommand.
 | `crates/weaver/src/bin/weaver.rs` | the slim agent-facing CLI (`summary`, `readme`, `status` [read or set level + message], `tag` [`set`/`rm`/`ls` a branch tag], `issue …`, `where`, `log`, `chatlog` [render the agent's conversation transcript], `hook`, `config` [read-only: `get`/`ls`; writes go through `loom config set` or the settings pane]) — every command drives `weaver-api::Client` over HTTP; none touch sqlite |
 | `crates/loom/src/web.rs` | axum routes, request/response types, SSE — **the API surface** (incl. the auth middleware + login/token/user handlers) |
 | `crates/loom/src/auth.rs` | authentication core: token/password crypto, the `users`/`api_tokens`/`auth_sessions` tables, the machine-local token, and the GitHub OAuth calls. `axum`-free so it unit-tests directly |
+| `crates/loom/src/client_context.rs` | named endpoint and credential resolution for the `loom` CLI: XDG user config, private credentials, and repository context selection |
 | `crates/loom/src/server.rs` | bind, write `server.json`, spawn bg tasks |
 | `crates/loom/src/monitor.rs` | status detection, orphan marking, hook-event consumer, and the shared lifecycle-promotion path (`promote_lifecycle`) both the terminal hook consumer and the ACP turn-boundary driver (`record_acp_lifecycle`) run through |
 | `crates/loom/src/watch.rs` | the watch engine: cron timer + event dispatcher + the round executor (the script subprocess executor every program runs on) |
@@ -643,10 +644,11 @@ to be restricted to the host metrics agent at the deployment edge). The static
 SPA needs no API principal. Protected requests resolve the
 request to a `Principal` three ways, in order:
 
-- **API token** — an `Authorization: Bearer loom_…` header. This is the
-  `LOOM_TOKEN` a CI job or a remote `loom` CLI presents. Tokens are random
-  secrets stored only as a SHA-256 hash (`api_tokens.token_hash`); the plaintext
-  is shown once at creation. Managed under Settings → Tokens or `loom token`.
+- **API token** — an `Authorization: Bearer loom_…` header. This is the token a
+  remote `loom` CLI saves with `loom login`, or that an ephemeral client passes
+  in `LOOM_TOKEN`. Tokens are random secrets stored only as a SHA-256 hash
+  (`api_tokens.token_hash`); the plaintext is shown once at creation. Managed
+  under Settings → Tokens or `loom token`.
 - **Session cookie** — the opaque `loom_session` cookie set by a successful
   GitHub or username/password login, stored hashed in `auth_sessions`.
 - **Loopback trust** — a request from `127.0.0.1`/`::1` is taken to be the
@@ -686,6 +688,17 @@ behind a **same-host reverse proxy** (where forwarded requests look like
 loopback and so trust must be off) local automation still authenticates via this
 token, while remote callers must present their own. The local token is hidden
 from the token list and is not revocable from the UI.
+
+**CLI contexts.** The `loom` CLI stores named server URLs in
+`$XDG_CONFIG_HOME/loom/config.toml` and their personal API tokens in a separate
+mode-0600 `credentials.toml`. A repository `.loom/client.toml` may select a
+context by name, but cannot provide a URL or token. Resolution order is
+`--context`, an explicit `WEAVER_API`, `LOOM_CONTEXT`, repository selection,
+the user default, then local daemon discovery. `LOOM_TOKEN` overrides the
+selected context's token unless an explicit context selects a different
+endpoint than `WEAVER_API`. The machine-local token fallback is limited to
+loopback URLs, so a local token is never sent to a context that names a remote
+host.
 
 **Workload federation.** An admin-managed federation mapping fixes the provider,
 issuer, exact audience, identity, service tag, and allowed strict automation
@@ -792,9 +805,10 @@ builtins are stdlib-only and need neither).
 |---|---|---|
 | `WEAVER_HOME` | state directory | `~/.weaver` |
 | `WEAVER_DB` | sqlite path, read only by `loom` | `$WEAVER_HOME/weaver.db` |
-| `WEAVER_API` | loom URL (both sides — server binds, `weaver`/`loom` CLI clients talk) | `http://127.0.0.1:7878` |
+| `WEAVER_API` | explicit loom URL (server bind input and CLI override) | `http://127.0.0.1:7878` |
+| `LOOM_CONTEXT` | named context for the `loom` CLI when `WEAVER_API` is unset | user default |
 | `WEAVER_BRANCH` | the current branch key, set by `loom session launch` in the worktree — the only source `weaver` uses; unset, every `weaver` command fails with a friendly error | — |
-| `LOOM_TOKEN` | bearer token the `weaver`/`loom` CLIs and automation send; falls back to the machine-local token file on the same host | — |
+| `LOOM_TOKEN` | explicit bearer token for the `weaver`/`loom` CLIs and automation; `loom` otherwise uses its selected context credential or a loopback-only machine token | — |
 | `LOOM_OWNER_GITHUB` | GitHub login seeded as the owner on a fresh database; unset seeds no owner at all | — |
 | `LOOM_GITHUB_CLIENT_ID` / `LOOM_GITHUB_CLIENT_SECRET` | GitHub OAuth app credentials (override the settings-stored values) | — |
 | `WEAVER_TAPESTRY_DIR` | directory holding tapestry's per-session control sockets | `$WEAVER_HOME/sock` |

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -11,8 +11,9 @@ test.describe('settings · tokens', () => {
     await page.getByTestId('settings-tab-access').click();
     await expect(page.getByTestId('token-row')).toHaveCount(0);
 
-    // Create a token — the one-time secret banner appears with a `loom_` value.
-    await page.getByTestId('token-name').fill('github-actions');
+    // Personal tokens default to the recommended 30-day lifetime.
+    await expect(page.getByTestId('token-lifetime')).toHaveValue('30');
+    await page.getByTestId('token-name').fill('laptop');
     await page.getByTestId('token-create').click();
 
     const banner = page.getByTestId('new-token');
@@ -22,7 +23,8 @@ test.describe('settings · tokens', () => {
     // It now shows in the list.
     const row = page.getByTestId('token-row');
     await expect(row).toHaveCount(1);
-    await expect(row).toContainText('github-actions');
+    await expect(row).toContainText('laptop');
+    await expect(row).toContainText('Expires');
 
     // Revoke it (accept the confirm dialog) and it disappears.
     page.once('dialog', (d) => d.accept());


### PR DESCRIPTION
Remote Loom clients currently require manually pairing WEAVER_API and LOOM_TOKEN for every shell. Add named client contexts plus loom login/logout/context commands so a user can validate a personal API token once, store it in a mode-0600 credential file, and switch explicitly between local and hosted Loom servers. A repository may select a user-defined context by name without supplying an endpoint or credential.

Endpoint selection has one implementation shared by HTTP client construction and loom context current. An explicit context overrides the ambient endpoint, and Loom refuses to carry an injected local token to a different remote endpoint. The top-level context flag is captured in a write-once process value before dispatch because client construction remains lazy in leaf command handlers; it cannot change during a command.

The personal-token form now defaults to a recommended 30-day lifetime and replaces the ambiguous number input with named choices. It distinguishes these credentials from federated workflow tokens, whose fixed ten-minute lifetime is automatic and does not correspond to a personal-token choice.

Validated with the repository pre-commit gate, cargo test --workspace --locked, all 124 Playwright tests, and an isolated server smoke covering token creation, login validation, saved-context authentication, mode-0600 storage, and revocation.