### PR TITLE
feat(loom): split workspace and automation sessions

### DIFF
--- a/crates/loom/frontend/src/App.vue
+++ b/crates/loom/frontend/src/App.vue
@@ -44,6 +44,7 @@ const docTitle = computed(() => {
   if (typeof id === 'string' && route.path.startsWith(`/s/${id}`)) {
     return withSection(sessionById(id)?.branch.title || sessionById(id)?.branch.name);
   }
+  if (route.path === '/' && route.query.view === 'automation') return withSection('Automation');
   if (route.path === '/' && route.query.new !== undefined) return withSection('New Session');
   return withSection(route.meta.title as string | undefined);
 });

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -93,11 +93,16 @@ export const listSessions = (opts: { archived?: boolean; automation?: boolean } 
   return get(`/sessions${qs ? `?${qs}` : ''}`) as Promise<Session[]>;
 };
 
+/** Durable automation launch reservations, including failures that never
+ *  produced a usable session (`GET /api/runs`). */
+export const listRuns = () => get('/runs') as Promise<AutomationRun[]>;
+
 // --- Issues ----------------------------------------------------------------
 
 import type {
   Issue,
   Session,
+  AutomationRun,
   ArtifactMeta,
   ArtifactView,
   ArtifactWriteBody,

--- a/crates/loom/frontend/src/components/AutomationRunRow.vue
+++ b/crates/loom/frontend/src/components/AutomationRunRow.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { AutomationRun } from '../types';
+import { exactTime, timeAgo } from '../lib/time';
+import StatusBadge from './StatusBadge.vue';
+
+defineProps<{ run: AutomationRun; intervention: boolean }>();
+</script>
+
+<template>
+  <li
+    class="flex items-start gap-3 border-b border-line px-3 py-2.5 last:border-0"
+    data-testid="automation-run-only"
+    :data-run-id="run.id"
+  >
+    <span
+      class="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+      :class="intervention ? 'bg-block-line' : 'bg-info-line'"
+      aria-hidden="true"
+    ></span>
+    <div class="min-w-0 flex-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="font-serif text-[15px] font-semibold text-fg">
+          {{ intervention ? `Launch ${run.status}` : 'Provisioning session' }}
+        </span>
+        <StatusBadge :status="run.status" />
+      </div>
+      <p v-if="intervention && run.summary" class="mt-0.5 break-words font-mono text-xs text-block">
+        {{ run.summary }}
+      </p>
+    </div>
+    <div class="shrink-0 text-right font-mono text-2xs text-faint">
+      <div>{{ run.source }} · {{ run.service_tag }}</div>
+      <div>{{ run.profile }}</div>
+      <time
+        :datetime="run.updated_at"
+        :title="exactTime(run.updated_at)"
+        :aria-label="exactTime(run.updated_at)"
+      >
+        {{ timeAgo(run.updated_at) }}
+      </time>
+    </div>
+  </li>
+</template>

--- a/crates/loom/frontend/src/components/AutomationSessionRow.vue
+++ b/crates/loom/frontend/src/components/AutomationSessionRow.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Session } from '../types';
+import { exactTime, timeAgo } from '../lib/time';
+import { messageOf, signalChips } from '../lib/sessionState';
+import SignalChip from './SignalChip.vue';
+import StatusBadge from './StatusBadge.vue';
+
+const props = defineProps<{
+  session: Session;
+  parent?: Session;
+  tone: 'intervention' | 'active' | 'history';
+  clearingTag: string;
+}>();
+
+const emit = defineEmits<{ clearTag: [key: string] }>();
+
+const dotClass = computed(() => {
+  if (props.tone === 'intervention') return 'bg-block-line';
+  if (props.tone === 'active') return 'bg-ok-line';
+  return 'bg-line';
+});
+</script>
+
+<template>
+  <li
+    class="relative flex items-start gap-3 border-b border-line px-3 py-2.5 last:border-0"
+    :class="tone === 'history' && 'opacity-70 hover:opacity-100'"
+    data-testid="automation-session"
+    :data-session-id="session.id"
+  >
+    <span class="mt-1.5 h-2 w-2 shrink-0 rounded-full" :class="dotClass" aria-hidden="true"></span>
+    <div class="min-w-0 flex-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <router-link
+          :to="`/s/${session.id}`"
+          class="stretched-link truncate font-serif text-[15px] text-fg hover:text-accent"
+          :class="tone === 'history' ? 'font-medium' : 'font-semibold'"
+        >
+          {{ session.branch.title || session.branch.name }}
+        </router-link>
+        <StatusBadge :status="session.status" />
+        <SignalChip
+          v-for="chip in tone === 'intervention' ? signalChips(session) : []"
+          :key="chip.key"
+          class="relative z-10"
+          :chip="chip"
+          :busy="clearingTag === `${session.id}:${chip.key}`"
+          @clear="(key) => emit('clearTag', key)"
+        />
+      </div>
+      <p
+        v-if="tone !== 'history' && messageOf(session)"
+        class="mt-0.5 truncate font-serif text-[13px] text-muted"
+      >
+        {{ messageOf(session) }}
+      </p>
+      <p v-if="parent" class="mt-0.5 text-xs text-faint">
+        launched by
+        <router-link class="relative z-10 font-mono hover:text-accent" :to="`/s/${parent.id}`">
+          {{ parent.branch.title || parent.branch.name }}
+        </router-link>
+      </p>
+    </div>
+    <div class="shrink-0 text-right font-mono text-2xs text-faint">
+      <div>{{ session.origin }} · {{ session.profile }}@{{ session.profile_revision }}</div>
+      <div>{{ session.turn_count }} turn{{ session.turn_count === 1 ? '' : 's' }}</div>
+      <time
+        v-if="session.last_activity_at"
+        :datetime="session.last_activity_at"
+        :title="exactTime(session.last_activity_at)"
+        :aria-label="exactTime(session.last_activity_at)"
+      >
+        {{ timeAgo(session.last_activity_at) }}
+      </time>
+    </div>
+  </li>
+</template>

--- a/crates/loom/frontend/src/components/AutomationSessions.vue
+++ b/crates/loom/frontend/src/components/AutomationSessions.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { AutomationRun, Session } from '../types';
+import {
+  byAutomationPriority,
+  isAutomationHistory,
+  needsAutomationIntervention,
+  runNeedsIntervention,
+  unmatchedAutomationRuns,
+} from '../lib/automationSessions';
+import AutomationRunRow from './AutomationRunRow.vue';
+import AutomationSessionRow from './AutomationSessionRow.vue';
+
+const props = defineProps<{
+  sessions: Session[];
+  fleet: Session[];
+  runs: AutomationRun[];
+  historyOpen: boolean;
+  clearingTag: string;
+}>();
+
+const emit = defineEmits<{
+  toggleHistory: [];
+  clearTag: [sessionId: string, key: string];
+}>();
+
+const interventions = computed(() =>
+  props.sessions.filter(needsAutomationIntervention).sort(byAutomationPriority),
+);
+const active = computed(() =>
+  props.sessions
+    .filter((session) => !isAutomationHistory(session) && !needsAutomationIntervention(session))
+    .sort(byAutomationPriority),
+);
+const history = computed(() =>
+  props.sessions
+    .filter(isAutomationHistory)
+    .sort((a, b) => (b.last_activity_at || '').localeCompare(a.last_activity_at || '')),
+);
+const unmatched = computed(() => unmatchedAutomationRuns(props.runs, props.sessions));
+const failedRuns = computed(() =>
+  unmatched.value
+    .filter(runNeedsIntervention)
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
+);
+const creatingRuns = computed(() =>
+  unmatched.value
+    .filter((run) => !runNeedsIntervention(run))
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
+);
+
+const parentById = computed(() => {
+  const index = new Map<string, Session>();
+  for (const session of props.fleet) index.set(session.branch.id, session);
+  return index;
+});
+</script>
+
+<template>
+  <div class="space-y-4" data-testid="automation-pane">
+    <section aria-labelledby="automation-intervention-heading">
+      <div class="mb-1.5 flex items-center gap-2">
+        <h2
+          id="automation-intervention-heading"
+          class="text-2xs font-semibold uppercase tracking-wider text-muted"
+        >
+          Needs intervention
+        </h2>
+        <span
+          class="rounded-full bg-block-soft px-1.5 font-mono text-2xs text-block"
+          :aria-label="`${interventions.length + failedRuns.length} automation runs need intervention`"
+        >
+          {{ interventions.length + failedRuns.length }}
+        </span>
+      </div>
+
+      <ul
+        v-if="interventions.length || failedRuns.length"
+        class="rounded-md border border-line bg-surface"
+        data-testid="automation-interventions"
+      >
+        <AutomationSessionRow
+          v-for="session in interventions"
+          :key="session.id"
+          :session="session"
+          :parent="session.parent_id ? parentById.get(session.parent_id) : undefined"
+          tone="intervention"
+          :clearing-tag="clearingTag"
+          @clear-tag="(key) => emit('clearTag', session.id, key)"
+        />
+
+        <AutomationRunRow v-for="run in failedRuns" :key="run.id" :run="run" intervention />
+      </ul>
+      <p v-else class="rounded-md border border-dashed border-line px-3 py-3 text-sm text-muted">
+        No automation needs intervention.
+      </p>
+    </section>
+
+    <section aria-labelledby="automation-active-heading">
+      <div class="mb-1.5 flex items-center gap-2">
+        <h2
+          id="automation-active-heading"
+          class="text-2xs font-semibold uppercase tracking-wider text-muted"
+        >
+          Active
+        </h2>
+        <span class="rounded-full bg-subtle px-1.5 font-mono text-2xs text-faint">
+          {{ active.length + creatingRuns.length }}
+        </span>
+      </div>
+
+      <ul
+        v-if="active.length || creatingRuns.length"
+        class="rounded-md border border-line bg-surface"
+        data-testid="automation-active"
+      >
+        <AutomationSessionRow
+          v-for="session in active"
+          :key="session.id"
+          :session="session"
+          :parent="session.parent_id ? parentById.get(session.parent_id) : undefined"
+          tone="active"
+          :clearing-tag="clearingTag"
+          @clear-tag="(key) => emit('clearTag', session.id, key)"
+        />
+
+        <AutomationRunRow
+          v-for="run in creatingRuns"
+          :key="run.id"
+          :run="run"
+          :intervention="false"
+        />
+      </ul>
+      <p v-else class="rounded-md border border-dashed border-line px-3 py-3 text-sm text-muted">
+        No automation is active.
+      </p>
+    </section>
+
+    <section aria-labelledby="automation-history-heading">
+      <button
+        type="button"
+        class="flex w-full items-center gap-2 py-1.5 text-left text-2xs font-medium uppercase tracking-wider text-faint hover:text-muted"
+        :aria-expanded="historyOpen"
+        aria-controls="automation-history-list"
+        data-testid="automation-history-toggle"
+        @click="emit('toggleHistory')"
+      >
+        <span class="inline-block w-2 transition-transform" :class="historyOpen ? 'rotate-90' : ''"
+          >▸</span
+        >
+        <span id="automation-history-heading">History</span>
+        <span class="font-mono lowercase tracking-normal">{{ history.length }}</span>
+        <span class="h-px flex-1 bg-line"></span>
+      </button>
+
+      <ul
+        v-show="historyOpen"
+        id="automation-history-list"
+        class="rounded-md border border-line bg-surface"
+        data-testid="automation-history"
+      >
+        <AutomationSessionRow
+          v-for="session in history"
+          :key="session.id"
+          :session="session"
+          :parent="session.parent_id ? parentById.get(session.parent_id) : undefined"
+          tone="history"
+          :clearing-tag="clearingTag"
+        />
+        <li v-if="!history.length" class="px-3 py-4 text-center text-sm text-muted">
+          No automation history yet.
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -38,12 +38,16 @@ const props = defineProps<{ ws: Session }>();
 const emit = defineEmits<{ reload: [] }>();
 
 const router = useRouter();
+const fleetHref = computed(() =>
+  props.ws.class === 'automation' ? { path: '/', query: { view: 'automation' } } : '/',
+);
+const fleetLabel = computed(() => (props.ws.class === 'automation' ? '← automation' : '← all'));
 // The detail page's subject is the session itself, so a successful Remove has to
 // leave: route back to the fleet list rather than reload a page that is gone.
 const actions = useSessionActions(
   () => props.ws.id,
   () => emit('reload'),
-  () => router.push('/'),
+  () => router.push(fleetHref.value),
 );
 const { busy, notice, error, rename, clearTag, run } = actions;
 
@@ -187,7 +191,9 @@ async function submitHandoff() {
   <header class="mb-1 rounded-r border-l-2 border-transparent py-0.5 pl-3 pr-1">
     <!-- Row 1 — nav, title (inline rename), attention + lifecycle controls -->
     <div class="flex items-center gap-2.5">
-      <router-link to="/" class="shrink-0 text-sm text-muted hover:text-fg">← all</router-link>
+      <router-link :to="fleetHref" class="shrink-0 text-sm text-muted hover:text-fg">{{
+        fleetLabel
+      }}</router-link>
       <input
         v-if="editing"
         ref="inputEl"

--- a/crates/loom/frontend/src/components/StatusBadge.vue
+++ b/crates/loom/frontend/src/components/StatusBadge.vue
@@ -13,6 +13,8 @@ const palette: Record<string, string> = {
   orphaned: 'bg-subtle text-muted',
   done: 'bg-ok-soft text-ok ring-1 ring-inset ring-ok-line/30',
   error: 'bg-block-soft text-block ring-1 ring-inset ring-block-line/30',
+  failed: 'bg-block-soft text-block ring-1 ring-inset ring-block-line/30',
+  creating: 'bg-info-soft text-info ring-1 ring-inset ring-info-line/30',
   archived: 'bg-subtle text-faint',
 };
 

--- a/crates/loom/frontend/src/lib/automationSessions.ts
+++ b/crates/loom/frontend/src/lib/automationSessions.ts
@@ -1,0 +1,49 @@
+import type { AutomationRun, Session } from '../types';
+import { effectiveAttention } from './sessionState';
+
+const ACTIVE = new Set(['created', 'running']);
+const HISTORY = new Set(['done', 'archived']);
+
+export function isAutomationHistory(session: Session): boolean {
+  return HISTORY.has(session.status);
+}
+
+/** Lifecycle failures are operational exceptions even when no agent/watch has
+ *  had a chance to stamp a loud tag. Unknown live states fail open into the
+ *  intervention queue rather than disappearing. */
+export function needsAutomationIntervention(session: Session): boolean {
+  if (isAutomationHistory(session)) return false;
+  if (session.status === 'error' || session.status === 'orphaned') return true;
+  if (!ACTIVE.has(session.status)) return true;
+  return effectiveAttention(session).level !== 'ok';
+}
+
+/** Blocked first, then mechanical failures, then attention, then calm work. */
+export function automationPriority(session: Session): number {
+  const level = effectiveAttention(session).level;
+  if (level === 'blocked') return 0;
+  if (session.status === 'error' || session.status === 'orphaned') return 1;
+  if (level === 'attention') return 2;
+  return 3;
+}
+
+export function byAutomationPriority(a: Session, b: Session): number {
+  return (
+    automationPriority(a) - automationPriority(b) ||
+    (b.last_activity_at || '').localeCompare(a.last_activity_at || '')
+  );
+}
+
+/** Runs with sessions render through the richer Session row. Only reservations
+ *  whose preallocated session id is absent need their own operational row. */
+export function unmatchedAutomationRuns(
+  runs: AutomationRun[],
+  sessions: Session[],
+): AutomationRun[] {
+  const sessionIds = new Set(sessions.map((session) => session.id));
+  return runs.filter((run) => !sessionIds.has(run.session_id));
+}
+
+export function runNeedsIntervention(run: AutomationRun): boolean {
+  return run.status !== 'creating';
+}

--- a/crates/loom/frontend/src/lib/automationSessions.ts
+++ b/crates/loom/frontend/src/lib/automationSessions.ts
@@ -45,5 +45,5 @@ export function unmatchedAutomationRuns(
 }
 
 export function runNeedsIntervention(run: AutomationRun): boolean {
-  return run.status !== 'creating';
+  return run.status === 'failed';
 }

--- a/crates/loom/frontend/src/lib/sessionsStore.ts
+++ b/crates/loom/frontend/src/lib/sessionsStore.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue';
-import { listSessions } from '../api';
-import type { Session } from '../types';
+import { listRuns, listSessions } from '../api';
+import type { AutomationRun, Session } from '../types';
 
 // One shared snapshot of the fleet. The session list, the status bar, and the
 // detail page all read from here instead of each polling `/api/sessions` on
@@ -14,6 +14,7 @@ import type { Session } from '../types';
 // the view is a projection of REST state, never a separate browser-local truth.
 
 const sessions = ref<Session[]>([]);
+const runs = ref<AutomationRun[]>([]);
 // Last fetch reached the server? Drives the status bar's online dot; the cached
 // counts dim rather than vanish while the server is briefly unreachable.
 const online = ref(true);
@@ -21,14 +22,19 @@ const online = ref(true);
 let inflight: Promise<void> | null = null;
 
 // Pull the whole fleet, archived and automation-class sessions included — the
-// superset the list's archive/automation toggles need (the status bar and the
-// list itself just filter each out locally). Concurrent callers coalesce onto
-// the one in-flight request.
+// superset the Workspace/Automation panes and archive disclosures need (the
+// status bar and each pane project their own subset). Concurrent callers
+// coalesce onto the one in-flight request.
 async function refresh(): Promise<void> {
   if (inflight) return inflight;
   inflight = (async () => {
     try {
-      sessions.value = await listSessions({ archived: true, automation: true });
+      const [nextSessions, nextRuns] = await Promise.all([
+        listSessions({ archived: true, automation: true }),
+        listRuns(),
+      ]);
+      sessions.value = nextSessions;
+      runs.value = nextRuns;
       online.value = true;
     } catch {
       // Keep the last good snapshot; the status bar's offline dot says why.
@@ -63,5 +69,5 @@ function stopFleetPoll(): void {
 }
 
 export function useFleet() {
-  return { sessions, online, refresh, sessionById, startFleetPoll, stopFleetPoll };
+  return { sessions, runs, online, refresh, sessionById, startFleetPoll, stopFleetPoll };
 }

--- a/crates/loom/frontend/src/lib/time.ts
+++ b/crates/loom/frontend/src/lib/time.ts
@@ -18,3 +18,10 @@ export function timeAgo(iso: string | null | undefined, now: number = Date.now()
   if (wks < 5) return `${wks}w ago`;
   return `${Math.round(days / 30)}mo ago`;
 }
+
+/** Locale-formatted exact time for a relative timestamp's tooltip/a11y label.
+ *  Invalid input is preserved rather than silently disappearing. */
+export function exactTime(iso: string): string {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
+}

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -104,7 +104,8 @@ export interface Session {
   origin: string;
   /** `interactive` (a person's own session) or `automation` (agent/system
    *  launched). Automation-class sessions are excluded from the default fleet
-   *  list and issue board — the Automation toggle reveals them. */
+   *  list and issue board; the Sessions view gives them a separate Automation
+   *  pane. */
   class: string;
   /** Total agent turns run so far. */
   turn_count: number;
@@ -138,6 +139,24 @@ export interface Session {
    *  well-known claude/codex mode set — see `AcpConversation`. */
   available_modes?: string[];
   branch: Branch;
+}
+
+/** Durable automation launch reservation (`GET /api/runs`). A run normally
+ *  points at an automation-class Session, but a launch can fail before that
+ *  session becomes usable; the Automation pane keeps those failures visible. */
+export interface AutomationRun {
+  id: string;
+  actor_subject: string;
+  source: string;
+  service_tag: string;
+  profile: string;
+  idempotency_key: string;
+  session_id: string;
+  status: string;
+  outcome: string | null;
+  summary: string;
+  created_at: string;
+  updated_at: string;
 }
 
 // ── ACP conversation surface ────────────────────────────────────────────────

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -11,7 +11,14 @@ import NewSessionDrawer from '../components/NewSessionDrawer.vue';
 import SessionRowActions from '../components/SessionRowActions.vue';
 import SessionRemedyButton from '../components/SessionRemedyButton.vue';
 import AgentUsage from '../components/AgentUsage.vue';
+import AutomationSessions from '../components/AutomationSessions.vue';
 import { timeAgo } from '../lib/time';
+import {
+  isAutomationHistory,
+  needsAutomationIntervention,
+  runNeedsIntervention,
+  unmatchedAutomationRuns,
+} from '../lib/automationSessions';
 import {
   effectiveAttention,
   idleTag,
@@ -35,7 +42,7 @@ defineOptions({ name: 'SessionList' });
 // view paints from cache the instant it mounts (and, kept alive, stays painted
 // across navigation — no refetch flash, no re-animate). `refresh()` forces an
 // immediate re-pull after a write (create / clear tag).
-const { sessions, refresh } = useFleet();
+const { sessions, runs, refresh } = useFleet();
 
 // Attention filter — the dashboard's "which sessions need me?" control. The
 // URL query is the source of truth (`/?filter=attention`, the status bar's
@@ -61,29 +68,63 @@ function setFilter(f: AttentionFilter) {
   router.replace({ query: { ...route.query, filter: f === 'all' ? undefined : f } });
 }
 
+// The Sessions route has two URL-backed surfaces. Workspace is the default and
+// remains the human workbench; Automation is a purpose-built operational view.
+// Kept-alive route changes (including back/forward) flow through this computed
+// value without remounting the list.
+type SessionPane = 'workspace' | 'automation';
+const pane = computed<SessionPane>(() =>
+  route.query.view === 'automation' ? 'automation' : 'workspace',
+);
+const workspaceSessions = computed(() =>
+  sessions.value.filter((session) => session.class !== 'automation'),
+);
+const automationSessions = computed(() =>
+  sessions.value.filter((session) => session.class === 'automation'),
+);
+const unmatchedRuns = computed(() => unmatchedAutomationRuns(runs.value, automationSessions.value));
+const liveAutomationCount = computed(
+  () =>
+    automationSessions.value.filter((session) => !isAutomationHistory(session)).length +
+    unmatchedRuns.value.length,
+);
+const automationInterventionCount = computed(
+  () =>
+    automationSessions.value.filter(needsAutomationIntervention).length +
+    unmatchedRuns.value.filter(runNeedsIntervention).length,
+);
+const historyOpen = computed(() => pane.value === 'automation' && route.query.history === 'true');
+
+function paneQuery(next: SessionPane): Record<string, string | null | undefined> {
+  const query = { ...route.query };
+  if (next === 'automation') {
+    delete query.filter;
+    delete query.new;
+    query.view = 'automation';
+  } else {
+    delete query.view;
+    delete query.history;
+  }
+  return query as Record<string, string | null | undefined>;
+}
+
+function toggleAutomationHistory() {
+  const query = paneQuery('automation');
+  if (historyOpen.value) delete query.history;
+  else query.history = 'true';
+  router.replace({ query });
+}
+
 // Archived sessions are torn-down workstreams: kept for reference but clutter
 // the live fleet view. Hide them by default; a reveal chip brings them back.
 // They still show when there's nothing else to look at (an all-archived fleet),
 // so the list never reads as empty while archived rows exist.
 const showArchived = ref(false);
 
-// Automation-class sessions (agent/github/slack/watch/actions/ops launched —
-// see docs/loom-ui.md) are a background fleet, not the one a person is minding.
-// Hidden by default, same shape as the archived toggle below: a reveal chip
-// brings them back as ordinary cards (see the origin pill on the row).
-const showAutomation = ref(false);
-const automationCount = computed(
-  () => sessions.value.filter((s) => s.class === 'automation').length,
-);
-
-// The automation-aware base: every session when the toggle is on, else the
-// fleet minus automation-class rows. Everything downstream (archived count,
-// visible rows, filter-pill counts) reads through this so automation stays
-// fully invisible — not just hidden from the list, but from the tallies too —
-// until a person asks to see it.
-const filteredBase = computed<Session[]>(() =>
-  showAutomation.value ? sessions.value : sessions.value.filter((s) => s.class !== 'automation'),
-);
+// Every existing Workspace calculation reads this interactive-only base.
+// Automation has its own component and cannot leak into workspace counts,
+// threading, manual ordering, or the Parked shelf.
+const filteredBase = computed<Session[]>(() => workspaceSessions.value);
 
 const archivedCount = computed(
   () => filteredBase.value.filter((s) => s.status === 'archived').length,
@@ -368,7 +409,7 @@ const tokenConfigWarning = computed(() => error.value.startsWith(MISSING_GITHUB_
 // The New Session drawer is reflected in the URL (`/?new`), like the attention
 // filter above — so it's deep-linkable, the back button closes it, and the tab
 // title (composed in App.vue) can read "Weaver - New Session" while it's open.
-const showForm = computed(() => route.query.new !== undefined);
+const showForm = computed(() => pane.value === 'workspace' && route.query.new !== undefined);
 function openForm() {
   router.replace({ query: { ...route.query, new: null } });
 }
@@ -410,11 +451,66 @@ async function handleCreated() {
     <div class="mb-3 flex min-h-7 flex-wrap items-center gap-2.5">
       <h1 class="text-2xs font-semibold uppercase tracking-wider text-muted">Sessions</h1>
 
+      <nav
+        aria-label="Session surface"
+        class="inline-flex overflow-hidden rounded border border-line text-xs"
+        data-testid="session-panes"
+      >
+        <router-link
+          :to="{ path: '/', query: paneQuery('workspace') }"
+          data-testid="workspace-pane-link"
+          :aria-current="pane === 'workspace' ? 'page' : undefined"
+          :class="[
+            'flex items-center gap-1.5 px-2.5 py-1 font-medium transition-colors',
+            pane === 'workspace'
+              ? 'bg-accent text-accent-fg'
+              : 'bg-input text-muted hover:bg-subtle hover:text-fg',
+          ]"
+        >
+          Workspace
+          <span
+            class="rounded-full px-1.5 text-2xs leading-4"
+            :class="pane === 'workspace' ? 'bg-accent-fg/20' : 'bg-subtle text-faint'"
+            :aria-label="`${workspaceSessions.length} workspace sessions`"
+          >
+            {{ workspaceSessions.length }}
+          </span>
+        </router-link>
+        <router-link
+          :to="{ path: '/', query: paneQuery('automation') }"
+          data-testid="automation-pane-link"
+          :aria-current="pane === 'automation' ? 'page' : undefined"
+          :class="[
+            'flex items-center gap-1.5 border-l border-line px-2.5 py-1 font-medium transition-colors',
+            pane === 'automation'
+              ? 'bg-accent text-accent-fg'
+              : 'bg-input text-muted hover:bg-subtle hover:text-fg',
+          ]"
+        >
+          Automation
+          <span
+            class="rounded-full px-1.5 text-2xs leading-4"
+            :class="pane === 'automation' ? 'bg-accent-fg/20' : 'bg-subtle text-faint'"
+            :aria-label="`${liveAutomationCount} live automation runs`"
+          >
+            {{ liveAutomationCount }}
+          </span>
+          <span
+            v-if="automationInterventionCount"
+            class="rounded bg-block-soft px-1.5 text-2xs text-block ring-1 ring-inset ring-block-line/30"
+            data-testid="automation-intervention-badge"
+            :aria-label="`${automationInterventionCount} automation runs need intervention`"
+          >
+            {{ automationInterventionCount }} need intervention
+          </span>
+        </router-link>
+      </nav>
+
       <!-- Attention filter: jump straight to the sessions that need a human.
            Each segment pairs a label with its count in a small pill so the
            number reads as a count, not a suffix glued to the word. -->
       <div
-        v-if="filteredBase.length"
+        v-if="pane === 'workspace' && filteredBase.length"
         class="inline-flex overflow-hidden rounded border border-line text-xs"
       >
         <button
@@ -443,7 +539,7 @@ async function handleCreated() {
 
       <!-- Archived live below the fold: a quiet chip reveals/hides them. -->
       <button
-        v-if="archivedCount"
+        v-if="pane === 'workspace' && archivedCount"
         type="button"
         :aria-pressed="showArchived"
         :class="[
@@ -455,26 +551,11 @@ async function handleCreated() {
         {{ showArchived ? 'Hide' : 'Show' }} {{ archivedCount }} archived
       </button>
 
-      <!-- Automation-class sessions live below the fold too: same anatomy as
-           the archived chip, right alongside it. -->
-      <button
-        v-if="automationCount"
-        type="button"
-        :aria-pressed="showAutomation"
-        data-testid="automation-toggle"
-        :class="[
-          'rounded border border-line px-2.5 py-1 text-xs text-muted transition-colors',
-          showAutomation ? 'bg-subtle text-fg' : 'bg-input hover:bg-subtle',
-        ]"
-        @click="showAutomation = !showAutomation"
-      >
-        {{ showAutomation ? 'Hide' : 'Show' }} {{ automationCount }} automation
-      </button>
-
       <!-- Toggles the create form. Closed → primary (accent) call-to-action;
            open → a neutral "Cancel" so it never reads as a second primary
            action competing with the form's own Create button. -->
       <button
+        v-if="pane === 'workspace'"
         :class="[
           'ml-auto px-2.5 py-1 text-xs font-medium',
           showForm ? 'btn-secondary' : 'btn-primary',
@@ -507,7 +588,7 @@ async function handleCreated() {
     </div>
 
     <div
-      v-if="!filteredBase.length"
+      v-if="pane === 'workspace' && !filteredBase.length"
       class="rounded-md border border-dashed border-line p-6 text-center"
     >
       <p class="text-sm text-muted">No sessions yet.</p>
@@ -534,14 +615,14 @@ async function handleCreated() {
     <!-- Every session is resting — the live list is empty but the fleet isn't.
          Point at the shelf below rather than reading as "no sessions". -->
     <p
-      v-if="filteredBase.length && !liveRows.length"
+      v-if="pane === 'workspace' && filteredBase.length && !liveRows.length"
       class="rounded-md border border-dashed border-line px-4 py-3 text-center font-serif text-[13px] italic text-muted"
     >
       All sessions are resting on the shelf below.
     </p>
 
     <ul
-      v-if="liveRows.length"
+      v-if="pane === 'workspace' && liveRows.length"
       data-testid="session-list"
       class="fade-in rounded-md border border-line bg-surface"
       @dragover.prevent
@@ -740,7 +821,7 @@ async function handleCreated() {
          verb (and dragging a row back out) returns it. Shown while empty only
          mid-drag, so there's always somewhere to drop. -->
     <section
-      v-if="shelfCount || draggingId"
+      v-if="pane === 'workspace' && (shelfCount || draggingId)"
       data-testid="parked-shelf"
       class="mt-3 rounded-md transition-shadow"
       :class="overShelf && draggingId ? 'shadow-[inset_0_0_0_1px_var(--accent)]' : ''"
@@ -861,6 +942,17 @@ async function handleCreated() {
         </li>
       </ul>
     </section>
+
+    <AutomationSessions
+      v-if="pane === 'automation'"
+      :sessions="automationSessions"
+      :fleet="sessions"
+      :runs="runs"
+      :history-open="historyOpen"
+      :clearing-tag="clearingTag"
+      @toggle-history="toggleAutomationHistory"
+      @clear-tag="clearTag"
+    />
   </div>
 </template>
 

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -121,7 +121,29 @@ not VS Code:
   radius 4px on controls and 6px on panels. The 4/8/12/16 spacing grid.
 - **Numbers**: `tabular-nums` globally.
 
-## Fleet list: order & the resting shelf
+## Session surfaces
+
+Sessions has two URL-backed surfaces because a person's work and an automation
+execution have different operating rhythms:
+
+- **Workspace** is the default human workbench. It contains interactive-class
+  sessions only and keeps the attention filters, parent/child threads, manual
+  order, Parked shelf, and New session action.
+- **Automation** is an exceptions-first operational view. It contains
+  automation-class sessions only, puts blocked/error/orphaned/attention work
+  ahead of calm active work, and collapses done/archived history. Durable
+  `/api/runs` reservations without a matching session keep provisioning and
+  launch failures visible. Rows show origin, profile revision, turns, exact
+  activity time, and parent provenance without inheriting the Workspace's
+  manual order or parking controls.
+
+The Workspace / Automation links preserve the surface in the URL
+(`?view=automation`; `history=true` expands automation history). The Automation
+link carries a distinct intervention count even while Workspace is selected;
+archived history never inflates that live signal. The status bar remains the
+human fleet vital and excludes automation.
+
+## Workspace: order & the resting shelf
 
 The fleet list is where a long day's fatigue accumulates, so two controls keep it
 from becoming a wall of stale rows:

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -277,6 +277,20 @@ async function deleteAllSessions(baseUrl: string) {
   }
 }
 
+/** Automation launch reservations are durable and intentionally have no
+ *  product delete endpoint. Test workers own a private sqlite database, so
+ *  clear that audit table directly between tests to keep run-only failures
+ *  from leaking into later count assertions. */
+function deleteAllAutomationRuns(dbPath: string) {
+  try {
+    execFileSync("sqlite3", [dbPath, "DELETE FROM automation_runs;"], {
+      stdio: "pipe",
+    });
+  } catch {
+    /* best effort during startup/teardown */
+  }
+}
+
 /** Delete every watch on a server, best-effort — watches aren't tied
  *  to a session, so the per-test wipe clears them explicitly. */
 async function deleteAllWatches(baseUrl: string) {
@@ -658,11 +672,13 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
     // crashed prior test left) so every test starts from a deterministic empty
     // panel regardless of ordering.
     await deleteAllWatches(baseUrl);
+    deleteAllAutomationRuns(childEnv.WEAVER_DB!);
 
     await use(fixture);
 
     // Reset for the next test in this worker.
     await deleteAllSessions(baseUrl);
+    deleteAllAutomationRuns(childEnv.WEAVER_DB!);
     await deleteAllWatches(baseUrl);
     await deleteAllIssues(baseUrl);
   },

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -282,13 +282,9 @@ async function deleteAllSessions(baseUrl: string) {
  *  clear that audit table directly between tests to keep run-only failures
  *  from leaking into later count assertions. */
 function deleteAllAutomationRuns(dbPath: string) {
-  try {
-    execFileSync("sqlite3", [dbPath, "DELETE FROM automation_runs;"], {
-      stdio: "pipe",
-    });
-  } catch {
-    /* best effort during startup/teardown */
-  }
+  execFileSync("sqlite3", [dbPath, "DELETE FROM automation_runs;"], {
+    stdio: "pipe",
+  });
 }
 
 /** Delete every watch on a server, best-effort — watches aren't tied

--- a/e2e/tests/automation.spec.ts
+++ b/e2e/tests/automation.spec.ts
@@ -1,21 +1,5 @@
 import { test, expect } from "../fixtures/weaver";
 
-// Phase 1: automation session visibility. Sessions launched by a background
-// surface (a webhook, a watch, `/marinbot`, …) are stamped `class:
-// 'automation'` at create time and hidden from the fleet list by default — the
-// list is a person's workbench, not a log of every agent turn the server ever
-// ran. The Automation toggle (alongside the archived one) reveals them as
-// ordinary cards, with a quiet origin pill naming the surface that launched
-// them. See docs/loom-ui.md and crates/loom/frontend/src/views/SessionList.vue.
-//
-// `origin` is server-stamped and cannot be supplied by an API caller: a plain
-// create lands as `user`, and one carrying `parent_branch` as `agent` — the
-// only non-`user` origin reachable from a test, so that is what the pill
-// coverage uses.
-
-/** Create a session directly via the API with an explicit `class` —
- *  `weaver.seedSession` always creates an ordinary interactive session, so an
- *  automation-class row is seeded with a raw POST mirroring its request body. */
 async function seedAutomationSession(
   baseUrl: string,
   repoPath: string,
@@ -42,62 +26,18 @@ async function seedAutomationSession(
   return res.json();
 }
 
-test.describe("automation session visibility", () => {
-  test("an automation-class session is hidden from the default session list", async ({
-    page,
-    weaver,
-  }) => {
-    await seedAutomationSession(weaver.baseUrl, weaver.repoPath, {
-      name: "watch-triggered",
-      goal: "Triggered by a watch round",
-    });
-
-    await page.goto(weaver.baseUrl);
-
-    // Hidden by default — the fleet reads as empty, not "1 session".
-    await expect(page.getByText("No sessions yet.")).toBeVisible();
-    await expect(page.getByTestId("session-card")).toHaveCount(0);
+async function setLifecycle(baseUrl: string, id: string, status: string) {
+  const res = await fetch(`${baseUrl}/api/sessions/${id}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ status }),
   });
+  if (!res.ok)
+    throw new Error(`set lifecycle failed: ${res.status} ${await res.text()}`);
+}
 
-  test("the Automation toggle reveals an automation-class session", async ({
-    page,
-    weaver,
-  }) => {
-    const parent = await weaver.seedSession({
-      goal: "Parent work",
-      name: "parent-task",
-    });
-    // A sub-session launch (`parent_branch`) is stamped `origin: 'agent'` —
-    // the pill under test.
-    const automation = await seedAutomationSession(
-      weaver.baseUrl,
-      weaver.repoPath,
-      {
-        name: "delegated-run",
-        goal: "Delegated by the parent session",
-        parentBranch: parent.branch.id,
-      },
-    );
-
-    await page.goto(weaver.baseUrl);
-    await expect(page.getByTestId("session-card")).toHaveCount(1);
-
-    const toggle = page.getByTestId("automation-toggle");
-    await expect(toggle).toContainText("Show 1 automation");
-    await toggle.click();
-
-    const card = page.locator(`[data-session-id="${automation.id}"]`);
-    await expect(card).toBeVisible();
-    await expect(card).toContainText("delegated-run");
-    // A non-`user` origin renders as a quiet identity pill on the card.
-    await expect(card.getByTestId("origin-pill")).toHaveText("agent");
-
-    await expect(toggle).toContainText("Hide 1 automation");
-    await toggle.click();
-    await expect(page.getByTestId("session-card")).toHaveCount(1);
-  });
-
-  test("an ordinary session still appears by default alongside a hidden automation one", async ({
+test.describe("automation session surface", () => {
+  test("Workspace is the default and Automation is an isolated, linkable pane", async ({
     page,
     weaver,
   }) => {
@@ -105,21 +45,247 @@ test.describe("automation session visibility", () => {
       goal: "Regular work",
       name: "ordinary-task",
     });
-    await seedAutomationSession(weaver.baseUrl, weaver.repoPath, {
-      name: "ops-triggered",
-      goal: "Launched by an ops script",
-    });
+    const automation = await seedAutomationSession(
+      weaver.baseUrl,
+      weaver.repoPath,
+      {
+        name: "comment-rewrite",
+        goal: "Rewrite a GitHub comment",
+        parentBranch: ordinary.branch.id,
+      },
+    );
 
     await page.goto(weaver.baseUrl);
 
+    await expect(page.getByTestId("workspace-pane-link")).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
     await expect(page.getByTestId("session-card")).toHaveCount(1);
-    const card = page.locator(`[data-session-id="${ordinary.id}"]`);
-    await expect(card).toBeVisible();
-    await expect(card).toContainText("ordinary-task");
-    // A `user`-origin session (the default) carries no origin pill.
-    await expect(card.getByTestId("origin-pill")).toHaveCount(0);
+    await expect(
+      page.locator(`[data-session-id="${ordinary.id}"]`),
+    ).toBeVisible();
+    await expect(
+      page.locator(`[data-session-id="${automation.id}"]`),
+    ).toHaveCount(0);
 
-    await page.getByTestId("automation-toggle").click();
-    await expect(page.getByTestId("session-card")).toHaveCount(2);
+    const automationLink = page.getByTestId("automation-pane-link");
+    await expect(automationLink).toHaveAttribute("href", /view=automation/);
+    await automationLink.click();
+
+    await expect(page).toHaveURL(/view=automation/);
+    await expect(automationLink).toHaveAttribute("aria-current", "page");
+    await expect(page.getByTestId("session-card")).toHaveCount(0);
+    const row = page.locator(`[data-session-id="${automation.id}"]`);
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("comment-rewrite");
+    await expect(row).toContainText("agent");
+    await expect(row).toContainText("launched by ordinary-task");
+    await expect(page.getByRole("button", { name: "New session" })).toHaveCount(
+      0,
+    );
+
+    await page.goBack();
+    await expect(page.getByTestId("workspace-pane-link")).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    await expect(
+      page.locator(`[data-session-id="${ordinary.id}"]`),
+    ).toBeVisible();
+    await page.goForward();
+    await expect(page.getByTestId("automation-pane")).toBeVisible();
+
+    await row.click();
+    await expect(page).toHaveURL(new RegExp(`/s/${automation.id}$`));
+    await page.getByRole("link", { name: "← automation" }).click();
+    await expect(page).toHaveURL(/view=automation/);
+  });
+
+  test("direct Automation loads ignore Workspace-only query controls", async ({
+    page,
+    weaver,
+  }) => {
+    await seedAutomationSession(weaver.baseUrl, weaver.repoPath, {
+      name: "direct-run",
+      goal: "Open the operations pane directly",
+    });
+
+    await page.goto(`${weaver.baseUrl}/?view=automation&new&filter=attention`);
+
+    await expect(page.getByTestId("automation-pane")).toBeVisible();
+    await expect(page.getByTestId("filter-attention")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "New session" })).toHaveCount(
+      0,
+    );
+    await expect(page.getByText("Create session")).toHaveCount(0);
+    await expect(page).toHaveTitle("Weaver - Automation");
+
+    await page.goto(`${weaver.baseUrl}/?view=unknown&history=true`);
+    await expect(page.getByTestId("workspace-pane-link")).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    await expect(page.getByTestId("automation-pane")).toHaveCount(0);
+  });
+
+  test("exceptions are ordered blocked, lifecycle failures, then attention", async ({
+    page,
+    weaver,
+  }) => {
+    const blocked = await seedAutomationSession(
+      weaver.baseUrl,
+      weaver.repoPath,
+      {
+        name: "blocked-run",
+        goal: "Blocked",
+      },
+    );
+    const errored = await seedAutomationSession(
+      weaver.baseUrl,
+      weaver.repoPath,
+      {
+        name: "error-run",
+        goal: "Errored",
+      },
+    );
+    const orphaned = await seedAutomationSession(
+      weaver.baseUrl,
+      weaver.repoPath,
+      {
+        name: "orphaned-run",
+        goal: "Orphaned",
+      },
+    );
+    const attention = await seedAutomationSession(
+      weaver.baseUrl,
+      weaver.repoPath,
+      {
+        name: "attention-run",
+        goal: "Attention",
+      },
+    );
+    const calm = await seedAutomationSession(weaver.baseUrl, weaver.repoPath, {
+      name: "calm-run",
+      goal: "Calm",
+    });
+
+    await weaver.setStatus(blocked, "blocked", "policy needs a decision");
+    await setLifecycle(weaver.baseUrl, errored.id, "error");
+    await setLifecycle(weaver.baseUrl, orphaned.id, "orphaned");
+    await weaver.setStatus(attention, "attention", "review the generated text");
+
+    await page.goto(weaver.baseUrl);
+    await expect(
+      page.getByTestId("automation-intervention-badge"),
+    ).toContainText("4 need intervention");
+    await page.getByTestId("automation-pane-link").click();
+
+    const ids = await page
+      .getByTestId("automation-interventions")
+      .getByTestId("automation-session")
+      .evaluateAll((rows) =>
+        rows.map((row) => row.getAttribute("data-session-id")),
+      );
+    expect(ids[0]).toBe(blocked.id);
+    expect(new Set(ids.slice(1, 3))).toEqual(
+      new Set([errored.id, orphaned.id]),
+    );
+    expect(ids[3]).toBe(attention.id);
+
+    await expect(
+      page
+        .getByTestId("automation-active")
+        .locator(`[data-session-id="${calm.id}"]`),
+    ).toBeVisible();
+  });
+
+  test("done and archived sessions live only in URL-backed History", async ({
+    page,
+    weaver,
+  }) => {
+    const done = await seedAutomationSession(weaver.baseUrl, weaver.repoPath, {
+      name: "done-run",
+      goal: "Done",
+    });
+    const archived = await seedAutomationSession(
+      weaver.baseUrl,
+      weaver.repoPath,
+      {
+        name: "archived-run",
+        goal: "Archived",
+      },
+    );
+    await setLifecycle(weaver.baseUrl, done.id, "done");
+    await weaver.archiveSession(archived.id);
+
+    await page.goto(`${weaver.baseUrl}/?view=automation`);
+    await expect(
+      page.getByTestId("automation-active").getByTestId("automation-session"),
+    ).toHaveCount(0);
+    await expect(page.getByTestId("automation-history")).toBeHidden();
+
+    const historyToggle = page.getByTestId("automation-history-toggle");
+    await expect(historyToggle).toHaveAttribute("aria-expanded", "false");
+    await historyToggle.click();
+    await expect(page).toHaveURL(
+      /view=automation.*history=true|history=true.*view=automation/,
+    );
+    await expect(historyToggle).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByTestId("automation-history")).toBeVisible();
+    await expect(
+      page
+        .getByTestId("automation-history")
+        .locator(`[data-session-id="${done.id}"]`),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("automation-history")
+        .locator(`[data-session-id="${archived.id}"]`),
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByTestId("automation-history")).toBeVisible();
+  });
+
+  test("a failed launch with no session remains visible", async ({
+    page,
+    weaver,
+  }) => {
+    const response = await fetch(`${weaver.baseUrl}/api/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        profile: "default",
+        idempotency_key: `failed-launch-${Date.now()}`,
+        source: "ops",
+        session: {
+          cwd: "/definitely/missing/automation-repo",
+          title: "will-not-launch",
+          goal: "Exercise launch failure visibility",
+          agent: "shell",
+        },
+      }),
+    });
+    expect(response.ok).toBe(false);
+    const failure = await response.text();
+    expect(failure).toContain("must be automation-class");
+    await expect
+      .poll(async () => {
+        const runs = await fetch(`${weaver.baseUrl}/api/runs`);
+        return (await runs.json()) as Array<{ status: string }>;
+      })
+      .toEqual([expect.objectContaining({ status: "failed" })]);
+
+    await page.goto(weaver.baseUrl);
+    await expect(
+      page.getByTestId("automation-intervention-badge"),
+    ).toContainText("1 need intervention");
+    await page.getByTestId("automation-pane-link").click();
+
+    const failed = page.getByTestId("automation-run-only");
+    await expect(failed).toContainText("Launch failed");
+    await expect(failed).toContainText("ops");
+    await expect(failed).toContainText("default");
   });
 });

--- a/e2e/tests/automation.spec.ts
+++ b/e2e/tests/automation.spec.ts
@@ -288,4 +288,43 @@ test.describe("automation session surface", () => {
     await expect(failed).toContainText("ops");
     await expect(failed).toContainText("default");
   });
+
+  test("an unmatched running reservation remains active", async ({
+    page,
+    weaver,
+  }) => {
+    const now = new Date().toISOString();
+    await page.route("**/api/runs", async (route) => {
+      await route.fulfill({
+        json: [
+          {
+            id: "running-reservation",
+            actor_subject: "automation:test",
+            source: "actions",
+            service_tag: "comment-rewriter",
+            profile: "default",
+            idempotency_key: "running-reservation",
+            session_id: "not-yet-visible",
+            status: "running",
+            outcome: null,
+            summary: "",
+            created_at: now,
+            updated_at: now,
+          },
+        ],
+      });
+    });
+
+    await page.goto(`${weaver.baseUrl}/?view=automation`);
+
+    await expect(page.getByTestId("automation-intervention-badge")).toHaveCount(
+      0,
+    );
+    await expect(
+      page
+        .getByTestId("automation-active")
+        .getByTestId("automation-run-only"),
+    ).toContainText("running");
+    await expect(page.getByTestId("automation-interventions")).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
Separates Sessions into a default Workspace for long-lived interactive work and an Automation pane for exceptions-first operational runs. Automation keeps blocked, failed, and attention-needing work visible; collapses finished history; and includes durable launch failures that never produced a usable session. Pane state is shareable in the URL, and automation detail navigation returns to that surface.

Design and Codex Sol review disposition: https://loom.rjp.io/s/889fywi4/artifacts/design
Session: https://loom.rjp.io/s/889fywi4