### PR TITLE
feat(watch): calibrate agentic execution

### DIFF
--- a/crates/loom/frontend/src/lib/watch.ts
+++ b/crates/loom/frontend/src/lib/watch.ts
@@ -11,7 +11,14 @@ export const CAPABILITIES = [
   'interrupt',
   'launch',
 ] as const;
-export const GRANTABLE_CAPABILITIES = ['mark', 'escalate', 'nudge', 'interrupt', 'launch'] as const;
+export const GRANTABLE_CAPABILITIES = [
+  'judge',
+  'mark',
+  'escalate',
+  'nudge',
+  'interrupt',
+  'launch',
+] as const;
 
 // Final path segment of a repo root, for a short chip label.
 export function repoLabel(path: string): string {

--- a/crates/loom/frontend/src/lib/watch.ts
+++ b/crates/loom/frontend/src/lib/watch.ts
@@ -5,6 +5,7 @@ import type { Watch, WatchTrigger, WatchScope } from '../types';
 // the explicit grants below it.
 export const CAPABILITIES = [
   'observe',
+  'judge',
   'mark',
   'escalate',
   'nudge',

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -683,6 +683,8 @@ export interface Watch {
   /** The granted capability set (the intervention ladder). `observe` is
    *  implicit; the rest are explicit grants. */
   capabilities: string[];
+  /** Automation-safe ACP profile used by agent judgements and warm sessions. */
+  profile: string;
   model: string;
   effort: string;
   cooldown_secs: number;

--- a/crates/loom/frontend/src/views/Watches.vue
+++ b/crates/loom/frontend/src/views/Watches.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, computed, watch as watchEffect, onMounted, onActivated } from 'vue';
 import { useRouter } from 'vue-router';
 import { get, post, patch, del } from '../api';
-import type { Watch, WatchRun, WatchRunResult, ProgramView } from '../types';
+import type { Watch, WatchRun, WatchRunResult, ProgramView, Profile } from '../types';
 import OutcomeBadge from '../components/OutcomeBadge.vue';
 import AgentTerminal from '../components/AgentTerminal.vue';
 import ToggleSwitch from '../components/ToggleSwitch.vue';
@@ -29,6 +29,7 @@ const router = useRouter();
 
 const watches = ref<Watch[]>([]);
 const programs = ref<ProgramView[]>([]);
+const profiles = ref<Profile[]>([]);
 const loaded = ref(false);
 const error = ref('');
 const busy = ref(false);
@@ -60,6 +61,15 @@ const programInfo = computed(
 );
 
 const activeCount = computed(() => watches.value.filter((w) => w.enabled).length);
+const watchProfiles = computed(() =>
+  profiles.value.filter(
+    (profile) =>
+      profile.class === 'automation' &&
+      profile.strict &&
+      profile.env_clear &&
+      profile.protocol === 'acp',
+  ),
+);
 
 // ── Loading ─────────────────────────────────────────────────────────────────
 async function load() {
@@ -83,6 +93,14 @@ async function loadPrograms() {
     programs.value = (await get('/watches/programs')) as ProgramView[];
   } catch {
     // Supplementary: without the registry a program still shows as its ref.
+  }
+}
+
+async function loadProfiles() {
+  try {
+    profiles.value = (await get('/profiles')) as Profile[];
+  } catch {
+    // Supplementary: the stored profile name remains editable as plain data.
   }
 }
 
@@ -178,6 +196,7 @@ const notice = ref('');
 const draft = reactive({
   prompt: '',
   capabilities: {} as Record<string, boolean>,
+  profile: 'watch',
   model: '',
   effort: '',
   cooldown: 0,
@@ -188,6 +207,7 @@ function syncDraft(w: Watch) {
   draft.capabilities = Object.fromEntries(
     GRANTABLE_CAPABILITIES.map((c) => [c, w.capabilities.includes(c)]),
   );
+  draft.profile = w.profile;
   draft.model = w.model;
   draft.effort = w.effort;
   draft.cooldown = w.cooldown_secs;
@@ -212,6 +232,7 @@ async function saveConfig() {
     const body: Record<string, unknown> = {
       params: draft.prompt.trim() ? { prompt: draft.prompt.trim() } : {},
       capabilities: capabilitiesFrom(draft.capabilities),
+      profile: draft.profile.trim() || 'watch',
       model: draft.model,
       effort: draft.effort,
       cooldown_secs: Number(draft.cooldown) || 0,
@@ -243,6 +264,7 @@ const form = reactive({
   prompt: '',
   scopeAttention: '',
   repo: '',
+  profile: 'watch',
   capabilities: {
     mark: true,
     escalate: true,
@@ -263,6 +285,7 @@ function resetForm() {
   form.prompt = '';
   form.scopeAttention = '';
   form.repo = '';
+  form.profile = 'watch';
   form.capabilities = { mark: true, escalate: true, nudge: false, interrupt: false, launch: false };
 }
 
@@ -329,6 +352,7 @@ async function create() {
       program: programRef || 'builtin:status',
       params,
       capabilities: capabilitiesFrom(form.capabilities),
+      profile: form.profile.trim() || 'watch',
       // New watches go live immediately; the per-row toggle disables later.
       enabled: true,
     };
@@ -373,6 +397,7 @@ watchEffect(selectedId, () => {
 onMounted(() => {
   load().then(loadRuns);
   loadPrograms();
+  loadProfiles();
 });
 // Kept alive across navigation (App.vue): refresh on every return, guarded so
 // the initial mount doesn't fetch twice.
@@ -384,6 +409,7 @@ onActivated(() => {
   }
   load();
   loadRuns();
+  loadProfiles();
 });
 </script>
 
@@ -615,6 +641,20 @@ onActivated(() => {
               spellcheck="false"
               class="w-full rounded bg-input px-2 py-1.5 font-mono text-sm outline-none ring-accent focus:ring-1"
             />
+          </div>
+
+          <div>
+            <label class="mb-1 block text-xs text-muted">
+              Agent profile — automation-safe ACP profile for judgements
+            </label>
+            <select
+              v-model="form.profile"
+              class="w-full rounded bg-input px-2 py-1.5 font-mono text-sm outline-none ring-accent focus:ring-1"
+            >
+              <option v-for="profile in watchProfiles" :key="profile.name" :value="profile.name">
+                {{ profile.name }} — {{ profile.agent_kind }} / {{ profile.model || 'default' }}
+              </option>
+            </select>
           </div>
 
           <div>
@@ -936,6 +976,23 @@ onActivated(() => {
                 <dd class="font-mono">{{ scopeSummary(selected.scope) }}</dd>
                 <dt class="text-faint">Program</dt>
                 <dd class="font-mono">{{ selected.program }}</dd>
+
+                <dt class="text-faint">Agent profile</dt>
+                <dd v-if="!editing" class="font-mono">{{ selected.profile }}</dd>
+                <dd v-else>
+                  <select
+                    v-model="draft.profile"
+                    class="w-40 rounded bg-input px-2 py-1 font-mono text-sm outline-none ring-accent focus:ring-1"
+                  >
+                    <option
+                      v-for="profile in watchProfiles"
+                      :key="profile.name"
+                      :value="profile.name"
+                    >
+                      {{ profile.name }}
+                    </option>
+                  </select>
+                </dd>
 
                 <dt class="pt-1 text-faint">Capabilities</dt>
                 <dd>

--- a/crates/loom/profiles/watch.json
+++ b/crates/loom/profiles/watch.json
@@ -1,0 +1,23 @@
+{
+  "name": "watch",
+  "description": "Low-frequency agent judgement for fleet watches",
+  "agent_kind": "codex",
+  "model": "gpt-5.6-sol",
+  "effort": "medium",
+  "protocol": "acp",
+  "mode": "plan",
+  "class": "automation",
+  "strict": true,
+  "env_clear": true,
+  "ambient_allowlist": [],
+  "idle_archive_secs": 900,
+  "max_concurrent": 2,
+  "turn_budget": 1,
+  "prelude": "none",
+  "restricted": false,
+  "runtime_permissions": [],
+  "mcp_access": {
+    "mode": "none",
+    "groups": []
+  }
+}

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -1530,6 +1530,7 @@ impl<'a> AgentManager<'a> {
         prompt: &str,
         model: &str,
         effort: &str,
+        profile: Option<&crate::profile::Profile>,
         timeout: Duration,
     ) -> Option<String> {
         match metadata_for(self.db, runtime).await {
@@ -1562,11 +1563,81 @@ impl<'a> AgentManager<'a> {
                 return None;
             }
         };
-        let mcp_access = match serde_json::to_string(&weaver_api::McpPolicySnapshot::default()) {
-            Ok(value) => value,
-            Err(error) => {
-                tracing::warn!(runtime, %error, "failed to build empty one-shot MCP policy");
-                return None;
+        let (
+            extra_env,
+            env_clear,
+            mode,
+            prelude,
+            restricted,
+            allowed_tools,
+            mcp_access,
+            profile_model,
+            profile_effort,
+        ) = match profile {
+            Some(profile) => {
+                let mut extra_env = match crate::profile::env_pairs(self.db, &profile.name).await {
+                    Ok(env) => env,
+                    Err(error) => {
+                        tracing::warn!(runtime, profile = %profile.name, %error, "failed to resolve one-shot profile environment");
+                        return None;
+                    }
+                };
+                if profile.env_clear {
+                    let allowlist = match profile.ambient_names() {
+                        Ok(names) => names,
+                        Err(error) => {
+                            tracing::warn!(runtime, profile = %profile.name, %error, "failed to resolve one-shot profile ambient allowlist");
+                            return None;
+                        }
+                    };
+                    extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
+                }
+                let allowed_tools = match profile.effective_allowed_tool_rules() {
+                    Ok(rules) => match serde_json::to_string(&rules) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            tracing::warn!(runtime, profile = %profile.name, %error, "failed to serialize one-shot profile tools");
+                            return None;
+                        }
+                    },
+                    Err(error) => {
+                        tracing::warn!(runtime, profile = %profile.name, %error, "failed to resolve one-shot profile tools");
+                        return None;
+                    }
+                };
+                (
+                    extra_env,
+                    profile.env_clear,
+                    profile.mode.as_str(),
+                    profile.prelude.as_str(),
+                    profile.restricted,
+                    allowed_tools,
+                    profile.mcp_policy.clone(),
+                    profile.model.as_str(),
+                    profile.effort.as_str(),
+                )
+            }
+            None => {
+                let mcp_access = match serde_json::to_string(
+                    &weaver_api::McpPolicySnapshot::default(),
+                ) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        tracing::warn!(runtime, %error, "failed to build empty one-shot MCP policy");
+                        return None;
+                    }
+                };
+                (
+                    Vec::new(),
+                    false,
+                    "plan",
+                    "none",
+                    true,
+                    "[]".to_string(),
+                    mcp_access,
+                    "",
+                    "",
+                )
             }
         };
         let launch = match build_acp_launch(
@@ -1581,12 +1652,12 @@ impl<'a> AgentManager<'a> {
                 effort: "",
                 goal_file: None,
                 primer_file: None,
-                extra_env: &[],
-                env_clear: false,
-                mode: "plan",
-                prelude: "none",
-                restricted: true,
-                allowed_tools: "[]",
+                extra_env: &extra_env,
+                env_clear,
+                mode,
+                prelude,
+                restricted,
+                allowed_tools: &allowed_tools,
                 mcp_access: &mcp_access,
                 custom: custom.as_ref(),
             },
@@ -1600,15 +1671,25 @@ impl<'a> AgentManager<'a> {
                 return None;
             }
         };
-        let preferred_model = if model.trim().is_empty() {
+        let selected_model = if model.trim().is_empty() {
+            profile_model
+        } else {
+            model.trim()
+        };
+        let selected_effort = if effort.trim().is_empty() {
+            profile_effort
+        } else {
+            effort.trim()
+        };
+        let preferred_model = if selected_model.is_empty() {
             crate::acp::AcpPromptModel::Default
         } else {
-            crate::acp::AcpPromptModel::Exact(model.trim())
+            crate::acp::AcpPromptModel::Exact(selected_model)
         };
-        let preferred_effort = if effort.trim().is_empty() {
+        let preferred_effort = if selected_effort.is_empty() {
             crate::acp::AcpPromptEffort::Default
         } else {
-            crate::acp::AcpPromptEffort::Exact(effort.trim())
+            crate::acp::AcpPromptEffort::Exact(selected_effort)
         };
         match crate::acp::prompt_once(
             self.db,

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -837,7 +837,10 @@ struct AddOpts {
     /// Drawn from observe, judge, mark, escalate, nudge, interrupt, launch.
     #[arg(long, value_delimiter = ',')]
     capabilities: Option<Vec<String>>,
-    /// Model tier for `run_agent` judgement calls (e.g. sonnet, opus).
+    /// Automation-safe ACP profile for agent judgements (default `watch`).
+    #[arg(long)]
+    profile: Option<String>,
+    /// Model override for agent judgement calls.
     #[arg(long)]
     model: Option<String>,
     /// Reasoning effort for judgement calls.
@@ -3620,6 +3623,9 @@ async fn cmd_watch_add(opts: AddOpts) -> Result<()> {
     if let Some(caps) = &opts.capabilities {
         body.insert("capabilities".into(), json!(caps));
     }
+    if let Some(profile) = &opts.profile {
+        body.insert("profile".into(), json!(profile));
+    }
     if let Some(model) = &opts.model {
         body.insert("model".into(), json!(model));
     }
@@ -3639,6 +3645,7 @@ async fn cmd_watch_add(opts: AddOpts) -> Result<()> {
     println!("  trigger: {}", trigger_summary(&o));
     println!("  program: {}", str_field(&o, "program"));
     println!("  caps:    {}", capabilities_summary(&o));
+    println!("  profile: {}", str_field(&o, "profile"));
     println!(
         "  enabled: no — arm it with `loom watch enable {}`",
         opts.name
@@ -4225,6 +4232,7 @@ mod tests {
             program: None,
             prompt: None,
             capabilities: None,
+            profile: None,
             model: None,
             effort: None,
             cooldown: None,

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -75,7 +75,7 @@ enum Cmd {
     ///
     ///     loom watch programs                 # the builtin programs that ship with loom
     ///     loom watch new test-watch          # scaffold ~/.weaver/watches/test-watch.py
-    ///     loom watch add status --cron "0 * * * *" --capabilities observe,mark,escalate
+    ///     loom watch add status --cron "0 * * * *" --capabilities observe,judge,mark
     ///     loom watch run status --dry-run     # simulate; mutating actions are stubbed
     ///     loom watch enable status            # arm it
     ///     loom watch ls                       # the fleet of watchers
@@ -832,8 +832,8 @@ struct AddOpts {
     /// The stock-program judgement prompt; stored as `params.prompt`.
     #[arg(long)]
     prompt: Option<String>,
-    /// Comma-separated capability set (default `observe,mark,escalate`). Drawn
-    /// from observe, mark, escalate, nudge, interrupt, launch.
+    /// Comma-separated capability set (default `observe,judge,mark,escalate`).
+    /// Drawn from observe, judge, mark, escalate, nudge, interrupt, launch.
     #[arg(long, value_delimiter = ',')]
     capabilities: Option<Vec<String>>,
     /// Model tier for `run_agent` judgement calls (e.g. sonnet, opus).

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -832,7 +832,8 @@ struct AddOpts {
     /// The stock-program judgement prompt; stored as `params.prompt`.
     #[arg(long)]
     prompt: Option<String>,
-    /// Comma-separated capability set (default `observe,judge,mark,escalate`).
+    /// Comma-separated capability set (default `observe,judge,mark` for
+    /// `builtin:status`).
     /// Drawn from observe, judge, mark, escalate, nudge, interrupt, launch.
     #[arg(long, value_delimiter = ',')]
     capabilities: Option<Vec<String>>,

--- a/crates/loom/src/builtins.rs
+++ b/crates/loom/src/builtins.rs
@@ -38,6 +38,9 @@ pub struct BuiltinProgram {
     pub default_scope: &'static str,
     pub default_params: &'static str,
     pub default_capabilities: &'static [&'static str],
+    /// Whether the stock watch is live on first seed. Agentic and advisory-only
+    /// programs are opt-in; narrowly mechanical programs start enabled.
+    pub default_enabled: bool,
 }
 
 /// Every builtin program, in the order the panel lists them.
@@ -45,19 +48,22 @@ pub const BUILTINS: &[BuiltinProgram] = &[
     BuiltinProgram {
         name: "status",
         title: "Status check",
-        description: "When a session goes idle (the agent's finished-turn hook), \
+        description: "After a session stays inactive long enough to become stale, \
                       ask the judge model (the daemon's one-shot agent) for the \
                       set of attention tags it warrants and reconcile the watch's \
-                      own marks to that set. Names the kind of attention (review, \
-                      question, stuck, …) rather than a generic mark, and when it \
+                      own marks to that set. Uses a fixed vocabulary (human-review, \
+                      human-decision, agent-stuck) rather than a generic mark, and when it \
                       finds a genuine need it replaces the soothing `idle` mark \
                       with that real status. With no judge model available it \
-                      no-ops, never mirroring the agent's own attention tag.",
+                      no-ops, never mirroring the agent's own attention tag. \
+                      Agentic and opt-in; automatic rounds are paced to at most \
+                      one every 15 minutes.",
         source: include_str!("../watches/status.py"),
-        default_trigger: r#"{"on":["session.idle"]}"#,
+        default_trigger: r#"{"on":["session.stale"]}"#,
         default_scope: "{}",
         default_params: "{}",
-        default_capabilities: &["observe", "mark"],
+        default_capabilities: &["observe", "judge", "mark"],
+        default_enabled: false,
     },
     BuiltinProgram {
         name: "resume",
@@ -75,6 +81,7 @@ pub const BUILTINS: &[BuiltinProgram] = &[
         default_scope: "{}",
         default_params: "{}",
         default_capabilities: &["observe", "nudge", "mark"],
+        default_enabled: true,
     },
     BuiltinProgram {
         name: "pr-label",
@@ -88,6 +95,7 @@ pub const BUILTINS: &[BuiltinProgram] = &[
         default_scope: "{}",
         default_params: r#"{"label":"weaver"}"#,
         default_capabilities: &["observe"],
+        default_enabled: false,
     },
     BuiltinProgram {
         name: "review-wait",
@@ -107,6 +115,7 @@ pub const BUILTINS: &[BuiltinProgram] = &[
         default_scope: "{}",
         default_params: "{}",
         default_capabilities: &["observe", "mark"],
+        default_enabled: true,
     },
     BuiltinProgram {
         name: "archive-merged",
@@ -121,6 +130,7 @@ pub const BUILTINS: &[BuiltinProgram] = &[
         default_scope: "{}",
         default_params: "{}",
         default_capabilities: &["observe"],
+        default_enabled: false,
     },
 ];
 

--- a/crates/loom/src/profile.rs
+++ b/crates/loom/src/profile.rs
@@ -13,10 +13,13 @@ use crate::db::{now_iso, Db};
 
 pub const DEFAULT_PROFILE: &str = "default";
 
-const STOCK_PROFILES: &[(&str, &str)] = &[(
-    "github_comment.json",
-    include_str!("../profiles/github_comment.json"),
-)];
+const STOCK_PROFILES: &[(&str, &str)] = &[
+    (
+        "github_comment.json",
+        include_str!("../profiles/github_comment.json"),
+    ),
+    ("watch.json", include_str!("../profiles/watch.json")),
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Profile {
@@ -490,13 +493,18 @@ pub async fn remove(db: &Db, name: &str) -> Result<bool> {
     if name == DEFAULT_PROFILE {
         bail!("the default profile cannot be removed");
     }
-    let referenced: bool =
+    let session_referenced: bool =
         sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM sessions WHERE profile = ?)")
             .bind(name)
             .fetch_one(db)
             .await?;
-    if referenced {
-        bail!("profile '{name}' is referenced by sessions");
+    let watch_referenced: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM watches WHERE profile = ?)")
+            .bind(name)
+            .fetch_one(db)
+            .await?;
+    if session_referenced || watch_referenced {
+        bail!("profile '{name}' is referenced by sessions or watches");
     }
     Ok(sqlx::query("DELETE FROM profiles WHERE name = ?")
         .bind(name)
@@ -542,6 +550,31 @@ pub async fn env_pairs(db: &Db, profile: &str) -> Result<Vec<(String, String)>> 
         values.push((row.name, value));
     }
     Ok(values)
+}
+
+/// Build the explicit ambient baseline used by an env-cleared profile.
+/// Profile-owned values win over the small process baseline and any explicitly
+/// allowlisted ambient names.
+pub fn cleared_environment(
+    explicit: Vec<(String, String)>,
+    ambient_allowlist: &[String],
+) -> Vec<(String, String)> {
+    const BASELINE: &[&str] = &[
+        "PATH", "HOME", "SHELL", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE", "USER", "LOGNAME",
+    ];
+    let mut env = Vec::new();
+    for name in BASELINE.iter().copied().chain(
+        ambient_allowlist
+            .iter()
+            .map(String::as_str)
+            .filter(|name| !BASELINE.contains(name)),
+    ) {
+        if let Ok(value) = std::env::var(name) {
+            env.push((name.to_string(), value));
+        }
+    }
+    crate::repo_env::layer(&mut env, explicit);
+    env
 }
 
 pub async fn env_get(db: &Db, profile: &str, name: &str) -> Result<Option<String>> {
@@ -846,6 +879,13 @@ mod tests {
         let db = crate::db::connect_in_memory().await.unwrap();
         let stock = get(&db, "github_comment").await.unwrap().unwrap();
         assert!(stock.restricted);
+        let watch = get(&db, "watch").await.unwrap().unwrap();
+        assert_eq!(watch.agent_kind, "codex");
+        assert_eq!(watch.model, "gpt-5.6-sol");
+        assert_eq!(watch.effort, "medium");
+        assert_eq!(watch.mode, "plan");
+        assert!(watch.is_automation_safe());
+        assert!(!watch.restricted);
 
         let mut edited = stock.as_input().unwrap();
         edited.description = "operator-edited description".to_string();
@@ -891,6 +931,23 @@ mod tests {
 
         assert_eq!(unchanged.revision, existing.revision);
         assert_eq!(unchanged.updated_at, existing.updated_at);
+    }
+
+    #[tokio::test]
+    async fn profiles_selected_by_watches_cannot_be_removed() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        weaver_core::watch::create(
+            &db,
+            &weaver_core::watch::NewWatch {
+                name: "profile-owner".to_string(),
+                profile: "github_comment".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(remove(&db, "github_comment").await.is_err());
     }
 
     #[tokio::test]

--- a/crates/loom/src/watch.rs
+++ b/crates/loom/src/watch.rs
@@ -54,6 +54,12 @@ use weaver_core::watch::{self as watch_store, Watch};
 /// promptly without the loop being a busy spinner.
 const TICK: Duration = Duration::from_millis(1500);
 
+/// An automatic agent-backed watch may run at most once in this window. Model
+/// use is identified by the explicit `judge` capability, so the guard applies
+/// equally to builtins and custom programs. Manual runs remain available for
+/// authoring and diagnosis.
+pub const AGENTIC_MIN_COOLDOWN_SECS: i64 = 15 * 60;
+
 /// Read an integer setting, falling back to `default` on absence or parse
 /// failure. `weaver_core::config` has bool/string getters but no int getter, so
 /// the engine parses the raw value itself.
@@ -102,8 +108,8 @@ impl Drop for InFlightGuard {
 // Builtin seeding
 // ---------------------------------------------------------------------------
 
-/// Ensure every builtin program has its watch row, enabled and on the
-/// program's suggested defaults. Runs at engine start, keyed by name: a watch
+/// Ensure every builtin program has its watch row on the program's suggested
+/// enabled/config defaults. Runs at engine start, keyed by name: a watch
 /// the user has since reconfigured or disabled is left exactly as it is (the
 /// row exists), and a deleted one comes back on the next boot — builtins are
 /// stock; the off switch is the enabled toggle, not deletion.
@@ -123,7 +129,7 @@ pub async fn seed_builtins(db: &crate::Db) -> anyhow::Result<()> {
                 .iter()
                 .map(|c| c.to_string())
                 .collect(),
-            enabled: true,
+            enabled: b.default_enabled,
             ..Default::default()
         };
         let w = watch_store::create(db, &new).await?;
@@ -530,8 +536,9 @@ async fn triggering_session(state: &AppState, ev: &events::Event) -> Option<Stri
 /// 1. **no-overlap** — a re-fire while a round of the same watch is in
 ///    flight is dropped (no run row); the in-flight set is the gate.
 /// 2. **cooldown** — a fire inside `max(cooldown_secs, default_cooldown_secs)`
-///    of the last run is recorded `skipped`. A `manual`/`run-now`, and a watch's
-///    own self-scheduled `wake`, bypass it (the wake's delay is the gap).
+///    of the last run is recorded `skipped`. Agentic (`judge`) watches also
+///    have a 15-minute floor. A `manual`/`run-now` bypasses it; a mechanical
+///    watch's self-scheduled `wake` does too because the wake chose its gap.
 /// 3. **timeout** — the program is wrapped in a wall-clock budget; an overrun
 ///    is recorded `error`.
 /// 4. **no-recursion** — the survey ([`run_program`]) excludes watch warm
@@ -559,16 +566,20 @@ pub async fn fire(
     };
 
     let manual = trigger_reason == "manual" || trigger_reason.starts_with("run");
-    // A self-scheduled wake bypasses cooldown too: its backoff delay is the
-    // watch's own chosen gap, so a global cooldown must not strand the recheck.
-    let bypass_cooldown = manual || trigger_reason == "wake";
+    let agentic = o.capabilities().iter().any(|cap| cap == "judge");
+    // Mechanical self-wakes choose their own pacing and bypass the global
+    // default. Agentic self-wakes remain subject to the 15-minute floor.
+    let bypass_cooldown = manual || (trigger_reason == "wake" && !agentic);
     let now = Utc::now();
 
     // 2. Cooldown: a re-fire inside the gap is recorded `skipped` (a manual run
-    //    or a self-scheduled wake bypasses it).
-    let cooldown = o
+    //    bypasses it; a mechanical self-wake does too).
+    let mut cooldown = o
         .cooldown_secs
         .max(get_int(&state.db, "watch.default_cooldown_secs", 0).await);
+    if agentic {
+        cooldown = cooldown.max(AGENTIC_MIN_COOLDOWN_SECS);
+    }
     if !bypass_cooldown && cooldown > 0 {
         if let Some(last) = o.last_run_at.as_deref().and_then(parse_iso) {
             if (now - last).num_seconds() < cooldown {
@@ -1454,17 +1465,22 @@ mod tests {
 
     use crate::builtins::python3_available;
 
-    /// Boot seeding gives every builtin program a watch row, enabled and on
-    /// its suggested defaults — and leaves existing rows exactly as they are
+    /// Boot seeding gives every builtin program a watch row on its suggested
+    /// enabled/default state — and leaves existing rows exactly as they are
     /// on a re-run, so a user's disable/reconfigure survives restarts.
     #[tokio::test]
-    async fn seed_builtins_is_idempotent_and_enables_by_default() {
+    async fn seed_builtins_is_idempotent_and_uses_program_defaults() {
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_builtins(&db).await.unwrap();
         let all = watch_store::list(&db).await.unwrap();
         assert_eq!(all.len(), crate::builtins::BUILTINS.len());
         for w in &all {
-            assert!(w.enabled, "{}: builtins seed enabled", w.name);
+            let builtin = crate::builtins::find(&w.program).unwrap();
+            assert_eq!(
+                w.enabled, builtin.default_enabled,
+                "{}: builtin enabled default",
+                w.name
+            );
             assert_eq!(w.program, format!("builtin:{}", w.name));
         }
 
@@ -1482,7 +1498,9 @@ mod tests {
         seed_builtins(&db).await.unwrap();
         let restored = watch_store::list(&db).await.unwrap();
         assert_eq!(restored.len(), all.len());
-        assert!(restored.iter().any(|w| w.name == all[0].name && w.enabled));
+        let restored_watch = restored.iter().find(|w| w.name == all[0].name).unwrap();
+        let builtin = crate::builtins::find(&restored_watch.program).unwrap();
+        assert_eq!(restored_watch.enabled, builtin.default_enabled);
     }
 
     /// An `AppState` over a fresh in-memory db plus a watch registered on
@@ -1700,6 +1718,83 @@ rnd.finish("counted to %d" % n)
         let outcome = |id| runs.iter().find(|r| r.id == id).unwrap().outcome.as_str();
         assert_eq!(outcome(cron_id), "skipped", "cron is gated by cooldown");
         assert_ne!(outcome(wake_id), "skipped", "wake bypasses cooldown");
+    }
+
+    /// Holding `judge` makes a watch agentic: automatic cron and dynamic-wake
+    /// rounds both respect the engine's 15-minute floor even when the watch and
+    /// global default request no cooldown. A manual authoring run still bypasses
+    /// the floor.
+    #[tokio::test]
+    async fn agentic_watch_has_a_non_bypassable_automatic_cooldown() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not on PATH");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("agentic-noop.py");
+        std::fs::write(
+            &script,
+            "from weaver_loom import Round\nRound().finish('ok')\n",
+        )
+        .unwrap();
+        let (state, _) = script_fixture(&script.display().to_string()).await;
+        let o = watch_store::create(
+            &state.db,
+            &watch_store::NewWatch {
+                name: "agentic-gated".to_string(),
+                program: script.display().to_string(),
+                capabilities: vec!["observe".to_string(), "judge".to_string()],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "manual",
+            false,
+            &TriggerCtx::manual(),
+        )
+        .await
+        .unwrap();
+        let o = watch_store::get(&state.db, &o.id).await.unwrap().unwrap();
+        let cron_id = fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "cron",
+            false,
+            &TriggerCtx::scheduled(),
+        )
+        .await
+        .unwrap();
+        let wake_id = fire(
+            &state,
+            &new_in_flight(),
+            &o,
+            "wake",
+            false,
+            &TriggerCtx::scheduled(),
+        )
+        .await
+        .unwrap();
+
+        let runs = watch_store::recent_runs(&state.db, &o.id, 10)
+            .await
+            .unwrap();
+        for id in [cron_id, wake_id] {
+            let run = runs.iter().find(|r| r.id == id).unwrap();
+            assert_eq!(run.outcome, "skipped");
+            assert!(
+                run.summary
+                    .contains(&format!("cooldown: {AGENTIC_MIN_COOLDOWN_SECS}s")),
+                "agentic floor is recorded: {}",
+                run.summary
+            );
+        }
     }
 
     /// A due `wake_at` makes the timer emit one `cron` tick for that watch

--- a/crates/loom/src/watch.rs
+++ b/crates/loom/src/watch.rs
@@ -129,6 +129,7 @@ pub async fn seed_builtins(db: &crate::Db) -> anyhow::Result<()> {
                 .iter()
                 .map(|c| c.to_string())
                 .collect(),
+            profile: "watch".to_string(),
             enabled: b.default_enabled,
             ..Default::default()
         };
@@ -828,7 +829,7 @@ async fn uv_available() -> bool {
 /// precedent) that reaches the fleet only
 /// through the loom REST API. `$WEAVER_API` carries the daemon's own address
 /// and `$WEAVER_WATCH` the round config (`{id, name, program, params,
-/// scope, capabilities, model, effort, dry_run}`); the vendored `weaver_loom`
+/// scope, capabilities, profile, model, effort, dry_run}`); the vendored `weaver_loom`
 /// module rides
 /// `PYTHONPATH` so every program can import the API layer with no install
 /// step. The contract is to print one JSON object — `{outcome, summary,
@@ -853,6 +854,7 @@ async fn run_script(
         "params": o.params(),
         "scope": serde_json::to_value(o.scope()).unwrap_or(Value::Null),
         "capabilities": o.capabilities(),
+        "profile": o.profile,
         "model": o.model,
         "effort": o.effort,
         "dry_run": dry_run,

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -365,28 +365,6 @@ async fn automation_policy_defaults(db: &Db) -> (i64, i64) {
 /// Build the explicit ambient baseline used when Tapestry clears inheritance.
 /// Profile/repo values win over baseline and allowlisted ambient values; loom's
 /// own session variables are injected later by `agent::session_env`.
-fn cleared_environment(
-    explicit: Vec<(String, String)>,
-    ambient_allowlist: &[String],
-) -> Vec<(String, String)> {
-    const BASELINE: &[&str] = &[
-        "PATH", "HOME", "SHELL", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE", "USER", "LOGNAME",
-    ];
-    let mut env = Vec::new();
-    for name in BASELINE.iter().copied().chain(
-        ambient_allowlist
-            .iter()
-            .map(String::as_str)
-            .filter(|name| !BASELINE.contains(name)),
-    ) {
-        if let Ok(value) = std::env::var(name) {
-            env.push((name.to_string(), value));
-        }
-    }
-    repo_env::layer(&mut env, explicit);
-    env
-}
-
 async fn resume_environment(
     db: &Db,
     session: &Session,
@@ -407,7 +385,7 @@ async fn resume_environment(
     }
     let allowlist =
         serde_json::from_str::<Vec<String>>(&session.policy_ambient_allowlist).unwrap_or_default();
-    cleared_environment(env, &allowlist)
+    crate::profile::cleared_environment(env, &allowlist)
 }
 
 /// Overlay the launching user's personal GitHub token onto `env` as `GH_TOKEN`,
@@ -831,7 +809,7 @@ pub(crate) async fn provision_session(
         let allowlist = launch_profile
             .ambient_names()
             .map_err(|e| AppError::bad_request(e.to_string()))?;
-        extra_env = cleared_environment(extra_env, &allowlist);
+        extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
     }
     // Select the launching user's GitHub credential by overlaying it as
     // GH_TOKEN (design §6.3, "Level B"). See `apply_user_github_token` for the
@@ -2366,15 +2344,25 @@ pub(crate) async fn create_warm_session(
     tokio::fs::create_dir_all(&run_dir).await?;
     tracing::debug!(watch = %watch.id, session = %session_id, "allocated warm session id and run dir");
 
-    // Warm infrastructure resolves the same authoritative default profile as
-    // ordinary launches. Watches still supply their own model/effort selectors,
-    // but there is no second `agent.*` settings authority.
-    let launch_profile = crate::profile::get(&st.db, crate::profile::DEFAULT_PROFILE)
+    // Warm infrastructure resolves the profile selected by the watch. Its
+    // runtime/model/policy are authoritative; the watch's non-empty model and
+    // effort remain per-watch overrides.
+    let launch_profile = crate::profile::get(&st.db, &watch.profile)
         .await?
         .ok_or_else(|| {
-            AppError::new(StatusCode::INTERNAL_SERVER_ERROR, "default profile missing")
+            AppError::bad_request(format!("watch profile '{}' is missing", watch.profile))
         })?;
     let agent = launch_profile.agent_kind.clone();
+    let model = if watch.model.trim().is_empty() {
+        launch_profile.model.clone()
+    } else {
+        watch.model.clone()
+    };
+    let effort = if watch.effort.trim().is_empty() {
+        launch_profile.effort.clone()
+    } else {
+        watch.effort.clone()
+    };
     let goal_file = match watch
         .params()
         .get("prompt")
@@ -2404,7 +2392,7 @@ pub(crate) async fn create_warm_session(
         let allowlist = launch_profile
             .ambient_names()
             .map_err(|error| AppError::bad_request(error.to_string()))?;
-        extra_env = cleared_environment(extra_env, &allowlist);
+        extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
     }
 
     // Persist before exposing the scoped credential to the child. Token lookup
@@ -2438,8 +2426,8 @@ pub(crate) async fn create_warm_session(
             work_dir: work_dir.display().to_string(),
             term_session: term_session.clone(),
             agent_kind: agent.clone(),
-            model: watch.model.clone(),
-            effort: watch.effort.clone(),
+            model: model.clone(),
+            effort: effort.clone(),
             status: status.to_string(),
             github_repo: None,
             parent_branch_id: None,
@@ -2484,8 +2472,8 @@ pub(crate) async fn create_warm_session(
             primer_file: None,
             prelude: &launch_profile.prelude,
             server_addr: &st.addr,
-            model: &watch.model,
-            effort: &watch.effort,
+            model: &model,
+            effort: &effort,
             extra_env: &extra_env,
             env_clear: launch_profile.env_clear,
         },

--- a/crates/loom/src/web/watches.rs
+++ b/crates/loom/src/web/watches.rs
@@ -127,6 +127,8 @@ pub(super) async fn create_watch(
         })
     });
     validate_capabilities(&capabilities)?;
+    let profile = req.profile.unwrap_or(defaults.profile);
+    validate_watch_profile(&st.db, &profile).await?;
     let params = json_text(req.params, &defaults.params);
 
     // The script declares what wakes it: evaluate its subscription manifest
@@ -147,6 +149,7 @@ pub(super) async fn create_watch(
         program,
         params,
         capabilities,
+        profile,
         model: req.model.unwrap_or(defaults.model),
         effort: req.effort.unwrap_or(defaults.effort),
         cooldown_secs: req.cooldown_secs.unwrap_or(defaults.cooldown_secs),
@@ -199,6 +202,9 @@ pub(super) async fn patch_watch(
     if let Some(caps) = &req.capabilities {
         validate_capabilities(caps)?;
     }
+    if let Some(profile) = &req.profile {
+        validate_watch_profile(&st.db, profile).await?;
+    }
     if let Some(enabled) = req.enabled {
         watch_store::set_enabled(&st.db, &o.id, enabled).await?;
     }
@@ -223,6 +229,7 @@ pub(super) async fn patch_watch(
         program: req.program,
         params: req.params.map(|v| v.to_string()),
         capabilities: req.capabilities,
+        profile: req.profile,
         model: req.model,
         effort: req.effort,
         cooldown_secs: req.cooldown_secs,
@@ -283,22 +290,60 @@ pub(super) async fn agent_oneshot(
     let budget = ov_engine::get_int(&st.db, "watch.default_timeout_secs", 600)
         .await
         .max(1) as u64;
-    let runtime = req.agent.trim();
-    let runtime = if runtime.is_empty() {
-        "claude"
+    let profile = if req.profile.trim().is_empty() {
+        None
     } else {
-        runtime
+        Some(
+            crate::profile::get(&st.db, req.profile.trim())
+                .await?
+                .ok_or_else(|| {
+                    AppError::bad_request(format!("unknown profile '{}'", req.profile.trim()))
+                })?,
+        )
     };
+    if let Some(profile) = &profile {
+        if !profile.is_automation_safe() || profile.protocol != "acp" {
+            return Err(AppError::bad_request(format!(
+                "profile '{}' is not automation-safe ACP",
+                profile.name
+            )));
+        }
+    }
+    let runtime = req.agent.trim();
+    let runtime = profile
+        .as_ref()
+        .map(|profile| profile.agent_kind.as_str())
+        .unwrap_or_else(|| {
+            if runtime.is_empty() {
+                "claude"
+            } else {
+                runtime
+            }
+        });
     let output = agent::AgentManager::new(&st.db)
         .run_oneshot(
             runtime,
             &req.prompt,
             &req.model,
             &req.effort,
+            profile.as_ref(),
             std::time::Duration::from_secs(budget),
         )
         .await;
     Ok(Json(json!({ "output": output })))
+}
+
+async fn validate_watch_profile(db: &crate::Db, name: &str) -> ApiResult<()> {
+    let name = name.trim();
+    let profile = crate::profile::get(db, name)
+        .await?
+        .ok_or_else(|| AppError::bad_request(format!("unknown profile '{name}'")))?;
+    if !profile.is_automation_safe() || profile.protocol != "acp" {
+        return Err(AppError::bad_request(format!(
+            "watch profile '{name}' must be automation-safe and use ACP"
+        )));
+    }
+    Ok(())
 }
 
 pub(super) async fn watch_runs(

--- a/crates/loom/src/web/watches.rs
+++ b/crates/loom/src/web/watches.rs
@@ -117,7 +117,15 @@ pub(super) async fn create_watch(
     let defaults = watch_store::NewWatch::default();
     let program = req.program.unwrap_or(defaults.program);
     validate_program(&program)?;
-    let capabilities = req.capabilities.unwrap_or(defaults.capabilities);
+    let capabilities = req.capabilities.unwrap_or_else(|| {
+        crate::builtins::find(&program).map_or(defaults.capabilities, |builtin| {
+            builtin
+                .default_capabilities
+                .iter()
+                .map(|cap| (*cap).to_string())
+                .collect()
+        })
+    });
     validate_capabilities(&capabilities)?;
     let params = json_text(req.params, &defaults.params);
 

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -392,7 +392,7 @@ impl Drop for EnvVarGuard {
     }
 }
 
-/// The status program's wiring proof: an idle-triggered round asks the judge for
+/// The status program's wiring proof: a stale-triggered round asks the judge for
 /// a set of tags and reconciles its own marks — a recommended tag lands as its
 /// own typed key (never the agent's `attention` axis — no mirror), and a
 /// follow-up "nothing needed" verdict clears it. The program's decision logic
@@ -414,17 +414,21 @@ async fn builtin_status_round_applies_typed_tags_and_reconciles() {
     // The judge model is stubbed: a fixed tag set the round should apply.
     let _agent = fake_judge_agent(
         "weaver-fake-judge-status",
-        r#"[{"key":"review","value":"attention","note":"looks done"}]"#,
+        r#"[{"key":"human-review","value":"attention","note":"looks done"}]"#,
     );
 
     let o = enabled_watch(
         &state,
         watch_store::NewWatch {
             name: "status-check".to_string(),
-            trigger_spec: json!({ "on": ["session.idle"] }).to_string(),
+            trigger_spec: json!({ "on": ["session.stale"] }).to_string(),
             scope: json!({}).to_string(),
             program: "builtin:status".to_string(),
-            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            capabilities: vec![
+                "observe".to_string(),
+                "judge".to_string(),
+                "mark".to_string(),
+            ],
             ..Default::default()
         },
     )
@@ -442,12 +446,12 @@ async fn builtin_status_round_applies_typed_tags_and_reconciles() {
         .await
         .unwrap();
     assert_eq!(
-        branch_tag_value(&view, "review"),
+        branch_tag_value(&view, "human-review"),
         "attention",
         "the round applies the judge's typed tag"
     );
     assert_eq!(
-        branch_tag(&view, "review").unwrap()["set_by"],
+        branch_tag(&view, "human-review").unwrap()["set_by"],
         "status-check"
     );
     assert!(
@@ -466,7 +470,7 @@ async fn builtin_status_round_applies_typed_tags_and_reconciles() {
     assert!(
         arr.iter().any(|a| a["action"] == "tag"
             && a["session"] == session_id.as_str()
-            && a["key"] == "review"),
+            && a["key"] == "human-review"),
         "the run records a tag action: {actions}"
     );
 
@@ -481,7 +485,7 @@ async fn builtin_status_round_applies_typed_tags_and_reconciles() {
         .await
         .unwrap();
     assert!(
-        branch_tag(&view, "review").is_none(),
+        branch_tag(&view, "human-review").is_none(),
         "the empty verdict clears the watch's own mark"
     );
 
@@ -789,7 +793,7 @@ async fn rest_watch_lifecycle_and_validation() {
         .unwrap();
     let _agent = fake_judge_agent(
         "weaver-fake-judge-lifecycle",
-        r#"[{"key":"review","value":"attention","note":"looks done"}]"#,
+        r#"[{"key":"human-review","value":"attention","note":"looks done"}]"#,
     );
 
     // Create: structured trigger/scope/params JSON in, a WatchView out.
@@ -803,7 +807,7 @@ async fn rest_watch_lifecycle_and_validation() {
                 "scope": { "attention": "!ok" },
                 "program": "builtin:status",
                 "params": { "prompt": "is it stuck?" },
-                "capabilities": ["observe", "mark"],
+                "capabilities": ["observe", "judge", "mark"],
             }),
         )
         .await
@@ -815,7 +819,7 @@ async fn rest_watch_lifecycle_and_validation() {
     assert_eq!(created["trigger"]["cron"], "0 * * * *");
     assert_eq!(created["scope"]["attention"], "!ok");
     assert_eq!(created["params"]["prompt"], "is it stuck?");
-    assert_eq!(created["capabilities"][1], "mark");
+    assert_eq!(created["capabilities"][2], "mark");
     assert!(created["last_outcome"].is_null(), "never run yet");
 
     // A duplicate name is rejected (the client surfaces the error status).
@@ -882,7 +886,7 @@ async fn rest_watch_lifecycle_and_validation() {
         .await
         .unwrap();
     assert!(
-        branch_tag(&view, "review").is_none(),
+        branch_tag(&view, "human-review").is_none(),
         "a dry run applies no mark"
     );
 
@@ -1056,11 +1060,11 @@ async fn rest_lists_builtin_programs_and_validates_program_refs() {
         .find(|p| p["program"] == "builtin:status")
         .unwrap();
     assert!(
-        status["source"].as_str().unwrap().contains("session.idle"),
+        status["source"].as_str().unwrap().contains("session.stale"),
         "the status program is a script like every other builtin"
     );
-    // The status builtin wakes on the agent's finished-turn hook, not a timer.
-    assert_eq!(status["defaults"]["trigger"]["on"][0], "session.idle");
+    // The status builtin wakes once after sustained inactivity, not every turn.
+    assert_eq!(status["defaults"]["trigger"]["on"][0], "session.stale");
 
     // An unknown builtin is rejected at create time; a known script accepted.
     let bad = ts
@@ -1334,16 +1338,20 @@ async fn status_judgement_uses_the_oneshot_agent() {
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "judge me").await;
     let _agent = fake_judge_agent(
         "weaver-fake-judge-oneshot",
-        r#"[{"key":"stuck","value":"blocked","note":"the judge says so"}]"#,
+        r#"[{"key":"agent-stuck","value":"blocked","note":"the judge says so"}]"#,
     );
     let o = enabled_watch(
         &state,
         watch_store::NewWatch {
             name: "judge-watch".to_string(),
-            trigger_spec: json!({ "on": ["session.idle"] }).to_string(),
+            trigger_spec: json!({ "on": ["session.stale"] }).to_string(),
             program: "builtin:status".to_string(),
             params: json!({ "prompt": "is it stuck?" }).to_string(),
-            capabilities: vec!["observe".to_string(), "mark".to_string()],
+            capabilities: vec![
+                "observe".to_string(),
+                "judge".to_string(),
+                "mark".to_string(),
+            ],
             ..Default::default()
         },
     )
@@ -1358,13 +1366,16 @@ async fn status_judgement_uses_the_oneshot_agent() {
         .await
         .unwrap();
     assert_eq!(
-        branch_tag_value(&view, "stuck"),
+        branch_tag_value(&view, "agent-stuck"),
         "blocked",
         "the judge's verdict lands as a typed mark"
     );
     // (Parsing detail — the JSON tag-set extraction — is pytest-covered in
     // weaver_loom; here only the through-the-stack outcome matters.)
-    assert_eq!(branch_tag(&view, "stuck").unwrap()["set_by"], "judge-watch");
+    assert_eq!(
+        branch_tag(&view, "agent-stuck").unwrap()["set_by"],
+        "judge-watch"
+    );
 
     ts.client
         .delete(&format!("/api/sessions/{session_id}"))

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -355,7 +355,7 @@ async fn stale_session_emits_one_event_and_wakes_a_reactive_watch() {
 /// with a fixed response. Base64 keeps arbitrary judgement JSON out of the
 /// shell command's quoting surface.
 fn fake_judge_agent(_name: &str, out: &str) -> EnvVarGuard {
-    fake_judge_runtime("WEAVER_CLAUDE_ACP_CMD", out)
+    fake_judge_runtime("WEAVER_CODEX_ACP_CMD", out)
 }
 
 fn fake_judge_runtime(variable: &'static str, out: &str) -> EnvVarGuard {
@@ -364,7 +364,7 @@ fn fake_judge_runtime(variable: &'static str, out: &str) -> EnvVarGuard {
     EnvVarGuard::set(
         variable,
         &format!(
-            "FAKE_ACP_FIXED_OUTPUT_B64={encoded} {}",
+            "FAKE_ACP_MODELS=gpt-5.6-sol,fake-fast FAKE_ACP_FIXED_OUTPUT_B64={encoded} {}",
             crate::fixtures::fake_acp_agent_cmd()
         ),
     )
@@ -1304,7 +1304,7 @@ async fn status_judgement_uses_the_oneshot_agent() {
     let ts = TestServer::start().await;
 
     // The endpoint itself returns the adapter's fixed text; an empty prompt 400s.
-    let _endpoint_agent = fake_judge_agent("weaver-fake-judge-endpoint", "ping");
+    let _endpoint_agent = fake_judge_runtime("WEAVER_CLAUDE_ACP_CMD", "ping");
     let reply = ts
         .client
         .post("/api/agent/oneshot", json!({ "prompt": "ping" }))
@@ -1324,6 +1324,19 @@ async fn status_judgement_uses_the_oneshot_agent() {
         reply["output"], "codex selected",
         "the request selects a registered ACP runtime"
     );
+    let reply = ts
+        .client
+        .post(
+            "/api/agent/oneshot",
+            json!({ "prompt": "ping", "profile": "watch" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        reply["output"], "codex selected",
+        "the stock watch profile selects Codex"
+    );
+    drop(_codex_agent);
     assert!(
         ts.client
             .post("/api/agent/oneshot", json!({ "prompt": "" }))
@@ -1336,8 +1349,8 @@ async fn status_judgement_uses_the_oneshot_agent() {
     // drove the mark — there is no fallback that would have invented one.
     let state = engine_state(&ts).await;
     let (session_id, _branch_id, _repo_root) = make_session(&ts, "judge me").await;
-    let _agent = fake_judge_agent(
-        "weaver-fake-judge-oneshot",
+    let _agent = fake_judge_runtime(
+        "WEAVER_CODEX_ACP_CMD",
         r#"[{"key":"agent-stuck","value":"blocked","note":"the judge says so"}]"#,
     );
     let o = enabled_watch(
@@ -1394,8 +1407,8 @@ async fn set_config(state: &AppState, key: &str, value: &str) {
         .unwrap();
 }
 
-async fn set_default_profile_agent(state: &AppState, agent: &str) {
-    let mut profile = loom::profile::get(&state.db, loom::profile::DEFAULT_PROFILE)
+async fn set_watch_profile_agent(state: &AppState, agent: &str) {
+    let mut profile = loom::profile::get(&state.db, "watch")
         .await
         .unwrap()
         .unwrap()
@@ -1566,9 +1579,9 @@ async fn warm_session_is_re_adopted_across_restart_independent_of_auto_adopt() {
     // The restart policy under test: fleet auto-adopt off, warm-adopt on.
     set_config(&state, "server.auto_adopt", "false").await;
     set_config(&state, "watch.adopt_warm", "true").await;
-    // Warm sessions launch the default agent; pin it to `shell` so creation is
+    // Warm sessions launch the watch's profile agent; pin it to `shell` so creation is
     // deterministic without a real `claude` on PATH.
-    set_default_profile_agent(&state, "shell").await;
+    set_watch_profile_agent(&state, "shell").await;
 
     let repo_root = ts.repo_path().canonicalize().unwrap().display().to_string();
 
@@ -1595,6 +1608,8 @@ async fn warm_session_is_re_adopted_across_restart_independent_of_auto_adopt() {
         .await
         .unwrap()
         .unwrap();
+    assert_eq!(warm.profile, "watch");
+    assert_eq!(warm.agent_kind, "shell");
     assert!(
         backend::has_session(&warm.term_session).await,
         "the warm session has a live terminal"
@@ -1682,7 +1697,7 @@ async fn warm_session_is_re_adopted_across_restart_independent_of_auto_adopt() {
 async fn ensure_warm_session_reuses_the_same_session() {
     let ts = TestServer::start().await;
     let state = engine_state(&ts).await;
-    set_default_profile_agent(&state, "shell").await;
+    set_watch_profile_agent(&state, "shell").await;
 
     let repo_root = ts.repo_path().canonicalize().unwrap().display().to_string();
     let o = enabled_watch(

--- a/crates/loom/watches/status.py
+++ b/crates/loom/watches/status.py
@@ -1,9 +1,10 @@
 """status — when a session goes quiet, judge it and replace the calm idle mark.
 
-When the agent goes quiet, loom stamps a soothing, *quiet* ``idle`` mark — the
-calm "resting, no one needed" state (so an idle agent never reads as needing the
-user). On the agent's finished-turn hook (``session.idle``) this watch
-re-assesses just that session: it asks the judge model (the daemon's one-shot
+When the agent has stayed quiet long enough to become stale, loom has already
+stamped a soothing, *quiet* ``idle`` mark — the calm "resting, no one needed"
+state (so an idle agent never reads as needing the user). On the one-shot
+inactivity edge (``session.stale``) this watch re-assesses just that session: it
+asks the judge model (the daemon's one-shot
 agent) for advice on a set of attention tags to apply given the recent screen,
 then reconciles its own marks to that set — setting the recommended tags and
 clearing any it set earlier that no longer apply.
@@ -15,8 +16,8 @@ the real loud status it names. A "nothing needed" verdict leaves the soothing
 
 User attention is expensive, so the default prompt tells the model to flag a
 session ONLY when it genuinely needs the human, and to name the *kind* of
-attention (the tag key — `review`, `question`, `stuck`, …) rather than a generic
-"needs attention". The watch never mirrors the agent's own ``attention``
+attention from a fixed vocabulary rather than a generic "needs attention". The
+watch never mirrors the agent's own ``attention``
 self-report; that is the agent's signal, on its own key. With no judge model
 available (no agent, or an empty/garbled reply), the round is a no-op — it leaves
 every mark untouched (including ``idle``) rather than guess. Honours dry_run:
@@ -25,11 +26,19 @@ would-be writes are logged as actions and nothing mutates.
 
 from weaver_loom import IDLE_KEY, IDLE_VALUE, Round, parse_tag_recommendations
 
-#: Wake on the agent's finished-turn hook — "assess when the agent goes quiet".
-TRIGGERS = {"on": ["session.idle"]}
+#: Wake once after sustained inactivity, not after every completed turn.
+TRIGGERS = {"on": ["session.stale"]}
 
 #: Lines of terminal scrollback handed to the judge as context.
 SCREEN_LINES = 200
+
+#: Stable UI vocabulary. Prompting narrows the model; this allowlist enforces
+#: the contract when it still returns a creative key or mismatched severity.
+ALLOWED_TAGS = {
+    "human-review": "attention",
+    "human-decision": "attention",
+    "agent-stuck": "blocked",
+}
 
 #: The default judge prompt, overridable via params.prompt. Asks for a JSON array
 #: of {key, value, note} tags, or [] when the human is not needed.
@@ -42,13 +51,14 @@ DEFAULT_PROMPT = (
     "replaces the calm idle mark with a real status. Read the recent session "
     "screen below and decide which attention tags apply.\n\n"
     "Reply with ONLY a JSON array of objects "
-    '{"key": "<short-type>", "value": "attention" | "blocked", "note": "<one '
+    '{"key": "human-review" | "human-decision" | "agent-stuck", '
+    '"value": "attention" | "blocked", "note": "<direct screen evidence in one '
     'line>"}. Use an empty array [] when the session does not need the human (it '
     "stays calmly idle). The key names the KIND of attention; pick the few that "
     "fit, e.g.:\n"
-    '  - "review"   — work looks finished / a PR is ready to look at (value "attention")\n'
-    '  - "question" — waiting on a decision only the operator can make (value "attention")\n'
-    '  - "stuck"    — looping or erroring with no progress (value "blocked")\n'
+    '  - "human-review"   — work is ready for the operator to review (value "attention")\n'
+    '  - "human-decision" — waiting on a decision only the operator can make (value "attention")\n'
+    '  - "agent-stuck"    — looping or erroring with no progress (value "blocked")\n'
     "Do not invent noise, and do not restate the agent's own self-reported "
     "status — add only what an outside observer would flag."
 )
@@ -65,7 +75,14 @@ def judge_tags(rnd, session):
     out = rnd.client.agent(f"{prompt}\n\nSession screen:\n{screen}\n", rnd.model, rnd.effort)
     if not out:
         return None
-    return parse_tag_recommendations(out)
+    parsed = parse_tag_recommendations(out)
+    if parsed is None:
+        return None
+    return [
+        tag
+        for tag in parsed
+        if ALLOWED_TAGS.get(tag.get("key")) == tag.get("value")
+    ]
 
 
 def watch_tags(rnd, session):

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -1054,6 +1054,9 @@ pub struct WatchView {
     /// The granted capability set (the intervention ladder). `observe` is
     /// implicit; the rest are explicit grants.
     pub capabilities: Vec<String>,
+    /// Automation-safe launch profile used for agent judgements and warm
+    /// sessions.
+    pub profile: String,
     pub model: String,
     pub effort: String,
     pub cooldown_secs: i64,
@@ -1095,6 +1098,7 @@ impl WatchView {
             program: o.program.clone(),
             params: o.params(),
             capabilities: o.capabilities(),
+            profile: o.profile.clone(),
             model: o.model.clone(),
             effort: o.effort.clone(),
             cooldown_secs: o.cooldown_secs,
@@ -1394,6 +1398,10 @@ impl SendReq {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentOneshotReq {
     pub prompt: String,
+    /// Optional launch profile. When set, its runtime and policy are
+    /// authoritative; model and effort remain optional per-call overrides.
+    #[serde(default)]
+    pub profile: String,
     /// Registered ACP runtime. Empty preserves the historical Claude default.
     #[serde(default)]
     pub agent: String,
@@ -1560,6 +1568,8 @@ pub struct CreateWatchReq {
     #[serde(default)]
     pub capabilities: Option<Vec<String>>,
     #[serde(default)]
+    pub profile: Option<String>,
+    #[serde(default)]
     pub model: Option<String>,
     #[serde(default)]
     pub effort: Option<String>,
@@ -1588,6 +1598,8 @@ pub struct PatchWatchReq {
     pub params: Option<Value>,
     #[serde(default)]
     pub capabilities: Option<Vec<String>>,
+    #[serde(default)]
+    pub profile: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
     #[serde(default)]

--- a/crates/weaver-core/migrations/0014_calibrate_watches.sql
+++ b/crates/weaver-core/migrations/0014_calibrate_watches.sql
@@ -1,0 +1,29 @@
+-- Agent-backed watches are explicit and paced. Existing status watches need
+-- the `judge` capability to keep using the one-shot agent after that primitive
+-- becomes capability-gated.
+UPDATE watches
+   SET capabilities = json_insert(capabilities, '$[#]', 'judge'),
+       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+ WHERE program = 'builtin:status'
+   AND json_valid(capabilities)
+   AND NOT EXISTS (
+       SELECT 1 FROM json_each(capabilities) WHERE value = 'judge'
+   );
+
+-- Preserve user-customized triggers, but move the untouched stock status
+-- watcher off every finished turn and onto the one-shot stale edge.
+UPDATE watches
+   SET trigger_spec = '{"on":["session.stale"]}',
+       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+ WHERE name = 'status'
+   AND program = 'builtin:status'
+   AND trigger_spec = '{"on":["session.idle"]}';
+
+-- Agentic judgement is opt-in. The two advisory-only PR programs are also
+-- opt-in until they perform a real action rather than only recording `would`.
+UPDATE watches
+   SET enabled = 0,
+       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+ WHERE (name = 'status' AND program = 'builtin:status')
+    OR (name = 'pr-label' AND program = 'builtin:pr-label')
+    OR (name = 'archive-merged' AND program = 'builtin:archive-merged');

--- a/crates/weaver-core/migrations/0015_watch_profiles.sql
+++ b/crates/weaver-core/migrations/0015_watch_profiles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE watches ADD COLUMN profile TEXT NOT NULL DEFAULT 'watch';

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -88,6 +88,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "watches",
         include_str!("../migrations/0013_watches.sql"),
     ),
+    (
+        14,
+        "calibrate_watches",
+        include_str!("../migrations/0014_calibrate_watches.sql"),
+    ),
 ];
 
 /// Latest core schema version compiled into this binary.
@@ -476,6 +481,76 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count, MIGRATIONS.len() as i64);
+    }
+
+    #[tokio::test]
+    async fn watch_calibration_migrates_stock_rows_without_overwriting_copies() {
+        let pool = empty_pool().await;
+        run(&pool).await.unwrap();
+        for (name, program, trigger) in [
+            ("status", "builtin:status", r#"{"on":["session.idle"]}"#),
+            ("status-copy", "builtin:status", r#"{"cron":"0 * * * *"}"#),
+            ("pr-label", "builtin:pr-label", r#"{"on":["pr.opened"]}"#),
+            (
+                "archive-merged",
+                "builtin:archive-merged",
+                r#"{"on":["pr.merged"]}"#,
+            ),
+        ] {
+            sqlx::query(
+                "INSERT INTO watches
+                    (id, name, enabled, trigger_spec, scope, program, params,
+                     capabilities, model, effort, cooldown_secs)
+                 VALUES (?, ?, 1, ?, '{}', ?, '{}', '[\"observe\",\"mark\"]', '', '', 0)",
+            )
+            .bind(format!("{name}-id"))
+            .bind(name)
+            .bind(trigger)
+            .bind(program)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let migration = MIGRATIONS.iter().find(|(v, _, _)| *v == 14).unwrap().2;
+        for stmt in split_statements(migration) {
+            sqlx::query(&stmt).execute(&pool).await.unwrap();
+        }
+
+        let stock: (bool, String, String) = sqlx::query_as(
+            "SELECT enabled, trigger_spec, capabilities FROM watches WHERE name = 'status'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!stock.0);
+        assert_eq!(stock.1, r#"{"on":["session.stale"]}"#);
+        assert!(serde_json::from_str::<Vec<String>>(&stock.2)
+            .unwrap()
+            .iter()
+            .any(|cap| cap == "judge"));
+
+        let copy: (bool, String, String) = sqlx::query_as(
+            "SELECT enabled, trigger_spec, capabilities FROM watches WHERE name = 'status-copy'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(copy.0, "a user-created copy keeps its enabled state");
+        assert_eq!(copy.1, r#"{"cron":"0 * * * *"}"#);
+        assert!(serde_json::from_str::<Vec<String>>(&copy.2)
+            .unwrap()
+            .iter()
+            .any(|cap| cap == "judge"));
+
+        for name in ["pr-label", "archive-merged"] {
+            let enabled: bool = sqlx::query_scalar("SELECT enabled FROM watches WHERE name = ?")
+                .bind(name)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            assert!(!enabled, "{name} stock row becomes opt-in");
+        }
     }
 
     #[tokio::test]

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -93,6 +93,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "calibrate_watches",
         include_str!("../migrations/0014_calibrate_watches.sql"),
     ),
+    (
+        15,
+        "watch_profiles",
+        include_str!("../migrations/0015_watch_profiles.sql"),
+    ),
 ];
 
 /// Latest core schema version compiled into this binary.
@@ -551,6 +556,16 @@ mod tests {
                 .unwrap();
             assert!(!enabled, "{name} stock row becomes opt-in");
         }
+        let profiles: Vec<String> =
+            sqlx::query_scalar("SELECT DISTINCT profile FROM watches ORDER BY profile")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            profiles,
+            vec!["watch"],
+            "the additive profile migration selects the stock watch profile"
+        );
     }
 
     #[tokio::test]

--- a/crates/weaver-core/src/watch.rs
+++ b/crates/weaver-core/src/watch.rs
@@ -253,6 +253,7 @@ impl Watch {
 /// ladder). `observe` is implicit; the rest are explicit grants.
 pub const CAPABILITIES: &[&str] = &[
     "observe",
+    "judge",
     "mark",
     "escalate",
     "nudge",

--- a/crates/weaver-core/src/watch.rs
+++ b/crates/weaver-core/src/watch.rs
@@ -33,6 +33,9 @@ pub struct Watch {
     pub program: String,
     pub params: String,
     pub capabilities: String,
+    /// Automation-safe launch profile used by agent-backed rounds and warm
+    /// watch sessions.
+    pub profile: String,
     pub model: String,
     pub effort: String,
     pub cooldown_secs: i64,
@@ -279,6 +282,7 @@ pub struct NewWatch {
     pub program: String,
     pub params: String,
     pub capabilities: Vec<String>,
+    pub profile: String,
     pub model: String,
     pub effort: String,
     pub cooldown_secs: i64,
@@ -301,6 +305,7 @@ impl Default for NewWatch {
                 "mark".to_string(),
                 "escalate".to_string(),
             ],
+            profile: "watch".to_string(),
             model: String::new(),
             effort: String::new(),
             cooldown_secs: 0,
@@ -316,8 +321,8 @@ pub async fn create(db: &Db, new: &NewWatch) -> Result<Watch> {
     sqlx::query(
         "INSERT INTO watches
            (id, name, enabled, trigger_spec, scope, program, params, capabilities,
-            model, effort, cooldown_secs, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            profile, model, effort, cooldown_secs, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&new.name)
@@ -327,6 +332,7 @@ pub async fn create(db: &Db, new: &NewWatch) -> Result<Watch> {
     .bind(&new.program)
     .bind(&new.params)
     .bind(&caps)
+    .bind(&new.profile)
     .bind(&new.model)
     .bind(&new.effort)
     .bind(new.cooldown_secs)
@@ -403,6 +409,7 @@ pub struct WatchUpdate {
     pub program: Option<String>,
     pub params: Option<String>,
     pub capabilities: Option<Vec<String>>,
+    pub profile: Option<String>,
     pub model: Option<String>,
     pub effort: Option<String>,
     pub cooldown_secs: Option<i64>,
@@ -416,6 +423,7 @@ impl WatchUpdate {
             && self.program.is_none()
             && self.params.is_none()
             && self.capabilities.is_none()
+            && self.profile.is_none()
             && self.model.is_none()
             && self.effort.is_none()
             && self.cooldown_secs.is_none()
@@ -437,6 +445,7 @@ pub async fn update(db: &Db, id: &str, patch: &WatchUpdate) -> Result<()> {
            program       = COALESCE(?, program),
            params        = COALESCE(?, params),
            capabilities  = COALESCE(?, capabilities),
+           profile       = COALESCE(?, profile),
            model         = COALESCE(?, model),
            effort        = COALESCE(?, effort),
            cooldown_secs = COALESCE(?, cooldown_secs),
@@ -448,6 +457,7 @@ pub async fn update(db: &Db, id: &str, patch: &WatchUpdate) -> Result<()> {
     .bind(&patch.program)
     .bind(&patch.params)
     .bind(&caps)
+    .bind(&patch.profile)
     .bind(&patch.model)
     .bind(&patch.effort)
     .bind(patch.cooldown_secs)
@@ -822,6 +832,7 @@ mod tests {
             program: "builtin:status".into(),
             params: "{}".into(),
             capabilities: r#"["mark"]"#.into(),
+            profile: "watch".into(),
             model: String::new(),
             effort: String::new(),
             cooldown_secs: 0,

--- a/crates/weaver-py/tests/test_capabilities.py
+++ b/crates/weaver-py/tests/test_capabilities.py
@@ -14,6 +14,7 @@ import pytest
 def test_module_exposes_the_ladder():
     assert weaver_py.CAPABILITIES == [
         "observe",
+        "judge",
         "mark",
         "escalate",
         "nudge",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -827,9 +827,10 @@ A round runs the **program** the watch names:
 
 - **Builtin scripts** — real Python files in `crates/loom/watches/`,
   embedded into the binary and registered in `loom::builtins`:
-  `builtin:status` (stamp a `triage` mark on each in-scope session, judging
+  `builtin:status` (an opt-in agentic watch that stamps a `triage` mark on a
+  stale in-scope session, judging
   via the configured `prompt` through the daemon's one-shot agent when
-  available, else mirroring the agent's own `attention` tag),
+  available, otherwise leaving its marks untouched),
   `builtin:review-wait` (park a session whose open, non-draft PR awaits an
   external review — `review_decision` `REVIEW_REQUIRED` — under a quiet
   `awaiting: review` mark that sinks it below the calm default in the fleet
@@ -838,7 +839,9 @@ A round runs the **program** the watch names:
   and `builtin:archive-merged` (flag live sessions whose PR has merged, excluding
   those with `auto-archive: disabled`). The last two are **read-only**: they
   record `would:` actions and mutate nothing — the actual archive is still
-  `github.archive_on_merge`, above. The Watch
+  `github.archive_on_merge`, above — and are opt-in. Watches granted the
+  `judge` capability are agentic and the engine limits their automatic rounds
+  to at most one every 15 minutes; manual runs still bypass the interval. The Watch
   panel and `loom watch programs` list the registry; script sources
   render read-only (they ship with the binary).
 - **A custom program file** — an absolute path, conventionally

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -841,8 +841,13 @@ A round runs the **program** the watch names:
   record `would:` actions and mutate nothing — the actual archive is still
   `github.archive_on_merge`, above — and are opt-in. Watches granted the
   `judge` capability are agentic and the engine limits their automatic rounds
-  to at most one every 15 minutes; manual runs still bypass the interval. The Watch
-  panel and `loom watch programs` list the registry; script sources
+  to at most one every 15 minutes; manual runs still bypass the interval.
+  Agent judgements use the watch's selected automation-safe ACP profile. The
+  stock `watch` profile is Codex `gpt-5.6-sol` at medium effort, in plan mode
+  with a cleared environment and no profile-granted external tools or MCP
+  servers; a watch's non-empty model/effort fields override the profile
+  defaults. The Watch panel and
+  `loom watch programs` list the registry; script sources
   render read-only (they ship with the binary).
 - **A custom program file** — an absolute path, conventionally
   `~/.weaver/watches/<name>.py` (`loom watch new` scaffolds one).
@@ -854,9 +859,10 @@ loom can do is an HTTP route (including one-shot agent judgement, at
 There is deliberately no privileged in-Rust program shape: a builtin sees
 exactly the API a custom program sees.
 The contract: `$WEAVER_API` carries the daemon's base URL, `$WEAVER_WATCH`
-the round's config (`{id, name, program, params, scope, capabilities, model,
-effort, dry_run}`), and the script prints one JSON object — `{outcome, summary,
-actions}` — as its final stdout line. A non-zero exit, no result object, or a
+the round's config (`{id, name, program, params, scope, capabilities, profile,
+model, effort, dry_run}`), and the script prints one JSON object —
+`{outcome, summary, actions}` — as its final stdout line. A non-zero exit, no
+result object, or a
 blown round budget records the round as an `error`. A mutating program must
 honor `dry_run` (record `{would: …}` actions instead of acting) and stay inside
 its granted capabilities.

--- a/docs/plans/acp.md
+++ b/docs/plans/acp.md
@@ -583,11 +583,12 @@ throughout:
 - **`session/load` completeness** for long sessions. The journal being
   primary bounds the blast radius to fresh adopts.
 - **One-shot judgement calls** (`POST /api/agent/oneshot`, watches) use the
-  same `AgentManager` and configured ACP adapter as interactive launches. They
-  open a transient session with no MCP servers, apply requested model/effort
-  through advertised `configOptions`, prefer plan/read-only mode, and tear the
-  relay down after one response. The repository lint script remains an
-  independent development tool, not a Loom API path.
+  same `AgentManager` and configured ACP adapter as interactive launches. A
+  caller may select an automation-safe ACP profile, which supplies runtime,
+  env policy, mode, tools/MCP policy, and model/effort defaults; explicit
+  model/effort values override those defaults through advertised
+  `configOptions`. The relay is torn down after one response. The repository
+  lint script remains an independent development tool, not a Loom API path.
 
 ## Rejected alternatives
 

--- a/docs/plans/watches.md
+++ b/docs/plans/watches.md
@@ -388,7 +388,7 @@ flowchart TD
 
     stock --> api
     pyprog --> api
-    api["capability-gated API:<br/>sessions · preview · mark · nudge · run_agent · warm_session"]
+    api["capability-gated API:<br/>sessions · preview · judge · mark · nudge · warm_session"]
 
     api -->|observe / nudge / break| fleet["Fleet sessions<br/>(daemon = sole tmux owner)"]
     api -->|mark| triage["triage tag on branch"]
@@ -473,7 +473,7 @@ The motivating case, end to end. The **zero-code** form is a stock program:
 ```
 loom watch add status-check \
   --cron "0 * * * *" --scope "attention != ok" \
-  --capabilities observe,mark,escalate,nudge \
+  --capabilities observe,judge,mark,escalate,nudge \
   --program builtin:status \
   --prompt "If a session is progressing, mark it ok. If it looks stuck (same \
     action repeating, an unhandled error, no movement), mark it attention with a \

--- a/docs/plans/watches.md
+++ b/docs/plans/watches.md
@@ -243,11 +243,13 @@ warm/fresh/rules distinctions become *library calls inside the program*:
 - `ov.sessions(scope)` / `s.preview()` / `s.diff()` — observe (always allowed).
 - `s.mark(level, note)` — write the `triage` tag.
 - `s.nudge(text)` / `s.interrupt()` — the intervention ladder (capability-gated).
-- `ov.run_agent(prompt)` — run a **fresh**, restricted ACP session for a
-  judgement call through the same registered runtime and adapter Loom uses for
-  interactive agents. Model and effort selectors are applied through the
-  adapter's advertised configuration; the transient relay is torn down after
-  the response.
+- `ov.run_agent(prompt)` — run a **fresh** ACP session for a judgement call
+  through the watch's selected automation-safe profile. The profile supplies
+  runtime, environment, mode, tool/MCP policy, model, and effort; non-empty
+  watch model/effort values override its defaults through the adapter's
+  advertised configuration. The transient relay is torn down after the
+  response. The stock `watch` profile is Codex `gpt-5.6-sol`, medium effort,
+  plan mode, env-cleared, with no profile-granted external tools or MCP servers.
 - `ov.warm_session()` — get the watch's **persistent** session (created on
   first use, reused after), for accumulating judgement across rounds — "still
   stuck since last hour?" The binding handles create-or-reuse; the program just
@@ -409,7 +411,8 @@ through the same `weaver-api` the out-of-process programs use.
   with an optional `repo` filter), `scope` (JSON fleet query, repo-aware),
   `program` (`builtin:status` or a file path under `~/.weaver/watches/`),
   `params` (JSON for a stock program / the prompt), `capabilities` (JSON set),
-  `model`, `effort`, `cooldown_secs`, `last_run_at`, `next_run_at`,
+  `profile` (an automation-safe ACP launch profile; default `watch`), `model`,
+  `effort`, `cooldown_secs`, `last_run_at`, `next_run_at`,
   `warm_session_id` (nullable), `state` (the program's lookaside JSON, carried
   across rounds), `wake_at` (a one-shot dynamic re-trigger a round armed for
   itself, nullable), `created_at`, `updated_at`.
@@ -474,6 +477,7 @@ The motivating case, end to end. The **zero-code** form is a stock program:
 loom watch add status-check \
   --cron "0 * * * *" --scope "attention != ok" \
   --capabilities observe,judge,mark,escalate,nudge \
+  --profile watch \
   --program builtin:status \
   --prompt "If a session is progressing, mark it ok. If it looks stuck (same \
     action repeating, an unhandled error, no movement), mark it attention with a \

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -310,10 +310,11 @@ class Client:
     construction. Sessions and branches cross as plain dicts.
     """
 
-    def __init__(self, base=None, capabilities=None, credentials=None):
+    def __init__(self, base=None, capabilities=None, credentials=None, profile=""):
         self.base = _base_url(base)
         self.capabilities = list(capabilities or [])
         self.credentials = credentials
+        self.profile = profile
 
     def can(self, cap):
         """Whether this client holds ``cap`` (``observe`` is always held)."""
@@ -378,14 +379,18 @@ class Client:
         """The builtin watch program registry."""
         return self._request("GET", "/watches/programs")
 
-    def agent(self, prompt, model="", effort="", runtime=""):
+    def agent(self, prompt, model="", effort="", runtime="", profile=""):
         """Run a fresh ACP prompt in the daemon and return its text, or ``None``
-        when the runtime is absent or failed. ``runtime`` defaults to Claude for
-        compatibility. A judgement primitive: pair with
+        when the profile/runtime is absent or failed. The client profile is used
+        unless ``profile`` overrides it; without either, ``runtime`` defaults to
+        Claude for compatibility. A judgement primitive: pair with
         :func:`parse_judgement`. Needs ``judge``; watches holding that capability
         are paced by the engine to at most one automatic round per 15 minutes."""
         self._gate("judge")
         body = {"prompt": prompt, "model": model or "", "effort": effort or ""}
+        selected_profile = profile or self.profile
+        if selected_profile:
+            body["profile"] = selected_profile
         if runtime:
             body["agent"] = runtime
         reply = self._request(
@@ -464,7 +469,7 @@ class Round:
     """One watch round, as the engine runs it.
 
     Reads the round config from ``$WEAVER_WATCH`` (``{id, name, program,
-    params, scope, capabilities, model, effort, dry_run, state}``), builds a
+    params, scope, capabilities, profile, model, effort, dry_run, state}``), builds a
     :class:`Client` granted that round's capabilities, accumulates the action
     log, and prints the result the engine parses. A mutating program must
     check :attr:`dry_run` (record a :meth:`would` action instead of acting).
@@ -483,6 +488,9 @@ class Round:
         self.name = config.get("name", "")
         self.params = config.get("params") or {}
         self.scope = config.get("scope") or {}
+        #: Automation-safe launch profile used by agent judgements and warm
+        #: sessions. ``watch`` is the stock low-frequency Codex profile.
+        self.profile = config.get("profile") or "watch"
         #: The watch's configured agent model / reasoning effort — pass
         #: these to :meth:`Client.agent` so judgement honours the config.
         self.model = config.get("model", "")
@@ -499,7 +507,7 @@ class Round:
         self.trigger = config.get("trigger") or {}
         self.dry_run = bool(config.get("dry_run")) or self.mode == "register"
         caps = [] if self.mode == "register" else (config.get("capabilities") or [])
-        self.client = client or Client(capabilities=caps)
+        self.client = client or Client(capabilities=caps, profile=self.profile)
         self.actions = []
         #: How many live sessions the last survey admitted.
         self.surveyed = 0

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -59,7 +59,7 @@ import urllib.request
 DEFAULT_BASE = "http://127.0.0.1:7878"
 
 #: The intervention ladder, calm → loud. ``observe`` is implicit.
-CAPABILITIES = ["observe", "mark", "escalate", "nudge", "interrupt", "launch"]
+CAPABILITIES = ["observe", "judge", "mark", "escalate", "nudge", "interrupt", "launch"]
 
 #: Lifecycle states with no live session behind them.
 TERMINAL_STATUSES = {"done", "error", "archived"}
@@ -382,7 +382,9 @@ class Client:
         """Run a fresh ACP prompt in the daemon and return its text, or ``None``
         when the runtime is absent or failed. ``runtime`` defaults to Claude for
         compatibility. A judgement primitive: pair with
-        :func:`parse_judgement`."""
+        :func:`parse_judgement`. Needs ``judge``; watches holding that capability
+        are paced by the engine to at most one automatic round per 15 minutes."""
+        self._gate("judge")
         body = {"prompt": prompt, "model": model or "", "effort": effort or ""}
         if runtime:
             body["agent"] = runtime

--- a/python/weaver-loom/tests/test_status_program.py
+++ b/python/weaver-loom/tests/test_status_program.py
@@ -31,7 +31,7 @@ def load_program(name):
 
 status = load_program("status")
 
-TAGS = '[{"key": "review", "value": "attention", "note": "looks done"}]'
+TAGS = '[{"key": "human-review", "value": "attention", "note": "looks done"}]'
 
 
 class StubClient:
@@ -98,7 +98,7 @@ def test_judge_parses_the_agents_tag_set():
     client = StubClient(agent_reply=TAGS)
     rnd = make_round(client)
     assert status.judge_tags(rnd, session("s")) == [
-        {"key": "review", "value": "attention", "note": "looks done"}
+        {"key": "human-review", "value": "attention", "note": "looks done"}
     ]
 
 
@@ -113,6 +113,20 @@ def test_judge_is_none_without_an_agent():
 def test_judge_empty_array_is_the_calm_verdict():
     rnd = make_round(StubClient(agent_reply="nothing needed: []"))
     assert status.judge_tags(rnd, session("s")) == []
+
+
+def test_judge_drops_unknown_keys_and_mismatched_severity():
+    reply = json.dumps(
+        [
+            {"key": "creative-label", "value": "attention", "note": "vague"},
+            {"key": "human-review", "value": "blocked", "note": "wrong severity"},
+            {"key": "agent-stuck", "value": "blocked", "note": "looping"},
+        ]
+    )
+    rnd = make_round(StubClient(agent_reply=reply))
+    assert status.judge_tags(rnd, session("s")) == [
+        {"key": "agent-stuck", "value": "blocked", "note": "looping"}
+    ]
 
 
 def test_judge_uses_the_default_prompt_with_screen_and_model():
@@ -141,7 +155,7 @@ def test_judge_survives_a_dead_pane():
     client = NoPane(agent_reply=TAGS)
     rnd = make_round(client, params={"prompt": "judge"})
     assert status.judge_tags(rnd, session("s")) == [
-        {"key": "review", "value": "attention", "note": "looks done"}
+        {"key": "human-review", "value": "attention", "note": "looks done"}
     ]
     # The agent was still consulted, with an empty screen.
     assert any(c[0] == "agent" for c in client.calls)
@@ -156,14 +170,14 @@ def test_applies_tags_and_reconciles_its_own_dropped_marks(capsys):
     client = StubClient(
         capabilities=["mark"],
         agent_reply=TAGS,
-        sessions=[session("s", watch={"stuck": "blocked"})],
+        sessions=[session("s", watch={"agent-stuck": "blocked"})],
     )
     result = run_main(client, capsys)
     assert batches(client) == [
         (
             "set_tags",
             "s",
-            [{"key": "review", "value": "attention", "note": "looks done"}],
+            [{"key": "human-review", "value": "attention", "note": "looks done"}],
             "watch",
             [],
         )
@@ -176,7 +190,7 @@ def test_empty_verdict_clears_the_watchs_own_marks(capsys):
     client = StubClient(
         capabilities=["mark"],
         agent_reply="[]",
-        sessions=[session("s", watch={"review": "attention"})],
+        sessions=[session("s", watch={"human-review": "attention"})],
     )
     result = run_main(client, capsys)
     assert batches(client) == [("set_tags", "s", [], "watch", [])]
@@ -188,7 +202,7 @@ def test_no_judgement_leaves_every_mark_untouched(capsys):
     client = StubClient(
         capabilities=["mark"],
         agent_reply=None,
-        sessions=[session("s", watch={"review": "attention"})],
+        sessions=[session("s", watch={"human-review": "attention"})],
     )
     result = run_main(client, capsys)
     assert batches(client) == []
@@ -216,7 +230,7 @@ def test_without_mark_capability_only_observes(capsys):
     result = run_main(client, capsys)
     assert batches(client) == []
     assert result["actions"] == [
-        {"action": "observe", "session": "s", "key": "review",
+        {"action": "observe", "session": "s", "key": "human-review",
          "value": "attention", "note": "looks done"}
     ]
 
@@ -225,13 +239,13 @@ def test_dry_run_records_would_and_mutates_nothing(capsys):
     client = StubClient(
         capabilities=["mark"],
         agent_reply=TAGS,
-        sessions=[session("s", watch={"stuck": "blocked"})],
+        sessions=[session("s", watch={"agent-stuck": "blocked"})],
     )
     result = run_main(client, capsys, dry_run=True)
     assert batches(client) == []
-    assert {"would": "tag", "session": "s", "key": "review",
+    assert {"would": "tag", "session": "s", "key": "human-review",
             "value": "attention", "note": "looks done"} in result["actions"]
-    assert {"would": "clear", "session": "s", "key": "stuck"} in result["actions"]
+    assert {"would": "clear", "session": "s", "key": "agent-stuck"} in result["actions"]
     assert result["summary"] == "assessed 1 of 1, would apply 1 tag(s) (dry run, no writes applied)"
 
 
@@ -253,7 +267,7 @@ def test_real_status_replaces_the_soothing_idle_mark(capsys):
         (
             "set_tags",
             "s",
-            [{"key": "review", "value": "attention", "note": "looks done"}],
+            [{"key": "human-review", "value": "attention", "note": "looks done"}],
             "watch",
             [{"key": "idle", "value": "idle"}],
         )

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -100,8 +100,8 @@ def test_client_retries_one_unauthorized_request_with_refreshed_workload_token(
 class StubClient(Client):
     """A Client whose requests are recorded instead of sent."""
 
-    def __init__(self, capabilities=None, replies=None):
-        super().__init__(base="http://stub", capabilities=capabilities)
+    def __init__(self, capabilities=None, replies=None, profile=""):
+        super().__init__(base="http://stub", capabilities=capabilities, profile=profile)
         self.requests = []
         self.replies = replies or {}
 
@@ -224,7 +224,9 @@ def test_parse_tag_recommendations_none_vs_empty():
 
 def make_round(scope=None, sessions=None, capabilities=None, **config):
     client = StubClient(
-        capabilities=capabilities or [], replies={"/sessions": sessions or []}
+        capabilities=capabilities or [],
+        profile=config.get("profile", ""),
+        replies={"/sessions": sessions or []},
     )
     return Round(
         config={"name": "t", "scope": scope or {}, **config},
@@ -449,18 +451,28 @@ def test_nudge_carries_by_for_the_audit_event():
 
 
 def test_agent_returns_output_or_none():
-    c = StubClient(capabilities=["judge"], replies={"/agent/oneshot": {"output": "blocked: judged"}})
+    c = StubClient(
+        capabilities=["judge"],
+        profile="watch",
+        replies={"/agent/oneshot": {"output": "blocked: judged"}},
+    )
     assert c.agent("look", model="haiku", effort="low") == "blocked: judged"
     assert c.requests[-1] == (
         "POST",
         "/agent/oneshot",
-        {"prompt": "look", "model": "haiku", "effort": "low"},
+        {"prompt": "look", "model": "haiku", "effort": "low", "profile": "watch"},
     )
     assert c.agent("look", runtime="codex") == "blocked: judged"
     assert c.requests[-1] == (
         "POST",
         "/agent/oneshot",
-        {"prompt": "look", "model": "", "effort": "", "agent": "codex"},
+        {
+            "prompt": "look",
+            "model": "",
+            "effort": "",
+            "profile": "watch",
+            "agent": "codex",
+        },
     )
     # A degraded daemon reply ({output: null}) reads as None, not an error.
     absent = StubClient(capabilities=["judge"], replies={"/agent/oneshot": {"output": None}})
@@ -473,12 +485,15 @@ def test_agent_returns_output_or_none():
 def test_round_reads_config_and_finish_prints_the_contract(capsys):
     rnd = make_round(
         params={"prompt": "stuck?"},
+        profile="review-watch",
         model="haiku",
         effort="low",
         dry_run=True,
         capabilities=["mark"],
     )
     assert rnd.params == {"prompt": "stuck?"}
+    assert rnd.profile == "review-watch"
+    assert rnd.client.profile == "review-watch"
     assert (rnd.model, rnd.effort, rnd.dry_run) == ("haiku", "low", True)
     assert rnd.can("mark") and not rnd.can("nudge")
 

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -370,6 +370,7 @@ def test_observe_is_implicit_and_writes_are_gated():
         lambda: c.set_tags("s", []),
         lambda: c.clear_tag("s", "triage"),
         lambda: c.mark("s", "blocked"),
+        lambda: c.agent("judge"),
         lambda: c.nudge("s", "hello"),
         lambda: c.interrupt("s"),
     ):
@@ -382,6 +383,7 @@ def test_observe_is_implicit_and_writes_are_gated():
 def test_capabilities_constant_matches_the_ladder():
     assert CAPABILITIES == [
         "observe",
+        "judge",
         "mark",
         "escalate",
         "nudge",
@@ -447,7 +449,7 @@ def test_nudge_carries_by_for_the_audit_event():
 
 
 def test_agent_returns_output_or_none():
-    c = StubClient(replies={"/agent/oneshot": {"output": "blocked: judged"}})
+    c = StubClient(capabilities=["judge"], replies={"/agent/oneshot": {"output": "blocked: judged"}})
     assert c.agent("look", model="haiku", effort="low") == "blocked: judged"
     assert c.requests[-1] == (
         "POST",
@@ -461,7 +463,7 @@ def test_agent_returns_output_or_none():
         {"prompt": "look", "model": "", "effort": "", "agent": "codex"},
     )
     # A degraded daemon reply ({output: null}) reads as None, not an error.
-    absent = StubClient(replies={"/agent/oneshot": {"output": None}})
+    absent = StubClient(capabilities=["judge"], replies={"/agent/oneshot": {"output": None}})
     assert absent.agent("look") is None
 
 


### PR DESCRIPTION
Agent-backed watch programs now require an explicit judge capability. Automatic rounds for those watches have a hard 15-minute minimum interval, including dynamic self-wakes, while manual authoring runs remain available.

Watches now select a persisted agent profile. The stock watch profile uses Codex gpt-5.6-sol at medium effort with an automation-safe ACP policy; both one-shot judgements and warm watch sessions inherit its runtime, environment, mode, tool policy, model, and effort unless the watch explicitly overrides model or effort.

The stock status watch is now opt-in, wakes on the one-shot stale edge instead of every completed turn, and enforces a stable human-review, human-decision, and agent-stuck label vocabulary. Review-wait and transient-error recovery remain enabled as useful mechanical watches; the advisory-only PR label and archive programs become opt-in.

A migration updates existing builtin status capabilities and untouched triggers, disables the three noisy stock rows, preserves customized copies, and assigns existing watches to the stock watch profile.