### PR TITLE
feat(loom): add MCP profile control plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,12 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: crates/loom/frontend/package-lock.json
+      # Custom MCP integration tests execute their exact PEP 723 scripts through
+      # the same uv version shipped in the production container.
+      - name: Install uv for custom MCP tests
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.21"
       # Integration tests shell out to real `git` and spawn `tapestry` terminal
       # supervisors (PTYs); both are available on the runner without extra setup.
       - run: cargo test --workspace --locked

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ weaver config ls
 loom profile ls
 loom profile show default
 loom profile show github_comment
+loom mcp ls
+loom mcp show mcp/github/comment@v1
 # App-less deployments can give restricted GitHub tools a shared identity:
 loom profile env secret github_comment GH_TOKEN \
   projects/my-project/secrets/loom-github-ci-token/versions/latest
@@ -424,7 +426,7 @@ Notable settings:
 - Restricted profiles are Claude ACP automation envelopes for caller-supplied
   prompts. They suppress the Weaver prelude and repository setup/config, clear
   Claude setting sources, expose repository-scoped read tools plus fixed
-  server-side GitHub tools selected by the built-in `mcp/github/comment`
+  server-side GitHub tools selected by the built-in `mcp/github/comment@v1`
   capability set, and have Loom reject every unmatched permission request.
   Loom expands profile capability sets into exact permissions when it stamps a
   session and derives adapter processes from its trusted MCP registry; profiles
@@ -436,6 +438,11 @@ Notable settings:
   from its reviewed declarative manifest and remains operator-editable after the
   first seed. See
   [Restricted GitHub sessions](docs/restricted-sessions.md).
+- MCP capability sets are stable, provider-neutral profile policy. Inspect
+  their adapter, exact tool surface, version, and content digest with `loom mcp
+  ls` / `loom mcp show`; the Settings profile editor exposes the same registry.
+  Provider-specific runtime permission rules remain an implementation detail of
+  the selected agent, rather than the vocabulary used to name MCP access.
 - Profile environment values are write-only: API, CLI, and Settings responses
   expose names and update times, never secret values.
 - Ordinary sessions default `CARGO_TARGET_DIR` to the primary repository's

--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ Loom serves a JSON API under `/api`; the Vue SPA is the primary consumer.
   `POST /api/sessions/{id}/{note,archive,adopt,github}`,
   `GET /api/sessions/{id}/{diff,log,events}`,
   `GET /api/sessions/{id}/terminal` (WebSocket: xterm.js ⇄ the tapestry PTY)
+- `GET /api/mcps`, `GET POST /api/mcps/custom`, and
+  `GET PUT DELETE /api/mcps/custom/{path}` (builtin discovery and validated,
+  revisioned custom MCP administration)
+- `GET POST /api/profiles`, `GET PUT DELETE /api/profiles/{name}`,
+  `GET /api/profiles/{name}/effective`, and
+  `POST /api/profiles/{name}/probe`
 - `GET /api/branches`, `GET PATCH /api/branches/{id}`,
   `GET POST /api/branches/{id}/issues` (issues claimed by the branch),
   `GET PATCH DELETE /api/issues/{id}`
@@ -411,6 +417,12 @@ loom profile show default
 loom profile show github_comment
 loom mcp ls
 loom mcp show mcp/github/comment@v1
+loom profile add ops --agent codex --mcp github,messaging
+loom profile show ops --effective
+loom profile probe ops
+# Add or update a dependency-self-contained custom MCP (save validates it):
+loom mcp add /engineering/search/docs --label "Docs search" \
+  --file server.py --tests test_mcp.py
 # App-less deployments can give restricted GitHub tools a shared identity:
 loom profile env secret github_comment GH_TOKEN \
   projects/my-project/secrets/loom-github-ci-token/versions/latest
@@ -441,8 +453,22 @@ Notable settings:
 - MCP capability sets are stable, provider-neutral profile policy. Inspect
   their adapter, exact tool surface, version, and content digest with `loom mcp
   ls` / `loom mcp show`; the Settings profile editor exposes the same registry.
+  Profiles choose `none`, `all`, or an explicit comma-separated group list with
+  `--mcp`. Saving pins the exact capabilities to that profile revision; editing
+  the registry cannot silently widen it, and saving the profile again is the
+  explicit reconciliation point. The builtins cover fixed-repository GitHub
+  work, durable status updates, and fixed-thread Slack replies; all reuse Loom's existing
+  session-scoped routes, so provider credentials remain server-side.
   Provider-specific runtime permission rules remain an implementation detail of
   the selected agent, rather than the vocabulary used to name MCP access.
+- Administrators can add Python MCP servers under identities such as
+  `/engineering/search/docs`. Loom stores immutable source revisions in sqlite,
+  runs real MCP discovery plus optional tests through `uv`, and excludes failed
+  or disabled definitions from newly saved profile revisions. Custom scripts run with a
+  cleared environment, Loom-controlled uv dependency paths, and session-scoped
+  Loom API context, are never admitted to restricted profiles, and are operator
+  code rather than an OS sandbox. See the
+  [MCP/profile design](docs/plans/mcp-profiles.md).
 - Profile environment values are write-only: API, CLI, and Settings responses
   expose names and update times, never secret values.
 - Ordinary sessions default `CARGO_TARGET_DIR` to the primary repository's

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -431,10 +431,16 @@ export const deleteEnv = (name: string) =>
 
 // --- Launch profiles -------------------------------------------------------
 
-import type { Profile, ProfileInput } from './types';
+import type { CustomMcp, CustomMcpInput, Profile, ProfileInput } from './types';
 
 export const listProfiles = () => get('/profiles') as Promise<Profile[]>;
 export const getMcpRegistry = () => get('/mcps') as Promise<import('./types').McpRegistry>;
+export const createCustomMcp = (input: CustomMcpInput) =>
+  post('/mcps/custom', input) as Promise<CustomMcp>;
+export const updateCustomMcp = (identity: string, input: CustomMcpInput) =>
+  put(`/mcps/custom/${identity.replace(/^\/+/, '')}`, input) as Promise<CustomMcp>;
+export const deleteCustomMcp = (identity: string) =>
+  del(`/mcps/custom/${identity.replace(/^\/+/, '')}`);
 export const createProfile = (profile: ProfileInput) =>
   post('/profiles', profile) as Promise<Profile>;
 export const updateProfile = (name: string, profile: ProfileInput) =>

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -434,6 +434,7 @@ export const deleteEnv = (name: string) =>
 import type { Profile, ProfileInput } from './types';
 
 export const listProfiles = () => get('/profiles') as Promise<Profile[]>;
+export const getMcpRegistry = () => get('/mcps') as Promise<import('./types').McpRegistry>;
 export const createProfile = (profile: ProfileInput) =>
   post('/profiles', profile) as Promise<Profile>;
 export const updateProfile = (name: string, profile: ProfileInput) =>

--- a/crates/loom/frontend/src/components/McpPanel.vue
+++ b/crates/loom/frontend/src/components/McpPanel.vue
@@ -1,0 +1,202 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { createCustomMcp, deleteCustomMcp, getMcpRegistry, updateCustomMcp } from '../api';
+import type { CustomMcp, CustomMcpInput, McpRegistry } from '../types';
+import ToggleSwitch from './ToggleSwitch.vue';
+
+const registry = ref<McpRegistry | null>(null);
+const editing = ref<string | null>(null);
+const draft = ref<CustomMcpInput>(blank());
+const busy = ref(false);
+const error = ref('');
+
+const custom = computed(() => registry.value?.custom_servers ?? []);
+const isNew = computed(() => editing.value === '');
+
+function blank(): CustomMcpInput {
+  return {
+    identity: '',
+    label: '',
+    description: '',
+    source:
+      '# /// script\n# dependencies = ["mcp"]\n# ///\n\nfrom mcp.server.fastmcp import FastMCP\n\nserver = FastMCP("custom")\n\n@server.tool()\ndef example(value: str) -> str:\n    """Replace this example tool."""\n    return value\n\nserver.run()\n',
+    test_source: '',
+    enabled: true,
+  };
+}
+
+async function load() {
+  registry.value = await getMcpRegistry();
+}
+
+function add() {
+  editing.value = '';
+  draft.value = blank();
+  error.value = '';
+}
+
+function edit(server: CustomMcp) {
+  editing.value = server.identity;
+  draft.value = {
+    identity: server.identity,
+    label: server.label,
+    description: server.description,
+    source: server.source,
+    test_source: server.test_source,
+    enabled: server.enabled,
+  };
+  error.value = '';
+}
+
+function cancel() {
+  editing.value = null;
+  error.value = '';
+}
+
+async function save() {
+  busy.value = true;
+  error.value = '';
+  try {
+    const saved = isNew.value
+      ? await createCustomMcp(draft.value)
+      : await updateCustomMcp(editing.value as string, draft.value);
+    await load();
+    if (saved.validation_state === 'ready') editing.value = null;
+    else {
+      editing.value = saved.identity;
+      error.value = saved.validation_message || 'Validation failed.';
+    }
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function remove(server: CustomMcp) {
+  if (!window.confirm(`Delete custom MCP ${server.identity}? Existing sessions keep snapshots.`))
+    return;
+  busy.value = true;
+  try {
+    await deleteCustomMcp(server.identity);
+    await load();
+    if (editing.value === server.identity) editing.value = null;
+  } catch (e) {
+    error.value = (e as Error).message;
+  } finally {
+    busy.value = false;
+  }
+}
+
+onMounted(() => void load().catch((e) => (error.value = (e as Error).message)));
+</script>
+
+<template>
+  <section data-testid="mcp-panel" class="rounded-md border border-line bg-surface">
+    <header class="flex items-center gap-3 border-b border-line px-3 py-2">
+      <div>
+        <h3 class="text-sm font-semibold">MCP servers</h3>
+        <p class="text-xs text-muted">
+          Builtins are trusted Loom adapters. Custom Python scripts are revisioned, run through
+          <code>uv</code>, and tested over real MCP stdio before profiles can use them.
+        </p>
+      </div>
+      <button class="btn-secondary ml-auto px-2.5 py-1 text-xs" @click="add">Add custom MCP</button>
+    </header>
+
+    <p v-if="error" class="border-b border-line px-3 py-2 text-xs text-block">{{ error }}</p>
+
+    <div class="border-b border-line px-3 py-2">
+      <h4 class="mb-1 text-xs font-medium">Builtins</h4>
+      <ul class="space-y-1 text-xs text-muted">
+        <li v-for="set in registry?.capability_sets ?? []" :key="set.name">
+          <code>{{ set.name }}</code>
+          <span class="ml-1 rounded bg-input px-1 py-0.5">{{ set.group }}</span>
+          — {{ set.description }}
+        </li>
+      </ul>
+    </div>
+
+    <ul v-if="custom.length" class="divide-y divide-line">
+      <li v-for="server in custom" :key="server.identity" class="flex items-center gap-2 px-3 py-2">
+        <div class="min-w-0">
+          <div class="flex flex-wrap items-center gap-1.5">
+            <span class="text-sm font-medium">{{ server.label }}</span>
+            <code class="text-2xs text-faint">{{ server.identity }}</code>
+            <span
+              class="rounded px-1 py-0.5 text-2xs"
+              :class="
+                server.validation_state === 'ready'
+                  ? 'bg-ok-soft text-ok'
+                  : 'bg-block-soft text-block'
+              "
+            >
+              {{ server.validation_state }} · r{{ server.revision }}
+            </span>
+            <span v-if="!server.enabled" class="text-2xs text-faint">disabled</span>
+          </div>
+          <p class="truncate text-xs text-muted">
+            {{ server.description || server.tools.join(', ') || server.validation_message }}
+          </p>
+        </div>
+        <div class="ml-auto flex gap-1">
+          <button class="btn-secondary px-2 py-1 text-xs" @click="edit(server)">Edit</button>
+          <button class="btn-secondary px-2 py-1 text-xs text-block" @click="remove(server)">
+            Delete
+          </button>
+        </div>
+      </li>
+    </ul>
+    <p v-else class="px-3 py-2 text-xs text-muted">No custom MCP servers.</p>
+
+    <form v-if="editing !== null" class="space-y-3 border-t border-line p-3" @submit.prevent="save">
+      <div class="grid gap-3 sm:grid-cols-2">
+        <label class="text-xs">
+          Identity
+          <input
+            v-model="draft.identity"
+            :disabled="!isNew"
+            placeholder="/engineering/search/docs"
+            class="mt-1 w-full rounded bg-input px-2 py-1.5 font-mono"
+          />
+        </label>
+        <label class="text-xs">
+          Label
+          <input v-model="draft.label" class="mt-1 w-full rounded bg-input px-2 py-1.5" />
+        </label>
+      </div>
+      <label class="block text-xs">
+        Description
+        <input v-model="draft.description" class="mt-1 w-full rounded bg-input px-2 py-1.5" />
+      </label>
+      <label class="block text-xs">
+        Python MCP source (PEP 723)
+        <textarea
+          v-model="draft.source"
+          rows="18"
+          spellcheck="false"
+          class="mt-1 w-full rounded bg-input px-2 py-1.5 font-mono text-xs"
+        ></textarea>
+      </label>
+      <label class="block text-xs">
+        Tests (optional uv script; <code>LOOM_MCP_SOURCE</code> names the source file)
+        <textarea
+          v-model="draft.test_source"
+          rows="7"
+          spellcheck="false"
+          class="mt-1 w-full rounded bg-input px-2 py-1.5 font-mono text-xs"
+        ></textarea>
+      </label>
+      <div class="flex items-center gap-2">
+        <ToggleSwitch :model-value="draft.enabled" @update:model-value="draft.enabled = $event" />
+        <span class="text-xs text-muted">Enabled for ordinary profile selection</span>
+      </div>
+      <div class="flex gap-2">
+        <button class="btn-primary px-2.5 py-1 text-xs" :disabled="busy">Save and validate</button>
+        <button type="button" class="btn-secondary px-2.5 py-1 text-xs" @click="cancel">
+          Cancel
+        </button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/crates/loom/frontend/src/components/ProfilesPanel.vue
+++ b/crates/loom/frontend/src/components/ProfilesPanel.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
 import * as api from '../api';
-import type { AgentMetadata, Profile, ProfileInput } from '../types';
+import type { AgentMetadata, McpRegistry, Profile, ProfileInput } from '../types';
 
 const profiles = ref<Profile[]>([]);
 const agents = ref<AgentMetadata[]>([]);
+const mcpRegistry = ref<McpRegistry | null>(null);
 const selected = ref('default');
 const draft = ref<ProfileInput | null>(null);
 const creating = ref(false);
@@ -66,9 +67,14 @@ function choose(name: string) {
 
 async function load() {
   try {
-    const [items, metadata] = await Promise.all([api.listProfiles(), api.listAgents()]);
+    const [items, metadata, registry] = await Promise.all([
+      api.listProfiles(),
+      api.listAgents(),
+      api.getMcpRegistry(),
+    ]);
     profiles.value = items;
     agents.value = metadata.agents;
+    mcpRegistry.value = registry;
     choose(
       items.some((item) => item.name === selected.value)
         ? selected.value
@@ -348,7 +354,7 @@ onMounted(load);
             />
           </label>
           <label class="text-xs sm:col-span-2"
-            >Allowed Claude tools (one permission rule per line)
+            >MCP capability sets and runtime permissions (one per line)
             <textarea
               :value="draft.allowed_tools.join('\n')"
               rows="6"
@@ -360,7 +366,20 @@ onMounted(load);
                   .filter(Boolean)
               "
             />
+            <span class="mt-1 block text-muted">
+              Select a versioned set such as
+              <code>mcp/github/comment@v1</code>. Non-MCP lines are passed to the selected runtime
+              as its provider-specific permission policy.
+            </span>
           </label>
+          <div v-if="mcpRegistry?.capability_sets.length" class="text-xs sm:col-span-2">
+            <div class="mb-1 font-medium">Available trusted MCP capability sets</div>
+            <ul class="space-y-1 text-muted">
+              <li v-for="set in mcpRegistry.capability_sets" :key="set.name">
+                <code>{{ set.name }}</code> — {{ set.description }}
+              </li>
+            </ul>
+          </div>
           <div class="flex gap-2 sm:col-span-2">
             <button
               data-testid="profile-save"

--- a/crates/loom/frontend/src/components/ProfilesPanel.vue
+++ b/crates/loom/frontend/src/components/ProfilesPanel.vue
@@ -19,6 +19,15 @@ const current = computed(() => profiles.value.find((profile) => profile.name ===
 const selectedAgent = computed(() =>
   agents.value.find((agent) => agent.kind === draft.value?.agent_kind),
 );
+const mcpGroups = computed(() => {
+  const groups = new Map<string, boolean>();
+  for (const set of mcpRegistry.value?.capability_sets ?? []) groups.set(set.group, true);
+  for (const server of mcpRegistry.value?.custom_servers ?? [])
+    if (!groups.has(server.group)) groups.set(server.group, false);
+  return [...groups]
+    .map(([name, builtin]) => ({ name, builtin }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+});
 
 function normalizeAgentChoices(metadata = selectedAgent.value) {
   const profile = draft.value;
@@ -36,6 +45,22 @@ function normalizeAgentChoices(metadata = selectedAgent.value) {
 }
 
 watch(selectedAgent, normalizeAgentChoices);
+watch(
+  () => draft.value?.restricted,
+  (restricted) => {
+    if (!restricted || !draft.value) return;
+    if (draft.value.mcp_access.mode === 'all') {
+      draft.value.mcp_access = { mode: 'none', groups: [] };
+    } else if (draft.value.mcp_access.mode === 'groups') {
+      const builtins = new Set(
+        mcpGroups.value.filter((group) => group.builtin).map((group) => group.name),
+      );
+      draft.value.mcp_access.groups = draft.value.mcp_access.groups.filter((group) =>
+        builtins.has(group),
+      );
+    }
+  },
+);
 
 function editable(profile: Profile): ProfileInput {
   const {
@@ -51,7 +76,8 @@ function editable(profile: Profile): ProfileInput {
   return {
     ...input,
     ambient_allowlist: [...input.ambient_allowlist],
-    allowed_tools: [...input.allowed_tools],
+    runtime_permissions: [...input.runtime_permissions],
+    mcp_access: { ...input.mcp_access, groups: [...input.mcp_access.groups] },
   };
 }
 
@@ -106,7 +132,8 @@ function add() {
     turn_budget: null,
     prelude: 'weaver',
     restricted: false,
-    allowed_tools: [],
+    runtime_permissions: [],
+    mcp_access: { mode: 'none', groups: [] },
   };
 }
 
@@ -353,23 +380,71 @@ onMounted(load);
               "
             />
           </label>
+          <fieldset class="space-y-2 rounded border border-line p-2 sm:col-span-2">
+            <legend class="px-1 text-xs font-medium">MCP access</legend>
+            <div class="flex flex-wrap gap-1.5">
+              <button
+                v-for="mode in ['none', 'all', 'groups'] as const"
+                :key="mode"
+                type="button"
+                class="rounded border px-2.5 py-1 text-xs capitalize"
+                :disabled="draft.restricted && mode === 'all'"
+                :class="
+                  draft.mcp_access.mode === mode
+                    ? 'border-accent bg-accent text-accent-fg'
+                    : 'border-line bg-input text-muted'
+                "
+                @click="
+                  draft!.mcp_access = {
+                    mode,
+                    groups: mode === 'groups' ? draft!.mcp_access.groups : [],
+                  }
+                "
+              >
+                {{ mode }}
+              </button>
+            </div>
+            <div v-if="draft.mcp_access.mode === 'groups'" class="flex flex-wrap gap-2">
+              <label
+                v-for="group in mcpGroups"
+                :key="group.name"
+                class="flex items-center gap-1 text-xs"
+                :class="{ 'opacity-50': draft.restricted && !group.builtin }"
+              >
+                <input
+                  type="checkbox"
+                  :checked="draft.mcp_access.groups.includes(group.name)"
+                  :disabled="draft.restricted && !group.builtin"
+                  @change="
+                    draft!.mcp_access.groups = ($event.target as HTMLInputElement).checked
+                      ? [...draft!.mcp_access.groups, group.name]
+                      : draft!.mcp_access.groups.filter((value) => value !== group.name)
+                  "
+                />
+                <code>{{ group.name }}</code>
+              </label>
+            </div>
+            <p class="text-xs text-muted">
+              None starts no MCP processes. All includes every enabled builtin and custom MCP.
+              Restricted profiles may select trusted builtins only.
+            </p>
+          </fieldset>
           <label class="text-xs sm:col-span-2"
-            >MCP capability sets and runtime permissions (one per line)
+            >Runtime permissions (one provider-specific rule per line)
             <textarea
-              :value="draft.allowed_tools.join('\n')"
-              rows="6"
+              :value="draft.runtime_permissions.join('\n')"
+              rows="3"
               class="mt-1 w-full rounded bg-input px-2 py-1.5 font-mono"
               @input="
-                draft!.allowed_tools = ($event.target as HTMLTextAreaElement).value
+                draft!.runtime_permissions = ($event.target as HTMLTextAreaElement).value
                   .split('\n')
                   .map((v) => v.trim())
                   .filter(Boolean)
               "
             />
             <span class="mt-1 block text-muted">
-              Select a versioned set such as
-              <code>mcp/github/comment@v1</code>. Non-MCP lines are passed to the selected runtime
-              as its provider-specific permission policy.
+              Legacy escape hatch for restricted filesystem rules such as <code>Read(./**)</code>.
+              Integrations belong in MCP access above.
             </span>
           </label>
           <div v-if="mcpRegistry?.capability_sets.length" class="text-xs sm:col-span-2">

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -134,6 +134,8 @@ export interface Session {
   profile: string;
   profile_revision: number;
   launch_mode: string;
+  /** Exact capability snapshot stamped at launch. Custom source is redacted. */
+  mcp_policy: SessionMcpPolicy;
   /** The ACP modes the adapter offers, when the server exposes them. Absent today
    *  (SessionView carries only `current_mode`), so the mode chip falls back to the
    *  well-known claude/codex mode set — see `AcpConversation`. */
@@ -853,7 +855,8 @@ export interface Profile {
   turn_budget: number | null;
   prelude: 'weaver' | 'none';
   restricted: boolean;
-  allowed_tools: string[];
+  runtime_permissions: string[];
+  mcp_access: McpAccess;
   revision: number;
   created_at: string;
   updated_at: string;
@@ -872,6 +875,7 @@ export interface ProfileEnv {
 export interface McpRegistry {
   adapters: McpAdapter[];
   capability_sets: McpCapabilitySet[];
+  custom_servers: CustomMcp[];
 }
 
 export interface McpAdapter {
@@ -882,12 +886,55 @@ export interface McpAdapter {
 
 export interface McpCapabilitySet {
   name: string;
+  group: string;
   version: string;
   digest: string;
   description: string;
   adapter: string;
   tools: string[];
 }
+
+export interface McpAccess {
+  mode: 'none' | 'all' | 'groups';
+  groups: string[];
+}
+
+export interface SessionMcpPolicy {
+  selection: McpAccess;
+  capability_sets: McpCapabilitySet[];
+  custom_servers: SessionCustomMcp[];
+}
+
+export interface SessionCustomMcp {
+  identity: string;
+  group: string;
+  revision: number;
+  digest: string;
+  server_name: string;
+  tools: string[];
+}
+
+export interface CustomMcp {
+  identity: string;
+  group: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+  revision: number;
+  digest: string;
+  source: string;
+  test_source: string;
+  tools: string[];
+  validation_state: 'ready' | 'failed';
+  validation_message: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export type CustomMcpInput = Pick<
+  CustomMcp,
+  'identity' | 'label' | 'description' | 'enabled' | 'source' | 'test_source'
+>;
 
 export type ProfileInput = Omit<Profile, 'revision' | 'created_at' | 'updated_at' | 'env'>;
 

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -867,6 +867,28 @@ export interface ProfileEnv {
   updated_at: string;
 }
 
+/** Trusted MCP registry. Capability-set names are provider-neutral profile
+ * policy; a runtime translates their exact tools to its own protocol. */
+export interface McpRegistry {
+  adapters: McpAdapter[];
+  capability_sets: McpCapabilitySet[];
+}
+
+export interface McpAdapter {
+  name: string;
+  description: string;
+  server_name: string;
+}
+
+export interface McpCapabilitySet {
+  name: string;
+  version: string;
+  digest: string;
+  description: string;
+  adapter: string;
+  tools: string[];
+}
+
 export type ProfileInput = Omit<Profile, 'revision' | 'created_at' | 'updated_at' | 'env'>;
 
 /**

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -10,6 +10,7 @@ import SlackPanel from '../components/SlackPanel.vue';
 import EnvPanel from '../components/EnvPanel.vue';
 import LogsPanel from '../components/LogsPanel.vue';
 import ProfilesPanel from '../components/ProfilesPanel.vue';
+import McpPanel from '../components/McpPanel.vue';
 import CustomAgentsPanel from '../components/CustomAgentsPanel.vue';
 import AppearancePanel from '../components/AppearancePanel.vue';
 import SettingFieldRow from '../components/SettingFieldRow.vue';
@@ -44,7 +45,7 @@ const categories: CategoryItem[] = [
     id: 'agents',
     label: 'Agents',
     groups: ['Agents'],
-    summary: 'Default runtime profiles and custom agents for new work sessions.',
+    summary: 'Runtime profiles, MCP capabilities, and custom agents for new work sessions.',
   },
   {
     id: 'sessions',
@@ -310,6 +311,7 @@ onMounted(load);
 
         <div v-else-if="category === 'agents'" class="space-y-4">
           <ProfilesPanel :key="profilesKey" />
+          <McpPanel />
           <CustomAgentsPanel :agents="customAgents" @reload="reloadAgents" />
         </div>
 

--- a/crates/loom/migrations/0006_mcp_access.sql
+++ b/crates/loom/migrations/0006_mcp_access.sql
@@ -1,0 +1,60 @@
+ALTER TABLE profiles ADD COLUMN mcp_access TEXT NOT NULL
+    DEFAULT '{"mode":"none","groups":[]}';
+ALTER TABLE profiles ADD COLUMN mcp_policy TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE sessions ADD COLUMN policy_mcp_access TEXT NOT NULL
+    DEFAULT '{"selection":{"mode":"none","groups":[]},"capability_sets":[]}';
+
+-- Reclassify the one MCP capability set supported before this migration.
+-- Operators could copy the stock profile, so translate every profile that
+-- selected it rather than special-casing the stock name.
+UPDATE profiles
+SET mcp_access = '{"mode":"groups","groups":["github"]}'
+WHERE EXISTS (
+    SELECT 1 FROM json_each(
+        CASE WHEN json_valid(profiles.allowed_tools)
+             THEN profiles.allowed_tools ELSE '[]' END
+    )
+    WHERE value IN ('mcp/github/comment', 'mcp/github/comment@v1')
+);
+
+UPDATE profiles
+SET allowed_tools = (
+    SELECT json_group_array(value)
+    FROM json_each(
+        CASE WHEN json_valid(profiles.allowed_tools)
+             THEN profiles.allowed_tools ELSE '[]' END
+    )
+    WHERE value NOT IN ('mcp/github/comment', 'mcp/github/comment@v1')
+)
+WHERE EXISTS (
+    SELECT 1 FROM json_each(
+        CASE WHEN json_valid(profiles.allowed_tools)
+             THEN profiles.allowed_tools ELSE '[]' END
+    )
+    WHERE value IN ('mcp/github/comment', 'mcp/github/comment@v1')
+);
+
+CREATE TABLE custom_mcp_servers (
+    identity          TEXT PRIMARY KEY,
+    group_name        TEXT NOT NULL,
+    label             TEXT NOT NULL,
+    description       TEXT NOT NULL DEFAULT '',
+    enabled           INTEGER NOT NULL DEFAULT 1,
+    current_revision  INTEGER NOT NULL DEFAULT 1,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL
+);
+
+CREATE TABLE custom_mcp_revisions (
+    identity            TEXT NOT NULL REFERENCES custom_mcp_servers(identity) ON DELETE CASCADE,
+    revision            INTEGER NOT NULL,
+    source              TEXT NOT NULL,
+    test_source         TEXT NOT NULL DEFAULT '',
+    digest              TEXT NOT NULL,
+    tools_json          TEXT NOT NULL DEFAULT '[]',
+    validation_state    TEXT NOT NULL,
+    validation_message  TEXT NOT NULL DEFAULT '',
+    created_at          TEXT NOT NULL,
+    PRIMARY KEY (identity, revision)
+);

--- a/crates/loom/profiles/github_comment.json
+++ b/crates/loom/profiles/github_comment.json
@@ -17,6 +17,6 @@
   "restricted": true,
   "allowed_tools": [
     "Read(./**)",
-    "mcp/github/comment"
+    "mcp/github/comment@v1"
   ]
 }

--- a/crates/loom/profiles/github_comment.json
+++ b/crates/loom/profiles/github_comment.json
@@ -15,8 +15,11 @@
   "turn_budget": 4,
   "prelude": "none",
   "restricted": true,
-  "allowed_tools": [
-    "Read(./**)",
-    "mcp/github/comment@v1"
-  ]
+  "runtime_permissions": [
+    "Read(./**)"
+  ],
+  "mcp_access": {
+    "mode": "groups",
+    "groups": ["github"]
+  }
 }

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -99,6 +99,8 @@ pub struct AcpLaunch {
     /// supervisor, never on argv).
     pub env: Vec<(String, String)>,
     pub env_clear: bool,
+    /// Provider-neutral ACP v1 stdio MCP server descriptors.
+    pub mcp_servers: Vec<Value>,
     /// Open a fresh session or reload an existing one.
     pub new_or_load: NewOrLoad,
     /// The initial permission posture (`bypassPermissions`, `acceptEdits`,
@@ -1089,7 +1091,11 @@ impl Task {
         match &launch.new_or_load {
             NewOrLoad::New { cwd, meta } => {
                 let id = self.next_id();
-                let params = wire::new_session_params(&cwd.to_string_lossy(), meta.as_ref());
+                let params = wire::new_session_params(
+                    &cwd.to_string_lossy(),
+                    &launch.mcp_servers,
+                    meta.as_ref(),
+                );
                 self.stream
                     .write(&wire::request_line(id, method::SESSION_NEW, params))
                     .await?;
@@ -1129,6 +1135,7 @@ impl Task {
                 let params = wire::load_session_params(
                     acp_session_id,
                     &launch.cwd.to_string_lossy(),
+                    &launch.mcp_servers,
                     meta.as_ref(),
                 );
                 self.stream

--- a/crates/loom/src/acp/wire.rs
+++ b/crates/loom/src/acp/wire.rs
@@ -430,8 +430,8 @@ pub fn initialize_params() -> Value {
 
 /// `session/new` params. `meta` is the optional `_meta` object (adapter options
 /// such as `{"claudeCode":{"options":{...}}}`).
-pub fn new_session_params(cwd: &str, meta: Option<&Value>) -> Value {
-    let mut v = serde_json::json!({ "cwd": cwd, "mcpServers": [] });
+pub fn new_session_params(cwd: &str, mcp_servers: &[Value], meta: Option<&Value>) -> Value {
+    let mut v = serde_json::json!({ "cwd": cwd, "mcpServers": mcp_servers });
     if let Some(meta) = meta {
         v["_meta"] = meta.clone();
     }
@@ -439,8 +439,14 @@ pub fn new_session_params(cwd: &str, meta: Option<&Value>) -> Value {
 }
 
 /// `session/load` params.
-pub fn load_session_params(session_id: &str, cwd: &str, meta: Option<&Value>) -> Value {
-    let mut value = serde_json::json!({ "sessionId": session_id, "cwd": cwd, "mcpServers": [] });
+pub fn load_session_params(
+    session_id: &str,
+    cwd: &str,
+    mcp_servers: &[Value],
+    meta: Option<&Value>,
+) -> Value {
+    let mut value =
+        serde_json::json!({ "sessionId": session_id, "cwd": cwd, "mcpServers": mcp_servers });
     if let Some(meta) = meta {
         value["_meta"] = meta.clone();
     }
@@ -521,9 +527,20 @@ mod tests {
         let meta = serde_json::json!({
             "claudeCode": { "options": { "settingSources": [], "tools": ["Read"] } }
         });
-        let params = load_session_params("session-1", "/worktree", Some(&meta));
+        let servers = vec![json!({
+            "name": "loom_github",
+            "command": "/usr/bin/loom",
+            "args": ["mcp", "serve", "github"],
+            "env": [],
+        })];
+        let params = load_session_params("session-1", "/worktree", &servers, Some(&meta));
         assert_eq!(params["sessionId"], "session-1");
         assert_eq!(params["_meta"], meta);
+        assert_eq!(params["mcpServers"], json!(servers));
+
+        let fresh = new_session_params("/worktree", &servers, None);
+        assert_eq!(fresh["mcpServers"], json!(servers));
+        assert!(fresh.get("_meta").is_none());
     }
 
     #[test]

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -894,6 +894,8 @@ pub struct AcpLaunchSpec<'a> {
     pub restricted: bool,
     /// JSON array stamped on the session/profile.
     pub allowed_tools: &'a str,
+    /// Provider-neutral MCP policy snapshot stamped onto the session.
+    pub mcp_access: &'a str,
     /// The resolved custom agent when `runtime` names one (its `launch` command is
     /// the ACP adapter); `None` for the builtin claude.
     pub custom: Option<&'a CustomAgent>,
@@ -938,6 +940,11 @@ pub async fn build_acp_launch(
 
     let primer_text = read_opt(spec.primer_file).await;
     let mut goal_text = read_opt(spec.goal_file).await;
+    let allowed_tools: Vec<String> = serde_json::from_str(spec.allowed_tools)
+        .context("invalid session runtime-permission snapshot")?;
+    let mcp_snapshot: weaver_api::McpPolicySnapshot =
+        serde_json::from_str(spec.mcp_access).context("invalid session MCP policy snapshot")?;
+    let mcp_servers = crate::mcp::acp_server_configs(&allowed_tools, Some(&mcp_snapshot));
     if is_codex && goal_text.is_none() {
         // No appendSystemPrompt analogue: a primer-only launch seeds the primer
         // positionally, mirroring the terminal path's
@@ -1005,6 +1012,7 @@ pub async fn build_acp_launch(
         cwd: spec.work_dir.to_path_buf(),
         env,
         env_clear: spec.env_clear,
+        mcp_servers,
         new_or_load,
         // Codex boots directly in its mapped mode via `INITIAL_AGENT_MODE`; a
         // post-setup `session/set_mode` would re-send a claude-flavored id it
@@ -1179,9 +1187,8 @@ fn claude_acp_meta(
     if !mode.is_empty() {
         options.insert("permissionMode".to_string(), json!(mode));
     }
+    let allowed_tools: Vec<String> = serde_json::from_str(allowed_tools_json).unwrap_or_default();
     if restricted {
-        let allowed_tools: Vec<String> =
-            serde_json::from_str(allowed_tools_json).unwrap_or_default();
         let mut tools = Vec::<String>::new();
         for rule in &allowed_tools {
             let Some(name) = crate::profile::allowed_tool_name(rule) else {
@@ -1210,10 +1217,6 @@ fn claude_acp_meta(
         options.insert("tools".to_string(), json!(tools));
         options.insert("settingSources".to_string(), json!([]));
         options.insert("strictMcpConfig".to_string(), json!(true));
-        let mcp_servers = crate::mcp::server_configs(&allowed_tools);
-        if !mcp_servers.is_empty() {
-            options.insert("mcpServers".to_string(), Value::Object(mcp_servers));
-        }
     }
     if options.is_empty() {
         return None;
@@ -2125,11 +2128,7 @@ mod tests {
                 "mcp__loom_github__issue_comment"
             ])
         );
-        assert_eq!(restricted["mcpServers"]["loom_github"]["command"], "loom");
-        assert_eq!(
-            restricted["mcpServers"]["loom_github"]["args"],
-            json!(["mcp", "serve", "github"])
-        );
+        assert!(restricted.get("mcpServers").is_none());
         assert_eq!(opts2["permissionMode"], "plan");
     }
 
@@ -2159,6 +2158,8 @@ mod tests {
                 prelude: "none",
                 restricted: true,
                 allowed_tools: r#"["Read(./**)","mcp__loom_github__issue_edit"]"#,
+                mcp_access:
+                    r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[],"custom_servers":[]}"#,
                 custom: None,
             },
             AcpOpen::Fresh,
@@ -2182,5 +2183,21 @@ mod tests {
             .env
             .iter()
             .any(|(name, value)| { name == "CLAUDE_CODE_DISABLE_AUTO_MEMORY" && value == "1" }));
+        assert_eq!(launch.mcp_servers.len(), 1);
+        assert_eq!(launch.mcp_servers[0]["name"], "loom_github");
+        assert!(launch.mcp_servers[0]["command"]
+            .as_str()
+            .is_some_and(|command| std::path::Path::new(command).is_absolute()));
+        assert_eq!(
+            launch.mcp_servers[0]["args"],
+            json!(["mcp", "serve", "github"])
+        );
+        assert_eq!(
+            launch.mcp_servers[0]["env"],
+            json!([{
+                "name": "LOOM_MCP_ALLOWED_TOOLS",
+                "value": "[\"issue_edit\"]"
+            }])
+        );
     }
 }

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -2128,7 +2128,7 @@ mod tests {
         assert_eq!(restricted["mcpServers"]["loom_github"]["command"], "loom");
         assert_eq!(
             restricted["mcpServers"]["loom_github"]["args"],
-            json!(["mcp", "github"])
+            json!(["mcp", "serve", "github"])
         );
         assert_eq!(opts2["permissionMode"], "plan");
     }

--- a/crates/loom/src/automation.rs
+++ b/crates/loom/src/automation.rs
@@ -659,6 +659,7 @@ mod tests {
                 prelude: "weaver".to_string(),
                 restricted: false,
                 allowed_tools: vec![],
+                mcp_access: weaver_api::McpAccess::default(),
             },
         )
         .await

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -29,9 +29,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
-    /// Run one built-in stdio MCP adapter.
-    #[command(hide = true)]
-    Mcp { adapter: String },
+    /// Inspect trusted MCP capability sets, or run an internal stdio adapter.
+    Mcp {
+        #[command(subcommand)]
+        cmd: McpCmd,
+    },
     /// Manage the loom server daemon: run, start, stop, restart, status.
     ///
     /// `loom server run` runs the server in the foreground (REST API + Vue UI +
@@ -666,6 +668,17 @@ enum DeploymentCmd {
 }
 
 #[derive(Subcommand)]
+enum McpCmd {
+    /// List trusted MCP adapters and capability sets.
+    Ls,
+    /// Show one versioned capability set by name.
+    Show { name: String },
+    /// Run one trusted stdio adapter (used only by Loom's agent runtime).
+    #[command(hide = true)]
+    Serve { adapter: String },
+}
+
+#[derive(Subcommand)]
 enum ProfileCmd {
     /// Add a named launch profile.
     Add(Box<ProfileAddOpts>),
@@ -866,7 +879,7 @@ async fn run() -> Result<()> {
     let Cli { context, cmd } = Cli::parse();
     client::set_context_override(context.as_deref())?;
     match cmd {
-        Cmd::Mcp { adapter } => loom::mcp::serve(&adapter).await,
+        Cmd::Mcp { cmd } => run_mcp(cmd).await,
         Cmd::Server { cmd } => run_server(cmd).await,
         Cmd::Session { cmd } => run_session(cmd).await,
         Cmd::Issue { cmd } => run_issue(cmd).await,
@@ -955,6 +968,32 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
             branch,
             keep_branch,
         } => cmd_rm(branch, keep_branch).await,
+    }
+}
+
+async fn run_mcp(cmd: McpCmd) -> Result<()> {
+    match cmd {
+        McpCmd::Serve { adapter } => loom::mcp::serve(&adapter).await,
+        McpCmd::Ls => {
+            let registry = client::default()?.mcp_registry().await?;
+            for set in registry.capability_sets {
+                println!(
+                    "{:<30} {:<4} {:<12} {}",
+                    set.name, set.version, set.adapter, set.description
+                );
+            }
+            Ok(())
+        }
+        McpCmd::Show { name } => {
+            let registry = client::default()?.mcp_registry().await?;
+            let set = registry
+                .capability_sets
+                .into_iter()
+                .find(|set| set.name == name)
+                .ok_or_else(|| anyhow!("unknown MCP capability set '{name}'"))?;
+            println!("{}", serde_json::to_string_pretty(&set)?);
+            Ok(())
+        }
     }
 }
 

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -673,9 +673,34 @@ enum McpCmd {
     Ls,
     /// Show one versioned capability set by name.
     Show { name: String },
+    /// Add or replace an operator-authored uv MCP script.
+    Add(Box<McpAddOpts>),
+    /// Remove an operator-authored MCP definition.
+    Rm { identity: String },
     /// Run one trusted stdio adapter (used only by Loom's agent runtime).
     #[command(hide = true)]
     Serve { adapter: String },
+    /// Run an exact custom source snapshot (used only by the agent runtime).
+    #[command(hide = true)]
+    ServeCustom { identity: String },
+}
+
+#[derive(Args)]
+struct McpAddOpts {
+    /// Absolute identity, for example /engineering/search/docs.
+    identity: String,
+    #[arg(long)]
+    label: String,
+    #[arg(long, default_value = "")]
+    description: String,
+    /// Python script containing PEP 723 inline dependencies.
+    #[arg(long)]
+    file: String,
+    /// Optional uv Python test script.
+    #[arg(long)]
+    tests: Option<String>,
+    #[arg(long)]
+    disabled: bool,
 }
 
 #[derive(Subcommand)]
@@ -685,7 +710,14 @@ enum ProfileCmd {
     /// List profiles (secret values are never returned).
     Ls,
     /// Show one profile.
-    Show { name: String },
+    Show {
+        name: String,
+        /// Resolve the exact runtime permissions and MCP processes.
+        #[arg(long)]
+        effective: bool,
+    },
+    /// Validate and resolve a profile without launching a session.
+    Probe { name: String },
     /// Remove an unused profile (`default` is protected).
     Rm { name: String },
     /// Manage a profile's write-only environment.
@@ -730,9 +762,16 @@ struct ProfileAddOpts {
     /// Apply Loom's restricted automation security posture.
     #[arg(long)]
     restricted: bool,
-    /// Claude SDK tool rules allowed without an interactive approval.
-    #[arg(long, value_delimiter = ',')]
-    allowed_tool: Vec<String>,
+    /// Provider runtime permission rules (legacy; prefer --mcp).
+    #[arg(
+        long = "runtime-permission",
+        visible_alias = "allowed-tool",
+        value_delimiter = ','
+    )]
+    runtime_permission: Vec<String>,
+    /// MCP access mode: none, all, or a comma-separated group list.
+    #[arg(long, default_value = "none")]
+    mcp: String,
 }
 
 #[derive(Subcommand)]
@@ -974,24 +1013,84 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
 async fn run_mcp(cmd: McpCmd) -> Result<()> {
     match cmd {
         McpCmd::Serve { adapter } => loom::mcp::serve(&adapter).await,
+        McpCmd::ServeCustom { identity } => loom::custom_mcp::serve_from_env(&identity).await,
         McpCmd::Ls => {
             let registry = client::default()?.mcp_registry().await?;
-            for set in registry.capability_sets {
+            for set in &registry.capability_sets {
                 println!(
                     "{:<30} {:<4} {:<12} {}",
                     set.name, set.version, set.adapter, set.description
+                );
+            }
+            for server in &registry.custom_servers {
+                println!(
+                    "{:<30} r{:<3} {:<12} {}",
+                    server.identity, server.revision, server.validation_state, server.description
                 );
             }
             Ok(())
         }
         McpCmd::Show { name } => {
             let registry = client::default()?.mcp_registry().await?;
+            if let Some(server) = registry
+                .custom_servers
+                .iter()
+                .find(|server| server.identity == name)
+            {
+                println!("{}", serde_json::to_string_pretty(server)?);
+                return Ok(());
+            }
             let set = registry
                 .capability_sets
                 .into_iter()
                 .find(|set| set.name == name)
                 .ok_or_else(|| anyhow!("unknown MCP capability set '{name}'"))?;
             println!("{}", serde_json::to_string_pretty(&set)?);
+            Ok(())
+        }
+        McpCmd::Add(opts) => {
+            let source = std::fs::read_to_string(&opts.file)
+                .with_context(|| format!("reading custom MCP source {}", opts.file))?;
+            let test_source = match &opts.tests {
+                Some(path) => std::fs::read_to_string(path)
+                    .with_context(|| format!("reading custom MCP tests {path}"))?,
+                None => String::new(),
+            };
+            let req = weaver_api::CustomMcpReq {
+                identity: opts.identity.clone(),
+                label: opts.label.clone(),
+                description: opts.description.clone(),
+                source,
+                test_source,
+                enabled: !opts.disabled,
+            };
+            let registry = client::default()?.mcp_registry().await?;
+            let value = if registry
+                .custom_servers
+                .iter()
+                .any(|server| server.identity == opts.identity)
+            {
+                client::default()?
+                    .put_custom_mcp(&opts.identity, &req)
+                    .await?
+            } else {
+                client::default()?.create_custom_mcp(&req).await?
+            };
+            println!(
+                "{} revision {} ({})",
+                value.identity, value.revision, value.validation_state
+            );
+            if !value.validation_message.is_empty() {
+                println!("{}", value.validation_message);
+            }
+            if value.validation_state != "ready" {
+                bail!("custom MCP validation failed");
+            }
+            Ok(())
+        }
+        McpCmd::Rm { identity } => {
+            client::default()?.delete_custom_mcp(&identity).await?;
+            println!("removed {identity}");
             Ok(())
         }
     }
@@ -1289,7 +1388,8 @@ async fn run_profile(cmd: ProfileCmd) -> Result<()> {
                     turn_budget: opts.turn_budget,
                     prelude: opts.prelude,
                     restricted: opts.restricted,
-                    allowed_tools: opts.allowed_tool,
+                    runtime_permissions: opts.runtime_permission,
+                    mcp_access: parse_mcp_access(&opts.mcp)?,
                 })
                 .await?;
             println!(
@@ -1309,11 +1409,22 @@ async fn run_profile(cmd: ProfileCmd) -> Result<()> {
                 );
             }
         }
-        ProfileCmd::Show { name } => {
+        ProfileCmd::Show { name, effective } => {
             println!(
                 "{}",
-                serde_json::to_string_pretty(&client.get_profile(&name).await?)?
+                if effective {
+                    serde_json::to_string_pretty(&client.effective_profile(&name).await?)?
+                } else {
+                    serde_json::to_string_pretty(&client.get_profile(&name).await?)?
+                }
             );
+        }
+        ProfileCmd::Probe { name } => {
+            let probe = client.probe_profile(&name).await?;
+            println!("{}", serde_json::to_string_pretty(&probe)?);
+            if !probe.ok {
+                bail!("profile probe failed");
+            }
         }
         ProfileCmd::Rm { name } => {
             client.delete_profile(&name).await?;
@@ -1345,6 +1456,29 @@ async fn run_profile(cmd: ProfileCmd) -> Result<()> {
         },
     }
     Ok(())
+}
+
+fn parse_mcp_access(value: &str) -> Result<weaver_api::McpAccess> {
+    let value = value.trim();
+    if matches!(value, "none" | "all") {
+        return Ok(weaver_api::McpAccess {
+            mode: value.to_string(),
+            groups: Vec::new(),
+        });
+    }
+    let groups = value
+        .split(',')
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if groups.is_empty() {
+        bail!("--mcp must be 'none', 'all', or a comma-separated group list");
+    }
+    Ok(weaver_api::McpAccess {
+        mode: "groups".to_string(),
+        groups,
+    })
 }
 
 async fn cmd_token_create(name: String, expires_days: Option<i64>) -> Result<()> {
@@ -3708,6 +3842,58 @@ mod tests {
                     ..
                 }
             } if name == "production"
+        ));
+    }
+
+    #[test]
+    fn profile_mcp_cli_parses_modes_and_groups() {
+        assert_eq!(
+            parse_mcp_access("none").unwrap(),
+            weaver_api::McpAccess::default()
+        );
+        assert_eq!(
+            parse_mcp_access("all").unwrap(),
+            weaver_api::McpAccess {
+                mode: "all".to_string(),
+                groups: vec![],
+            }
+        );
+        assert_eq!(
+            parse_mcp_access("github, messaging").unwrap(),
+            weaver_api::McpAccess {
+                mode: "groups".to_string(),
+                groups: vec!["github".to_string(), "messaging".to_string()],
+            }
+        );
+        assert!(parse_mcp_access("").is_err());
+
+        let Cli { cmd, .. } =
+            Cli::try_parse_from(["loom", "mcp", "show", "mcp/github/comment@v1"]).unwrap();
+        assert!(matches!(
+            cmd,
+            Cmd::Mcp {
+                cmd: McpCmd::Show { name }
+            } if name == "mcp/github/comment@v1"
+        ));
+
+        let Cli { cmd, .. } = Cli::try_parse_from([
+            "loom",
+            "profile",
+            "add",
+            "ops",
+            "--agent",
+            "claude",
+            "--protocol",
+            "acp",
+            "--mcp",
+            "github,messaging",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cmd,
+            Cmd::Profile {
+                cmd: ProfileCmd::Add(options)
+            } if options.mcp == "github,messaging"
         ));
     }
 

--- a/crates/loom/src/custom_mcp.rs
+++ b/crates/loom/src/custom_mcp.rs
@@ -1,0 +1,678 @@
+//! Operator-authored MCP programs stored and revisioned in Loom's database.
+//!
+//! Definitions are admin configuration and may execute arbitrary code. They are
+//! validated before use and are never admitted to restricted sessions.
+
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine as _;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use sqlx::FromRow;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
+    process::Command,
+};
+use weaver_api::{CustomMcpReq, CustomMcpSnapshot, CustomMcpView};
+
+use crate::db::{now_iso, Db};
+
+const SOURCE_MAX_BYTES: usize = 128 * 1024;
+const TEST_MAX_BYTES: usize = 128 * 1024;
+const DIAGNOSTIC_MAX_BYTES: usize = 16 * 1024;
+const MCP_RESPONSE_MAX_BYTES: u64 = 1024 * 1024;
+const TOOL_MAX_COUNT: usize = 256;
+const VALIDATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, FromRow)]
+struct Row {
+    identity: String,
+    group_name: String,
+    label: String,
+    description: String,
+    enabled: bool,
+    current_revision: i64,
+    source: String,
+    test_source: String,
+    digest: String,
+    tools_json: String,
+    validation_state: String,
+    validation_message: String,
+    created_at: String,
+    updated_at: String,
+}
+
+fn row_query() -> &'static str {
+    "SELECT s.identity, s.group_name, s.label, s.description, s.enabled,
+            s.current_revision, r.source, r.test_source, r.digest, r.tools_json,
+            r.validation_state, r.validation_message, s.created_at, s.updated_at
+     FROM custom_mcp_servers s
+     JOIN custom_mcp_revisions r
+       ON r.identity = s.identity AND r.revision = s.current_revision"
+}
+
+fn into_view(row: Row) -> Result<CustomMcpView> {
+    Ok(CustomMcpView {
+        identity: row.identity,
+        group: row.group_name,
+        label: row.label,
+        description: row.description,
+        enabled: row.enabled,
+        revision: row.current_revision,
+        digest: row.digest,
+        source: row.source,
+        test_source: row.test_source,
+        tools: serde_json::from_str(&row.tools_json).context("invalid custom MCP tools")?,
+        validation_state: row.validation_state,
+        validation_message: row.validation_message,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })
+}
+
+pub fn validate_identity(identity: &str) -> Result<String> {
+    let identity = identity.trim();
+    if !identity.starts_with('/') || identity.len() > 160 {
+        bail!("custom MCP identity must start with '/' and be at most 160 bytes");
+    }
+    let parts = identity[1..].split('/').collect::<Vec<_>>();
+    if parts.len() < 2
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || part.len() > 64
+                || !part
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        })
+    {
+        bail!(
+            "custom MCP identity must be /group/name[/name...] using letters, digits, '-' or '_'"
+        );
+    }
+    Ok(parts[0].to_string())
+}
+
+fn validate_request(req: &CustomMcpReq) -> Result<String> {
+    let group = validate_identity(&req.identity)?;
+    if crate::mcp::is_builtin_group(&group) {
+        bail!(
+            "custom MCP group '{group}' is reserved by a trusted builtin; choose a distinct group"
+        );
+    }
+    if req.label.trim().is_empty() || req.label.len() > 128 {
+        bail!("custom MCP label must contain 1 to 128 bytes");
+    }
+    if req.description.len() > 4096 {
+        bail!("custom MCP description must be at most 4096 bytes");
+    }
+    if req.source.trim().is_empty() || req.source.len() > SOURCE_MAX_BYTES {
+        bail!("custom MCP source must contain 1 to {SOURCE_MAX_BYTES} bytes");
+    }
+    if req.test_source.len() > TEST_MAX_BYTES {
+        bail!("custom MCP tests must be at most {TEST_MAX_BYTES} bytes");
+    }
+    Ok(group)
+}
+
+fn digest(source: &str, test_source: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(source);
+    hasher.update([0]);
+    hasher.update(test_source);
+    format!("sha256:{}", hex::encode(hasher.finalize()))
+}
+
+fn bounded(text: impl AsRef<str>) -> String {
+    let text = text.as_ref();
+    if text.len() <= DIAGNOSTIC_MAX_BYTES {
+        text.to_string()
+    } else {
+        let mut end = DIAGNOSTIC_MAX_BYTES;
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &text[..end])
+    }
+}
+
+fn uv_bin() -> String {
+    std::env::var("LOOM_UV_BIN").unwrap_or_else(|_| "uv".to_string())
+}
+
+fn uv_command(cache_dir: &std::path::Path, session_context: bool) -> Command {
+    let mut command = Command::new(uv_bin());
+    command.env_clear();
+    if let Some(path) = std::env::var_os("PATH") {
+        command.env("PATH", path);
+    }
+    command.env(
+        "UV_CACHE_DIR",
+        std::env::var_os("UV_CACHE_DIR").unwrap_or_else(|| cache_dir.into()),
+    );
+    command.env(
+        "UV_PYTHON_INSTALL_DIR",
+        std::env::var_os("UV_PYTHON_INSTALL_DIR")
+            .unwrap_or_else(|| cache_dir.with_file_name(".uv-python").into()),
+    );
+    if session_context {
+        for name in [
+            "WEAVER_API",
+            "WEAVER_BRANCH",
+            "LOOM_SESSION_ID",
+            "LOOM_TOKEN",
+        ] {
+            if let Some(value) = std::env::var_os(name) {
+                command.env(name, value);
+            }
+        }
+    }
+    command
+}
+
+async fn run_tests(source_path: &std::path::Path, test_source: &str) -> Result<String> {
+    if test_source.trim().is_empty() {
+        return Ok(String::new());
+    }
+    let dir = source_path
+        .parent()
+        .context("custom MCP source has no parent")?;
+    let test_path = dir.join("test_mcp.py");
+    tokio::fs::write(&test_path, test_source).await?;
+    let mut command = uv_command(&dir.join(".uv-cache"), false);
+    let mut child = command
+        .args(["run", "--script"])
+        .arg(&test_path)
+        .env("LOOM_MCP_SOURCE", source_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("launching custom MCP tests through uv")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("custom MCP test stdout unavailable")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("custom MCP test stderr unavailable")?;
+    let stdout_task = tokio::spawn(read_bounded(stdout));
+    let stderr_task = tokio::spawn(read_bounded(stderr));
+    let status = match tokio::time::timeout(VALIDATION_TIMEOUT, child.wait()).await {
+        Ok(status) => status?,
+        Err(_) => {
+            let _ = child.kill().await;
+            stdout_task.abort();
+            stderr_task.abort();
+            bail!("custom MCP tests timed out");
+        }
+    };
+    let (stdout, stderr) = tokio::try_join!(stdout_task, stderr_task)?;
+    let stdout = stdout?;
+    let stderr = stderr?;
+    let diagnostics = format!(
+        "{}{}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
+    if !status.success() {
+        bail!("custom MCP tests failed:\n{}", bounded(diagnostics));
+    }
+    Ok(bounded(diagnostics))
+}
+
+async fn read_bounded(mut reader: impl AsyncRead + Unpin) -> std::io::Result<Vec<u8>> {
+    let mut retained = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let count = reader.read(&mut buffer).await?;
+        if count == 0 {
+            break;
+        }
+        let remaining = DIAGNOSTIC_MAX_BYTES.saturating_sub(retained.len());
+        retained.extend_from_slice(&buffer[..count.min(remaining)]);
+    }
+    Ok(retained)
+}
+
+async fn smoke(source_path: &std::path::Path) -> Result<Vec<String>> {
+    let dir = source_path
+        .parent()
+        .context("custom MCP source has no parent")?;
+    let mut command = uv_command(&dir.join(".uv-cache"), false);
+    let mut child = command
+        .args(["run", "--script"])
+        .arg(source_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("launching custom MCP through uv")?;
+    let mut stdin = child.stdin.take().context("custom MCP stdin unavailable")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("custom MCP stdout unavailable")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("custom MCP stderr unavailable")?;
+    let stderr_task = tokio::spawn(read_bounded(stderr));
+    let result = async {
+        stdin
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"loom-validator\",\"version\":\"1\"}}}\n{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n",
+            )
+            .await?;
+        stdin.flush().await?;
+        let mut lines = BufReader::new(stdout.take(MCP_RESPONSE_MAX_BYTES)).lines();
+        let mut tools = None;
+        let deadline = tokio::time::Instant::now() + VALIDATION_TIMEOUT;
+        for _ in 0..8 {
+            let line = tokio::time::timeout_at(deadline, lines.next_line())
+                .await
+                .context("custom MCP tools/list timed out")??
+                .context("custom MCP closed before tools/list")?;
+            let value: Value =
+                serde_json::from_str(&line).context("custom MCP returned invalid JSON")?;
+            if value.get("id") == Some(&json!(2)) {
+                let listed = value
+                    .pointer("/result/tools")
+                    .and_then(Value::as_array)
+                    .context("custom MCP tools/list result is missing tools")?;
+                let names = listed
+                    .iter()
+                    .map(|tool| {
+                        tool.get("name")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                            .context("custom MCP tool is missing a name")
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                if names.len() > TOOL_MAX_COUNT {
+                    bail!("custom MCP may advertise at most {TOOL_MAX_COUNT} tools");
+                }
+                tools = Some(names);
+                break;
+            }
+        }
+        tools.context("custom MCP did not answer tools/list")
+    }
+    .await;
+    drop(stdin);
+    let _ = child.kill().await;
+    let stderr = stderr_task.await??;
+    let tools = result.with_context(|| {
+        let stderr = bounded(String::from_utf8_lossy(&stderr));
+        if stderr.is_empty() {
+            "custom MCP produced no stderr diagnostics".to_string()
+        } else {
+            format!("custom MCP stderr:\n{stderr}")
+        }
+    })?;
+    if tools.is_empty() {
+        bail!("custom MCP must advertise at least one tool");
+    }
+    if tools.iter().any(|name| {
+        name.is_empty()
+            || name.len() > 64
+            || !name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    }) {
+        bail!("custom MCP tool names must use letters, digits, '-' or '_'");
+    }
+    Ok(tools)
+}
+
+async fn validate_source(source: &str, test_source: &str) -> (String, Vec<String>, String) {
+    let result = async {
+        let dir = tempfile::tempdir().context("creating custom MCP validation directory")?;
+        let source_path = dir.path().join("server.py");
+        tokio::fs::write(&source_path, source).await?;
+        let tools = smoke(&source_path).await?;
+        let diagnostics = run_tests(&source_path, test_source).await?;
+        Ok::<_, anyhow::Error>((tools, diagnostics))
+    }
+    .await;
+    match result {
+        Ok((tools, diagnostics)) => ("ready".to_string(), tools, diagnostics),
+        Err(error) => (
+            "failed".to_string(),
+            Vec::new(),
+            bounded(format!("{error:#}")),
+        ),
+    }
+}
+
+pub async fn list(db: &Db) -> Result<Vec<CustomMcpView>> {
+    let rows = sqlx::query_as::<_, Row>(&format!("{} ORDER BY s.identity", row_query()))
+        .fetch_all(db)
+        .await?;
+    rows.into_iter().map(into_view).collect()
+}
+
+pub async fn get(db: &Db, identity: &str) -> Result<Option<CustomMcpView>> {
+    let row = sqlx::query_as::<_, Row>(&format!("{} WHERE s.identity = ?", row_query()))
+        .bind(identity)
+        .fetch_optional(db)
+        .await?;
+    row.map(into_view).transpose()
+}
+
+pub async fn upsert(db: &Db, req: &CustomMcpReq) -> Result<CustomMcpView> {
+    let group = validate_request(req)?;
+    let existing = get(db, &req.identity).await?;
+    if let Some(existing) = &existing {
+        if existing.source == req.source
+            && existing.test_source == req.test_source
+            && existing.label == req.label.trim()
+            && existing.description == req.description.trim()
+            && existing.enabled == req.enabled
+        {
+            return Ok(existing.clone());
+        }
+    }
+    let revision = existing.as_ref().map_or(1, |value| value.revision + 1);
+    let (validation_state, tools, validation_message) =
+        validate_source(&req.source, &req.test_source).await;
+    let now = now_iso();
+    let mut tx = db.begin().await?;
+    sqlx::query(
+        "INSERT INTO custom_mcp_servers
+         (identity, group_name, label, description, enabled, current_revision, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(identity) DO UPDATE SET
+          group_name=excluded.group_name, label=excluded.label,
+          description=excluded.description, enabled=excluded.enabled,
+          current_revision=excluded.current_revision, updated_at=excluded.updated_at",
+    )
+    .bind(req.identity.trim())
+    .bind(group)
+    .bind(req.label.trim())
+    .bind(req.description.trim())
+    .bind(req.enabled)
+    .bind(revision)
+    .bind(existing.as_ref().map_or(now.as_str(), |value| value.created_at.as_str()))
+    .bind(&now)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO custom_mcp_revisions
+         (identity, revision, source, test_source, digest, tools_json,
+          validation_state, validation_message, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(req.identity.trim())
+    .bind(revision)
+    .bind(&req.source)
+    .bind(&req.test_source)
+    .bind(digest(&req.source, &req.test_source))
+    .bind(serde_json::to_string(&tools)?)
+    .bind(validation_state)
+    .bind(validation_message)
+    .bind(&now)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    get(db, req.identity.trim())
+        .await?
+        .ok_or_else(|| anyhow!("custom MCP vanished after upsert"))
+}
+
+pub async fn remove(db: &Db, identity: &str) -> Result<bool> {
+    let Some(target) = get(db, identity).await? else {
+        return Ok(false);
+    };
+    for profile in crate::profile::list(db).await? {
+        if profile
+            .mcp_policy_snapshot()?
+            .custom_servers
+            .iter()
+            .any(|server| server.identity == identity)
+        {
+            bail!(
+                "custom MCP '{}' is pinned by profile '{}'; update the profile before removing it",
+                identity,
+                profile.name
+            );
+        }
+    }
+    let group_has_other_server = list(db)
+        .await?
+        .iter()
+        .any(|server| server.identity != identity && server.group == target.group);
+    if !group_has_other_server {
+        for profile in crate::profile::list(db).await? {
+            let access = profile.mcp_access()?;
+            if access.mode == "groups" && access.groups.contains(&target.group) {
+                bail!(
+                    "custom MCP group '{}' is selected by profile '{}'; update the profile before removing its last server",
+                    target.group,
+                    profile.name
+                );
+            }
+        }
+    }
+    Ok(
+        sqlx::query("DELETE FROM custom_mcp_servers WHERE identity = ?")
+            .bind(identity)
+            .execute(db)
+            .await?
+            .rows_affected()
+            > 0,
+    )
+}
+
+pub fn ready_snapshots(items: &[CustomMcpView]) -> Vec<CustomMcpSnapshot> {
+    items
+        .iter()
+        .filter(|item| item.enabled && item.validation_state == "ready")
+        .map(|item| CustomMcpSnapshot {
+            server_name: server_name(&item.identity),
+            identity: item.identity.clone(),
+            group: item.group.clone(),
+            revision: item.revision,
+            digest: item.digest.clone(),
+            tools: item.tools.clone(),
+            source: item.source.clone(),
+        })
+        .collect()
+}
+
+pub fn server_name(identity: &str) -> String {
+    let digest = Sha256::digest(identity.as_bytes());
+    format!("loom_custom_{}", &hex::encode(digest)[..12])
+}
+
+pub fn permission_rule(server_name: &str, tool: &str) -> String {
+    format!("mcp__{server_name}__{tool}")
+}
+
+async fn forward_runtime_response(
+    line: &str,
+    pending_tool_lists: &mut Vec<Value>,
+    client_stdout: &mut (impl tokio::io::AsyncWrite + Unpin),
+) -> Result<()> {
+    let mut value: Value =
+        serde_json::from_str(line).context("custom MCP wrote invalid JSON to stdout")?;
+    if let Some(position) = value
+        .get("id")
+        .and_then(|id| pending_tool_lists.iter().position(|pending| pending == id))
+    {
+        pending_tool_lists.swap_remove(position);
+        if let Some(tools) = value.pointer_mut("/result/tools") {
+            *tools = crate::mcp::runtime_tools(tools.take());
+        }
+    }
+    client_stdout
+        .write_all(serde_json::to_string(&value)?.as_bytes())
+        .await?;
+    client_stdout.write_all(b"\n").await?;
+    client_stdout.flush().await?;
+    Ok(())
+}
+
+/// Decode the exact source carried in a session-stamped server config and
+/// proxy stdio to its uv-managed process.
+pub async fn serve_from_env(identity: &str) -> Result<()> {
+    validate_identity(identity)?;
+    let encoded = std::env::var("LOOM_CUSTOM_MCP_SOURCE_B64")
+        .context("custom MCP source is missing from the session snapshot")?;
+    let source = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .context("decoding custom MCP source")?;
+    let dir = tempfile::tempdir().context("creating custom MCP runtime directory")?;
+    let source_path = dir.path().join("server.py");
+    tokio::fs::write(&source_path, source).await?;
+    let mut command = uv_command(&dir.path().join(".uv-cache"), true);
+    let mut child = command
+        .args(["run", "--script"])
+        .arg(&source_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .kill_on_drop(true)
+        .spawn()
+        .context("launching custom MCP through uv")?;
+    let mut child_stdin = Some(child.stdin.take().context("custom MCP stdin unavailable")?);
+    let child_stdout = child
+        .stdout
+        .take()
+        .context("custom MCP stdout unavailable")?;
+    let mut client_lines = BufReader::new(tokio::io::stdin()).lines();
+    let mut server_lines = BufReader::new(child_stdout).lines();
+    let mut client_stdout = tokio::io::stdout();
+    let mut pending_tool_lists = Vec::<Value>::new();
+
+    loop {
+        tokio::select! {
+            request = client_lines.next_line() => {
+                let Some(line) = request? else {
+                    let mut stdin = child_stdin
+                        .take()
+                        .context("custom MCP stdin closed unexpectedly")?;
+                    stdin.shutdown().await?;
+                    drop(stdin);
+                    let drain = async {
+                        while let Some(line) = server_lines.next_line().await? {
+                            forward_runtime_response(
+                                &line,
+                                &mut pending_tool_lists,
+                                &mut client_stdout,
+                            )
+                            .await?;
+                        }
+                        Ok::<_, anyhow::Error>(())
+                    };
+                    match tokio::time::timeout(Duration::from_secs(5), drain).await {
+                        Ok(result) => result?,
+                        Err(_) => {
+                            child.kill().await?;
+                            bail!("custom MCP '{identity}' did not exit after stdin closed");
+                        }
+                    }
+                    break;
+                };
+                let value: Value = serde_json::from_str(&line)
+                    .context("custom MCP proxy received invalid client JSON")?;
+                if value.get("method").and_then(Value::as_str) == Some("tools/list") {
+                    if let Some(id) = value.get("id") {
+                        pending_tool_lists.push(id.clone());
+                    }
+                }
+                if value.get("method").and_then(Value::as_str) == Some("tools/call") {
+                    if let Some(name) = value.pointer("/params/name").and_then(Value::as_str) {
+                        if !crate::mcp::runtime_tool_allowed(name) {
+                            if let Some(id) = value.get("id") {
+                                let response = json!({
+                                    "jsonrpc": "2.0",
+                                    "id": id,
+                                    "error": {
+                                        "code": -32601,
+                                        "message": format!(
+                                            "custom MCP tool '{name}' is not allowed by this session"
+                                        )
+                                    }
+                                });
+                                client_stdout
+                                    .write_all(serde_json::to_string(&response)?.as_bytes())
+                                    .await?;
+                                client_stdout.write_all(b"\n").await?;
+                                client_stdout.flush().await?;
+                            }
+                            continue;
+                        }
+                    }
+                }
+                let stdin = child_stdin
+                    .as_mut()
+                    .context("custom MCP stdin closed unexpectedly")?;
+                stdin.write_all(line.as_bytes()).await?;
+                stdin.write_all(b"\n").await?;
+                stdin.flush().await?;
+            }
+            response = server_lines.next_line() => {
+                let Some(line) = response? else {
+                    break;
+                };
+                forward_runtime_response(
+                    &line,
+                    &mut pending_tool_lists,
+                    &mut client_stdout,
+                )
+                .await?;
+            }
+        }
+    }
+    drop(child_stdin);
+    let status = match tokio::time::timeout(Duration::from_secs(5), child.wait()).await {
+        Ok(status) => status?,
+        Err(_) => {
+            child.kill().await?;
+            bail!("custom MCP '{identity}' did not exit after stdin closed");
+        }
+    };
+    if !status.success() {
+        bail!("custom MCP '{identity}' exited with {status}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identities_are_absolute_grouped_paths() {
+        assert_eq!(
+            validate_identity("/engineering/search/docs").unwrap(),
+            "engineering"
+        );
+        assert!(validate_identity("engineering/search").is_err());
+        assert!(validate_identity("/one").is_err());
+        assert!(validate_identity("/bad/../name").is_err());
+    }
+
+    #[test]
+    fn server_names_and_permissions_are_stable() {
+        let name = server_name("/engineering/search/docs");
+        assert_eq!(name, server_name("/engineering/search/docs"));
+        assert!(permission_rule(&name, "lookup").starts_with("mcp__loom_custom_"));
+    }
+
+    #[test]
+    fn builtin_groups_cannot_be_shadowed() {
+        let error = validate_request(&CustomMcpReq {
+            identity: "/github/shadow".to_string(),
+            label: "shadow".to_string(),
+            source: "print('no')".to_string(),
+            enabled: true,
+            ..Default::default()
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("reserved by a trusted builtin"));
+    }
+}

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -35,6 +35,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "restricted-profiles",
         include_str!("../migrations/0005_restricted_profiles.sql"),
     ),
+    (
+        6,
+        "mcp-access",
+        include_str!("../migrations/0006_mcp_access.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -84,6 +89,7 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
 
     LOOM_STREAM.ensure_indicator(pool).await?;
     LOOM_STREAM.apply_pending(pool).await?;
+    crate::profile::backfill_mcp_policies(pool).await?;
     crate::profile::normalize_default(pool).await?;
     crate::profile::seed_stock_profiles(pool).await?;
 
@@ -263,7 +269,7 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5]);
+        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6]);
 
         let columns = table_columns(&db, "sessions").await.unwrap();
         for expected in [
@@ -281,6 +287,7 @@ mod tests {
             "policy_prelude",
             "policy_restricted",
             "policy_allowed_tools",
+            "policy_mcp_access",
         ] {
             assert!(
                 columns.iter().any(|column| column == expected),
@@ -296,10 +303,7 @@ mod tests {
         assert_eq!(stock.prelude, "none");
         assert_eq!(stock.agent_kind, "claude");
         assert_eq!(stock.mode, "default");
-        assert!(stock
-            .allowed_tool_rules()
-            .unwrap()
-            .contains(&"mcp/github/comment@v1".to_string()));
+        assert_eq!(stock.mcp_access().unwrap().groups, vec!["github"]);
 
         insert_branch(&db, "t1").await;
         sqlx::query(
@@ -310,6 +314,39 @@ mod tests {
         .execute(&db)
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn mcp_migration_preserves_legacy_profile_intent() {
+        let db = core_connect_in_memory().await.unwrap();
+        for (_, _, migration) in LOOM_MIGRATIONS.iter().take(5) {
+            for statement in split_statements(migration) {
+                sqlx::query(&statement).execute(&db).await.unwrap();
+            }
+        }
+        sqlx::query(
+            "UPDATE profiles
+             SET allowed_tools = '[\"Read(./**)\",\"mcp/github/comment@v1\"]'
+             WHERE name = 'default'",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        for statement in split_statements(LOOM_MIGRATIONS[5].2) {
+            sqlx::query(&statement).execute(&db).await.unwrap();
+        }
+
+        let row =
+            sqlx::query("SELECT allowed_tools, mcp_access FROM profiles WHERE name = 'default'")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(row.get::<String, _>("allowed_tools"), r#"["Read(./**)"]"#);
+        assert_eq!(
+            row.get::<String, _>("mcp_access"),
+            r#"{"mode":"groups","groups":["github"]}"#
+        );
     }
 
     /// Regression for the on-disk upgrade path: loom once opened the shared
@@ -363,7 +400,7 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5]);
+        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6]);
         let index_sql: String = sqlx::query_scalar(
             "SELECT sql FROM sqlite_master
              WHERE type = 'index' AND name = 'idx_sessions_active_branch'",
@@ -437,7 +474,7 @@ mod tests {
             .fetch_one(&db)
             .await
             .unwrap();
-        assert_eq!(count, 5);
+        assert_eq!(count, 6);
 
         // Adoption replaced the historical index predicate: archived history
         // no longer prevents a new active session from claiming the branch.

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -299,7 +299,7 @@ mod tests {
         assert!(stock
             .allowed_tool_rules()
             .unwrap()
-            .contains(&"mcp/github/comment".to_string()));
+            .contains(&"mcp/github/comment@v1".to_string()));
 
         insert_branch(&db, "t1").await;
         sqlx::query(

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -17,6 +17,7 @@ pub mod chatlog;
 pub mod client;
 pub mod client_context;
 pub mod custom_agents;
+pub mod custom_mcp;
 pub mod db;
 pub mod endpoint;
 pub mod envfile;

--- a/crates/loom/src/mcp/github.rs
+++ b/crates/loom/src/mcp/github.rs
@@ -33,11 +33,13 @@ pub(super) const ADAPTER: Adapter = Adapter {
     expand_tool_set,
     is_permission_rule,
     server_config,
+    tools,
     serve: serve_boxed,
 };
 
 const CAPABILITY_SETS: &[CapabilitySet] = &[CapabilitySet {
     name: COMMENT_TOOL_SET_V1,
+    group: "github",
     version: "v1",
     description: "Read, comment on, and edit the issue or pull request bound to the session.",
     tools: &GITHUB_TOOL_NAMES,
@@ -152,6 +154,12 @@ fn error(id: &Value, code: i64, message: impl Into<String>) -> Value {
 }
 
 async fn call_tool(name: &str, arguments: Value) -> Result<Value> {
+    if !GITHUB_TOOL_NAMES.contains(&name) {
+        anyhow::bail!("unknown GitHub tool '{name}'");
+    }
+    if !super::runtime_tool_allowed(name) {
+        anyhow::bail!("GitHub tool '{name}' is not allowed by this session");
+    }
     let session_id =
         std::env::var("LOOM_SESSION_ID").context("restricted MCP is missing LOOM_SESSION_ID")?;
     let path = format!(
@@ -195,7 +203,7 @@ async fn dispatch(request: Value) -> Option<Value> {
             )
         }
         "ping" => result(&id, json!({})),
-        "tools/list" => result(&id, json!({ "tools": tools() })),
+        "tools/list" => result(&id, json!({ "tools": super::runtime_tools(tools()) })),
         "tools/call" => {
             let name = request.pointer("/params/name").and_then(Value::as_str);
             let arguments = request
@@ -208,7 +216,7 @@ async fn dispatch(request: Value) -> Option<Value> {
                     Err(err) => result(
                         &id,
                         json!({
-                            "content": [{ "type": "text", "text": err.to_string() }],
+                            "content": [{ "type": "text", "text": format!("{err:#}") }],
                             "isError": true
                         }),
                     ),

--- a/crates/loom/src/mcp/github.rs
+++ b/crates/loom/src/mcp/github.rs
@@ -9,10 +9,11 @@ use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-use super::{Adapter, ServeFuture};
+use super::{Adapter, CapabilitySet, ServeFuture};
 
 const SERVER_NAME: &str = "loom_github";
 const COMMENT_TOOL_SET: &str = "mcp/github/comment";
+const COMMENT_TOOL_SET_V1: &str = "mcp/github/comment@v1";
 pub(crate) const BODY_MAX_BYTES: usize = 65_536;
 pub(crate) const TITLE_MAX_BYTES: usize = 256;
 const GITHUB_TOOL_NAMES: [&str; 6] = [
@@ -27,11 +28,24 @@ const GITHUB_TOOL_NAMES: [&str; 6] = [
 pub(super) const ADAPTER: Adapter = Adapter {
     name: "github",
     server_name: SERVER_NAME,
+    description: "Repository-scoped GitHub issue and pull-request operations.",
+    capability_sets,
     expand_tool_set,
     is_permission_rule,
     server_config,
     serve: serve_boxed,
 };
+
+const CAPABILITY_SETS: &[CapabilitySet] = &[CapabilitySet {
+    name: COMMENT_TOOL_SET_V1,
+    version: "v1",
+    description: "Read, comment on, and edit the issue or pull request bound to the session.",
+    tools: &GITHUB_TOOL_NAMES,
+}];
+
+fn capability_sets() -> &'static [CapabilitySet] {
+    CAPABILITY_SETS
+}
 
 pub(crate) fn permission_rule(tool: &str) -> Option<String> {
     GITHUB_TOOL_NAMES
@@ -46,7 +60,7 @@ fn is_permission_rule(rule: &str) -> bool {
 }
 
 fn expand_tool_set(name: &str) -> Option<Vec<String>> {
-    (name == COMMENT_TOOL_SET).then(|| {
+    (matches!(name, COMMENT_TOOL_SET | COMMENT_TOOL_SET_V1)).then(|| {
         GITHUB_TOOL_NAMES
             .iter()
             .map(|tool| permission_rule(tool).expect("registered GitHub tool"))
@@ -58,7 +72,7 @@ fn server_config() -> Value {
     json!({
         "type": "stdio",
         "command": "loom",
-        "args": ["mcp", ADAPTER.name]
+        "args": ["mcp", "serve", ADAPTER.name]
     })
 }
 
@@ -246,7 +260,7 @@ mod tests {
 
     #[test]
     fn comment_set_expands_to_the_fixed_surface() {
-        let expanded = expand_tool_set("mcp/github/comment").unwrap();
+        let expanded = expand_tool_set("mcp/github/comment@v1").unwrap();
         assert_eq!(expanded.len(), GITHUB_TOOL_NAMES.len());
         assert_eq!(expanded[0], permission_rule(GITHUB_TOOL_NAMES[0]).unwrap());
         assert!(expand_tool_set("mcp/github/admin").is_none());
@@ -255,6 +269,9 @@ mod tests {
     #[test]
     fn registry_launches_the_generic_adapter_command() {
         let config = server_config();
-        assert_eq!(config["args"], serde_json::json!(["mcp", "github"]));
+        assert_eq!(
+            config["args"],
+            serde_json::json!(["mcp", "serve", "github"])
+        );
     }
 }

--- a/crates/loom/src/mcp/messaging.rs
+++ b/crates/loom/src/mcp/messaging.rs
@@ -1,0 +1,262 @@
+//! Built-in session messaging MCP adapter.
+//!
+//! Both operations are facades over Loom's existing session-scoped REST
+//! routes. Credentials, branch/thread routing, durable status events, and
+//! GitHub/Slack mirroring remain server-side.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use super::{Adapter, CapabilitySet, ServeFuture};
+
+const SERVER_NAME: &str = "loom_messaging";
+const TOOL_NAMES: [&str; 2] = ["status_update", "slack_reply"];
+
+pub(super) const ADAPTER: Adapter = Adapter {
+    name: "messaging",
+    server_name: SERVER_NAME,
+    description: "Session status and fixed-thread messaging through Loom routing.",
+    capability_sets,
+    expand_tool_set,
+    is_permission_rule,
+    server_config,
+    tools,
+    serve: serve_boxed,
+};
+
+const STATUS_TOOLS: &[&str] = &["status_update"];
+const SLACK_TOOLS: &[&str] = &["slack_reply"];
+const CAPABILITY_SETS: &[CapabilitySet] = &[
+    CapabilitySet {
+        name: "mcp/messaging/status@v1",
+        group: "messaging",
+        version: "v1",
+        description: "Update the durable Weaver status and its configured mirrors.",
+        tools: STATUS_TOOLS,
+    },
+    CapabilitySet {
+        name: "mcp/slack/message@v1",
+        group: "messaging",
+        version: "v1",
+        description: "Post a message to the Slack thread fixed to this session.",
+        tools: SLACK_TOOLS,
+    },
+];
+
+fn capability_sets() -> &'static [CapabilitySet] {
+    CAPABILITY_SETS
+}
+
+fn permission_rule(tool: &str) -> Option<String> {
+    TOOL_NAMES
+        .contains(&tool)
+        .then(|| format!("mcp__{SERVER_NAME}__{tool}"))
+}
+
+fn is_permission_rule(rule: &str) -> bool {
+    TOOL_NAMES
+        .iter()
+        .any(|tool| permission_rule(tool).as_deref() == Some(rule))
+}
+
+fn expand_tool_set(name: &str) -> Option<Vec<String>> {
+    CAPABILITY_SETS
+        .iter()
+        .find(|set| set.name == name)
+        .map(|set| {
+            set.tools
+                .iter()
+                .map(|tool| permission_rule(tool).expect("registered messaging tool"))
+                .collect()
+        })
+}
+
+fn server_config() -> Value {
+    json!({
+        "type": "stdio",
+        "command": "loom",
+        "args": ["mcp", "serve", ADAPTER.name]
+    })
+}
+
+fn serve_boxed() -> ServeFuture {
+    Box::pin(serve())
+}
+
+fn tools() -> Value {
+    json!([
+        {
+            "name": "status_update",
+            "description": "Update this session's durable status. Configured GitHub and Slack status cards are updated automatically.",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "level": { "type": "string", "enum": ["ok", "attention", "blocked"] },
+                    "message": { "type": "string", "maxLength": 4096 }
+                },
+                "required": ["level", "message"]
+            }
+        },
+        {
+            "name": "slack_reply",
+            "description": "Post a message to the Slack thread fixed to this session.",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "text": { "type": "string", "minLength": 1, "maxLength": 4000 }
+                },
+                "required": ["text"]
+            }
+        }
+    ])
+}
+
+async fn call_tool(name: &str, arguments: Value) -> Result<Value> {
+    if !TOOL_NAMES.contains(&name) {
+        bail!("unknown messaging tool '{name}'");
+    }
+    if !super::runtime_tool_allowed(name) {
+        bail!("messaging tool '{name}' is not allowed by this session");
+    }
+    let session_id =
+        std::env::var("LOOM_SESSION_ID").context("messaging MCP is missing LOOM_SESSION_ID")?;
+    let token = weaver_api::endpoint::token_from_env()
+        .context("messaging MCP is missing its session-scoped LOOM_TOKEN")?;
+    let client = weaver_api::Client::new(weaver_api::endpoint::base_url()).with_token(Some(token));
+    let session = client
+        .get_session(&session_id)
+        .await
+        .context("resolving the messaging MCP session")?;
+    let text = match name {
+        "status_update" => {
+            let level = arguments
+                .get("level")
+                .and_then(Value::as_str)
+                .context("status_update requires level")?;
+            let message = arguments
+                .get("message")
+                .and_then(Value::as_str)
+                .context("status_update requires message")?;
+            if message.len() > 4096 {
+                bail!("status_update message must be at most 4096 bytes");
+            }
+            client
+                .set_branch_status(&session.branch.id, level, message)
+                .await?;
+            format!("status updated to {level}")
+        }
+        "slack_reply" => {
+            let text = arguments
+                .get("text")
+                .and_then(Value::as_str)
+                .context("slack_reply requires text")?;
+            if text.is_empty() || text.len() > 4000 {
+                bail!("slack_reply text must contain 1 to 4000 bytes");
+            }
+            client
+                .post(
+                    &format!(
+                        "/api/branches/{}/slack/reply",
+                        percent_encoding::utf8_percent_encode(
+                            &session.branch.id,
+                            percent_encoding::NON_ALPHANUMERIC
+                        )
+                    ),
+                    json!({ "text": text }),
+                )
+                .await?;
+            "message posted to the session Slack thread".to_string()
+        }
+        _ => unreachable!(),
+    };
+    Ok(json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": false
+    }))
+}
+
+fn result(id: &Value, value: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": value })
+}
+
+fn error(id: &Value, code: i64, message: impl Into<String>) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message.into() } })
+}
+
+async fn dispatch(request: Value) -> Option<Value> {
+    let id = request.get("id")?.clone();
+    let method = request.get("method").and_then(Value::as_str).unwrap_or("");
+    Some(match method {
+        "initialize" => result(
+            &id,
+            json!({
+                "protocolVersion": request.pointer("/params/protocolVersion")
+                    .and_then(Value::as_str).unwrap_or("2024-11-05"),
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": SERVER_NAME, "version": env!("CARGO_PKG_VERSION") }
+            }),
+        ),
+        "ping" => result(&id, json!({})),
+        "tools/list" => result(&id, json!({ "tools": super::runtime_tools(tools()) })),
+        "tools/call" => {
+            let name = request.pointer("/params/name").and_then(Value::as_str);
+            let arguments = request
+                .pointer("/params/arguments")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            match name {
+                Some(name) => match call_tool(name, arguments).await {
+                    Ok(value) => result(&id, value),
+                    Err(err) => result(
+                        &id,
+                        json!({
+                            "content": [{ "type": "text", "text": format!("{err:#}") }],
+                            "isError": true
+                        }),
+                    ),
+                },
+                None => error(&id, -32602, "tools/call requires params.name"),
+            }
+        }
+        _ => error(&id, -32601, format!("method not found: {method}")),
+    })
+}
+
+async fn serve() -> Result<()> {
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    let mut stdout = tokio::io::stdout();
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let request: Value =
+            serde_json::from_str(&line).map_err(|error| anyhow!("invalid MCP request: {error}"))?;
+        if let Some(response) = dispatch(request).await {
+            stdout
+                .write_all(serde_json::to_string(&response)?.as_bytes())
+                .await?;
+            stdout.write_all(b"\n").await?;
+            stdout.flush().await?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn messaging_sets_are_grouped_and_exact() {
+        assert_eq!(CAPABILITY_SETS.len(), 2);
+        assert!(CAPABILITY_SETS.iter().all(|set| set.group == "messaging"));
+        assert_eq!(
+            expand_tool_set("mcp/messaging/status@v1").unwrap(),
+            vec!["mcp__loom_messaging__status_update"]
+        );
+        assert_eq!(tools().as_array().unwrap().len(), 2);
+    }
+}

--- a/crates/loom/src/mcp/mod.rs
+++ b/crates/loom/src/mcp/mod.rs
@@ -7,12 +7,14 @@
 //! configuration.
 
 use anyhow::{bail, Result};
+use base64::Engine as _;
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
-use std::{future::Future, pin::Pin};
+use std::{collections::HashSet, future::Future, pin::Pin};
 use weaver_api::{McpAdapterView, McpCapabilitySetView, McpRegistryView};
 
 pub(crate) mod github;
+pub(crate) mod messaging;
 
 type ServeFuture = Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 
@@ -24,6 +26,7 @@ pub(crate) struct Adapter {
     expand_tool_set: fn(&str) -> Option<Vec<String>>,
     is_permission_rule: fn(&str) -> bool,
     server_config: fn() -> Value,
+    tools: fn() -> Value,
     serve: fn() -> ServeFuture,
 }
 
@@ -32,12 +35,14 @@ pub(crate) struct Adapter {
 /// identity rather than silently widening an unchanged profile selection.
 pub(crate) struct CapabilitySet {
     pub name: &'static str,
+    pub group: &'static str,
     pub version: &'static str,
     pub description: &'static str,
     pub tools: &'static [&'static str],
 }
 
-const ADAPTERS: &[Adapter] = &[github::ADAPTER];
+const ADAPTERS: &[Adapter] = &[github::ADAPTER, messaging::ADAPTER];
+pub(crate) const ALLOWED_TOOLS_ENV: &str = "LOOM_MCP_ALLOWED_TOOLS";
 
 pub(crate) fn is_tool_set(name: &str) -> bool {
     ADAPTERS
@@ -45,10 +50,36 @@ pub(crate) fn is_tool_set(name: &str) -> bool {
         .any(|adapter| (adapter.expand_tool_set)(name).is_some())
 }
 
+pub(crate) fn is_builtin_group(group: &str) -> bool {
+    ADAPTERS.iter().any(|adapter| {
+        (adapter.capability_sets)()
+            .iter()
+            .any(|set| set.group == group)
+    })
+}
+
 pub(crate) fn registry() -> McpRegistryView {
     let mut adapters = Vec::new();
     let mut capability_sets = Vec::new();
     for adapter in ADAPTERS {
+        let advertised = (adapter.tools)();
+        let advertised_names = advertised
+            .as_array()
+            .expect("builtin MCP tools must be an array")
+            .iter()
+            .map(|tool| {
+                tool["name"]
+                    .as_str()
+                    .expect("builtin MCP tool must have a name")
+            })
+            .collect::<Vec<_>>();
+        for set in (adapter.capability_sets)() {
+            assert!(
+                set.tools.iter().all(|tool| advertised_names.contains(tool)),
+                "builtin MCP capability set {} advertises an unknown tool",
+                set.name
+            );
+        }
         adapters.push(McpAdapterView {
             name: adapter.name.to_string(),
             description: adapter.description.to_string(),
@@ -58,8 +89,9 @@ pub(crate) fn registry() -> McpRegistryView {
             let tools = set.tools.iter().map(|tool| tool.to_string()).collect();
             capability_sets.push(McpCapabilitySetView {
                 name: set.name.to_string(),
+                group: set.group.to_string(),
                 version: set.version.to_string(),
-                digest: capability_set_digest(set),
+                digest: capability_set_digest(adapter, set, &advertised),
                 description: set.description.to_string(),
                 adapter: adapter.name.to_string(),
                 tools,
@@ -69,17 +101,147 @@ pub(crate) fn registry() -> McpRegistryView {
     McpRegistryView {
         adapters,
         capability_sets,
+        custom_servers: Vec::new(),
     }
 }
 
-fn capability_set_digest(set: &CapabilitySet) -> String {
+/// Report whether an exact profile snapshot is still launchable. Profiles
+/// remain inspectable when a set is retired or a custom server is disabled,
+/// but a new session must not silently substitute current registry content.
+pub(crate) async fn snapshot_errors(
+    db: &crate::Db,
+    snapshot: &weaver_api::McpPolicySnapshot,
+) -> Result<Vec<String>> {
+    let current = registry();
+    let custom = crate::custom_mcp::list(db).await?;
+    let mut errors = Vec::new();
+    for pinned in &snapshot.capability_sets {
+        match current
+            .capability_sets
+            .iter()
+            .find(|candidate| candidate.name == pinned.name)
+        {
+            None => errors.push(format!(
+                "built-in capability set '{}' is no longer supported",
+                pinned.name
+            )),
+            Some(candidate) if candidate != pinned => errors.push(format!(
+                "built-in capability set '{}' changed (pinned {}, current {}); save the profile to reconcile it",
+                pinned.name, pinned.digest, candidate.digest
+            )),
+            Some(_) => {}
+        }
+    }
+    for pinned in &snapshot.custom_servers {
+        match custom
+            .iter()
+            .find(|candidate| candidate.identity == pinned.identity)
+        {
+            None => errors.push(format!(
+                "custom MCP '{}' was removed; save the profile to reconcile it",
+                pinned.identity
+            )),
+            Some(candidate) if !candidate.enabled => errors.push(format!(
+                "custom MCP '{}' is disabled; enable it or save the profile to reconcile it",
+                pinned.identity
+            )),
+            Some(_) => {}
+        }
+    }
+    Ok(errors)
+}
+
+pub(crate) async fn resolve_access(
+    db: &crate::Db,
+    access: &weaver_api::McpAccess,
+) -> Result<weaver_api::McpPolicySnapshot> {
+    let registry = registry();
+    let custom = crate::custom_mcp::list(db).await?;
+    let ready_custom = crate::custom_mcp::ready_snapshots(&custom);
+    let capability_sets = match access.mode.as_str() {
+        "none" => Vec::new(),
+        "all" => registry.capability_sets,
+        "groups" => {
+            for group in &access.groups {
+                if !registry
+                    .capability_sets
+                    .iter()
+                    .any(|set| &set.group == group)
+                    && !custom.iter().any(|server| &server.group == group)
+                {
+                    bail!("unknown MCP group '{group}'");
+                }
+            }
+            registry
+                .capability_sets
+                .into_iter()
+                .filter(|set| access.groups.contains(&set.group))
+                .collect()
+        }
+        other => bail!("MCP access mode must be 'none', 'all', or 'groups', got '{other}'"),
+    };
+    let custom_servers = match access.mode.as_str() {
+        "none" => Vec::new(),
+        "all" => ready_custom,
+        "groups" => ready_custom
+            .into_iter()
+            .filter(|server| access.groups.contains(&server.group))
+            .collect(),
+        _ => unreachable!(),
+    };
+    Ok(weaver_api::McpPolicySnapshot {
+        selection: access.clone(),
+        capability_sets,
+        custom_servers,
+    })
+}
+
+pub(crate) fn rules_for_snapshot(snapshot: &weaver_api::McpPolicySnapshot) -> Result<Vec<String>> {
+    let names = snapshot
+        .capability_sets
+        .iter()
+        .map(|set| set.name.clone())
+        .collect::<Vec<_>>();
+    let mut rules = expand_tool_sets(&names)?;
+    for server in &snapshot.custom_servers {
+        for tool in &server.tools {
+            push_unique(
+                &mut rules,
+                crate::custom_mcp::permission_rule(&server.server_name, tool),
+            );
+        }
+    }
+    Ok(rules)
+}
+
+fn capability_set_digest(adapter: &Adapter, set: &CapabilitySet, advertised: &Value) -> String {
     let mut hasher = Sha256::new();
+    hasher.update(adapter.name);
+    hasher.update([0]);
+    hasher.update(adapter.server_name);
+    hasher.update([0]);
+    hasher.update(adapter.description);
+    hasher.update([0]);
     hasher.update(set.name);
     hasher.update([0]);
+    hasher.update(set.group);
+    hasher.update([0]);
     hasher.update(set.version);
+    hasher.update([0]);
+    hasher.update(set.description);
     for tool in set.tools {
         hasher.update([0]);
         hasher.update(tool);
+        if let Some(definition) = advertised
+            .as_array()
+            .and_then(|tools| tools.iter().find(|value| value["name"] == **tool))
+        {
+            hasher.update([0]);
+            hasher.update(
+                serde_json::to_vec(definition)
+                    .expect("builtin MCP tool definitions must serialize"),
+            );
+        }
     }
     format!("sha256:{}", hex::encode(hasher.finalize()))
 }
@@ -112,14 +274,139 @@ pub(crate) fn expand_tool_sets(rules: &[String]) -> Result<Vec<String>> {
 pub(crate) fn server_configs(allowed_rules: &[String]) -> Map<String, Value> {
     let mut servers = Map::new();
     for adapter in ADAPTERS {
-        if allowed_rules
+        let surface = (adapter.tools)();
+        let allowed_tools = surface
+            .as_array()
+            .expect("builtin MCP tools must be an array")
             .iter()
-            .any(|rule| (adapter.is_permission_rule)(rule))
+            .filter_map(|tool| tool["name"].as_str())
+            .filter(|tool| {
+                allowed_rules
+                    .iter()
+                    .any(|rule| rule == &format!("mcp__{}__{tool}", adapter.server_name))
+            })
+            .collect::<Vec<_>>();
+        if !allowed_tools.is_empty()
+            && allowed_rules
+                .iter()
+                .any(|rule| (adapter.is_permission_rule)(rule))
         {
-            servers.insert(adapter.server_name.to_string(), (adapter.server_config)());
+            let mut config = (adapter.server_config)();
+            config
+                .as_object_mut()
+                .expect("builtin MCP server config must be an object")
+                .insert(
+                    "env".to_string(),
+                    serde_json::json!({
+                        "LOOM_MCP_ALLOWED_TOOLS": serde_json::to_string(&allowed_tools)
+                            .expect("builtin MCP allowed tool names must serialize")
+                    }),
+                );
+            servers.insert(adapter.server_name.to_string(), config);
         }
     }
     servers
+}
+
+fn runtime_allowed_tools() -> Option<HashSet<String>> {
+    let value = std::env::var(ALLOWED_TOOLS_ENV).ok()?;
+    Some(
+        serde_json::from_str::<Vec<String>>(&value)
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
+    )
+}
+
+pub(crate) fn runtime_tool_allowed(name: &str) -> bool {
+    runtime_allowed_tools().is_none_or(|allowed| allowed.contains(name))
+}
+
+pub(crate) fn runtime_tools(tools: Value) -> Value {
+    let Some(allowed) = runtime_allowed_tools() else {
+        return tools;
+    };
+    Value::Array(
+        tools
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter(|tool| {
+                tool["name"]
+                    .as_str()
+                    .is_some_and(|name| allowed.contains(name))
+            })
+            .cloned()
+            .collect(),
+    )
+}
+
+pub(crate) fn server_configs_for_snapshot(
+    allowed_rules: &[String],
+    snapshot: Option<&weaver_api::McpPolicySnapshot>,
+) -> Map<String, Value> {
+    let mut servers = server_configs(allowed_rules);
+    if let Some(snapshot) = snapshot {
+        for custom in &snapshot.custom_servers {
+            let prefix = format!("mcp__{}__", custom.server_name);
+            if allowed_rules.iter().any(|rule| rule.starts_with(&prefix)) {
+                servers.insert(
+                    custom.server_name.clone(),
+                    serde_json::json!({
+                        "type": "stdio",
+                        "command": "loom",
+                        "args": ["mcp", "serve-custom", custom.identity],
+                        "env": {
+                            "LOOM_CUSTOM_MCP_SOURCE_B64":
+                                base64::engine::general_purpose::STANDARD.encode(&custom.source),
+                            "LOOM_MCP_ALLOWED_TOOLS":
+                                serde_json::to_string(&custom.tools)
+                                    .expect("custom MCP allowed tool names must serialize")
+                        }
+                    }),
+                );
+            }
+        }
+    }
+    servers
+}
+
+/// Convert Loom's trusted server map to ACP v1's provider-neutral stdio shape.
+pub(crate) fn acp_server_configs(
+    allowed_rules: &[String],
+    snapshot: Option<&weaver_api::McpPolicySnapshot>,
+) -> Vec<Value> {
+    let loom_command = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.to_str().map(str::to_string))
+        .unwrap_or_else(|| "loom".to_string());
+    server_configs_for_snapshot(allowed_rules, snapshot)
+        .into_iter()
+        .map(|(name, config)| {
+            let command = match config["command"].as_str().unwrap_or_default() {
+                "loom" => loom_command.clone(),
+                command => command.to_string(),
+            };
+            let env = config["env"]
+                .as_object()
+                .map(|env| {
+                    env.iter()
+                        .filter_map(|(name, value)| {
+                            value
+                                .as_str()
+                                .map(|value| serde_json::json!({ "name": name, "value": value }))
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            serde_json::json!({
+                "name": name,
+                "command": command,
+                "args": config["args"].as_array().cloned().unwrap_or_default(),
+                "env": env,
+            })
+        })
+        .collect()
 }
 
 pub async fn serve(adapter: &str) -> Result<()> {
@@ -165,6 +452,10 @@ mod tests {
         let servers = server_configs(&["mcp__loom_github__issue_view".to_string()]);
         assert_eq!(servers.len(), 1);
         assert!(servers.contains_key("loom_github"));
+        assert_eq!(
+            servers["loom_github"]["env"]["LOOM_MCP_ALLOWED_TOOLS"],
+            "[\"issue_view\"]"
+        );
     }
 
     #[test]
@@ -174,5 +465,85 @@ mod tests {
         assert_eq!(set.name, "mcp/github/comment@v1");
         assert!(set.digest.starts_with("sha256:"));
         assert_eq!(set.tools.len(), 6);
+    }
+
+    #[tokio::test]
+    async fn access_resolves_none_all_and_groups() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let none = super::resolve_access(
+            &db,
+            &weaver_api::McpAccess {
+                mode: "none".into(),
+                groups: vec![],
+            },
+        )
+        .await
+        .unwrap();
+        assert!(none.capability_sets.is_empty());
+        let github = super::resolve_access(
+            &db,
+            &weaver_api::McpAccess {
+                mode: "groups".into(),
+                groups: vec!["github".into()],
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(github.capability_sets.len(), 1);
+        assert!(super::resolve_access(
+            &db,
+            &weaver_api::McpAccess {
+                mode: "groups".into(),
+                groups: vec!["missing".into()],
+            }
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn changed_builtin_content_invalidates_a_pinned_profile_snapshot() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let mut snapshot = super::resolve_access(
+            &db,
+            &weaver_api::McpAccess {
+                mode: "groups".into(),
+                groups: vec!["github".into()],
+            },
+        )
+        .await
+        .unwrap();
+        snapshot.capability_sets[0].digest = "sha256:stale".to_string();
+        let errors = super::snapshot_errors(&db, &snapshot).await.unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("save the profile to reconcile"));
+    }
+
+    #[test]
+    fn every_adapter_satisfies_the_registry_contract() {
+        for adapter in super::ADAPTERS {
+            let listed = (adapter.tools)();
+            let names = listed
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|tool| tool["name"].as_str().unwrap())
+                .collect::<Vec<_>>();
+            assert!(!names.is_empty(), "{} has no tools", adapter.name);
+            for tool in names {
+                let permission = format!("mcp__{}__{tool}", adapter.server_name);
+                assert!((adapter.is_permission_rule)(&permission));
+                assert!(
+                    (adapter.capability_sets)()
+                        .iter()
+                        .any(|set| set.tools.contains(&tool)),
+                    "{} tool {tool} belongs to no capability set",
+                    adapter.name
+                );
+            }
+            let config = (adapter.server_config)();
+            assert_eq!(config["command"], "loom");
+            assert_eq!(config["args"][0], "mcp");
+        }
     }
 }

--- a/crates/loom/src/mcp/mod.rs
+++ b/crates/loom/src/mcp/mod.rs
@@ -8,19 +8,33 @@
 
 use anyhow::{bail, Result};
 use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
 use std::{future::Future, pin::Pin};
+use weaver_api::{McpAdapterView, McpCapabilitySetView, McpRegistryView};
 
 pub(crate) mod github;
 
 type ServeFuture = Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 
-struct Adapter {
+pub(crate) struct Adapter {
     name: &'static str,
     server_name: &'static str,
+    description: &'static str,
+    capability_sets: fn() -> &'static [CapabilitySet],
     expand_tool_set: fn(&str) -> Option<Vec<String>>,
     is_permission_rule: fn(&str) -> bool,
     server_config: fn() -> Value,
     serve: fn() -> ServeFuture,
+}
+
+/// A stable, provider-neutral set of MCP operations.  A set's digest is part
+/// of the operator-visible contract: adding a tool requires a new versioned
+/// identity rather than silently widening an unchanged profile selection.
+pub(crate) struct CapabilitySet {
+    pub name: &'static str,
+    pub version: &'static str,
+    pub description: &'static str,
+    pub tools: &'static [&'static str],
 }
 
 const ADAPTERS: &[Adapter] = &[github::ADAPTER];
@@ -29,6 +43,45 @@ pub(crate) fn is_tool_set(name: &str) -> bool {
     ADAPTERS
         .iter()
         .any(|adapter| (adapter.expand_tool_set)(name).is_some())
+}
+
+pub(crate) fn registry() -> McpRegistryView {
+    let mut adapters = Vec::new();
+    let mut capability_sets = Vec::new();
+    for adapter in ADAPTERS {
+        adapters.push(McpAdapterView {
+            name: adapter.name.to_string(),
+            description: adapter.description.to_string(),
+            server_name: adapter.server_name.to_string(),
+        });
+        for set in (adapter.capability_sets)() {
+            let tools = set.tools.iter().map(|tool| tool.to_string()).collect();
+            capability_sets.push(McpCapabilitySetView {
+                name: set.name.to_string(),
+                version: set.version.to_string(),
+                digest: capability_set_digest(set),
+                description: set.description.to_string(),
+                adapter: adapter.name.to_string(),
+                tools,
+            });
+        }
+    }
+    McpRegistryView {
+        adapters,
+        capability_sets,
+    }
+}
+
+fn capability_set_digest(set: &CapabilitySet) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(set.name);
+    hasher.update([0]);
+    hasher.update(set.version);
+    for tool in set.tools {
+        hasher.update([0]);
+        hasher.update(tool);
+    }
+    format!("sha256:{}", hex::encode(hasher.finalize()))
 }
 
 /// Expand profile-facing capability sets into the exact rules persisted on a
@@ -91,7 +144,7 @@ mod tests {
     fn expands_sets_and_preserves_ordinary_rules() {
         let rules = vec![
             "Read(./**)".to_string(),
-            "mcp/github/comment".to_string(),
+            "mcp/github/comment@v1".to_string(),
             "Read(./**)".to_string(),
         ];
         let expanded = expand_tool_sets(&rules).unwrap();
@@ -112,5 +165,14 @@ mod tests {
         let servers = server_configs(&["mcp__loom_github__issue_view".to_string()]);
         assert_eq!(servers.len(), 1);
         assert!(servers.contains_key("loom_github"));
+    }
+
+    #[test]
+    fn registry_exposes_versioned_provider_neutral_sets() {
+        let registry = super::registry();
+        let set = &registry.capability_sets[0];
+        assert_eq!(set.name, "mcp/github/comment@v1");
+        assert!(set.digest.starts_with("sha256:"));
+        assert_eq!(set.tools.len(), 6);
     }
 }

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -649,6 +649,8 @@ mod tests {
             policy_prelude: "weaver".to_string(),
             policy_restricted: false,
             policy_allowed_tools: "[]".to_string(),
+            policy_mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[]}"#
+                .to_string(),
             creator_kind: "user".to_string(),
             creator_subject: "owner".to_string(),
             parent_session_id: None,

--- a/crates/loom/src/profile.rs
+++ b/crates/loom/src/profile.rs
@@ -39,6 +39,10 @@ pub struct Profile {
     pub restricted: bool,
     /// JSON array in storage; parsed through [`allowed_tool_rules`].
     pub allowed_tools: String,
+    /// Provider-neutral MCP selection JSON.
+    pub mcp_access: String,
+    /// Exact resolved registry snapshot pinned to this profile revision.
+    pub mcp_policy: String,
     pub revision: i64,
     pub created_at: String,
     pub updated_at: String,
@@ -57,10 +61,32 @@ impl Profile {
         serde_json::from_str(&self.allowed_tools).context("invalid profile allowed tools")
     }
 
+    pub fn mcp_access(&self) -> Result<weaver_api::McpAccess> {
+        serde_json::from_str(&self.mcp_access).context("invalid profile MCP access")
+    }
+
+    pub fn mcp_policy_snapshot(&self) -> Result<weaver_api::McpPolicySnapshot> {
+        serde_json::from_str(&self.mcp_policy).context("invalid profile MCP policy snapshot")
+    }
+
     /// Exact rules to stamp onto a session. Profiles retain concise built-in
     /// MCP set names, but launched sessions are immutable and auditable.
     pub fn effective_allowed_tool_rules(&self) -> Result<Vec<String>> {
-        crate::mcp::expand_tool_sets(&self.allowed_tool_rules()?)
+        let snapshot = self.mcp_policy_snapshot()?;
+        self.effective_allowed_tool_rules_for(&snapshot)
+    }
+
+    pub fn effective_allowed_tool_rules_for(
+        &self,
+        snapshot: &weaver_api::McpPolicySnapshot,
+    ) -> Result<Vec<String>> {
+        let mut rules = crate::mcp::expand_tool_sets(&self.allowed_tool_rules()?)?;
+        for rule in crate::mcp::rules_for_snapshot(snapshot)? {
+            if !rules.contains(&rule) {
+                rules.push(rule);
+            }
+        }
+        Ok(rules)
     }
 
     pub fn as_input(&self) -> Result<ProfileInput> {
@@ -82,6 +108,7 @@ impl Profile {
             prelude: self.prelude.clone(),
             restricted: self.restricted,
             allowed_tools: self.allowed_tool_rules()?,
+            mcp_access: self.mcp_access()?,
         })
     }
 }
@@ -118,8 +145,10 @@ pub struct ProfileInput {
     pub prelude: String,
     #[serde(default)]
     pub restricted: bool,
-    #[serde(default)]
+    #[serde(default, alias = "runtime_permissions")]
     pub allowed_tools: Vec<String>,
+    #[serde(default)]
+    pub mcp_access: weaver_api::McpAccess,
 }
 
 fn default_class() -> String {
@@ -206,7 +235,10 @@ pub fn validate_name(name: &str) -> std::result::Result<(), String> {
     Ok(())
 }
 
-async fn validate_input(db: &Db, input: &ProfileInput) -> Result<(String, String)> {
+async fn validate_input(
+    db: &Db,
+    input: &ProfileInput,
+) -> Result<(String, String, weaver_api::McpPolicySnapshot)> {
     validate_name(input.name.trim()).map_err(|e| anyhow!(e))?;
     if !matches!(input.class.trim(), "interactive" | "automation") {
         bail!("profile class must be 'interactive' or 'automation'");
@@ -237,6 +269,30 @@ async fn validate_input(db: &Db, input: &ProfileInput) -> Result<(String, String
     {
         bail!("invalid profile allowed tool rule");
     }
+    let mcp_snapshot = crate::mcp::resolve_access(db, &input.mcp_access).await?;
+    let custom_selected = crate::custom_mcp::list(db).await?.iter().any(|server| {
+        input.mcp_access.mode == "all"
+            || (input.mcp_access.mode == "groups"
+                && input.mcp_access.groups.contains(&server.group))
+    });
+    if input.mcp_access.mode != "groups" && !input.mcp_access.groups.is_empty() {
+        bail!("MCP groups may only be set when MCP access mode is 'groups'");
+    }
+    if input.mcp_access.mode == "groups" && input.mcp_access.groups.is_empty() {
+        bail!("MCP access mode 'groups' requires at least one group");
+    }
+    if input.mcp_access.groups.len() > 64 {
+        bail!("an MCP profile may select at most 64 groups");
+    }
+    let mut unique_groups = std::collections::HashSet::new();
+    if input
+        .mcp_access
+        .groups
+        .iter()
+        .any(|group| group.len() > 64 || !unique_groups.insert(group))
+    {
+        bail!("MCP groups must be unique and at most 64 bytes");
+    }
     let agent_kind = input.agent_kind.trim();
     let meta = crate::agent::metadata_for(db, agent_kind)
         .await?
@@ -259,6 +315,15 @@ async fn validate_input(db: &Db, input: &ProfileInput) -> Result<(String, String
     ) {
         bail!("invalid profile mode '{mode}'");
     }
+    if protocol != "acp"
+        && (input.mcp_access.mode != "none"
+            || input
+                .allowed_tools
+                .iter()
+                .any(|rule| is_restricted_mcp_tool_set(rule)))
+    {
+        bail!("MCP access requires the ACP protocol");
+    }
     if input.restricted
         && (input.class.trim() != "automation"
             || !input.strict
@@ -267,7 +332,9 @@ async fn validate_input(db: &Db, input: &ProfileInput) -> Result<(String, String
             || protocol != "acp"
             || mode != "default"
             || input.prelude.trim() != "none"
-            || input.allowed_tools.is_empty()
+            || input.mcp_access.mode == "all"
+            || (input.allowed_tools.is_empty() && mcp_snapshot.capability_sets.is_empty())
+            || custom_selected
             || input
                 .allowed_tools
                 .iter()
@@ -276,7 +343,7 @@ async fn validate_input(db: &Db, input: &ProfileInput) -> Result<(String, String
     {
         bail!("restricted profiles must be strict env-cleared Claude ACP automation profiles with prelude 'none', mode 'default', no ambient allowlist, repository-scoped read rules, and/or reviewed built-in MCP tool sets");
     }
-    Ok((protocol, mode))
+    Ok((protocol, mode, mcp_snapshot))
 }
 
 pub async fn active_count(db: &Db, name: &str) -> Result<i64> {
@@ -308,7 +375,7 @@ pub async fn get(db: &Db, name: &str) -> Result<Option<Profile>> {
 
 pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
     let name = input.name.trim();
-    let (protocol, mode) = validate_input(db, input).await?;
+    let (protocol, mode, mcp_policy) = validate_input(db, input).await?;
     let normalized = ProfileInput {
         name: name.to_string(),
         description: input.description.trim().to_string(),
@@ -327,17 +394,24 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
         prelude: input.prelude.trim().to_string(),
         restricted: input.restricted,
         allowed_tools: input.allowed_tools.clone(),
+        mcp_access: input.mcp_access.clone(),
     };
     let ambient = serde_json::to_string(&normalized.ambient_allowlist)?;
     let allowed_tools = serde_json::to_string(&normalized.allowed_tools)?;
+    let mcp_access = serde_json::to_string(&normalized.mcp_access)?;
+    let mcp_policy_json = serde_json::to_string(&mcp_policy)?;
     if let Some(existing) = get(db, name).await? {
-        if existing.as_input()? == normalized {
+        if existing.as_input()? == normalized && existing.mcp_policy_snapshot()? == mcp_policy {
             return Ok(existing);
         }
         let widens_restricted_tools = existing.restricted
             && widens_allowlist(
-                &existing.effective_allowed_tool_rules()?,
-                &crate::mcp::expand_tool_sets(&normalized.allowed_tools)?,
+                &existing.effective_allowed_tool_rules_for(&existing.mcp_policy_snapshot()?)?,
+                &{
+                    let mut rules = crate::mcp::expand_tool_sets(&normalized.allowed_tools)?;
+                    rules.extend(crate::mcp::rules_for_snapshot(&mcp_policy)?);
+                    rules
+                },
             );
         if existing.is_automation_safe()
             && has_automation_sessions(db, name).await?
@@ -357,8 +431,8 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
          (name, description, agent_kind, model, effort, protocol, mode, class,
           strict, env_clear, ambient_allowlist, idle_archive_secs, max_concurrent,
           turn_budget, revision, created_at, updated_at, prelude, restricted,
-          allowed_tools)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)
+          allowed_tools, mcp_access, mcp_policy)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(name) DO UPDATE SET
           description=excluded.description, agent_kind=excluded.agent_kind,
           model=excluded.model, effort=excluded.effort, protocol=excluded.protocol,
@@ -367,7 +441,8 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
           idle_archive_secs=excluded.idle_archive_secs,
           max_concurrent=excluded.max_concurrent, turn_budget=excluded.turn_budget,
           prelude=excluded.prelude, restricted=excluded.restricted,
-          allowed_tools=excluded.allowed_tools,
+          allowed_tools=excluded.allowed_tools, mcp_access=excluded.mcp_access,
+          mcp_policy=excluded.mcp_policy,
           revision=profiles.revision + 1, updated_at=excluded.updated_at",
     )
     .bind(name)
@@ -389,6 +464,8 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
     .bind(&normalized.prelude)
     .bind(normalized.restricted)
     .bind(allowed_tools)
+    .bind(mcp_access)
+    .bind(mcp_policy_json)
     .execute(db)
     .await?;
     get(db, name)
@@ -632,6 +709,23 @@ pub async fn seed_stock_profiles(db: &Db) -> Result<()> {
     Ok(())
 }
 
+/// Populate the exact MCP snapshot for profiles created before migration 6.
+/// This is a compatibility backfill, so it does not advance their revision.
+pub async fn backfill_mcp_policies(db: &Db) -> Result<()> {
+    for profile in list(db).await? {
+        if !profile.mcp_policy.is_empty() {
+            continue;
+        }
+        let snapshot = crate::mcp::resolve_access(db, &profile.mcp_access()?).await?;
+        sqlx::query("UPDATE profiles SET mcp_policy = ? WHERE name = ? AND mcp_policy = ''")
+            .bind(serde_json::to_string(&snapshot)?)
+            .bind(&profile.name)
+            .execute(db)
+            .await?;
+    }
+    Ok(())
+}
+
 /// Repair the one-time legacy seed through the same runtime metadata validators
 /// new profile writes use. Valid profiles are left untouched; a stale removed
 /// custom agent or selector falls back to the builtin default instead of making
@@ -658,6 +752,7 @@ pub async fn normalize_default(db: &Db) -> Result<()> {
         prelude: current.prelude.clone(),
         restricted: current.restricted,
         allowed_tools: current.allowed_tool_rules().unwrap_or_default(),
+        mcp_access: current.mcp_access().unwrap_or_default(),
     };
     if validate_input(db, &input).await.is_ok() {
         return Ok(());
@@ -716,6 +811,33 @@ mod tests {
         input.allowed_tools = vec!["Read(../**)".to_string()];
         assert!(upsert(&db, &input).await.is_err());
         input.allowed_tools = vec!["Glob(/etc/**)".to_string()];
+        assert!(upsert(&db, &input).await.is_err());
+
+        input.allowed_tools = vec!["Read(./**)".to_string()];
+        input.mcp_access = weaver_api::McpAccess {
+            mode: "all".to_string(),
+            groups: Vec::new(),
+        };
+        assert!(upsert(&db, &input).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn mcp_selection_requires_groups_and_acp() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let mut input = get(&db, DEFAULT_PROFILE)
+            .await
+            .unwrap()
+            .unwrap()
+            .as_input()
+            .unwrap();
+        input.mcp_access = weaver_api::McpAccess {
+            mode: "groups".to_string(),
+            groups: Vec::new(),
+        };
+        assert!(upsert(&db, &input).await.is_err());
+
+        input.mcp_access.groups = vec!["github".to_string()];
+        input.protocol = "terminal".to_string();
         assert!(upsert(&db, &input).await.is_err());
     }
 

--- a/crates/loom/src/profile.rs
+++ b/crates/loom/src/profile.rs
@@ -695,7 +695,7 @@ mod tests {
         assert_eq!(allowed_tool_name("Bash"), Some("Bash"));
         assert_eq!(allowed_tool_name("Bash(gh issue view:*"), None);
         assert_eq!(allowed_tool_name(" Bash(gh issue view:*)"), None);
-        assert!(is_restricted_mcp_tool_set("mcp/github/comment"));
+        assert!(is_restricted_mcp_tool_set("mcp/github/comment@v1"));
         assert!(!is_restricted_mcp_tool_set("mcp/github/admin"));
     }
 
@@ -710,7 +710,7 @@ mod tests {
         input.allowed_tools = vec!["Read(./**)".to_string()];
         assert!(upsert(&db, &input).await.is_ok());
 
-        input.allowed_tools = vec!["mcp/github/comment".to_string()];
+        input.allowed_tools = vec!["mcp/github/comment@v1".to_string()];
         assert!(upsert(&db, &input).await.is_ok());
 
         input.allowed_tools = vec!["Read(../**)".to_string()];

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -110,6 +110,7 @@ pub struct Session {
     pub policy_prelude: String,
     pub policy_restricted: bool,
     pub policy_allowed_tools: String,
+    pub policy_mcp_access: String,
     /// Stable creator identity. `created_by` remains display attribution only.
     pub creator_kind: String,
     pub creator_subject: String,
@@ -194,6 +195,7 @@ pub struct SessionLaunchPolicy {
     pub prelude: String,
     pub restricted: bool,
     pub allowed_tools: String,
+    pub mcp_access: String,
     pub creator_kind: String,
     pub creator_subject: String,
     pub parent_session_id: Option<String>,
@@ -222,6 +224,8 @@ impl SessionLaunchPolicy {
             prelude: "weaver".to_string(),
             restricted: false,
             allowed_tools: "[]".to_string(),
+            mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[]}"#
+                .to_string(),
             creator_kind: creator_kind.to_string(),
             creator_subject: s.created_by.clone().unwrap_or_else(|| s.origin.clone()),
             parent_session_id: None,
@@ -252,10 +256,10 @@ pub async fn insert_with_policy(
           origin, class, tracking_issue_id, last_activity_at, created_at,
           profile, launch_mode, profile_revision, policy_env_clear,
           policy_ambient_allowlist, policy_idle_archive_secs, policy_turn_budget,
-          policy_prelude, policy_restricted, policy_allowed_tools,
+          policy_prelude, policy_restricted, policy_allowed_tools, policy_mcp_access,
           creator_kind, creator_subject, parent_session_id, automation_run_id)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&s.id)
     .bind(&s.branch_id)
@@ -285,6 +289,7 @@ pub async fn insert_with_policy(
     .bind(&policy.prelude)
     .bind(policy.restricted)
     .bind(&policy.allowed_tools)
+    .bind(&policy.mcp_access)
     .bind(&policy.creator_kind)
     .bind(&policy.creator_subject)
     .bind(&policy.parent_session_id)

--- a/crates/loom/src/web/mcps.rs
+++ b/crates/loom/src/web/mcps.rs
@@ -1,0 +1,13 @@
+//! Provider-neutral inspection of Loom's trusted MCP registry.
+
+use axum::{extract::State, Json};
+use weaver_api::McpRegistryView;
+
+use super::{ApiResult, AppState};
+
+/// Lists compiled-in adapters and their versioned capability sets.  Commands
+/// are intentionally absent: profiles select a reviewed capability name, never
+/// executable process configuration.
+pub(super) async fn list_mcps(State(_st): State<AppState>) -> ApiResult<Json<McpRegistryView>> {
+    Ok(Json(crate::mcp::registry()))
+}

--- a/crates/loom/src/web/mcps.rs
+++ b/crates/loom/src/web/mcps.rs
@@ -1,13 +1,82 @@
-//! Provider-neutral inspection of Loom's trusted MCP registry.
+//! Provider-neutral inspection and administration of Loom's MCP registry.
 
-use axum::{extract::State, Json};
-use weaver_api::McpRegistryView;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use weaver_api::{CustomMcpReq, CustomMcpView, McpRegistryView};
 
-use super::{ApiResult, AppState};
+use super::{ApiResult, AppError, AppState};
 
-/// Lists compiled-in adapters and their versioned capability sets.  Commands
-/// are intentionally absent: profiles select a reviewed capability name, never
-/// executable process configuration.
-pub(super) async fn list_mcps(State(_st): State<AppState>) -> ApiResult<Json<McpRegistryView>> {
-    Ok(Json(crate::mcp::registry()))
+pub(super) async fn list_mcps(State(st): State<AppState>) -> ApiResult<Json<McpRegistryView>> {
+    let mut registry = crate::mcp::registry();
+    registry.custom_servers = crate::custom_mcp::list(&st.db).await?;
+    Ok(Json(registry))
+}
+
+pub(super) async fn list_custom_mcps(
+    State(st): State<AppState>,
+) -> ApiResult<Json<Vec<CustomMcpView>>> {
+    Ok(Json(crate::custom_mcp::list(&st.db).await?))
+}
+
+pub(super) async fn create_custom_mcp(
+    State(st): State<AppState>,
+    Json(req): Json<CustomMcpReq>,
+) -> ApiResult<(StatusCode, Json<CustomMcpView>)> {
+    if crate::custom_mcp::get(&st.db, req.identity.trim())
+        .await?
+        .is_some()
+    {
+        return Err(AppError::new(
+            StatusCode::CONFLICT,
+            format!("custom MCP '{}' already exists", req.identity.trim()),
+        ));
+    }
+    let value = crate::custom_mcp::upsert(&st.db, &req)
+        .await
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    Ok((StatusCode::CREATED, Json(value)))
+}
+
+fn identity_from_path(path: &str) -> String {
+    format!("/{}", path.trim_matches('/'))
+}
+
+pub(super) async fn get_custom_mcp(
+    State(st): State<AppState>,
+    Path(identity): Path<String>,
+) -> ApiResult<Json<CustomMcpView>> {
+    crate::custom_mcp::get(&st.db, &identity_from_path(&identity))
+        .await?
+        .map(Json)
+        .ok_or_else(|| AppError::not_found("custom MCP"))
+}
+
+pub(super) async fn put_custom_mcp(
+    State(st): State<AppState>,
+    Path(identity): Path<String>,
+    Json(mut req): Json<CustomMcpReq>,
+) -> ApiResult<Json<CustomMcpView>> {
+    req.identity = identity_from_path(&identity);
+    Ok(Json(
+        crate::custom_mcp::upsert(&st.db, &req)
+            .await
+            .map_err(|error| AppError::bad_request(error.to_string()))?,
+    ))
+}
+
+pub(super) async fn delete_custom_mcp(
+    State(st): State<AppState>,
+    Path(identity): Path<String>,
+) -> ApiResult<StatusCode> {
+    let removed = crate::custom_mcp::remove(&st.db, &identity_from_path(&identity))
+        .await
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    if removed {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AppError::not_found("custom MCP"))
+    }
 }

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -75,6 +75,7 @@ mod discussion;
 mod env;
 mod issues;
 mod logview;
+mod mcps;
 mod profiles;
 mod repo_env;
 mod repos;
@@ -95,6 +96,7 @@ use discussion::*;
 use env::*;
 use issues::*;
 use logview::*;
+use mcps::*;
 use profiles::*;
 use repo_env::*;
 use repos::*;
@@ -749,6 +751,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/settings", get(get_settings).patch(patch_settings))
         .route("/deployment/reconcile", post(reconcile_deployment))
+        .route("/mcps", get(list_mcps))
         .route("/profiles", get(list_profiles).post(create_profile))
         .route(
             "/profiles/{name}",

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -134,7 +134,7 @@ use crate::db::Db;
 use crate::events::EventBus;
 use crate::github;
 use crate::session::{self as session_mod, Session};
-use weaver_api::{BranchView, SessionView};
+use weaver_api::{BranchView, McpPolicySnapshot, SessionMcpPolicyView, SessionView};
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::Branch;
 use weaver_core::tags;
@@ -313,6 +313,14 @@ pub(crate) async fn session_view(
     } else {
         None
     };
+    let mcp_policy = serde_json::from_str::<McpPolicySnapshot>(&session.policy_mcp_access)
+        .map(|snapshot| SessionMcpPolicyView::from(&snapshot))
+        .map_err(|error| {
+            AppError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("invalid session MCP policy snapshot: {error}"),
+            )
+        })?;
     Ok(SessionView {
         id: session.id.clone(),
         status: session.status.clone(),
@@ -344,6 +352,7 @@ pub(crate) async fn session_view(
         profile: session.profile.clone(),
         profile_revision: session.profile_revision,
         launch_mode: session.launch_mode.clone(),
+        mcp_policy,
         branch: bv,
     })
 }
@@ -752,7 +761,19 @@ pub fn router(state: AppState) -> Router {
         .route("/settings", get(get_settings).patch(patch_settings))
         .route("/deployment/reconcile", post(reconcile_deployment))
         .route("/mcps", get(list_mcps))
+        .route(
+            "/mcps/custom",
+            get(list_custom_mcps).post(create_custom_mcp),
+        )
+        .route(
+            "/mcps/custom/{*identity}",
+            get(get_custom_mcp)
+                .put(put_custom_mcp)
+                .delete(delete_custom_mcp),
+        )
         .route("/profiles", get(list_profiles).post(create_profile))
+        .route("/profiles/{name}/effective", get(effective_profile))
+        .route("/profiles/{name}/probe", post(probe_profile))
         .route(
             "/profiles/{name}",
             get(get_profile).put(put_profile).delete(delete_profile),

--- a/crates/loom/src/web/profiles.rs
+++ b/crates/loom/src/web/profiles.rs
@@ -3,7 +3,10 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use weaver_api::{ProfileEnvView, ProfileReq, ProfileView, PutProfileEnvReq};
+use weaver_api::{
+    EffectiveProfileView, McpServerProcessView, ProfileEnvView, ProfileProbeView, ProfileReq,
+    ProfileView, PutProfileEnvReq,
+};
 
 use crate::profile::{self, Profile, ProfileInput};
 
@@ -27,7 +30,8 @@ pub(super) fn input(req: ProfileReq, name: String) -> ProfileInput {
         turn_budget: req.turn_budget,
         prelude: req.prelude,
         restricted: req.restricted,
-        allowed_tools: req.allowed_tools,
+        allowed_tools: req.runtime_permissions,
+        mcp_access: req.mcp_access,
     }
 }
 
@@ -45,8 +49,11 @@ pub(super) async fn view(st: &AppState, profile: Profile) -> ApiResult<ProfileVi
             updated_at: entry.updated_at,
         })
         .collect();
-    let allowed_tools = profile
+    let runtime_permissions = profile
         .allowed_tool_rules()
+        .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let mcp_access = profile
+        .mcp_access()
         .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(ProfileView {
         name: profile.name,
@@ -65,7 +72,8 @@ pub(super) async fn view(st: &AppState, profile: Profile) -> ApiResult<ProfileVi
         turn_budget: profile.turn_budget,
         prelude: profile.prelude,
         restricted: profile.restricted,
-        allowed_tools,
+        runtime_permissions,
+        mcp_access,
         revision: profile.revision,
         created_at: profile.created_at,
         updated_at: profile.updated_at,
@@ -89,6 +97,62 @@ pub(super) async fn get_profile(
         .await?
         .ok_or_else(|| AppError::not_found("profile"))?;
     Ok(Json(view(&st, item).await?))
+}
+
+async fn effective(st: &AppState, item: Profile) -> ApiResult<EffectiveProfileView> {
+    let mcp_policy = item
+        .mcp_policy_snapshot()
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    let runtime_permissions = item
+        .effective_allowed_tool_rules_for(&mcp_policy)
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    let mcp_servers = crate::mcp::acp_server_configs(&runtime_permissions, Some(&mcp_policy))
+        .into_iter()
+        .map(|config| McpServerProcessView {
+            name: config["name"].as_str().unwrap_or_default().to_string(),
+            command: config["command"].as_str().unwrap_or_default().to_string(),
+            args: config["args"]
+                .as_array()
+                .map(|args| {
+                    args.iter()
+                        .filter_map(|arg| arg.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        })
+        .collect();
+    Ok(EffectiveProfileView {
+        profile: view(st, item).await?,
+        mcp_policy,
+        runtime_permissions,
+        mcp_servers,
+    })
+}
+
+pub(super) async fn effective_profile(
+    State(st): State<AppState>,
+    Path(name): Path<String>,
+) -> ApiResult<Json<EffectiveProfileView>> {
+    let item = profile::get(&st.db, &name)
+        .await?
+        .ok_or_else(|| AppError::not_found("profile"))?;
+    Ok(Json(effective(&st, item).await?))
+}
+
+pub(super) async fn probe_profile(
+    State(st): State<AppState>,
+    Path(name): Path<String>,
+) -> ApiResult<Json<ProfileProbeView>> {
+    let item = profile::get(&st.db, &name)
+        .await?
+        .ok_or_else(|| AppError::not_found("profile"))?;
+    let effective = effective(&st, item).await?;
+    let errors = crate::mcp::snapshot_errors(&st.db, &effective.mcp_policy).await?;
+    Ok(Json(ProfileProbeView {
+        ok: errors.is_empty(),
+        effective,
+        errors,
+    }))
 }
 
 pub(super) async fn create_profile(

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1064,12 +1064,24 @@ pub(crate) async fn provision_session(
     } else {
         (0, 0)
     };
+    let mcp_policy = launch_profile
+        .mcp_policy_snapshot()
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    let mcp_errors = crate::mcp::snapshot_errors(&st.db, &mcp_policy).await?;
+    if !mcp_errors.is_empty() {
+        return Err(AppError::bad_request(format!(
+            "profile MCP policy is unavailable: {}",
+            mcp_errors.join("; ")
+        )));
+    }
     let stamped_allowed_tools = serde_json::to_string(
         &launch_profile
-            .effective_allowed_tool_rules()
+            .effective_allowed_tool_rules_for(&mcp_policy)
             .map_err(|error| AppError::bad_request(error.to_string()))?,
     )
     .map_err(|error| AppError::bad_request(error.to_string()))?;
+    let stamped_mcp_access = serde_json::to_string(&mcp_policy)
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
     let (creator_kind, creator_subject) = actor.creator_identity();
     let launch_policy = session_mod::SessionLaunchPolicy {
         profile: profile_name.clone(),
@@ -1082,6 +1094,7 @@ pub(crate) async fn provision_session(
         prelude: launch_profile.prelude.clone(),
         restricted: launch_profile.restricted,
         allowed_tools: stamped_allowed_tools.clone(),
+        mcp_access: stamped_mcp_access,
         creator_kind: creator_kind.to_string(),
         creator_subject,
         parent_session_id,
@@ -1333,6 +1346,7 @@ pub(crate) async fn provision_session(
                 prelude: &launch_profile.prelude,
                 restricted: launch_profile.restricted,
                 allowed_tools: &stamped_allowed_tools,
+                mcp_access: &launch_policy.mcp_access,
                 custom: custom.as_ref(),
             },
             agent::AcpOpen::Fresh,
@@ -2071,12 +2085,24 @@ pub(crate) async fn create_warm_session(
     // a transient authentication failure during startup.
     let status = agent::initial_status(&st.db, &agent).await;
     let (inherited_idle, inherited_turn_budget) = automation_policy_defaults(&st.db).await;
+    let mcp_policy = launch_profile
+        .mcp_policy_snapshot()
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    let mcp_errors = crate::mcp::snapshot_errors(&st.db, &mcp_policy).await?;
+    if !mcp_errors.is_empty() {
+        return Err(AppError::bad_request(format!(
+            "profile MCP policy is unavailable: {}",
+            mcp_errors.join("; ")
+        )));
+    }
     let stamped_allowed_tools = serde_json::to_string(
         &launch_profile
-            .effective_allowed_tool_rules()
+            .effective_allowed_tool_rules_for(&mcp_policy)
             .map_err(|error| AppError::bad_request(error.to_string()))?,
     )
     .map_err(|error| AppError::bad_request(error.to_string()))?;
+    let stamped_mcp_access = serde_json::to_string(&mcp_policy)
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
     let session = session_mod::insert_with_policy(
         &st.db,
         &NewSession {
@@ -2108,6 +2134,7 @@ pub(crate) async fn create_warm_session(
             prelude: launch_profile.prelude.clone(),
             restricted: launch_profile.restricted,
             allowed_tools: stamped_allowed_tools,
+            mcp_access: stamped_mcp_access,
             creator_kind: "system".to_string(),
             creator_subject: format!("watch:{}", watch.id),
             parent_session_id: None,
@@ -2288,6 +2315,7 @@ async fn adopt_terminal_into_acp(
             prelude: &session.policy_prelude,
             restricted: session.policy_restricted,
             allowed_tools: &session.policy_allowed_tools,
+            mcp_access: &session.policy_mcp_access,
             custom: None,
         },
         open,
@@ -2387,6 +2415,7 @@ async fn adopt_acp(
                 prelude: &session.policy_prelude,
                 restricted: session.policy_restricted,
                 allowed_tools: &session.policy_allowed_tools,
+                mcp_access: &session.policy_mcp_access,
                 custom: custom.as_ref(),
             },
             open,
@@ -3008,6 +3037,7 @@ pub(super) async fn handoff_session(
             prelude: &session.policy_prelude,
             restricted: session.policy_restricted,
             allowed_tools: &session.policy_allowed_tools,
+            mcp_access: &session.policy_mcp_access,
             custom: custom.as_ref(),
         },
         agent::AcpOpen::Fresh,

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -271,6 +271,8 @@ async fn seed_classed_session(
             prelude: "weaver".to_string(),
             restricted: false,
             allowed_tools: "[]".to_string(),
+            mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[]}"#
+                .to_string(),
             creator_kind: "system".to_string(),
             creator_subject: "test".to_string(),
             parent_session_id: None,

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -96,6 +96,7 @@ async fn start_new_with_env(
         cwd: cwd.clone(),
         env,
         env_clear: false,
+        mcp_servers: vec![],
         new_or_load: NewOrLoad::New { cwd, meta: None },
         mode: mode.map(str::to_string),
         initial_model: None,
@@ -124,6 +125,7 @@ async fn silent_setup_stage_times_out_and_cleans_provider_state() {
             "session/new".to_string(),
         )],
         env_clear: false,
+        mcp_servers: vec![],
         new_or_load: NewOrLoad::New { cwd, meta: None },
         mode: None,
         initial_model: None,
@@ -360,6 +362,7 @@ async fn launch_model_and_effort_replace_adapter_config_defaults() {
         cwd: cwd.clone(),
         env: vec![],
         env_clear: false,
+        mcp_servers: vec![],
         new_or_load: NewOrLoad::New { cwd, meta: None },
         mode: None,
         initial_model: Some("fake-deep".to_string()),
@@ -394,6 +397,7 @@ async fn load_preserves_adapter_restored_model_and_effort() {
         cwd: cwd.clone(),
         env: vec![],
         env_clear: false,
+        mcp_servers: vec![],
         new_or_load: NewOrLoad::Load {
             acp_session_id: "fake-loaded".to_string(),
             meta: None,
@@ -2568,6 +2572,7 @@ async fn codex_acp_launch_maps_the_adapter_contract() {
         prelude: "weaver",
         restricted: false,
         allowed_tools: "[]",
+        mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[],"custom_servers":[]}"#,
         custom: None,
     };
 

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -19,6 +19,7 @@ mod diagnostics;
 mod env;
 mod ide;
 mod logs;
+mod mcp_conformance;
 mod pane;
 mod profiles;
 mod recover;

--- a/crates/loom/tests/integration/mcp_conformance.rs
+++ b/crates/loom/tests/integration/mcp_conformance.rs
@@ -1,0 +1,289 @@
+//! Real-process conformance for every trusted builtin MCP adapter.
+
+use std::process::Stdio;
+
+use base64::Engine as _;
+use serde_json::{json, Value};
+use serial_test::serial;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::Command,
+};
+
+use crate::fixtures::TestServer;
+
+fn loom_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_loom")
+}
+
+async fn run_adapter(adapter: &str) -> (Vec<Value>, std::process::ExitStatus) {
+    let mut child = Command::new(loom_bin())
+        .args(["mcp", "serve", adapter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    stdin
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\"}}\n{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"unknown/method\",\"params\":{}}\n",
+        )
+        .await
+        .unwrap();
+    stdin
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"not_registered\",\"arguments\":{}}}\n",
+        )
+        .await
+        .unwrap();
+    drop(stdin);
+    let mut lines = BufReader::new(child.stdout.take().unwrap()).lines();
+    let mut values = Vec::new();
+    while let Some(line) = lines.next_line().await.unwrap() {
+        values.push(serde_json::from_str(&line).unwrap());
+    }
+    let status = child.wait().await.unwrap();
+    (values, status)
+}
+
+async fn run_filtered_adapter(adapter: &str, tools: &[&str]) -> Vec<Value> {
+    let mut child = Command::new(loom_bin())
+        .args(["mcp", "serve", adapter])
+        .env(
+            "LOOM_MCP_ALLOWED_TOOLS",
+            serde_json::to_string(tools).unwrap(),
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"issue_edit\",\"arguments\":{}}}\n",
+        )
+        .await
+        .unwrap();
+    let mut lines = BufReader::new(child.stdout.take().unwrap()).lines();
+    let mut values = Vec::new();
+    while let Some(line) = lines.next_line().await.unwrap() {
+        values.push(serde_json::from_str(&line).unwrap());
+    }
+    assert!(child.wait().await.unwrap().success());
+    values
+}
+
+#[tokio::test]
+async fn every_builtin_speaks_mcp_stdio() {
+    for (adapter, expected_tools) in [("github", 6), ("messaging", 2)] {
+        let (values, status) = run_adapter(adapter).await;
+        assert!(status.success(), "{adapter} did not exit cleanly");
+        assert_eq!(values.len(), 4, "{adapter} replied to a notification");
+        assert_eq!(values[0]["id"], 1);
+        assert_eq!(values[1]["id"], 2);
+        assert_eq!(
+            values[1]["result"]["tools"].as_array().unwrap().len(),
+            expected_tools
+        );
+        assert_eq!(
+            values[2],
+            json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "error": { "code": -32601, "message": "method not found: unknown/method" }
+            })
+        );
+        assert_eq!(values[3]["id"], 4);
+        assert_eq!(values[3]["result"]["isError"], true);
+        assert!(values[3]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("unknown"));
+    }
+}
+
+#[tokio::test]
+async fn malformed_json_fails_closed_and_clean_eof_succeeds() {
+    let clean = Command::new(loom_bin())
+        .args(["mcp", "serve", "github"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .status()
+        .await
+        .unwrap();
+    assert!(clean.success());
+
+    let mut malformed = Command::new(loom_bin())
+        .args(["mcp", "serve", "messaging"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    malformed
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"not json\n")
+        .await
+        .unwrap();
+    let output = malformed.wait_with_output().await.unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid MCP"));
+}
+
+#[tokio::test]
+async fn builtin_process_exposes_only_the_session_stamped_tools() {
+    let values = run_filtered_adapter("github", &["issue_view"]).await;
+    assert_eq!(
+        values[0]["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["issue_view"]
+    );
+    assert_eq!(values[1]["result"]["isError"], true);
+    assert!(values[1]["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("not allowed by this session"));
+}
+
+#[tokio::test]
+async fn custom_proxy_enforces_the_profile_stamped_tool_surface() {
+    let source = r#"
+import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    if request.get("method") == "tools/list":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {"tools": [
+                {"name": "allowed", "inputSchema": {"type": "object"}},
+                {"name": "surprise", "inputSchema": {"type": "object"}},
+            ]},
+        }), flush=True)
+"#;
+    let mut child = Command::new(loom_bin())
+        .args(["mcp", "serve-custom", "/tests/filter"])
+        .env(
+            "LOOM_CUSTOM_MCP_SOURCE_B64",
+            base64::engine::general_purpose::STANDARD.encode(source),
+        )
+        .env("LOOM_MCP_ALLOWED_TOOLS", "[\"allowed\"]")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"surprise\",\"arguments\":{}}}\n",
+        )
+        .await
+        .unwrap();
+    let mut lines = BufReader::new(child.stdout.take().unwrap()).lines();
+    let mut values = Vec::new();
+    while let Some(line) = lines.next_line().await.unwrap() {
+        values.push(serde_json::from_str::<Value>(&line).unwrap());
+    }
+    assert!(child.wait().await.unwrap().success());
+
+    let listed = values.iter().find(|value| value["id"] == 1).unwrap();
+    assert_eq!(
+        listed["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["allowed"]
+    );
+    let rejected = values.iter().find(|value| value["id"] == 2).unwrap();
+    assert!(rejected["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("not allowed by this session"));
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn messaging_status_tool_uses_the_session_scoped_status_route() {
+    let ts = TestServer::start().await;
+    let branch = loom::branch::upsert(&ts.state.db, &ts.cwd(), "weaver/mcp-status", "main")
+        .await
+        .unwrap();
+    loom::session::insert(
+        &ts.state.db,
+        &loom::session::NewSession {
+            id: "mcpstatussession".to_string(),
+            branch_id: branch.id.clone(),
+            work_dir: ts.cwd(),
+            term_session: "weaver-mcp-status".to_string(),
+            agent_kind: "claude".to_string(),
+            model: String::new(),
+            effort: String::new(),
+            status: "running".to_string(),
+            github_repo: None,
+            parent_branch_id: None,
+            managed_by: None,
+            created_by: None,
+            protocol: "acp".to_string(),
+            origin: "user".to_string(),
+            class: "interactive".to_string(),
+            tracking_issue_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    let token =
+        loom::auth::create_session_token(&ts.state.db, None, "mcpstatussession", &branch.id)
+            .await
+            .unwrap();
+
+    let mut child = Command::new(loom_bin())
+        .args(["mcp", "serve", "messaging"])
+        .env("WEAVER_API", format!("http://{}", ts.addr))
+        .env("LOOM_TOKEN", token)
+        .env("LOOM_SESSION_ID", "mcpstatussession")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    stdin
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"status_update\",\"arguments\":{\"level\":\"attention\",\"message\":\"review the MCP design\"}}}\n",
+        )
+        .await
+        .unwrap();
+    drop(stdin);
+    let mut lines = BufReader::new(child.stdout.take().unwrap()).lines();
+    let _: Value = serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+    let response: Value = serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+    assert_eq!(response["result"]["isError"], false, "{response}");
+    assert!(child.wait().await.unwrap().success());
+
+    let branch = loom::branch::get(&ts.state.db, &branch.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(branch.description, "review the MCP design");
+    let attention =
+        weaver_core::tags::get(&ts.state.db, &branch.id, weaver_core::tags::ATTENTION_KEY)
+            .await
+            .unwrap()
+            .unwrap();
+    assert_eq!(attention.value, "attention");
+}

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -46,11 +46,13 @@ async fn stock_github_comment_profile_round_trips_restricted_policy() {
     assert_eq!(profile["mode"], "default");
     assert_eq!(profile["prelude"], "none");
     assert_eq!(profile["restricted"], true);
-    assert!(profile["allowed_tools"]
+    assert!(profile["runtime_permissions"]
         .as_array()
         .unwrap()
         .iter()
-        .any(|rule| rule == "mcp/github/comment@v1"));
+        .any(|rule| rule == "Read(./**)"));
+    assert_eq!(profile["mcp_access"]["mode"], "groups");
+    assert_eq!(profile["mcp_access"]["groups"], json!(["github"]));
     assert!(profile["env"].as_array().unwrap().is_empty());
 }
 
@@ -69,6 +71,204 @@ async fn mcp_registry_is_inspectable_without_source_access() {
     assert!(set["digest"].as_str().unwrap().starts_with("sha256:"));
     assert_eq!(set["adapter"], "github");
     assert_eq!(set["tools"].as_array().unwrap().len(), 6);
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_mcp_crud_validates_source_and_profiles_select_its_group() {
+    let ts = TestServer::start().await;
+    let source = r#"
+import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    if "id" not in request:
+        continue
+    if request["method"] == "initialize":
+        result = {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "test-custom", "version": "1"},
+        }
+    elif request["method"] == "tools/list":
+        result = {
+            "tools": [{
+                "name": "ping",
+                "description": "Return a value.",
+                "inputSchema": {"type": "object"},
+            }]
+        }
+    else:
+        continue
+    print(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": result}), flush=True)
+"#;
+    let test_source = r#"
+import os
+from pathlib import Path
+
+assert "tools/list" in Path(os.environ["LOOM_MCP_SOURCE"]).read_text()
+print("custom tests passed")
+"#;
+    let custom = ts
+        .client
+        .post(
+            "/api/mcps/custom",
+            json!({
+                "identity": "/ops/status",
+                "label": "Status helper",
+                "description": "Test custom MCP",
+                "source": source,
+                "test_source": test_source,
+                "enabled": true
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(custom["group"], "ops");
+    assert_eq!(custom["revision"], 1);
+    assert_eq!(custom["validation_state"], "ready");
+    assert_eq!(custom["tools"], json!(["ping"]));
+    assert!(custom["validation_message"]
+        .as_str()
+        .unwrap()
+        .contains("custom tests passed"));
+
+    let registry = ts.client.get("/api/mcps").await.unwrap();
+    assert!(registry["custom_servers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|server| server["identity"] == "/ops/status"));
+
+    let profile_req = json!({
+        "name": "custom-tools",
+        "description": "ordinary ACP profile with custom tools",
+        "agent_kind": "claude",
+        "protocol": "acp",
+        "mode": "default",
+        "mcp_access": {"mode": "groups", "groups": ["ops"]}
+    });
+    let created_profile = ts
+        .client
+        .post("/api/profiles", profile_req.clone())
+        .await
+        .unwrap();
+    assert_eq!(created_profile["revision"], 1);
+    let effective = ts
+        .client
+        .get("/api/profiles/custom-tools/effective")
+        .await
+        .unwrap();
+    assert_eq!(
+        effective["mcp_policy"]["custom_servers"][0]["identity"],
+        "/ops/status"
+    );
+    assert_eq!(effective["mcp_policy"]["custom_servers"][0]["revision"], 1);
+    assert!(effective["runtime_permissions"][0]
+        .as_str()
+        .unwrap()
+        .starts_with("mcp__loom_custom_"));
+    assert!(
+        std::path::Path::new(effective["mcp_servers"][0]["command"].as_str().unwrap())
+            .is_absolute()
+    );
+    assert_eq!(
+        effective["mcp_servers"][0]["args"],
+        json!(["mcp", "serve-custom", "/ops/status"])
+    );
+    let probe = ts
+        .client
+        .post("/api/profiles/custom-tools/probe", json!({}))
+        .await
+        .unwrap();
+    assert_eq!(probe["ok"], true);
+
+    let source_v2 = source.replace("Return a value.", "Return a pinned value.");
+    let edited = ts
+        .client
+        .put(
+            "/api/mcps/custom/ops/status",
+            json!({
+                "identity": "/ignored/by/put/path",
+                "label": "Status helper",
+                "description": "Test custom MCP",
+                "source": source_v2.clone(),
+                "test_source": test_source,
+                "enabled": true
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(edited["revision"], 2);
+    let still_pinned = ts
+        .client
+        .get("/api/profiles/custom-tools/effective")
+        .await
+        .unwrap();
+    assert_eq!(
+        still_pinned["mcp_policy"]["custom_servers"][0]["revision"],
+        1
+    );
+
+    let reconciled = ts
+        .client
+        .put("/api/profiles/custom-tools", profile_req)
+        .await
+        .unwrap();
+    assert_eq!(reconciled["revision"], 2);
+    let effective = ts
+        .client
+        .get("/api/profiles/custom-tools/effective")
+        .await
+        .unwrap();
+    assert_eq!(effective["mcp_policy"]["custom_servers"][0]["revision"], 2);
+
+    let disabled = ts
+        .client
+        .put(
+            "/api/mcps/custom/ops/status",
+            json!({
+                "identity": "/ignored/by/put/path",
+                "label": "Status helper",
+                "description": "Test custom MCP",
+                "source": source_v2,
+                "test_source": test_source,
+                "enabled": false
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(disabled["identity"], "/ops/status");
+    assert_eq!(disabled["revision"], 3);
+    let probe = ts
+        .client
+        .post("/api/profiles/custom-tools/probe", json!({}))
+        .await
+        .unwrap();
+    assert_eq!(probe["ok"], false);
+    assert!(probe["errors"][0].as_str().unwrap().contains("is disabled"));
+
+    let response = reqwest::Client::new()
+        .delete(format!("http://{}/api/mcps/custom/ops/status", ts.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(response.text().await.unwrap().contains("pinned by profile"));
+
+    let response = reqwest::Client::new()
+        .delete(format!("http://{}/api/profiles/custom-tools", ts.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let response = reqwest::Client::new()
+        .delete(format!("http://{}/api/mcps/custom/ops/status", ts.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
 }
 
 #[serial]
@@ -101,6 +301,14 @@ async fn restricted_profile_sends_the_caller_goal_as_the_first_prompt() {
         )
         .await
         .unwrap();
+    assert_eq!(
+        session["mcp_policy"]["capability_sets"][0]["name"],
+        "mcp/github/comment@v1"
+    );
+    assert!(session["mcp_policy"]["capability_sets"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .starts_with("sha256:"));
     let id = session["id"].as_str().unwrap();
     assert!(ts
         .client
@@ -249,6 +457,14 @@ async fn restricted_github_tool_uses_the_server_side_token_and_fixed_repo() {
     let stamped: Vec<String> = serde_json::from_str(&stamped).unwrap();
     assert!(stamped.contains(&"mcp__loom_github__issue_edit".to_string()));
     assert!(!stamped.contains(&"mcp/github/comment".to_string()));
+    let mcp_policy: String =
+        sqlx::query_scalar("SELECT policy_mcp_access FROM sessions WHERE id = ?")
+            .bind(id)
+            .fetch_one(&ts.state.db)
+            .await
+            .unwrap();
+    assert!(mcp_policy.contains("mcp/github/comment@v1"));
+    assert!(mcp_policy.contains("sha256:"));
     let tracking = weaver_core::issue::add(
         &ts.state.db,
         &weaver_core::issue::NewIssue {
@@ -411,14 +627,15 @@ async fn deployment_manifest_reconciles_profiles_secret_refs_and_workload_identi
             "profile": {
                 "name": "ops",
                 "description": "operations automation",
-                "agent_kind": "shell",
-                "protocol": "terminal",
+                "agent_kind": "claude",
+                "protocol": "acp",
                 "mode": "plan",
                 "class": "automation",
                 "strict": true,
                 "env_clear": true,
                 "max_concurrent": 1,
-                "turn_budget": 20
+                "turn_budget": 20,
+                "mcp_access": {"mode": "groups", "groups": ["messaging"]}
             },
             "env": [{
                 "name": "KUBECONFIG",
@@ -444,6 +661,10 @@ async fn deployment_manifest_reconciles_profiles_secret_refs_and_workload_identi
         .await
         .unwrap();
     assert_eq!(first["profiles"][0]["revision"], 1);
+    assert_eq!(
+        first["profiles"][0]["mcp_access"],
+        json!({"mode": "groups", "groups": ["messaging"]})
+    );
     assert_eq!(first["profiles"][0]["env"][0]["source"], "gcp_secret");
     assert_eq!(
         first["profiles"][0]["env"][0]["secret_ref"],

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -50,8 +50,25 @@ async fn stock_github_comment_profile_round_trips_restricted_policy() {
         .as_array()
         .unwrap()
         .iter()
-        .any(|rule| rule == "mcp/github/comment"));
+        .any(|rule| rule == "mcp/github/comment@v1"));
     assert!(profile["env"].as_array().unwrap().is_empty());
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_registry_is_inspectable_without_source_access() {
+    let ts = TestServer::start().await;
+    let registry = ts.client.get("/api/mcps").await.unwrap();
+    let set = registry["capability_sets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|set| set["name"] == "mcp/github/comment@v1")
+        .expect("GitHub comment MCP set");
+    assert_eq!(set["version"], "v1");
+    assert!(set["digest"].as_str().unwrap().starts_with("sha256:"));
+    assert_eq!(set["adapter"], "github");
+    assert_eq!(set["tools"].as_array().unwrap().len(), 6);
 }
 
 #[serial]

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -13,11 +13,12 @@ use serde_json::Value;
 use crate::dto::{
     AnchorDto, ArtifactMeta, ArtifactUpsertReq, ArtifactView, AutomationTokenReq,
     AutomationTokenView, BranchStatusReq, BranchView, CommentDto, CreateEventReq, CreateIssueReq,
-    CreateRepoIssueReq, CreateReq, CreateTokenReq, CreateWatchReq, CreatedTokenView, DeploymentReq,
-    DeploymentView, DiagnosticsView, FederationReq, FederationView, HandoffReq, IssueView,
-    McpRegistryView, NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq,
-    ProfileReq, ProfileView, PutProfileEnvReq, ReadinessView, RunReq, RunView, RunWatchReq,
-    SendReq, SessionView, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
+    CreateRepoIssueReq, CreateReq, CreateTokenReq, CreateWatchReq, CreatedTokenView, CustomMcpReq,
+    CustomMcpView, DeploymentReq, DeploymentView, DiagnosticsView, EffectiveProfileView,
+    FederationReq, FederationView, HandoffReq, IssueView, McpRegistryView, NewCommentBody,
+    NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileProbeView, ProfileReq,
+    ProfileView, PutProfileEnvReq, ReadinessView, RunReq, RunView, RunWatchReq, SendReq,
+    SessionView, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
 };
 
 /// A client for one loom server, identified by its base URL.
@@ -680,6 +681,32 @@ impl Client {
         self.get_typed("/api/mcps").await
     }
 
+    pub async fn create_custom_mcp(&self, req: &CustomMcpReq) -> Result<CustomMcpView> {
+        self.send_typed(Method::POST, "/api/mcps/custom", Some(req))
+            .await
+    }
+
+    pub async fn put_custom_mcp(
+        &self,
+        identity: &str,
+        req: &CustomMcpReq,
+    ) -> Result<CustomMcpView> {
+        self.send_typed(
+            Method::PUT,
+            &format!("/api/mcps/custom/{}", identity.trim_start_matches('/')),
+            Some(req),
+        )
+        .await
+    }
+
+    pub async fn delete_custom_mcp(&self, identity: &str) -> Result<Value> {
+        self.delete(&format!(
+            "/api/mcps/custom/{}",
+            identity.trim_start_matches('/')
+        ))
+        .await
+    }
+
     /// List named launch profiles. Secret environment values are withheld.
     pub async fn list_profiles(&self) -> Result<Vec<ProfileView>> {
         self.get_typed("/api/profiles").await
@@ -688,6 +715,20 @@ impl Client {
     pub async fn get_profile(&self, name: &str) -> Result<ProfileView> {
         self.get_typed(&format!("/api/profiles/{}", Self::seg(name)))
             .await
+    }
+
+    pub async fn effective_profile(&self, name: &str) -> Result<EffectiveProfileView> {
+        self.get_typed(&format!("/api/profiles/{}/effective", Self::seg(name)))
+            .await
+    }
+
+    pub async fn probe_profile(&self, name: &str) -> Result<ProfileProbeView> {
+        self.send_typed::<(), _>(
+            Method::POST,
+            &format!("/api/profiles/{}/probe", Self::seg(name)),
+            None,
+        )
+        .await
     }
 
     pub async fn create_profile(&self, req: &ProfileReq) -> Result<ProfileView> {

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -15,9 +15,9 @@ use crate::dto::{
     AutomationTokenView, BranchStatusReq, BranchView, CommentDto, CreateEventReq, CreateIssueReq,
     CreateRepoIssueReq, CreateReq, CreateTokenReq, CreateWatchReq, CreatedTokenView, DeploymentReq,
     DeploymentView, DiagnosticsView, FederationReq, FederationView, HandoffReq, IssueView,
-    NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileReq,
-    ProfileView, PutProfileEnvReq, ReadinessView, RunReq, RunView, RunWatchReq, SendReq,
-    SessionView, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
+    McpRegistryView, NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq,
+    ProfileReq, ProfileView, PutProfileEnvReq, ReadinessView, RunReq, RunView, RunWatchReq,
+    SendReq, SessionView, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
 };
 
 /// A client for one loom server, identified by its base URL.
@@ -673,6 +673,11 @@ impl Client {
     /// Admin-only redacted operational inventory (`GET /api/diagnostics`).
     pub async fn diagnostics(&self) -> Result<DiagnosticsView> {
         self.get_typed("/api/diagnostics").await
+    }
+
+    /// Trusted MCP adapters and their provider-neutral capability sets.
+    pub async fn mcp_registry(&self) -> Result<McpRegistryView> {
+        self.get_typed("/api/mcps").await
     }
 
     /// List named launch profiles. Secret environment values are withheld.

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -279,6 +279,34 @@ pub struct ProfileEnvView {
     pub updated_at: String,
 }
 
+/// One trusted MCP adapter Loom can launch.  This is deliberately provider
+/// neutral: clients select a capability set, while an agent runtime translates
+/// its tools into that provider's permission vocabulary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpAdapterView {
+    pub name: String,
+    pub description: String,
+    pub server_name: String,
+}
+
+/// An inspectable, content-addressed collection of MCP tools.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpCapabilitySetView {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+    pub description: String,
+    pub adapter: String,
+    pub tools: Vec<String>,
+}
+
+/// The trusted MCP registry exposed to operators and the settings UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpRegistryView {
+    pub adapters: Vec<McpAdapterView>,
+    pub capability_sets: Vec<McpCapabilitySetView>,
+}
+
 /// Body for creating or replacing a profile.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProfileReq {

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -195,6 +195,9 @@ pub struct SessionView {
     /// Resolved launch permission posture, immutable for this session.
     #[serde(default)]
     pub launch_mode: String,
+    /// Exact, source-redacted MCP capability snapshot stamped at launch.
+    #[serde(default)]
+    pub mcp_policy: SessionMcpPolicyView,
     pub branch: BranchView,
 }
 
@@ -261,7 +264,9 @@ pub struct ProfileView {
     #[serde(default)]
     pub restricted: bool,
     #[serde(default)]
-    pub allowed_tools: Vec<String>,
+    pub runtime_permissions: Vec<String>,
+    #[serde(default)]
+    pub mcp_access: McpAccess,
     pub revision: i64,
     pub created_at: String,
     pub updated_at: String,
@@ -290,9 +295,10 @@ pub struct McpAdapterView {
 }
 
 /// An inspectable, content-addressed collection of MCP tools.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpCapabilitySetView {
     pub name: String,
+    pub group: String,
     pub version: String,
     pub digest: String,
     pub description: String,
@@ -305,6 +311,151 @@ pub struct McpCapabilitySetView {
 pub struct McpRegistryView {
     pub adapters: Vec<McpAdapterView>,
     pub capability_sets: Vec<McpCapabilitySetView>,
+    #[serde(default)]
+    pub custom_servers: Vec<CustomMcpView>,
+}
+
+/// Provider-neutral MCP selection carried by a profile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpAccess {
+    /// `none`, `all`, or `groups`.
+    pub mode: String,
+    #[serde(default)]
+    pub groups: Vec<String>,
+}
+
+impl Default for McpAccess {
+    fn default() -> Self {
+        Self {
+            mode: "none".to_string(),
+            groups: Vec::new(),
+        }
+    }
+}
+
+/// Exact MCP registry content stamped onto a launched session.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpPolicySnapshot {
+    pub selection: McpAccess,
+    #[serde(default)]
+    pub capability_sets: Vec<McpCapabilitySetView>,
+    #[serde(default)]
+    pub custom_servers: Vec<CustomMcpSnapshot>,
+}
+
+/// Source-redacted MCP audit policy returned on ordinary session views.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionMcpPolicyView {
+    pub selection: McpAccess,
+    #[serde(default)]
+    pub capability_sets: Vec<McpCapabilitySetView>,
+    #[serde(default)]
+    pub custom_servers: Vec<SessionCustomMcpView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionCustomMcpView {
+    pub identity: String,
+    pub group: String,
+    pub revision: i64,
+    pub digest: String,
+    pub server_name: String,
+    pub tools: Vec<String>,
+}
+
+impl From<&McpPolicySnapshot> for SessionMcpPolicyView {
+    fn from(snapshot: &McpPolicySnapshot) -> Self {
+        Self {
+            selection: snapshot.selection.clone(),
+            capability_sets: snapshot.capability_sets.clone(),
+            custom_servers: snapshot
+                .custom_servers
+                .iter()
+                .map(|server| SessionCustomMcpView {
+                    identity: server.identity.clone(),
+                    group: server.group.clone(),
+                    revision: server.revision,
+                    digest: server.digest.clone(),
+                    server_name: server.server_name.clone(),
+                    tools: server.tools.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Exact executable custom MCP revision stamped onto a session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CustomMcpSnapshot {
+    pub identity: String,
+    pub group: String,
+    pub revision: i64,
+    pub digest: String,
+    pub server_name: String,
+    pub tools: Vec<String>,
+    /// Source is part of the immutable recovery snapshot. It is operator-authored
+    /// code, never a credential, and is not exposed in ordinary session views.
+    pub source: String,
+}
+
+/// Body for creating or updating an operator-authored MCP server.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CustomMcpReq {
+    pub identity: String,
+    pub label: String,
+    #[serde(default)]
+    pub description: String,
+    pub source: String,
+    #[serde(default)]
+    pub test_source: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Latest custom MCP definition and validation result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomMcpView {
+    pub identity: String,
+    pub group: String,
+    pub label: String,
+    pub description: String,
+    pub enabled: bool,
+    pub revision: i64,
+    pub digest: String,
+    pub source: String,
+    pub test_source: String,
+    pub tools: Vec<String>,
+    pub validation_state: String,
+    pub validation_message: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerProcessView {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+/// Fully resolved non-secret profile policy without launching a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EffectiveProfileView {
+    pub profile: ProfileView,
+    pub mcp_policy: McpPolicySnapshot,
+    pub runtime_permissions: Vec<String>,
+    pub mcp_servers: Vec<McpServerProcessView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileProbeView {
+    pub ok: bool,
+    pub effective: EffectiveProfileView,
+    pub errors: Vec<String>,
 }
 
 /// Body for creating or replacing a profile.
@@ -340,8 +491,12 @@ pub struct ProfileReq {
     pub prelude: String,
     #[serde(default)]
     pub restricted: bool,
+    /// Provider-specific fallback permissions. New integrations should use
+    /// `mcp_access`; `allowed_tools` remains a read-compatible input alias.
+    #[serde(default, alias = "allowed_tools")]
+    pub runtime_permissions: Vec<String>,
     #[serde(default)]
-    pub allowed_tools: Vec<String>,
+    pub mcp_access: McpAccess,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1486,4 +1641,30 @@ pub struct SetGithubConfigReq {
     pub client_id: String,
     #[serde(default)]
     pub client_secret: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_mcp_policy_redacts_custom_source_but_keeps_audit_identity() {
+        let snapshot = McpPolicySnapshot {
+            custom_servers: vec![CustomMcpSnapshot {
+                identity: "/ops/status".to_string(),
+                group: "ops".to_string(),
+                revision: 3,
+                digest: "sha256:abc".to_string(),
+                server_name: "loom_custom_abc".to_string(),
+                tools: vec!["status".to_string()],
+                source: "operator-only source".to_string(),
+            }],
+            ..Default::default()
+        };
+        let audit = SessionMcpPolicyView::from(&snapshot);
+        let encoded = serde_json::to_string(&audit).unwrap();
+        assert!(!encoded.contains("operator-only source"));
+        assert!(encoded.contains("/ops/status"));
+        assert!(encoded.contains("sha256:abc"));
+    }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -722,7 +722,7 @@ automation with `prelude = none`, `mode = default`, no ambient allowlist, and
 scoped Claude SDK tool rules. The first prompt is the caller's complete
 `session.goal`; Loom does not add `WEAVER.md` or infer rewrite instructions.
 Profiles select reviewed built-in MCP capability sets such as
-`mcp/github/comment`; the MCP registry expands them into exact permissions at
+`mcp/github/comment@v1`; the MCP registry expands them into exact permissions at
 session creation and derives the trusted adapter command from those stamped
 rules. Repository/profile data never supplies executable MCP configuration.
 Restricted launch and recovery omit repository environment/setup and Claude

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,6 +54,9 @@ other `weaver` subcommand.
 | `crates/loom/src/builtins.rs` | the builtin watch program registry; the script programs are real Python files in `crates/loom/watches/`, embedded into the binary |
 | `python/weaver-loom/` | the pure-Python layer over the loom REST API (`weaver_loom`: client + watch round context); stdlib-only, uv-buildable, vendored onto every script's `PYTHONPATH` by the engine; server-free contract tests in `tests/` (`uv run pytest`, CI's `python-binding` job) |
 | `crates/loom/src/agent.rs` | launching agents: resolving the execution `protocol`, launching a `terminal` agent into a per-session PTY (installing its `.claude/settings.local.json` hooks) or building an `acp` launch (`build_acp_launch` — the adapter command, `_meta` options, and goal), plus the one-shot headless agent behind `POST /api/agent/oneshot` |
+| `crates/loom/src/mcp/` | trusted builtin MCP registry and stdio adapters: provider-neutral versioned capability sets, exact permission translation, and the fixed GitHub/messaging bridges |
+| `crates/loom/src/custom_mcp.rs` | operator-authored MCP definitions: grouped path identities, immutable sqlite revisions, bounded `uv` validation, and exact session-snapshot execution |
+| `crates/loom/src/profile.rs` | named launch policy, including provider-neutral `mcp_access` resolution and the restricted-profile trust boundary |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
 | `crates/loom/src/chatlog.rs` | conversation log: capture at archive (write the iris `chat.json` + rendered `chat.md` under `session.log_dir`) and serve it for the Conversation tab (`conversation()` — a terminal session's live transcript, an acp session's chat journal mapped to iris (`journal_to_log`), else the capture) |
 | `crates/loom/src/backend.rs` | the terminal-management seam: every programmatic terminal op (create/has/capture/send/kill/list) drives the session's `tapestry` supervisor. Also the ACP transport seam — `new_relay_session`/`subscribe_relay`/`relay_write`/`relay_ack` drive a session's tapestry **relay** supervisor (a durable JSON-RPC frame spool) |
@@ -250,8 +253,11 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/ready` | public structured readiness: database access plus core and loom migration versions; optional future remote runner degradation will be reported without failing the whole API |
 | `GET /metrics` | public OpenMetrics scrape derived from durable session/profile/run/migration state; labels are bounded operational dimensions and never contain session/branch/path/user/token/error values (deployments normally restrict this at the public edge) |
 | `GET /api/diagnostics` | admin-only redacted counts, profile capacity, automation failures/staleness, orphan/error inventory, migration state, and non-secret federation metadata; backs Settings → Diagnostics |
-| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false` — and `automation` — default `false`; create resolves `profile` or `default`, permits launch selectors only when the profile is non-strict, stamps the resolved profile revision/policy, opens a tracking issue, and returns its id as `tracking_issue`) |
-| `GET POST /api/profiles`; `GET PUT DELETE /api/profiles/{name}` | named launch-policy CRUD, including prelude and restricted Claude tool policy; profile secret values are never returned |
+| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false` — and `automation` — default `false`; create resolves `profile` or `default`, permits launch selectors only when the profile is non-strict, stamps the resolved profile revision/policy, opens a tracking issue, and returns its id as `tracking_issue`; views include the exact source-redacted MCP audit snapshot) |
+| `GET POST /api/profiles`; `GET PUT DELETE /api/profiles/{name}` | named launch-policy CRUD, including provider-neutral `mcp_access`, prelude, and the runtime-permission compatibility escape hatch; profile secret values are never returned |
+| `GET /api/profiles/{name}/effective`; `POST /api/profiles/{name}/probe` | inspect the exact profile-revision capability sets, custom revisions, runtime permission translation, and MCP processes without launching; probe also reports retired builtins and removed/disabled pinned custom definitions |
+| `GET /api/mcps` | merged trusted-builtin and operator-authored MCP registry |
+| `GET POST /api/mcps/custom`; `GET PUT DELETE /api/mcps/custom/{path}` | admin-only custom MCP CRUD; every write creates an immutable revision and validates real MCP discovery plus optional tests through `uv` |
 | `PUT DELETE /api/profiles/{profile}/env/{name}` | write-only profile environment management; a write supplies exactly one literal `value` or a full GCP Secret Manager `secret_ref`, and reads expose only source/reference metadata |
 | `POST /api/deployment/reconcile` | admin-only idempotent reconciliation of deployment-managed profiles, environment references, and federation mappings; pruning never touches operator-managed rows |
 | `POST /api/auth/federate` | exchange an exact mapped, signature-verified GitHub or Google OIDC identity for a ten-minute Ed25519-signed, profile-scoped Loom automation token |
@@ -740,6 +746,26 @@ handoff and permission-mode changes are forbidden. The stock `github_comment`
 profile contains the policy only; its reviewed JSON manifest is seeded when
 absent and then remains operator-editable. App-less deployments must provide
 its write-only `GH_TOKEN`.
+
+**MCP/profile control plane.** A profile stores `mcp_access` as `none`, `all`,
+or an explicit group list. Saving resolves the trusted builtin registry and
+enabled, validated custom definitions and pins the exact result to that profile
+revision. Launch validates availability, copies the capability
+identities/digests and custom source revisions into
+`sessions.policy_mcp_access`, and gives every ACP runtime native `mcpServers`
+descriptors whose subprocess tool surfaces are filtered to the stamped rules.
+Neither an unchanged profile nor recovery re-resolves the current registry.
+Custom definitions live under
+absolute identities such as `/engineering/search/docs`; their first segment is
+the selectable group. A save runs `initialize` and `tools/list`, then optional
+tests, through `uv run --script`. Runtime children start from a cleared
+environment with only `PATH`, Loom-controlled uv cache/interpreter paths, and
+session-scoped Loom API context. Custom code is
+admin-authored and dependency-contained, not sandboxed; it cannot use
+builtin-reserved group names or enter restricted sessions. Loom also refuses to
+remove a server pinned by a profile, or the last server in a group while an
+explicit profile selection still references it. The detailed rationale and diagrams are in
+[plans/mcp-profiles.md](plans/mcp-profiles.md).
 
 **Cookies** are `HttpOnly; SameSite=Lax; Path=/`; the `Secure` attribute is
 added when `auth.cookie_secure` is on (set it when loom is reached over HTTPS).

--- a/docs/plans/mcp-profiles.md
+++ b/docs/plans/mcp-profiles.md
@@ -1,0 +1,329 @@
+# MCP and profile control plane
+
+Status: implemented design for Weaver issue #611
+
+Related GitHub work: [#174](https://github.com/marin-community/loom/issues/174),
+[#181](https://github.com/marin-community/loom/issues/181), and
+[#183](https://github.com/marin-community/loom/issues/183), building on the
+restricted-session foundation in
+[#179](https://github.com/marin-community/loom/pull/179) and
+[#191](https://github.com/marin-community/loom/pull/191).
+
+> **Decision:** Profiles select provider-neutral MCP groups (`none`, `all`, or
+> an explicit group list). Loom resolves that selection into an immutable,
+> content-addressed session snapshot. Agent adapters translate the snapshot into
+> provider-specific launch configuration only at the final runtime boundary.
+
+## Why this model
+
+The restricted GitHub work established the right security foundations:
+
+- PR #179 moved executable MCP configuration into a trusted Rust registry and
+  let the `github_comment` profile select a reviewed capability set.
+- Sessions persist exact expanded permission names, so recovery does not
+  re-expand a changed registry entry.
+- PR #191 keeps GitHub credentials server-side and repository-scoped.
+- Profile revisions already provide a stable launch contract for automation.
+
+The old public model nevertheless combined two concepts in `allowed_tools`:
+
+1. provider-native permission strings such as `Read(./**)`; and
+2. Loom integration choices such as `mcp/github/comment`.
+
+That made every profile look Claude-specific, gave other runtimes no clean
+contract, and could not express “all messaging MCPs”, “only the GitHub group”,
+or “no MCPs”. It also had nowhere safe to put operator-authored MCP programs.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    UI[Settings / CLI / deployment manifest]
+    PROFILE[(profiles)]
+    REG[Trusted builtin registry]
+    CUSTOM[(custom_mcp_servers)]
+    RESOLVE[Policy resolver]
+    SNAP[(sessions.policy_mcp_access)]
+    ADAPTER[Agent adapter]
+    MCP[MCP stdio processes]
+    API[Loom session-scoped REST]
+    GH[GitHub]
+    SLACK[Slack]
+    STATUS[Branch status + routing]
+
+    UI -->|none / all / groups| PROFILE
+    UI -->|source + tests| CUSTOM
+    REG --> RESOLVE
+    CUSTOM --> RESOLVE
+    PROFILE --> RESOLVE
+    RESOLVE -->|exact names, digests, revisions| PROFILE
+    PROFILE -->|copy pinned profile policy| SNAP
+    SNAP --> ADAPTER
+    ADAPTER --> MCP
+    MCP --> API
+    API --> GH
+    API --> SLACK
+    API --> STATUS
+```
+
+The separation is deliberate:
+
+- **Registry entries describe capability.** They have an identity, group,
+  version or revision, content digest, description, exact tools, and a launch
+  descriptor. A builtin digest covers the adapter/server identity, set
+  metadata, ordered tool names, and full advertised tool schemas—not merely the
+  friendly set name.
+- **Profiles select and pin policy.** `mcp_access` is `{mode, groups}`. Saving
+  resolves it into exact capability content on that profile revision; it
+  contains neither commands nor provider permission syntax.
+- **Sessions own history.** Launch stores the full resolved snapshot, including
+  custom source, revision, digest, and exact capability sets. Recovery consumes
+  this snapshot instead of today’s registry. Ordinary session views expose the
+  exact identities, digests, revisions, and tools for audit while redacting
+  custom source.
+- **Adapters translate.** ACP receives its native `mcpServers` descriptors.
+  Claude’s `allowedTools` remains only the final restricted-runtime permission
+  translation, not the public profile vocabulary.
+
+## Profile contract
+
+```json
+{
+  "name": "ops",
+  "agent_kind": "codex",
+  "runtime_permissions": [],
+  "mcp_access": {
+    "mode": "groups",
+    "groups": ["github", "messaging"]
+  }
+}
+```
+
+Modes:
+
+- `none`: no MCP processes.
+- `all`: every enabled builtin and custom MCP visible to ordinary sessions.
+- `groups`: every enabled MCP whose group exactly matches a selected group.
+
+Restricted profiles may select explicit trusted-builtin groups only; their
+future-widening `all` mode is rejected. Custom definitions cannot use a builtin
+group name, preventing a later operator definition from shadowing or widening a
+restricted profile. Unknown groups fail profile writes and deployment
+reconciliation; they never silently reduce or broaden access.
+
+`runtime_permissions` is a backward-compatible escape hatch for restricted
+filesystem rules. The API accepts legacy `allowed_tools` input as an alias, but
+returns the provider-neutral name.
+
+## Builtins and routing
+
+| Identity / group | Purpose | Credential and routing boundary |
+|---|---|---|
+| `mcp/github/comment@v1` / `github` | Issue/PR view, comment, and edit | Existing repository-fixed REST bridge and server-side GitHub credential path from PRs #179/#191 |
+| `mcp/messaging/status@v1` / `messaging` | Update the session’s Weaver status | Existing branch-status API; its durable event is mirrored to wired GitHub and Slack threads |
+| `mcp/slack/message@v1` / `messaging` | Post in the session-bound Slack thread | Existing fixed-thread route; the workspace bot token stays in Loom |
+
+> **Why status stays a CLI and gains an MCP facade:** `weaver status` is already
+> the lifecycle contract used by prompts, humans, hooks, watches, the dashboard,
+> and status cards. Replacing it would split state. The MCP tool is a structured
+> convenience for runtimes that prefer tools; it calls the same API and creates
+> the same event. Routing remains downstream of that event.
+
+> **Why not expose generic Slack or GitHub SDKs:** Sessions already carry a
+> repository or thread identity. Fixed, task-shaped operations keep credentials
+> out of agent environments and prevent a profile from accidentally granting
+> workspace-wide authority.
+
+## Custom MCP definitions
+
+Custom definitions use an absolute logical identity such as
+`/engineering/search/docs`; the first path segment is the selectable group.
+They live in SQLite because this is operator configuration rather than
+repository content, and because source revisions must survive worktree archive.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Validating: Save and validate
+    Validating --> Ready: MCP smoke + optional tests pass
+    Validating --> Failed: bounded diagnostics
+    Failed --> Validating: edit and retry
+    Ready --> Validating: edit creates revision
+    Ready --> Disabled: operator disables
+    Disabled --> Validating: edit or re-enable
+```
+
+Each immutable revision stores:
+
+- identity, derived group, label, and description;
+- Python source with optional PEP 723 inline dependencies;
+- optional test source;
+- revision and SHA-256 digest;
+- discovered tool names, validation state, and bounded diagnostics;
+- created and updated timestamps.
+
+Save launches the script with `uv run --script`, performs real MCP
+`initialize` and `tools/list` calls with a timeout, validates the advertised
+tool names, and then runs optional authored tests with `LOOM_MCP_SOURCE`
+pointing to the materialized server. Failed revisions remain editable and
+inspectable but are excluded from profile snapshots.
+Removing the last server in an explicitly selected custom group is rejected
+until the referencing profiles are updated, so ordinary administration cannot
+silently turn a valid group selection into an unknown one.
+
+Editing a definition does not mutate existing profile revisions. A profile
+continues to report and launch its pinned custom revision until the profile is
+saved again; that explicit reconciliation advances the profile revision.
+Disabling a pinned definition makes probe and new launch fail with a corrective
+error instead of silently dropping the process. Existing sessions continue
+from their own source snapshot.
+
+The runtime materializes the exact session-stamped source into a private
+temporary directory and launches it through `uv run --script`. The child starts
+from a cleared environment and receives only `PATH`, Loom-controlled uv
+cache/interpreter locations, plus the session-scoped Loom API context
+(`WEAVER_API`, `WEAVER_BRANCH`, `LOOM_SESSION_ID`, and `LOOM_TOKEN`). A
+deployment-level uv cache is reused when configured (including the standalone
+container's persistent `/opt/uv` volume); otherwise validation gets a private
+temporary cache. Cloud and provider credentials are not ambient custom-MCP
+inputs.
+
+The Loom wrapper also filters `tools/list` and rejects `tools/call` against the
+profile-stamped tool names. That defense is required even though source is
+snapshotted: a script can resolve dependencies or branch on runtime state, and
+ACP runtimes without a provider-specific permission list must still receive the
+same exact surface that validation approved.
+
+Validation is an execution check, not an OS sandbox. Only administrators can
+author custom MCPs, and restricted sessions reject them. Repository content can
+neither define nor edit executable MCP configuration. Filesystem isolation from
+[#180](https://github.com/marin-community/loom/issues/180) remains a separate
+security boundary.
+
+## Launch and recovery
+
+```mermaid
+sequenceDiagram
+    participant C as CLI / SPA / deployment
+    participant P as Profile service
+    participant R as MCP resolver
+    participant S as Session DB
+    participant A as Agent adapter
+
+    C->>P: save profile with mcp_access
+    P->>R: validate mode and groups
+    R-->>P: exact current capabilities
+    P-->>C: profile revision
+    P->>P: pin policy to profile revision
+    C->>S: launch with profile
+    S->>S: validate pinned capability availability
+    S->>S: copy profile policy to policy_mcp_access
+    S->>A: create ACP mcpServers from snapshot
+    Note over S,A: recovery repeats from the snapshot
+```
+
+This resolves #181’s audit and recovery problem without making versioning the
+main user experience. Builtins use readable versions and content digests.
+Custom revisions are immutable. Changing a builtin requires a new identity;
+editing a custom MCP creates a new revision. An unchanged profile revision
+therefore cannot silently widen when the registry changes. Saving that profile
+is the explicit reconciliation point and advances its revision. Existing
+sessions continue with their stamped policy and source.
+
+## REST, CLI, and UI
+
+REST:
+
+- `GET /api/mcps` — merged builtin/custom registry.
+- `GET/POST /api/mcps/custom` and
+  `GET/PUT/DELETE /api/mcps/custom/{path}` — definition CRUD; writes validate.
+- `GET /api/profiles/{name}/effective` — resolved policy preview.
+- `POST /api/profiles/{name}/probe` — availability and disabled/failed checks.
+- ordinary session responses include the source-redacted exact MCP snapshot
+  stamped at launch.
+
+CLI:
+
+- `loom mcp ls|show`
+- `loom mcp add /group/name --label ... --file server.py [--tests test.py]`
+- `loom mcp rm /group/name`
+- `loom profile show <name> --effective`
+- `loom profile probe <name>`
+
+The Settings page provides source and test editors, validation output, and
+enable/disable state. The profile editor renders `none`/`all`/group selection
+from the registry. Provider-specific runtime permissions remain a clearly
+labelled legacy escape hatch rather than “Allowed Claude tools”.
+
+## Conformance and security tests
+
+The implementation incorporates the reusable portion of #183:
+
+- every registered builtin advertises tools belonging to a declared set;
+- permission translation and server selection are exact;
+- builtin subprocesses receive and enforce the session-stamped tool subset, so
+  later sets on a shared adapter cannot widen `tools/list`;
+- every real builtin subprocess passes initialize, tools/list, notification,
+  unknown method/tool, malformed input, and clean-EOF checks;
+- the messaging status tool is exercised through a real subprocess, a
+  session-scoped token, and the existing durable branch-status route;
+- fresh launch and recovery use the same provider-neutral ACP descriptor shape;
+- custom source is smoke-tested over real MCP stdio through `uv`;
+- custom runtime discovery and calls are filtered to the profile-stamped tool
+  names even if the underlying script advertises something new;
+- custom definitions cannot shadow trusted groups or enter restricted sessions;
+- existing restricted-session tests keep GitHub credentials server-side.
+
+OS-level filesystem isolation from #180 and conditional mutation preconditions
+from [#182](https://github.com/marin-community/loom/issues/182) remain separate
+security projects. This design preserves those boundaries and does not claim to
+implement them.
+
+## Alternatives rejected
+
+1. **Keep `allowed_tools` and add prefixes.** Cheap initially, but it leaks
+   Claude policy into every client and cannot represent executable revision
+   identity safely.
+2. **Let profiles store arbitrary MCP command JSON.** That turns deployment or
+   repository data into an execution-injection path and weakens PR #179’s
+   reviewed restricted-session boundary.
+3. **Install every MCP globally.** Every agent would inherit dependency,
+   credential, and unnecessarily broad tool-surface coupling.
+4. **Replace `weaver status` with a messaging MCP.** That would fork the durable
+   status/event model and strand terminal agents and hooks.
+5. **Store custom MCP files in repositories.** Untrusted checkout content would
+   choose executable launch configuration, and revisions would disappear with
+   archived worktrees.
+
+## References
+
+- [MCP base protocol and lifecycle](https://modelcontextprotocol.io/specification/2025-06-18/basic)
+  defines the JSON-RPC initialization and notification contract used by
+  validation and the real-process conformance harness.
+- [MCP stdio transport](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports)
+  defines subprocess ownership and newline-delimited stdin/stdout framing.
+- [MCP tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
+  defines `tools/list`, `tools/call`, and the advertised schema surface that
+  capability-set digests cover.
+- [Agent Client Protocol](https://github.com/agentclientprotocol/agent-client-protocol)
+  is the provider-neutral agent boundary; its session lifecycle carries native
+  `mcpServers` on new and loaded sessions.
+- [uv single-file scripts](https://docs.astral.sh/uv/guides/scripts/) documents
+  PEP 723 inline dependencies, isolated environments, caching, and optional
+  script lockfiles.
+- Existing Loom work: issues
+  [#174](https://github.com/marin-community/loom/issues/174),
+  [#180](https://github.com/marin-community/loom/issues/180),
+  [#181](https://github.com/marin-community/loom/issues/181),
+  [#182](https://github.com/marin-community/loom/issues/182), and
+  [#183](https://github.com/marin-community/loom/issues/183); restricted-session
+  PRs [#179](https://github.com/marin-community/loom/pull/179) and
+  [#191](https://github.com/marin-community/loom/pull/191).
+
+## Result
+
+Profiles are now a stable, provider-neutral integration contract. Builtins keep
+credentials and routing inside Loom. Custom MCPs are editable and
+dependency-self-contained without being confused for a sandbox. Session
+snapshots make launches auditable and recovery deterministic. The model extends
+the existing restricted-session work instead of weakening it.

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -31,7 +31,10 @@ deployment-reconciliation contract; loading policy implicitly from a managed
 checkout would let repository content choose its own launch boundary and is
 deliberately unsupported. Custom profiles may compose the built-in capability
 sets Loom recognizes, but cannot define executable MCP adapters from repository
-content.
+content. Operator-authored custom MCPs are available to ordinary profiles only;
+their groups cannot shadow trusted builtin groups, and restricted profiles
+require explicit builtin groups rather than future-widening `all`, even though
+both use the same provider-neutral `mcp_access` contract.
 
 ## GitHub credential policy
 

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -8,7 +8,7 @@ the workflow owns task semantics, stale-write checks, and prose policy.
 The stock `github_comment` profile uses Claude over ACP with no Weaver prelude,
 no repository environment or setup script, no Claude user/project/local
 settings, repository-scoped read tools, and a fixed GitHub issue/PR MCP surface.
-The profile selects that reviewed surface as `mcp/github/comment`; Loom expands
+The profile selects that reviewed surface as `mcp/github/comment@v1`; Loom expands
 the set into exact tool permissions when it stamps the session and launches the
 corresponding built-in adapter from its registry. Profile data cannot provide an
 adapter command. New adapter families belong in `crates/loom/src/mcp/` and must

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -82,6 +82,91 @@ test.describe("settings · profiles", () => {
     await expect(mode).toHaveValue("bypassPermissions");
   });
 
+  test("custom MCP source validates and becomes a selectable profile group", async ({
+    page,
+    weaver,
+  }) => {
+    const source = `# /// script
+# requires-python = ">=3.11"
+# ///
+import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    if "id" not in request:
+        continue
+    method = request.get("method")
+    if method == "initialize":
+        result = {
+            "protocolVersion": request["params"]["protocolVersion"],
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "docs-search", "version": "1"},
+        }
+        response = {"jsonrpc": "2.0", "id": request["id"], "result": result}
+    elif method == "tools/list":
+        tool = {
+            "name": "lookup",
+            "description": "Search the docs",
+            "inputSchema": {"type": "object", "properties": {}},
+        }
+        response = {
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {"tools": [tool]},
+        }
+    else:
+        response = {
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "error": {"code": -32601, "message": "not found"},
+        }
+    print(json.dumps(response), flush=True)
+`;
+
+    await page.goto(`${weaver.baseUrl}/settings`);
+    const panel = page.getByTestId("mcp-panel");
+    await panel.getByRole("button", { name: "Add custom MCP" }).click();
+    await panel.getByLabel("Identity").fill("/docs/search");
+    await panel.getByLabel("Label").fill("Docs search");
+    await panel.getByLabel("Python MCP source (PEP 723)").fill(source);
+    await panel.getByRole("button", { name: "Save and validate" }).click();
+    await expect(panel.getByText("ready · r1")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const custom = (await (
+      await fetch(`${weaver.baseUrl}/api/mcps/custom/docs/search`)
+    ).json()) as {
+      identity: string;
+      group: string;
+      tools: string[];
+      validation_state: string;
+    };
+    expect(custom).toMatchObject({
+      identity: "/docs/search",
+      group: "docs",
+      tools: ["lookup"],
+      validation_state: "ready",
+    });
+
+    await page.reload();
+    await page.getByTestId("profile-agent").selectOption("codex");
+    await page.getByLabel("Protocol").selectOption("acp");
+    const access = page.getByRole("group", { name: "MCP access" });
+    await access.getByRole("button", { name: "groups" }).click();
+    await access.getByLabel("docs").check();
+    await page.getByTestId("profile-save").click();
+    await expect(page.getByText("Saved default.")).toBeVisible();
+
+    const profile = (await (
+      await fetch(`${weaver.baseUrl}/api/profiles/default`)
+    ).json()) as {
+      mcp_access: { mode: string; groups: string[] };
+    };
+    expect(profile.mcp_access).toEqual({ mode: "groups", groups: ["docs"] });
+  });
+
   test("overlapping settings are consolidated into workspace and access", async ({
     page,
     weaver,


### PR DESCRIPTION
## MCP and profile contract

Profiles now expose provider-neutral `mcp_access`: none, all, or explicit groups. Saving pins exact builtin digests, custom source revisions, and tool names to the profile revision; launch copies that policy to the session, and recovery uses the stamped snapshot. Provider-native rules remain available as the clearly named `runtime_permissions` compatibility escape hatch.

ACP new and load requests receive native `mcpServers` descriptors for every runtime. Builtin and custom subprocesses filter both discovery and calls to the session-stamped tool surface, while ordinary session views expose a source-redacted audit snapshot.

## Builtins and custom servers

The trusted registry now includes the existing repository-fixed GitHub bridge plus structured durable status updates and fixed-thread Slack replies. The status tool deliberately reuses the `weaver status` API and routing event instead of creating a second lifecycle model, keeping GitHub and Slack mirroring server-side.

Administrators can author Python MCP servers under grouped identities such as `/engineering/search/docs`. Loom stores immutable revisions in SQLite, runs real MCP initialize/discovery and optional tests through `uv run --script`, bounds diagnostics and time, clears the child environment, and excludes failed or disabled definitions from new policy snapshots. Restricted profiles accept trusted builtin groups only.

Settings and `loom mcp` provide the inline editor, validation output, CRUD, group selection, effective-policy preview, and profile probing. The detailed design, Mermaid flows, alternatives, references, and relationship to prior work are in the [published artifact](https://loom.rjp.io/s/umomjifz/artifacts/design) and `docs/plans/mcp-profiles.md`.

Fixes #181.
Addresses the MCP/profile and effective-preview portion of #174.
Advances the reusable adapter-conformance portion of #183.
Filesystem isolation in #180, conditional GitHub mutations in #182, and the remaining adversarial-runtime work in #183 stay separate.