### PR TITLE
Disable Codex account apps in Loom sessions

### DIFF
--- a/.agents/ops/2026-07-25-shared-codex-github-identity.md
+++ b/.agents/ops/2026-07-25-shared-codex-github-identity.md
@@ -1,0 +1,56 @@
+# Shared Codex GitHub identity crossed Loom sessions
+
+## Status
+
+Mitigation implemented locally; production deployment is pending.
+
+## Impact
+
+On 2026-07-24, a Loom Codex session created by `rjpower` posted GitHub issue
+comment `5073906073` as `yonromai`. The comment announced a child Loom session
+for PR 7606. Romain Yon did not create or interact with either session.
+
+## Evidence
+
+- GitHub attributes comment `5073906073` to the
+  `chatgpt-codex-connector` app and the `yonromai` user.
+- The parent session `nxm6ul1e` transcript records a
+  `codex_apps.github.add_comment_to_issue` invocation at the comment timestamp
+  with the exact published body.
+- Loom records `nxm6ul1e` as created by `rjpower`; it created child session
+  `24f9f8d7`.
+- The agent process's `GH_TOKEN` identifies as the Loom bot, so neither the
+  injected token nor shell `gh` produced the comment.
+- All Loom sessions share the persisted Codex login. That account had a
+  server-side GitHub connector authorization whose GitHub identity was
+  `yonromai`.
+
+## Root cause
+
+Loom intentionally shares Claude and Codex provider accounts, but Codex's
+account-level connected apps were also inherited. The model could therefore
+write to GitHub through the persistent connector identity independently of
+Loom's injected GitHub credential and session ownership.
+
+This was not a stale Romain session or a recent login by Romain. It was an
+`rjpower`-owned session acting through an older connector authorization attached
+to the shared Codex account.
+
+## Corrective change
+
+- Keep the shared Claude and Codex authentication state.
+- Disable Codex account-level apps in the container at startup.
+- Pass `--disable apps` to terminal Codex launches.
+- Force `features.apps=false` into ACP `CODEX_CONFIG`, while preserving all
+  other operator configuration.
+- Continue routing GitHub writes through Loom's injected bot token or the
+  restricted server-side GitHub endpoint.
+
+## Verification
+
+- `cargo check -p loom`
+- `cargo test -p loom agent::tests::codex_runtime_runs_codex_with_its_prompt -- --exact`
+- `cargo test -p loom agent::tests::codex_acp_disables_apps_without_discarding_operator_config -- --exact`
+- `cargo test -p loom --test integration acp::codex_acp_launch_maps_the_adapter_contract -- --exact --test-threads=1`
+
+No live Loom process was restarted or reconfigured during the investigation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -265,6 +265,13 @@ if [ "${1:-}" = loom ] && [ "${2:-}" = server ]; then
     [ -x "$HOME/.local/bin/codex" ] \
       || echo "loom: WARNING: native Codex install failed (offline?); the codex runtime is unavailable until a later boot installs it" >&2
   fi
+  if [ -x "$HOME/.local/bin/codex" ]; then
+    # The ChatGPT login is shared for model access, but account-level apps carry
+    # the identity of whoever authorized them. Keep them unavailable to every
+    # Codex process in this multi-user container; Loom supplies GitHub identity.
+    "$HOME/.local/bin/codex" features disable apps >/dev/null \
+      || echo "loom: WARNING: could not disable Codex account-level apps" >&2
+  fi
   if ! command -v claude-agent-acp >/dev/null 2>&1 || ! command -v codex-acp >/dev/null 2>&1; then
     echo "loom: installing the ACP adapters into $HOME/.npm-global ..." >&2
     # The ACP adapters loom's sessions speak through (docs/plans/acp.md). Exact

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -418,8 +418,11 @@ fn codex_command(ctx: &AgentLaunchContext<'_>) -> String {
         format!(" {args}")
     };
     match ctx.goal_file.or(ctx.primer_file) {
-        Some(f) => format!("codex{args} \"$(cat {})\"", sh_single_quote_path(f)),
-        None => format!("codex{args}"),
+        Some(f) => format!(
+            "codex --disable apps{args} \"$(cat {})\"",
+            sh_single_quote_path(f)
+        ),
+        None => format!("codex --disable apps{args}"),
     }
 }
 
@@ -981,9 +984,7 @@ pub async fn build_acp_launch(
             "DEFAULT_AUTH_REQUEST",
             r#"{"methodId":"api-key"}"#,
         );
-        if let Some(cfg) = codex_acp_config(spec.model, spec.effort) {
-            push_env_default(&mut env, "CODEX_CONFIG", &cfg);
-        }
+        force_codex_apps_disabled(&mut env, spec.model, spec.effort)?;
         push_env_default(&mut env, "INITIAL_AGENT_MODE", &codex_acp_mode(spec.mode));
     }
 
@@ -1119,9 +1120,42 @@ async fn codex_acp_cmd(db: &Db) -> String {
     npm_adapter_cmd("codex-acp", "@agentclientprotocol/codex-acp")
 }
 
-/// The `CODEX_CONFIG` JSON for the codex adapter (merged into the Codex session
-/// config): model and reasoning effort, only when set. `None` when neither is.
-fn codex_acp_config(model: &str, effort: &str) -> Option<String> {
+/// Force Codex's account-level app connectors off while preserving the shared
+/// provider login and any operator-supplied adapter configuration.
+fn force_codex_apps_disabled(
+    env: &mut Vec<(String, String)>,
+    model: &str,
+    effort: &str,
+) -> Result<()> {
+    let mut config = match env
+        .iter()
+        .rev()
+        .find_map(|(name, value)| (name == "CODEX_CONFIG").then_some(value))
+    {
+        Some(value) => serde_json::from_str::<Value>(value).context("invalid CODEX_CONFIG JSON")?,
+        None => Value::Object(codex_acp_config(model, effort)),
+    };
+    let config = config
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("CODEX_CONFIG must be a JSON object"))?;
+    let features = config
+        .entry("features".to_string())
+        .or_insert_with(|| json!({}));
+    let features = features
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("CODEX_CONFIG.features must be a JSON object"))?;
+    features.insert("apps".to_string(), json!(false));
+
+    env.retain(|(name, _)| name != "CODEX_CONFIG");
+    env.push((
+        "CODEX_CONFIG".to_string(),
+        Value::Object(config.clone()).to_string(),
+    ));
+    Ok(())
+}
+
+/// Base `CODEX_CONFIG` for the Codex ACP adapter.
+fn codex_acp_config(model: &str, effort: &str) -> Map<String, Value> {
     let mut cfg = Map::new();
     let model = model.trim();
     if !model.is_empty() {
@@ -1130,10 +1164,7 @@ fn codex_acp_config(model: &str, effort: &str) -> Option<String> {
     if let Some(e) = effort_flag(effort) {
         cfg.insert("model_reasoning_effort".to_string(), json!(e));
     }
-    if cfg.is_empty() {
-        return None;
-    }
-    Some(Value::Object(cfg).to_string())
+    cfg
 }
 
 /// Map the launch mode onto a codex-acp `INITIAL_AGENT_MODE` id. The create API
@@ -1975,7 +2006,7 @@ mod tests {
             "",
         );
         assert!(
-            fresh.contains("codex \"$(cat '/x/goal.txt')\"; "),
+            fresh.contains("codex --disable apps \"$(cat '/x/goal.txt')\"; "),
             "got: {fresh}"
         );
         // Codex has no scoped resume, so adopt re-launches fresh with the primer.
@@ -1988,7 +2019,7 @@ mod tests {
             "",
         );
         assert!(
-            adopt.contains("codex \"$(cat '/x/goal.txt')\"; "),
+            adopt.contains("codex --disable apps \"$(cat '/x/goal.txt')\"; "),
             "got: {adopt}"
         );
     }
@@ -2006,7 +2037,7 @@ mod tests {
             "",
         );
         assert!(
-            fresh.contains("codex \"$(cat '/x/primer.txt')\"; "),
+            fresh.contains("codex --disable apps \"$(cat '/x/primer.txt')\"; "),
             "got: {fresh}"
         );
     }
@@ -2159,7 +2190,9 @@ mod tests {
             "xhigh",
         );
         assert!(
-            script.contains("codex --model gpt-5.5 -c model_reasoning_effort=\\\"xhigh\\\""),
+            script.contains(
+                "codex --disable apps --model gpt-5.5 -c model_reasoning_effort=\\\"xhigh\\\""
+            ),
             "got: {script}"
         );
     }
@@ -2355,17 +2388,35 @@ mod tests {
 
     #[test]
     fn codex_acp_config_carries_only_configured_fields() {
-        assert!(codex_acp_config("", "").is_none());
+        assert!(codex_acp_config("", "").is_empty());
 
-        let cfg: Value =
-            serde_json::from_str(&codex_acp_config("gpt-5.3-codex", "high").unwrap()).unwrap();
+        let cfg = codex_acp_config("gpt-5.3-codex", "high");
         assert_eq!(cfg["model"], "gpt-5.3-codex");
         assert_eq!(cfg["model_reasoning_effort"], "high");
 
-        let model_only: Value =
-            serde_json::from_str(&codex_acp_config("gpt-5.3-codex", " ").unwrap()).unwrap();
+        let model_only = codex_acp_config("gpt-5.3-codex", " ");
         assert_eq!(model_only["model"], "gpt-5.3-codex");
         assert!(model_only.get("model_reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn codex_acp_disables_apps_without_discarding_operator_config() {
+        let mut env = vec![(
+            "CODEX_CONFIG".to_string(),
+            r#"{"model":"operator","features":{"shell_snapshot":true,"apps":true}}"#.to_string(),
+        )];
+
+        force_codex_apps_disabled(&mut env, "ignored", "high").unwrap();
+
+        let config: Value = serde_json::from_str(
+            env.iter()
+                .find_map(|(name, value)| (name == "CODEX_CONFIG").then_some(value))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(config["model"], "operator");
+        assert_eq!(config["features"]["shell_snapshot"], true);
+        assert_eq!(config["features"]["apps"], false);
     }
 
     #[test]

--- a/crates/loom/src/agent.rs
+++ b/crates/loom/src/agent.rs
@@ -1154,7 +1154,6 @@ fn force_codex_apps_disabled(
     Ok(())
 }
 
-/// Base `CODEX_CONFIG` for the Codex ACP adapter.
 fn codex_acp_config(model: &str, effort: &str) -> Map<String, Value> {
     let mut cfg = Map::new();
     let model = model.trim();
@@ -2005,9 +2004,10 @@ mod tests {
             "",
             "",
         );
-        assert!(
-            fresh.contains("codex --disable apps \"$(cat '/x/goal.txt')\"; "),
-            "got: {fresh}"
+        // This rendered shell command is the terminal runtime contract.
+        assert_eq!(
+            fresh,
+            "codex --disable apps \"$(cat '/x/goal.txt')\"; exec \"${SHELL:-/bin/sh}\""
         );
         // Codex has no scoped resume, so adopt re-launches fresh with the primer.
         let adopt = launch_script(
@@ -2018,9 +2018,9 @@ mod tests {
             "",
             "",
         );
-        assert!(
-            adopt.contains("codex --disable apps \"$(cat '/x/goal.txt')\"; "),
-            "got: {adopt}"
+        assert_eq!(
+            adopt,
+            "codex --disable apps \"$(cat '/x/goal.txt')\"; exec \"${SHELL:-/bin/sh}\""
         );
     }
 
@@ -2036,9 +2036,9 @@ mod tests {
             "",
             "",
         );
-        assert!(
-            fresh.contains("codex --disable apps \"$(cat '/x/primer.txt')\"; "),
-            "got: {fresh}"
+        assert_eq!(
+            fresh,
+            "codex --disable apps \"$(cat '/x/primer.txt')\"; exec \"${SHELL:-/bin/sh}\""
         );
     }
 
@@ -2189,11 +2189,10 @@ mod tests {
             "gpt-5.5",
             "xhigh",
         );
-        assert!(
-            script.contains(
-                "codex --disable apps --model gpt-5.5 -c model_reasoning_effort=\\\"xhigh\\\""
-            ),
-            "got: {script}"
+        assert_eq!(
+            script,
+            "codex --disable apps --model gpt-5.5 -c model_reasoning_effort=\\\"xhigh\\\" \
+             \"$(cat '/x/goal.txt')\"; exec \"${SHELL:-/bin/sh}\""
         );
     }
 

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -2962,6 +2962,7 @@ async fn codex_acp_launch_maps_the_adapter_contract() {
     let cfg: Value = serde_json::from_str(&env_of(&launch, "CODEX_CONFIG")[0]).unwrap();
     assert_eq!(cfg["model"], "gpt-5.3-codex");
     assert_eq!(cfg["model_reasoning_effort"], "high");
+    assert_eq!(cfg["features"]["apps"], false);
     assert_eq!(launch.initial_model.as_deref(), Some("gpt-5.3-codex"));
     assert_eq!(launch.initial_effort.as_deref(), Some("high"));
     assert!(
@@ -2974,7 +2975,8 @@ async fn codex_acp_launch_maps_the_adapter_contract() {
         NewOrLoad::Load { .. } => panic!("a fresh launch opens session/new"),
     }
 
-    // An operator-provided CODEX_CONFIG wins; a goalless launch seeds the primer.
+    // Operator config is preserved, except that account-level apps remain
+    // disabled; a goalless launch seeds the primer.
     let operator = [(
         "CODEX_CONFIG".to_string(),
         r#"{"model":"mine"}"#.to_string(),
@@ -2986,7 +2988,9 @@ async fn codex_acp_launch_maps_the_adapter_contract() {
     )
     .await
     .unwrap();
-    assert_eq!(env_of(&launch, "CODEX_CONFIG"), vec![r#"{"model":"mine"}"#]);
+    let cfg: Value = serde_json::from_str(&env_of(&launch, "CODEX_CONFIG")[0]).unwrap();
+    assert_eq!(cfg["model"], "mine");
+    assert_eq!(cfg["features"]["apps"], false);
     assert_eq!(launch.goal.as_deref(), Some("orient first"));
 
     let loaded = loom::agent::build_acp_launch(

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -290,19 +290,28 @@ login — e.g. `docker compose exec loom loom token add ci`.
 
 ### Agent authentication
 
-If you did not set `ANTHROPIC_API_KEY`, log in to Claude once interactively; the
-credentials persist in `~/.claude.json` on the `loom_home` volume:
+Loom intentionally shares one Claude account and one Codex account across
+sessions. If you did not set `ANTHROPIC_API_KEY`, log in to Claude once
+interactively; the credentials persist in `~/.claude.json` on the `loom_home`
+volume:
 
 ```sh
 docker compose exec loom claude    # follow the prompts, then exit
 ```
 
-The Codex runtime authenticates the same way — set `OPENAI_API_KEY`, or log in
-once interactively (persisted under `~/.codex` on the same volume):
+Codex authenticates the same way: set `OPENAI_API_KEY`, or log in once
+interactively (persisted under `~/.codex` on the same volume):
 
 ```sh
 docker compose exec loom codex login    # follow the prompts, then exit
 ```
+
+The shared Codex login is used only for model access. At startup, Loom disables
+Codex account-level apps in the container, so a GitHub connector authorized on
+that account cannot become a session's write identity. The terminal and ACP
+launch paths enforce the same setting. GitHub CLI access instead uses the
+credential Loom injects into the agent environment; restricted profiles perform
+GitHub mutations through Loom's server-side tool endpoint.
 
 ## Wire the `@loom` GitHub trigger
 


### PR DESCRIPTION
Keep Loom's shared Claude and Codex provider authentication while disabling
Codex account-level apps in the multi-user container.

A session created by `rjpower` posted
https://github.com/marin-community/marin/pull/7606#issuecomment-5073906073
through `chatgpt-codex-connector`, whose GitHub authorization was `yonromai`.
The session's `GH_TOKEN` identified as the Loom bot, so shell `gh` was not
involved. The shared Codex account's connected app bypassed Loom's session
ownership and injected GitHub credential.

Disable account apps at container startup and enforce `features.apps=false` for
terminal and ACP Codex launches. GitHub writes continue through Loom's injected
bot token or restricted server-side endpoint. The checked-in incident record
preserves the attribution evidence.
