### PR TITLE
fix(loom): expand full command lines

### DIFF
--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -1085,6 +1085,12 @@ function activitySummary(row: Extract<Row, { type: 'activity' }>): string {
 function hasDetail(t: ToolCallPayload): boolean {
   return (t.content ?? []).some((c) => c.type === 'diff' || (c.type === 'text' && !!c.text));
 }
+// Execute titles are the command line itself. Keep long commands compact in the
+// activity list, but always let the operator disclose the complete command even
+// when the call produced no output to use as a detail panel.
+function canExpandTool(t: ToolCallPayload): boolean {
+  return t.tool_kind === 'execute' || hasDetail(t);
+}
 interface DiffLine {
   sign: '-' | '+';
   text: string;
@@ -1320,18 +1326,32 @@ function goTo(anchor: string) {
                     <button
                       type="button"
                       class="acp-activity-line"
-                      :disabled="!hasDetail(entry.item.tool)"
+                      :disabled="!canExpandTool(entry.item.tool)"
+                      :aria-expanded="
+                        canExpandTool(entry.item.tool)
+                          ? foldOpen(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed)
+                          : undefined
+                      "
                       @click="toggleFold(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed)"
                     >
                       <span class="acp-tool-glyph">{{ toolGlyph(entry.item.tool.tool_kind) }}</span>
-                      <span class="truncate">{{
-                        entry.item.tool.title || entry.item.tool.tool_kind
-                      }}</span>
+                      <span
+                        class="acp-activity-title"
+                        :class="{
+                          truncate: !foldOpen(
+                            `tool-${entry.item.tool.tool_call_id}`,
+                            entry.item.failed,
+                          ),
+                          open: foldOpen(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed),
+                        }"
+                        data-testid="acp-activity-title"
+                        >{{ entry.item.tool.title || entry.item.tool.tool_kind }}</span
+                      >
                       <span v-if="entry.item.failed" class="acp-activity-status text-block"
                         >failed</span
                       >
                       <span
-                        v-else-if="hasDetail(entry.item.tool)"
+                        v-else-if="canExpandTool(entry.item.tool)"
                         class="chev sm"
                         :class="{
                           open: foldOpen(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed),
@@ -1955,6 +1975,11 @@ function goTo(anchor: string) {
 .acp-activity-line:not(:disabled):hover {
   background: color-mix(in srgb, var(--subtle) 55%, transparent);
   color: var(--fg);
+}
+.acp-activity-title.open {
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 .acp-activity-status {
   margin-left: auto;

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -1131,6 +1131,12 @@ function toggleFold(key: string, dflt = false) {
   m.set(key, !foldOpen(key, dflt));
   folds.value = m;
 }
+function activityItemOpen(item: ActivityItem): boolean {
+  return foldOpen(`tool-${item.tool.tool_call_id}`, item.failed);
+}
+function toggleActivityItem(item: ActivityItem) {
+  toggleFold(`tool-${item.tool.tool_call_id}`, item.failed);
+}
 
 // ── Working timer (elapsed + time since observable progress) ─────────────────
 const clock = ref(Date.now());
@@ -1328,21 +1334,16 @@ function goTo(anchor: string) {
                       class="acp-activity-line"
                       :disabled="!canExpandTool(entry.item.tool)"
                       :aria-expanded="
-                        canExpandTool(entry.item.tool)
-                          ? foldOpen(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed)
-                          : undefined
+                        canExpandTool(entry.item.tool) ? activityItemOpen(entry.item) : undefined
                       "
-                      @click="toggleFold(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed)"
+                      @click="toggleActivityItem(entry.item)"
                     >
                       <span class="acp-tool-glyph">{{ toolGlyph(entry.item.tool.tool_kind) }}</span>
                       <span
                         class="acp-activity-title"
                         :class="{
-                          truncate: !foldOpen(
-                            `tool-${entry.item.tool.tool_call_id}`,
-                            entry.item.failed,
-                          ),
-                          open: foldOpen(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed),
+                          truncate: !activityItemOpen(entry.item),
+                          open: activityItemOpen(entry.item),
                         }"
                         data-testid="acp-activity-title"
                         >{{ entry.item.tool.title || entry.item.tool.tool_kind }}</span
@@ -1354,16 +1355,13 @@ function goTo(anchor: string) {
                         v-else-if="canExpandTool(entry.item.tool)"
                         class="chev sm"
                         :class="{
-                          open: foldOpen(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed),
+                          open: activityItemOpen(entry.item),
                         }"
                         >▸</span
                       >
                     </button>
                     <div
-                      v-if="
-                        hasDetail(entry.item.tool) &&
-                        foldOpen(`tool-${entry.item.tool.tool_call_id}`, entry.item.failed)
-                      "
+                      v-if="hasDetail(entry.item.tool) && activityItemOpen(entry.item)"
                       class="acp-detail"
                       data-testid="acp-detail"
                     >

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -256,6 +256,27 @@ test.describe('acp conversation', () => {
     await expect(page.getByTestId('acp-activity-item')).toHaveCount(2);
   });
 
+  test('expands a truncated command line in an activity run', async ({ page, weaver }) => {
+    const command =
+      'kubectl --kubeconfig /home/operator/.kube/cluster --context production -n services exec deployment/api -- printenv';
+    await openAcp(page, weaver, { goal: `tool:execute:${command}|say:done` });
+    await expect(page.getByText('done', { exact: true })).toBeVisible();
+
+    await page.getByTestId('acp-activity-head').click();
+    const item = page.getByTestId('acp-activity-item');
+    const title = item.getByTestId('acp-activity-title');
+    await expect(title).toHaveClass(/truncate/);
+    await expect(item.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+    await expect.poll(() => title.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true);
+    const collapsedHeight = await title.evaluate((el) => el.clientHeight);
+
+    await item.getByRole('button').click();
+    await expect(title).not.toHaveClass(/truncate/);
+    await expect(title).toHaveText(command);
+    await expect(item.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+    await expect.poll(() => title.evaluate((el) => el.clientHeight)).toBeGreaterThan(collapsedHeight);
+  });
+
   test('a failed call opens its group and shows the failure', async ({ page, weaver }) => {
     await openAcp(page, weaver, { goal: 'tool:read:Read config|toolfail:cargo test|say:after' });
     const conv = page.getByTestId('acp-conversation');


### PR DESCRIPTION
Keep ACP activity commands compact by default while making execute rows a disclosure that wraps the complete command on click. The same keyboard-accessible control continues to reveal tool output or diffs when present.

Add an end-to-end regression that proves a genuinely overflowing command grows to its full multi-line height when expanded.

Weaver session: https://loom.rjp.io/s/5gmwvtcs