### PR TITLE
fix(loom): colocate session shells with agents

### DIFF
--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -77,6 +77,44 @@ pub async fn new_session(
     env_clear: bool,
     memory_max_gb: u64,
 ) -> Result<()> {
+    new_session_with_placement(name, cwd, script, env, env_clear, memory_max_gb, None).await
+}
+
+/// Create a detached PTY session in the same runner placement as `owner`.
+///
+/// With the Docker runner this starts another Tapestry supervisor inside the
+/// owner's existing container. With the local runner both supervisors already
+/// share the same host, so placement is unchanged.
+pub async fn new_session_colocated(
+    name: &str,
+    cwd: &std::path::Path,
+    script: &str,
+    env: &[(&str, &str)],
+    env_clear: bool,
+    memory_max_gb: u64,
+    owner: &str,
+) -> Result<()> {
+    new_session_with_placement(
+        name,
+        cwd,
+        script,
+        env,
+        env_clear,
+        memory_max_gb,
+        Some(owner),
+    )
+    .await
+}
+
+async fn new_session_with_placement(
+    name: &str,
+    cwd: &std::path::Path,
+    script: &str,
+    env: &[(&str, &str)],
+    env_clear: bool,
+    memory_max_gb: u64,
+    owner: Option<&str>,
+) -> Result<()> {
     tracing::info!(session = %name, cwd = %cwd.display(), memory_max_gb, "spawning terminal session");
     let script = match memory_max_gb {
         0 => script.to_string(),
@@ -95,7 +133,10 @@ pub async fn new_session(
         segment_max_bytes: None,
         supervisor_bin: supervisor_bin.as_deref(),
     };
-    let result = runner::spawn(&options, memory_max_gb).await;
+    let result = match owner {
+        Some(owner) => runner::spawn_colocated(&options, memory_max_gb, owner).await,
+        None => runner::spawn(&options, memory_max_gb).await,
+    };
     match &result {
         Ok(()) => tracing::info!(session = %name, "terminal session spawned"),
         Err(e) => tracing::warn!(session = %name, error = %e, "failed to spawn terminal session"),

--- a/crates/loom/src/runner.rs
+++ b/crates/loom/src/runner.rs
@@ -2,9 +2,10 @@
 //!
 //! Transport remains the shared Unix socket and relay spool under
 //! `WEAVER_TAPESTRY_DIR`. A runner only decides where the supervisor process
-//! lives. Production uses a Docker container per supervisor so replacing the
-//! Loom control-plane container does not kill live agents; local development
-//! keeps the detached-process behavior.
+//! lives. Production uses a Docker container per agent, with auxiliary
+//! supervisors such as its debug shells colocated there, so replacing the Loom
+//! control-plane container does not kill live sessions; local development keeps
+//! the detached-process behavior.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -13,7 +14,8 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use bollard::errors::Error as DockerError;
-use bollard::models::{ContainerCreateBody, HostConfig, HostConfigCgroupnsModeEnum};
+use bollard::exec::StartExecResults;
+use bollard::models::{ContainerCreateBody, ExecConfig, HostConfig, HostConfigCgroupnsModeEnum};
 use bollard::query_parameters::{
     AttachContainerOptionsBuilder, CreateContainerOptionsBuilder, ListContainersOptionsBuilder,
     LogsOptionsBuilder, RemoveContainerOptionsBuilder,
@@ -44,8 +46,14 @@ pub trait Runner: Send + Sync {
     /// Verify that the placement backend is ready to accept launches.
     async fn validate(&self) -> Result<()>;
 
-    /// Start or adopt the supervisor described by `opts`.
-    async fn start(&self, opts: &tapestry::LaunchOptions<'_>, memory_max_gb: u64) -> Result<()>;
+    /// Start or adopt the supervisor described by `opts`. When `container_of`
+    /// is set, place it alongside that existing supervisor where supported.
+    async fn start(
+        &self,
+        opts: &tapestry::LaunchOptions<'_>,
+        memory_max_gb: u64,
+        container_of: Option<&str>,
+    ) -> Result<()>;
 
     /// Remove placement resources for a supervisor whose socket is gone.
     async fn remove(&self, name: &str) -> Result<()>;
@@ -60,7 +68,12 @@ impl Runner for ProcessRunner {
         Ok(())
     }
 
-    async fn start(&self, opts: &tapestry::LaunchOptions<'_>, _memory_max_gb: u64) -> Result<()> {
+    async fn start(
+        &self,
+        opts: &tapestry::LaunchOptions<'_>,
+        _memory_max_gb: u64,
+        _container_of: Option<&str>,
+    ) -> Result<()> {
         tapestry::spawn_detached(opts).await
     }
 
@@ -79,7 +92,8 @@ struct ContainerConfig {
     api_url: String,
 }
 
-/// Runs each supervisor in its own Docker container.
+/// Runs primary supervisors in their own Docker containers and can exec
+/// auxiliary supervisors into an existing primary's container.
 pub struct ContainerRunner {
     docker: Docker,
     config: ContainerConfig,
@@ -237,6 +251,123 @@ impl ContainerRunner {
             ..Default::default()
         })
     }
+
+    fn exec_config(&self, opts: &tapestry::LaunchOptions<'_>) -> Result<ExecConfig> {
+        if !opts.cwd.starts_with(Path::new(CONTAINER_HOME)) {
+            bail!(
+                "ContainerRunner work directory {} is outside {CONTAINER_HOME}",
+                opts.cwd.display()
+            );
+        }
+        let workdir = opts
+            .cwd
+            .to_str()
+            .context("ContainerRunner work directory is not UTF-8")?;
+        Ok(ExecConfig {
+            attach_stdin: Some(true),
+            attach_stdout: Some(true),
+            attach_stderr: Some(true),
+            cmd: Some(vec![
+                "tapestry".to_string(),
+                "supervise".to_string(),
+                "-".to_string(),
+            ]),
+            working_dir: Some(workdir.to_string()),
+            ..Default::default()
+        })
+    }
+
+    async fn start_in_container(
+        &self,
+        opts: &tapestry::LaunchOptions<'_>,
+        owner: &str,
+    ) -> Result<()> {
+        if tapestry::Client::is_alive(opts.name).await {
+            return Ok(());
+        }
+        let container = container_name(owner);
+        match self.container_state(owner).await? {
+            Some(true) => {}
+            Some(false) => bail!(
+                "cannot place supervisor {} in stopped session container {container}",
+                opts.name
+            ),
+            None => bail!(
+                "cannot place supervisor {} in missing session container {container}",
+                opts.name
+            ),
+        }
+
+        let spec = tapestry::encode_launch_spec(opts, &[("WEAVER_API", &self.config.api_url)])?;
+        let exec = self
+            .docker
+            .create_exec(&container, self.exec_config(opts)?)
+            .await
+            .with_context(|| {
+                format!(
+                    "creating supervisor {} in session container {container}",
+                    opts.name
+                )
+            })?;
+        let StartExecResults::Attached {
+            mut output,
+            mut input,
+        } = self
+            .docker
+            .start_exec(&exec.id, None)
+            .await
+            .with_context(|| {
+                format!(
+                    "starting supervisor {} in session container {container}",
+                    opts.name
+                )
+            })?
+        else {
+            bail!(
+                "supervisor {} unexpectedly started detached in session container {container}",
+                opts.name
+            );
+        };
+        let output_task = tokio::spawn(async move {
+            while output.try_next().await?.is_some() {}
+            Ok::<(), DockerError>(())
+        });
+        let delivery = async {
+            input
+                .write_all(&spec)
+                .await
+                .context("sending launch spec to colocated session supervisor")?;
+            input
+                .flush()
+                .await
+                .context("flushing colocated session supervisor launch input")
+        }
+        .await;
+        if let Err(error) = delivery {
+            drop(input);
+            output_task.abort();
+            return Err(error);
+        }
+        if let Err(error) = wait_for_supervisor(opts.name).await {
+            drop(input);
+            output_task.abort();
+            return Err(error).with_context(|| {
+                format!(
+                    "colocated supervisor {} did not become ready in session container {container}",
+                    opts.name
+                )
+            });
+        }
+        drop(input);
+        output_task.abort();
+        tracing::info!(
+            session = %opts.name,
+            owner,
+            %container,
+            "ContainerRunner supervisor ready in existing container"
+        );
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -273,7 +404,15 @@ impl Runner for ContainerRunner {
         Ok(())
     }
 
-    async fn start(&self, opts: &tapestry::LaunchOptions<'_>, memory_max_gb: u64) -> Result<()> {
+    async fn start(
+        &self,
+        opts: &tapestry::LaunchOptions<'_>,
+        memory_max_gb: u64,
+        container_of: Option<&str>,
+    ) -> Result<()> {
+        if let Some(owner) = container_of {
+            return self.start_in_container(opts, owner).await;
+        }
         let container = container_name(opts.name);
         match self.container_state(opts.name).await? {
             Some(true) => {
@@ -439,7 +578,23 @@ pub async fn validate() -> Result<()> {
 
 /// Start a supervisor using the configured placement backend.
 pub async fn spawn(opts: &tapestry::LaunchOptions<'_>, memory_max_gb: u64) -> Result<()> {
-    configured_runner().await?.start(opts, memory_max_gb).await
+    configured_runner()
+        .await?
+        .start(opts, memory_max_gb, None)
+        .await
+}
+
+/// Start a supervisor in the same placement container as `owner`. Local-process
+/// placement has no container boundary, so this is equivalent to [`spawn`].
+pub async fn spawn_colocated(
+    opts: &tapestry::LaunchOptions<'_>,
+    memory_max_gb: u64,
+    owner: &str,
+) -> Result<()> {
+    configured_runner()
+        .await?
+        .start(opts, memory_max_gb, Some(owner))
+        .await
 }
 
 /// Remove placement resources after a supervisor's socket is gone.
@@ -600,6 +755,28 @@ mod tests {
             .contains(&"/var/run/docker.sock:/var/run/docker.sock".to_string()));
 
         let rendered = serde_json::to_string(&body).unwrap();
+        assert!(!rendered.contains("super-secret"));
+        assert!(!rendered.contains("API_TOKEN"));
+        assert!(!rendered.contains("agent --secret"));
+    }
+
+    #[test]
+    fn colocated_exec_uses_the_existing_container_without_launch_secrets() {
+        let env = [("API_TOKEN", "super-secret")];
+        let cwd = Path::new("/home/app/.weaver/repos/example/.worktrees/abc");
+        let config = container_runner()
+            .exec_config(&launch_options(cwd, &env))
+            .unwrap();
+
+        assert_eq!(
+            config.cmd,
+            Some(vec!["tapestry".into(), "supervise".into(), "-".into()])
+        );
+        assert_eq!(config.working_dir.as_deref(), Some(cwd.to_str().unwrap()));
+        assert_eq!(config.attach_stdin, Some(true));
+        assert_eq!(config.attach_stdout, Some(true));
+        assert_eq!(config.attach_stderr, Some(true));
+        let rendered = serde_json::to_string(&config).unwrap();
         assert!(!rendered.contains("super-secret"));
         assert!(!rendered.contains("API_TOKEN"));
         assert!(!rendered.contains("agent --secret"));

--- a/crates/loom/src/shell.rs
+++ b/crates/loom/src/shell.rs
@@ -12,8 +12,9 @@
 //!   reset with [`restart`].
 //!
 //! * Per-session **debug shells** ([`ensure_debug`]): one or more login shells
-//!   *in a session's worktree*, carrying its `WEAVER_BRANCH`, for poking at the
-//!   agent's checkout (run the tests, inspect the diff) beside the live agent.
+//!   in the session agent's runner placement (the same container with the
+//!   Docker runner), rooted in its worktree and carrying its `WEAVER_BRANCH`,
+//!   for poking at the agent's checkout beside the live agent.
 //!   They are spawned lazily on first attach and swept with the session on
 //!   archive/remove ([`kill_debug_all`]) so a worktree shell never outlives the
 //!   worktree it sits in. The UI rediscovers open ones after a reload via
@@ -155,13 +156,14 @@ pub async fn ensure_debug(
     let (script, env) = shell_script(st, Some(&branch.id)).await;
     let cwd = PathBuf::from(&session.work_dir);
     tracing::info!(session = %name, cwd = %cwd.display(), "spawning session debug shell");
-    backend::new_session(
+    backend::new_session_colocated(
         &name,
         &cwd,
         &script,
         &env_refs(&env),
         false,
         backend::memory_max_gb(&st.db).await,
+        &session.term_session,
     )
     .await?;
     Ok(name)

--- a/crates/loom/tests/docker_runner.rs
+++ b/crates/loom/tests/docker_runner.rs
@@ -3,7 +3,8 @@
 //! Build the test image with `HOST_UID=$(id -u)` and `HOST_GID=$(id -g)`, then
 //! run `cargo test -p loom --test docker_runner -- --ignored`. The regular suite
 //! stays Docker-free. This smoke covers placement, launcher death, shared socket
-//! access, and a callback over the configured sibling network.
+//! access, colocating a second supervisor, and a callback over the configured
+//! sibling network.
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -74,7 +75,7 @@ fn docker_runner_child() {
         let options = tapestry::LaunchOptions {
             name: &session,
             cwd: Path::new("/home/app/work"),
-            script: "python3 -c 'import os, urllib.request; print(urllib.request.urlopen(os.environ[\"WEAVER_API\"], timeout=5).status)'; printf 'runner-ready\\n'; sleep 60",
+            script: "python3 -c 'import os, urllib.request; print(urllib.request.urlopen(os.environ[\"WEAVER_API\"], timeout=5).status)'; printf 'runner-ready owner-host=%s\\n' \"$(cat /etc/hostname)\"; sleep 60",
             env: &[],
             env_clear: false,
             cols: 80,
@@ -153,20 +154,64 @@ fn docker_runner_supervisor_outlives_its_launcher() {
     let runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.block_on(async {
         assert!(tapestry::Client::is_alive(&session).await);
-        let mut screen = String::new();
+        let mut owner_screen = String::new();
         for _ in 0..200 {
-            screen = loom::backend::capture(&session, 0).await.unwrap();
-            if screen.contains("runner-ready") && screen.contains("200") {
+            owner_screen = loom::backend::capture(&session, 0).await.unwrap();
+            if owner_screen.contains("runner-ready") && owner_screen.contains("200") {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
+        assert!(owner_screen.contains("runner-ready"));
+        assert!(owner_screen.contains("200"));
+
+        let colocated = format!("{session}-shell");
+        let options = tapestry::LaunchOptions {
+            name: &colocated,
+            cwd: Path::new("/home/app/work"),
+            script: "printf 'shell-ready colocated-host=%s\\n' \"$(cat /etc/hostname)\"; sleep 60",
+            env: &[],
+            env_clear: false,
+            cols: 80,
+            rows: 24,
+            mode: tapestry::Mode::Pty,
+            segment_max_bytes: None,
+            supervisor_bin: None,
+        };
+        loom::runner::spawn_colocated(&options, 1, &session)
+            .await
+            .unwrap();
+
+        let mut shell_screen = String::new();
+        for _ in 0..200 {
+            shell_screen = loom::backend::capture(&colocated, 0).await.unwrap();
+            if shell_screen.contains("shell-ready") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let owner_host = owner_screen
+            .split("owner-host=")
+            .nth(1)
+            .and_then(|tail| tail.split_whitespace().next())
+            .expect("owner should print its container hostname");
+        let colocated_host = shell_screen
+            .split("colocated-host=")
+            .nth(1)
+            .and_then(|tail| tail.split_whitespace().next())
+            .expect("shell should print its container hostname");
+        assert_eq!(
+            colocated_host, owner_host,
+            "colocated supervisor should run in the owner's container"
+        );
+
+        loom::backend::kill_session_and_wait(&colocated)
+            .await
+            .unwrap();
         loom::backend::kill_session_and_wait(&session)
             .await
             .unwrap();
         assert!(!tapestry::Client::is_alive(&session).await);
-        assert!(screen.contains("runner-ready"));
-        assert!(screen.contains("200"));
     });
     drop(fixture);
 }

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -54,9 +54,11 @@ services:
     # request path), so warnings rely on the per-request span (method/path) instead.
     environment:
       RUST_BACKTRACE: "1"
-      # Place every Tapestry supervisor in its own sibling container. These
-      # containers share the durable home/tool volumes and control socket;
-      # recreating this control-plane service therefore leaves live agents up.
+      # Place every agent's primary Tapestry supervisor in its own sibling
+      # container. Auxiliary supervisors such as its debug shells are colocated
+      # there. The containers share the durable home/tool volumes and control
+      # socket; recreating this control-plane service therefore leaves live
+      # sessions up.
       LOOM_RUNNER: docker
       LOOM_SESSION_IMAGE: ${LOOM_IMAGE:-loom:latest}
       LOOM_SESSION_HOME_VOLUME: loom_loom_home


### PR DESCRIPTION
Session debug shells now request runner-level colocation with their owning agent supervisor. The Docker runner launches the auxiliary Tapestry supervisor inside the existing session container, while the local runner retains its current detached-process behavior.

This keeps terminal transport, environment delivery, liveness, reconnection, and cleanup on the normal backend path while giving operators a shell in the agent's exact runtime environment. The isolated Docker lifecycle smoke now asserts that the agent and shell report the same container hostname, and the standalone deployment comments describe the primary-plus-auxiliary placement model.