### PR TITLE
fix(loom): persist ACP composer metadata

### DIFF
--- a/crates/loom/migrations/0008_acp_metadata.sql
+++ b/crates/loom/migrations/0008_acp_metadata.sql
@@ -1,0 +1,8 @@
+-- ACP adapters advertise their composer controls at runtime. Keep the latest
+-- complete snapshot so a provider exit or loom restart does not reduce an
+-- inspectable conversation to an empty, "dumb" composer.
+CREATE TABLE session_acp_metadata (
+    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    metadata   TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -51,7 +51,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tapestry::RelayEvent;
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -155,7 +155,8 @@ pub struct SseEvent {
 /// kept as ACP-shaped JSON: command inputs and session config options are an
 /// extensible protocol surface, and loom forwards fields it does not yet render
 /// instead of narrowing the wire contract and making adapters stale again.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
 pub struct AcpMetadata {
     pub commands: Vec<Value>,
     pub config_options: Vec<Value>,
@@ -843,6 +844,19 @@ struct Task {
 }
 
 impl Task {
+    async fn load_persisted_metadata(db: &Db, session_id: &str) -> Result<AcpMetadata> {
+        let Some(stored) = session::get_acp_metadata(db, session_id).await? else {
+            return Ok(AcpMetadata::default());
+        };
+        serde_json::from_str(&stored).context("decoding persisted ACP metadata")
+    }
+
+    async fn persist_metadata(&self) -> Result<()> {
+        let metadata = self.metadata.lock().unwrap().clone();
+        let encoded = serde_json::to_string(&metadata)?;
+        session::set_acp_metadata(&self.db, &self.session_id, &encoded).await
+    }
+
     async fn fresh(
         state: &AppState,
         session: &session::Session,
@@ -930,6 +944,8 @@ impl Task {
         let next_seq = max_seq + 1;
         let turns_dispatched = if max_seq < 0 { 0 } else { current_turn + 1 };
 
+        let metadata = Self::load_persisted_metadata(&state.db, &session.id).await?;
+        let steering_cap = metadata.steering_supported;
         Ok(Self {
             db: state.db.clone(),
             bus: state.bus.clone(),
@@ -953,11 +969,11 @@ impl Task {
             // applying a newer session selection to an older turn.
             effective_mode,
             current_mode: session.current_mode.clone(),
-            metadata: Arc::new(Mutex::new(AcpMetadata::default())),
+            metadata: Arc::new(Mutex::new(metadata)),
             pending_mode: HashMap::new(),
             pending_config: HashMap::new(),
             load_session_cap: false,
-            steering_cap: false,
+            steering_cap,
             pending_steers: HashMap::new(),
             external_turn,
             pending_external: None,
@@ -1240,6 +1256,7 @@ impl Task {
         if let Some(mode) = &self.current_mode {
             session::set_current_mode(&self.db, &self.session_id, mode).await?;
         }
+        self.persist_metadata().await?;
 
         if let Some(goal) = &launch.goal {
             match handoff {
@@ -1500,9 +1517,15 @@ impl Task {
             }
             SessionUpdate::AvailableCommandsUpdate { available_commands } => {
                 self.replace_commands(available_commands, true);
+                if let Err(error) = self.persist_metadata().await {
+                    tracing::warn!(session = %self.session_id, %error, "failed to persist acp metadata");
+                }
             }
             SessionUpdate::ConfigOptionUpdate { config_options } => {
                 self.replace_config_options(config_options, true);
+                if let Err(error) = self.persist_metadata().await {
+                    tracing::warn!(session = %self.session_id, %error, "failed to persist acp metadata");
+                }
                 if let Some(mode) = &self.current_mode {
                     let _ = session::set_current_mode(&self.db, &self.session_id, mode).await;
                 }
@@ -1613,11 +1636,15 @@ impl Task {
                 {
                     Some(updated) => {
                         self.replace_config_options(updated.config_options, true);
+                        let persisted = self.persist_metadata().await;
                         if let Some(mode) = &self.current_mode {
                             let _ =
                                 session::set_current_mode(&self.db, &self.session_id, mode).await;
                         }
-                        Ok(self.metadata.lock().unwrap().clone())
+                        match persisted {
+                            Ok(()) => Ok(self.metadata.lock().unwrap().clone()),
+                            Err(error) => Err(error),
+                        }
                     }
                     None => Err(anyhow!(
                         "session/set_config_option returned an invalid response"

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -45,6 +45,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "automation-channels",
         include_str!("../migrations/0007_automation_channels.sql"),
     ),
+    (
+        8,
+        "acp-metadata",
+        include_str!("../migrations/0008_acp_metadata.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -275,7 +280,7 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7, 8]);
 
         let columns = table_columns(&db, "sessions").await.unwrap();
         for expected in [
@@ -406,7 +411,7 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7, 8]);
         let index_sql: String = sqlx::query_scalar(
             "SELECT sql FROM sqlite_master
              WHERE type = 'index' AND name = 'idx_sessions_active_branch'",
@@ -480,7 +485,7 @@ mod tests {
             .fetch_one(&db)
             .await
             .unwrap();
-        assert_eq!(count, 7);
+        assert_eq!(count, 8);
 
         // Adoption replaced the historical index predicate: archived history
         // no longer prevents a new active session from claiming the branch.

--- a/crates/loom/src/session.rs
+++ b/crates/loom/src/session.rs
@@ -559,10 +559,39 @@ pub async fn set_current_mode(db: &Db, id: &str, mode_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Store the latest complete provider-owned ACP composer metadata. It remains
+/// available after the live task or loom process disappears, and is replaced
+/// atomically whenever the adapter advertises a refreshed control surface.
+pub async fn set_acp_metadata(db: &Db, id: &str, metadata: &str) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO session_acp_metadata (session_id, metadata, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(session_id) DO UPDATE
+         SET metadata = excluded.metadata, updated_at = excluded.updated_at",
+    )
+    .bind(id)
+    .bind(metadata)
+    .bind(now_iso())
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Read the last complete provider-owned ACP composer metadata snapshot.
+pub async fn get_acp_metadata(db: &Db, id: &str) -> Result<Option<String>> {
+    Ok(
+        sqlx::query_scalar("SELECT metadata FROM session_acp_metadata WHERE session_id = ?")
+            .bind(id)
+            .fetch_optional(db)
+            .await?,
+    )
+}
+
 /// Clear state owned by one ACP adapter process after setup fails. The stable
 /// loom session, journal, runtime profile, and durable human prompt queue stay
 /// intact so the failed session can be inspected or handed off.
 pub async fn clear_acp_state(db: &Db, id: &str) -> Result<()> {
+    let mut tx = db.begin().await?;
     sqlx::query(
         "UPDATE sessions
          SET acp_session_id = NULL, acp_ack_seq = 0, acp_inflight = NULL,
@@ -570,8 +599,13 @@ pub async fn clear_acp_state(db: &Db, id: &str) -> Result<()> {
          WHERE id = ?",
     )
     .bind(id)
-    .execute(db)
+    .execute(&mut *tx)
     .await?;
+    sqlx::query("DELETE FROM session_acp_metadata WHERE session_id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
     Ok(())
 }
 
@@ -596,6 +630,7 @@ pub async fn prepare_handoff(
     effort: &str,
     status: &str,
 ) -> Result<()> {
+    let mut tx = db.begin().await?;
     sqlx::query(
         "UPDATE sessions
          SET agent_kind = ?, model = ?, effort = ?, status = ?,
@@ -608,8 +643,13 @@ pub async fn prepare_handoff(
     .bind(effort)
     .bind(status)
     .bind(id)
-    .execute(db)
+    .execute(&mut *tx)
     .await?;
+    sqlx::query("DELETE FROM session_acp_metadata WHERE session_id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
     tracing::info!(session = %id, agent_kind, model, effort, status, "session runtime handed off");
     Ok(())
 }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -3587,11 +3587,13 @@ pub(super) async fn get_session_chat(
     } else {
         None
     };
-    let metadata = st
-        .acp
-        .get(&session.id)
-        .map(|handle| handle.metadata())
-        .unwrap_or_default();
+    let metadata = match st.acp.get(&session.id) {
+        Some(handle) => handle.metadata(),
+        None => match session_mod::get_acp_metadata(&st.db, &session.id).await? {
+            Some(raw) => serde_json::from_str(&raw)?,
+            None => crate::acp::AcpMetadata::default(),
+        },
+    };
     // Storage uses '' for compatibility with long-lived NOT NULL databases;
     // keep that sentinel out of the public conversation contract.
     let pending_prompt = session

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -348,6 +348,66 @@ async fn composer_metadata_and_config_options_round_trip() {
     assert_eq!(changed["value"], true);
 }
 
+/// Composer controls belong to the durable conversation, not only the live
+/// ACP task. A provider that exits after an account/resource error must leave
+/// its last model, effort, command, and config snapshot inspectable.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn composer_metadata_survives_live_task_loss() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-durable-metadata", None, None).await;
+    poll_metadata(&ts, "acp-durable-metadata", Duration::from_secs(5)).await;
+
+    ts.client
+        .put(
+            "/api/sessions/acp-durable-metadata/config/model",
+            json!({ "value": "fake-deep" }),
+        )
+        .await
+        .expect("model config changes");
+    ts.client
+        .put(
+            "/api/sessions/acp-durable-metadata/config/thought_level",
+            json!({ "value": "high" }),
+        )
+        .await
+        .expect("effort config changes");
+
+    assert!(ts.state.acp.stop("acp-durable-metadata"));
+    let chat = ts
+        .client
+        .get("/api/sessions/acp-durable-metadata/chat")
+        .await
+        .expect("durable chat remains available");
+    let options = chat["metadata"]["config_options"].as_array().unwrap();
+    assert!(options
+        .iter()
+        .any(|option| option["id"] == "model" && option["currentValue"] == "fake-deep"));
+    assert!(options.iter().any(|option| {
+        option["category"] == "thought_level" && option["currentValue"] == "high"
+    }));
+    assert!(!chat["metadata"]["commands"].as_array().unwrap().is_empty());
+
+    // A Loom restart re-attaches to the surviving relay without another ACP
+    // handshake. The new live handle must start with the durable snapshot
+    // instead of masking it with an empty in-memory value.
+    acp::attach(&ts.state, "acp-durable-metadata")
+        .await
+        .expect("relay re-attaches");
+    let attached = ts
+        .client
+        .get("/api/sessions/acp-durable-metadata/chat")
+        .await
+        .expect("re-attached chat remains available");
+    let attached_options = attached["metadata"]["config_options"].as_array().unwrap();
+    assert!(attached_options
+        .iter()
+        .any(|option| option["id"] == "model" && option["currentValue"] == "fake-deep"));
+    assert!(attached_options.iter().any(|option| {
+        option["category"] == "thought_level" && option["currentValue"] == "high"
+    }));
+}
+
 /// Launch selectors can already be active in the underlying runtime while an
 /// adapter's initial configOptions still reflect its own defaults. The
 /// handshake reconciles both selectors through ACP before exposing metadata.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,6 +170,8 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
     blocked by its predecessor), `recent_repos`,
     `branch_github` (per-branch PR snapshot), `chat_blocks` (the ACP
     [chat journal](#rest-api): one row per `(session_id, turn, seq)` block),
+    `session_acp_metadata` (the latest provider-advertised composer controls,
+    retained when its live task exits or Loom restarts),
     and the auth tables `users` (the approved-operator allowlist, seeded with
     the owner), `api_tokens` (hashed bearer tokens), and `auth_sessions`
     (hashed login cookies). See [Authentication](#authentication). Loom-owned
@@ -281,7 +283,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a live turn is steered when supported, otherwise cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
 | `POST /api/sessions/{id}/interrupt` | stop the current turn — a break (Escape) to the terminal for a `terminal` session, `session/cancel` for an `acp` one |
 | `GET /api/sessions/{id}/preview?lines=N` | capture the screen as `{screen}`; `lines` adds scrollback above the visible screen (for an `acp` session, `{screen}` is the last `lines` journal blocks rendered as compact text) |
-| `GET /api/sessions/{id}/chat` | The newest 200 blocks of the ACP session's DB-backed journal, `older_cursor`, live-turn state, pending prompt, effective mode, and composer metadata; pass the cursor as `before_turn` + `before_seq` to page backward |
+| `GET /api/sessions/{id}/chat` | The newest 200 blocks of the ACP session's DB-backed journal, `older_cursor`, live-turn state, pending prompt, effective mode, and durable composer metadata (the last provider-advertised controls remain after provider exit/restart); pass the cursor as `before_turn` + `before_seq` to page backward |
 | `GET /api/sessions/{id}/chat/stream` | SSE tail of the live journal: `block` (a committed block), `delta` (a streaming message/thought chunk), `tool` (a live tool-call update), `turn` (started / ended) |
 | `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, steered, turn}` — dispatch a user message as a `session/prompt`; a live turn uses the advertised codex-acp steering extension, with the durable next-turn queue as fallback |
 | `DELETE /api/sessions/{id}/prompt` | atomically retract unseen next-turn feedback and return `{text}` for editing; 409 when the current ACP state has no queue available to retract |


### PR DESCRIPTION
Persist the latest provider-advertised ACP composer metadata so model, reasoning effort, commands, permissions, and other controls remain available when an adapter exits or Loom reattaches after a restart.

Restore that snapshot into reattached task handles and clear it atomically when setup fails or a provider handoff begins. Add migration and regression coverage for live-task loss and restart reattach.