### PR TITLE
fix(loom): deliver cross-session sends immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ loom session launch "Fix the flaky test" --repo ~/code/other       # a local che
 loom session launch "How do I run this?" --repo acme/widgets       # a GitHub repo — cloned on first use
 loom session poll <session>           # one-shot status (lifecycle + attention)
 loom session wait <session>           # block until it finishes or needs you
-loom session send <session> "try the curl again"   # type a message + Enter (trigger an agent round)
+loom session send <session> "try the curl again"   # deliver now (steer ACP, or interrupt + restart)
 loom session break <session>          # send Escape — interrupt the current turn
 loom session preview <session>        # print the recent terminal screen
 loom session url [<session>]          # its dashboard URL (yours by default) — the link to share
@@ -141,10 +141,11 @@ pin a parent with `--base` (also a field in the web create form).
 
 Once a session is up, the other verbs interact with it: `loom session poll`
 reads its status, `loom session wait` blocks until it finishes or raises
-attention, `loom session send` types a message into the agent's terminal (and
-submits it to trigger a round), `loom session break` sends Escape to interrupt
-the current turn, and `loom session preview` prints the recent terminal screen.
-Each takes a session key — an id, branch id, branch name, or `repo:branch`.
+attention, `loom session send` delivers a message immediately (typing and
+submitting it for a terminal agent; steering or restarting an ACP turn),
+`loom session break` interrupts the current turn, and `loom session preview`
+prints the recent terminal screen. Each takes a session key — an id, branch id,
+branch name, or `repo:branch`.
 
 `loom session url` prints a session's dashboard URL — the link to hand a person,
 resolved against loom's externally-visible address (the `auth.base_url` setting,
@@ -243,6 +244,8 @@ next turn. Unseen queued feedback can be pulled back into the composer with its
 **Edit** action or ArrowUp from an empty composer. The live status names visible
 thinking, writing, or tool activity and reports how long it has been since the
 agent produced an observable update; quiet time is not guessed to mean stuck.
+Cross-session `loom session send` is immediate control input instead: it steers
+a supported live turn, or cancels that turn and starts the message as a new one.
 
 Whenever a session is archived — by the Archive button or automatically on merge
 — loom first captures that conversation to disk: it finds the agent's transcript

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -197,12 +197,40 @@ impl AcpHandle {
         force_steer: bool,
         resources: Vec<Value>,
     ) -> Result<PromptAck> {
+        let delivery = if force_steer {
+            PromptDelivery::ForceSteer
+        } else {
+            PromptDelivery::Queue
+        };
+        self.send_prompt(text, by, delivery, resources).await
+    }
+
+    /// Deliver a cross-session send without leaving it behind a live turn:
+    /// steer when the adapter supports it, otherwise cancel the current turn
+    /// and start the message normally.
+    pub async fn send_now(
+        &self,
+        text: String,
+        by: Option<String>,
+        resources: Vec<Value>,
+    ) -> Result<PromptAck> {
+        self.send_prompt(text, by, PromptDelivery::Immediate, resources)
+            .await
+    }
+
+    async fn send_prompt(
+        &self,
+        text: String,
+        by: Option<String>,
+        delivery: PromptDelivery,
+        resources: Vec<Value>,
+    ) -> Result<PromptAck> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(Command::Prompt {
                 text,
                 by,
-                force_steer,
+                delivery,
                 resources,
                 reply: tx,
             })
@@ -538,11 +566,21 @@ pub async fn attach(state: &AppState, session_id: &str) -> Result<()> {
 // Commands (REST → task)
 // ---------------------------------------------------------------------------
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PromptDelivery {
+    /// Preserve the conversation composer's queue-first behavior.
+    Queue,
+    /// Require the adapter's steering extension and surface rejection.
+    ForceSteer,
+    /// Cross-session control: steer, or cancel and restart as a fallback.
+    Immediate,
+}
+
 enum Command {
     Prompt {
         text: String,
         by: Option<String>,
-        force_steer: bool,
+        delivery: PromptDelivery,
         resources: Vec<Value>,
         reply: oneshot::Sender<Result<PromptAck>>,
     },
@@ -726,14 +764,15 @@ struct PendingSteer {
     text: String,
     by: Option<String>,
     turn: i64,
-    forced: bool,
+    delivery: PromptDelivery,
     /// Exact durable queue prefix promoted by this request. Consumed only after
     /// the adapter accepts steering, preserving messages appended behind it.
     promoted_queue: Option<String>,
     resources: Vec<Value>,
-    /// Forced steering waits for the adapter's final answer. An ordinary send is
-    /// acknowledged as durably queued before steering starts, so it carries no
-    /// waiting HTTP reply and cannot lock the composer behind a private RPC.
+    /// Forced and immediate delivery wait for the adapter's final answer. An
+    /// ordinary composer prompt is acknowledged as durably queued before
+    /// steering starts, so it carries no waiting HTTP reply and cannot lock the
+    /// composer behind a private RPC.
     reply: Option<oneshot::Sender<Result<PromptAck>>>,
 }
 
@@ -1761,15 +1800,25 @@ impl Task {
                     ?error,
                     "steering failed"
                 );
-                if pending.forced {
-                    let detail = error
-                        .map(|e| e.to_string())
-                        .unwrap_or_else(|| format!("adapter returned {outcome:?}"));
-                    if let Some(reply) = pending.reply {
-                        let _ = reply.send(Err(anyhow!("adapter rejected forced steer: {detail}")));
+                match pending.delivery {
+                    PromptDelivery::Queue => self.fallback_prompt(pending).await,
+                    PromptDelivery::ForceSteer => {
+                        let detail = error
+                            .map(|e| e.to_string())
+                            .unwrap_or_else(|| format!("adapter returned {outcome:?}"));
+                        if let Some(reply) = pending.reply {
+                            let _ =
+                                reply.send(Err(anyhow!("adapter rejected forced steer: {detail}")));
+                        }
                     }
-                } else {
-                    self.fallback_prompt(pending).await;
+                    PromptDelivery::Immediate => {
+                        let result = self
+                            .restart_prompt(pending.text, pending.by, pending.resources)
+                            .await;
+                        if let Some(reply) = pending.reply {
+                            let _ = reply.send(result);
+                        }
+                    }
                 }
             }
         }
@@ -1824,6 +1873,18 @@ impl Task {
         if let Some(reply) = pending.reply {
             let _ = reply.send(ack);
         }
+    }
+
+    async fn restart_prompt(
+        &mut self,
+        text: String,
+        by: Option<String>,
+        resources: Vec<Value>,
+    ) -> Result<PromptAck> {
+        if self.turn_live {
+            self.cancel_live_turn().await?;
+        }
+        self.start_prompt(text, by, resources).await
     }
 
     async fn queue_prompt(&self, text: &str, resources: &[Value]) -> Result<PromptAck> {
@@ -2266,7 +2327,7 @@ impl Task {
             Command::Prompt {
                 text,
                 by,
-                force_steer,
+                delivery,
                 resources,
                 reply,
             } => {
@@ -2281,7 +2342,7 @@ impl Task {
                             method::SESSION_STEERING,
                             wire::steering_params(&self.acp_session_id, &text, &resources),
                         );
-                        if force_steer {
+                        if delivery != PromptDelivery::Queue {
                             // Explicit steering reports the adapter's real answer
                             // and does not also leave a queued copy behind if the
                             // private extension is rejected.
@@ -2293,7 +2354,7 @@ impl Task {
                                             text,
                                             by,
                                             turn: self.current_turn,
-                                            forced: true,
+                                            delivery,
                                             promoted_queue: None,
                                             resources,
                                             reply: Some(reply),
@@ -2301,7 +2362,12 @@ impl Task {
                                     );
                                 }
                                 Err(error) => {
-                                    let _ = reply.send(Err(error));
+                                    let result = if delivery == PromptDelivery::Immediate {
+                                        self.restart_prompt(text, by, resources).await
+                                    } else {
+                                        Err(error)
+                                    };
+                                    let _ = reply.send(result);
                                 }
                             }
                         } else {
@@ -2320,7 +2386,7 @@ impl Task {
                                                     text,
                                                     by,
                                                     turn: self.current_turn,
-                                                    forced: false,
+                                                    delivery,
                                                     promoted_queue: Some(promoted_queue),
                                                     resources,
                                                     reply: None,
@@ -2339,18 +2405,28 @@ impl Task {
                                 }
                             }
                         }
-                    } else if force_steer {
-                        let message = if self.steering_cap {
-                            "another steer is still pending; retry when it settles"
-                        } else {
-                            "this agent does not support steering; queue the feedback or stop and send it"
-                        };
-                        let _ = reply.send(Err(anyhow!(message)));
                     } else {
-                        // A failed queue write must surface — a 202 that silently
-                        // dropped the prompt would be worse than an error.
-                        let ack = self.queue_prompt(&text, &resources).await;
-                        let _ = reply.send(ack);
+                        match delivery {
+                            PromptDelivery::Queue => {
+                                // A failed queue write must surface — a 202 that
+                                // silently dropped the prompt would be worse
+                                // than an error.
+                                let ack = self.queue_prompt(&text, &resources).await;
+                                let _ = reply.send(ack);
+                            }
+                            PromptDelivery::ForceSteer => {
+                                let message = if self.steering_cap {
+                                    "another steer is still pending; retry when it settles"
+                                } else {
+                                    "this agent does not support steering; queue the feedback or stop and send it"
+                                };
+                                let _ = reply.send(Err(anyhow!(message)));
+                            }
+                            PromptDelivery::Immediate => {
+                                let ack = self.restart_prompt(text, by, resources).await;
+                                let _ = reply.send(ack);
+                            }
+                        }
                     }
                 } else {
                     let ack = self.start_prompt(text, by, resources).await;
@@ -2397,7 +2473,7 @@ impl Task {
                                         text: queued.clone(),
                                         by,
                                         turn: self.current_turn,
-                                        forced: true,
+                                        delivery: PromptDelivery::ForceSteer,
                                         promoted_queue: Some(queued),
                                         resources: Vec::new(),
                                         reply: Some(reply),

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -301,8 +301,8 @@ enum SessionCmd {
         #[arg(long)]
         lifecycle_only: bool,
     },
-    /// Type a message into a session's agent pane (and submit it to trigger an
-    /// agent round).
+    /// Deliver a message to a session now. ACP sessions steer a supported live
+    /// turn, or stop it and start the message as a new turn.
     Send {
         /// Session key: id, branch id, branch name, or `repo:branch`.
         session: String,

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -3087,14 +3087,14 @@ pub(super) async fn send_session(
     Json(req): Json<SendReq>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
-    // For an ACP session a send is a prompt (steered into a supported live turn,
-    // otherwise queued): delegate to the ACP task while keeping the same `nudge`
-    // audit. This makes `loom session send` uniform across both backends.
+    // A cross-session send must not sit behind an ACP turn indefinitely. Steer
+    // a supported live turn; otherwise cancel it and immediately start this
+    // message as a fresh turn, while keeping the same `nudge` audit.
     if session.protocol == "acp" {
         let handle = require_acp_task(&st, &session)?;
         let by = author_or_manual(req.by.as_deref());
         let ack = handle
-            .prompt(req.text.clone(), Some(by.clone()), false, Vec::new())
+            .send_now(req.text.clone(), Some(by.clone()), Vec::new())
             .await
             .map_err(|e| AppError::conflict(e.to_string()))?;
         events::record(

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1265,6 +1265,105 @@ async fn prompt_stops_and_sends_queue_without_steering_capability() {
     }));
 }
 
+/// Cross-session `/send` is control-plane input, not ordinary composer
+/// feedback. Without steering support it must cancel a live turn and start the
+/// message immediately instead of leaving it in the durable next-turn queue.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_send_restarts_a_live_turn_without_steering() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-send-restart", None, None).await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-send-restart/prompt",
+            json!({ "text": "wait:1200|say:stale" }),
+        )
+        .await
+        .unwrap();
+    let sent = ts
+        .client
+        .post(
+            "/api/sessions/acp-send-restart/send",
+            json!({ "text": "say:take this now" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(sent["queued"], false, "response: {sent}");
+    assert_eq!(sent["steered"], false, "response: {sent}");
+    assert_eq!(sent["turn"], 1, "the replacement opens the next turn");
+
+    let chat = poll_chat(&ts, "acp-send-restart", Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "take this now"
+        })
+    })
+    .await;
+    assert!(chat["pending_prompt"].is_null());
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 0
+            && block["kind"] == "turn_end"
+            && block["payload"]["stop_reason"] == "cancelled"
+    }));
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 1
+            && block["kind"] == "user_message"
+            && block["payload"]["text"] == "say:take this now"
+    }));
+}
+
+/// A steering-capable ACP adapter receives cross-session `/send` input in the
+/// live turn, preserving its work while still avoiding the next-turn queue.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_send_steers_a_live_turn_when_supported() {
+    let ts = TestServer::start().await;
+    start_new_with_env(
+        &ts,
+        "acp-send-steer",
+        None,
+        None,
+        vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
+    )
+    .await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-send-steer/prompt",
+            json!({ "text": "wait:1200|say:first" }),
+        )
+        .await
+        .unwrap();
+    let sent = ts
+        .client
+        .post(
+            "/api/sessions/acp-send-steer/send",
+            json!({ "text": "say:changed course" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(sent["queued"], false, "response: {sent}");
+    assert_eq!(sent["steered"], true, "response: {sent}");
+    assert_eq!(sent["turn"], 0);
+
+    let chat = poll_chat(&ts, "acp-send-steer", Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "changed coursefirst"
+        })
+    })
+    .await;
+    assert!(chat["pending_prompt"].is_null());
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert_eq!(count_kind(blocks, "turn_end"), 1);
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 0
+            && block["kind"] == "user_message"
+            && block["payload"]["text"] == "say:changed course"
+            && block["payload"]["steered"] == true
+    }));
+}
+
 /// Composer-selected files are resolved inside the worktree and forwarded as
 /// ACP resource_link blocks, not left as adapter-specific `@file` prose.
 #[serial]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -277,7 +277,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
 | `GET /api/sessions/{id}/conversation` | the agent conversation as a normalized iris log (live transcript, else the archive capture); 404 when there is none — backs the Conversation tab |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ the session's tapestry PTY (the interaction surface) |
-| `POST /api/sessions/{id}/send` | type `{text}` into the agent's terminal (`submit`, default true, follows it with Enter); for an `acp` session it delegates to the prompt path (steering a supported live turn, otherwise queueing), keeping the same `nudge` audit |
+| `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a live turn is steered when supported, otherwise cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
 | `POST /api/sessions/{id}/interrupt` | stop the current turn — a break (Escape) to the terminal for a `terminal` session, `session/cancel` for an `acp` one |
 | `GET /api/sessions/{id}/preview?lines=N` | capture the screen as `{screen}`; `lines` adds scrollback above the visible screen (for an `acp` session, `{screen}` is the last `lines` journal blocks rendered as compact text) |
 | `GET /api/sessions/{id}/chat` | The newest 200 blocks of the ACP session's DB-backed journal, `older_cursor`, live-turn state, pending prompt, effective mode, and composer metadata; pass the cursor as `before_turn` + `before_seq` to page backward |
@@ -382,8 +382,9 @@ uniformly. For a `terminal` session each requires a live terminal (else 409). An
 `acp` session has no PTY, so the same verbs map onto the protocol — keeping the
 CLI (`loom session {send,break,preview}`) and its `nudge` audit uniform across
 backends: `send` delegates to the prompt path (steered when supported, otherwise
-queued while a turn is live), `interrupt` is a `session/cancel`, and `preview` renders the
-last journal blocks as compact plain text instead of a vt100 screen capture.
+cancelled and restarted with the message), `interrupt` is a `session/cancel`,
+and `preview` renders the last journal blocks as compact plain text instead of
+a vt100 screen capture.
 
 ## Runtime conventions
 


### PR DESCRIPTION
Make control-plane session sends deliver immediately to ACP agents. A live turn now uses adapter steering when available; otherwise loom cancels it and starts a fresh prompt, while conversation-composer sends retain durable queue semantics.

Add integration coverage for both delivery branches and document the distinction.