### PR TITLE
fix(loom): avoid reinjecting session goals

### DIFF
--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1127,17 +1127,11 @@ pub(crate) async fn provision_session(
     // Goal, scratch, and tracking context ride in as the positional prompt that
     // seeds the session's first turn.
     let goal_file = {
-        let supports_hooks = agent::metadata_for(&st.db, &runtime)
-            .await
-            .ok()
-            .flatten()
-            .is_some_and(|metadata| metadata.supports_hooks);
         let scratch = scratch_note(&scratch_names);
-        let entrance = entrance_note(&title, tracking_issue);
+        let entrance = entrance_note(tracking_issue);
         let launch_prompt = build_launch_prompt(
             &goal,
             &launch_profile.prelude,
-            supports_hooks,
             &entrance,
             scratch.as_deref(),
         );
@@ -1465,20 +1459,16 @@ pub(crate) async fn provision_session(
     session_view(&st.db, &session, &branch).await
 }
 
-/// The session's launch prompt: a pointer to the goal rather than a copy of
-/// it. The goal lives once, as the `goal` artifact (`weaver summary` opens
-/// with it) — pasting it here made a second copy that drifted the moment the
-/// agent revved the artifact. The pointer routes through the `weaver` CLI so
-/// it orients hookless agents (Codex, custom) too, which never receive the
-/// WEAVER.md primer. Mirrors [`scratch_note`]: it rides on the prompt only
-/// (goal.txt), never the stored goal.
-fn entrance_note(title: &str, tracking_issue: Option<i64>) -> String {
-    let mut note = format!(
-        "Your task: {title}.\n\n\
-         Run `weaver summary` first — it prints the full goal, your current \
-         status, and the open tasks. `weaver readme` prints the complete \
-         workflow guide when it is not already in your context."
-    );
+/// Session-specific operating context appended after the goal. Keep this
+/// compact: the goal is the outcome, the primer owns durable workflow rules,
+/// and this note only supplies the tracking contract that neither can know
+/// ahead of time. `weaver summary` is a recovery path, not a mandatory first
+/// tool call that would inject the goal a second time.
+fn entrance_note(tracking_issue: Option<i64>) -> String {
+    let mut note = "You are working in a Weaver session. Use `weaver summary` \
+                    to recover context if needed and `weaver readme` for the \
+                    complete workflow guide."
+        .to_string();
     if let Some(id) = tracking_issue {
         note.push_str(&format!(
             " This session is tracked as weaver issue #{id}: keep `weaver \
@@ -1491,20 +1481,13 @@ fn entrance_note(title: &str, tracking_issue: Option<i64>) -> String {
 }
 
 /// Construct the positional first prompt from the stamped prelude policy.
-/// `none` deliberately makes the caller's goal the whole orientation; the
-/// normal Weaver profile keeps the established hook-capable/hookless split.
-fn build_launch_prompt(
-    goal: &str,
-    prelude: &str,
-    supports_hooks: bool,
-    entrance: &str,
-    scratch: Option<&str>,
-) -> String {
+/// The user's goal is always the opening user message: making an agent fetch it
+/// through `weaver summary` on turn one adds latency and duplicates the goal in
+/// context. `none` deliberately omits all Weaver orientation.
+fn build_launch_prompt(goal: &str, prelude: &str, entrance: &str, scratch: Option<&str>) -> String {
     let mut parts = Vec::new();
     if !goal.is_empty() {
-        if prelude == "none" || !supports_hooks {
-            parts.push(goal);
-        }
+        parts.push(goal);
         if prelude == "weaver" {
             parts.push(entrance);
         }
@@ -3886,17 +3869,18 @@ mod tests {
     }
 
     #[test]
-    fn entrance_note_points_at_the_goal_instead_of_pasting_it() {
-        let note = entrance_note("Wire the flux capacitor", Some(42));
-        assert!(note.contains("Wire the flux capacitor"));
-        // The orientation is a pointer, not a copy: the goal is fetched.
+    fn entrance_note_keeps_catch_up_out_of_the_first_turn() {
+        let note = entrance_note(Some(42));
         assert!(note.contains("weaver summary"));
+        assert!(note.contains("recover context"));
+        assert!(!note.contains("summary` first"));
+        assert!(!note.contains("prints the full goal"));
         // It tells the agent exactly how to signal "done".
         assert!(note.contains("weaver issue #42"));
         assert!(note.contains("weaver issue close 42"));
         assert!(note.contains("weaver status"));
         // Untracked sessions get the orientation with no issue contract.
-        let untracked = entrance_note("Poke around", None);
+        let untracked = entrance_note(None);
         assert!(untracked.contains("weaver summary"));
         assert!(!untracked.contains("issue"));
     }
@@ -3904,17 +3888,11 @@ mod tests {
     #[test]
     fn restricted_prelude_delivers_the_caller_goal_without_weaver_orientation() {
         let goal = "Rewrite only the issue body.\nBody hash: abc123";
+        let entrance = "weaver session metadata";
+        assert_eq!(build_launch_prompt(goal, "none", entrance, None), goal);
         assert_eq!(
-            build_launch_prompt(goal, "none", true, "run weaver summary", None),
-            goal
-        );
-        assert_eq!(
-            build_launch_prompt(goal, "weaver", true, "run weaver summary", None),
-            "run weaver summary"
-        );
-        assert_eq!(
-            build_launch_prompt(goal, "weaver", false, "run weaver summary", None),
-            format!("{goal}\n\nrun weaver summary")
+            build_launch_prompt(goal, "weaver", entrance, None),
+            format!("{goal}\n\n{entrance}")
         );
     }
 }

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -2490,7 +2490,7 @@ async fn builtin_codex_launches_over_codex_acp() {
         .client
         .post(
             "/api/sessions",
-            json!({ "goal": "say:codex online", "cwd": ts.cwd(),
+            json!({ "title": "Codex prompt shape", "goal": "say:codex online", "cwd": ts.cwd(),
                     "agent": "codex", "protocol": "acp" }),
         )
         .await
@@ -2503,6 +2503,24 @@ async fn builtin_codex_launches_over_codex_acp() {
     })
     .await;
     let blocks = chat["blocks"].as_array().unwrap();
+    let prompt = blocks
+        .iter()
+        .find(|b| b["kind"] == "user_message")
+        .and_then(|b| b["payload"]["text"].as_str())
+        .expect("the opening user prompt");
+    assert_eq!(
+        prompt.matches("say:codex online").count(),
+        1,
+        "the opening prompt contains the goal exactly once: {prompt}"
+    );
+    assert!(
+        prompt.contains("Use `weaver summary` to recover context if needed"),
+        "summary is offered as recovery: {prompt}"
+    );
+    assert!(
+        !prompt.contains("Run `weaver summary` first"),
+        "the opening prompt must not request a tool call that reinjects the goal: {prompt}"
+    );
     let reply = blocks
         .iter()
         .find(|b| b["kind"] == "agent_message")

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -15,8 +15,9 @@ sub-sessions"). Report yourself with `weaver`; drive sessions with `loom`.
 ## The `weaver` CLI
 
 On your `PATH`; every command talks to the loom server, which is already
-running. Start with `weaver summary`, and re-run it whenever you lose the
-thread — after a context compaction weaver replays it for you automatically.
+running. Your opening user message already contains the goal. Run `weaver
+summary` whenever you need to recover the thread — after a context compaction
+weaver replays it for you automatically.
 
 - `weaver summary` — the catch-up: goal, status, artifacts, open discussion,
   outstanding tasks, and what to do next.


### PR DESCRIPTION
Make the caller's goal the opening user message for every normal Weaver launch, then keep the appended session note limited to recovery, status, and completion metadata. This prevents hookless agents from receiving the full goal and immediately running weaver summary to receive it again, while still preserving summary as the catch-up path after context loss.

Update the Weaver primer to match the launch contract and cover the actual Codex ACP opening message with an integration assertion that the goal appears exactly once. The shape follows current agent-prompt guidance: lead with the outcome, remove repeated instructions, keep durable workflow rules separate, and retrieve context only when needed.

Research: https://developers.openai.com/api/docs/guides/prompt-guidance-gpt-5p6 and https://cloud.google.com/discover/ai-context-engineering