### PR TITLE
fix(loom): keep ACP controls and file drops accurate

### DIFF
--- a/crates/loom/frontend/src/components/ScratchPanel.vue
+++ b/crates/loom/frontend/src/components/ScratchPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue';
+import { ref, onMounted, onActivated, onDeactivated, onUnmounted } from 'vue';
 import { get, upload, del } from '../api';
 import type { ScratchFile } from '../types';
 
@@ -105,21 +105,36 @@ async function remove(name: string) {
   }
 }
 
-onMounted(() => {
+let listening = false;
+function activate() {
+  if (listening) return;
+  listening = true;
   refresh();
   window.addEventListener('dragenter', onDragEnter);
   window.addEventListener('dragleave', onDragLeave);
   window.addEventListener('dragover', onDragOver);
   window.addEventListener('drop', onDrop);
   window.addEventListener('loom:scratch-changed', onScratchChanged);
-});
-onUnmounted(() => {
+}
+function deactivate() {
+  if (!listening) return;
+  listening = false;
+  depth = 0;
+  dragging.value = false;
   window.removeEventListener('dragenter', onDragEnter);
   window.removeEventListener('dragleave', onDragLeave);
   window.removeEventListener('dragover', onDragOver);
   window.removeEventListener('drop', onDrop);
   window.removeEventListener('loom:scratch-changed', onScratchChanged);
-});
+}
+
+// SessionDetail is kept alive across navigation. Its component tree remains
+// mounted while hidden, so global drop ownership must follow activation rather
+// than mount lifetime or an old session will consume New Session's file drops.
+onMounted(activate);
+onActivated(activate);
+onDeactivated(deactivate);
+onUnmounted(deactivate);
 </script>
 
 <template>

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -50,7 +50,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::Serialize;
 use serde_json::{json, Value};
 use tapestry::RelayEvent;
@@ -105,6 +105,13 @@ pub struct AcpLaunch {
     /// `default`, `plan`), applied via `session/set_mode` after setup. `None`
     /// leaves the adapter's default mode.
     pub mode: Option<String>,
+    /// Resolved launch selectors that must also be reflected in the adapter's
+    /// live config controls. Some adapters pass these through to the underlying
+    /// runtime before constructing their ACP `configOptions`, so the model can
+    /// be correct while the advertised picker is still on its own default.
+    pub initial_model: Option<String>,
+    /// The matching reasoning-effort selector, when the launch pinned one.
+    pub initial_effort: Option<String>,
     /// The session's goal, sent as the first `session/prompt` (journaled as the
     /// first `user_message`). `None` waits for the first REST prompt.
     pub goal: Option<String>,
@@ -966,6 +973,93 @@ impl Task {
         }
     }
 
+    /// Bring the adapter-owned model/effort controls into line with Loom's
+    /// resolved launch selectors. Claude's adapter, for example, forwards the
+    /// `_meta` model to the SDK but independently seeds its model config option
+    /// from settings/defaults. Going through the ordinary ACP config method
+    /// gives both sides one acknowledged state before the first prompt.
+    async fn reconcile_initial_config(
+        &mut self,
+        launch: &AcpLaunch,
+        cmd_rx: &mut mpsc::Receiver<Command>,
+    ) -> Result<()> {
+        for (kind, desired) in [
+            ("model", launch.initial_model.as_deref()),
+            ("effort", launch.initial_effort.as_deref()),
+        ] {
+            let Some(desired) = desired.map(str::trim).filter(|value| !value.is_empty()) else {
+                continue;
+            };
+            let option = {
+                let metadata = self.metadata.lock().unwrap();
+                metadata.config_options.iter().find_map(|option| {
+                    let id = option.get("id").and_then(Value::as_str)?;
+                    let category = option.get("category").and_then(Value::as_str);
+                    let matches = match kind {
+                        "model" => category == Some("model") || id == "model",
+                        "effort" => {
+                            category == Some("thought_level")
+                                || id == "effort"
+                                || id.contains("reasoning")
+                        }
+                        _ => false,
+                    };
+                    matches.then(|| {
+                        (
+                            id.to_string(),
+                            option
+                                .get("currentValue")
+                                .and_then(Value::as_str)
+                                .map(str::to_string),
+                        )
+                    })
+                })
+            };
+            let Some((config_id, current)) = option else {
+                // Older/custom adapters may not expose this selector. The
+                // launch channel still owns the runtime value in that case.
+                continue;
+            };
+            if current.as_deref() == Some(desired) {
+                continue;
+            }
+
+            let id = self.next_id();
+            self.stream
+                .write(&wire::request_line(
+                    id,
+                    method::SESSION_SET_CONFIG_OPTION,
+                    wire::set_config_option_params(
+                        &self.acp_session_id,
+                        &config_id,
+                        Value::String(desired.to_string()),
+                    ),
+                ))
+                .await?;
+            let (result, error) = self
+                .recv_until_response(
+                    id,
+                    method::SESSION_SET_CONFIG_OPTION,
+                    launch.setup_timeout,
+                    cmd_rx,
+                )
+                .await?;
+            let result = result.ok_or_else(|| {
+                anyhow!(
+                    "session/set_config_option failed while applying launch {kind} '{desired}': {error:?}"
+                )
+            })?;
+            let updated: wire::SetConfigOptionResult =
+                serde_json::from_value(result).with_context(|| {
+                    format!(
+                        "session/set_config_option returned invalid launch {kind} state for '{desired}'"
+                    )
+                })?;
+            self.replace_config_options(updated.config_options, false);
+        }
+        Ok(())
+    }
+
     // -- handshake ----------------------------------------------------------
 
     async fn handshake(
@@ -1066,6 +1160,8 @@ impl Task {
             }
         }
         session::set_acp(&self.db, &self.session_id, &self.acp_session_id).await?;
+
+        self.reconcile_initial_config(launch, cmd_rx).await?;
 
         if let Some(mode) = &launch.mode {
             let id = self.next_id();

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -914,6 +914,7 @@ pub async fn build_acp_launch(
     spec: &AcpLaunchSpec<'_>,
     open: AcpOpen,
 ) -> Result<AcpLaunch> {
+    let is_fresh = matches!(open, AcpOpen::Fresh);
     let is_codex = spec.custom.is_none() && spec.runtime == "codex";
     let is_claude = spec.custom.is_none() && !is_codex;
     let adapter_cmd = match spec.custom {
@@ -1009,6 +1010,12 @@ pub async fn build_acp_launch(
         // post-setup `session/set_mode` would re-send a claude-flavored id it
         // does not advertise.
         mode: (!is_codex).then(|| spec.mode.to_string()),
+        // Loading must preserve adapter-restored live choices: the user may
+        // have changed either selector after launch.
+        initial_model: (is_fresh && !spec.model.trim().is_empty())
+            .then(|| spec.model.trim().to_string()),
+        initial_effort: (is_fresh && !spec.effort.trim().is_empty())
+            .then(|| spec.effort.trim().to_string()),
         goal,
         setup_timeout: std::time::Duration::from_secs(30),
     })

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -98,6 +98,8 @@ async fn start_new_with_env(
         env_clear: false,
         new_or_load: NewOrLoad::New { cwd, meta: None },
         mode: mode.map(str::to_string),
+        initial_model: None,
+        initial_effort: None,
         goal: goal.map(str::to_string),
         setup_timeout: Duration::from_secs(5),
     };
@@ -124,6 +126,8 @@ async fn silent_setup_stage_times_out_and_cleans_provider_state() {
         env_clear: false,
         new_or_load: NewOrLoad::New { cwd, meta: None },
         mode: None,
+        initial_model: None,
+        initial_effort: None,
         goal: Some("say:never starts".to_string()),
         setup_timeout: Duration::from_millis(150),
     };
@@ -340,6 +344,78 @@ async fn composer_metadata_and_config_options_round_trip() {
         .await
         .expect("boolean config changes");
     assert_eq!(changed["value"], true);
+}
+
+/// Launch selectors can already be active in the underlying runtime while an
+/// adapter's initial configOptions still reflect its own defaults. The
+/// handshake reconciles both selectors through ACP before exposing metadata.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn launch_model_and_effort_replace_adapter_config_defaults() {
+    let ts = TestServer::start().await;
+    make_session(&ts, "acp-launch-config").await;
+    let cwd = ts.repo_path().to_path_buf();
+    let launch = AcpLaunch {
+        adapter_cmd: agent_cmd(),
+        cwd: cwd.clone(),
+        env: vec![],
+        env_clear: false,
+        new_or_load: NewOrLoad::New { cwd, meta: None },
+        mode: None,
+        initial_model: Some("fake-deep".to_string()),
+        initial_effort: Some("high".to_string()),
+        goal: None,
+        setup_timeout: Duration::from_secs(5),
+    };
+    acp::start(&ts.state, "acp-launch-config", launch)
+        .await
+        .expect("acp session starts");
+
+    let metadata = poll_metadata(&ts, "acp-launch-config", Duration::from_secs(5)).await;
+    let options = metadata["config_options"].as_array().unwrap();
+    assert!(options
+        .iter()
+        .any(|option| option["id"] == "model" && option["currentValue"] == "fake-deep"));
+    assert!(options.iter().any(|option| {
+        option["category"] == "thought_level" && option["currentValue"] == "high"
+    }));
+}
+
+/// A loaded ACP conversation owns its restored live selectors. Launch-time
+/// defaults must not overwrite model or effort choices made before restart.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_preserves_adapter_restored_model_and_effort() {
+    let ts = TestServer::start().await;
+    make_session(&ts, "acp-load-config").await;
+    let cwd = ts.repo_path().to_path_buf();
+    let launch = AcpLaunch {
+        adapter_cmd: agent_cmd(),
+        cwd: cwd.clone(),
+        env: vec![],
+        env_clear: false,
+        new_or_load: NewOrLoad::Load {
+            acp_session_id: "fake-loaded".to_string(),
+            meta: None,
+        },
+        mode: None,
+        initial_model: None,
+        initial_effort: None,
+        goal: None,
+        setup_timeout: Duration::from_secs(5),
+    };
+    acp::start(&ts.state, "acp-load-config", launch)
+        .await
+        .expect("acp session loads");
+
+    let metadata = poll_metadata(&ts, "acp-load-config", Duration::from_secs(5)).await;
+    let options = metadata["config_options"].as_array().unwrap();
+    assert!(options
+        .iter()
+        .any(|option| option["id"] == "model" && option["currentValue"] == "fake-fast"));
+    assert!(options.iter().any(|option| {
+        option["category"] == "thought_level" && option["currentValue"] == "medium"
+    }));
 }
 
 /// 1. New session end to end: prompt → journal has user_message + agent_message +
@@ -2501,6 +2577,8 @@ async fn codex_acp_launch_maps_the_adapter_contract() {
     let cfg: Value = serde_json::from_str(&env_of(&launch, "CODEX_CONFIG")[0]).unwrap();
     assert_eq!(cfg["model"], "gpt-5.3-codex");
     assert_eq!(cfg["model_reasoning_effort"], "high");
+    assert_eq!(launch.initial_model.as_deref(), Some("gpt-5.3-codex"));
+    assert_eq!(launch.initial_effort.as_deref(), Some("high"));
     assert!(
         launch.mode.is_none(),
         "the mode boots via INITIAL_AGENT_MODE, not a claude-id set_mode"
@@ -2525,6 +2603,16 @@ async fn codex_acp_launch_maps_the_adapter_contract() {
     .unwrap();
     assert_eq!(env_of(&launch, "CODEX_CONFIG"), vec![r#"{"model":"mine"}"#]);
     assert_eq!(launch.goal.as_deref(), Some("orient first"));
+
+    let loaded = loom::agent::build_acp_launch(
+        &ts.state.db,
+        &spec(None, &[]),
+        loom::agent::AcpOpen::Load("existing-acp-session".to_string()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(loaded.initial_model, None);
+    assert_eq!(loaded.initial_effort, None);
 }
 
 /// K. Phase 7, adopt-after-the-flip: an orphaned *terminal* session whose

--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -81,6 +81,31 @@ test.describe('creating a session via the UI form', () => {
     expect(files.map((f) => f.name).sort()).toEqual(['shot.png', 'trace.log']);
   });
 
+  test('a cached session does not consume new-session file drops', async ({ page, weaver }) => {
+    const existing = await weaver.seedSession({ goal: 'Keep this session warm', name: 'warm' });
+    await page.goto(`${weaver.baseUrl}/s/${existing.id}`);
+    await expect(page.getByTestId('scratch-panel')).toBeVisible();
+
+    // SessionDetail is kept alive after returning to the fleet. Its whole-window
+    // scratch drop target must deactivate so the new-session picker owns this
+    // image instead of uploading it into the hidden old session.
+    await page.locator('[data-rail="sessions"]').click();
+    await page.getByRole('button', { name: 'New session' }).click();
+    const dropzone = page.getByTestId('scratch-picker-dropzone');
+    const dataTransfer = await page.evaluateHandle(() => {
+      const dt = new DataTransfer();
+      dt.items.add(new File(['image'], 'new-session.png', { type: 'image/png' }));
+      return dt;
+    });
+    await dropzone.dispatchEvent('dragenter', { dataTransfer });
+    await expect(page.getByTestId('scratch-dropzone')).toHaveCount(0);
+    await dropzone.dispatchEvent('drop', { dataTransfer });
+    await expect(page.getByTestId('scratch-picker-file')).toContainText('new-session.png');
+
+    const oldScratch = await fetch(`${weaver.baseUrl}/api/sessions/${existing.id}/scratch`);
+    expect((await oldScratch.json()) as { name: string }[]).toEqual([]);
+  });
+
   test('an agent startup failure opens its recoverable session', async ({ page, weaver }) => {
     const failed = await weaver.seedSession({ goal: 'Recover me', name: 'failed-create' });
     await page.route('**/api/sessions', async (route) => {


### PR DESCRIPTION
Reconcile fresh ACP session model and effort controls with Loom's resolved launch selectors before the first prompt, so the UI cannot advertise an adapter default such as Fable while the runtime is pinned to Opus. Loaded sessions keep their restored live choices.

Deactivate keep-alive session scratch listeners while their detail page is hidden, allowing New Session to retain dropped images instead of a cached prior session consuming them. Adds ACP and Playwright regression coverage.