### PR TITLE
fix(loom): make session teardown unconditional

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -89,7 +89,7 @@ export const listSessions = (
 ) => {
   const params = new URLSearchParams();
   if (opts.archived) params.set('archived', 'true');
-  if (opts.automation) params.set('automation', 'true');
+  if (opts.automation || opts.managed) params.set('automation', 'true');
   if (opts.managed) params.set('managed', 'true');
   const qs = params.toString();
   return get(`/sessions${qs ? `?${qs}` : ''}`) as Promise<Session[]>;

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -80,15 +80,17 @@ export const uploadSessionScratch = (id: string, file: File) =>
 
 // --- Sessions ----------------------------------------------------------------
 
-/** The fleet: every session, optionally widened past the two default-hidden
+/** The fleet: every session, optionally widened past the default-hidden
  *  categories. `archived` includes torn-down sessions; `automation` includes
- *  agent/system-launched sessions (`class: 'automation'`) — background work a
- *  person didn't start, hidden from the fleet list by default. Symmetric flags,
- *  both off by default (`GET /api/sessions`). */
-export const listSessions = (opts: { archived?: boolean; automation?: boolean } = {}) => {
+ *  background work; admin-only `managed` includes watch-owned warm sessions.
+ *  All are off by default (`GET /api/sessions`). */
+export const listSessions = (
+  opts: { archived?: boolean; automation?: boolean; managed?: boolean } = {},
+) => {
   const params = new URLSearchParams();
   if (opts.archived) params.set('archived', 'true');
   if (opts.automation) params.set('automation', 'true');
+  if (opts.managed) params.set('managed', 'true');
   const qs = params.toString();
   return get(`/sessions${qs ? `?${qs}` : ''}`) as Promise<Session[]>;
 };

--- a/crates/loom/frontend/src/components/AutomationRunRow.vue
+++ b/crates/loom/frontend/src/components/AutomationRunRow.vue
@@ -1,21 +1,60 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { del, post } from '../api';
 import type { AutomationRun } from '../types';
 import { exactTime, timeAgo } from '../lib/time';
 import StatusBadge from './StatusBadge.vue';
 
 const props = defineProps<{ run: AutomationRun; intervention: boolean; history?: boolean }>();
+const emit = defineEmits<{ changed: []; error: [message: string] }>();
+const open = ref(false);
+const busy = ref('');
+const canArchive = computed(
+  () => props.run.status !== 'cancelled' && props.run.status !== 'completed',
+);
 
 const title = computed(() => {
   if (props.intervention) return `Launch ${props.run.status}`;
   if (props.history) return `Run ${props.run.status}`;
   return 'Provisioning session';
 });
+
+async function act(name: string, fn: () => Promise<void>) {
+  open.value = false;
+  busy.value = name;
+  try {
+    await fn();
+    emit('changed');
+  } catch (error) {
+    emit('error', (error as Error).message);
+  } finally {
+    busy.value = '';
+  }
+}
+
+function archive() {
+  if (
+    !confirm(
+      'Archive this launch attempt? Any reserved runtime is torn down and the attempt is kept in history.',
+    )
+  )
+    return;
+  void act('archive', async () => {
+    await post(`/sessions/${props.run.session_id}/archive`);
+  });
+}
+
+function remove() {
+  if (!confirm('Remove this launch attempt and any reserved runtime?')) return;
+  void act('remove', async () => {
+    await del(`/sessions/${props.run.session_id}`);
+  });
+}
 </script>
 
 <template>
   <li
-    class="flex items-start gap-3 border-b border-line px-3 py-2.5 last:border-0"
+    class="group relative flex items-start gap-3 border-b border-line px-3 py-2.5 last:border-0"
     data-testid="automation-run-only"
     :data-run-id="run.id"
   >
@@ -45,6 +84,49 @@ const title = computed(() => {
       >
         {{ timeAgo(run.updated_at) }}
       </time>
+    </div>
+    <div class="relative z-10 shrink-0">
+      <button
+        type="button"
+        data-testid="run-actions"
+        :aria-label="`Actions for launch ${run.id}`"
+        :aria-expanded="open"
+        :disabled="!!busy"
+        :class="[
+          'rounded px-1.5 py-0.5 text-sm leading-none text-faint transition-colors',
+          'hover:bg-subtle hover:text-fg focus-visible:opacity-100 disabled:opacity-50',
+          open ? 'bg-subtle text-fg opacity-100' : 'opacity-0 group-hover:opacity-100',
+        ]"
+        @click="open = !open"
+      >
+        ⋯
+      </button>
+      <div v-if="open" class="fixed inset-0 z-20" @click="open = false"></div>
+      <div
+        v-if="open"
+        class="absolute right-0 top-full z-30 mt-1 w-64 overflow-hidden rounded border border-line bg-surface py-1 shadow-lg"
+        data-testid="run-actions-menu"
+      >
+        <button
+          v-if="canArchive"
+          type="button"
+          data-testid="run-action-archive"
+          class="block w-full px-3 py-1.5 text-left text-fg transition-colors hover:bg-subtle"
+          @click="archive"
+        >
+          <span class="block text-xs font-medium">Archive</span>
+          <span class="block text-2xs text-faint">Tear down runtime, keep launch history</span>
+        </button>
+        <button
+          type="button"
+          data-testid="run-action-remove"
+          class="block w-full px-3 py-1.5 text-left text-block transition-colors hover:bg-block-soft"
+          @click="remove"
+        >
+          <span class="block text-xs font-medium">Remove</span>
+          <span class="block text-2xs text-faint">Delete this attempt and reserved runtime</span>
+        </button>
+      </div>
     </div>
   </li>
 </template>

--- a/crates/loom/frontend/src/components/AutomationSessions.vue
+++ b/crates/loom/frontend/src/components/AutomationSessions.vue
@@ -99,7 +99,14 @@ const parentById = computed(() => {
           @error="(message) => emit('error', message)"
         />
 
-        <AutomationRunRow v-for="run in failedRuns" :key="run.id" :run="run" intervention />
+        <AutomationRunRow
+          v-for="run in failedRuns"
+          :key="run.id"
+          :run="run"
+          intervention
+          @changed="emit('changed')"
+          @error="(message) => emit('error', message)"
+        />
       </ul>
       <p v-else class="rounded-md border border-dashed border-line px-3 py-3 text-sm text-muted">
         No automation needs intervention.
@@ -141,6 +148,8 @@ const parentById = computed(() => {
           :key="run.id"
           :run="run"
           :intervention="false"
+          @changed="emit('changed')"
+          @error="(message) => emit('error', message)"
         />
       </ul>
       <p v-else class="rounded-md border border-dashed border-line px-3 py-3 text-sm text-muted">
@@ -189,6 +198,8 @@ const parentById = computed(() => {
           :run="run"
           :intervention="false"
           history
+          @changed="emit('changed')"
+          @error="(message) => emit('error', message)"
         />
         <li
           v-if="!history.length && !historyRuns.length"

--- a/crates/loom/frontend/src/lib/sessionsStore.ts
+++ b/crates/loom/frontend/src/lib/sessionsStore.ts
@@ -30,7 +30,7 @@ async function refresh(): Promise<void> {
   inflight = (async () => {
     try {
       const [nextSessions, nextRuns] = await Promise.all([
-        listSessions({ archived: true, automation: true }),
+        listSessions({ archived: true, automation: true, managed: true }),
         listRuns(),
       ]);
       sessions.value = nextSessions;

--- a/crates/loom/frontend/src/lib/sessionsStore.ts
+++ b/crates/loom/frontend/src/lib/sessionsStore.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { listRuns, listSessions } from '../api';
+import { ApiError, listRuns, listSessions } from '../api';
 import type { AutomationRun, Session } from '../types';
 
 // One shared snapshot of the fleet. The session list, the status bar, and the
@@ -21,6 +21,19 @@ const online = ref(true);
 
 let inflight: Promise<void> | null = null;
 
+async function listInventory(): Promise<Session[]> {
+  try {
+    return await listSessions({ archived: true, automation: true, managed: true });
+  } catch (error) {
+    // Managed warm sessions are an admin inventory. A narrower principal still
+    // gets the ordinary fleet instead of making the whole UI appear offline.
+    if (error instanceof ApiError && error.status === 403) {
+      return listSessions({ archived: true, automation: true });
+    }
+    throw error;
+  }
+}
+
 // Pull the whole fleet, archived and automation-class sessions included — the
 // superset the Workspace/Automation panes and archive disclosures need (the
 // status bar and each pane project their own subset). Concurrent callers
@@ -29,10 +42,7 @@ async function refresh(): Promise<void> {
   if (inflight) return inflight;
   inflight = (async () => {
     try {
-      const [nextSessions, nextRuns] = await Promise.all([
-        listSessions({ archived: true, automation: true, managed: true }),
-        listRuns(),
-      ]);
+      const [nextSessions, nextRuns] = await Promise.all([listInventory(), listRuns()]);
       sessions.value = nextSessions;
       runs.value = nextRuns;
       online.value = true;

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -337,6 +337,12 @@ enum SessionCmd {
         /// Include archived (torn-down) sessions.
         #[arg(long)]
         archived: bool,
+        /// Include automation-class sessions.
+        #[arg(long)]
+        automation: bool,
+        /// Include engine-managed watch sessions (admin only; implies automation).
+        #[arg(long)]
+        managed: bool,
         /// Case-insensitive substring filter over title / branch / goal.
         #[arg(long)]
         search: Option<String>,
@@ -352,7 +358,10 @@ enum SessionCmd {
     Show { branch: String },
     /// Attach your terminal to a session (also `loom attach`).
     Attach { branch: String },
-    /// Archive a session: tear down terminal + worktree, keep branch + history.
+    /// Archive a session or failed launch: tear down runtime, keep history.
+    ///
+    /// An unmatched automation launch is addressed by its reserved session id,
+    /// the same id shown in the Automation pane/API.
     Archive { branch: String },
     /// Recreate the terminal session for an orphaned session.
     Adopt { branch: String },
@@ -376,7 +385,7 @@ enum SessionCmd {
         #[arg(long)]
         mode: Option<String>,
     },
-    /// Remove a session (worktree + terminal + DB row).
+    /// Remove a session or unmatched launch attempt and its runtime.
     Rm {
         branch: String,
         #[arg(long)]
@@ -937,7 +946,7 @@ async fn run() -> Result<()> {
         Cmd::Setup { cmd } => run_setup(cmd).await,
         Cmd::Config { cmd } => run_config(cmd).await,
         Cmd::Launch(opts) => cmd_launch(opts.into()).await,
-        Cmd::Ps => cmd_ps(false, None).await,
+        Cmd::Ps => cmd_ps(false, false, false, None).await,
         Cmd::Attach { branch } => cmd_attach(branch).await,
         Cmd::Open => cmd_open().await,
         Cmd::Completions { shell } => {
@@ -989,7 +998,12 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
         } => cmd_session_send(session, message.join(" "), !no_enter).await,
         SessionCmd::Break { session } => cmd_session_break(session).await,
         SessionCmd::Preview { session, lines } => cmd_session_preview(session, lines).await,
-        SessionCmd::Ls { archived, search } => cmd_ps(archived, search).await,
+        SessionCmd::Ls {
+            archived,
+            automation,
+            managed,
+            search,
+        } => cmd_ps(archived, automation, managed, search).await,
         SessionCmd::Rename { session, title } => cmd_session_rename(session, title.join(" ")).await,
         SessionCmd::Show { branch } => cmd_show(branch).await,
         SessionCmd::Attach { branch } => cmd_attach(branch).await,
@@ -3091,13 +3105,24 @@ async fn cmd_session_preview(key: String, lines: usize) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_ps(archived: bool, search: Option<String>) -> Result<()> {
+async fn cmd_ps(
+    archived: bool,
+    automation: bool,
+    managed: bool,
+    search: Option<String>,
+) -> Result<()> {
     let client = client::default()?;
     // Hide archived sessions by default; `--search` narrows by substring. Both
     // ride the same query the dashboard uses, so the CLI and UI stay one surface.
     let mut query = Vec::new();
     if archived {
         query.push("archived=true".to_string());
+    }
+    if automation || managed {
+        query.push("automation=true".to_string());
+    }
+    if managed {
+        query.push("managed=true".to_string());
     }
     if let Some(s) = search.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         query.push(format!("q={}", encode_query(s)));
@@ -3310,10 +3335,14 @@ async fn cmd_archive(key: String) -> Result<()> {
             json!({}),
         )
         .await?;
-    println!(
-        "archived {} (terminal + worktree removed; branch and history kept)",
-        str_field(&res, "branch")
-    );
+    if str_field(&res, "kind") == "launch_attempt" {
+        println!("archived launch attempt {key} (reserved runtime removed; history kept)");
+    } else {
+        println!(
+            "archived {} (terminal + worktree removed; branch and history kept)",
+            str_field(&res, "branch")
+        );
+    }
     if let Some(warnings) = res.get("warnings").and_then(Value::as_array) {
         for w in warnings {
             if let Some(w) = w.as_str() {

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -39,6 +39,7 @@ pub mod runs;
 pub(crate) mod runtime;
 pub mod server;
 pub mod session;
+pub mod session_manager;
 pub mod setup;
 pub mod shell;
 pub mod slack;

--- a/crates/loom/src/runs.rs
+++ b/crates/loom/src/runs.rs
@@ -1,5 +1,7 @@
 //! Durable, idempotent automation-run reservations.
 
+use std::collections::HashSet;
+
 use anyhow::Result;
 use sqlx::FromRow;
 use weaver_api::RunView;
@@ -128,6 +130,12 @@ pub async fn route_channel(db: &Db, run_id: &str) -> Result<ChannelAction> {
         .bind(run_id)
         .fetch_one(&mut *tx)
         .await?;
+    // Idempotent redelivery observes a terminal attempt; it must never reclaim
+    // the channel and turn an operator cancellation back into provisioning.
+    if matches!(run.status.as_str(), "failed" | "cancelled" | "completed") {
+        tx.commit().await?;
+        return Ok(ChannelAction::Ready(run));
+    }
     let channel = run
         .channel
         .clone()
@@ -303,17 +311,24 @@ pub async fn list_for(db: &Db, subject: Option<&str>) -> Result<Vec<Run>> {
     }
 }
 
-pub async fn launched(db: &Db, id: &str, session_id: &str) -> Result<()> {
-    sqlx::query(
+/// Mark a launch reservation live only while it still owns the launch.
+///
+/// Archive/remove first make a reservation terminal. A provisioning request
+/// that finishes after that cancellation must not resurrect it as `running`;
+/// the caller uses the `false` result to tear down its late-created session.
+pub async fn launched(db: &Db, id: &str, session_id: &str) -> Result<bool> {
+    Ok(sqlx::query(
         "UPDATE automation_runs SET status = 'running', updated_at = ?
-         WHERE id = ? AND session_id = ?",
+         WHERE id = ? AND session_id = ?
+           AND status IN ('creating', 'waiting', 'delivering')",
     )
     .bind(now_iso())
     .bind(id)
     .bind(session_id)
     .execute(db)
-    .await?;
-    Ok(())
+    .await?
+    .rows_affected()
+        == 1)
 }
 
 /// Claim a reservation abandoned while provisioning. A live request keeps its
@@ -347,25 +362,32 @@ pub async fn claim_stale_delivery(db: &Db, id: &str) -> Result<bool> {
         == 1)
 }
 
-pub async fn waiting(db: &Db, id: &str) -> Result<()> {
-    sqlx::query("UPDATE automation_runs SET status = 'waiting', updated_at = ? WHERE id = ?")
-        .bind(now_iso())
-        .bind(id)
-        .execute(db)
-        .await?;
-    Ok(())
+pub async fn waiting(db: &Db, id: &str) -> Result<bool> {
+    Ok(sqlx::query(
+        "UPDATE automation_runs SET status = 'waiting', updated_at = ?
+         WHERE id = ? AND status IN ('creating', 'delivering', 'waiting')",
+    )
+    .bind(now_iso())
+    .bind(id)
+    .execute(db)
+    .await?
+    .rows_affected()
+        == 1)
 }
 
-pub async fn failed(db: &Db, id: &str, summary: &str) -> Result<()> {
-    sqlx::query(
-        "UPDATE automation_runs SET status = 'failed', outcome = 'failed', summary = ?, updated_at = ? WHERE id = ?",
+pub async fn failed(db: &Db, id: &str, summary: &str) -> Result<bool> {
+    Ok(sqlx::query(
+        "UPDATE automation_runs
+         SET status = 'failed', outcome = 'failed', summary = ?, updated_at = ?
+         WHERE id = ? AND status IN ('creating', 'waiting', 'delivering', 'running')",
     )
     .bind(summary)
     .bind(now_iso())
     .bind(id)
     .execute(db)
-    .await?;
-    Ok(())
+    .await?
+    .rows_affected()
+        == 1)
 }
 
 fn stale_before() -> String {
@@ -377,18 +399,124 @@ fn stale_before() -> String {
 /// reservation preserves idempotency/audit history; changing its status keeps
 /// it out of the active provisioning queue.
 pub async fn cancel_for_session(db: &Db, session_id: &str) -> Result<()> {
-    sqlx::query(
+    cancel_for_session_with_summary(db, session_id, "session removed by user").await?;
+    Ok(())
+}
+
+/// Make every run that references a reserved session id terminal.
+///
+/// This is the launch-attempt equivalent of session archive: the idempotency
+/// and audit row stays, but it no longer owns a runtime and cannot be promoted
+/// back to `running` by a late provisioning response.
+pub async fn cancel_for_session_with_summary(
+    db: &Db,
+    session_id: &str,
+    summary: &str,
+) -> Result<u64> {
+    Ok(sqlx::query(
         "UPDATE automation_runs
          SET status = 'cancelled', outcome = 'cancelled',
-             summary = 'session removed by user', updated_at = ?
+             summary = ?, updated_at = ?
          WHERE session_id = ?
            AND status IN ('creating', 'waiting', 'delivering', 'running', 'failed')",
     )
+    .bind(summary)
     .bind(now_iso())
     .bind(session_id)
     .execute(db)
+    .await?
+    .rows_affected())
+}
+
+/// Every run record for one reserved session id, newest first.
+pub async fn list_for_session(db: &Db, session_id: &str) -> Result<Vec<Run>> {
+    Ok(sqlx::query_as::<_, Run>(
+        "SELECT * FROM automation_runs WHERE session_id = ? ORDER BY created_at DESC",
+    )
+    .bind(session_id)
+    .fetch_all(db)
+    .await?)
+}
+
+/// Session ids whose unmatched automation reservations may still be
+/// provisioning. The external-runtime reconciler preserves these names during
+/// rolling restarts; terminal run history owns no supervisor.
+pub async fn runtime_owner_ids(db: &Db) -> Result<HashSet<String>> {
+    Ok(sqlx::query_scalar::<_, String>(
+        "SELECT DISTINCT session_id
+         FROM automation_runs
+         WHERE status = 'creating'
+           AND NOT EXISTS (
+               SELECT 1 FROM sessions WHERE sessions.id = automation_runs.session_id
+           )",
+    )
+    .fetch_all(db)
+    .await?
+    .into_iter()
+    .collect())
+}
+
+/// Non-terminal sessions that materialized after their launch attempt lost
+/// ownership.
+///
+/// The request path normally notices a cancelled promotion and removes the
+/// late session immediately. This query closes the crash window between
+/// session creation and that check: the periodic resource reconciler marks the
+/// recorded session `error` and tears down its runtime, leaving a visible,
+/// removable DB record rather than an unowned agent.
+pub async fn invalidate_sessions_from_cancelled_launches(db: &Db) -> Result<Vec<String>> {
+    Ok(sqlx::query_scalar::<_, String>(
+        "UPDATE sessions
+         SET status = 'error'
+         WHERE automation_run_id IS NOT NULL
+           AND status NOT IN ('done', 'error', 'archived')
+           AND (
+               NOT EXISTS (
+                   SELECT 1 FROM automation_runs r
+                   WHERE r.id = sessions.automation_run_id
+               )
+               OR EXISTS (
+                   SELECT 1 FROM automation_runs r
+                   WHERE r.id = sessions.automation_run_id
+                     AND r.status = 'cancelled'
+                     AND r.summary IN (
+                         'launch attempt archived by user',
+                         'launch attempt removed by user'
+                     )
+               )
+           )
+         RETURNING id",
+    )
+    .fetch_all(db)
+    .await?)
+}
+
+/// Remove every launch-attempt record for a reserved session id.
+///
+/// Channel ownership rows refer to automation runs without `ON DELETE CASCADE`,
+/// so release those first. This is deliberately separate from cancellation:
+/// callers terminalize the run before external teardown, then remove history
+/// only after teardown has been attempted.
+pub async fn delete_for_session(db: &Db, session_id: &str) -> Result<u64> {
+    let mut tx = weaver_core::db::begin_immediate(db).await?;
+    sqlx::query(
+        "DELETE FROM automation_channels
+         WHERE session_id = ?
+            OR owner_run_id IN (
+                SELECT id FROM automation_runs WHERE session_id = ?
+            )",
+    )
+    .bind(session_id)
+    .bind(session_id)
+    .execute(&mut *tx)
     .await?;
-    Ok(())
+    let deleted = sqlx::query("DELETE FROM automation_runs WHERE session_id = ?")
+        .bind(session_id)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+    tx.commit().await?;
+    Ok(deleted)
 }
 
 /// Repair reservations whose provisioning request or session disappeared.
@@ -548,6 +676,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_channel_delivery_cannot_reclaim_its_channel() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let run = match reserve(
+            &db,
+            NewRun {
+                subject: "subject",
+                source: "grafana",
+                service_tag: "grafana",
+                profile: "default",
+                idempotency_key: "cancelled-channel",
+                channel: Some("operator"),
+                request_json: "{}",
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Reservation::Created(run) => run,
+            Reservation::Existing(_) => unreachable!(),
+        };
+        assert!(matches!(
+            route_channel(&db, &run.id).await.unwrap(),
+            ChannelAction::Launch(_)
+        ));
+        cancel_for_session_with_summary(&db, &run.session_id, "launch attempt archived by user")
+            .await
+            .unwrap();
+
+        let ChannelAction::Ready(cancelled) = route_channel(&db, &run.id).await.unwrap() else {
+            panic!("cancelled delivery must remain terminal");
+        };
+        assert_eq!(cancelled.status, "cancelled");
+        assert_eq!(
+            get(&db, &run.id).await.unwrap().unwrap().status,
+            "cancelled"
+        );
+    }
+
+    #[tokio::test]
     async fn startup_reconciles_reservations_without_sessions() {
         let db = crate::db::connect_in_memory().await.unwrap();
         let run = match reserve(
@@ -605,6 +772,44 @@ mod tests {
         assert_eq!(cancelled.status, "cancelled");
         assert_eq!(cancelled.outcome.as_deref(), Some("cancelled"));
         assert_eq!(cancelled.summary, "session removed by user");
+    }
+
+    #[tokio::test]
+    async fn cancellation_wins_over_a_late_launch_promotion() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let run = match reserve(
+            &db,
+            NewRun {
+                subject: "subject",
+                source: "ops",
+                service_tag: "grafana",
+                profile: "default",
+                idempotency_key: "cancelled-race",
+                channel: None,
+                request_json: "{}",
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Reservation::Created(run) => run,
+            Reservation::Existing(_) => unreachable!(),
+        };
+
+        cancel_for_session_with_summary(&db, &run.session_id, "operator cancelled")
+            .await
+            .unwrap();
+        assert!(
+            !launched(&db, &run.id, &run.session_id).await.unwrap(),
+            "a late create response must not resurrect a cancelled run"
+        );
+        let cancelled = get(&db, &run.id).await.unwrap().unwrap();
+        assert_eq!(cancelled.status, "cancelled");
+        assert_eq!(cancelled.summary, "operator cancelled");
+        assert!(!runtime_owner_ids(&db)
+            .await
+            .unwrap()
+            .contains(&run.session_id));
     }
 
     #[tokio::test]

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -11,7 +11,7 @@ use tokio::net::TcpListener;
 use crate::events::EventBus;
 use crate::session as session_mod;
 use crate::web::AppState;
-use crate::{backend, config, db, github, monitor, runner, watch, web};
+use crate::{backend, config, db, github, monitor, runner, session_manager, watch, web};
 use weaver_core::branch as branch_mod;
 use weaver_core::watch as watch_store;
 
@@ -105,6 +105,19 @@ pub async fn run(addr: &str) -> Result<()> {
         acp: crate::acp::AcpRegistry::new(),
         launch_gate: crate::launch_gate::RepoLaunchGate::default(),
     };
+
+    // Detached supervisors outlive this control process. Before reattaching or
+    // adopting anything, remove only Loom-namespaced runtimes that have no
+    // durable session/active-reservation owner. This is the inverse of the
+    // monitor's missing-supervisor -> orphaned transition.
+    match session_manager::reconcile_supervisors(&state.db).await {
+        Ok(report) if !report.warnings.is_empty() => tracing::warn!(
+            warnings = report.warnings.len(),
+            "session resource reconciliation completed with warnings"
+        ),
+        Ok(_) => {}
+        Err(error) => tracing::warn!(%error, "initial session resource reconciliation failed"),
+    }
 
     let server_state = ServerState {
         pid: std::process::id(),
@@ -325,6 +338,7 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
         Err(e) => tracing::warn!("could not prepare the machine-local token: {e}"),
     }
     tokio::spawn(monitor::run(state.clone()));
+    tokio::spawn(session_manager::run(state.db.clone()));
     // The GitHub poller is always spawned; it self-gates on the `github.poll`
     // setting and on `gh` being available, so it idles cheaply when GitHub
     // integration is off or unavailable.
@@ -339,7 +353,9 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
     // presence and the `slack.enabled` switch, so an unconfigured loom idles
     // here cheaply.
     tokio::spawn(crate::slack::run(state.clone()));
-    tracing::debug!("background tasks spawned (monitor, github poll, watch, ide reaper, slack)");
+    tracing::debug!(
+        "background tasks spawned (monitor, session reconciler, github poll, watch, ide reaper, slack)"
+    );
     // `into_make_service_with_connect_info` surfaces the peer `SocketAddr` to the
     // auth middleware, which uses it to recognise (and optionally trust) loopback.
     axum::serve(

--- a/crates/loom/src/session_manager.rs
+++ b/crates/loom/src/session_manager.rs
@@ -1,0 +1,179 @@
+//! Database-backed ownership reconciliation for detached session resources.
+//!
+//! Tapestry supervisors deliberately outlive `loom server run`. That makes a
+//! control-plane restart safe, but it also means the external runtime needs the
+//! inverse of the monitor's orphan check:
+//!
+//! * session row + missing supervisor -> the monitor marks the row `orphaned`;
+//! * supervisor + no durable owner -> this manager tears the supervisor down.
+//!
+//! Only Loom's two deterministic namespaces are considered. The operator
+//! scratch shell and unrelated Tapestry users are never touched.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::db::Db;
+use crate::{backend, runs, session, shell};
+
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ReconcileReport {
+    pub inspected: usize,
+    pub invalidated_sessions: usize,
+    pub removed_agents: usize,
+    pub removed_debug_shells: usize,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum OwnedResource<'a> {
+    Agent(&'a str),
+    DebugShell(&'a str),
+}
+
+/// Parse only supervisor names reserved by Loom.
+fn owned_resource(name: &str) -> Option<OwnedResource<'_>> {
+    if let Some(id) = name.strip_prefix("weaver-").filter(|id| !id.is_empty()) {
+        return Some(OwnedResource::Agent(id));
+    }
+    let rest = name.strip_prefix("loom-shell-")?;
+    let (id, index) = rest.rsplit_once('-')?;
+    if id.is_empty() || index.parse::<u32>().is_err() {
+        return None;
+    }
+    Some(OwnedResource::DebugShell(id))
+}
+
+/// Tear down the deterministic runtime names held by an automation launch
+/// reservation that never produced a session row.
+///
+/// Every operation is idempotent. A launch racing cancellation performs a
+/// second ownership check before promotion and tears down any later session it
+/// managed to create.
+pub async fn teardown_reserved_runtime(session_id: &str) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let agent = format!("weaver-{session_id}");
+    if let Err(error) = backend::kill_session_and_wait(&agent).await {
+        warnings.push(format!("terminal remove: {error}"));
+    }
+    shell::kill_debug_all(session_id).await;
+    warnings
+}
+
+/// Reconcile every live Loom-owned supervisor against durable ownership.
+///
+/// Every non-archived session owns its agent and debug supervisors, including
+/// inspectable `done`/`error` sessions. An active automation run temporarily
+/// owns the agent's deterministic name before a session row appears. Archived,
+/// missing, and cancellation-invalidated sessions own no runtime.
+pub async fn reconcile_supervisors(db: &Db) -> Result<ReconcileReport> {
+    // Close the only crash window in cancellation-wins provisioning: a session
+    // row may have landed just before the request was cancelled, while the
+    // provisioning task died before it could perform its final ownership check.
+    // Keep the row visible for an operator, but make it terminal before runtime
+    // classification so its supervisor is removed below.
+    let invalidated: HashSet<String> = runs::invalidate_sessions_from_cancelled_launches(db)
+        .await?
+        .into_iter()
+        .collect();
+    for id in &invalidated {
+        tracing::warn!(
+            session = id,
+            "session materialized after its launch attempt was cancelled; marked error"
+        );
+    }
+
+    let sessions: HashMap<String, String> = session::list(db)
+        .await?
+        .into_iter()
+        .map(|session| (session.id, session.status))
+        .collect();
+    let run_owners = runs::runtime_owner_ids(db).await?;
+    let supervisors = backend::list_sessions().await?;
+    let mut report = ReconcileReport {
+        inspected: supervisors.len(),
+        invalidated_sessions: invalidated.len(),
+        ..ReconcileReport::default()
+    };
+
+    for name in supervisors {
+        let Some(resource) = owned_resource(&name) else {
+            continue;
+        };
+        let keep = match resource {
+            OwnedResource::Agent(id) => {
+                !invalidated.contains(id)
+                    && (sessions.get(id).is_some_and(|status| status != "archived")
+                        || run_owners.contains(id))
+            }
+            OwnedResource::DebugShell(id) => {
+                !invalidated.contains(id)
+                    && sessions.get(id).is_some_and(|status| status != "archived")
+            }
+        };
+        if keep {
+            continue;
+        }
+
+        match backend::kill_session(&name).await {
+            Ok(()) => match resource {
+                OwnedResource::Agent(_) => report.removed_agents += 1,
+                OwnedResource::DebugShell(_) => report.removed_debug_shells += 1,
+            },
+            Err(error) => report.warnings.push(format!("{name}: {error}")),
+        }
+    }
+
+    if report.invalidated_sessions > 0
+        || report.removed_agents > 0
+        || report.removed_debug_shells > 0
+    {
+        tracing::warn!(
+            invalidated_sessions = report.invalidated_sessions,
+            removed_agents = report.removed_agents,
+            removed_debug_shells = report.removed_debug_shells,
+            warnings = report.warnings.len(),
+            "removed detached session resources without a live database owner"
+        );
+    }
+    Ok(report)
+}
+
+/// Periodically converge detached supervisors after startup. A one-shot pass
+/// runs before adoption in `server::run`; this loop handles a process crash or
+/// a late provisioning/cancellation race after the server is already serving.
+pub async fn run(db: Db) {
+    let start = tokio::time::Instant::now() + RECONCILE_INTERVAL;
+    let mut interval = tokio::time::interval_at(start, RECONCILE_INTERVAL);
+    loop {
+        interval.tick().await;
+        if let Err(error) = reconcile_supervisors(&db).await {
+            tracing::warn!(%error, "session resource reconciliation failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_only_loom_owned_supervisor_names() {
+        assert_eq!(
+            owned_resource("weaver-abc-123"),
+            Some(OwnedResource::Agent("abc-123"))
+        );
+        assert_eq!(
+            owned_resource("loom-shell-abc-123-7"),
+            Some(OwnedResource::DebugShell("abc-123"))
+        );
+        assert_eq!(owned_resource("loom-scratch-shell"), None);
+        assert_eq!(owned_resource("somebody-elses-tapestry"), None);
+        assert_eq!(owned_resource("weaver-"), None);
+        assert_eq!(owned_resource("loom-shell-id-not-a-number"), None);
+    }
+}

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -127,6 +127,32 @@ enum LaunchFailure {
     Retryable,
 }
 
+/// Tear down a session that finished provisioning after its automation
+/// reservation was archived or removed. Cancellation wins: a late response may
+/// not resurrect the run or leave its worktree/supervisor detached from the
+/// operator-visible lifecycle record.
+async fn remove_late_session(st: &AppState, session_id: &str) {
+    let Ok(Some((session, branch))) = crate::session::with_branch(&st.db, session_id).await else {
+        return;
+    };
+    match super::sessions::remove(st, &session, &branch, false).await {
+        Ok(warnings) if !warnings.is_empty() => tracing::warn!(
+            session = session_id,
+            warnings = warnings.len(),
+            "late cancelled automation session removed with warnings"
+        ),
+        Ok(_) => tracing::info!(
+            session = session_id,
+            "removed session that completed after automation cancellation"
+        ),
+        Err(error) => tracing::warn!(
+            session = session_id,
+            error = %error.message(),
+            "could not remove session that completed after automation cancellation"
+        ),
+    }
+}
+
 async fn launch_run(
     st: &AppState,
     req: RunReq,
@@ -144,19 +170,44 @@ async fn launch_run(
     );
     match crate::runtime::create_session(st.clone(), req.session, actor).await {
         Ok(session) => {
-            crate::runs::launched(&st.db, &run.id, &session.id).await?;
-            run_view(st, &run.id).await
+            if crate::runs::launched(&st.db, &run.id, &session.id).await? {
+                run_view(st, &run.id).await
+            } else {
+                remove_late_session(st, &session.id).await;
+                Err(AppError::conflict(
+                    "automation launch was archived or removed while provisioning",
+                ))
+            }
         }
         Err(error) => {
-            match failure {
+            let still_owned = match failure {
                 LaunchFailure::Final => {
-                    crate::runs::failed(&st.db, &run.id, &format!("{error:?}"))
-                        .await
-                        .ok();
+                    match crate::runs::failed(&st.db, &run.id, &format!("{error:?}")).await {
+                        Ok(owned) => owned,
+                        Err(record_error) => {
+                            tracing::warn!(
+                                run = %run.id,
+                                error = %record_error,
+                                "could not record automation launch failure"
+                            );
+                            true
+                        }
+                    }
                 }
-                LaunchFailure::Retryable => {
-                    crate::runs::waiting(&st.db, &run.id).await.ok();
-                }
+                LaunchFailure::Retryable => match crate::runs::waiting(&st.db, &run.id).await {
+                    Ok(owned) => owned,
+                    Err(record_error) => {
+                        tracing::warn!(
+                            run = %run.id,
+                            error = %record_error,
+                            "could not return automation launch to waiting"
+                        );
+                        true
+                    }
+                },
+            };
+            if !still_owned {
+                remove_late_session(st, &run.session_id).await;
             }
             Err(error)
         }
@@ -214,7 +265,11 @@ async fn prompt_channel_run(
     )
     .await
     .ok();
-    crate::runs::launched(&st.db, &run.id, &session.id).await?;
+    if !crate::runs::launched(&st.db, &run.id, &session.id).await? {
+        return Err(AppError::conflict(
+            "automation delivery was archived or removed while running",
+        ));
+    }
     run_view(st, &run.id).await
 }
 
@@ -340,7 +395,10 @@ pub(super) async fn create_run(
                 return Ok(Json(run.into()));
             }
             crate::runs::Reservation::Existing(run)
-                if matches!(run.status.as_str(), "running" | "failed") =>
+                if matches!(
+                    run.status.as_str(),
+                    "running" | "failed" | "cancelled" | "completed"
+                ) =>
             {
                 return Ok(Json(run.into()));
             }

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -212,6 +212,9 @@ impl AppError {
     pub fn message(&self) -> &str {
         &self.message
     }
+    fn is_not_found(&self) -> bool {
+        self.status == StatusCode::NOT_FOUND
+    }
     #[cfg(test)]
     fn status(&self) -> StatusCode {
         self.status

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1948,7 +1948,9 @@ async fn remove_locked(
     // Cancellation is the durable boundary: an automation request that
     // finishes provisioning after this point cannot promote itself.
     crate::runs::cancel_for_session(&st.db, &session.id).await?;
-    backend::kill_session_and_wait(&session.term_session).await?;
+    if let Err(error) = backend::kill_session_and_wait(&session.term_session).await {
+        warnings.push(format!("terminal remove: {error}"));
+    }
     if session.protocol == "acp" {
         st.acp.stop(&session.id);
     }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -88,6 +88,11 @@ pub(super) struct ListSessionsQuery {
     /// opts in with `?automation=true`, symmetric with `archived`.
     #[serde(default)]
     automation: bool,
+    /// Include engine-managed warm sessions. This is an operator inventory
+    /// escape hatch: normal fleet/survey callers must not see a watcher's own
+    /// infrastructure and recurse into it.
+    #[serde(default)]
+    managed: bool,
     /// Case-insensitive substring filter over a session's title, branch name,
     /// and goal (`loom session ls --search auth`). Absent/blank matches everything.
     #[serde(default)]
@@ -96,8 +101,15 @@ pub(super) struct ListSessionsQuery {
 
 pub(super) async fn list_sessions(
     State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
     Query(q): Query<ListSessionsQuery>,
 ) -> ApiResult<Json<Vec<SessionView>>> {
+    if q.managed && !principal.is_admin() {
+        return Err(AppError::new(
+            StatusCode::FORBIDDEN,
+            "admin grant required to list managed sessions",
+        ));
+    }
     // The fleet listing shows work, not infrastructure: engine-managed (warm)
     // sessions are excluded here, so neither the dashboard nor a watch
     // round's survey (scripts read this route) ever sees a watcher's own
@@ -116,10 +128,14 @@ pub(super) async fn list_sessions(
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_lowercase);
-    let sessions = session_mod::list_visible(&st.db).await?;
+    let sessions = if q.managed {
+        session_mod::list(&st.db).await?
+    } else {
+        session_mod::list_visible(&st.db).await?
+    };
     let mut views: Vec<SessionView> = Vec::with_capacity(sessions.len());
     for s in sessions {
-        if warm.contains(&s.id) {
+        if !q.managed && warm.contains(&s.id) {
             continue;
         }
         // Archived sessions are torn down — hidden unless the caller opts in.
@@ -1881,11 +1897,61 @@ pub(super) async fn delete_session(
     Path(key): Path<String>,
     Query(q): Query<DeleteQuery>,
 ) -> ApiResult<Json<Value>> {
-    let (session, branch) = require_session(&st.db, &key).await?;
-    tracing::info!(session = %session.id, branch = %branch.id, keep_branch = q.keep_branch, "deleting session");
+    let (session, branch) = match require_session(&st.db, &key).await {
+        Ok(found) => found,
+        Err(error) if error.is_not_found() => {
+            return delete_launch_attempt(&st, &key).await;
+        }
+        Err(error) => return Err(error),
+    };
+    let warnings = remove(&st, &session, &branch, q.keep_branch).await?;
+    Ok(Json(json!({
+        "deleted": true,
+        "kind": "session",
+        "warnings": warnings
+    })))
+}
+
+/// Fully remove one durable session and all resources it owns.
+///
+/// Shared by the session route and automation cancellation races. External
+/// teardown is intentionally idempotent: a missing terminal/worktree is
+/// already removed, while failures are returned as warnings after the durable
+/// ownership rows have been released.
+pub(crate) async fn remove(
+    st: &AppState,
+    session: &Session,
+    _branch: &Branch,
+    keep_branch: bool,
+) -> Result<Vec<String>, AppError> {
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    let Some((current_session, current_branch)) =
+        session_mod::with_branch(&st.db, &session.id).await?
+    else {
+        // A competing remove already achieved the requested end state.
+        return Ok(Vec::new());
+    };
+    remove_locked(st, &current_session, &current_branch, keep_branch).await
+}
+
+/// Shared deletion after the caller has acquired [`LIFECYCLE_LOCK`] and
+/// refreshed the session row.
+async fn remove_locked(
+    st: &AppState,
+    session: &Session,
+    branch: &Branch,
+    keep_branch: bool,
+) -> Result<Vec<String>, AppError> {
+    tracing::info!(session = %session.id, branch = %branch.id, keep_branch, "deleting session");
     let mut warnings: Vec<String> = Vec::new();
 
-    backend::kill_session(&session.term_session).await.ok();
+    // Cancellation is the durable boundary: an automation request that
+    // finishes provisioning after this point cannot promote itself.
+    crate::runs::cancel_for_session(&st.db, &session.id).await?;
+    backend::kill_session_and_wait(&session.term_session).await?;
+    if session.protocol == "acp" {
+        st.acp.stop(&session.id);
+    }
     crate::shell::kill_debug_all(&session.id).await;
     st.ide.kill(&session.id);
     let repo_root = PathBuf::from(&branch.repo_root);
@@ -1895,7 +1961,7 @@ pub(super) async fn delete_session(
         warnings.push(format!("worktree remove: {e}"));
         tokio::fs::remove_dir_all(&work_dir).await.ok();
     }
-    if !q.keep_branch {
+    if !keep_branch {
         tracing::debug!(session = %session.id, branch_name = %branch.branch, "deleting git branch");
         if let Err(e) = git::delete_branch(&repo_root, &branch.branch).await {
             warnings.push(format!("delete branch: {e}"));
@@ -1905,7 +1971,6 @@ pub(super) async fn delete_session(
         .await
         .ok();
     crate::auth::revoke_session_tokens(&st.db, &session.id).await?;
-    crate::runs::cancel_for_session(&st.db, &session.id).await?;
     session_mod::delete(&st.db, &session.id).await?;
     // Release this branch's claimed issues back to the repo backlog before the
     // branch row goes away — issues are repo-owned and must outlive teardown.
@@ -1915,11 +1980,42 @@ pub(super) async fn delete_session(
     // Drop the branch row too — deleting a session takes its branch with it.
     branch_mod::delete(&st.db, &branch.id).await?;
     if warnings.is_empty() {
-        tracing::info!(session = %session.id, branch = %branch.id, keep_branch = q.keep_branch, "session deleted");
+        tracing::info!(session = %session.id, branch = %branch.id, keep_branch, "session deleted");
     } else {
         tracing::warn!(branch = %branch.id, warnings = warnings.len(), "session removed with warnings");
     }
-    Ok(Json(json!({ "deleted": true, "warnings": warnings })))
+    Ok(warnings)
+}
+
+/// Remove a launch reservation that failed before a `sessions` row existed.
+///
+/// `loom session rm <reserved-session-id>` therefore has the same escape hatch
+/// as a real session. Terminalize first so an in-flight create cannot promote
+/// the run after the operator removes it.
+async fn delete_launch_attempt(st: &AppState, session_id: &str) -> ApiResult<Json<Value>> {
+    if crate::runs::list_for_session(&st.db, session_id)
+        .await?
+        .is_empty()
+    {
+        return Err(AppError::not_found("session"));
+    }
+    crate::runs::cancel_for_session_with_summary(
+        &st.db,
+        session_id,
+        "launch attempt removed by user",
+    )
+    .await?;
+    let warnings = crate::session_manager::teardown_reserved_runtime(session_id).await;
+    st.ide.kill(session_id);
+    crate::auth::revoke_session_tokens(&st.db, session_id)
+        .await
+        .ok();
+    crate::runs::delete_for_session(&st.db, session_id).await?;
+    Ok(Json(json!({
+        "deleted": true,
+        "kind": "launch_attempt",
+        "warnings": warnings
+    })))
 }
 
 // ---------------------------------------------------------------------------
@@ -1994,6 +2090,9 @@ async fn archive_locked(
     warnings.extend(log_warnings);
     tracing::debug!(session = %session.id, "captured conversation transcript before teardown");
 
+    // Cancellation is the durable boundary: an automation request that
+    // finishes provisioning after this point cannot promote itself.
+    crate::runs::cancel_for_session_with_summary(&st.db, &session.id, "session archived").await?;
     // The row must never say `archived` while its supervisor is still live.
     // A tapestry kill is acknowledged before the socket disappears, so wait
     // for teardown and fail without flipping the row if it cannot complete.
@@ -2057,12 +2156,49 @@ pub(super) async fn archive_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
 ) -> ApiResult<Json<Value>> {
-    let (session, branch) = require_session(&st.db, &key).await?;
+    let (session, branch) = match require_session(&st.db, &key).await {
+        Ok(found) => found,
+        Err(error) if error.is_not_found() => {
+            return archive_launch_attempt(&st, &key).await;
+        }
+        Err(error) => return Err(error),
+    };
     tracing::debug!(key = %key, session = %session.id, "handling archive session request");
     let warnings = archive(&st, &session, &branch).await?;
-    Ok(Json(
-        json!({ "archived": true, "branch": branch.branch, "warnings": warnings }),
-    ))
+    Ok(Json(json!({
+        "archived": true,
+        "kind": "session",
+        "branch": branch.branch,
+        "warnings": warnings
+    })))
+}
+
+/// Archive an unmatched launch attempt: tear down any deterministic reserved
+/// runtime and preserve the now-cancelled automation row as history.
+async fn archive_launch_attempt(st: &AppState, session_id: &str) -> ApiResult<Json<Value>> {
+    if crate::runs::list_for_session(&st.db, session_id)
+        .await?
+        .is_empty()
+    {
+        return Err(AppError::not_found("session"));
+    }
+    crate::runs::cancel_for_session_with_summary(
+        &st.db,
+        session_id,
+        "launch attempt archived by user",
+    )
+    .await?;
+    let warnings = crate::session_manager::teardown_reserved_runtime(session_id).await;
+    st.ide.kill(session_id);
+    crate::auth::revoke_session_tokens(&st.db, session_id)
+        .await
+        .ok();
+    Ok(Json(json!({
+        "archived": true,
+        "kind": "launch_attempt",
+        "branch": session_id,
+        "warnings": warnings
+    })))
 }
 
 /// `GET /api/sessions/{id}/shells` — the live worktree debug-shell indices for a

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -25,6 +25,7 @@ mod profiles;
 mod recover;
 mod repos;
 mod scratch;
+mod session_management;
 mod sessions;
 mod shell;
 mod terminal;

--- a/crates/loom/tests/integration/session_management.rs
+++ b/crates/loom/tests/integration/session_management.rs
@@ -1,0 +1,305 @@
+//! Session ownership and the launch-attempt escape hatches.
+
+use std::time::Duration;
+
+use serde_json::json;
+use serial_test::serial;
+
+use loom::backend;
+use loom::runs::{self, NewRun, Reservation};
+
+use crate::fixtures::TestServer;
+
+async fn reserve(ts: &TestServer, key: &str) -> runs::Run {
+    match runs::reserve(
+        &ts.state.db,
+        NewRun {
+            subject: "automation:test",
+            source: "grafana",
+            service_tag: "grafana",
+            profile: "default",
+            idempotency_key: key,
+            channel: None,
+            request_json: "{}",
+        },
+    )
+    .await
+    .unwrap()
+    {
+        Reservation::Created(run) => run,
+        Reservation::Existing(_) => panic!("test reservation must be new"),
+    }
+}
+
+async fn wait_dead(name: &str) {
+    for _ in 0..100 {
+        if !backend::has_session(name).await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("supervisor {name} did not stop");
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_launch_attempt_can_be_archived_then_removed_by_reserved_session_id() {
+    let ts = TestServer::start().await;
+    let run = reserve(&ts, "failed-attempt").await;
+    assert!(runs::failed(&ts.state.db, &run.id, "capacity exhausted")
+        .await
+        .unwrap());
+
+    let archived = ts
+        .client
+        .post(
+            &format!("/api/sessions/{}/archive", run.session_id),
+            json!({}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(archived["archived"], true);
+    assert_eq!(archived["kind"], "launch_attempt");
+    let cancelled = runs::get(&ts.state.db, &run.id).await.unwrap().unwrap();
+    assert_eq!(cancelled.status, "cancelled");
+    assert_eq!(cancelled.summary, "launch attempt archived by user");
+
+    let removed = ts
+        .client
+        .delete(&format!("/api/sessions/{}", run.session_id))
+        .await
+        .unwrap();
+    assert_eq!(removed["deleted"], true);
+    assert_eq!(removed["kind"], "launch_attempt");
+    assert!(runs::get(&ts.state.db, &run.id).await.unwrap().is_none());
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn archiving_a_creating_attempt_tears_down_its_reserved_runtime() {
+    let ts = TestServer::start().await;
+    let run = reserve(&ts, "creating-attempt").await;
+    let term = format!("weaver-{}", run.session_id);
+    backend::new_session(&term, ts.repo_path(), "sleep 60", &[], false, 0)
+        .await
+        .unwrap();
+    assert!(backend::has_session(&term).await);
+
+    ts.client
+        .post(
+            &format!("/api/sessions/{}/archive", run.session_id),
+            json!({}),
+        )
+        .await
+        .unwrap();
+    wait_dead(&term).await;
+    assert_eq!(
+        runs::get(&ts.state.db, &run.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        "cancelled"
+    );
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn supervisor_reconciliation_removes_only_unowned_loom_resources() {
+    let ts = TestServer::start().await;
+    let active = reserve(&ts, "active-owner").await;
+    let owned = format!("weaver-{}", active.session_id);
+    let finished = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "finished but inspectable",
+                "cwd": ts.cwd(),
+                "agent": "shell"
+            }),
+        )
+        .await
+        .unwrap();
+    let finished_id = finished["id"].as_str().unwrap();
+    let finished_term = finished["term_session"].as_str().unwrap();
+    ts.client
+        .patch(
+            &format!("/api/sessions/{finished_id}"),
+            json!({ "status": "done" }),
+        )
+        .await
+        .unwrap();
+    let stray = "weaver-no-database-owner";
+    let unrelated = "other-tapestry-user";
+    for name in [&owned, stray, unrelated] {
+        backend::new_session(name, ts.repo_path(), "sleep 60", &[], false, 0)
+            .await
+            .unwrap();
+    }
+
+    let report = loom::session_manager::reconcile_supervisors(&ts.state.db)
+        .await
+        .unwrap();
+    assert_eq!(report.removed_agents, 1);
+    wait_dead(stray).await;
+    assert!(backend::has_session(&owned).await);
+    assert!(
+        backend::has_session(finished_term).await,
+        "rollout must preserve supervisors owned by inspectable terminal sessions"
+    );
+    assert!(backend::has_session(unrelated).await);
+
+    runs::cancel_for_session(&ts.state.db, &active.session_id)
+        .await
+        .unwrap();
+    loom::session_manager::reconcile_supervisors(&ts.state.db)
+        .await
+        .unwrap();
+    wait_dead(&owned).await;
+    ts.client
+        .delete(&format!("/api/sessions/{finished_id}"))
+        .await
+        .unwrap();
+    backend::kill_session(unrelated).await.unwrap();
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reconciliation_terminalizes_a_session_that_landed_after_cancellation() {
+    let ts = TestServer::start().await;
+    let run = reserve(&ts, "cancel-race").await;
+    let session = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "late automation session",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "class": "automation"
+            }),
+        )
+        .await
+        .unwrap();
+    let id = session["id"].as_str().unwrap();
+    let term = session["term_session"].as_str().unwrap();
+    sqlx::query("UPDATE sessions SET automation_run_id = ? WHERE id = ?")
+        .bind(&run.id)
+        .bind(id)
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE automation_runs SET session_id = ? WHERE id = ?")
+        .bind(id)
+        .bind(&run.id)
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+    runs::cancel_for_session_with_summary(&ts.state.db, id, "launch attempt archived by user")
+        .await
+        .unwrap();
+
+    let report = loom::session_manager::reconcile_supervisors(&ts.state.db)
+        .await
+        .unwrap();
+    assert_eq!(report.invalidated_sessions, 1);
+    wait_dead(term).await;
+    let view = ts.client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(view["status"], "error");
+
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn admin_inventory_can_see_and_remove_managed_sessions() {
+    let ts = TestServer::start().await;
+    let session = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "managed inventory",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "class": "automation"
+            }),
+        )
+        .await
+        .unwrap();
+    let id = session["id"].as_str().unwrap();
+    sqlx::query("UPDATE sessions SET managed_by = 'watch-test' WHERE id = ?")
+        .bind(id)
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+
+    let ordinary = ts
+        .client
+        .get("/api/sessions?automation=true&archived=true")
+        .await
+        .unwrap();
+    assert!(ordinary.as_array().unwrap().is_empty());
+
+    let admin = ts
+        .client
+        .get("/api/sessions?automation=true&archived=true&managed=true")
+        .await
+        .unwrap();
+    assert_eq!(admin.as_array().unwrap().len(), 1);
+    assert_eq!(admin[0]["id"], id);
+
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn every_recorded_session_state_can_be_archived_and_removed() {
+    let ts = TestServer::start().await;
+    for status in ["created", "running", "orphaned", "done", "error"] {
+        let session = ts
+            .client
+            .post(
+                "/api/sessions",
+                json!({
+                    "goal": format!("archive {status}"),
+                    "name": format!("archive-{status}"),
+                    "cwd": ts.cwd(),
+                    "agent": "shell"
+                }),
+            )
+            .await
+            .unwrap();
+        let id = session["id"].as_str().unwrap();
+        ts.client
+            .patch(&format!("/api/sessions/{id}"), json!({ "status": status }))
+            .await
+            .unwrap();
+
+        let archived = ts
+            .client
+            .post(&format!("/api/sessions/{id}/archive"), json!({}))
+            .await
+            .unwrap();
+        assert_eq!(archived["archived"], true, "could not archive {status}");
+        let view = ts.client.get(&format!("/api/sessions/{id}")).await.unwrap();
+        assert_eq!(view["status"], "archived");
+
+        // Archive is idempotent and remove remains available afterwards.
+        ts.client
+            .post(&format!("/api/sessions/{id}/archive"), json!({}))
+            .await
+            .unwrap();
+        ts.client
+            .delete(&format!("/api/sessions/{id}"))
+            .await
+            .unwrap();
+    }
+}

--- a/crates/loom/tests/integration/session_management.rs
+++ b/crates/loom/tests/integration/session_management.rs
@@ -32,7 +32,7 @@ async fn reserve(ts: &TestServer, key: &str) -> runs::Run {
 }
 
 async fn wait_dead(name: &str) {
-    for _ in 0..100 {
+    for _ in 0..300 {
         if !backend::has_session(name).await {
             return;
         }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,6 +58,7 @@ other `weaver` subcommand.
 | `crates/loom/src/custom_mcp.rs` | operator-authored MCP definitions: grouped path identities, immutable sqlite revisions, bounded `uv` validation, and exact session-snapshot execution |
 | `crates/loom/src/profile.rs` | named launch policy, including provider-neutral `mcp_access` resolution and the restricted-profile trust boundary |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
+| `crates/loom/src/session_manager.rs` | database-backed ownership reconciliation for detached agent/debug supervisors; removes Loom-namespaced runtimes without a live session or active launch-reservation owner |
 | `crates/loom/src/chatlog.rs` | conversation log: capture at archive (write the iris `chat.json` + rendered `chat.md` under `session.log_dir`) and serve it for the Conversation tab (`conversation()` — a terminal session's live transcript, an acp session's chat journal mapped to iris (`journal_to_log`), else the capture) |
 | `crates/loom/src/backend.rs` | the terminal-management seam: every programmatic terminal op (create/has/capture/send/kill/list) drives the session's `tapestry` supervisor. Also the ACP transport seam — `new_relay_session`/`subscribe_relay`/`relay_write`/`relay_ack` drive a session's tapestry **relay** supervisor (a durable JSON-RPC frame spool) |
 | `crates/tapestry/` | the per-session detached supervisor that outlives loom. Two modes: a **terminal** (PTY + vt100 screen emulator + unix control socket, streaming raw PTY bytes so an attached xterm owns its own scrollback/search), and a **relay** (a headless stdio subprocess whose stdout is split into newline-delimited frames, spooled with monotonic seqs, and replayed to a subscriber from any cursor — the durable transport under `loom::acp`) |
@@ -253,7 +254,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/ready` | public structured readiness: database access plus core and loom migration versions; optional future remote runner degradation will be reported without failing the whole API |
 | `GET /metrics` | public OpenMetrics scrape derived from durable session/profile/run/migration state; labels are bounded operational dimensions and never contain session/branch/path/user/token/error values (deployments normally restrict this at the public edge) |
 | `GET /api/diagnostics` | admin-only redacted counts, profile capacity, automation failures/staleness, orphan/error inventory, migration state, and non-secret federation metadata; backs Settings → Diagnostics |
-| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false` — and `automation` — default `false`; create resolves `profile` or `default`, permits launch selectors only when the profile is non-strict, stamps the resolved profile revision/policy, opens a tracking issue, and returns its id as `tracking_issue`; views include the exact source-redacted MCP audit snapshot) |
+| `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false` — `automation` — default `false` — and admin-only `managed` — default `false`; create resolves `profile` or `default`, permits launch selectors only when the profile is non-strict, stamps the resolved profile revision/policy, opens a tracking issue, and returns its id as `tracking_issue`; views include the exact source-redacted MCP audit snapshot) |
 | `GET POST /api/profiles`; `GET PUT DELETE /api/profiles/{name}` | named launch-policy CRUD, including provider-neutral `mcp_access`, prelude, and the runtime-permission compatibility escape hatch; profile secret values are never returned |
 | `GET /api/profiles/{name}/effective`; `POST /api/profiles/{name}/probe` | inspect the exact profile-revision capability sets, custom revisions, runtime permission translation, and MCP processes without launching; probe also reports retired builtins and removed/disabled pinned custom definitions |
 | `GET /api/mcps` | merged trusted-builtin and operator-authored MCP registry |
@@ -263,11 +264,11 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `POST /api/auth/federate` | exchange an exact mapped, signature-verified GitHub or Google OIDC identity for a ten-minute Ed25519-signed, profile-scoped Loom automation token |
 | `GET POST /api/runs`; `GET /api/runs/{id}` | durable, subject-scoped automation runs with idempotency reservation; an optional channel routes distinct deliveries through one live ACP session, and verified GitHub callers may provide a validated deterministic key or use the workflow run/attempt |
 | `POST /api/sessions/{id}/restricted-github/{tool}` | session-token-scoped fixed GitHub operations for a restricted session; checks stamped tool policy, fixes the target repository and thread from the session, and resolves a GitHub App token or explicit App-less profile token server-side |
-| `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description) |
+| `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description); DELETE also accepts an unmatched automation run's reserved session id, tearing down and removing the failed launch attempt |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear one branch tag — the well-known `attention` and `triage` keys plus any free-form key |
 | `PUT /api/sessions/{id}/tags` | atomically replace one author's complete tag set, with optional exact `(key, value)` clears for lifecycle marks; the watch-safe write path |
 | `GET /api/sessions/{id}/url` | the session's dashboard URL as `{url}`, built from the externally-visible origin (`auth.base_url`, else the request's own Host) — what `loom session url` prints, so an agent can link a PR back to its session without inventing a loopback link |
-| `POST /api/sessions/{id}/{archive,adopt}` | actions |
+| `POST /api/sessions/{id}/{archive,adopt}` | actions; archive also accepts an unmatched automation run's reserved session id, cancelling its runtime while preserving run history |
 | `POST /api/sessions/{id}/handoff` | replace an idle ACP session's agent runtime/profile while preserving its loom session, worktree, branch, and canonical chat journal; the new provider receives a bounded dialogue replay and the journal records a compact handoff boundary |
 | `POST /api/sessions/{id}/github` | re-poll the branch's GitHub PR now and return the updated session |
 | `GET POST DELETE /api/sessions/{id}/scratch` | list / drop / remove worktree `scratch/` reference files |
@@ -350,8 +351,8 @@ is off, there is no PR, or `gh` is unavailable. See [GitHub
 integration](#github-integration).
 
 Status is two orthogonal axes. The session's `status` is the **lifecycle**
-(orchestrator-owned, mechanical): `created` / `launching` / `running` /
-`orphaned` / `done` / `error`. The branch's **`attention` tag** (value
+(orchestrator-owned, mechanical): `created` / `running` / `orphaned` / `done` /
+`error` / `archived`. The branch's **`attention` tag** (value
 `attention` | `blocked`, absent ⇒ calm) plus its `description` (a one-line
 current-state message) are the **agent-declared** "does this need me?" signal,
 both set via `weaver status`. The dashboard resolves and filters on the
@@ -409,6 +410,13 @@ last journal blocks as compact plain text instead of a vt100 screen capture.
   journal keeps flowing; adopt re-attaches when the relay outlived a crashed task,
   or respawns the adapter and reopens the conversation via `session/load` (falling
   back to a fresh session re-oriented from the goal) when the relay is gone too.
+- **No unowned session runtimes:** the database is the ownership authority for
+  detached supervisors. Startup and periodic reconciliation remove
+  `weaver-<id>` agent supervisors and `loom-shell-<id>-<index>` debug shells
+  without a non-archived session/active-launch-reservation owner; inspectable
+  `done`/`error` sessions remain owners, and the monitor handles the
+  inverse mismatch by marking a session row with no supervisor `orphaned`.
+  See [Session lifecycle](session-lifecycle.md).
 
 ## Status & tags
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -1,0 +1,120 @@
+# Session lifecycle
+
+Loom's database owns every agent runtime. A detached Tapestry supervisor may
+outlive the `loom server run` process, but it may not outlive its durable owner.
+Conversely, losing a supervisor does not erase its session record: Loom marks
+the session orphaned so it can be adopted or archived.
+
+Automation launch attempts have a short phase before a session exists. Their
+`automation_runs` row reserves the future session id and remains visible when
+validation, capacity, clone, or fetch fails. Archive and remove accept that
+reserved id too, so an early failure is never an unactionable pseudo-session.
+
+## State transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> Reserved: automation reserves session id
+    [*] --> Created: session row created
+
+    Reserved --> Created: provisioning reaches session creation
+    Reserved --> FailedAttempt: validation / capacity / repository failure
+    Reserved --> CancelledAttempt: archive
+    Reserved --> Removed: remove
+    FailedAttempt --> CancelledAttempt: archive
+    FailedAttempt --> Removed: remove
+    CancelledAttempt --> Removed: remove history
+
+    Created --> Running: supervisor starts
+    Created --> Error: setup / launch fails
+    Created --> Archived: archive
+    Created --> Removed: remove
+
+    Running --> Orphaned: supervisor disappears
+    Running --> Done: agent finishes
+    Running --> Error: agent / control failure
+    Running --> Archived: archive
+    Running --> Removed: remove
+
+    Orphaned --> Running: adopt
+    Orphaned --> Archived: archive
+    Orphaned --> Removed: remove
+
+    Error --> Running: handoff / recover
+    Error --> Archived: archive
+    Error --> Removed: remove
+
+    Done --> Archived: archive
+    Done --> Removed: remove
+
+    Archived --> Running: recover
+    Archived --> Removed: remove
+
+    state "Launch failed" as FailedAttempt
+    state "Launch cancelled" as CancelledAttempt
+    state "Deleted" as Removed
+```
+
+The session lifecycle is the mechanical `sessions.status` axis:
+`created`, `running`, `orphaned`, `done`, `error`, or `archived`. It remains
+separate from branch attention tags, which describe whether the agent needs a
+person.
+
+`automation_runs.status` describes delivery/provisioning rather than agent
+liveness: `creating`, `waiting`, `delivering`, `running`, `failed`,
+`cancelled`, or `completed`.
+
+## Actions
+
+- **Adopt** recreates a missing supervisor for an orphaned worktree.
+- **Recover** recreates an archived worktree and resumes its agent.
+- **Archive** tears down terminal, debug shells, editor, credentials, and
+  worktree while keeping the session/attempt and branch history.
+- **Remove** performs the same teardown and deletes the durable record. A
+  session remove also deletes its branch unless `keep_branch=true`.
+
+Archive and remove are accepted in every state. External teardown is
+idempotent: a missing runtime or worktree means that part is already complete.
+An automation cancellation is written before teardown, and the final
+`creating -> running` promotion is conditional. If provisioning finishes after
+cancellation, cancellation wins and Loom removes the late-created session.
+
+Both actions use the same REST/CLI path for full sessions and unmatched launch
+attempts:
+
+```text
+POST   /api/sessions/{session-or-reserved-id}/archive
+DELETE /api/sessions/{session-or-reserved-id}
+
+loom session archive <session-or-reserved-id>
+loom session rm <session-or-reserved-id>
+```
+
+## Ownership reconciliation
+
+Loom periodically inventories Tapestry's live supervisors against the database:
+
+```mermaid
+flowchart LR
+    DB[(DB session owner)] -->|supervisor missing| O[mark orphaned]
+    S[detached supervisor] -->|DB owner missing| K[kill supervisor]
+    DB -->|both exist| L[keep live]
+    S -->|both exist| L
+```
+
+- `weaver-<id>` belongs to an existing, non-archived session (including an
+  inspectable `done`/`error` session) or an active automation reservation for
+  `<id>`.
+- `loom-shell-<id>-<index>` belongs to an existing, non-archived session.
+- An unowned name in either namespace is torn down.
+- `loom-scratch-shell` and names outside Loom's namespaces are untouched.
+
+The first reconciliation runs before restart adoption; a background pass keeps
+the invariant convergent after crashes and cancellation races. Active
+reservations protect early provisioning during a rolling deployment, while
+existing session rows protect every live agent that predates the new server.
+
+Admin inventory can opt into managed watch sessions with
+`GET /api/sessions?automation=true&archived=true&managed=true`. The default
+fleet and survey continue to exclude managed sessions so a watch never surveys
+its own infrastructure.

--- a/e2e/tests/automation.spec.ts
+++ b/e2e/tests/automation.spec.ts
@@ -279,7 +279,7 @@ test.describe("automation session surface", () => {
     ).toBeVisible();
   });
 
-  test("a failed launch with no session remains visible", async ({
+  test("a failed launch with no session can be archived and removed", async ({
     page,
     weaver,
   }) => {
@@ -318,6 +318,24 @@ test.describe("automation session surface", () => {
     await expect(failed).toContainText("Launch failed");
     await expect(failed).toContainText("ops");
     await expect(failed).toContainText("default");
+
+    await failed.hover();
+    await failed.getByTestId("run-actions").click();
+    page.once("dialog", (dialog) => dialog.accept());
+    await failed.getByTestId("run-action-archive").click();
+    await expect(page.getByTestId("automation-interventions")).toHaveCount(0);
+
+    await page.getByTestId("automation-history-toggle").click();
+    const archived = page
+      .getByTestId("automation-history")
+      .getByTestId("automation-run-only");
+    await expect(archived).toContainText("Run cancelled");
+
+    await archived.hover();
+    await archived.getByTestId("run-actions").click();
+    page.once("dialog", (dialog) => dialog.accept());
+    await archived.getByTestId("run-action-remove").click();
+    await expect(archived).toHaveCount(0);
   });
 
   test("an unmatched running reservation remains active", async ({


### PR DESCRIPTION
Make every automation lifecycle record actionable, including launch attempts that fail before a session row exists. Archive/remove now cancel first, win races with late provisioning, and share idempotent teardown with recorded sessions.

Add DB-backed reconciliation for detached Loom supervisors, preserve rollout-safe owners, expose managed sessions to admins, and document the full lifecycle with Mermaid diagrams.

Loom: https://loom.rjp.io/s/ph108mgd