### PR TITLE
feat(loom): add normalized self-history search

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ plus a readable `chat.md` under `session.log_dir`
 (default `~/.iris/logs/sessions/<branch>/`). `weaver chatlog` renders the same
 log for a live session on the command line.
 
+Agents can page or literally search that same normalized history through
+session-scoped REST. ACP reads its durable journal; terminal agents normalize
+their native transcript on read and use the archived Iris capture as fallback.
+The optional `mcp/history/self@v1` capability is a thin self-only facade over
+those routes. See [Session history and search](docs/session-history.md) for the
+record, cursor, source, and authorization contract.
+
 Once a branch's PR merges, loom archives the session automatically — tearing
 down its terminal and worktree while keeping the branch and its weaver history,
 the same as the Archive button. To keep one session until you archive it
@@ -471,8 +478,9 @@ Notable settings:
   `--mcp`. Saving pins the exact capabilities to that profile revision; editing
   the registry cannot silently widen it, and saving the profile again is the
   explicit reconciliation point. The builtins cover fixed-repository GitHub
-  work, durable status updates, and fixed-thread Slack replies; all reuse Loom's existing
-  session-scoped routes, so provider credentials remain server-side.
+  work, durable status updates, fixed-thread Slack replies, and normalized
+  self-history/search; all reuse Loom's existing session-scoped routes, so
+  provider credentials remain server-side.
   Provider-specific runtime permission rules remain an implementation detail of
   the selected agent, rather than the vocabulary used to name MCP access.
 - Administrators can add Python MCP servers under identities such as

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -998,6 +998,30 @@ export interface IrisLog {
   messages: IrisMessage[];
 }
 
+/** One provider-neutral record from `GET /sessions/{id}/history[/search]`.
+ * Optional fields are present only when the source transcript supplies them;
+ * ACP tool activity, in particular, does not claim invocation arguments. */
+export interface HistoryRecord {
+  cursor: string;
+  kind: 'message' | 'reasoning' | 'tool_call' | 'tool_result' | 'context' | 'event' | 'image';
+  role?: string;
+  content?: string;
+  tool_name?: string;
+  tool_input?: unknown;
+  tool_status?: string;
+  is_error?: boolean;
+  event_name?: string;
+  locations?: Array<{ path: string; line?: number }>;
+  timestamp?: string;
+}
+
+/** A newest-tail page returned in chronological display order. */
+export interface HistoryPage {
+  source: string;
+  records: HistoryRecord[];
+  older_cursor?: string;
+}
+
 /** One captured server log line. Mirrors `loom::logs::LogLine`. */
 export interface LogLine {
   seq: number;

--- a/crates/loom/src/chatlog.rs
+++ b/crates/loom/src/chatlog.rs
@@ -322,7 +322,7 @@ pub async fn journal_to_log(db: &Db, session: &Session) -> Option<Log> {
 
 /// Flatten a `tool_call` block's `content` array into readable result text: text
 /// parts verbatim, diff parts as a compact `path` + `- old` / `+ new` snippet.
-fn tool_content_text(content: Option<&Value>) -> String {
+pub(crate) fn tool_content_text(content: Option<&Value>) -> String {
     let Some(arr) = content.and_then(Value::as_array) else {
         return String::new();
     };
@@ -348,7 +348,7 @@ fn tool_content_text(content: Option<&Value>) -> String {
 
 /// A one-line context note for an ACP-only block kind, flattened into the iris
 /// export as injected context.
-fn context_note(kind: &str, p: &Value) -> String {
+pub(crate) fn context_note(kind: &str, p: &Value) -> String {
     match kind {
         kind::PLAN => {
             let entries = p.get("entries").and_then(Value::as_array);

--- a/crates/loom/src/history.rs
+++ b/crates/loom/src/history.rs
@@ -1,0 +1,395 @@
+//! Provider-neutral, paged session history and literal search.
+//!
+//! ACP's canonical source is the durable `chat_blocks` journal. Terminal
+//! providers keep native JSONL outside Loom, so their existing Iris normalizer
+//! is read on demand (with `chatlog`'s file-fingerprint cache) and the archived
+//! Iris capture remains the durable fallback. This module flattens either source
+//! into one honest record vocabulary without manufacturing data a provider did
+//! not supply.
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+use weaver_api::{HistoryLocationView, HistoryPageView, HistoryRecordView};
+use weaver_core::branch::Branch;
+use weaver_core::transcript::iris::{Block, Log, Role};
+
+use crate::chat::kind;
+use crate::session::Session;
+use crate::Db;
+
+pub const DEFAULT_LIMIT: usize = 100;
+pub const MAX_LIMIT: usize = 200;
+pub const MAX_QUERY_BYTES: usize = 1024;
+pub const KINDS: &[&str] = &[
+    "message",
+    "reasoning",
+    "tool_call",
+    "tool_result",
+    "context",
+    "event",
+    "image",
+];
+
+#[derive(Debug, Default)]
+pub struct PageOptions {
+    pub before: Option<String>,
+    pub limit: Option<usize>,
+    pub kinds: Vec<String>,
+    pub query: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum PageError {
+    BadRequest(String),
+    Internal(anyhow::Error),
+}
+
+impl PageError {
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self::BadRequest(message.into())
+    }
+}
+
+impl From<anyhow::Error> for PageError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Internal(error)
+    }
+}
+
+/// Load the source appropriate to `session`, normalize it, filter it, and return
+/// a newest-tail page in chronological display order.
+pub async fn page(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+    options: PageOptions,
+) -> Result<HistoryPageView, PageError> {
+    let limit = options.limit.unwrap_or(DEFAULT_LIMIT);
+    if !(1..=MAX_LIMIT).contains(&limit) {
+        return Err(PageError::bad_request(format!(
+            "limit must be between 1 and {MAX_LIMIT}"
+        )));
+    }
+    let kinds = validate_kinds(&options.kinds)?;
+    let query = options
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|query| !query.is_empty())
+        .map(str::to_lowercase);
+    if options.query.is_some() && query.is_none() {
+        return Err(PageError::bad_request("q must not be empty"));
+    }
+    if options
+        .query
+        .as_ref()
+        .is_some_and(|query| query.len() > MAX_QUERY_BYTES)
+    {
+        return Err(PageError::bad_request(format!(
+            "q must be at most {MAX_QUERY_BYTES} bytes"
+        )));
+    }
+
+    let (source, records) = load(db, session, branch).await?;
+    let end = match options.before.as_deref() {
+        Some(before) => records
+            .iter()
+            .position(|record| record.cursor == before)
+            .ok_or_else(|| {
+                PageError::bad_request("before is not a cursor from this session history")
+            })?,
+        None => records.len(),
+    };
+    let mut matching = records[..end]
+        .iter()
+        .filter(|record| kinds.is_empty() || kinds.contains(record.kind.as_str()))
+        .filter(|record| {
+            query
+                .as_deref()
+                .is_none_or(|needle| searchable_text(record).to_lowercase().contains(needle))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let has_more = matching.len() > limit;
+    if has_more {
+        matching.drain(..matching.len() - limit);
+    }
+    let older_cursor = has_more.then(|| {
+        matching
+            .first()
+            .expect("a non-zero page limit retains a record")
+            .cursor
+            .clone()
+    });
+    Ok(HistoryPageView {
+        source,
+        records: matching,
+        older_cursor,
+    })
+}
+
+fn validate_kinds(kinds: &[String]) -> Result<HashSet<&str>, PageError> {
+    let mut out = HashSet::new();
+    for value in kinds {
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        if !KINDS.contains(&value) {
+            return Err(PageError::bad_request(format!(
+                "unknown history kind '{value}'; expected one of {}",
+                KINDS.join(", ")
+            )));
+        }
+        out.insert(value);
+    }
+    Ok(out)
+}
+
+async fn load(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+) -> Result<(String, Vec<HistoryRecordView>), anyhow::Error> {
+    if session.protocol == "acp" {
+        let blocks = crate::chat::list(db, &session.id).await?;
+        return Ok((
+            "acp".to_string(),
+            blocks.iter().map(acp_record).collect::<Vec<_>>(),
+        ));
+    }
+    Ok(
+        match crate::chatlog::conversation(db, session, branch).await {
+            Some(log) => {
+                let source = log.source.clone();
+                (source, iris_records(&log))
+            }
+            None => (session.agent_kind.clone(), Vec::new()),
+        },
+    )
+}
+
+fn acp_record(block: &crate::chat::ChatBlockView) -> HistoryRecordView {
+    let payload = &block.payload;
+    let text = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|text| !text.is_empty())
+            .map(str::to_string)
+    };
+    let mut record = blank(
+        format!("acp:{}:{}", block.turn, block.seq),
+        "event",
+        Some(block.created_at.clone()),
+    );
+    match block.kind.as_str() {
+        kind::USER_MESSAGE => {
+            record.kind = "message".to_string();
+            record.role = Some("user".to_string());
+            record.content = text("text");
+        }
+        kind::AGENT_MESSAGE => {
+            record.kind = "message".to_string();
+            record.role = Some("assistant".to_string());
+            record.content = text("text");
+        }
+        kind::THOUGHT => {
+            record.kind = "reasoning".to_string();
+            record.role = Some("assistant".to_string());
+            record.content = text("text");
+        }
+        kind::TOOL_CALL => {
+            record.kind = "tool_call".to_string();
+            record.tool_name = text("title").or_else(|| text("tool_kind"));
+            // ACP ToolCall has no invocation-arguments field. Do not reinterpret
+            // output content or locations as input.
+            record.content = Some(crate::chatlog::tool_content_text(payload.get("content")))
+                .filter(|text| !text.is_empty());
+            record.tool_status = text("status");
+            record.is_error = Some(record.tool_status.as_deref() == Some("failed"));
+            record.locations = payload
+                .get("locations")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|location| {
+                    Some(HistoryLocationView {
+                        path: location.get("path")?.as_str()?.to_string(),
+                        line: location.get("line").and_then(Value::as_u64),
+                    })
+                })
+                .collect();
+        }
+        other => {
+            record.event_name = Some(other.to_string());
+            record.content = Some(if other == kind::TURN_END {
+                let reason = payload
+                    .get("stop_reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
+                format!("turn ended: {reason}")
+            } else {
+                crate::chatlog::context_note(other, payload)
+            });
+        }
+    }
+    record
+}
+
+fn iris_records(log: &Log) -> Vec<HistoryRecordView> {
+    let mut records = Vec::new();
+    for (message_index, message) in log.messages.iter().enumerate() {
+        for (block_index, block) in message.blocks.iter().enumerate() {
+            let cursor = format!("iris:{message_index}:{block_index}");
+            let timestamp = message.timestamp.clone();
+            let role = role_name(message.role).to_string();
+            let mut record = match block {
+                Block::Text { text } => {
+                    let kind = if message.role == Role::Context {
+                        "context"
+                    } else {
+                        "message"
+                    };
+                    let mut record = blank(cursor, kind, timestamp);
+                    record.role = Some(role);
+                    record.content = nonempty(text);
+                    record
+                }
+                Block::Thinking { text } => {
+                    let mut record = blank(cursor, "reasoning", timestamp);
+                    record.role = Some(role);
+                    record.content = nonempty(text);
+                    record
+                }
+                Block::ToolUse { name, input } => {
+                    let mut record = blank(cursor, "tool_call", timestamp);
+                    record.role = Some(role);
+                    record.tool_name = nonempty(name);
+                    record.tool_input = (!input.is_null()).then(|| input.clone());
+                    record
+                }
+                Block::ToolResult { output, is_error } => {
+                    let mut record = blank(cursor, "tool_result", timestamp);
+                    record.role = Some(role);
+                    record.content = nonempty(output);
+                    record.is_error = Some(*is_error);
+                    record
+                }
+                Block::Image => blank(cursor, "image", timestamp),
+            };
+            if record.kind == "context" {
+                record.event_name = Some("context".to_string());
+            }
+            records.push(record);
+        }
+    }
+    records
+}
+
+fn blank(cursor: String, kind: &str, timestamp: Option<String>) -> HistoryRecordView {
+    HistoryRecordView {
+        cursor,
+        kind: kind.to_string(),
+        role: None,
+        content: None,
+        tool_name: None,
+        tool_input: None,
+        tool_status: None,
+        is_error: None,
+        event_name: None,
+        locations: Vec::new(),
+        timestamp,
+    }
+}
+
+fn nonempty(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn role_name(role: Role) -> &'static str {
+    match role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Context => "context",
+    }
+}
+
+fn searchable_text(record: &HistoryRecordView) -> String {
+    let mut parts = vec![record.kind.as_str()];
+    for value in [
+        record.role.as_deref(),
+        record.content.as_deref(),
+        record.tool_name.as_deref(),
+        record.tool_status.as_deref(),
+        record.event_name.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        parts.push(value);
+    }
+    let input = record
+        .tool_input
+        .as_ref()
+        .and_then(|value| serde_json::to_string(value).ok())
+        .unwrap_or_default();
+    let locations = record
+        .locations
+        .iter()
+        .map(|location| location.path.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("{} {input} {locations}", parts.join(" "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use weaver_core::transcript::iris::{Message, Role};
+
+    #[test]
+    fn iris_tool_input_is_optional_but_preserved_when_present() {
+        let log = Log {
+            source: "codex".to_string(),
+            messages: vec![Message::new(
+                Role::Assistant,
+                Some("now".to_string()),
+                vec![
+                    Block::ToolUse {
+                        name: "exec".to_string(),
+                        input: json!({ "cmd": "cargo test" }),
+                    },
+                    Block::tool_result("ok", false),
+                ],
+            )],
+            ..Default::default()
+        };
+        let records = iris_records(&log);
+        assert_eq!(records[0].kind, "tool_call");
+        assert_eq!(records[0].tool_input, Some(json!({ "cmd": "cargo test" })));
+        assert_eq!(records[1].kind, "tool_result");
+    }
+
+    #[test]
+    fn acp_tool_activity_does_not_invent_arguments() {
+        let record = acp_record(&crate::chat::ChatBlockView {
+            turn: 2,
+            seq: 3,
+            kind: kind::TOOL_CALL.to_string(),
+            payload: json!({
+                "title": "Run tests",
+                "status": "completed",
+                "content": [{ "type": "text", "text": "all green" }],
+                "locations": [{ "path": "/repo/src.rs", "line": 7 }]
+            }),
+            created_at: "now".to_string(),
+        });
+        assert_eq!(record.cursor, "acp:2:3");
+        assert_eq!(record.tool_name.as_deref(), Some("Run tests"));
+        assert_eq!(record.content.as_deref(), Some("all green"));
+        assert!(record.tool_input.is_none());
+    }
+}

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -25,6 +25,7 @@ pub mod github;
 pub mod github_app;
 pub mod github_manifest;
 pub mod github_trigger;
+pub mod history;
 pub mod ide;
 pub mod launch_gate;
 pub mod logs;

--- a/crates/loom/src/mcp/history.rs
+++ b/crates/loom/src/mcp/history.rs
@@ -1,0 +1,303 @@
+//! Built-in session self-history MCP adapter.
+//!
+//! This is deliberately only a facade: the REST history resources own source
+//! normalization, pagination, filtering, literal search, and authorization.
+//! The tool surface has no session selector; it resolves `LOOM_SESSION_ID` and
+//! calls the corresponding session route with the scoped token.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use super::{Adapter, CapabilitySet, ServeFuture};
+
+const SERVER_NAME: &str = "loom_history";
+const TOOL_NAMES: [&str; 2] = ["history", "search"];
+const HISTORY_TOOLS: &[&str] = &TOOL_NAMES;
+const CAPABILITY_SETS: &[CapabilitySet] = &[CapabilitySet {
+    name: "mcp/history/self@v1",
+    group: "history",
+    version: "v1",
+    description: "Page and literally search the normalized history of this session.",
+    tools: HISTORY_TOOLS,
+}];
+
+pub(super) const ADAPTER: Adapter = Adapter {
+    name: "history",
+    server_name: SERVER_NAME,
+    description: "Session-scoped normalized history and literal search.",
+    capability_sets,
+    expand_tool_set,
+    is_permission_rule,
+    server_config,
+    tools,
+    serve: serve_boxed,
+};
+
+fn capability_sets() -> &'static [CapabilitySet] {
+    CAPABILITY_SETS
+}
+
+fn permission_rule(tool: &str) -> Option<String> {
+    TOOL_NAMES
+        .contains(&tool)
+        .then(|| format!("mcp__{SERVER_NAME}__{tool}"))
+}
+
+fn is_permission_rule(rule: &str) -> bool {
+    TOOL_NAMES
+        .iter()
+        .any(|tool| permission_rule(tool).as_deref() == Some(rule))
+}
+
+fn expand_tool_set(name: &str) -> Option<Vec<String>> {
+    CAPABILITY_SETS
+        .iter()
+        .find(|set| set.name == name)
+        .map(|set| {
+            set.tools
+                .iter()
+                .map(|tool| permission_rule(tool).expect("registered history tool"))
+                .collect()
+        })
+}
+
+fn server_config() -> Value {
+    json!({
+        "type": "stdio",
+        "command": "loom",
+        "args": ["mcp", "serve", ADAPTER.name]
+    })
+}
+
+fn serve_boxed() -> ServeFuture {
+    Box::pin(serve())
+}
+
+fn tools() -> Value {
+    let common = json!({
+        "before": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Exclusive opaque cursor returned as older_cursor by the preceding page."
+        },
+        "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": crate::history::MAX_LIMIT
+        },
+        "kinds": {
+            "type": "array",
+            "items": { "type": "string", "enum": crate::history::KINDS },
+            "uniqueItems": true,
+            "description": "Optional normalized record-kind filter."
+        }
+    });
+    json!([
+        {
+            "name": "history",
+            "description": "Page normalized records for this session. Records are chronological within each newest-tail page; follow older_cursor backward. Tool input is present only when the source transcript supplied it.",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": common
+            }
+        },
+        {
+            "name": "search",
+            "description": "Case-insensitive literal search over this session's normalized records. Uses the same paging cursor and optional kind filters as history.",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "q": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": crate::history::MAX_QUERY_BYTES
+                    },
+                    "before": common["before"],
+                    "limit": common["limit"],
+                    "kinds": common["kinds"]
+                },
+                "required": ["q"]
+            }
+        }
+    ])
+}
+
+fn optional_args(arguments: &Value) -> Result<(Option<&str>, Option<usize>, Vec<String>)> {
+    let before = match arguments.get("before") {
+        Some(value) => Some(
+            value
+                .as_str()
+                .filter(|value| !value.is_empty())
+                .context("before must be a non-empty string")?,
+        ),
+        None => None,
+    };
+    let limit = match arguments.get("limit") {
+        Some(value) => Some(
+            usize::try_from(value.as_u64().context("limit must be a positive integer")?)
+                .context("limit is too large")?,
+        ),
+        None => None,
+    };
+    let kinds = match arguments.get("kinds") {
+        Some(value) => value
+            .as_array()
+            .context("kinds must be an array")?
+            .iter()
+            .map(|kind| {
+                kind.as_str()
+                    .context("every kind must be a string")
+                    .map(str::to_string)
+            })
+            .collect::<Result<Vec<_>>>()?,
+        None => Vec::new(),
+    };
+    Ok((before, limit, kinds))
+}
+
+async fn call_tool(name: &str, arguments: Value) -> Result<Value> {
+    if !TOOL_NAMES.contains(&name) {
+        bail!("unknown history tool '{name}'");
+    }
+    if !super::runtime_tool_allowed(name) {
+        bail!("history tool '{name}' is not allowed by this session");
+    }
+    let allowed = match name {
+        "history" => &["before", "limit", "kinds"][..],
+        "search" => &["q", "before", "limit", "kinds"][..],
+        _ => unreachable!(),
+    };
+    let object = arguments
+        .as_object()
+        .context("history tool arguments must be an object")?;
+    if let Some(unknown) = object.keys().find(|key| !allowed.contains(&key.as_str())) {
+        bail!("unknown argument '{unknown}' for history tool '{name}'");
+    }
+    let session_id =
+        std::env::var("LOOM_SESSION_ID").context("history MCP is missing LOOM_SESSION_ID")?;
+    let token = weaver_api::endpoint::token_from_env()
+        .context("history MCP is missing its session-scoped LOOM_TOKEN")?;
+    let client = weaver_api::Client::new(weaver_api::endpoint::base_url()).with_token(Some(token));
+    let (before, limit, kinds) = optional_args(&arguments)?;
+    let page = match name {
+        "history" => {
+            client
+                .get_session_history(&session_id, before, limit, &kinds)
+                .await?
+        }
+        "search" => {
+            let query = arguments
+                .get("q")
+                .and_then(Value::as_str)
+                .context("search requires q")?;
+            client
+                .search_session_history(&session_id, query, before, limit, &kinds)
+                .await?
+        }
+        _ => unreachable!(),
+    };
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&page)?
+        }],
+        "isError": false
+    }))
+}
+
+fn result(id: &Value, value: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": value })
+}
+
+fn error(id: &Value, code: i64, message: impl Into<String>) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message.into() } })
+}
+
+async fn dispatch(request: Value) -> Option<Value> {
+    let id = request.get("id")?.clone();
+    let method = request.get("method").and_then(Value::as_str).unwrap_or("");
+    Some(match method {
+        "initialize" => result(
+            &id,
+            json!({
+                "protocolVersion": request.pointer("/params/protocolVersion")
+                    .and_then(Value::as_str).unwrap_or("2024-11-05"),
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": SERVER_NAME, "version": env!("CARGO_PKG_VERSION") }
+            }),
+        ),
+        "ping" => result(&id, json!({})),
+        "tools/list" => result(&id, json!({ "tools": super::runtime_tools(tools()) })),
+        "tools/call" => {
+            let name = request.pointer("/params/name").and_then(Value::as_str);
+            let arguments = request
+                .pointer("/params/arguments")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            match name {
+                Some(name) => match call_tool(name, arguments).await {
+                    Ok(value) => result(&id, value),
+                    Err(err) => result(
+                        &id,
+                        json!({
+                            "content": [{ "type": "text", "text": format!("{err:#}") }],
+                            "isError": true
+                        }),
+                    ),
+                },
+                None => error(&id, -32602, "tools/call requires params.name"),
+            }
+        }
+        _ => error(&id, -32601, format!("method not found: {method}")),
+    })
+}
+
+async fn serve() -> Result<()> {
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    let mut stdout = tokio::io::stdout();
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let request: Value =
+            serde_json::from_str(&line).map_err(|error| anyhow!("invalid MCP request: {error}"))?;
+        if let Some(response) = dispatch(request).await {
+            stdout
+                .write_all(serde_json::to_string(&response)?.as_bytes())
+                .await?;
+            stdout.write_all(b"\n").await?;
+            stdout.flush().await?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn self_history_surface_has_no_session_selector() {
+        let surface = tools();
+        for tool in surface.as_array().unwrap() {
+            assert!(tool["inputSchema"]["properties"]
+                .get("session_id")
+                .is_none());
+        }
+        assert_eq!(
+            expand_tool_set("mcp/history/self@v1").unwrap(),
+            vec!["mcp__loom_history__history", "mcp__loom_history__search"]
+        );
+    }
+
+    #[tokio::test]
+    async fn unadvertised_session_selector_fails_closed() {
+        let error = call_tool("history", json!({ "session_id": "sibling" }))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("unknown argument 'session_id'"));
+    }
+}

--- a/crates/loom/src/mcp/mod.rs
+++ b/crates/loom/src/mcp/mod.rs
@@ -14,6 +14,7 @@ use std::{collections::HashSet, future::Future, pin::Pin};
 use weaver_api::{McpAdapterView, McpCapabilitySetView, McpRegistryView};
 
 pub(crate) mod github;
+pub(crate) mod history;
 pub(crate) mod messaging;
 
 type ServeFuture = Pin<Box<dyn Future<Output = Result<()>> + Send>>;
@@ -41,7 +42,7 @@ pub(crate) struct CapabilitySet {
     pub tools: &'static [&'static str],
 }
 
-const ADAPTERS: &[Adapter] = &[github::ADAPTER, messaging::ADAPTER];
+const ADAPTERS: &[Adapter] = &[github::ADAPTER, history::ADAPTER, messaging::ADAPTER];
 pub(crate) const ALLOWED_TOOLS_ENV: &str = "LOOM_MCP_ALLOWED_TOOLS";
 
 pub(crate) fn is_tool_set(name: &str) -> bool {

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -649,6 +649,8 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/sessions/{id}/log", get(log_session))
         .route("/sessions/{id}/conversation", get(conversation_session))
+        .route("/sessions/{id}/history", get(session_history))
+        .route("/sessions/{id}/history/search", get(search_session_history))
         .route("/sessions/{id}/files", get(list_session_files))
         .route("/sessions/{id}/events", get(events_sse))
         .route("/sessions/{id}/terminal", get(crate::terminal::terminal_ws))

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -26,7 +26,8 @@ use crate::{
     setup,
 };
 use weaver_api::{
-    CreateReq, HandoffReq, PatchSessionReq, SendReq, SessionView, SetTagsReq, TagReq,
+    CreateReq, HandoffReq, HistoryPageView, PatchSessionReq, SendReq, SessionView, SetTagsReq,
+    TagReq,
 };
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::Branch;
@@ -3173,6 +3174,89 @@ pub(super) async fn conversation_session(
     // than letting a large response stall unrelated async routes.
     let body = tokio::task::spawn_blocking(move || serde_json::to_vec(&log)).await??;
     Ok(([(header::CONTENT_TYPE, "application/json")], body).into_response())
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct HistoryPageQuery {
+    before: Option<String>,
+    limit: Option<usize>,
+    /// Comma-separated normalized record kinds.
+    kinds: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct HistorySearchQuery {
+    q: String,
+    before: Option<String>,
+    limit: Option<usize>,
+    /// Comma-separated normalized record kinds.
+    kinds: Option<String>,
+}
+
+fn history_kinds(value: Option<&str>) -> Vec<String> {
+    value
+        .into_iter()
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn history_error(error: crate::history::PageError) -> AppError {
+    match error {
+        crate::history::PageError::BadRequest(message) => AppError::bad_request(message),
+        crate::history::PageError::Internal(error) => error.into(),
+    }
+}
+
+/// A provider-neutral page of this session's conversation records. ACP reads
+/// its durable journal; terminal sessions normalize their native transcript on
+/// read and fall back to the archived Iris capture.
+pub(super) async fn session_history(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Query(query): Query<HistoryPageQuery>,
+) -> ApiResult<Json<HistoryPageView>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    let page = crate::history::page(
+        &st.db,
+        &session,
+        &branch,
+        crate::history::PageOptions {
+            before: query.before,
+            limit: query.limit,
+            kinds: history_kinds(query.kinds.as_deref()),
+            query: None,
+        },
+    )
+    .await
+    .map_err(history_error)?;
+    Ok(Json(page))
+}
+
+/// Case-insensitive literal search over the same normalized, session-scoped
+/// records and cursor contract as [`session_history`].
+pub(super) async fn search_session_history(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Query(query): Query<HistorySearchQuery>,
+) -> ApiResult<Json<HistoryPageView>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    let page = crate::history::page(
+        &st.db,
+        &session,
+        &branch,
+        crate::history::PageOptions {
+            before: query.before,
+            limit: query.limit,
+            kinds: history_kinds(query.kinds.as_deref()),
+            query: Some(query.q),
+        },
+    )
+    .await
+    .map_err(history_error)?;
+    Ok(Json(page))
 }
 
 pub(super) async fn events_sse(

--- a/crates/loom/tests/integration/auth.rs
+++ b/crates/loom/tests/integration/auth.rs
@@ -226,6 +226,15 @@ async fn session_token_is_limited_to_its_tree_and_work_items() {
         loom::auth::create_session_token(&ts.state.db, Some("rjpower"), session_id, branch_id)
             .await
             .unwrap();
+    let sibling = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({ "cwd": ts.cwd(), "goal": "scoped sibling", "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let sibling_id = sibling["id"].as_str().unwrap().to_string();
 
     let unrelated = weaver_core::issue::add(
         &ts.state.db,
@@ -257,6 +266,13 @@ async fn session_token_is_limited_to_its_tree_and_work_items() {
         .await
         .unwrap();
     assert_eq!(issue.status(), StatusCode::OK);
+    let own_history = http
+        .get(url(&ts, &format!("/api/sessions/{session_id}/history")))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(own_history.status(), StatusCode::OK);
 
     let child = http
         .post(url(&ts, "/api/sessions"))
@@ -280,6 +296,22 @@ async fn session_token_is_limited_to_its_tree_and_work_items() {
         .await
         .unwrap();
     assert_eq!(unrelated.status(), StatusCode::FORBIDDEN);
+    for path in [
+        format!("/api/sessions/{sibling_id}/history"),
+        format!("/api/sessions/{sibling_id}/history/search?q=secret"),
+    ] {
+        let sibling_history = http
+            .get(url(&ts, &path))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            sibling_history.status(),
+            StatusCode::FORBIDDEN,
+            "session token read sibling history through {path}"
+        );
+    }
     let admin = http
         .get(url(&ts, "/api/auth/tokens"))
         .bearer_auth(&token)

--- a/crates/loom/tests/integration/conversation.rs
+++ b/crates/loom/tests/integration/conversation.rs
@@ -51,6 +51,38 @@ async fn conversation_endpoint_returns_the_iris_log() {
     assert_eq!(messages[0]["blocks"][0]["text"], "do the work");
     assert_eq!(messages[1]["role"], "assistant");
     assert_eq!(messages[1]["blocks"][0]["text"], "Working on it.");
+
+    // The normalized history resource reads the same live terminal transcript,
+    // but gives agents a bounded, cursor-paged record contract.
+    let latest = client
+        .get(&format!("/api/sessions/{id}/history?limit=1"))
+        .await
+        .unwrap();
+    assert_eq!(latest["source"], "claude");
+    assert_eq!(latest["records"].as_array().unwrap().len(), 1);
+    assert_eq!(latest["records"][0]["kind"], "message");
+    assert_eq!(latest["records"][0]["role"], "assistant");
+    assert_eq!(latest["records"][0]["content"], "Working on it.");
+    let cursor = latest["older_cursor"].as_str().unwrap();
+
+    let older = client
+        .get(&format!(
+            "/api/sessions/{id}/history?limit=1&before={cursor}"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(older["records"][0]["role"], "user");
+    assert_eq!(older["records"][0]["content"], "do the work");
+    assert!(older.get("older_cursor").is_none());
+
+    let search = client
+        .get(&format!(
+            "/api/sessions/{id}/history/search?q=WORKING&kinds=message"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(search["records"].as_array().unwrap().len(), 1);
+    assert_eq!(search["records"][0]["role"], "assistant");
 }
 
 /// The ACP endpoint opens at a bounded tail and pages backward with an exclusive
@@ -108,4 +140,88 @@ async fn chat_endpoint_pages_long_journals_from_the_tail() {
     assert_eq!(blocks.first().unwrap()["seq"], 0);
     assert_eq!(blocks.last().unwrap()["seq"], 4);
     assert!(older["older_cursor"].is_null());
+}
+
+/// ACP tool records expose only fields the protocol supplied. In particular,
+/// content and locations are not mislabeled as invocation arguments.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn acp_history_search_is_literal_filtered_and_honest_about_tool_input() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let sess = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "search tools", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = sess["id"].as_str().unwrap().to_string();
+    sqlx::query("UPDATE sessions SET protocol = 'acp' WHERE id = ?")
+        .bind(&id)
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+    loom::chat::insert(
+        &ts.state.db,
+        &id,
+        0,
+        0,
+        loom::chat::kind::USER_MESSAGE,
+        &json!({ "text": "please run the focused check" }),
+    )
+    .await
+    .unwrap();
+    loom::chat::insert(
+        &ts.state.db,
+        &id,
+        0,
+        1,
+        loom::chat::kind::TOOL_CALL,
+        &json!({
+            "tool_call_id": "call-1",
+            "title": "Run focused check",
+            "tool_kind": "execute",
+            "status": "completed",
+            "content": [{ "type": "text", "text": "all green" }],
+            "locations": [{ "path": "/repo/src/lib.rs", "line": 9 }]
+        }),
+    )
+    .await
+    .unwrap();
+
+    let page = client
+        .get(&format!(
+            "/api/sessions/{id}/history/search?q=GREEN&kinds=tool_call"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(page["source"], "acp");
+    assert_eq!(page["records"].as_array().unwrap().len(), 1);
+    let tool = &page["records"][0];
+    assert_eq!(tool["kind"], "tool_call");
+    assert_eq!(tool["tool_name"], "Run focused check");
+    assert_eq!(tool["tool_status"], "completed");
+    assert_eq!(tool["content"], "all green");
+    assert_eq!(tool["locations"][0]["path"], "/repo/src/lib.rs");
+    assert!(
+        tool.get("tool_input").is_none(),
+        "ACP did not supply invocation arguments"
+    );
+
+    assert!(
+        client
+            .get(&format!("/api/sessions/{id}/history?kinds=made_up"))
+            .await
+            .is_err(),
+        "unknown filters fail closed"
+    );
+    assert!(
+        client
+            .get(&format!("/api/sessions/{id}/history/search?q="))
+            .await
+            .is_err(),
+        "empty searches are rejected"
+    );
 }

--- a/crates/loom/tests/integration/mcp_conformance.rs
+++ b/crates/loom/tests/integration/mcp_conformance.rs
@@ -78,7 +78,7 @@ async fn run_filtered_adapter(adapter: &str, tools: &[&str]) -> Vec<Value> {
 
 #[tokio::test]
 async fn every_builtin_speaks_mcp_stdio() {
-    for (adapter, expected_tools) in [("github", 6), ("messaging", 2)] {
+    for (adapter, expected_tools) in [("github", 6), ("history", 2), ("messaging", 2)] {
         let (values, status) = run_adapter(adapter).await;
         assert!(status.success(), "{adapter} did not exit cleanly");
         assert_eq!(values.len(), 4, "{adapter} replied to a notification");
@@ -286,4 +286,82 @@ async fn messaging_status_tool_uses_the_session_scoped_status_route() {
             .unwrap()
             .unwrap();
     assert_eq!(attention.value, "attention");
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn history_tools_resolve_self_and_call_the_rest_contract() {
+    let ts = TestServer::start().await;
+    let branch = loom::branch::upsert(&ts.state.db, &ts.cwd(), "weaver/mcp-history", "main")
+        .await
+        .unwrap();
+    loom::session::insert(
+        &ts.state.db,
+        &loom::session::NewSession {
+            id: "mcphistorysession".to_string(),
+            branch_id: branch.id.clone(),
+            work_dir: ts.cwd(),
+            term_session: "weaver-mcp-history".to_string(),
+            agent_kind: "claude".to_string(),
+            model: String::new(),
+            effort: String::new(),
+            status: "running".to_string(),
+            github_repo: None,
+            parent_branch_id: None,
+            managed_by: None,
+            created_by: None,
+            protocol: "acp".to_string(),
+            origin: "user".to_string(),
+            class: "interactive".to_string(),
+            tracking_issue_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    loom::chat::insert(
+        &ts.state.db,
+        "mcphistorysession",
+        0,
+        0,
+        loom::chat::kind::AGENT_MESSAGE,
+        &json!({ "text": "the searchable answer" }),
+    )
+    .await
+    .unwrap();
+    let token =
+        loom::auth::create_session_token(&ts.state.db, None, "mcphistorysession", &branch.id)
+            .await
+            .unwrap();
+
+    let mut child = Command::new(loom_bin())
+        .args(["mcp", "serve", "history"])
+        .env("WEAVER_API", format!("http://{}", ts.addr))
+        .env("LOOM_TOKEN", token)
+        .env("LOOM_SESSION_ID", "mcphistorysession")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"history\",\"arguments\":{\"limit\":1}}}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"search\",\"arguments\":{\"q\":\"SEARCHABLE\",\"kinds\":[\"message\"]}}}\n",
+        )
+        .await
+        .unwrap();
+    let mut lines = BufReader::new(child.stdout.take().unwrap()).lines();
+    for id in [1, 2] {
+        let response: Value =
+            serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+        assert_eq!(response["id"], id);
+        assert_eq!(response["result"]["isError"], false, "{response}");
+        let page: Value =
+            serde_json::from_str(response["result"]["content"][0]["text"].as_str().unwrap())
+                .unwrap();
+        assert_eq!(page["source"], "acp");
+        assert_eq!(page["records"][0]["content"], "the searchable answer");
+    }
+    assert!(child.wait().await.unwrap().success());
 }

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -15,10 +15,10 @@ use crate::dto::{
     AutomationTokenView, BranchStatusReq, BranchView, CommentDto, CreateEventReq, CreateIssueReq,
     CreateRepoIssueReq, CreateReq, CreateTokenReq, CreateWatchReq, CreatedTokenView, CustomMcpReq,
     CustomMcpView, DeploymentReq, DeploymentView, DiagnosticsView, EffectiveProfileView,
-    FederationReq, FederationView, HandoffReq, IssueView, McpRegistryView, NewCommentBody,
-    NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileProbeView, ProfileReq,
-    ProfileView, PutProfileEnvReq, ReadinessView, RunReq, RunView, RunWatchReq, SendReq,
-    SessionView, SetTagsReq, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
+    FederationReq, FederationView, HandoffReq, HistoryPageView, IssueView, McpRegistryView,
+    NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileProbeView,
+    ProfileReq, ProfileView, PutProfileEnvReq, ReadinessView, RunReq, RunView, RunWatchReq,
+    SendReq, SessionView, SetTagsReq, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
 };
 
 /// A client for one loom server, identified by its base URL.
@@ -157,6 +157,69 @@ impl Client {
     pub async fn get_session(&self, key: &str) -> Result<SessionView> {
         self.get_typed(&format!("/api/sessions/{}", Self::seg(key)))
             .await
+    }
+
+    /// Page normalized records for one session
+    /// (`GET /api/sessions/{key}/history`). `before` is the exclusive opaque
+    /// cursor returned by the preceding page.
+    pub async fn get_session_history(
+        &self,
+        key: &str,
+        before: Option<&str>,
+        limit: Option<usize>,
+        kinds: &[String],
+    ) -> Result<HistoryPageView> {
+        let query = Self::history_query(before, limit, kinds, None);
+        self.get_typed(&format!("/api/sessions/{}/history{query}", Self::seg(key)))
+            .await
+    }
+
+    /// Case-insensitive literal search over one session's normalized records
+    /// (`GET /api/sessions/{key}/history/search`).
+    pub async fn search_session_history(
+        &self,
+        key: &str,
+        search: &str,
+        before: Option<&str>,
+        limit: Option<usize>,
+        kinds: &[String],
+    ) -> Result<HistoryPageView> {
+        let query = Self::history_query(before, limit, kinds, Some(search));
+        self.get_typed(&format!(
+            "/api/sessions/{}/history/search{query}",
+            Self::seg(key)
+        ))
+        .await
+    }
+
+    fn history_query(
+        before: Option<&str>,
+        limit: Option<usize>,
+        kinds: &[String],
+        search: Option<&str>,
+    ) -> String {
+        let encode = |value: &str| {
+            percent_encoding::utf8_percent_encode(value, percent_encoding::NON_ALPHANUMERIC)
+                .to_string()
+        };
+        let mut fields = Vec::new();
+        if let Some(search) = search {
+            fields.push(format!("q={}", encode(search)));
+        }
+        if let Some(before) = before {
+            fields.push(format!("before={}", encode(before)));
+        }
+        if let Some(limit) = limit {
+            fields.push(format!("limit={limit}"));
+        }
+        if !kinds.is_empty() {
+            fields.push(format!("kinds={}", encode(&kinds.join(","))));
+        }
+        if fields.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", fields.join("&"))
+        }
     }
 
     /// Launch a new session (`POST /api/sessions`).

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -201,6 +201,57 @@ pub struct SessionView {
     pub branch: BranchView,
 }
 
+/// One provider-neutral conversation record returned by the session history
+/// API. Optional fields are capability claims, not placeholders: notably,
+/// `tool_input` is absent when the source protocol did not provide invocation
+/// arguments (ACP currently provides only tool title/status/content/locations).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HistoryRecordView {
+    /// Opaque, source-stable position used as the exclusive paging cursor.
+    pub cursor: String,
+    /// `message`, `reasoning`, `tool_call`, `tool_result`, `context`, `event`,
+    /// or `image`.
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_input: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub locations: Vec<HistoryLocationView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+}
+
+/// A source-provided file location attached to a normalized history record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryLocationView {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u64>,
+}
+
+/// One newest-tail page of normalized session history. Records are returned in
+/// chronological display order; pass `older_cursor` as `before` to continue
+/// backward. The same envelope is used by literal search.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HistoryPageView {
+    /// Normalizer/source label (`acp`, `claude`, `codex`, ...).
+    pub source: String,
+    pub records: Vec<HistoryRecordView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub older_cursor: Option<String>,
+}
+
 /// Cumulative session cost optionally reported alongside ACP context usage.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AcpCost {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,12 +54,13 @@ other `weaver` subcommand.
 | `crates/loom/src/builtins.rs` | the builtin watch program registry; the script programs are real Python files in `crates/loom/watches/`, embedded into the binary |
 | `python/weaver-loom/` | the pure-Python layer over the loom REST API (`weaver_loom`: client + watch round context); stdlib-only, uv-buildable, vendored onto every script's `PYTHONPATH` by the engine; server-free contract tests in `tests/` (`uv run pytest`, CI's `python-binding` job) |
 | `crates/loom/src/agent.rs` | launching agents: resolving the execution `protocol`, launching a `terminal` agent into a per-session PTY (installing its `.claude/settings.local.json` hooks) or building an `acp` launch (`build_acp_launch` — the adapter command, `_meta` options, and goal), plus the one-shot headless agent behind `POST /api/agent/oneshot` |
-| `crates/loom/src/mcp/` | trusted builtin MCP registry and stdio adapters: provider-neutral versioned capability sets, exact permission translation, and the fixed GitHub/messaging bridges |
+| `crates/loom/src/mcp/` | trusted builtin MCP registry and stdio adapters: provider-neutral versioned capability sets, exact permission translation, and the fixed GitHub/messaging/self-history bridges |
 | `crates/loom/src/custom_mcp.rs` | operator-authored MCP definitions: grouped path identities, immutable sqlite revisions, bounded `uv` validation, and exact session-snapshot execution |
 | `crates/loom/src/profile.rs` | named launch policy, including provider-neutral `mcp_access` resolution and the restricted-profile trust boundary |
 | `crates/loom/src/session.rs` | `Session` row + sqlx queries |
 | `crates/loom/src/session_manager.rs` | database-backed ownership reconciliation for detached agent/debug supervisors; removes Loom-namespaced runtimes without a live session or active launch-reservation owner |
 | `crates/loom/src/chatlog.rs` | conversation log: capture at archive (write the iris `chat.json` + rendered `chat.md` under `session.log_dir`) and serve it for the Conversation tab (`conversation()` — a terminal session's live transcript, an acp session's chat journal mapped to iris (`journal_to_log`), else the capture) |
+| `crates/loom/src/history.rs` | provider-neutral session-history records and bounded paging/literal search across the ACP journal or terminal Iris normalization; optional fields describe only source-supplied data |
 | `crates/loom/src/backend.rs` | the terminal-management seam: every programmatic terminal op (create/has/capture/send/kill/list) drives the session's `tapestry` supervisor. Also the ACP transport seam — `new_relay_session`/`subscribe_relay`/`relay_write`/`relay_ack` drive a session's tapestry **relay** supervisor (a durable JSON-RPC frame spool) |
 | `crates/tapestry/` | the per-session detached supervisor that outlives loom. Two modes: a **terminal** (PTY + vt100 screen emulator + unix control socket, streaming raw PTY bytes so an attached xterm owns its own scrollback/search), and a **relay** (a headless stdio subprocess whose stdout is split into newline-delimited frames, spooled with monotonic seqs, and replayed to a subscriber from any cursor — the durable transport under `loom::acp`) |
 | `crates/loom/src/terminal.rs` | WebSocket ⇄ live-terminal bridge: xterm.js ⇄ the tapestry session socket |
@@ -277,6 +278,8 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET PUT /api/sessions/{id}/artifacts/{name}` | read content + projected refs (`rev=N` for a revision) / write a user edit as a new revision |
 | `GET /api/sessions/{id}/{diff,log,events}` | reads + SSE stream |
 | `GET /api/sessions/{id}/conversation` | the agent conversation as a normalized iris log (live transcript, else the archive capture); 404 when there is none — backs the Conversation tab |
+| `GET /api/sessions/{id}/history` | a bounded newest-tail page of provider-neutral records in chronological display order; `before`, `limit`, and `kinds` own backward pagination/filtering |
+| `GET /api/sessions/{id}/history/search` | case-insensitive literal `q` search over the same session-scoped records and cursor/filter contract |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ the session's tapestry PTY (the interaction surface) |
 | `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a live turn is steered when supported, otherwise cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
 | `POST /api/sessions/{id}/interrupt` | stop the current turn — a break (Escape) to the terminal for a `terminal` session, `session/cancel` for an `acp` one |
@@ -567,6 +570,13 @@ composer at its foot sends a new prompt straight to the agent pane via `POST
 agent's lifecycle edges (the `status`/`tag` SSE events that fire at each
 turn boundary), so a reply lands without a manual reload. The composer hides
 once the terminal is gone (orphaned/done/archived), leaving the read-only log.
+
+Agent recall uses the related
+[normalized history/search contract](session-history.md). ACP records come
+directly from `chat_blocks`; terminal records reuse the fingerprint-cached Iris
+normalizer on read and the archived `chat.json` fallback. The trusted
+`mcp/history/self@v1` adapter resolves only its own `LOOM_SESSION_ID` and calls
+these REST routes, so it adds no parallel data model or authorization path.
 
 Orphan detection is independent: if the session's supervisor is no longer alive,
 the session becomes `orphaned` and is eligible for `loom adopt`.

--- a/docs/plans/mcp-profiles.md
+++ b/docs/plans/mcp-profiles.md
@@ -120,6 +120,7 @@ returns the provider-neutral name.
 | Identity / group | Purpose | Credential and routing boundary |
 |---|---|---|
 | `mcp/github/comment@v1` / `github` | Issue/PR view, comment, and edit | Existing repository-fixed REST bridge and server-side GitHub credential path from PRs #179/#191 |
+| `mcp/history/self@v1` / `history` | Page and literally search normalized self-history | Existing session history REST routes; the adapter fixes the target to `LOOM_SESSION_ID` and carries only its session token |
 | `mcp/messaging/status@v1` / `messaging` | Update the session’s Weaver status | Existing branch-status API; its durable event is mirrored to wired GitHub and Slack threads |
 | `mcp/slack/message@v1` / `messaging` | Post in the session-bound Slack thread | Existing fixed-thread route; the workspace bot token stays in Loom |
 

--- a/docs/session-history.md
+++ b/docs/session-history.md
@@ -1,0 +1,55 @@
+# Session history and search
+
+Loom exposes one provider-neutral record contract for agent recall:
+
+```text
+GET /api/sessions/{id}/history
+GET /api/sessions/{id}/history/search?q=<literal>
+```
+
+Both routes accept `before=<opaque cursor>`, `limit=1..200` (default 100), and
+`kinds=<comma-separated kinds>`. A response is a newest-tail page whose
+`records` are in chronological display order. If `older_cursor` is present,
+pass it as the next request's exclusive `before` cursor. Search is
+case-insensitive literal matching over the same normalized records; it is not
+semantic or repository-wide search.
+
+The record kinds are `message`, `reasoning`, `tool_call`, `tool_result`,
+`context`, `event`, and `image`. Common prose is in `content`. Tool records can
+also carry `tool_name`, `tool_status`, `is_error`, `locations`, and optionally
+`tool_input`.
+
+Optional fields are capability claims, not empty compatibility slots. In
+particular, ACP's `ToolCall` update supplies a title, kind, status, result
+content, and locations but no invocation-arguments field. ACP history therefore
+omits `tool_input`; it never relabels result content as input. Claude and Codex
+terminal transcripts can include tool input, so their normalized records retain
+it when present.
+
+## Sources and durability
+
+- ACP sessions read the durable SQLite `chat_blocks` journal, preserving its
+  stable `(turn, seq)` positions behind opaque cursors.
+- Terminal sessions normalize the provider's native JSONL transcript through
+  Iris on read. The existing file-fingerprint cache avoids repeated parsing,
+  and the archived Iris `chat.json` is the durable fallback after teardown.
+
+Terminal records are intentionally not imported into a second live SQLite
+store. The native transcript remains mutable while an agent runs, and Loom
+already has a single-flight, fingerprint-invalidated read path plus archive
+capture. Importing would require a second cursor, synchronization, partial-write
+recovery, and provenance policy while duplicating the same content. Read-time
+normalization is the smaller coherent model; a future import should replace it
+only if cross-session indexing needs durable materialization.
+
+## Authorization and MCP
+
+REST owns session resolution, pagination, filters, search, and authorization.
+The normal session-token grant applies: a caller can read its bound session
+tree, but an unrelated sibling session receives `403`.
+
+The built-in `mcp/history/self@v1` capability set exposes `history` and `search`
+tools. Their schemas have no session selector. The stdio adapter resolves
+`LOOM_SESSION_ID`, uses the session-scoped `LOOM_TOKEN`, and calls the REST
+routes above. Profiles can select the `history` MCP group (or `all`); the
+session's pinned capability snapshot still determines the exact tools launched.


### PR DESCRIPTION
## What

Adds paged, provider-neutral REST history and literal search across ACP journals and terminal Iris transcripts, plus the versioned self-scoped MCP facade that resolves the bound session and delegates to REST.

## Why

ACP exposes tool titles, status, content, and locations but not invocation arguments, so the contract keeps tool input optional and never fabricates it. Terminal transcripts remain normalized on read through the existing fingerprint cache and archive fallback, avoiding a second mutable store.