### PR TITLE
fix(loom): use GitHub App for restricted sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,11 +429,12 @@ Notable settings:
   Loom expands profile capability sets into exact permissions when it stamps a
   session and derives adapter processes from its trusted MCP registry; profiles
   never supply executable MCP configuration. The GitHub credential never enters
-  the agent process. Loom uses the requester's stored token first, a profile
-  `GH_TOKEN` second, and the configured GitHub App's short-lived,
-  repository-scoped installation token otherwise. The stock `github_comment`
-  profile is seeded from its reviewed declarative manifest and remains
-  operator-editable after the first seed. See
+  the agent process. Loom uses the configured GitHub App's short-lived,
+  repository-scoped installation token. An App-less deployment can explicitly
+  configure a profile `GH_TOKEN`; personal user tokens remain exclusive to
+  ordinary interactive sessions. The stock `github_comment` profile is seeded
+  from its reviewed declarative manifest and remains operator-editable after the
+  first seed. See
   [Restricted GitHub sessions](docs/restricted-sessions.md).
 - Profile environment values are write-only: API, CLI, and Settings responses
   expose names and update times, never secret values.

--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ weaver config ls
 loom profile ls
 loom profile show default
 loom profile show github_comment
+# App-less deployments can give restricted GitHub tools a shared identity:
 loom profile env secret github_comment GH_TOKEN \
   projects/my-project/secrets/loom-github-ci-token/versions/latest
 ```
@@ -428,11 +429,11 @@ Notable settings:
   Loom expands profile capability sets into exact permissions when it stamps a
   session and derives adapter processes from its trusted MCP registry; profiles
   never supply executable MCP configuration. The GitHub credential never enters
-  the agent process. The stock
-  `github_comment` profile is seeded from its reviewed declarative manifest and
-  remains operator-editable after the first seed. It is ready for
-  GitHub-originated editorial/comment tasks after an operator adds its
-  write-only `GH_TOKEN` environment value. See
+  the agent process. Loom uses the requester's stored token first, a profile
+  `GH_TOKEN` second, and the configured GitHub App's short-lived,
+  repository-scoped installation token otherwise. The stock `github_comment`
+  profile is seeded from its reviewed declarative manifest and remains
+  operator-editable after the first seed. See
   [Restricted GitHub sessions](docs/restricted-sessions.md).
 - Profile environment values are write-only: API, CLI, and Settings responses
   expose names and update times, never secret values.

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -141,8 +141,8 @@ export const getMyGithubToken = () => get('/auth/github-token') as Promise<Githu
 export const setMyGithubToken = (token: string) =>
   put('/auth/github-token', { token }) as Promise<GithubTokenStatus>;
 
-/** Clear your personal GitHub token; your sessions fall back to the shared
- *  ambient token (`DELETE /api/auth/github-token`). */
+/** Clear your personal GitHub token; new interactive sessions retain any
+ *  credential supplied by their selected profile (`DELETE /api/auth/github-token`). */
 export const deleteMyGithubToken = () => del('/auth/github-token');
 
 interface RepoEnvEnvelope {

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -79,7 +79,11 @@ async function saveMyGithubToken() {
 }
 
 async function clearMyGithubToken() {
-  if (!confirm('Remove your GitHub token? Your sessions will fall back to the shared token.'))
+  if (
+    !confirm(
+      "Remove your personal GitHub token? New interactive sessions will use their profile's credential, if configured.",
+    )
+  )
     return;
   busy.value = true;
   try {
@@ -258,15 +262,20 @@ onMounted(() => {
       </h2>
       <div class="rounded-md border border-line bg-surface px-3 py-2.5">
         <p class="text-xs text-muted mb-2">
-          A fine-grained token your sessions use for <code class="font-mono">git push</code> and
-          <code class="font-mono">gh</code>, so your agents act as you.
+          A fine-grained token your ordinary interactive sessions use for
+          <code class="font-mono">git push</code> and <code class="font-mono">gh</code>, so your
+          agents act as you. Restricted automation uses the GitHub App instead.
           <a class="text-accent underline" :href="PAT_CREATE_URL" target="_blank" rel="noopener">
             Create one</a
           >
           with <span class="font-medium">Contents</span> and
           <span class="font-medium">Pull requests</span> read/write on the repos you work in.
           <span :class="ghTokenStatus?.set ? 'text-accent' : 'text-faint'">
-            {{ ghTokenStatus?.set ? 'Set.' : 'Not set — sessions use the shared token.' }}
+            {{
+              ghTokenStatus?.set
+                ? 'Set.'
+                : 'Not set — interactive sessions use their profile credential, if configured.'
+            }}
           </span>
         </p>
         <div class="flex flex-wrap items-center gap-2">

--- a/crates/loom/frontend/src/components/EnvPanel.vue
+++ b/crates/loom/frontend/src/components/EnvPanel.vue
@@ -4,9 +4,8 @@ import * as api from '../api';
 import type { EnvVar } from '../types';
 import SettingsTableSection from './SettingsTableSection.vue';
 
-// Operator-managed environment variables, exported into every agent session
-// loom launches (on top of loom's own WEAVER_*/LOOM_TOKEN). A flat name/value
-// store edited at runtime — registry tokens, GH_HOST, ANTHROPIC_BASE_URL, etc.
+// The default profile's environment variables. Other profiles have independent
+// environment stores, and restricted profiles never inherit these values.
 const vars = ref<EnvVar[]>([]);
 // Per-name editable draft so an in-progress value edit survives a reload.
 const drafts = ref<Record<string, string>>({});
@@ -92,11 +91,12 @@ const add = () =>
 <template>
   <div>
     <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
-      Agent environment
+      Default profile environment
     </h2>
     <p class="mb-3 text-xs text-faint">
-      Variables exported into new agent sessions loom launches. Changes apply to future sessions
-      only.
+      Variables exported into new sessions that use the default profile. Other profiles use their
+      own environment; restricted profiles do not inherit these values. Values on this screen are
+      readable configuration, not a secret store. Changes apply to future sessions only.
     </p>
 
     <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -805,8 +805,8 @@ export interface User {
   created_at: string;
 }
 
-/** One operator-managed agent environment variable. Exported into every
- *  interactive agent session loom launches. Mirrors `agent_env::EnvVar`. */
+/** One readable environment variable on the default profile. Mirrors
+ *  `agent_env::EnvVar`. */
 export interface EnvVar {
   name: string;
   value: string;

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -496,10 +496,12 @@ async function handleCreated() {
           >Add your GitHub token</RouterLink
         >
         or configure
-        <RouterLink class="text-accent underline" :to="{ path: '/settings', query: { tab: 'env' } }"
-          >GH_TOKEN</RouterLink
+        <RouterLink
+          class="text-accent underline"
+          :to="{ path: '/settings', query: { tab: 'profiles' } }"
+          >the selected profile</RouterLink
         >
-        before creating an agent session.
+        with a write-only <code class="font-mono">GH_TOKEN</code> before creating an agent session.
       </template>
       <template v-else>{{ error }}</template>
     </div>

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -75,7 +75,7 @@ const categories: CategoryItem[] = [
   {
     id: 'environment',
     label: 'Environment',
-    summary: 'Environment variables exported into future agent sessions.',
+    summary: 'Readable environment variables exported into future default-profile sessions.',
   },
   {
     id: 'access',

--- a/crates/loom/src/agent_env.rs
+++ b/crates/loom/src/agent_env.rs
@@ -1,14 +1,12 @@
 //! Compatibility facade for the default profile's environment variables.
 //!
-//! These are exported into every interactive agent session loom launches —
-//! alongside loom's own `WEAVER_*` / `LOOM_TOKEN` — so the operator can add a
-//! registry token, a `GH_HOST`, an `ANTHROPIC_BASE_URL`, etc. at runtime from
-//! the settings pane, without rebuilding the image or editing the deploy env
-//! file. The one-shot judgement agent runs env-stripped and gets none of them
-//! (see [`crate::agent`]); watch scripts are likewise stripped but do receive
-//! `GH_TOKEN` (via [`get`]), since loom's *own* GitHub reads — the PR poll loop
-//! and github watches' `gh` calls — run in the server process, which has no
-//! ambient GitHub auth of its own.
+//! These are the protected `default` profile's environment. They are exported
+//! only into sessions launched with that profile, alongside loom's own
+//! `WEAVER_*` / `LOOM_TOKEN`. Other profiles have independent environment
+//! stores, and restricted profiles never inherit these values. The one-shot
+//! judgement agent runs env-stripped and gets none of them (see
+//! [`crate::agent`]); watch scripts are likewise stripped but do receive
+//! `GH_TOKEN` (via [`get`]) for legacy App-less GitHub reads.
 //!
 //! This remains a flat name/value API for existing settings, setup, GitHub,
 //! watch, and shell callers, but storage lives in `profile_env` under the

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -161,10 +161,9 @@ enum Cmd {
     ///
     ///     loom setup github-app --base-url https://loom.team.dev
     ///
-    /// `loom setup secrets` prompts for the paste-once secrets every agent
-    /// session needs (an Anthropic API key, a GitHub token) and stores them as
-    /// operator environment variables, live for every session launched from
-    /// then on:
+    /// `loom setup secrets` prompts for paste-once agent secrets (an Anthropic
+    /// API key, a GitHub token) and stores them on the default profile. They
+    /// apply to future sessions launched with that profile:
     ///
     ///     loom setup secrets
     Setup {
@@ -455,7 +454,7 @@ enum WatchCmd {
 enum SetupCmd {
     /// Create the GitHub App loom uses, via GitHub's manifest flow.
     GithubApp(GithubAppOpts),
-    /// Prompt for and store the paste-once agent secrets (Anthropic key, GitHub token).
+    /// Prompt for and store default-profile agent secrets (Anthropic key, GitHub token).
     Secrets(SecretsOpts),
 }
 
@@ -1982,7 +1981,7 @@ async fn cmd_setup_secrets(opts: SecretsOpts) -> Result<()> {
         .map(|(k, _)| k)
         .collect();
 
-    println!("Paste-once secrets for the agents loom launches (leave blank to skip).");
+    println!("Paste-once secrets for the default profile (leave blank to skip).");
     let anthropic = prompt_secret(
         "ANTHROPIC_API_KEY",
         existing_names.contains("ANTHROPIC_API_KEY"),
@@ -2010,8 +2009,8 @@ async fn cmd_setup_secrets(opts: SecretsOpts) -> Result<()> {
     }
     println!();
     println!(
-        "Stored {} as operator environment variables — every session launched from now \
-         on gets them (Settings → Environment in the web UI, or `GET /api/env`).",
+        "Stored {} on the default profile — future sessions using that profile get them \
+         (Settings → Environment in the web UI, or `GET /api/env`).",
         stored.join(", ")
     );
     println!(

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -334,6 +334,37 @@ impl GithubApp {
         self.installation_token(installation_id).await
     }
 
+    async fn issue_json(&self, owner: &str, name: &str, number: i64) -> Result<serde_json::Value> {
+        let token = self.token_for_repo(owner, name).await?;
+        let url = format!("{}/repos/{owner}/{name}/issues/{number}", self.api_base);
+        let resp = self
+            .http
+            .get(&url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("fetching the issue")?;
+        let resp = check_status(resp, "fetching the issue").await?;
+        resp.json().await.context("parsing issue json")
+    }
+
+    /// Fetch the title, body, and URL used to seed a managed-repository launch.
+    pub(crate) async fn issue(
+        &self,
+        owner: &str,
+        name: &str,
+        number: i64,
+    ) -> Result<crate::github::Issue> {
+        let value = self.issue_json(owner, name, number).await?;
+        Ok(crate::github::Issue {
+            title: value["title"].as_str().unwrap_or_default().to_string(),
+            body: value["body"].as_str().unwrap_or_default().to_string(),
+            url: value["html_url"].as_str().unwrap_or_default().to_string(),
+        })
+    }
+
     // -- installation as allowlist ------------------------------------------
 
     /// When the App is installed on `slug`, ensure that repo is in the managed
@@ -509,22 +540,7 @@ impl GithubApi for GithubApp {
             return self.fallback.issue_state(repo, number).await;
         }
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
-        let token = self.token_for_repo(&slug.owner, &slug.name).await?;
-        let url = format!(
-            "{}/repos/{}/{}/issues/{number}",
-            self.api_base, slug.owner, slug.name
-        );
-        let resp = self
-            .http
-            .get(&url)
-            .header(reqwest::header::ACCEPT, GH_ACCEPT)
-            .header("X-GitHub-Api-Version", GH_API_VERSION)
-            .bearer_auth(&token)
-            .send()
-            .await
-            .context("fetching the issue")?;
-        let resp = check_status(resp, "fetching the issue").await?;
-        let v: serde_json::Value = resp.json().await.context("parsing issue json")?;
+        let v = self.issue_json(&slug.owner, &slug.name, number).await?;
         Ok(crate::github_trigger::IssueState {
             state: v["state"].as_str().unwrap_or_default().to_string(),
             title: v["title"].as_str().unwrap_or_default().to_string(),
@@ -625,7 +641,7 @@ async fn check_status(resp: reqwest::Response, what: &str) -> Result<reqwest::Re
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -678,6 +694,10 @@ CwIDAQAB
 -----END PUBLIC KEY-----";
 
     const TEST_APP_ID: i64 = 123456;
+
+    pub(crate) fn credentials() -> (i64, &'static str) {
+        (TEST_APP_ID, TEST_PRIVATE_KEY)
+    }
 
     // -- JWT ----------------------------------------------------------------
 
@@ -832,6 +852,8 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         Json(json!({
             "state": "closed",
             "title": format!("issue {number} of {owner}/{name}"),
+            "body": "issue body",
+            "html_url": format!("https://github.com/{owner}/{name}/issues/{number}"),
             "updated_at": "2026-07-18T12:00:00Z",
         }))
     }
@@ -1004,6 +1026,19 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             mock.last_comment_auth.lock().unwrap().clone(),
             Some("Bearer ghs_installation_token".to_string()),
         );
+    }
+
+    #[tokio::test]
+    async fn issue_fetch_uses_installation_token() {
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+
+        let issue = app.issue("acme", "widgets", 7).await.unwrap();
+
+        assert_eq!(issue.title, "issue 7 of acme/widgets");
+        assert_eq!(issue.body, "issue body");
+        assert_eq!(issue.url, "https://github.com/acme/widgets/issues/7");
     }
 
     #[tokio::test]

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -772,6 +772,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
 
     /// The id the mock stamps on every created comment.
     const MOCK_COMMENT_ID: i64 = 4242;
+    pub(crate) const MOCK_INSTALLATION_TOKEN: &str = "ghs_installation_token";
     /// A comment id the mock's PATCH route answers with 404, standing in for a
     /// comment a human deleted.
     const MOCK_DELETED_COMMENT_ID: i64 = 404_404;
@@ -779,7 +780,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn mock_access_tokens(State(s): State<Arc<MockState>>) -> Json<Value> {
         s.token_mints.fetch_add(1, Ordering::SeqCst);
         let exp = Utc::now() + Duration::seconds(s.expiry_offset_secs);
-        Json(json!({ "token": "ghs_installation_token", "expires_at": exp.to_rfc3339() }))
+        Json(json!({ "token": MOCK_INSTALLATION_TOKEN, "expires_at": exp.to_rfc3339() }))
     }
 
     async fn mock_installation(
@@ -984,7 +985,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
 
         let t1 = app.installation_token(42).await.unwrap();
         let t2 = app.installation_token(42).await.unwrap();
-        assert_eq!(t1, "ghs_installation_token");
+        assert_eq!(t1, MOCK_INSTALLATION_TOKEN);
         assert_eq!(t1, t2);
         assert_eq!(
             mock.token_mints.load(Ordering::SeqCst),
@@ -1033,7 +1034,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         // The request carried the minted installation token, not the App JWT.
         assert_eq!(
             mock.last_comment_auth.lock().unwrap().clone(),
-            Some("Bearer ghs_installation_token".to_string()),
+            Some(format!("Bearer {MOCK_INSTALLATION_TOKEN}")),
         );
     }
 
@@ -1067,7 +1068,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         assert_eq!(updates[0]["body"], "On it — now with a trail");
         assert_eq!(
             mock.last_comment_auth.lock().unwrap().clone(),
-            Some("Bearer ghs_installation_token".to_string()),
+            Some(format!("Bearer {MOCK_INSTALLATION_TOKEN}")),
         );
 
         // A 404 (the comment was deleted) is a clean `false`, not an error —

--- a/crates/loom/src/github_app.rs
+++ b/crates/loom/src/github_app.rs
@@ -695,10 +695,6 @@ CwIDAQAB
 
     const TEST_APP_ID: i64 = 123456;
 
-    pub(crate) fn credentials() -> (i64, &'static str) {
-        (TEST_APP_ID, TEST_PRIVATE_KEY)
-    }
-
     // -- JWT ----------------------------------------------------------------
 
     /// The minted App JWT verifies against the public key and carries the
@@ -948,6 +944,14 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     /// tests stay parallel-safe.
     async fn configured_app(api_base: String, fallback: Arc<dyn GithubApi>) -> GithubApp {
         let db = crate::db::connect_in_memory().await.unwrap();
+        configured_app_for_db(db, api_base, fallback).await
+    }
+
+    async fn configured_app_for_db(
+        db: Db,
+        api_base: String,
+        fallback: Arc<dyn GithubApi>,
+    ) -> GithubApp {
         weaver_core::config::apply(
             &db,
             &[
@@ -961,6 +965,11 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         .await
         .unwrap();
         GithubApp::with_parts(db, api_base, fallback)
+    }
+
+    pub(crate) async fn configured_test_app(db: Db) -> GithubApp {
+        let base = spawn_mock(MockState::new(3600)).await;
+        configured_app_for_db(db, base, Arc::new(crate::github_trigger::GhCli)).await
     }
 
     // -- installation token exchange + caching ------------------------------
@@ -1029,7 +1038,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     }
 
     #[tokio::test]
-    async fn issue_fetch_uses_installation_token() {
+    async fn issue_fetch_maps_github_response() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock).await;
         let app = configured_app(base, Arc::new(RecordingFallback::default())).await;

--- a/crates/loom/src/github_trigger.rs
+++ b/crates/loom/src/github_trigger.rs
@@ -606,13 +606,23 @@ impl GithubTrigger {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_app(app: Arc<crate::github_app::GithubApp>) -> Arc<Self> {
+        Arc::new(Self {
+            gh: app.clone(),
+            app: Some(app),
+            limiter: Mutex::new(HashMap::new()),
+        })
+    }
+
     /// The GitHub gateway, for the permission check and the reply.
     pub fn gh(&self) -> &dyn GithubApi {
         self.gh.as_ref()
     }
 
-    /// The GitHub App client, when one is configured on this trigger — the
-    /// webhook uses it to treat an App-installed repo as implicitly allowlisted.
+    /// The GitHub App client, when one is configured on this trigger. The
+    /// webhook uses it to treat an App-installed repo as implicitly allowlisted,
+    /// and restricted GitHub tools use its repo-scoped installation tokens.
     pub fn app(&self) -> Option<&crate::github_app::GithubApp> {
         self.app.as_deref()
     }

--- a/crates/loom/src/user_token.rs
+++ b/crates/loom/src/user_token.rs
@@ -3,9 +3,9 @@
 //!
 //! For an ordinary interactive session, loom injects the token as `GH_TOKEN`
 //! into the session env ([`crate::runtime::create_session`]), overriding the
-//! shared ambient credential. A restricted session keeps the token server-side
-//! and resolves it only for its fixed GitHub tool surface. Combined with the
-//! per-user commit author identity loom already sets
+//! selected profile credential. Restricted sessions use the GitHub App (or an
+//! explicit App-less profile credential) instead. Combined with the per-user
+//! commit author identity loom already sets
 //! ([`crate::auth::commit_identity`]), ordinary pushes are attributed to them.
 //!
 //! The value is **write-only** over the API: callers learn only *that* a token is

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -580,7 +580,8 @@ pub(super) async fn set_github_token(
 }
 
 /// `DELETE /api/auth/github-token` — clear the caller's personal GitHub token;
-/// their sessions then fall back to the shared ambient GH_TOKEN.
+/// new interactive sessions then retain any credential supplied by the selected
+/// profile.
 pub(super) async fn delete_github_token(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -741,7 +741,7 @@ pub fn router(state: AppState) -> Router {
             get(list_repo_issues).post(create_repo_issue),
         )
         // Per-repo environment variables (write-only values), layered into a
-        // session's terminal above the global agent_env.
+        // non-restricted session's terminal above its selected profile.
         .route("/repos/env", get(get_repo_env))
         .route(
             "/repos/env/{name}",
@@ -759,7 +759,7 @@ pub fn router(state: AppState) -> Router {
             axum::routing::put(put_profile_env).delete(delete_profile_env),
         )
         .route("/slack/status", get(slack_status))
-        // Operator-managed agent environment variables.
+        // Readable compatibility facade for the default profile's environment.
         .route("/env", get(get_env))
         .route(
             "/env/{name}",

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -277,8 +277,9 @@ async fn handle_trigger(
 
     // Resolve the commenter to their loom user (proven to exist by `authorize`).
     // Attributing the launch to them makes their personal GitHub token the
-    // session's `GH_TOKEN` — so its push / `gh` act as them — with the ambient
-    // token as the fallback (see `apply_user_github_token`).
+    // session's `GH_TOKEN` — so its push / `gh` act as them — while preserving
+    // any credential supplied by the selected profile when no personal token
+    // is stored (see `apply_user_github_token`).
     let username = match crate::auth::user_by_github(&st.db, &author).await {
         Ok(Some(u)) => u.username,
         _ => {

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -28,28 +28,11 @@ struct ToolArguments {
     title: Option<String>,
 }
 
-async fn github_token(
+async fn restricted_github_token(
     st: &AppState,
-    created_by: Option<&str>,
     profile: &str,
     repo: &crate::repo::RepoSlug,
 ) -> ApiResult<String> {
-    if let Some(username) = created_by {
-        if let Some(token) = crate::user_token::get(&st.db, username).await? {
-            if !token.trim().is_empty() {
-                return Ok(token);
-            }
-        }
-    }
-    if let Some(token) = crate::profile::env_pairs(&st.db, profile)
-        .await
-        .map_err(|error| AppError::new(StatusCode::BAD_GATEWAY, error.to_string()))?
-        .into_iter()
-        .find_map(|(name, value)| (name == "GH_TOKEN").then_some(value))
-        .filter(|value| !value.trim().is_empty())
-    {
-        return Ok(token);
-    }
     if let Some(app) = st.trigger.app() {
         if app.is_configured().await {
             return app
@@ -65,6 +48,15 @@ async fn github_token(
                     )
                 });
         }
+    }
+    if let Some(token) = crate::profile::env_pairs(&st.db, profile)
+        .await
+        .map_err(|error| AppError::new(StatusCode::BAD_GATEWAY, error.to_string()))?
+        .into_iter()
+        .find_map(|(name, value)| (name == "GH_TOKEN").then_some(value))
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(token);
     }
     Err(AppError::new(
         StatusCode::SERVICE_UNAVAILABLE,
@@ -224,7 +216,7 @@ pub(super) async fn restricted_github_tool(
             "GitHub tool target does not match the session's linked thread",
         ));
     }
-    let token = github_token(&st, session.created_by.as_deref(), &session.profile, &repo).await?;
+    let token = restricted_github_token(&st, &session.profile, &repo).await?;
     let config_dir = crate::db::run_dir(&session.id).join("restricted-gh-config");
     tokio::fs::create_dir_all(&config_dir)
         .await
@@ -254,9 +246,10 @@ pub(super) async fn restricted_github_tool(
 mod tests {
     use std::sync::Arc;
 
+    use axum::http::StatusCode;
     use serde_json::json;
 
-    use super::{github_token, validate_arguments};
+    use super::{restricted_github_token, validate_arguments};
 
     #[test]
     fn only_the_fixed_mcp_tools_map_to_permissions() {
@@ -278,8 +271,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn github_app_is_the_restricted_tool_credential_fallback() {
+    async fn github_app_precedes_the_restricted_profile_credential() {
         let db = crate::db::connect_in_memory().await.unwrap();
+        crate::profile::env_set(&db, "github_comment", "GH_TOKEN", "profile-token")
+            .await
+            .unwrap();
         let app = Arc::new(crate::github_app::tests::configured_test_app(db.clone()).await);
         let state = super::AppState {
             db,
@@ -291,10 +287,16 @@ mod tests {
         };
         let repo = crate::repo::parse_slug("marin-community/loom").unwrap();
 
-        let resolved = github_token(&state, None, "github_comment", &repo)
+        let resolved = restricted_github_token(&state, "github_comment", &repo)
             .await
             .unwrap();
 
         assert_eq!(resolved, "ghs_installation_token");
+
+        let uninstalled = crate::repo::parse_slug("uninstalled/loom").unwrap();
+        let error = restricted_github_token(&state, "github_comment", &uninstalled)
+            .await
+            .unwrap_err();
+        assert_eq!(error.status(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -291,7 +291,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(resolved, "ghs_installation_token");
+        assert_ne!(
+            resolved, "profile-token",
+            "the profile credential must not override a configured App"
+        );
 
         let uninstalled = crate::repo::parse_slug("uninstalled/loom").unwrap();
         let error = restricted_github_token(&state, "github_comment", &uninstalled)

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -28,27 +28,48 @@ struct ToolArguments {
     title: Option<String>,
 }
 
-async fn github_token(st: &AppState, session: &crate::session::Session) -> ApiResult<String> {
-    if let Some(username) = session.created_by.as_deref() {
+async fn github_token(
+    st: &AppState,
+    created_by: Option<&str>,
+    profile: &str,
+    repo: &crate::repo::RepoSlug,
+) -> ApiResult<String> {
+    if let Some(username) = created_by {
         if let Some(token) = crate::user_token::get(&st.db, username).await? {
             if !token.trim().is_empty() {
                 return Ok(token);
             }
         }
     }
-    let token = crate::profile::env_pairs(&st.db, &session.profile)
+    if let Some(token) = crate::profile::env_pairs(&st.db, profile)
         .await
         .map_err(|error| AppError::new(StatusCode::BAD_GATEWAY, error.to_string()))?
         .into_iter()
         .find_map(|(name, value)| (name == "GH_TOKEN").then_some(value))
         .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| {
-            AppError::new(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "restricted GitHub credential is unavailable",
-            )
-        })?;
-    Ok(token)
+    {
+        return Ok(token);
+    }
+    if let Some(app) = st.trigger.app() {
+        if app.is_configured().await {
+            return app
+                .token_for_repo(&repo.owner, &repo.name)
+                .await
+                .map_err(|error| {
+                    AppError::new(
+                        StatusCode::BAD_GATEWAY,
+                        format!(
+                            "could not mint a GitHub App token for {}: {error}",
+                            repo.slug()
+                        ),
+                    )
+                });
+        }
+    }
+    Err(AppError::new(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "restricted GitHub credential is unavailable",
+    ))
 }
 
 fn validate_arguments(tool: &str, value: serde_json::Value) -> ApiResult<ToolArguments> {
@@ -187,8 +208,8 @@ pub(super) async fn restricted_github_tool(
         .as_deref()
         .ok_or_else(|| AppError::bad_request("session has no fixed GitHub repository"))?;
     let repo = crate::repo::parse_slug(repo)
-        .map_err(|_| AppError::bad_request("session GitHub repository is invalid"))?
-        .slug();
+        .map_err(|_| AppError::bad_request("session GitHub repository is invalid"))?;
+    let repo_slug = repo.slug();
     let arguments = validate_arguments(&tool, req.arguments)?;
     let tracking_issue = match session.tracking_issue_id {
         Some(id) => weaver_core::issue::get(&st.db, id).await?,
@@ -196,14 +217,14 @@ pub(super) async fn restricted_github_tool(
     }
     .ok_or_else(|| AppError::bad_request("session has no linked GitHub thread"))?;
     if tracking_issue.github_issue != Some(arguments.number)
-        || tracking_issue.github_repo.as_deref() != Some(repo.as_str())
+        || tracking_issue.github_repo.as_deref() != Some(repo_slug.as_str())
     {
         return Err(AppError::new(
             StatusCode::FORBIDDEN,
             "GitHub tool target does not match the session's linked thread",
         ));
     }
-    let token = github_token(&st, &session).await?;
+    let token = github_token(&st, session.created_by.as_deref(), &session.profile, &repo).await?;
     let config_dir = crate::db::run_dir(&session.id).join("restricted-gh-config");
     tokio::fs::create_dir_all(&config_dir)
         .await
@@ -225,14 +246,18 @@ pub(super) async fn restricted_github_tool(
                 )
             })?;
     }
-    let text = invoke_gh(&repo, &tool, &arguments, &token, &config_dir).await?;
+    let text = invoke_gh(&repo_slug, &tool, &arguments, &token, &config_dir).await?;
     Ok(Json(RestrictedGithubToolView { text }))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::validate_arguments;
+    use std::sync::Arc;
+
+    use axum::{routing::get, routing::post, Json, Router};
     use serde_json::json;
+
+    use super::{github_token, validate_arguments};
 
     #[test]
     fn only_the_fixed_mcp_tools_map_to_permissions() {
@@ -251,5 +276,66 @@ mod tests {
         assert!(
             validate_arguments("issue_edit", json!({ "number": 7, "body": "clean body" })).is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn github_app_is_the_restricted_tool_credential_fallback() {
+        async fn installation() -> Json<serde_json::Value> {
+            Json(json!({ "id": 42 }))
+        }
+
+        async fn token() -> Json<serde_json::Value> {
+            Json(json!({
+                "token": "ghs_repo_scoped",
+                "expires_at": "2099-01-01T00:00:00Z"
+            }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let router = Router::new()
+            .route("/repos/{owner}/{name}/installation", get(installation))
+            .route("/app/installations/{id}/access_tokens", post(token));
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let (app_id, private_key) = crate::github_app::tests::credentials();
+        weaver_core::config::apply(
+            &db,
+            &[
+                (
+                    crate::github_app::APP_ID_KEY.to_string(),
+                    Some(app_id.to_string()),
+                ),
+                (
+                    crate::github_app::APP_PRIVATE_KEY_KEY.to_string(),
+                    Some(private_key.to_string()),
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+        let app = Arc::new(crate::github_app::GithubApp::with_parts(
+            db.clone(),
+            format!("http://{address}"),
+            Arc::new(crate::github_trigger::GhCli),
+        ));
+        let state = super::AppState {
+            db,
+            bus: crate::events::EventBus::new(),
+            addr: "127.0.0.1:0".to_string(),
+            ide: Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
+            trigger: crate::github_trigger::GithubTrigger::with_app(app),
+            acp: crate::acp::AcpRegistry::new(),
+        };
+        let repo = crate::repo::parse_slug("marin-community/loom").unwrap();
+
+        let resolved = github_token(&state, None, "github_comment", &repo)
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, "ghs_repo_scoped");
     }
 }

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -254,7 +254,6 @@ pub(super) async fn restricted_github_tool(
 mod tests {
     use std::sync::Arc;
 
-    use axum::{routing::get, routing::post, Json, Router};
     use serde_json::json;
 
     use super::{github_token, validate_arguments};
@@ -280,48 +279,8 @@ mod tests {
 
     #[tokio::test]
     async fn github_app_is_the_restricted_tool_credential_fallback() {
-        async fn installation() -> Json<serde_json::Value> {
-            Json(json!({ "id": 42 }))
-        }
-
-        async fn token() -> Json<serde_json::Value> {
-            Json(json!({
-                "token": "ghs_repo_scoped",
-                "expires_at": "2099-01-01T00:00:00Z"
-            }))
-        }
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let address = listener.local_addr().unwrap();
-        let router = Router::new()
-            .route("/repos/{owner}/{name}/installation", get(installation))
-            .route("/app/installations/{id}/access_tokens", post(token));
-        tokio::spawn(async move {
-            axum::serve(listener, router).await.unwrap();
-        });
-
         let db = crate::db::connect_in_memory().await.unwrap();
-        let (app_id, private_key) = crate::github_app::tests::credentials();
-        weaver_core::config::apply(
-            &db,
-            &[
-                (
-                    crate::github_app::APP_ID_KEY.to_string(),
-                    Some(app_id.to_string()),
-                ),
-                (
-                    crate::github_app::APP_PRIVATE_KEY_KEY.to_string(),
-                    Some(private_key.to_string()),
-                ),
-            ],
-        )
-        .await
-        .unwrap();
-        let app = Arc::new(crate::github_app::GithubApp::with_parts(
-            db.clone(),
-            format!("http://{address}"),
-            Arc::new(crate::github_trigger::GhCli),
-        ));
+        let app = Arc::new(crate::github_app::tests::configured_test_app(db.clone()).await);
         let state = super::AppState {
             db,
             bus: crate::events::EventBus::new(),
@@ -336,6 +295,6 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(resolved, "ghs_repo_scoped");
+        assert_eq!(resolved, "ghs_installation_token");
     }
 }

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -291,9 +291,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_ne!(
-            resolved, "profile-token",
-            "the profile credential must not override a configured App"
+        assert_eq!(
+            resolved,
+            crate::github_app::tests::MOCK_INSTALLATION_TOKEN,
+            "the App credential must override the configured profile credential"
         );
 
         let uninstalled = crate::repo::parse_slug("uninstalled/loom").unwrap();

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2981,6 +2981,8 @@ pub(super) async fn handoff_session(
     let mut extra_env = resume_environment(&st.db, &session, &repo_root, &repo_cfg).await;
     rotate_session_token(&st.db, &session, &mut extra_env).await?;
     apply_user_github_token(&st.db, &mut extra_env, session.created_by.as_deref()).await;
+    // Restricted sessions return before this handoff path, so an App credential
+    // cannot be relevant here.
     ensure_github_token_available(
         &st.db,
         &extra_env,

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -34,7 +34,7 @@ use super::scratch::{scratch_note, write_initial_scratch};
 use super::{author_or_manual, require_branch, require_session, session_view};
 use super::{ApiResult, AppError, AppState};
 
-const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub token configured. Add your personal GitHub token in Settings > Account, or configure GH_TOKEN in Settings > Environment.";
+const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub token configured. Add your personal GitHub token in Settings > Account, or configure a write-only GH_TOKEN on the selected profile.";
 const HANDOFF_HISTORY_CHARS: usize = 64 * 1024;
 
 /// Resolve an optional per-request ACP permission posture over the workspace
@@ -258,13 +258,13 @@ fn repo_cfg_or_default(repo_root: &std::path::Path) -> weaver_core::repo_config:
     })
 }
 
-/// Build the environment exported into a session's agent terminal, layered in
-/// priority order: the profile environment, then the per-repo [`repo_env`], then
-/// the repo's committed `.weaver/config.toml` `[env]` — each layer overriding the
-/// previous for a shared name. Loom fills in its repo-local defaults last only
-/// when no layer supplied the name. Best-effort: a database error in a layer
-/// degrades to the layers that did resolve. `cfg` is the already-loaded repo
-/// config (the caller reads it once for env, setup, and defaults).
+/// Build the environment exported into a session's agent terminal, starting
+/// with the selected profile and then layering the per-repo [`repo_env`] and
+/// committed `.weaver/config.toml` `[env]`. A strict profile keeps ownership of
+/// its declared names; a restricted profile receives only its own environment.
+/// Loom fills in its repo-local defaults last only when no layer supplied the
+/// name. Best-effort: a database error in a layer degrades to the layers that
+/// did resolve. `cfg` is the already-loaded repo config.
 async fn launch_env_for_profile(
     db: &Db,
     repo_root: &std::path::Path,
@@ -381,11 +381,10 @@ async fn resume_environment(
 /// Overlay the launching user's personal GitHub token onto `env` as `GH_TOKEN`,
 /// so the session's `git push` / `gh` act as that user (their pushes and PRs are
 /// attributed to them, matching the per-user commit identity loom already sets).
-/// The user's registered token takes precedence over any ambient `GH_TOKEN`; when
-/// they have none, whatever a lower env layer set (the ambient Settings →
-/// Environment value, `repo_env`, or the repo file) stands as the fallback. Only
-/// for a launch that carries a `created_by` username. Best-effort: a lookup
-/// failure is logged, never fatal, so a token-store hiccup can't block a launch.
+/// The user's registered token takes precedence over any `GH_TOKEN` from the
+/// selected profile, repository environment, or committed repo config. Only for
+/// a launch that carries a `created_by` username. Best-effort: a lookup failure
+/// is logged, never fatal, so a token-store hiccup can't block a launch.
 async fn apply_user_github_token(
     db: &Db,
     env: &mut Vec<(String, String)>,
@@ -398,14 +397,14 @@ async fn apply_user_github_token(
             tracing::info!(%username, "applied user github token as GH_TOKEN");
         }
         Ok(_) => {
-            tracing::debug!(%username, "no personal github token on file, leaving ambient GH_TOKEN")
+            tracing::debug!(%username, "no personal github token on file, retaining session GH_TOKEN")
         }
         Err(e) => tracing::warn!(%username, "failed to load user github token: {e}"),
     }
 }
 
 /// Set `name` in `env`, replacing an existing entry in place (so a user token
-/// overrides an ambient value) or appending it when absent.
+/// overrides a lower-precedence value) or appending it when absent.
 fn set_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
     if let Some(slot) = env.iter_mut().find(|(k, _)| k == name) {
         slot.1 = value;
@@ -756,9 +755,10 @@ pub(crate) async fn provision_session(
     };
     let runtime = agent.clone();
     tracing::debug!(agent = %agent, runtime = %runtime, "resolved agent runtime");
-    // The resolved launch environment: global agent_env < per-repo repo_env < the
-    // repo file's [env]. It is needed before provisioning so a real agent launch
-    // can stop cleanly when neither the user nor the deployment provides GH_TOKEN.
+    // The resolved launch environment: selected profile < per-repo repo_env <
+    // the repo file's [env]. It is needed before provisioning so a real agent
+    // launch can stop cleanly when neither the user nor an environment layer
+    // provides GH_TOKEN.
     let mut extra_env = launch_env_for_profile(
         &st.db,
         &repo_root,
@@ -778,7 +778,8 @@ pub(crate) async fn provision_session(
     // GH_TOKEN (design §6.3, "Level B"). See `apply_user_github_token` for the
     // precedence rules. This happens before preflight. Ordinary sessions export
     // it; a restricted ACP launch removes it from the adapter environment and
-    // the server-side GitHub tool resolves the same user's token on demand.
+    // its server-side GitHub tool independently resolves an App or profile
+    // credential.
     apply_user_github_token(&st.db, &mut extra_env, created_by.as_deref()).await;
 
     // Normalize and validate the model / effort selections through the resolved
@@ -3726,8 +3727,10 @@ mod tests {
             .unwrap();
     }
 
+    #[serial_test::serial]
     #[tokio::test]
     async fn restricted_builtin_accepts_configured_github_app() {
+        let _env = EnvVarGuard::unset("GH_TOKEN");
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
         weaver_core::config::apply(

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -745,6 +745,13 @@ pub(crate) async fn provision_session(
     };
     tracing::debug!(repo_root = %repo_root.display(), "loaded repo config");
 
+    // A GitHub App token is repository-scoped. A managed slug gives both the
+    // preflight and issue seeding an exact installation target; a local path
+    // must keep using an explicitly supplied session credential.
+    let managed_slug = req
+        .repo
+        .as_deref()
+        .and_then(|repo| crate::repo::parse_slug(repo).ok());
     let agent_overridden = req
         .agent
         .as_deref()
@@ -824,7 +831,7 @@ pub(crate) async fn provision_session(
         .unwrap_or(&launch_profile.mode)
         .to_string();
     tracing::debug!(model = %model, effort = %effort, protocol = %protocol, "resolved and validated model/effort/protocol");
-    let restricted_github_app = if launch_profile.restricted {
+    let restricted_github_app = if launch_profile.restricted && managed_slug.is_some() {
         st.trigger.app()
     } else {
         None
@@ -848,10 +855,6 @@ pub(crate) async fn provision_session(
     let mut description = String::new();
     let mut github_repo = None;
     let mut github_issue: Option<i64> = None;
-    let managed_slug = req
-        .repo
-        .as_deref()
-        .and_then(|repo| crate::repo::parse_slug(repo).ok());
     if let Some(number) = req.issue {
         tracing::info!(issue = number, repo = %repo_root.display(), "fetching github issue to seed session");
         let issue = fetch_launch_issue(&st, &repo_root, managed_slug.as_ref(), number)

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -450,6 +450,7 @@ async fn ensure_github_token_available(
     env: &[(String, String)],
     created_by: Option<&str>,
     runtime: &str,
+    restricted_github_app: Option<&crate::github_app::GithubApp>,
 ) -> ApiResult<()> {
     // Only the builtin PR-driving agents (claude/codex) need GitHub credentials to
     // push as the user. A custom agent is operator-defined — it may be a manual
@@ -480,11 +481,33 @@ async fn ensure_github_token_available(
     {
         return Ok(());
     }
+    // Restricted sessions do not push directly. Their fixed GitHub tools can
+    // mint a repository-scoped installation token on demand; callers pass the
+    // App only for that launch posture.
+    if let Some(app) = restricted_github_app {
+        if app.is_configured().await {
+            return Ok(());
+        }
+    }
     tracing::warn!(created_by = ?created_by, runtime = %runtime, "launch blocked: no github token available");
     Err(AppError::new(
         StatusCode::PRECONDITION_REQUIRED,
         MISSING_GITHUB_TOKEN_MESSAGE,
     ))
+}
+
+async fn fetch_launch_issue(
+    st: &AppState,
+    repo_root: &std::path::Path,
+    managed_repo: Option<&crate::repo::RepoSlug>,
+    number: i64,
+) -> anyhow::Result<github::Issue> {
+    if let (Some(app), Some(repo)) = (st.trigger.app(), managed_repo) {
+        if app.is_configured().await {
+            return app.issue(&repo.owner, &repo.name, number).await;
+        }
+    }
+    github::fetch_issue(repo_root, number).await
 }
 
 /// The configured wall-clock budget for a repo setup run.
@@ -800,7 +823,19 @@ pub(crate) async fn provision_session(
         .unwrap_or(&launch_profile.mode)
         .to_string();
     tracing::debug!(model = %model, effort = %effort, protocol = %protocol, "resolved and validated model/effort/protocol");
-    ensure_github_token_available(&st.db, &extra_env, created_by.as_deref(), &runtime).await?;
+    let restricted_github_app = if launch_profile.restricted {
+        st.trigger.app()
+    } else {
+        None
+    };
+    ensure_github_token_available(
+        &st.db,
+        &extra_env,
+        created_by.as_deref(),
+        &runtime,
+        restricted_github_app,
+    )
+    .await?;
     tracing::debug!(runtime = %runtime, "github token availability check passed");
 
     // Build title/goal/description; an optional GitHub issue seeds all three.
@@ -812,9 +847,13 @@ pub(crate) async fn provision_session(
     let mut description = String::new();
     let mut github_repo = None;
     let mut github_issue: Option<i64> = None;
+    let managed_slug = req
+        .repo
+        .as_deref()
+        .and_then(|repo| crate::repo::parse_slug(repo).ok());
     if let Some(number) = req.issue {
         tracing::info!(issue = number, repo = %repo_root.display(), "fetching github issue to seed session");
-        let issue = github::fetch_issue(&repo_root, number)
+        let issue = fetch_launch_issue(&st, &repo_root, managed_slug.as_ref(), number)
             .await
             .map_err(|e| AppError::bad_request(format!("issue #{number}: {e}")))?;
         if title.is_none() {
@@ -829,7 +868,10 @@ pub(crate) async fn provision_session(
         }
         description = issue.body.clone();
         github_issue = Some(number);
-        github_repo = github::repo_slug(&repo_root).await.ok();
+        github_repo = match managed_slug.as_ref() {
+            Some(repo) => Some(repo.slug()),
+            None => github::repo_slug(&repo_root).await.ok(),
+        };
         tracing::debug!(issue = number, github_repo = ?github_repo, "seeded session fields from github issue");
     } else if let Some(number) = req.github_issue {
         // The caller already holds the thread (the `@loom` trigger): record the
@@ -2942,8 +2984,14 @@ pub(super) async fn handoff_session(
     let mut extra_env = resume_environment(&st.db, &session, &repo_root, &repo_cfg).await;
     rotate_session_token(&st.db, &session, &mut extra_env).await?;
     apply_user_github_token(&st.db, &mut extra_env, session.created_by.as_deref()).await;
-    ensure_github_token_available(&st.db, &extra_env, session.created_by.as_deref(), &runtime)
-        .await?;
+    ensure_github_token_available(
+        &st.db,
+        &extra_env,
+        session.created_by.as_deref(),
+        &runtime,
+        None,
+    )
+    .await?;
     let blocks = crate::chat::list(&st.db, &session.id).await?;
     let prompt = crate::chat::handoff_prompt(&branch.goal, &blocks, HANDOFF_HISTORY_CHARS);
     let prompt_file = db::run_dir(&session.id).join("handoff.txt");
@@ -3613,6 +3661,7 @@ mod tests {
             &[("FOO".to_string(), "bar".to_string())],
             Some("alice"),
             "codex",
+            None,
         )
         .await
         .unwrap_err();
@@ -3630,7 +3679,7 @@ mod tests {
         crate::user_token::set(&db, "alice", "ghp_alice")
             .await
             .unwrap();
-        ensure_github_token_available(&db, &[], Some("alice"), "claude")
+        ensure_github_token_available(&db, &[], Some("alice"), "claude", None)
             .await
             .unwrap();
 
@@ -3640,6 +3689,7 @@ mod tests {
             &[("GH_TOKEN".to_string(), "ghp_shared".to_string())],
             Some("alice"),
             "codex",
+            None,
         )
         .await
         .unwrap();
@@ -3657,6 +3707,7 @@ mod tests {
             &[("GH_TOKEN".to_string(), " ".to_string())],
             Some("alice"),
             "codex",
+            None,
         )
         .await
         .unwrap_err();
@@ -3670,11 +3721,43 @@ mod tests {
 
         // A custom (non-builtin) agent is exempt — it may never touch GitHub, and
         // the operator supplies any credentials it needs via env.
-        ensure_github_token_available(&db, &[], Some("alice"), "my-custom-agent")
+        ensure_github_token_available(&db, &[], Some("alice"), "my-custom-agent", None)
             .await
             .unwrap();
         // A webhook launch carries an attribution string, not an approved user.
-        ensure_github_token_available(&db, &[], Some("github-webhook (octo)"), "codex")
+        ensure_github_token_available(&db, &[], Some("github-webhook (octo)"), "codex", None)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn restricted_builtin_accepts_configured_github_app() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        seed_user(&db, "alice").await;
+        let (app_id, private_key) = crate::github_app::tests::credentials();
+        weaver_core::config::apply(
+            &db,
+            &[
+                (
+                    crate::github_app::APP_ID_KEY.to_string(),
+                    Some(app_id.to_string()),
+                ),
+                (
+                    crate::github_app::APP_PRIVATE_KEY_KEY.to_string(),
+                    Some(private_key.to_string()),
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+        let app = crate::github_app::GithubApp::new(db.clone());
+
+        let err = ensure_github_token_available(&db, &[], Some("alice"), "claude", None)
+            .await
+            .unwrap_err();
+        assert_eq!(err.status(), StatusCode::PRECONDITION_REQUIRED);
+
+        ensure_github_token_available(&db, &[], Some("alice"), "claude", Some(&app))
             .await
             .unwrap();
     }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -877,11 +877,7 @@ pub(crate) async fn provision_session(
         // The caller already holds the thread (the `@loom` trigger): record the
         // GitHub link on the tracking issue without the fetch-and-seed above.
         github_issue = Some(number);
-        github_repo = req
-            .repo
-            .as_deref()
-            .and_then(|r| crate::repo::parse_slug(r).ok())
-            .map(|s| s.slug());
+        github_repo = managed_slug.as_ref().map(|repo| repo.slug());
     }
 
     // Claiming an existing weaver issue seeds the same three fields from it.
@@ -3734,17 +3730,16 @@ mod tests {
     async fn restricted_builtin_accepts_configured_github_app() {
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
-        let (app_id, private_key) = crate::github_app::tests::credentials();
         weaver_core::config::apply(
             &db,
             &[
                 (
                     crate::github_app::APP_ID_KEY.to_string(),
-                    Some(app_id.to_string()),
+                    Some("123456".to_string()),
                 ),
                 (
                     crate::github_app::APP_PRIVATE_KEY_KEY.to_string(),
-                    Some(private_key.to_string()),
+                    Some("configured-for-preflight".to_string()),
                 ),
             ],
         )

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -223,7 +223,7 @@ async fn restricted_github_tool_uses_the_server_side_token_and_fixed_repo() {
         & 0o777;
     assert_eq!(config_mode, 0o700);
 
-    let fallback = ts
+    let second_response = ts
         .client
         .post(
             &format!("/api/sessions/{id}/restricted-github/issue_view"),
@@ -231,7 +231,7 @@ async fn restricted_github_tool_uses_the_server_side_token_and_fixed_repo() {
         )
         .await
         .unwrap();
-    assert!(fallback["text"]
+    assert!(second_response["text"]
         .as_str()
         .unwrap()
         .contains("profile:issue view 7 --repo octo/fixed"));

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -132,7 +132,6 @@ async fn restricted_github_tool_uses_the_server_side_token_and_fixed_repo() {
         &gh,
         "#!/bin/sh\n\
          case \"$GH_TOKEN\" in\n\
-           requester-token) printf 'requester:' ;;\n\
            server-only-token) printf 'profile:' ;;\n\
            *) exit 17 ;;\n\
          esac\n\
@@ -214,7 +213,7 @@ async fn restricted_github_tool_uses_the_server_side_token_and_fixed_repo() {
         .await
         .unwrap();
     let text = response["text"].as_str().unwrap();
-    assert!(text.contains("requester:issue edit 7 --repo octo/fixed --body clean body"));
+    assert!(text.contains("profile:issue edit 7 --repo octo/fixed --body clean body"));
     assert!(!text.contains("server-only-token"));
     assert!(!text.contains("requester-token"));
     let config_mode = std::fs::metadata(loom::db::run_dir(id).join("restricted-gh-config"))
@@ -224,9 +223,6 @@ async fn restricted_github_tool_uses_the_server_side_token_and_fixed_repo() {
         & 0o777;
     assert_eq!(config_mode, 0o700);
 
-    loom::user_token::remove(&ts.state.db, "rjpower")
-        .await
-        .unwrap();
     let fallback = ts
         .client
         .post(

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -7,12 +7,12 @@ use std::os::unix::fs::PermissionsExt;
 
 use crate::fixtures::TestServer;
 
-struct EnvVarSet {
+struct EnvVarGuard {
     name: &'static str,
     previous: Option<std::ffi::OsString>,
 }
 
-impl EnvVarSet {
+impl EnvVarGuard {
     fn set(name: &'static str, value: &str) -> Self {
         let previous = std::env::var_os(name);
         std::env::set_var(name, value);
@@ -26,7 +26,7 @@ impl EnvVarSet {
     }
 }
 
-impl Drop for EnvVarSet {
+impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         match &self.previous {
             Some(value) => std::env::set_var(self.name, value),
@@ -57,7 +57,7 @@ async fn stock_github_comment_profile_round_trips_restricted_policy() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restricted_profile_sends_the_caller_goal_as_the_first_prompt() {
-    let _adapter = EnvVarSet::set(
+    let _adapter = EnvVarGuard::set(
         "WEAVER_CLAUDE_ACP_CMD",
         &crate::fixtures::fake_acp_agent_cmd(),
     );
@@ -132,7 +132,7 @@ async fn restricted_profile_sends_the_caller_goal_as_the_first_prompt() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn local_restricted_launch_does_not_treat_the_app_as_an_unscoped_credential() {
-    let _token = EnvVarSet::unset("GH_TOKEN");
+    let _token = EnvVarGuard::unset("GH_TOKEN");
     let ts = TestServer::start().await;
     weaver_core::config::apply(
         &ts.state.db,
@@ -193,8 +193,8 @@ async fn restricted_github_tool_uses_the_server_side_token_and_fixed_repo() {
         dir.path().display(),
         std::env::var("PATH").unwrap_or_default()
     );
-    let _path = EnvVarSet::set("PATH", &path);
-    let _adapter = EnvVarSet::set(
+    let _path = EnvVarGuard::set("PATH", &path);
+    let _adapter = EnvVarGuard::set(
         "WEAVER_CLAUDE_ACP_CMD",
         &crate::fixtures::fake_acp_agent_cmd(),
     );

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -150,22 +150,26 @@ async fn local_restricted_launch_does_not_treat_the_app_as_an_unscoped_credentia
     .await
     .unwrap();
 
-    let error = ts
-        .client
-        .post(
-            "/api/sessions",
-            json!({
-                "cwd": ts.cwd(),
-                "profile": "github_comment",
-                "goal": "no repository installation target"
-            }),
-        )
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/api/sessions", ts.addr))
+        .json(&json!({
+            "cwd": ts.cwd(),
+            "profile": "github_comment",
+            "goal": "no repository installation target"
+        }))
+        .send()
         .await
-        .unwrap_err()
-        .to_string();
+        .unwrap();
 
-    assert!(error.contains("server returned 428"), "{error}");
-    assert!(error.contains("No GitHub token configured"), "{error}");
+    assert_eq!(response.status(), StatusCode::PRECONDITION_REQUIRED);
+    assert!(ts
+        .client
+        .get("/api/sessions")
+        .await
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .is_empty());
 }
 
 #[serial]

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -18,6 +18,12 @@ impl EnvVarSet {
         std::env::set_var(name, value);
         Self { name, previous }
     }
+
+    fn unset(name: &'static str) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::remove_var(name);
+        Self { name, previous }
+    }
 }
 
 impl Drop for EnvVarSet {
@@ -121,6 +127,45 @@ async fn restricted_profile_sends_the_caller_goal_as_the_first_prompt() {
         );
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_restricted_launch_does_not_treat_the_app_as_an_unscoped_credential() {
+    let _token = EnvVarSet::unset("GH_TOKEN");
+    let ts = TestServer::start().await;
+    weaver_core::config::apply(
+        &ts.state.db,
+        &[
+            (
+                loom::github_app::APP_ID_KEY.to_string(),
+                Some("123456".to_string()),
+            ),
+            (
+                loom::github_app::APP_PRIVATE_KEY_KEY.to_string(),
+                Some("configured-for-preflight".to_string()),
+            ),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let error = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({
+                "cwd": ts.cwd(),
+                "profile": "github_comment",
+                "goal": "no repository installation target"
+            }),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("server returned 428"), "{error}");
+    assert!(error.contains("No GitHub token configured"), "{error}");
 }
 
 #[serial]

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -264,7 +264,6 @@ async fn restricted_github_tool_uses_the_server_side_token_and_fixed_repo() {
     let text = response["text"].as_str().unwrap();
     assert!(text.contains("profile:issue edit 7 --repo octo/fixed --body clean body"));
     assert!(!text.contains("server-only-token"));
-    assert!(!text.contains("requester-token"));
     let config_mode = std::fs::metadata(loom::db::run_dir(id).join("restricted-gh-config"))
         .unwrap()
         .permissions()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -256,7 +256,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `POST /api/deployment/reconcile` | admin-only idempotent reconciliation of deployment-managed profiles, environment references, and federation mappings; pruning never touches operator-managed rows |
 | `POST /api/auth/federate` | exchange an exact mapped, signature-verified GitHub or Google OIDC identity for a ten-minute Ed25519-signed, profile-scoped Loom automation token |
 | `GET POST /api/runs`; `GET /api/runs/{id}` | durable, subject-scoped automation runs with idempotency reservation; verified GitHub callers may provide a validated deterministic key, otherwise the workflow run/attempt is used |
-| `POST /api/sessions/{id}/restricted-github/{tool}` | session-token-scoped fixed GitHub operations for a restricted session; checks stamped tool policy, fixes the target repository and thread from the session, and resolves the requester/profile/GitHub App token server-side |
+| `POST /api/sessions/{id}/restricted-github/{tool}` | session-token-scoped fixed GitHub operations for a restricted session; checks stamped tool policy, fixes the target repository and thread from the session, and resolves a GitHub App token or explicit App-less profile token server-side |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear a branch tag — the well-known `attention` and `triage` keys plus any free-form key |
 | `GET /api/sessions/{id}/url` | the session's dashboard URL as `{url}`, built from the externally-visible origin (`auth.base_url`, else the request's own Host) — what `loom session url` prints, so an agent can link a PR back to its session without inventing a loopback link |
@@ -728,10 +728,12 @@ rules. Repository/profile data never supplies executable MCP configuration.
 Restricted launch and recovery omit repository environment/setup and Claude
 user/project/local settings. Repository reads are path-scoped, and GitHub
 mutations use a fixed MCP bridge backed by a session-scoped REST endpoint. Loom
-resolves the requester's token, a profile token, or the configured GitHub App's
-short-lived repository installation token server-side and invokes `gh` without
-a shell against the session's fixed repository and linked thread; the
-credential never enters the agent environment. Allowed rules execute directly;
+uses the configured GitHub App's short-lived repository installation token
+server-side, with an explicit profile token available only to App-less
+deployments, and invokes `gh` without a shell against the session's fixed
+repository and linked thread. Personal user tokens remain exclusive to ordinary
+interactive sessions, and no credential enters the restricted agent
+environment. Allowed rules execute directly;
 any remaining ACP permission request is answered with the adapter's one-shot
 rejection (or a cancelled outcome), including after `session/load`. Runtime
 handoff and permission-mode changes are forbidden. The stock `github_comment`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -256,7 +256,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `POST /api/deployment/reconcile` | admin-only idempotent reconciliation of deployment-managed profiles, environment references, and federation mappings; pruning never touches operator-managed rows |
 | `POST /api/auth/federate` | exchange an exact mapped, signature-verified GitHub or Google OIDC identity for a ten-minute Ed25519-signed, profile-scoped Loom automation token |
 | `GET POST /api/runs`; `GET /api/runs/{id}` | durable, subject-scoped automation runs with idempotency reservation; verified GitHub callers may provide a validated deterministic key, otherwise the workflow run/attempt is used |
-| `POST /api/sessions/{id}/restricted-github/{tool}` | session-token-scoped fixed GitHub operations for a restricted session; checks stamped tool policy, fixes the target repository and thread from the session, and resolves the requester/profile token server-side |
+| `POST /api/sessions/{id}/restricted-github/{tool}` | session-token-scoped fixed GitHub operations for a restricted session; checks stamped tool policy, fixes the target repository and thread from the session, and resolves the requester/profile/GitHub App token server-side |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear a branch tag — the well-known `attention` and `triage` keys plus any free-form key |
 | `GET /api/sessions/{id}/url` | the session's dashboard URL as `{url}`, built from the externally-visible origin (`auth.base_url`, else the request's own Host) — what `loom session url` prints, so an agent can link a PR back to its session without inventing a loopback link |
@@ -728,14 +728,16 @@ rules. Repository/profile data never supplies executable MCP configuration.
 Restricted launch and recovery omit repository environment/setup and Claude
 user/project/local settings. Repository reads are path-scoped, and GitHub
 mutations use a fixed MCP bridge backed by a session-scoped REST endpoint. Loom
-resolves the requester/profile GitHub token server-side and invokes `gh` without
-a shell against the session's fixed repository and linked thread; the credential
-never enters the agent environment. Allowed rules execute directly; any remaining ACP permission
-request is answered with the adapter's one-shot rejection (or a cancelled
-outcome), including after `session/load`. Runtime handoff and permission-mode
-changes are forbidden. The stock `github_comment` profile contains the policy
-only; its reviewed JSON manifest is seeded when absent and then remains
-operator-editable. Deployment must provide its write-only `GH_TOKEN`.
+resolves the requester's token, a profile token, or the configured GitHub App's
+short-lived repository installation token server-side and invokes `gh` without
+a shell against the session's fixed repository and linked thread; the
+credential never enters the agent environment. Allowed rules execute directly;
+any remaining ACP permission request is answered with the adapter's one-shot
+rejection (or a cancelled outcome), including after `session/load`. Runtime
+handoff and permission-mode changes are forbidden. The stock `github_comment`
+profile contains the policy only; its reviewed JSON manifest is seeded when
+absent and then remains operator-editable. App-less deployments must provide
+its write-only `GH_TOKEN`.
 
 **Cookies** are `HttpOnly; SameSite=Lax; Path=/`; the `Secure` attribute is
 added when `auth.cookie_secure` is on (set it when loom is reached over HTTPS).

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -69,10 +69,11 @@ The reply (step 8) reaches GitHub through the [GitHub App](#the-github-app) when
 one is configured — with a short-lived, per-installation token — and otherwise
 through the `gh` CLI's ambient `GH_TOKEN`. The **session itself** acts as the
 commenter: its `GH_TOKEN` is that user's personal token (**Settings → Account**),
-falling back to the ambient `GH_TOKEN` when they have none — so its pushes and
-`gh` replies are attributed to them. Separately, the poll loop posts a one-time
-back-link comment (`Working on this in loom: {base}/s/{id}`) on a session's open
-PR when one isn't already linked, so a reader of the PR can jump to the session.
+falling back to its selected profile when they have none — so its pushes and
+`gh` replies use the configured session identity. Separately, the poll loop
+posts a one-time back-link comment (`Working on this in loom: {base}/s/{id}`) on
+a session's open PR when one isn't already linked, so a reader of the PR can
+jump to the session.
 
 ## The status card
 

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -17,11 +17,13 @@ The MCP bridge calls a session-scoped Loom endpoint; Loom runs `gh` server-side
 against the session's fixed repository and linked issue/PR number, so neither a
 general shell nor the GitHub token enters the agent process. Anything outside
 the configured Claude permission rules is rejected by Loom.
-The profile intentionally has no token in its seed. Loom resolves the
-requester's stored token first, a profile `GH_TOKEN` second, and the configured
-GitHub App's short-lived installation token for the fixed repository otherwise.
-An App-less deployment can configure a least-privilege CI identity as the
-profile's write-only `GH_TOKEN`. Its stock policy lives in
+The profile intentionally has no token in its seed. Loom uses the configured
+GitHub App's short-lived installation token for the fixed repository. If an App
+is configured but is not installed on that repository, the operation fails
+rather than falling back to a broader credential. An App-less deployment can
+configure a least-privilege CI identity as the profile's write-only `GH_TOKEN`.
+Personal user tokens remain exclusive to ordinary interactive sessions. The
+stock policy lives in
 `crates/loom/profiles/github_comment.json`, not in a schema migration. Loom
 seeds a missing stock profile through normal validation and does not overwrite
 later operator edits. Custom profiles use the same REST/CLI/UI or
@@ -30,6 +32,20 @@ checkout would let repository content choose its own launch boundary and is
 deliberately unsupported. Custom profiles may compose the built-in capability
 sets Loom recognizes, but cannot define executable MCP adapters from repository
 content.
+
+## GitHub credential policy
+
+| Use case | Primary credential | Fallback |
+| --- | --- | --- |
+| Ordinary interactive session | Launching user's personal token from **Settings → Account** | Selected profile's `GH_TOKEN`, then lower session environment layers |
+| Restricted GitHub tool | Short-lived GitHub App installation token for the session's fixed repository | Profile `GH_TOKEN` only when no App is configured |
+| GitHub Actions calling Loom | GitHub OIDC exchanged for a ten-minute Loom automation token | None |
+
+The same environment variable name appears inside an ordinary session because
+`git` and `gh` expect it, but the stores and trust boundaries are separate.
+When a GitHub App is configured, a mint or installation failure is an error:
+Loom does not silently widen authority by falling back to a personal or shared
+PAT.
 
 ## GitHub Actions request
 
@@ -87,8 +103,8 @@ fixed GitHub tool. Prefer the configured GitHub App, whose installation token is
 short-lived and scoped to the session's fixed repository. App-less deployments
 can put a least-privilege token in the profile's write-only environment,
 preferably as a deployment-managed Secret Manager reference. The existing
-human/comment launch path uses the approved requester's stored GitHub token by
-default, also server-side for a restricted session.
+ordinary interactive launch path uses the approved requester's stored GitHub
+token by default; restricted sessions do not.
 
 ## Production rollout
 
@@ -109,5 +125,6 @@ default, also server-side for a restricted session.
    exchange above, keeping its current body-hash/stale-write prompt. Roll the
    action revision through `marin-community/*` consumers in batches.
 
-Disable the federation mapping or remove the profile token to stop new runs.
-That rollback does not affect interactive Loom sessions.
+Disable the federation mapping to stop new runs. On an App-less deployment,
+removing the profile token also disables the fixed GitHub operations. Neither
+rollback affects interactive Loom sessions.

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -17,16 +17,19 @@ The MCP bridge calls a session-scoped Loom endpoint; Loom runs `gh` server-side
 against the session's fixed repository and linked issue/PR number, so neither a
 general shell nor the GitHub token enters the agent process. Anything outside
 the configured Claude permission rules is rejected by Loom.
-The profile intentionally has no token in its seed. Configure a least-privilege
-CI identity as its write-only `GH_TOKEN` before enabling a federation mapping.
-Its stock policy lives in `crates/loom/profiles/github_comment.json`, not in a
-schema migration. Loom seeds a missing stock profile through normal validation
-and does not overwrite later operator edits. Custom profiles use the same
-REST/CLI/UI or deployment-reconciliation contract; loading policy implicitly
-from a managed checkout would let repository content choose its own launch
-boundary and is deliberately unsupported. Custom profiles may compose the
-built-in capability sets Loom recognizes, but cannot define executable MCP
-adapters from repository content.
+The profile intentionally has no token in its seed. Loom resolves the
+requester's stored token first, a profile `GH_TOKEN` second, and the configured
+GitHub App's short-lived installation token for the fixed repository otherwise.
+An App-less deployment can configure a least-privilege CI identity as the
+profile's write-only `GH_TOKEN`. Its stock policy lives in
+`crates/loom/profiles/github_comment.json`, not in a schema migration. Loom
+seeds a missing stock profile through normal validation and does not overwrite
+later operator edits. Custom profiles use the same REST/CLI/UI or
+deployment-reconciliation contract; loading policy implicitly from a managed
+checkout would let repository content choose its own launch boundary and is
+deliberately unsupported. Custom profiles may compose the built-in capability
+sets Loom recognizes, but cannot define executable MCP adapters from repository
+content.
 
 ## GitHub Actions request
 
@@ -79,16 +82,20 @@ the compatibility behavior of deduplicating one workflow run attempt; a body
 hash key converges retries and reruns for the same source description.
 
 Do not put `GH_TOKEN` in the request or prompt. Automation requests are stored
-for audit and idempotency. The token belongs in the profile's write-only
-environment, preferably as a deployment-managed Secret Manager reference. Loom
-resolves it only while executing a fixed GitHub tool. The existing human/comment
-launch path uses the approved requester's stored GitHub token by default, also
-server-side for a restricted session.
+for audit and idempotency. Loom resolves a credential only while executing a
+fixed GitHub tool. Prefer the configured GitHub App, whose installation token is
+short-lived and scoped to the session's fixed repository. App-less deployments
+can put a least-privilege token in the profile's write-only environment,
+preferably as a deployment-managed Secret Manager reference. The existing
+human/comment launch path uses the approved requester's stored GitHub token by
+default, also server-side for a restricted session.
 
 ## Production rollout
 
-1. Declare `github_comment` in the production Pulumi profile manifest with its
-   `GH_TOKEN` secret reference, and grant the Loom VM access to that secret.
+1. Configure and install the production GitHub App on each target repository.
+   For an App-less deployment, declare `github_comment` in the Pulumi profile
+   manifest with a least-privilege `GH_TOKEN` secret reference and grant the
+   Loom VM access to that secret.
 2. Add one `githubFederations` entry per approved caller workflow, constrained
    to the numeric repository id, exact workflow ref, event/ref where useful, and
    only `github_comment`.


### PR DESCRIPTION
Restricted GitHub tools now use the configured GitHub App installation token for the fixed repository. If the App cannot mint for that repository, the operation fails closed; App-less deployments may explicitly configure a profile `GH_TOKEN`. Personal user tokens remain exclusive to ordinary interactive sessions.

Managed `--issue` launches use the same App path for issue seeding, and launch preflight accepts the App only for restricted sessions. Settings now identifies personal, default-profile, and restricted credential scopes; launch errors direct shared secrets to the write-only profile store instead of the readable default-profile environment.

A production synthetic run rewrote issue #190 through the fixed `issue_view` and `issue_edit` surface: https://loom.oa.dev/s/m9i2jf0h. The temporary profile token used to exercise the pre-change server was removed after the run.