### PR TITLE
fix(loom): improve agent configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,10 @@ Notable settings:
   [Restricted GitHub sessions](docs/restricted-sessions.md).
 - Profile environment values are write-only: API, CLI, and Settings responses
   expose names and update times, never secret values.
+- Ordinary sessions default `CARGO_TARGET_DIR` to the primary repository's
+  `target/` directory, so Rust builds are reused across its Weaver worktrees.
+  A profile, per-repo environment value, or committed `[env]` entry can override
+  it; restricted profiles receive no repository-derived defaults.
 - `server.auto_adopt` — adopt every recoverable session on daemon startup.
 - `github.poll` — poll GitHub (via `gh`) for each session's PR, review, and
   check status (on by default; a no-op without `gh` or a GitHub remote).

--- a/crates/loom/frontend/src/components/ProfilesPanel.vue
+++ b/crates/loom/frontend/src/components/ProfilesPanel.vue
@@ -34,11 +34,6 @@ function normalizeAgentChoices(metadata = selectedAgent.value) {
   }
 }
 
-function changeAgent(event: Event) {
-  if (!draft.value) return;
-  draft.value.agent_kind = (event.target as HTMLSelectElement).value;
-}
-
 watch(selectedAgent, normalizeAgentChoices);
 
 function editable(profile: Profile): ProfileInput {
@@ -202,9 +197,8 @@ onMounted(load);
             >Agent
             <select
               data-testid="profile-agent"
-              :value="draft.agent_kind"
+              v-model="draft.agent_kind"
               class="mt-1 w-full rounded bg-input px-2 py-1.5"
-              @change="changeAgent"
             >
               <option v-for="agent in agents" :key="agent.kind" :value="agent.kind">
                 {{ agent.label }}

--- a/crates/loom/frontend/src/components/ProfilesPanel.vue
+++ b/crates/loom/frontend/src/components/ProfilesPanel.vue
@@ -212,7 +212,24 @@ onMounted(load);
           </label>
           <label class="text-xs"
             >Model
+            <input
+              v-if="selectedAgent?.accepts_raw_model"
+              data-testid="profile-model"
+              v-model="draft.model"
+              list="profile-model-options"
+              placeholder="Agent default"
+              class="mt-1 w-full rounded bg-input px-2 py-1.5"
+            />
+            <datalist v-if="selectedAgent?.accepts_raw_model" id="profile-model-options">
+              <option
+                v-for="model in selectedAgent.models"
+                :key="model.id"
+                :value="model.id"
+                :label="model.label"
+              />
+            </datalist>
             <select
+              v-else
               data-testid="profile-model"
               v-model="draft.model"
               class="mt-1 w-full rounded bg-input px-2 py-1.5"

--- a/crates/loom/frontend/src/components/ProfilesPanel.vue
+++ b/crates/loom/frontend/src/components/ProfilesPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import * as api from '../api';
 import type { AgentMetadata, Profile, ProfileInput } from '../types';
 
@@ -19,12 +19,9 @@ const selectedAgent = computed(() =>
   agents.value.find((agent) => agent.kind === draft.value?.agent_kind),
 );
 
-function changeAgent(event: Event) {
+function normalizeAgentChoices(metadata = selectedAgent.value) {
   const profile = draft.value;
-  if (!profile) return;
-  profile.agent_kind = (event.target as HTMLSelectElement).value;
-  const metadata = selectedAgent.value;
-  if (!metadata) return;
+  if (!profile || !metadata) return;
   if (
     profile.model &&
     !metadata.accepts_raw_model &&
@@ -36,6 +33,13 @@ function changeAgent(event: Event) {
     profile.effort = '';
   }
 }
+
+function changeAgent(event: Event) {
+  if (!draft.value) return;
+  draft.value.agent_kind = (event.target as HTMLSelectElement).value;
+}
+
+watch(selectedAgent, normalizeAgentChoices);
 
 function editable(profile: Profile): ProfileInput {
   const {
@@ -59,6 +63,7 @@ function choose(name: string) {
   selected.value = name;
   const profile = profiles.value.find((item) => item.name === name);
   draft.value = profile ? editable(profile) : null;
+  normalizeAgentChoices();
   creating.value = false;
   error.value = '';
   notice.value = '';

--- a/crates/loom/frontend/src/components/ProfilesPanel.vue
+++ b/crates/loom/frontend/src/components/ProfilesPanel.vue
@@ -15,6 +15,27 @@ const envName = ref('');
 const envValue = ref('');
 
 const current = computed(() => profiles.value.find((profile) => profile.name === selected.value));
+const selectedAgent = computed(() =>
+  agents.value.find((agent) => agent.kind === draft.value?.agent_kind),
+);
+
+function changeAgent(event: Event) {
+  const profile = draft.value;
+  if (!profile) return;
+  profile.agent_kind = (event.target as HTMLSelectElement).value;
+  const metadata = agents.value.find((agent) => agent.kind === profile.agent_kind);
+  if (!metadata) return;
+  if (
+    profile.model &&
+    !metadata.accepts_raw_model &&
+    !metadata.models.some((choice) => choice.id === profile.model)
+  ) {
+    profile.model = '';
+  }
+  if (profile.effort && !metadata.efforts.some((choice) => choice.id === profile.effort)) {
+    profile.effort = '';
+  }
+}
 
 function editable(profile: Profile): ProfileInput {
   const {
@@ -176,8 +197,9 @@ onMounted(load);
             >Agent
             <select
               data-testid="profile-agent"
-              v-model="draft.agent_kind"
+              :value="draft.agent_kind"
               class="mt-1 w-full rounded bg-input px-2 py-1.5"
+              @change="changeAgent"
             >
               <option v-for="agent in agents" :key="agent.kind" :value="agent.kind">
                 {{ agent.label }}
@@ -190,19 +212,37 @@ onMounted(load);
           </label>
           <label class="text-xs"
             >Model
-            <input
+            <select
               data-testid="profile-model"
               v-model="draft.model"
               class="mt-1 w-full rounded bg-input px-2 py-1.5"
-            />
+            >
+              <option value="">Agent default</option>
+              <option
+                v-for="model in selectedAgent?.models ?? []"
+                :key="model.id"
+                :value="model.id"
+              >
+                {{ model.label }}
+              </option>
+            </select>
           </label>
           <label class="text-xs"
             >Effort
-            <input
+            <select
               data-testid="profile-effort"
               v-model="draft.effort"
               class="mt-1 w-full rounded bg-input px-2 py-1.5"
-            />
+            >
+              <option value="">Agent default</option>
+              <option
+                v-for="effort in selectedAgent?.efforts ?? []"
+                :key="effort.id"
+                :value="effort.id"
+              >
+                {{ effort.label }}
+              </option>
+            </select>
           </label>
           <label class="text-xs"
             >Protocol

--- a/crates/loom/frontend/src/components/ProfilesPanel.vue
+++ b/crates/loom/frontend/src/components/ProfilesPanel.vue
@@ -23,7 +23,7 @@ function changeAgent(event: Event) {
   const profile = draft.value;
   if (!profile) return;
   profile.agent_kind = (event.target as HTMLSelectElement).value;
-  const metadata = agents.value.find((agent) => agent.kind === profile.agent_kind);
+  const metadata = selectedAgent.value;
   if (!metadata) return;
   if (
     profile.model &&

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -259,11 +259,12 @@ fn repo_cfg_or_default(repo_root: &std::path::Path) -> weaver_core::repo_config:
 }
 
 /// Build the environment exported into a session's agent terminal, layered in
-/// priority order: the operator's global [`agent_env`], then the per-repo
-/// [`repo_env`], then the repo's committed `.weaver/config.toml` `[env]` — each
-/// layer overriding the previous for a shared name. Best-effort: a database error
-/// in a layer degrades to the layers that did resolve. `cfg` is the already-loaded
-/// repo config (the caller reads it once for env, setup, and defaults).
+/// priority order: the profile environment, then the per-repo [`repo_env`], then
+/// the repo's committed `.weaver/config.toml` `[env]` — each layer overriding the
+/// previous for a shared name. Loom fills in its repo-local defaults last only
+/// when no layer supplied the name. Best-effort: a database error in a layer
+/// degrades to the layers that did resolve. `cfg` is the already-loaded repo
+/// config (the caller reads it once for env, setup, and defaults).
 async fn launch_env_for_profile(
     db: &Db,
     repo_root: &std::path::Path,
@@ -296,8 +297,25 @@ async fn launch_env_for_profile(
         repo_env::layer(&mut env, repo_pairs);
         repo_env::layer(&mut env, config_pairs);
     }
+    apply_repo_env_defaults(&mut env, repo_root);
     tracing::debug!(repo = %repo_root_str, profile = profile_name, strict, env_vars = env.len(), "layered launch environment");
     env
+}
+
+/// Defaults shared by every ordinary worktree for one repository. Cargo's
+/// normal worktree-local `target/` defeats incremental reuse across Weaver
+/// sessions; pinning it to the primary repository root gives every branch the
+/// same cache. An explicit profile, per-repo, or committed config value wins.
+///
+/// Restricted profiles deliberately skip repo-derived defaults along with the
+/// other repository environment layers.
+fn apply_repo_env_defaults(env: &mut Vec<(String, String)>, repo_root: &std::path::Path) {
+    if !env.iter().any(|(name, _)| name == "CARGO_TARGET_DIR") {
+        env.push((
+            "CARGO_TARGET_DIR".to_string(),
+            repo_root.join("target").display().to_string(),
+        ));
+    }
 }
 
 async fn automation_policy_defaults(db: &Db) -> (i64, i64) {
@@ -3474,6 +3492,45 @@ mod tests {
             env,
             vec![("GH_TOKEN".to_string(), "profile-token".to_string())]
         );
+    }
+
+    #[tokio::test]
+    async fn ordinary_environment_shares_cargo_target_at_the_repo_root() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        let cfg = weaver_core::repo_config::RepoConfig::default();
+
+        let env = launch_env_for_profile(&db, repo, &cfg, "default", false, false).await;
+
+        assert!(env.iter().any(|(name, value)| {
+            name == "CARGO_TARGET_DIR" && value == &repo.join("target").display().to_string()
+        }));
+    }
+
+    #[tokio::test]
+    async fn explicit_cargo_target_overrides_the_repo_default() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        crate::repo_env::set(
+            &db,
+            &repo.display().to_string(),
+            "CARGO_TARGET_DIR",
+            "/custom/cargo-target",
+        )
+        .await
+        .unwrap();
+        let cfg = weaver_core::repo_config::RepoConfig::default();
+
+        let env = launch_env_for_profile(&db, repo, &cfg, "default", false, false).await;
+        let targets: Vec<_> = env
+            .iter()
+            .filter(|(name, _)| name == "CARGO_TARGET_DIR")
+            .collect();
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].1, "/custom/cargo-target");
     }
 
     #[test]

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -14,19 +14,23 @@ test.describe("settings · profiles", () => {
         efforts: { id: string; label: string }[];
       }[];
     };
+    const claude = registry.agents.find((agent) => agent.kind === "claude")!;
     const codex = registry.agents.find((agent) => agent.kind === "codex")!;
     await page.goto(`${weaver.baseUrl}/settings`);
 
     const agent = page.getByTestId("profile-agent");
+    const model = page.getByTestId("profile-model");
+    const effort = page.getByTestId("profile-effort");
     await expect(agent.locator("option")).toContainText([
       "Claude",
       "Codex",
       "Shell",
     ]);
 
+    await agent.selectOption("claude");
+    await model.selectOption(claude.models[0].id);
     await agent.selectOption("codex");
-    const model = page.getByTestId("profile-model");
-    const effort = page.getByTestId("profile-effort");
+    await expect(model).toHaveValue("");
     await expect(model.locator("option")).toContainText([
       "Agent default",
       ...codex.models.map((choice) => choice.label),

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -25,8 +25,18 @@ test.describe("settings · profiles", () => {
     ]);
 
     await agent.selectOption("codex");
-    await page.getByTestId("profile-model").fill(codex.models[0].id);
-    await page.getByTestId("profile-effort").fill(codex.efforts[0].id);
+    const model = page.getByTestId("profile-model");
+    const effort = page.getByTestId("profile-effort");
+    await expect(model.locator("option")).toContainText([
+      "Agent default",
+      ...codex.models.map((choice) => choice.label),
+    ]);
+    await expect(effort.locator("option")).toContainText([
+      "Agent default",
+      ...codex.efforts.map((choice) => choice.label),
+    ]);
+    await model.selectOption(codex.models[0].id);
+    await effort.selectOption(codex.efforts[0].id);
     await page.getByTestId("profile-save").click();
     await expect(page.getByText("Saved default.")).toBeVisible();
 


### PR DESCRIPTION
Use the agent registry to populate profile model and effort selectors, including an explicit agent-default choice and a raw-model fallback for compatible runtimes. Switching runtimes now clears selections the new agent cannot accept.

Default ordinary sessions to the primary repository’s Cargo target directory so Rust artifacts are reused across Weaver worktrees. Explicit profile, repository, and committed environment settings still take precedence, while restricted profiles remain isolated.