### PR TITLE
fix(loom): serialize session provisioning by repo

### DIFF
--- a/crates/loom/frontend/src/components/AutomationRunRow.vue
+++ b/crates/loom/frontend/src/components/AutomationRunRow.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { AutomationRun } from '../types';
 import { exactTime, timeAgo } from '../lib/time';
 import StatusBadge from './StatusBadge.vue';
 
-defineProps<{ run: AutomationRun; intervention: boolean }>();
+const props = defineProps<{ run: AutomationRun; intervention: boolean; history?: boolean }>();
+
+const title = computed(() => {
+  if (props.intervention) return `Launch ${props.run.status}`;
+  if (props.history) return `Run ${props.run.status}`;
+  return 'Provisioning session';
+});
 </script>
 
 <template>
@@ -20,7 +27,7 @@ defineProps<{ run: AutomationRun; intervention: boolean }>();
     <div class="min-w-0 flex-1">
       <div class="flex flex-wrap items-center gap-2">
         <span class="font-serif text-[15px] font-semibold text-fg">
-          {{ intervention ? `Launch ${run.status}` : 'Provisioning session' }}
+          {{ title }}
         </span>
         <StatusBadge :status="run.status" />
       </div>

--- a/crates/loom/frontend/src/components/AutomationSessionRow.vue
+++ b/crates/loom/frontend/src/components/AutomationSessionRow.vue
@@ -5,6 +5,7 @@ import { exactTime, timeAgo } from '../lib/time';
 import { messageOf, signalChips } from '../lib/sessionState';
 import SignalChip from './SignalChip.vue';
 import StatusBadge from './StatusBadge.vue';
+import SessionRowActions from './SessionRowActions.vue';
 
 const props = defineProps<{
   session: Session;
@@ -13,7 +14,7 @@ const props = defineProps<{
   clearingTag: string;
 }>();
 
-const emit = defineEmits<{ clearTag: [key: string] }>();
+const emit = defineEmits<{ clearTag: [key: string]; changed: []; error: [message: string] }>();
 
 const dotClass = computed(() => {
   if (props.tone === 'intervention') return 'bg-block-line';
@@ -24,7 +25,7 @@ const dotClass = computed(() => {
 
 <template>
   <li
-    class="relative flex items-start gap-3 border-b border-line px-3 py-2.5 last:border-0"
+    class="group relative flex items-start gap-3 border-b border-line px-3 py-2.5 last:border-0"
     :class="tone === 'history' && 'opacity-70 hover:opacity-100'"
     data-testid="automation-session"
     :data-session-id="session.id"
@@ -74,5 +75,10 @@ const dotClass = computed(() => {
         {{ timeAgo(session.last_activity_at) }}
       </time>
     </div>
+    <SessionRowActions
+      :ws="session"
+      @changed="emit('changed')"
+      @error="(message) => emit('error', message)"
+    />
   </li>
 </template>

--- a/crates/loom/frontend/src/components/AutomationSessions.vue
+++ b/crates/loom/frontend/src/components/AutomationSessions.vue
@@ -4,6 +4,7 @@ import type { AutomationRun, Session } from '../types';
 import {
   byAutomationPriority,
   isAutomationHistory,
+  isAutomationRunHistory,
   needsAutomationIntervention,
   runNeedsIntervention,
   unmatchedAutomationRuns,
@@ -22,6 +23,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   toggleHistory: [];
   clearTag: [sessionId: string, key: string];
+  changed: [];
+  error: [message: string];
 }>();
 
 const interventions = computed(() =>
@@ -45,7 +48,12 @@ const failedRuns = computed(() =>
 );
 const creatingRuns = computed(() =>
   unmatched.value
-    .filter((run) => !runNeedsIntervention(run))
+    .filter((run) => !runNeedsIntervention(run) && !isAutomationRunHistory(run))
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
+);
+const historyRuns = computed(() =>
+  unmatched.value
+    .filter(isAutomationRunHistory)
     .sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
 );
 
@@ -87,6 +95,8 @@ const parentById = computed(() => {
           tone="intervention"
           :clearing-tag="clearingTag"
           @clear-tag="(key) => emit('clearTag', session.id, key)"
+          @changed="emit('changed')"
+          @error="(message) => emit('error', message)"
         />
 
         <AutomationRunRow v-for="run in failedRuns" :key="run.id" :run="run" intervention />
@@ -122,6 +132,8 @@ const parentById = computed(() => {
           tone="active"
           :clearing-tag="clearingTag"
           @clear-tag="(key) => emit('clearTag', session.id, key)"
+          @changed="emit('changed')"
+          @error="(message) => emit('error', message)"
         />
 
         <AutomationRunRow
@@ -149,7 +161,9 @@ const parentById = computed(() => {
           >▸</span
         >
         <span id="automation-history-heading">History</span>
-        <span class="font-mono lowercase tracking-normal">{{ history.length }}</span>
+        <span class="font-mono lowercase tracking-normal">{{
+          history.length + historyRuns.length
+        }}</span>
         <span class="h-px flex-1 bg-line"></span>
       </button>
 
@@ -166,8 +180,20 @@ const parentById = computed(() => {
           :parent="session.parent_id ? parentById.get(session.parent_id) : undefined"
           tone="history"
           :clearing-tag="clearingTag"
+          @changed="emit('changed')"
+          @error="(message) => emit('error', message)"
         />
-        <li v-if="!history.length" class="px-3 py-4 text-center text-sm text-muted">
+        <AutomationRunRow
+          v-for="run in historyRuns"
+          :key="run.id"
+          :run="run"
+          :intervention="false"
+          history
+        />
+        <li
+          v-if="!history.length && !historyRuns.length"
+          class="px-3 py-4 text-center text-sm text-muted"
+        >
           No automation history yet.
         </li>
       </ul>

--- a/crates/loom/frontend/src/lib/automationSessions.ts
+++ b/crates/loom/frontend/src/lib/automationSessions.ts
@@ -47,3 +47,7 @@ export function unmatchedAutomationRuns(
 export function runNeedsIntervention(run: AutomationRun): boolean {
   return run.status === 'failed';
 }
+
+export function isAutomationRunHistory(run: AutomationRun): boolean {
+  return run.status === 'cancelled' || run.status === 'completed';
+}

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -15,6 +15,7 @@ import AutomationSessions from '../components/AutomationSessions.vue';
 import { timeAgo } from '../lib/time';
 import {
   isAutomationHistory,
+  isAutomationRunHistory,
   needsAutomationIntervention,
   runNeedsIntervention,
   unmatchedAutomationRuns,
@@ -86,7 +87,7 @@ const unmatchedRuns = computed(() => unmatchedAutomationRuns(runs.value, automat
 const liveAutomationCount = computed(
   () =>
     automationSessions.value.filter((session) => !isAutomationHistory(session)).length +
-    unmatchedRuns.value.length,
+    unmatchedRuns.value.filter((run) => !isAutomationRunHistory(run)).length,
 );
 const automationInterventionCount = computed(
   () =>
@@ -952,6 +953,8 @@ async function handleCreated() {
       :clearing-tag="clearingTag"
       @toggle-history="toggleAutomationHistory"
       @clear-tag="clearTag"
+      @changed="refresh"
+      @error="error = $event"
     />
   </div>
 </template>

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -97,6 +97,7 @@ async fn migrate_loom(pool: &Db) -> Result<()> {
     crate::profile::backfill_mcp_policies(pool).await?;
     crate::profile::normalize_default(pool).await?;
     crate::profile::seed_stock_profiles(pool).await?;
+    crate::runs::reconcile_missing_sessions(pool).await?;
 
     // Configuration-dependent seeding is intentionally not a migration. If the
     // first start has no owner configured, a later restart must retry it.

--- a/crates/loom/src/github.rs
+++ b/crates/loom/src/github.rs
@@ -1341,6 +1341,7 @@ mod tests {
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             trigger,
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         };
         Fixture {
             _repo: repo,

--- a/crates/loom/src/launch_gate.rs
+++ b/crates/loom/src/launch_gate.rs
@@ -1,0 +1,82 @@
+//! Per-repository serialization for new session provisioning.
+//!
+//! Git stores refs and worktree metadata in one repository-wide namespace.
+//! Provisioning two sessions concurrently against the same checkout therefore
+//! races clone/fetch, branch selection, and `git worktree add`. Different
+//! repositories remain independent.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Weak};
+
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+#[derive(Clone, Default)]
+pub struct RepoLaunchGate {
+    locks: Arc<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>>,
+}
+
+pub struct RepoLaunchPermit {
+    _guard: OwnedMutexGuard<()>,
+}
+
+impl RepoLaunchGate {
+    /// Wait until no other new session is being provisioned for `repo`.
+    ///
+    /// The caller keeps the returned permit until the agent has started (or
+    /// provisioning fails). Weak entries make the registry self-pruning once a
+    /// repository has no active or waiting launches.
+    pub async fn acquire(&self, repo: &Path) -> RepoLaunchPermit {
+        let lock = {
+            let mut locks = self.locks.lock().await;
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            match locks.get(repo).and_then(Weak::upgrade) {
+                Some(lock) => lock,
+                None => {
+                    let lock = Arc::new(Mutex::new(()));
+                    locks.insert(repo.to_path_buf(), Arc::downgrade(&lock));
+                    lock
+                }
+            }
+        };
+        RepoLaunchPermit {
+            _guard: lock.lock_owned().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn same_repo_waits_until_the_agent_start_permit_drops() {
+        let gate = RepoLaunchGate::default();
+        let first = gate.acquire(Path::new("/repos/one")).await;
+
+        let waiting_gate = gate.clone();
+        let waiter =
+            tokio::spawn(async move { waiting_gate.acquire(Path::new("/repos/one")).await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!waiter.is_finished());
+
+        drop(first);
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("same-repo waiter should be released")
+            .expect("waiter task should complete");
+    }
+
+    #[tokio::test]
+    async fn different_repos_provision_independently() {
+        let gate = RepoLaunchGate::default();
+        let _first = gate.acquire(Path::new("/repos/one")).await;
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            gate.acquire(Path::new("/repos/two")),
+        )
+        .await
+        .expect("a different repository must not wait");
+    }
+}

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -26,6 +26,7 @@ pub mod github_app;
 pub mod github_manifest;
 pub mod github_trigger;
 pub mod ide;
+pub mod launch_gate;
 pub mod logs;
 pub mod loom_config;
 pub mod mcp;

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -771,6 +771,7 @@ mod tests {
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             trigger: crate::github_trigger::GithubTrigger::production(db),
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         }
     }
 

--- a/crates/loom/src/repo.rs
+++ b/crates/loom/src/repo.rs
@@ -251,6 +251,32 @@ pub enum ResolveError {
     Clone(String),
 }
 
+async fn registration(
+    db: &Db,
+    input: &str,
+) -> std::result::Result<(RepoSlug, ManagedRepo), ResolveError> {
+    let slug = parse_slug(input).map_err(ResolveError::BadRequest)?;
+    let slug_str = slug.slug();
+    let registered = get_registered(db, &slug_str)
+        .await
+        .map_err(|e| ResolveError::Clone(e.to_string()))?
+        .ok_or_else(|| {
+            tracing::info!(repo = %slug_str, "repo not registered; refusing clone");
+            ResolveError::BadRequest(format!(
+                "repo '{slug_str}' is not registered — register it via POST /api/repos first"
+            ))
+        })?;
+    Ok((slug, registered))
+}
+
+/// Resolve a managed-repo reference to its registered on-disk path without
+/// touching the clone. Session provisioning uses this stable path as its gate
+/// key so clone/fetch itself is serialized with the rest of launch.
+pub async fn registered_path(db: &Db, input: &str) -> std::result::Result<PathBuf, ResolveError> {
+    let (_, registered) = registration(db, input).await?;
+    Ok(PathBuf::from(registered.path))
+}
+
 /// Resolve a managed-repo reference to its on-disk clone, ensuring it is present.
 /// `input` is a slug or URL; it is parsed strictly (traversal rejected), looked
 /// up in the registered allowlist (an unregistered repo is refused — the trigger
@@ -267,17 +293,8 @@ pub async fn resolve_clone(
     app: Option<&crate::github_app::GithubApp>,
 ) -> std::result::Result<PathBuf, ResolveError> {
     tracing::debug!(input, "resolving managed repo clone");
-    let slug = parse_slug(input).map_err(ResolveError::BadRequest)?;
+    let (slug, registered) = registration(db, input).await?;
     let slug_str = slug.slug();
-    let registered = get_registered(db, &slug_str)
-        .await
-        .map_err(|e| ResolveError::Clone(e.to_string()))?
-        .ok_or_else(|| {
-            tracing::info!(repo = %slug_str, "repo not registered; refusing clone");
-            ResolveError::BadRequest(format!(
-                "repo '{slug_str}' is not registered — register it via POST /api/repos first"
-            ))
-        })?;
     let dest = PathBuf::from(&registered.path);
     let token = match app {
         Some(app) => match app.token_for_repo(&slug.owner, &slug.name).await {

--- a/crates/loom/src/runs.rs
+++ b/crates/loom/src/runs.rs
@@ -373,6 +373,46 @@ fn stale_before() -> String {
         .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
+/// Close the durable run when its session is deliberately removed. Keeping the
+/// reservation preserves idempotency/audit history; changing its status keeps
+/// it out of the active provisioning queue.
+pub async fn cancel_for_session(db: &Db, session_id: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE automation_runs
+         SET status = 'cancelled', outcome = 'cancelled',
+             summary = 'session removed by user', updated_at = ?
+         WHERE session_id = ?
+           AND status IN ('creating', 'waiting', 'delivering', 'running', 'failed')",
+    )
+    .bind(now_iso())
+    .bind(session_id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Repair reservations whose provisioning request or session disappeared.
+/// A fresh `creating` lease may still belong to an older server draining during
+/// a rolling restart, so only the same five-minute stale lease accepted by
+/// [`claim_stale`] is abandoned. A `running` run must already have inserted its
+/// session and is inconsistent immediately when that row is absent.
+pub async fn reconcile_missing_sessions(db: &Db) -> Result<u64> {
+    Ok(sqlx::query(
+        "UPDATE automation_runs
+         SET status = 'cancelled', outcome = 'cancelled',
+             summary = 'session provisioning was interrupted', updated_at = ?
+         WHERE (status = 'running' OR (status = 'creating' AND updated_at <= ?))
+           AND NOT EXISTS (
+               SELECT 1 FROM sessions WHERE sessions.id = automation_runs.session_id
+           )",
+    )
+    .bind(now_iso())
+    .bind(stale_before())
+    .execute(db)
+    .await?
+    .rows_affected())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -451,7 +491,6 @@ mod tests {
         assert!(claim_stale(&db, &run.id).await.unwrap());
         assert!(!claim_stale(&db, &run.id).await.unwrap());
     }
-
     #[tokio::test]
     async fn channel_waits_for_its_owner_and_replaces_a_failed_launch() {
         let db = crate::db::connect_in_memory().await.unwrap();
@@ -506,5 +545,99 @@ mod tests {
             route_channel(&db, &second.id).await.unwrap(),
             ChannelAction::Launch(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn startup_reconciles_reservations_without_sessions() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let run = match reserve(
+            &db,
+            NewRun {
+                subject: "subject",
+                source: "ops",
+                service_tag: "grafana",
+                profile: "default",
+                idempotency_key: "missing-session",
+                channel: None,
+                request_json: "{}",
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Reservation::Created(run) => run,
+            Reservation::Existing(_) => unreachable!(),
+        };
+        launched(&db, &run.id, &run.session_id).await.unwrap();
+
+        assert_eq!(reconcile_missing_sessions(&db).await.unwrap(), 1);
+        let repaired = get(&db, &run.id).await.unwrap().unwrap();
+        assert_eq!(repaired.status, "cancelled");
+        assert_eq!(repaired.outcome.as_deref(), Some("cancelled"));
+        assert_eq!(repaired.summary, "session provisioning was interrupted");
+    }
+
+    #[tokio::test]
+    async fn removing_a_session_cancels_its_durable_run() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let run = match reserve(
+            &db,
+            NewRun {
+                subject: "subject",
+                source: "ops",
+                service_tag: "grafana",
+                profile: "default",
+                idempotency_key: "removed-session",
+                channel: None,
+                request_json: "{}",
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Reservation::Created(run) => run,
+            Reservation::Existing(_) => unreachable!(),
+        };
+        launched(&db, &run.id, &run.session_id).await.unwrap();
+
+        cancel_for_session(&db, &run.session_id).await.unwrap();
+        let cancelled = get(&db, &run.id).await.unwrap().unwrap();
+        assert_eq!(cancelled.status, "cancelled");
+        assert_eq!(cancelled.outcome.as_deref(), Some("cancelled"));
+        assert_eq!(cancelled.summary, "session removed by user");
+    }
+
+    #[tokio::test]
+    async fn startup_preserves_fresh_creating_leases_but_cancels_stale_ones() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let run = match reserve(
+            &db,
+            NewRun {
+                subject: "subject",
+                source: "ops",
+                service_tag: "grafana",
+                profile: "default",
+                idempotency_key: "creating-session",
+                channel: None,
+                request_json: "{}",
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Reservation::Created(run) => run,
+            Reservation::Existing(_) => unreachable!(),
+        };
+
+        assert_eq!(reconcile_missing_sessions(&db).await.unwrap(), 0);
+        sqlx::query("UPDATE automation_runs SET updated_at = '2000-01-01T00:00:00.000Z'")
+            .execute(&db)
+            .await
+            .unwrap();
+        assert_eq!(reconcile_missing_sessions(&db).await.unwrap(), 1);
+        assert_eq!(
+            get(&db, &run.id).await.unwrap().unwrap().status,
+            "cancelled"
+        );
     }
 }

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -103,6 +103,7 @@ pub async fn run(addr: &str) -> Result<()> {
         ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
         trigger,
         acp: crate::acp::AcpRegistry::new(),
+        launch_gate: crate::launch_gate::RepoLaunchGate::default(),
     };
 
     let server_state = ServerState {

--- a/crates/loom/src/watch.rs
+++ b/crates/loom/src/watch.rs
@@ -1483,6 +1483,7 @@ mod tests {
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         };
         let o = watch_store::create(
             &state.db,
@@ -1701,6 +1702,7 @@ rnd.finish("counted to %d" % n)
             addr: "127.0.0.1:0".to_string(),
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         };
         // A reactive watch (no cron) — the scheduled half of the timer skips
         // it; only the wake half should fire it.

--- a/crates/loom/src/web/artifacts.rs
+++ b/crates/loom/src/web/artifacts.rs
@@ -434,6 +434,7 @@ mod tests {
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             trigger: crate::github_trigger::GithubTrigger::production(db),
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         }
     }
 

--- a/crates/loom/src/web/branches.rs
+++ b/crates/loom/src/web/branches.rs
@@ -298,6 +298,7 @@ mod tests {
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             trigger: crate::github_trigger::GithubTrigger::production(db),
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         }
     }
 

--- a/crates/loom/src/web/issues.rs
+++ b/crates/loom/src/web/issues.rs
@@ -470,6 +470,7 @@ mod tests {
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             trigger: crate::github_trigger::GithubTrigger::production(db),
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         }
     }
 

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -155,6 +155,9 @@ pub struct AppState {
     /// `/chat`, `/prompt`, `/permissions`, `/mode`, and `/interrupt` routes drive
     /// an `acp` session through, and subscribe to its SSE stream on.
     pub acp: crate::acp::AcpRegistry,
+    /// Serializes new-session provisioning within one repository while allowing
+    /// unrelated repositories to launch independently.
+    pub launch_gate: crate::launch_gate::RepoLaunchGate,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -284,6 +284,7 @@ mod tests {
             ide: Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             trigger: crate::github_trigger::GithubTrigger::with_app(app),
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         };
         let repo = crate::repo::parse_slug("marin-community/loom").unwrap();
 

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -665,15 +665,6 @@ pub(crate) async fn provision_session(
             "strict profile '{profile_name}' does not allow launch overrides"
         )));
     }
-    if launch_profile.max_concurrent > 0
-        && crate::profile::active_count(&st.db, &profile_name).await?
-            >= launch_profile.max_concurrent
-    {
-        return Err(AppError::conflict(format!(
-            "profile '{profile_name}' has reached its max_concurrent limit ({})",
-            launch_profile.max_concurrent
-        )));
-    }
     // The session's class — automation machinery vs interactive fleet work. An
     // explicit request value wins (validated); otherwise derived from the origin.
     // github/slack default to interactive deliberately: a person asked for that
@@ -697,12 +688,12 @@ pub(crate) async fn provision_session(
             _ => launch_profile.class.clone(),
         },
     };
-    // Resolve the repo root. An explicit managed `repo` (a slug/URL) is
-    // allowlist-checked and cloned-if-absent into the managed store, then used
-    // directly; otherwise fork from `cwd`'s repo (the default). The traversal /
-    // allowlist gate lives in `repo::resolve_clone`.
-    let repo_root = match req.repo.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-        Some(input) => repo::resolve_clone(&st.db, input, st.trigger.app())
+    let managed_repo = req.repo.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    // Resolve the stable repository identity without mutating it, then hold its
+    // launch permit through clone/fetch, worktree setup, and agent startup. A
+    // different repository gets a different permit and remains independent.
+    let repo_key = match managed_repo {
+        Some(input) => repo::registered_path(&st.db, input)
             .await
             .map_err(|e| match e {
                 repo::ResolveError::BadRequest(m) => AppError::bad_request(m),
@@ -714,6 +705,35 @@ pub(crate) async fn provision_session(
                 .await
                 .map_err(|e| AppError::bad_request(e.to_string()))?
         }
+    };
+    let repo_key = repo_key.canonicalize().unwrap_or(repo_key);
+    tracing::debug!(repo = %repo_key.display(), "waiting for repository launch gate");
+    let launch_permit = st.launch_gate.acquire(&repo_key).await;
+    tracing::debug!(repo = %repo_key.display(), "acquired repository launch gate");
+
+    // Recheck capacity only after reaching the front of the repository queue.
+    // Earlier launches have inserted their live session rows by this point, so
+    // a burst cannot all observe the same stale count and over-admit itself.
+    if launch_profile.max_concurrent > 0
+        && crate::profile::active_count(&st.db, &profile_name).await?
+            >= launch_profile.max_concurrent
+    {
+        return Err(AppError::conflict(format!(
+            "profile '{profile_name}' has reached its max_concurrent limit ({})",
+            launch_profile.max_concurrent
+        )));
+    }
+
+    // Now acquire the managed clone (inside the gate), or reuse the local root
+    // resolved above. The traversal / allowlist boundary lives in `repo`.
+    let repo_root = match managed_repo {
+        Some(input) => repo::resolve_clone(&st.db, input, st.trigger.app())
+            .await
+            .map_err(|e| match e {
+                repo::ResolveError::BadRequest(m) => AppError::bad_request(m),
+                repo::ResolveError::Clone(m) => AppError::new(StatusCode::BAD_GATEWAY, m),
+            })?,
+        None => repo_key,
     };
     // Canonicalize so repo identity matches the `weaver` CLI's resolver — issues
     // are keyed on this path and the two binaries must agree on it.
@@ -1448,6 +1468,9 @@ pub(crate) async fn provision_session(
         session
     };
     tracing::debug!(session = %session.id, status = %status, "inserted session row");
+    // The next launch may begin once this agent is live. The remaining writes
+    // are bookkeeping and do not touch repository or worktree state.
+    drop(launch_permit);
 
     if let Err(e) = repo::record_use(&st.db, &branch.repo_root).await {
         tracing::warn!(branch = %branch.id, error = %e, "failed to record recent repo");
@@ -1771,6 +1794,7 @@ pub(super) async fn delete_session(
         .await
         .ok();
     crate::auth::revoke_session_tokens(&st.db, &session.id).await?;
+    crate::runs::cancel_for_session(&st.db, &session.id).await?;
     session_mod::delete(&st.db, &session.id).await?;
     // Release this branch's claimed issues back to the repo backlog before the
     // branch row goes away — issues are repo-owned and must outlive teardown.
@@ -2004,6 +2028,7 @@ pub(crate) async fn create_warm_session(
     let repo_root = repo_root
         .canonicalize()
         .unwrap_or_else(|_| repo_root.to_path_buf());
+    let launch_permit = st.launch_gate.acquire(&repo_root).await;
     let repo_root_str = repo_root.display().to_string();
     let base = git::default_base(&repo_root).await?;
 
@@ -2176,6 +2201,7 @@ pub(crate) async fn create_warm_session(
         ));
     }
     tracing::info!(watch = %watch.id, session = %session_id, "warm session agent terminal launched");
+    drop(launch_permit);
 
     repo::record_use(&st.db, &repo_root_str).await.ok();
     tracing::info!(
@@ -3819,6 +3845,7 @@ mod tests {
             ide: std::sync::Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
             trigger: crate::github_trigger::GithubTrigger::production(db.clone()),
             acp: crate::acp::AcpRegistry::new(),
+            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         };
         let child = branch_mod::upsert(&db, "/r", "weaver/child", "main")
             .await

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -112,6 +112,7 @@ async fn hook_event_drives_session_status() {
         ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
         trigger: loom::github_trigger::GithubTrigger::production(pool.clone()),
         acp: loom::acp::AcpRegistry::new(),
+        launch_gate: loom::launch_gate::RepoLaunchGate::default(),
     };
     tokio::spawn(server::serve(state, listener));
 

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -184,6 +184,7 @@ impl TestServer {
             ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
             trigger,
             acp: loom::acp::AcpRegistry::new(),
+            launch_gate: loom::launch_gate::RepoLaunchGate::default(),
         };
         // The watch master switch ships on by default, but these tests
         // drive the engine directly and must not race the background loop that

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -109,6 +109,53 @@ async fn create_lists_and_tears_down() {
     assert_eq!(recent[0]["active_branches"], 0);
 }
 
+/// New-session provisioning waits at the repository boundary before it fetches,
+/// selects a branch, or creates a worktree. Holding the same gate here gives the
+/// route a deterministic concurrency test without racing real git subprocesses.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_creation_waits_for_the_repository_launch_gate() {
+    let ts = TestServer::start().await;
+    let repo = ts.repo_path().canonicalize().unwrap();
+    let permit = ts.state.launch_gate.acquire(&repo).await;
+    let client = weaver_api::Client::new(format!("http://{}", ts.addr));
+    let cwd = ts.cwd();
+
+    let launch = tokio::spawn(async move {
+        client
+            .post(
+                "/api/sessions",
+                json!({
+                    "goal": "wait for repository",
+                    "cwd": cwd,
+                    "agent": "shell",
+                }),
+            )
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(
+        !launch.is_finished(),
+        "launch should wait while the repository permit is held"
+    );
+    assert!(
+        !ts.repo_path().join(".worktrees").exists(),
+        "git provisioning must not begin before the permit is acquired"
+    );
+
+    drop(permit);
+    let session = tokio::time::timeout(std::time::Duration::from_secs(5), launch)
+        .await
+        .expect("launch should resume when the repository is ready")
+        .unwrap()
+        .unwrap();
+    let id = session["id"].as_str().unwrap();
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
 /// A real agent launch needs either the launching user's GitHub token or a
 /// default GH_TOKEN source. Without one, reject before provisioning anything.
 #[serial]

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -42,6 +42,7 @@ async fn engine_state(ts: &TestServer) -> AppState {
         addr: ts.addr.to_string(),
         ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
         acp: loom::acp::AcpRegistry::new(),
+        launch_gate: loom::launch_gate::RepoLaunchGate::default(),
     }
 }
 

--- a/crates/loom/tests/repo_setup.rs
+++ b/crates/loom/tests/repo_setup.rs
@@ -120,6 +120,7 @@ async fn start_server() -> (TestHome, loom::client::Client, db::Db, String) {
         ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
         trigger: loom::github_trigger::GithubTrigger::production(pool.clone()),
         acp: loom::acp::AcpRegistry::new(),
+        launch_gate: loom::launch_gate::RepoLaunchGate::default(),
     };
     tokio::spawn(server::serve(state, listener));
 

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -63,6 +63,7 @@ impl Env {
             ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
             trigger,
             acp: loom::acp::AcpRegistry::new(),
+            launch_gate: loom::launch_gate::RepoLaunchGate::default(),
         };
         tokio::spawn(server::serve(state, listener));
 

--- a/e2e/tests/automation.spec.ts
+++ b/e2e/tests/automation.spec.ts
@@ -248,6 +248,37 @@ test.describe("automation session surface", () => {
     await expect(page.getByTestId("automation-history")).toBeVisible();
   });
 
+  test("automation sessions expose the same lifecycle controls as workspace sessions", async ({
+    page,
+    weaver,
+  }) => {
+    const session = await seedAutomationSession(
+      weaver.baseUrl,
+      weaver.repoPath,
+      {
+        name: "administer-run",
+        goal: "Administer this automation",
+      },
+    );
+
+    await page.goto(`${weaver.baseUrl}/?view=automation`);
+    const active = page
+      .getByTestId("automation-active")
+      .locator(`[data-session-id="${session.id}"]`);
+    await active.hover();
+    await active.getByTestId("row-actions").click();
+    page.once("dialog", (dialog) => dialog.accept());
+    await active.getByTestId("row-action-archive").click();
+    await expect(active).toHaveCount(0);
+
+    await page.getByTestId("automation-history-toggle").click();
+    await expect(
+      page
+        .getByTestId("automation-history")
+        .locator(`[data-session-id="${session.id}"]`),
+    ).toBeVisible();
+  });
+
   test("a failed launch with no session remains visible", async ({
     page,
     weaver,
@@ -304,10 +335,26 @@ test.describe("automation session surface", () => {
             service_tag: "comment-rewriter",
             profile: "default",
             idempotency_key: "running-reservation",
+            channel: null,
             session_id: "not-yet-visible",
             status: "running",
             outcome: null,
             summary: "",
+            created_at: now,
+            updated_at: now,
+          },
+          {
+            id: "cancelled-reservation",
+            actor_subject: "automation:test",
+            source: "actions",
+            service_tag: "comment-rewriter",
+            profile: "default",
+            idempotency_key: "cancelled-reservation",
+            channel: null,
+            session_id: "removed-session",
+            status: "cancelled",
+            outcome: "cancelled",
+            summary: "session removed by user",
             created_at: now,
             updated_at: now,
           },
@@ -321,10 +368,14 @@ test.describe("automation session surface", () => {
       0,
     );
     await expect(
-      page
-        .getByTestId("automation-active")
-        .getByTestId("automation-run-only"),
+      page.getByTestId("automation-active").getByTestId("automation-run-only"),
     ).toContainText("running");
     await expect(page.getByTestId("automation-interventions")).toHaveCount(0);
+    await page.getByTestId("automation-history-toggle").click();
+    await expect(
+      page
+        .getByTestId("automation-history")
+        .getByTestId("automation-run-only"),
+    ).toContainText("Run cancelled");
   });
 });


### PR DESCRIPTION
Serialize session provisioning by canonical repository path from clone/fetch through agent startup, and recheck profile capacity after queued launches acquire the gate. This prevents same-repo Git ref/worktree races and max-concurrent stampedes while preserving parallel launches for different repositories.

Make automation sessions fully manageable from the Automation pane, cancel linked durable runs when a session is removed, reconcile interrupted provisioning records on startup, and move cancelled records into History. Bulk selection remains an API-first follow-up so it can be shared by the UI and CLI instead of becoming a browser-only fan-out.

The tracked loom session URL could not be resolved because this automation credential does not grant the session-inspection route.