### PR TITLE
feat(loom): route automation runs through channels

### DIFF
--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -153,6 +153,7 @@ export interface AutomationRun {
   service_tag: string;
   profile: string;
   idempotency_key: string;
+  channel: string | null;
   session_id: string;
   status: string;
   outcome: string | null;

--- a/crates/loom/migrations/0007_automation_channels.sql
+++ b/crates/loom/migrations/0007_automation_channels.sql
@@ -1,0 +1,13 @@
+ALTER TABLE automation_runs ADD COLUMN channel TEXT;
+
+CREATE TABLE automation_channels (
+    actor_subject TEXT NOT NULL,
+    source        TEXT NOT NULL,
+    service_tag   TEXT NOT NULL,
+    profile       TEXT NOT NULL REFERENCES profiles(name),
+    channel       TEXT NOT NULL,
+    owner_run_id  TEXT NOT NULL REFERENCES automation_runs(id),
+    session_id    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    PRIMARY KEY (actor_subject, source, service_tag, profile, channel)
+);

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -40,6 +40,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "mcp-access",
         include_str!("../migrations/0006_mcp_access.sql"),
     ),
+    (
+        7,
+        "automation-channels",
+        include_str!("../migrations/0007_automation_channels.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -269,7 +274,7 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6]);
+        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7]);
 
         let columns = table_columns(&db, "sessions").await.unwrap();
         for expected in [
@@ -400,7 +405,7 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6]);
+        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7]);
         let index_sql: String = sqlx::query_scalar(
             "SELECT sql FROM sqlite_master
              WHERE type = 'index' AND name = 'idx_sessions_active_branch'",
@@ -474,7 +479,7 @@ mod tests {
             .fetch_one(&db)
             .await
             .unwrap();
-        assert_eq!(count, 6);
+        assert_eq!(count, 7);
 
         // Adoption replaced the historical index predicate: archived history
         // no longer prevents a new active session from claiming the branch.

--- a/crates/loom/src/runs.rs
+++ b/crates/loom/src/runs.rs
@@ -14,6 +14,7 @@ pub struct Run {
     pub service_tag: String,
     pub profile: String,
     pub idempotency_key: String,
+    pub channel: Option<String>,
     pub request_json: String,
     pub session_id: String,
     pub status: String,
@@ -32,6 +33,7 @@ impl From<Run> for RunView {
             service_tag: run.service_tag,
             profile: run.profile,
             idempotency_key: run.idempotency_key,
+            channel: run.channel,
             session_id: run.session_id,
             status: run.status,
             outcome: run.outcome,
@@ -47,38 +49,70 @@ pub enum Reservation {
     Existing(Run),
 }
 
-pub async fn reserve(
-    db: &Db,
-    subject: &str,
-    source: &str,
-    service_tag: &str,
-    profile: &str,
-    idempotency_key: &str,
-    request_json: &str,
-) -> Result<Reservation> {
+pub struct NewRun<'a> {
+    pub subject: &'a str,
+    pub source: &'a str,
+    pub service_tag: &'a str,
+    pub profile: &'a str,
+    pub idempotency_key: &'a str,
+    pub channel: Option<&'a str>,
+    pub request_json: &'a str,
+}
+
+pub enum ChannelAction {
+    Launch(Run),
+    Prompt(Run),
+    Ready(Run),
+    Busy(Run),
+}
+
+#[derive(FromRow)]
+struct ChannelOwner {
+    owner_run_id: String,
+    session_id: String,
+    run_status: String,
+    run_updated_at: String,
+    session_status: Option<String>,
+    session_protocol: Option<String>,
+}
+
+pub fn validate_channel(channel: &str) -> Result<()> {
+    if channel.is_empty()
+        || channel.len() > 64
+        || !channel
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
+    {
+        anyhow::bail!("channel must be 1-64 ASCII letters, digits, '.', '_', ':', or '-'");
+    }
+    Ok(())
+}
+
+pub async fn reserve(db: &Db, request: NewRun<'_>) -> Result<Reservation> {
     let id = weaver_core::branch::new_id();
     let session_id = weaver_core::branch::new_id();
     let now = now_iso();
     let result = sqlx::query(
         "INSERT INTO automation_runs
-         (id, actor_subject, source, service_tag, profile, idempotency_key, request_json,
-          session_id, status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'creating', ?, ?)
+         (id, actor_subject, source, service_tag, profile, idempotency_key, channel,
+          request_json, session_id, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'creating', ?, ?)
          ON CONFLICT(actor_subject, idempotency_key) DO NOTHING",
     )
     .bind(&id)
-    .bind(subject)
-    .bind(source)
-    .bind(service_tag)
-    .bind(profile)
-    .bind(idempotency_key)
-    .bind(request_json)
+    .bind(request.subject)
+    .bind(request.source)
+    .bind(request.service_tag)
+    .bind(request.profile)
+    .bind(request.idempotency_key)
+    .bind(request.channel)
+    .bind(request.request_json)
     .bind(&session_id)
     .bind(&now)
     .bind(&now)
     .execute(db)
     .await?;
-    let run = get_by_key(db, subject, idempotency_key)
+    let run = get_by_key(db, request.subject, request.idempotency_key)
         .await?
         .expect("inserted or conflicting automation run exists");
     Ok(if result.rows_affected() == 1 {
@@ -86,6 +120,152 @@ pub async fn reserve(
     } else {
         Reservation::Existing(run)
     })
+}
+
+pub async fn route_channel(db: &Db, run_id: &str) -> Result<ChannelAction> {
+    let mut tx = weaver_core::db::begin_immediate(db).await?;
+    let mut run = sqlx::query_as::<_, Run>("SELECT * FROM automation_runs WHERE id = ?")
+        .bind(run_id)
+        .fetch_one(&mut *tx)
+        .await?;
+    let channel = run
+        .channel
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("automation run has no channel"))?;
+    validate_channel(&channel)?;
+
+    let owner = sqlx::query_as::<_, ChannelOwner>(
+        "SELECT c.owner_run_id, c.session_id, r.status AS run_status,
+                r.updated_at AS run_updated_at, s.status AS session_status,
+                s.protocol AS session_protocol
+         FROM automation_channels c
+         JOIN automation_runs r ON r.id = c.owner_run_id
+         LEFT JOIN sessions s ON s.id = c.session_id
+         WHERE c.actor_subject = ? AND c.source = ? AND c.service_tag = ?
+           AND c.profile = ? AND c.channel = ?",
+    )
+    .bind(&run.actor_subject)
+    .bind(&run.source)
+    .bind(&run.service_tag)
+    .bind(&run.profile)
+    .bind(&channel)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let action = match owner {
+        None => {
+            sqlx::query(
+                "INSERT INTO automation_channels
+                 (actor_subject, source, service_tag, profile, channel, owner_run_id,
+                  session_id, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&run.actor_subject)
+            .bind(&run.source)
+            .bind(&run.service_tag)
+            .bind(&run.profile)
+            .bind(&channel)
+            .bind(&run.id)
+            .bind(&run.session_id)
+            .bind(now_iso())
+            .execute(&mut *tx)
+            .await?;
+            ChannelAction::Launch(run)
+        }
+        Some(owner)
+            if owner.session_status.as_deref() == Some("running")
+                && owner.session_protocol.as_deref() == Some("acp") =>
+        {
+            if owner.owner_run_id == run.id {
+                sqlx::query(
+                    "UPDATE automation_runs SET status = 'running', session_id = ?, updated_at = ?
+                     WHERE id = ?",
+                )
+                .bind(&owner.session_id)
+                .bind(now_iso())
+                .bind(&run.id)
+                .execute(&mut *tx)
+                .await?;
+                run.session_id = owner.session_id;
+                run.status = "running".to_string();
+                ChannelAction::Ready(run)
+            } else {
+                sqlx::query(
+                    "UPDATE automation_runs
+                     SET status = 'delivering', session_id = ?, updated_at = ?
+                     WHERE id = ?",
+                )
+                .bind(&owner.session_id)
+                .bind(now_iso())
+                .bind(&run.id)
+                .execute(&mut *tx)
+                .await?;
+                run.session_id = owner.session_id;
+                run.status = "delivering".to_string();
+                ChannelAction::Prompt(run)
+            }
+        }
+        Some(owner)
+            if owner.owner_run_id == run.id
+                && owner.session_status.is_none()
+                && owner.run_status == "creating"
+                && owner.run_updated_at > stale_before() =>
+        {
+            ChannelAction::Busy(run)
+        }
+        Some(owner)
+            if matches!(
+                owner.session_status.as_deref(),
+                Some("created" | "orphaned")
+            ) || (owner.session_status.is_none()
+                && owner.run_status == "creating"
+                && owner.run_updated_at > stale_before()) =>
+        {
+            sqlx::query(
+                "UPDATE automation_runs SET status = 'waiting', updated_at = ? WHERE id = ?",
+            )
+            .bind(now_iso())
+            .bind(&run.id)
+            .execute(&mut *tx)
+            .await?;
+            run.status = "waiting".to_string();
+            ChannelAction::Busy(run)
+        }
+        Some(_) => {
+            let session_id = weaver_core::branch::new_id();
+            sqlx::query(
+                "UPDATE automation_channels
+                 SET owner_run_id = ?, session_id = ?, updated_at = ?
+                 WHERE actor_subject = ? AND source = ? AND service_tag = ?
+                   AND profile = ? AND channel = ?",
+            )
+            .bind(&run.id)
+            .bind(&session_id)
+            .bind(now_iso())
+            .bind(&run.actor_subject)
+            .bind(&run.source)
+            .bind(&run.service_tag)
+            .bind(&run.profile)
+            .bind(&channel)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE automation_runs
+                 SET status = 'creating', session_id = ?, updated_at = ?
+                 WHERE id = ?",
+            )
+            .bind(&session_id)
+            .bind(now_iso())
+            .bind(&run.id)
+            .execute(&mut *tx)
+            .await?;
+            run.session_id = session_id;
+            run.status = "creating".to_string();
+            ChannelAction::Launch(run)
+        }
+    };
+    tx.commit().await?;
+    Ok(action)
 }
 
 pub async fn get(db: &Db, id: &str) -> Result<Option<Run>> {
@@ -140,19 +320,40 @@ pub async fn launched(db: &Db, id: &str, session_id: &str) -> Result<()> {
 /// five-minute lease; after that, exactly one retry may resume with the same
 /// preallocated session id.
 pub async fn claim_stale(db: &Db, id: &str) -> Result<bool> {
-    let stale_before = (chrono::Utc::now() - chrono::Duration::minutes(5))
-        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
     Ok(sqlx::query(
         "UPDATE automation_runs SET updated_at = ?
          WHERE id = ? AND status = 'creating' AND updated_at <= ?",
     )
     .bind(now_iso())
     .bind(id)
-    .bind(stale_before)
+    .bind(stale_before())
     .execute(db)
     .await?
     .rows_affected()
         == 1)
+}
+
+pub async fn claim_stale_delivery(db: &Db, id: &str) -> Result<bool> {
+    Ok(sqlx::query(
+        "UPDATE automation_runs SET status = 'waiting', updated_at = ?
+         WHERE id = ? AND status = 'delivering' AND updated_at <= ?",
+    )
+    .bind(now_iso())
+    .bind(id)
+    .bind(stale_before())
+    .execute(db)
+    .await?
+    .rows_affected()
+        == 1)
+}
+
+pub async fn waiting(db: &Db, id: &str) -> Result<()> {
+    sqlx::query("UPDATE automation_runs SET status = 'waiting', updated_at = ? WHERE id = ?")
+        .bind(now_iso())
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(())
 }
 
 pub async fn failed(db: &Db, id: &str, summary: &str) -> Result<()> {
@@ -167,6 +368,11 @@ pub async fn failed(db: &Db, id: &str, summary: &str) -> Result<()> {
     Ok(())
 }
 
+fn stale_before() -> String {
+    (chrono::Utc::now() - chrono::Duration::minutes(5))
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -176,12 +382,15 @@ mod tests {
         let db = crate::db::connect_in_memory().await.unwrap();
         let first = reserve(
             &db,
-            "subject",
-            "actions",
-            "weaver-actions",
-            "default",
-            "delivery",
-            "{}",
+            NewRun {
+                subject: "subject",
+                source: "actions",
+                service_tag: "weaver-actions",
+                profile: "default",
+                idempotency_key: "delivery",
+                channel: None,
+                request_json: "{}",
+            },
         )
         .await
         .unwrap();
@@ -191,12 +400,15 @@ mod tests {
         };
         let second = reserve(
             &db,
-            "subject",
-            "actions",
-            "weaver-actions",
-            "default",
-            "delivery",
-            "different",
+            NewRun {
+                subject: "subject",
+                source: "actions",
+                service_tag: "weaver-actions",
+                profile: "default",
+                idempotency_key: "delivery",
+                channel: None,
+                request_json: "different",
+            },
         )
         .await
         .unwrap();
@@ -215,12 +427,15 @@ mod tests {
         let db = crate::db::connect_in_memory().await.unwrap();
         let run = match reserve(
             &db,
-            "subject",
-            "actions",
-            "weaver-actions",
-            "default",
-            "key",
-            "{}",
+            NewRun {
+                subject: "subject",
+                source: "actions",
+                service_tag: "weaver-actions",
+                profile: "default",
+                idempotency_key: "key",
+                channel: None,
+                request_json: "{}",
+            },
         )
         .await
         .unwrap()
@@ -235,5 +450,61 @@ mod tests {
             .unwrap();
         assert!(claim_stale(&db, &run.id).await.unwrap());
         assert!(!claim_stale(&db, &run.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn channel_waits_for_its_owner_and_replaces_a_failed_launch() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let first = match reserve(
+            &db,
+            NewRun {
+                subject: "subject",
+                source: "grafana",
+                service_tag: "grafana",
+                profile: "default",
+                idempotency_key: "first",
+                channel: Some("operator"),
+                request_json: "{}",
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Reservation::Created(run) => run,
+            Reservation::Existing(_) => unreachable!(),
+        };
+        assert!(matches!(
+            route_channel(&db, &first.id).await.unwrap(),
+            ChannelAction::Launch(_)
+        ));
+
+        let second = match reserve(
+            &db,
+            NewRun {
+                subject: "subject",
+                source: "grafana",
+                service_tag: "grafana",
+                profile: "default",
+                idempotency_key: "second",
+                channel: Some("operator"),
+                request_json: "{}",
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Reservation::Created(run) => run,
+            Reservation::Existing(_) => unreachable!(),
+        };
+        assert!(matches!(
+            route_channel(&db, &second.id).await.unwrap(),
+            ChannelAction::Busy(_)
+        ));
+
+        failed(&db, &first.id, "launch failed").await.unwrap();
+        assert!(matches!(
+            route_channel(&db, &second.id).await.unwrap(),
+            ChannelAction::Launch(_)
+        ));
     }
 }

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -335,6 +335,11 @@ pub(super) async fn create_run(
     if req.channel.is_some() {
         let run = match reservation {
             crate::runs::Reservation::Existing(run)
+                if run.channel.as_deref() != req.channel.as_deref() =>
+            {
+                return Ok(Json(run.into()));
+            }
+            crate::runs::Reservation::Existing(run)
                 if matches!(run.status.as_str(), "running" | "failed") =>
             {
                 return Ok(Json(run.into()));

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -115,6 +115,129 @@ fn run_identity(
     }
 }
 
+async fn run_view(st: &AppState, id: &str) -> ApiResult<Json<RunView>> {
+    let run = crate::runs::get(&st.db, id)
+        .await?
+        .ok_or_else(|| AppError::not_found("automation run"))?;
+    Ok(Json(run.into()))
+}
+
+enum LaunchFailure {
+    Final,
+    Retryable,
+}
+
+async fn launch_run(
+    st: &AppState,
+    req: RunReq,
+    subject: String,
+    profiles: Vec<String>,
+    run: crate::runs::Run,
+    failure: LaunchFailure,
+) -> ApiResult<Json<RunView>> {
+    let actor = crate::runtime::Actor::automation(
+        req.source,
+        subject,
+        profiles,
+        run.id.clone(),
+        run.session_id.clone(),
+    );
+    match crate::runtime::create_session(st.clone(), req.session, actor).await {
+        Ok(session) => {
+            crate::runs::launched(&st.db, &run.id, &session.id).await?;
+            run_view(st, &run.id).await
+        }
+        Err(error) => {
+            match failure {
+                LaunchFailure::Final => {
+                    crate::runs::failed(&st.db, &run.id, &format!("{error:?}"))
+                        .await
+                        .ok();
+                }
+                LaunchFailure::Retryable => {
+                    crate::runs::waiting(&st.db, &run.id).await.ok();
+                }
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn prompt_channel_run(
+    st: &AppState,
+    req: &RunReq,
+    run: crate::runs::Run,
+) -> ApiResult<Json<RunView>> {
+    let Some(session) = crate::session::get(&st.db, &run.session_id)
+        .await?
+        .filter(|session| session.status == "running" && session.protocol == "acp")
+    else {
+        crate::runs::waiting(&st.db, &run.id).await.ok();
+        return Err(AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "automation channel session is not ready; retry this delivery",
+        ));
+    };
+    let Some(handle) = st.acp.get(&session.id) else {
+        crate::runs::waiting(&st.db, &run.id).await.ok();
+        return Err(AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "automation channel session is being adopted; retry this delivery",
+        ));
+    };
+    let channel = run
+        .channel
+        .as_deref()
+        .expect("channel dispatch requires a channel");
+    let by = format!("automation:{}/{channel}", run.service_tag);
+    let goal = req
+        .session
+        .goal
+        .clone()
+        .expect("channel runs require a goal");
+    if let Err(error) = handle
+        .prompt(goal.clone(), Some(by.clone()), false, Vec::new())
+        .await
+    {
+        crate::runs::waiting(&st.db, &run.id).await.ok();
+        return Err(AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("automation channel rejected the update: {error}"),
+        ));
+    }
+    crate::events::record(
+        &st.db,
+        &st.bus,
+        &session.branch_id,
+        "nudge",
+        serde_json::json!({ "by": by, "text": goal }),
+    )
+    .await
+    .ok();
+    crate::runs::launched(&st.db, &run.id, &session.id).await?;
+    run_view(st, &run.id).await
+}
+
+async fn dispatch_channel_run(
+    st: &AppState,
+    subject: String,
+    profiles: Vec<String>,
+    run: crate::runs::Run,
+) -> ApiResult<Json<RunView>> {
+    let req: RunReq = serde_json::from_str(&run.request_json)?;
+    match crate::runs::route_channel(&st.db, &run.id).await? {
+        crate::runs::ChannelAction::Launch(run) => {
+            launch_run(st, req, subject, profiles, run, LaunchFailure::Retryable).await
+        }
+        crate::runs::ChannelAction::Prompt(run) => prompt_channel_run(st, &req, run).await,
+        crate::runs::ChannelAction::Ready(run) => Ok(Json(run.into())),
+        crate::runs::ChannelAction::Busy(_) => Err(AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "automation channel is provisioning or orphaned; retry this delivery",
+        )),
+    }
+}
+
 pub(super) async fn create_run(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,
@@ -129,6 +252,34 @@ pub(super) async fn create_run(
     }
     req.session.profile = Some(profile.clone());
     req.session.class = None;
+    req.channel = match req.channel.take() {
+        Some(channel) => {
+            let channel = channel.trim().to_string();
+            crate::runs::validate_channel(&channel)
+                .map_err(|error| AppError::bad_request(error.to_string()))?;
+            if req
+                .session
+                .goal
+                .as_deref()
+                .map(str::trim)
+                .is_none_or(str::is_empty)
+            {
+                return Err(AppError::bad_request(
+                    "channel automation runs require a non-empty session goal",
+                ));
+            }
+            let launch_profile = crate::profile::get(&st.db, &profile)
+                .await?
+                .ok_or_else(|| AppError::bad_request(format!("unknown profile '{profile}'")))?;
+            if launch_profile.protocol != "acp" {
+                return Err(AppError::bad_request(
+                    "automation channels require an ACP profile",
+                ));
+            }
+            Some(channel)
+        }
+        None => None,
+    };
 
     let idempotency_key = match &principal.automation_context {
         Some(context) if context.provider == "github" => {
@@ -170,14 +321,39 @@ pub(super) async fn create_run(
         .unwrap_or(req.source.as_str());
     let reservation = crate::runs::reserve(
         &st.db,
-        &subject,
-        &req.source,
-        service_tag,
-        &profile,
-        &idempotency_key,
-        &request_json,
+        crate::runs::NewRun {
+            subject: &subject,
+            source: &req.source,
+            service_tag,
+            profile: &profile,
+            idempotency_key: &idempotency_key,
+            channel: req.channel.as_deref(),
+            request_json: &request_json,
+        },
     )
     .await?;
+    if req.channel.is_some() {
+        let run = match reservation {
+            crate::runs::Reservation::Existing(run)
+                if matches!(run.status.as_str(), "running" | "failed") =>
+            {
+                return Ok(Json(run.into()));
+            }
+            crate::runs::Reservation::Existing(run) if run.status == "delivering" => {
+                if !crate::runs::claim_stale_delivery(&st.db, &run.id).await? {
+                    return Err(AppError::new(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "automation channel delivery is in progress; retry this delivery",
+                    ));
+                }
+                crate::runs::get(&st.db, &run.id)
+                    .await?
+                    .ok_or_else(|| AppError::not_found("automation run"))?
+            }
+            crate::runs::Reservation::Existing(run) | crate::runs::Reservation::Created(run) => run,
+        };
+        return dispatch_channel_run(&st, subject, profiles, run).await;
+    }
     let run = match reservation {
         crate::runs::Reservation::Existing(run) => {
             if let Some(session) = crate::session::get(&st.db, &run.session_id).await? {
@@ -199,28 +375,7 @@ pub(super) async fn create_run(
         }
         crate::runs::Reservation::Created(run) => run,
     };
-    let actor = crate::runtime::Actor::automation(
-        req.source.clone(),
-        subject,
-        profiles,
-        run.id.clone(),
-        run.session_id.clone(),
-    );
-    match crate::runtime::create_session(st.clone(), req.session, actor).await {
-        Ok(session) => {
-            crate::runs::launched(&st.db, &run.id, &session.id).await?;
-            let run = crate::runs::get(&st.db, &run.id)
-                .await?
-                .ok_or_else(|| AppError::not_found("automation run"))?;
-            Ok(Json(run.into()))
-        }
-        Err(error) => {
-            crate::runs::failed(&st.db, &run.id, &format!("{error:?}"))
-                .await
-                .ok();
-            Err(error)
-        }
-    }
+    launch_run(&st, req, subject, profiles, run, LaunchFailure::Final).await
 }
 
 pub(super) async fn list_runs(

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -620,6 +620,95 @@ async fn strict_profile_crud_withholds_secrets_and_stamps_sessions() {
 
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries() {
+    let _adapter = EnvVarGuard::set(
+        "WEAVER_CLAUDE_ACP_CMD",
+        &crate::fixtures::fake_acp_agent_cmd(),
+    );
+    let ts = TestServer::start().await;
+    ts.client
+        .post(
+            "/api/profiles",
+            json!({
+                "name": "ops",
+                "description": "operations intake",
+                "agent_kind": "claude",
+                "protocol": "acp",
+                "mode": "default",
+                "class": "automation",
+                "strict": true,
+                "env_clear": true,
+                "max_concurrent": 1,
+                "turn_budget": 20,
+                "prelude": "none"
+            }),
+        )
+        .await
+        .unwrap();
+
+    let first_request = json!({
+        "profile": "ops",
+        "source": "grafana",
+        "channel": "operator",
+        "idempotency_key": "alert:first",
+        "session": {
+            "cwd": ts.cwd(),
+            "title": "Grafana operator",
+            "goal": "first alert"
+        }
+    });
+    let first = ts.client.post("/api/runs", first_request).await.unwrap();
+    let second_request = json!({
+        "profile": "ops",
+        "source": "grafana",
+        "channel": "operator",
+        "idempotency_key": "alert:second",
+        "session": {
+            "cwd": ts.cwd(),
+            "title": "Grafana operator",
+            "goal": "second alert"
+        }
+    });
+    let second = ts
+        .client
+        .post("/api/runs", second_request.clone())
+        .await
+        .unwrap();
+    let duplicate = ts.client.post("/api/runs", second_request).await.unwrap();
+
+    assert_ne!(first["id"], second["id"]);
+    assert_eq!(first["session_id"], second["session_id"]);
+    assert_eq!(second["id"], duplicate["id"]);
+    assert_eq!(second["channel"], "operator");
+
+    let sessions = ts
+        .client
+        .get("/api/sessions?automation=true")
+        .await
+        .unwrap();
+    assert_eq!(sessions.as_array().unwrap().len(), 1);
+
+    let chat = ts
+        .client
+        .get(&format!(
+            "/api/sessions/{}/chat",
+            first["session_id"].as_str().unwrap()
+        ))
+        .await
+        .unwrap();
+    let second_deliveries = chat["blocks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|block| {
+            block["kind"] == "user_message" && block["payload"]["text"] == "second alert"
+        })
+        .count();
+    assert_eq!(second_deliveries, 1);
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn deployment_manifest_reconciles_profiles_secret_refs_and_workload_identity() {
     let ts = TestServer::start().await;
     let manifest = json!({

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -625,6 +625,7 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
         "WEAVER_CLAUDE_ACP_CMD",
         &crate::fixtures::fake_acp_agent_cmd(),
     );
+    let _github_token = EnvVarGuard::set("GH_TOKEN", "test-token");
     let ts = TestServer::start().await;
     ts.client
         .post(

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -658,7 +658,11 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
             "goal": "first alert"
         }
     });
-    let first = ts.client.post("/api/runs", first_request).await.unwrap();
+    let first = ts
+        .client
+        .post("/api/runs", first_request.clone())
+        .await
+        .unwrap();
     let second_request = json!({
         "profile": "ops",
         "source": "grafana",
@@ -676,11 +680,21 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
         .await
         .unwrap();
     let duplicate = ts.client.post("/api/runs", second_request).await.unwrap();
+    let mut collision_request = first_request;
+    collision_request["channel"] = json!("another-operator");
+    collision_request["session"]["goal"] = json!("must not be delivered");
+    let collision = ts
+        .client
+        .post("/api/runs", collision_request)
+        .await
+        .unwrap();
 
     assert_ne!(first["id"], second["id"]);
     assert_eq!(first["session_id"], second["session_id"]);
     assert_eq!(second["id"], duplicate["id"]);
     assert_eq!(second["channel"], "operator");
+    assert_eq!(collision["id"], first["id"]);
+    assert_eq!(collision["channel"], "operator");
 
     let sessions = ts
         .client

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -629,6 +629,11 @@ pub struct RunReq {
     pub idempotency_key: String,
     #[serde(default = "actions_source")]
     pub source: String,
+    /// Stable conversation route for related automation deliveries. Each
+    /// idempotency key remains a distinct run; channel deliveries reuse one
+    /// live ACP session.
+    #[serde(default)]
+    pub channel: Option<String>,
     pub session: CreateReq,
 }
 
@@ -658,6 +663,7 @@ pub struct RunView {
     pub service_tag: String,
     pub profile: String,
     pub idempotency_key: String,
+    pub channel: Option<String>,
     pub session_id: String,
     pub status: String,
     pub outcome: Option<String>,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -261,7 +261,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `PUT DELETE /api/profiles/{profile}/env/{name}` | write-only profile environment management; a write supplies exactly one literal `value` or a full GCP Secret Manager `secret_ref`, and reads expose only source/reference metadata |
 | `POST /api/deployment/reconcile` | admin-only idempotent reconciliation of deployment-managed profiles, environment references, and federation mappings; pruning never touches operator-managed rows |
 | `POST /api/auth/federate` | exchange an exact mapped, signature-verified GitHub or Google OIDC identity for a ten-minute Ed25519-signed, profile-scoped Loom automation token |
-| `GET POST /api/runs`; `GET /api/runs/{id}` | durable, subject-scoped automation runs with idempotency reservation; verified GitHub callers may provide a validated deterministic key, otherwise the workflow run/attempt is used |
+| `GET POST /api/runs`; `GET /api/runs/{id}` | durable, subject-scoped automation runs with idempotency reservation; an optional channel routes distinct deliveries through one live ACP session, and verified GitHub callers may provide a validated deterministic key or use the workflow run/attempt |
 | `POST /api/sessions/{id}/restricted-github/{tool}` | session-token-scoped fixed GitHub operations for a restricted session; checks stamped tool policy, fixes the target repository and thread from the session, and resolves a GitHub App token or explicit App-less profile token server-side |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear a branch tag — the well-known `attention` and `triage` keys plus any free-form key |

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -100,6 +100,13 @@ GitHub caller keys accept up to 128 ASCII letters, digits, `.`, `_`, `:`, and
 the compatibility behavior of deduplicating one workflow run attempt; a body
 hash key converges retries and reruns for the same source description.
 
+Automation callers may also set `channel` to route distinct idempotency keys
+through one live ACP session. The channel is scoped to the verified subject,
+service tag, profile, and source. A busy session queues the update through its
+durable ACP prompt path; a provisioning or orphaned channel returns a retryable
+error instead of acknowledging an undelivered update. Channel names accept up
+to 64 ASCII letters, digits, `.`, `_`, `:`, and `-`.
+
 Do not put `GH_TOKEN` in the request or prompt. Automation requests are stored
 for audit and idempotency. Loom resolves a credential only while executing a
 fixed GitHub tool. Prefer the configured GitHub App, whose installation token is


### PR DESCRIPTION
Add actor-scoped automation channels to POST /api/runs so distinct, idempotent deliveries can reuse one live ACP session. Channel ownership is scoped by caller, source, service tag, profile, and channel; provisioning and orphaned owners return a retryable response rather than acknowledging an undelivered update.

Keep a durable run record for every delivery and preserve the existing behavior for callers that omit a channel. This gives alerting integrations one operator conversation while leaving incident delegation to that operator.