### PR TITLE
feat(loom): add atomic issue bulk triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ Three flags seed the task from existing work instead of a fresh description:
 from a GitHub issue (via the `gh` CLI), `--claim 7` takes them from an existing
 weaver issue and moves it out of the repo backlog, and `--branch <name>` resumes
 an existing branch. `loom issue ls` prints the repo's board across branches.
+Batch commands use the same atomic API as the Issues pane:
+`loom issue close 7 9`, `loom issue reopen 7 9`,
+`loom issue tag --key area --value ui 7 9`,
+`loom issue untag --key area 7 9`, and `loom issue delete 7 9`.
+If any ID or precondition is invalid, none of the requested issues changes.
 
 Every launch opens a **tracking issue** claimed by the new branch — the task as
 a weaver issue — and the launch prints its number. That number is the handle

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -103,6 +103,9 @@ export const listRuns = () => get('/runs') as Promise<AutomationRun[]>;
 
 import type {
   Issue,
+  IssueAction,
+  IssueActionsResult,
+  IssueTagInput,
   Session,
   AutomationRun,
   ArtifactMeta,
@@ -228,10 +231,13 @@ export const listIssues = (opts: { all?: boolean; automation?: boolean } = {}) =
 export const launchSessionForIssue = (repoRoot: string, issueId: number) =>
   post('/sessions', { cwd: repoRoot, claim_issue: issueId }) as Promise<Session>;
 
-/** Create an unclaimed repo-level backlog issue. Tags aren't part of the create
- *  body — apply them as follow-up `setIssueTag` upserts on the returned id. */
-export const createRepoIssue = (repoRoot: string, title: string, body = '') =>
-  post('/repos/issues', { repo_root: repoRoot, title, body }) as Promise<Issue>;
+/** Create an unclaimed repo-level backlog issue and its initial tags atomically. */
+export const createRepoIssue = (
+  repoRoot: string,
+  title: string,
+  body = '',
+  tags: IssueTagInput[] = [],
+) => post('/repos/issues', { repo_root: repoRoot, title, body, tags }) as Promise<Issue>;
 
 /** Patch an issue's editable fields. Blank `github` unlinks it;
  *  `claimed_branch: null` returns it to the unclaimed backlog. */
@@ -252,6 +258,10 @@ export const clearSessionGithub = (id: string) => del(`/sessions/${id}/github`) 
 
 /** Delete an issue outright. */
 export const deleteIssue = (id: number) => del(`/issues/${id}`);
+
+/** Apply one action atomically to every issue id. */
+export const issueActions = (ids: number[], action: IssueAction) =>
+  post('/issues/actions', { ids, action }) as Promise<IssueActionsResult>;
 
 /** Set (upsert) a free-form label on an issue. */
 export const setIssueTag = (id: number, key: string, value: string, note = '') =>

--- a/crates/loom/frontend/src/components/ConfirmDialog.vue
+++ b/crates/loom/frontend/src/components/ConfirmDialog.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, ref, useId, watch } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean;
+    title: string;
+    description: string;
+    confirmLabel: string;
+    busy?: boolean;
+    danger?: boolean;
+    confirmDisabled?: boolean;
+  }>(),
+  {
+    busy: false,
+    danger: false,
+    confirmDisabled: false,
+  },
+);
+
+const emit = defineEmits<{ confirm: []; cancel: [] }>();
+const dialogId = useId();
+const titleId = `${dialogId}-title`;
+const descriptionId = `${dialogId}-description`;
+const panel = ref<HTMLElement | null>(null);
+const cancelButton = ref<HTMLButtonElement | null>(null);
+let returnFocus: HTMLElement | null = null;
+
+function focusable(): HTMLElement[] {
+  return Array.from(
+    panel.value?.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+    ) ?? [],
+  ).filter((element) => !element.hasAttribute('hidden'));
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (!props.open) return;
+  if (event.key === 'Escape' && !props.busy) {
+    event.preventDefault();
+    emit('cancel');
+    return;
+  }
+  if (event.key !== 'Tab') return;
+  const items = focusable();
+  if (!items.length) {
+    event.preventDefault();
+    panel.value?.focus();
+    return;
+  }
+  const first = items[0];
+  const last = items[items.length - 1];
+  if (!panel.value?.contains(document.activeElement)) {
+    event.preventDefault();
+    (event.shiftKey ? last : first).focus();
+    return;
+  }
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+watch(
+  () => props.open,
+  async (open) => {
+    if (open) {
+      returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      document.addEventListener('keydown', onKeydown);
+      await nextTick();
+      cancelButton.value?.focus();
+    } else {
+      document.removeEventListener('keydown', onKeydown);
+      await nextTick();
+      returnFocus?.focus();
+      returnFocus = null;
+    }
+  },
+);
+
+onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-canvas/75 p-4"
+      data-testid="confirm-dialog-backdrop"
+      @mousedown.self="!busy && emit('cancel')"
+    >
+      <section
+        ref="panel"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+        :aria-describedby="descriptionId"
+        tabindex="-1"
+        class="w-full max-w-md rounded-md border border-line bg-surface p-4 shadow-xl"
+        data-testid="confirm-dialog"
+      >
+        <h2 :id="titleId" class="text-base font-semibold text-fg">{{ title }}</h2>
+        <p :id="descriptionId" class="mt-2 text-sm text-muted">{{ description }}</p>
+        <div v-if="$slots.default" class="mt-4">
+          <slot></slot>
+        </div>
+        <div class="mt-5 flex justify-end gap-2">
+          <button
+            ref="cancelButton"
+            type="button"
+            class="btn-secondary px-3 py-1.5 text-sm"
+            :disabled="busy"
+            data-testid="confirm-dialog-cancel"
+            @click="emit('cancel')"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            :class="danger ? 'btn-danger' : 'btn-primary'"
+            class="px-3 py-1.5 text-sm"
+            :disabled="busy || confirmDisabled"
+            data-testid="confirm-dialog-confirm"
+            @click="emit('confirm')"
+          >
+            {{ busy ? 'Working…' : confirmLabel }}
+          </button>
+        </div>
+      </section>
+    </div>
+  </Teleport>
+</template>

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -454,6 +454,32 @@ export interface Issue {
   tags: Tag[];
 }
 
+export interface IssueTagInput {
+  key: string;
+  value: string;
+  note?: string;
+  by?: string;
+}
+
+export type IssueAction =
+  | { type: 'close' }
+  | { type: 'reopen' }
+  | { type: 'tag'; key: string; value: string; note?: string; by?: string }
+  | { type: 'untag'; key: string }
+  | { type: 'delete' };
+
+export interface IssueActionsResult {
+  issues: Issue[];
+  deleted_ids: number[];
+}
+
+/** One invalid ID or precondition in an atomic issue action's error details. */
+export interface IssueActionProblem {
+  id: number;
+  code: string;
+  error: string;
+}
+
 // --- Artifacts -------------------------------------------------------------
 // Named, versioned documents an agent (or the user) writes *to weaver*, not to
 // the repo — designs, reports, the `plan`. Scoped like issues (branch-scoped or

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
-import { ref, reactive, computed, nextTick, onMounted, onActivated } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, reactive, computed, nextTick, onMounted, onActivated, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import {
+  ApiError,
   listSessions,
   listIssues,
   createRepoIssue,
   patchIssue,
   deleteIssue,
+  issueActions,
   setIssueTag,
   clearIssueTag,
   launchSessionForIssue,
 } from '../api';
-import type { Issue, Session, Tag } from '../types';
+import type { Issue, IssueAction, IssueActionProblem, Session, Tag } from '../types';
+import ConfirmDialog from '../components/ConfirmDialog.vue';
 import TagPill from '../components/TagPill.vue';
 import { timeAgo } from '../lib/time';
 
@@ -19,6 +22,7 @@ import { timeAgo } from '../lib/time';
 defineOptions({ name: 'Issues' });
 
 const router = useRouter();
+const route = useRoute();
 
 // The Issues pane — the cross-repo weaver issue board, sibling to the session
 // list and the watch panel. API-first: every row is an `IssueView` from
@@ -47,6 +51,26 @@ const showAutomation = ref(false);
 const search = ref('');
 const repoFilter = ref('');
 
+// A session badge can deep-link to `/issues?repo_root=…&branch=…`. This scope
+// is stronger than the ordinary filters: it is always visible in the toolbar,
+// applies before pagination/selection, and changing it clears any prior
+// selection so a batch cannot silently cross the URL boundary.
+const scopeRepo = computed(() =>
+  typeof route.query.repo_root === 'string' ? route.query.repo_root : '',
+);
+const scopeBranch = computed(() =>
+  typeof route.query.branch === 'string' ? route.query.branch : '',
+);
+const scopeKey = computed(() => `${scopeRepo.value}\0${scopeBranch.value}`);
+const hasScope = computed(() => Boolean(scopeRepo.value || scopeBranch.value));
+
+function clearScope() {
+  const query = { ...route.query };
+  delete query.repo_root;
+  delete query.branch;
+  router.replace({ query });
+}
+
 // Per-issue UI state: which row's editor is open, the edit draft, the per-row
 // new-tag input, and a busy flag that disables a row's controls mid-call.
 const editing = ref<number | null>(null);
@@ -71,8 +95,10 @@ async function load() {
     issues.value = iss;
     sessions.value = ses;
     error.value = '';
+    return true;
   } catch (e) {
     error.value = (e as Error).message;
+    return false;
   } finally {
     loaded.value = true;
   }
@@ -103,8 +129,7 @@ const multiRepo = computed(() => repos.value.length > 1);
 
 // --- Create issue ----------------------------------------------------------
 // The "New issue" form files an unclaimed backlog item via `POST /repos/issues`.
-// That endpoint takes no tags, so any tags staged here are applied as follow-up
-// `setIssueTag` upserts on the returned id.
+// Initial tags travel in that create command and persist atomically with it.
 const showCreate = ref(false);
 const createRepo = ref('');
 const createDraft = reactive<{ title: string; body: string }>({ title: '', body: '' });
@@ -119,6 +144,7 @@ const createTitleInput = ref<HTMLInputElement | null>(null);
 // nothing is loaded, in which case the form falls back to a free-text path.
 const repoChoices = computed(() => {
   const set = new Set<string>();
+  if (scopeRepo.value) set.add(scopeRepo.value);
   for (const i of issues.value) set.add(i.repo_root);
   for (const s of sessions.value) set.add(s.branch.repo_root);
   return [...set].sort();
@@ -127,8 +153,8 @@ const repoChoices = computed(() => {
 async function openCreate() {
   showCreate.value = true;
   createError.value = '';
-  // Default to the active repo filter, else the first known repo.
-  createRepo.value = repoFilter.value || repoChoices.value[0] || '';
+  // The URL scope is authoritative, then the ordinary repo filter / first repo.
+  createRepo.value = scopeRepo.value || repoFilter.value || repoChoices.value[0] || '';
   await nextTick();
   createTitleInput.value?.focus();
 }
@@ -176,12 +202,8 @@ async function submitCreate() {
   creating.value = true;
   createError.value = '';
   try {
-    let created = await createRepoIssue(repo, title, createDraft.body);
-    // Apply staged tags as upserts; each call returns the updated issue, so the
-    // last response carries the fully-tagged row we insert into the list.
-    for (const t of createTags.value) {
-      created = await setIssueTag(created.id, t.key, t.value);
-    }
+    const tags = createTags.value.map(({ key, value, note }) => ({ key, value, note }));
+    const created = await createRepoIssue(repo, title, createDraft.body, tags);
     issues.value.unshift(created);
     // Surface the new issue even if a different-repo filter is active.
     if (repoFilter.value && repoFilter.value !== created.repo_root) repoFilter.value = '';
@@ -193,9 +215,23 @@ async function submitCreate() {
   }
 }
 
+const scoped = computed(() =>
+  issues.value.filter((i) => {
+    if (scopeRepo.value && i.repo_root !== scopeRepo.value) return false;
+    if (
+      scopeBranch.value &&
+      i.claimed_branch !== scopeBranch.value &&
+      i.source_branch !== scopeBranch.value
+    ) {
+      return false;
+    }
+    return true;
+  }),
+);
+
 const visible = computed(() => {
   const q = search.value.trim().toLowerCase();
-  return issues.value.filter((i) => {
+  return scoped.value.filter((i) => {
     if (!showClosed.value && i.status !== 'open') return false;
     if (!showAutomation.value && isAutomationClaimed(i)) return false;
     if (repoFilter.value && i.repo_root !== repoFilter.value) return false;
@@ -207,7 +243,89 @@ const visible = computed(() => {
   });
 });
 
-const openCount = computed(() => issues.value.filter((i) => i.status === 'open').length);
+const openCount = computed(() => scoped.value.filter((i) => i.status === 'open').length);
+
+// Dense client-side pages keep the board quick to scan while selection remains
+// ID-based across pages, filters, kept-alive activation, and API refreshes.
+const PAGE_SIZE = 25;
+const page = ref(1);
+const pageCount = computed(() => Math.max(1, Math.ceil(visible.value.length / PAGE_SIZE)));
+const pageIssues = computed(() =>
+  visible.value.slice((page.value - 1) * PAGE_SIZE, page.value * PAGE_SIZE),
+);
+watch(
+  () => visible.value.length,
+  () => {
+    page.value = Math.min(page.value, pageCount.value);
+  },
+);
+
+const selected = ref<Set<number>>(new Set());
+const lastSelected = ref<number | null>(null);
+const selectedCount = computed(() => selected.value.size);
+const selectedOnPage = computed(
+  () => pageIssues.value.filter((issue) => selected.value.has(issue.id)).length,
+);
+const allPageSelected = computed(
+  () => pageIssues.value.length > 0 && selectedOnPage.value === pageIssues.value.length,
+);
+const selectedMatching = computed(
+  () => visible.value.filter((issue) => selected.value.has(issue.id)).length,
+);
+const allMatchingSelected = computed(
+  () => visible.value.length > 0 && selectedMatching.value === visible.value.length,
+);
+
+function replaceSelection(next: Set<number>) {
+  selected.value = next;
+}
+
+function toggleSelection(issue: Issue, event: MouseEvent) {
+  const next = new Set(selected.value);
+  const selecting = !next.has(issue.id);
+  if (event.shiftKey && lastSelected.value != null) {
+    const from = visible.value.findIndex((candidate) => candidate.id === lastSelected.value);
+    const to = visible.value.findIndex((candidate) => candidate.id === issue.id);
+    if (from >= 0 && to >= 0) {
+      const [start, end] = from < to ? [from, to] : [to, from];
+      for (const candidate of visible.value.slice(start, end + 1)) {
+        if (selecting) next.add(candidate.id);
+        else next.delete(candidate.id);
+      }
+    }
+  } else if (selecting) {
+    next.add(issue.id);
+  } else {
+    next.delete(issue.id);
+  }
+  lastSelected.value = issue.id;
+  replaceSelection(next);
+}
+
+function toggleVisibleSelection() {
+  const next = new Set(selected.value);
+  for (const issue of pageIssues.value) {
+    if (allPageSelected.value) next.delete(issue.id);
+    else next.add(issue.id);
+  }
+  replaceSelection(next);
+}
+
+function selectAllMatching() {
+  const next = new Set(selected.value);
+  for (const issue of visible.value) next.add(issue.id);
+  replaceSelection(next);
+}
+
+function clearSelection() {
+  replaceSelection(new Set());
+  lastSelected.value = null;
+}
+
+watch(scopeKey, (_next, previous) => {
+  if (previous !== undefined) clearSelection();
+  page.value = 1;
+});
 
 // Sessions indexed by `(repo_root, branch)` so a row resolves its references
 // with a map lookup instead of rescanning the whole session list — `refsFor`
@@ -311,13 +429,159 @@ async function launch(i: Issue) {
   }
 }
 
-async function remove(i: Issue) {
-  if (!confirm(`Delete issue #${i.id} "${i.title}"? This cannot be undone.`)) return;
-  await withBusy(i.id, async () => {
-    await deleteIssue(i.id);
-    issues.value = issues.value.filter((x) => x.id !== i.id);
-    if (editing.value === i.id) editing.value = null;
-  });
+interface BatchFeedback {
+  success: boolean;
+  message: string;
+  problems: IssueActionProblem[];
+}
+
+const batchBusy = ref(false);
+const batchFeedback = ref<BatchFeedback | null>(null);
+const lastBatch = ref<{ ids: number[]; action: IssueAction } | null>(null);
+
+function actionLabel(action: IssueAction): string {
+  switch (action.type) {
+    case 'close':
+      return 'Close';
+    case 'reopen':
+      return 'Reopen';
+    case 'tag':
+      return `Tag ${action.key}: ${action.value}`;
+    case 'untag':
+      return `Remove tag ${action.key}`;
+    case 'delete':
+      return 'Delete';
+  }
+}
+
+function actionProblems(error: unknown): IssueActionProblem[] {
+  if (!(error instanceof ApiError)) return [];
+  const details = error.body.details;
+  if (!details || typeof details !== 'object') return [];
+  const problems = (details as { problems?: unknown }).problems;
+  if (!Array.isArray(problems)) return [];
+  return problems.filter(
+    (problem): problem is IssueActionProblem =>
+      problem != null &&
+      typeof problem === 'object' &&
+      typeof (problem as IssueActionProblem).id === 'number' &&
+      typeof (problem as IssueActionProblem).code === 'string' &&
+      typeof (problem as IssueActionProblem).error === 'string',
+  );
+}
+
+async function runBatch(ids: number[], action: IssueAction): Promise<boolean> {
+  if (!ids.length) return false;
+  batchBusy.value = true;
+  batchFeedback.value = null;
+  lastBatch.value = { ids: [...ids], action };
+  try {
+    const result = await issueActions(ids, action);
+    const affected = result.issues.length + result.deleted_ids.length;
+    const refreshed = await load();
+    clearSelection();
+    batchFeedback.value = {
+      success: true,
+      message: `${actionLabel(action)} applied to ${affected} issue${affected === 1 ? '' : 's'}.${
+        refreshed ? '' : ' The list could not be refreshed; retry the refresh below.'
+      }`,
+      problems: [],
+    };
+    return true;
+  } catch (failure) {
+    const problems = actionProblems(failure);
+    batchFeedback.value = {
+      success: false,
+      message: `${(failure as Error).message}. No issues were changed.`,
+      problems,
+    };
+    return false;
+  } finally {
+    batchBusy.value = false;
+  }
+}
+
+function runSelected(action: IssueAction) {
+  return runBatch([...selected.value], action);
+}
+
+function removeProblemIds() {
+  const next = new Set(selected.value);
+  for (const problem of batchFeedback.value?.problems ?? []) next.delete(problem.id);
+  replaceSelection(next);
+}
+
+function retryLastBatch() {
+  if (!lastBatch.value) return;
+  const ids = selected.value.size ? [...selected.value] : lastBatch.value.ids;
+  if (lastBatch.value.action.type === 'delete') {
+    deleteRequest.value = { ids };
+    return;
+  }
+  runBatch(ids, lastBatch.value.action);
+}
+
+const deleteRequest = ref<{ ids: number[]; single?: Issue } | null>(null);
+
+function requestDelete(issue: Issue) {
+  deleteRequest.value = { ids: [issue.id], single: issue };
+}
+
+function requestBulkDelete() {
+  deleteRequest.value = { ids: [...selected.value] };
+}
+
+async function confirmDelete() {
+  const request = deleteRequest.value;
+  if (!request) return;
+  if (request.single) {
+    const issue = request.single;
+    const removed = await withBusy(issue.id, async () => {
+      await deleteIssue(issue.id);
+      issues.value = issues.value.filter((candidate) => candidate.id !== issue.id);
+      if (editing.value === issue.id) editing.value = null;
+      const next = new Set(selected.value);
+      next.delete(issue.id);
+      replaceSelection(next);
+      return true;
+    });
+    if (removed) deleteRequest.value = null;
+    return;
+  }
+  await runBatch(request.ids, { type: 'delete' });
+  deleteRequest.value = null;
+}
+
+const tagDialogOpen = ref(false);
+const tagMode = ref<'tag' | 'untag'>('tag');
+const bulkTagKey = ref('');
+const bulkTagValue = ref('');
+const bulkTagError = ref('');
+
+function openTagDialog() {
+  tagMode.value = 'tag';
+  bulkTagKey.value = '';
+  bulkTagValue.value = '';
+  bulkTagError.value = '';
+  tagDialogOpen.value = true;
+}
+
+async function confirmTag() {
+  const key = bulkTagKey.value.trim();
+  const value = bulkTagValue.value.trim();
+  if (!key) {
+    bulkTagError.value = 'A tag key is required.';
+    return;
+  }
+  if (tagMode.value === 'tag' && !value) {
+    bulkTagError.value = 'A tag value is required.';
+    return;
+  }
+  bulkTagError.value = '';
+  const action: IssueAction =
+    tagMode.value === 'tag' ? { type: 'tag', key, value, by: 'manual' } : { type: 'untag', key };
+  await runSelected(action);
+  tagDialogOpen.value = false;
 }
 
 function startEdit(i: Issue) {
@@ -378,8 +642,120 @@ async function removeTag(i: Issue, key: string) {
     <div class="mb-3 flex min-h-7 flex-wrap items-center gap-2.5">
       <h1 class="text-2xs font-semibold uppercase tracking-wider text-muted">Issues</h1>
       <span class="pill font-mono" data-testid="issues-open-count">{{ openCount }} open</span>
+      <span
+        v-if="hasScope"
+        class="flex items-center gap-1 rounded bg-info-soft px-2 py-0.5 font-mono text-2xs text-info"
+        data-testid="issues-active-scope"
+      >
+        <span>
+          Scoped to
+          {{ scopeRepo ? repoName(scopeRepo) : 'all repos'
+          }}{{ scopeBranch ? ` / ${branchLabel(scopeBranch)}` : '' }}
+        </span>
+        <button
+          type="button"
+          class="rounded px-1 hover:bg-subtle"
+          data-testid="issues-clear-scope"
+          aria-label="Clear issue scope"
+          @click="clearScope"
+        >
+          ×
+        </button>
+      </span>
 
-      <div class="ml-auto flex flex-wrap items-center gap-2">
+      <div
+        v-if="selectedCount"
+        class="ml-auto flex flex-wrap items-center gap-1.5"
+        data-testid="issues-bulk-toolbar"
+      >
+        <strong class="mr-1 text-xs text-fg" data-testid="issues-selected-count"
+          >{{ selectedCount }} selected</strong
+        >
+        <span v-if="selectedMatching !== selectedCount" class="mr-1 text-2xs text-muted">
+          {{ selectedMatching }} match filters
+        </span>
+        <input
+          v-model="search"
+          type="search"
+          placeholder="Filter selected view…"
+          data-testid="issues-search"
+          class="w-40 rounded bg-input px-2 py-1 text-xs text-fg outline-none ring-accent placeholder:text-faint focus:ring-1"
+        />
+        <button
+          v-if="pageIssues.length"
+          type="button"
+          class="btn-secondary px-2 py-1 text-xs"
+          data-testid="issues-select-visible"
+          @click="toggleVisibleSelection"
+        >
+          {{ allPageSelected ? 'Deselect' : 'Select' }} visible {{ pageIssues.length }}
+        </button>
+        <button
+          v-if="!allMatchingSelected && visible.length > selectedMatching"
+          type="button"
+          class="btn-secondary px-2 py-1 text-xs"
+          data-testid="issues-select-matching"
+          @click="selectAllMatching"
+        >
+          Select all matching {{ visible.length }}
+        </button>
+        <button
+          type="button"
+          class="rounded px-2 py-1 text-xs text-muted hover:bg-subtle hover:text-fg"
+          data-testid="issues-bulk-close"
+          :disabled="batchBusy"
+          @click="runSelected({ type: 'close' })"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          class="rounded px-2 py-1 text-xs text-muted hover:bg-subtle hover:text-fg"
+          data-testid="issues-bulk-reopen"
+          :disabled="batchBusy"
+          @click="runSelected({ type: 'reopen' })"
+        >
+          Reopen
+        </button>
+        <button
+          type="button"
+          class="rounded px-2 py-1 text-xs text-muted hover:bg-subtle hover:text-fg"
+          data-testid="issues-bulk-tag"
+          :disabled="batchBusy"
+          @click="openTagDialog"
+        >
+          Tag
+        </button>
+        <button
+          type="button"
+          class="rounded px-2 py-1 text-xs text-block hover:bg-block-soft"
+          data-testid="issues-bulk-delete"
+          :disabled="batchBusy"
+          @click="requestBulkDelete"
+        >
+          Delete
+        </button>
+        <button
+          type="button"
+          class="rounded px-2 py-1 text-xs text-muted hover:bg-subtle hover:text-fg"
+          data-testid="issues-selection-clear"
+          :disabled="batchBusy"
+          @click="clearSelection"
+        >
+          Clear
+        </button>
+      </div>
+
+      <div v-else class="ml-auto flex flex-wrap items-center gap-2">
+        <button
+          v-if="pageIssues.length"
+          type="button"
+          class="btn-secondary px-2 py-1 text-xs"
+          data-testid="issues-select-visible"
+          @click="toggleVisibleSelection"
+        >
+          Select visible {{ pageIssues.length }}
+        </button>
         <input
           v-model="search"
           type="search"
@@ -388,7 +764,7 @@ async function removeTag(i: Issue, key: string) {
           class="w-48 rounded bg-input px-2 py-1 text-xs text-fg outline-none ring-accent placeholder:text-faint focus:ring-1"
         />
         <select
-          v-if="multiRepo"
+          v-if="multiRepo && !scopeRepo"
           v-model="repoFilter"
           data-testid="issues-repo-filter"
           class="rounded bg-input px-2 py-1 text-xs text-fg outline-none ring-accent focus:ring-1"
@@ -428,7 +804,7 @@ async function removeTag(i: Issue, key: string) {
     <!--
       New-issue form. Grouped into quiet labeled fields (Repository / Title /
       Body / Tags), matching the session create form's light treatment. Files an
-      unclaimed backlog item; staged tags apply as follow-up upserts.
+      unclaimed backlog item with its staged tags in one atomic create command.
     -->
     <form
       v-if="showCreate"
@@ -546,7 +922,54 @@ async function removeTag(i: Issue, key: string) {
       </div>
     </form>
 
-    <p v-if="error" class="mb-3 text-sm text-block" data-testid="issues-error">{{ error }}</p>
+    <div
+      v-if="batchFeedback"
+      :role="batchFeedback.success ? 'status' : 'alert'"
+      :class="
+        batchFeedback.success
+          ? 'border-ok-line bg-ok-soft text-ok'
+          : 'border-block-line bg-block-soft text-block'
+      "
+      class="mb-3 rounded border p-3 text-sm"
+      data-testid="issues-batch-feedback"
+    >
+      <p>{{ batchFeedback.message }}</p>
+      <ul v-if="batchFeedback.problems.length" class="mt-2 space-y-1 font-mono text-xs">
+        <li v-for="problem in batchFeedback.problems" :key="`${problem.id}-${problem.code}`">
+          #{{ problem.id }} — {{ problem.error }}
+        </li>
+      </ul>
+      <div v-if="!batchFeedback.success" class="mt-2 flex gap-2">
+        <button
+          v-if="batchFeedback.problems.length"
+          type="button"
+          class="btn-secondary px-2 py-1 text-xs"
+          data-testid="issues-remove-invalid"
+          @click="removeProblemIds"
+        >
+          Remove invalid from selection
+        </button>
+        <button
+          type="button"
+          class="btn-secondary px-2 py-1 text-xs"
+          data-testid="issues-batch-retry"
+          :disabled="batchBusy"
+          @click="retryLastBatch"
+        >
+          Retry batch
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-if="error"
+      role="alert"
+      class="mb-3 flex items-center gap-2 text-sm text-block"
+      data-testid="issues-error"
+    >
+      <span>{{ error }}</span>
+      <button type="button" class="btn-secondary px-2 py-0.5 text-xs" @click="load">Retry</button>
+    </div>
 
     <p v-if="!loaded" class="text-sm text-muted">Loading…</p>
     <p
@@ -554,7 +977,21 @@ async function removeTag(i: Issue, key: string) {
       class="rounded-md border border-dashed border-line p-6 text-center text-sm text-faint"
       data-testid="issues-empty"
     >
-      {{ issues.length ? 'No issues match the current filter.' : 'No issues yet.' }}
+      {{
+        issues.length
+          ? hasScope
+            ? 'No issues match this scope and the current filters.'
+            : 'No issues match the current filters.'
+          : 'No issues yet.'
+      }}
+      <button
+        v-if="hasScope"
+        type="button"
+        class="ml-2 text-accent hover:underline"
+        @click="clearScope"
+      >
+        Clear scope
+      </button>
     </p>
 
     <!-- One bordered board, hairline-divided rows (the fleet-list anatomy).
@@ -566,16 +1003,27 @@ async function removeTag(i: Issue, key: string) {
       data-testid="issues-list"
     >
       <li
-        v-for="i in visible"
+        v-for="i in pageIssues"
         :key="i.id"
         class="group border-b border-line px-3 py-2 last:border-0 transition-colors hover:bg-subtle/50"
-        :class="{ 'opacity-60': i.status !== 'open' }"
+        :class="{
+          'opacity-60': i.status !== 'open',
+          'bg-info-soft/60': selected.has(i.id),
+        }"
         data-testid="issue-row"
         :data-issue-id="i.id"
       >
         <!-- Row 1: status dot · id · title (click to edit) · repo chip ·
              actions (hover-revealed) · freshness -->
         <div class="flex items-center gap-2">
+          <input
+            type="checkbox"
+            class="shrink-0 accent-accent"
+            data-testid="issue-select"
+            :checked="selected.has(i.id)"
+            :aria-label="`Select issue #${i.id}: ${i.title}`"
+            @click.stop="toggleSelection(i, $event)"
+          />
           <span
             class="flex shrink-0 items-center gap-1.5 font-mono text-2xs"
             :class="i.status === 'open' ? 'text-accent' : 'text-faint'"
@@ -591,7 +1039,7 @@ async function removeTag(i: Issue, key: string) {
           <span class="shrink-0 font-mono text-2xs text-faint">#{{ i.id }}</span>
           <button
             type="button"
-            class="min-w-0 flex-1 truncate text-left font-serif text-[15px] text-fg hover:text-accent"
+            class="min-w-0 flex-1 truncate text-left text-sm text-fg hover:text-accent"
             :class="{ 'line-through decoration-muted': i.status !== 'open' }"
             data-testid="issue-title"
             :title="editing === i.id ? 'Collapse editor' : 'Edit issue'"
@@ -674,7 +1122,7 @@ async function removeTag(i: Issue, key: string) {
               class="rounded px-1.5 py-0.5 text-2xs text-muted hover:bg-block-soft hover:text-block"
               data-testid="issue-delete"
               :disabled="busy[i.id]"
-              @click="remove(i)"
+              @click="requestDelete(i)"
             >
               Delete
             </button>
@@ -813,5 +1261,102 @@ async function removeTag(i: Issue, key: string) {
         </div>
       </li>
     </ul>
+
+    <nav
+      v-if="visible.length > PAGE_SIZE"
+      class="mt-3 flex items-center justify-between text-xs text-muted"
+      aria-label="Issue pages"
+      data-testid="issues-pagination"
+    >
+      <span>
+        {{ (page - 1) * PAGE_SIZE + 1 }}–{{ Math.min(page * PAGE_SIZE, visible.length) }} of
+        {{ visible.length }}
+      </span>
+      <span class="flex items-center gap-2">
+        <button
+          type="button"
+          class="btn-secondary px-2 py-1"
+          data-testid="issues-page-previous"
+          :disabled="page === 1"
+          @click="page--"
+        >
+          Previous
+        </button>
+        <span class="font-mono">Page {{ page }} / {{ pageCount }}</span>
+        <button
+          type="button"
+          class="btn-secondary px-2 py-1"
+          data-testid="issues-page-next"
+          :disabled="page === pageCount"
+          @click="page++"
+        >
+          Next
+        </button>
+      </span>
+    </nav>
+
+    <ConfirmDialog
+      :open="deleteRequest !== null"
+      :title="
+        deleteRequest?.single
+          ? `Delete issue #${deleteRequest.single.id}?`
+          : 'Delete selected issues?'
+      "
+      :description="
+        deleteRequest?.single
+          ? `Permanently delete “${deleteRequest.single.title}”. This cannot be undone.`
+          : `Permanently delete ${deleteRequest?.ids.length ?? 0} selected issues${
+              hasScope ? ' in the active scope' : ''
+            }. This cannot be undone.`
+      "
+      confirm-label="Delete permanently"
+      danger
+      :busy="batchBusy || Boolean(deleteRequest?.single && busy[deleteRequest.single.id])"
+      @cancel="deleteRequest = null"
+      @confirm="confirmDelete"
+    />
+
+    <ConfirmDialog
+      :open="tagDialogOpen"
+      title="Update tags"
+      :description="`Apply one tag action atomically to ${selectedCount} selected issue${
+        selectedCount === 1 ? '' : 's'
+      }${hasScope ? ' in the active scope' : ''}.`"
+      :confirm-label="tagMode === 'tag' ? 'Apply tag' : 'Remove tag'"
+      :busy="batchBusy"
+      @cancel="tagDialogOpen = false"
+      @confirm="confirmTag"
+    >
+      <div class="space-y-3">
+        <label class="block text-sm text-muted">
+          Action
+          <select
+            v-model="tagMode"
+            class="mt-1 w-full rounded border border-line bg-input px-2 py-1.5 text-fg"
+            data-testid="issues-tag-mode"
+          >
+            <option value="tag">Set tag</option>
+            <option value="untag">Remove tag</option>
+          </select>
+        </label>
+        <label class="block text-sm text-muted">
+          Key
+          <input
+            v-model="bulkTagKey"
+            class="mt-1 w-full rounded border border-line bg-input px-2 py-1.5 text-fg"
+            data-testid="issues-bulk-tag-key"
+          />
+        </label>
+        <label v-if="tagMode === 'tag'" class="block text-sm text-muted">
+          Value
+          <input
+            v-model="bulkTagValue"
+            class="mt-1 w-full rounded border border-line bg-input px-2 py-1.5 text-fg"
+            data-testid="issues-bulk-tag-value"
+          />
+        </label>
+        <p v-if="bulkTagError" role="alert" class="text-sm text-block">{{ bulkTagError }}</p>
+      </div>
+    </ConfirmDialog>
   </div>
 </template>

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -9,6 +9,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use serde_json::{json, Value};
+use weaver_api::{IssueAction, IssueActionsReq};
 
 use loom::client::{self, Client};
 use weaver_core::db::Db;
@@ -135,7 +136,7 @@ enum Cmd {
         #[command(subcommand)]
         cmd: DeploymentCmd,
     },
-    /// Show the repo's issue board (every issue across branches + backlog).
+    /// Inspect and triage issues with atomic batch actions.
     Issue {
         #[command(subcommand)]
         cmd: IssueCmd,
@@ -227,7 +228,7 @@ enum ServerCmd {
     Status,
 }
 
-/// Subcommands under `loom issue` — the read-only issue board.
+/// Subcommands under `loom issue`.
 #[derive(Subcommand)]
 enum IssueCmd {
     /// Show the repo's issue board (every issue across branches + backlog).
@@ -238,6 +239,40 @@ enum IssueCmd {
         /// Show only the unclaimed backlog.
         #[arg(long)]
         backlog: bool,
+    },
+    /// Close every issue in one atomic command.
+    Close {
+        #[arg(required = true)]
+        ids: Vec<i64>,
+    },
+    /// Reopen every issue in one atomic command.
+    Reopen {
+        #[arg(required = true)]
+        ids: Vec<i64>,
+    },
+    /// Set one tag on every issue in one atomic command.
+    Tag {
+        #[arg(long)]
+        key: String,
+        #[arg(long)]
+        value: String,
+        #[arg(long, default_value = "")]
+        note: String,
+        #[arg(required = true)]
+        ids: Vec<i64>,
+    },
+    /// Remove one tag from every issue in one atomic command.
+    Untag {
+        #[arg(long)]
+        key: String,
+        #[arg(required = true)]
+        ids: Vec<i64>,
+    },
+    /// Permanently delete every issue in one atomic command.
+    #[command(alias = "rm")]
+    Delete {
+        #[arg(required = true)]
+        ids: Vec<i64>,
     },
 }
 
@@ -976,10 +1011,34 @@ async fn run_server(cmd: ServerCmd) -> Result<()> {
     }
 }
 
-/// Dispatch the `loom issue <verb>` subcommands (the read-only board).
+/// Dispatch the `loom issue <verb>` subcommands.
 async fn run_issue(cmd: IssueCmd) -> Result<()> {
     match cmd {
         IssueCmd::Ls { all, backlog } => cmd_issues(all, backlog).await,
+        IssueCmd::Close { ids } => cmd_issue_action(ids, IssueAction::Close, "closed").await,
+        IssueCmd::Reopen { ids } => cmd_issue_action(ids, IssueAction::Reopen, "reopened").await,
+        IssueCmd::Tag {
+            key,
+            value,
+            note,
+            ids,
+        } => {
+            cmd_issue_action(
+                ids,
+                IssueAction::Tag {
+                    key,
+                    value,
+                    note,
+                    by: Some("manual".to_string()),
+                },
+                "tagged",
+            )
+            .await
+        }
+        IssueCmd::Untag { key, ids } => {
+            cmd_issue_action(ids, IssueAction::Untag { key }, "untagged").await
+        }
+        IssueCmd::Delete { ids } => cmd_issue_action(ids, IssueAction::Delete, "deleted").await,
     }
 }
 
@@ -3205,6 +3264,38 @@ async fn cmd_issues(all: bool, backlog: bool) -> Result<()> {
     Ok(())
 }
 
+async fn cmd_issue_action(ids: Vec<i64>, action: IssueAction, verb: &str) -> Result<()> {
+    let count = ids.len();
+    let result = client::default()?
+        .issue_actions(&IssueActionsReq { ids, action })
+        .await?;
+    let affected = result.issues.len() + result.deleted_ids.len();
+    if affected != count {
+        bail!("server returned {affected} affected issues for a {count}-issue command");
+    }
+    println!(
+        "{verb} {affected} issue{}",
+        if affected == 1 { "" } else { "s" }
+    );
+    let ids = if result.deleted_ids.is_empty() {
+        result
+            .issues
+            .into_iter()
+            .map(|issue| issue.id)
+            .collect::<Vec<_>>()
+    } else {
+        result.deleted_ids
+    };
+    println!(
+        "{}",
+        ids.into_iter()
+            .map(|id| format!("#{id}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    Ok(())
+}
+
 async fn cmd_show(key: String) -> Result<()> {
     let client = client::default()?;
     let ws = client
@@ -3880,6 +3971,31 @@ mod tests {
                 }
             } if name == "production"
         ));
+    }
+
+    #[test]
+    fn issue_bulk_commands_parse_multiple_ids() {
+        let Cli { cmd, .. } = Cli::try_parse_from([
+            "loom", "issue", "tag", "--key", "area", "--value", "ui", "41", "42",
+        ])
+        .unwrap();
+        match cmd {
+            Cmd::Issue {
+                cmd:
+                    IssueCmd::Tag {
+                        key,
+                        value,
+                        note,
+                        ids,
+                    },
+            } => {
+                assert_eq!(key, "area");
+                assert_eq!(value, "ui");
+                assert!(note.is_empty());
+                assert_eq!(ids, vec![41, 42]);
+            }
+            _ => panic!("expected issue tag command"),
+        }
     }
 
     #[test]

--- a/crates/loom/src/web/issues.rs
+++ b/crates/loom/src/web/issues.rs
@@ -6,9 +6,12 @@ use axum::{
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
-use weaver_api::{CreateIssueReq, CreateRepoIssueReq, IssueView, PatchIssueReq, TagReq};
+use weaver_api::{
+    CreateIssueReq, CreateRepoIssueReq, IssueAction, IssueActionProblem as IssueActionProblemView,
+    IssueActionsReq, IssueActionsResult, IssueTagInput, IssueView, PatchIssueReq, TagReq,
+};
 use weaver_core::branch as branch_mod;
-use weaver_core::issue::Issue;
+use weaver_core::issue::{BulkIssueAction, Issue, NewIssueTag};
 
 use crate::db::Db;
 use crate::events;
@@ -53,6 +56,35 @@ async fn issue_views(db: &Db, issues: Vec<Issue>) -> ApiResult<Vec<IssueView>> {
         out.push(issue_view(db, i).await?);
     }
     Ok(out)
+}
+
+fn initial_issue_tags(tags: Vec<IssueTagInput>) -> ApiResult<Vec<NewIssueTag>> {
+    let mut seen = std::collections::HashSet::new();
+    tags.into_iter()
+        .map(|tag| {
+            let key = tag.key.trim();
+            let value = tag.value.trim();
+            if key.is_empty() {
+                return Err(AppError::bad_request("tag key is required"));
+            }
+            if value.is_empty() {
+                return Err(AppError::bad_request(format!(
+                    "invalid value for '{key}' — must be non-empty"
+                )));
+            }
+            if !seen.insert(key.to_string()) {
+                return Err(AppError::bad_request(format!(
+                    "duplicate initial tag key '{key}'"
+                )));
+            }
+            Ok(NewIssueTag {
+                key: key.to_string(),
+                value: value.to_string(),
+                note: tag.note.trim().to_string(),
+                set_by: author_or_manual(tag.by.as_deref()),
+            })
+        })
+        .collect()
 }
 
 /// Every issue across every repo — the loom dashboard's cross-repo issue board.
@@ -113,8 +145,9 @@ pub(super) async fn create_branch_issue(
     if req.title.trim().is_empty() {
         return Err(AppError::bad_request("issue title is required"));
     }
+    let tags = initial_issue_tags(req.tags)?;
     let branch = require_branch(&st.db, &key).await?;
-    let issue = weaver_core::issue::add(
+    let issue = weaver_core::issue::add_with_tags(
         &st.db,
         &weaver_core::issue::NewIssue {
             repo_root: branch.repo_root.clone(),
@@ -125,6 +158,7 @@ pub(super) async fn create_branch_issue(
             github_issue: req.github_issue,
             ..Default::default()
         },
+        &tags,
     )
     .await?;
     events::record(
@@ -152,6 +186,66 @@ async fn issue_event_branch(db: &Db, issue: &Issue) -> Option<String> {
         .ok()
         .flatten()?;
     Some(branch.id)
+}
+
+async fn record_issue_event(st: &AppState, issue: &Issue, kind: &str, payload: Value) {
+    if let Some(branch_id) = issue_event_branch(&st.db, issue).await {
+        events::record(&st.db, &st.bus, &branch_id, kind, payload)
+            .await
+            .ok();
+    }
+}
+
+async fn change_issue_status(st: &AppState, issue: &Issue, status: &str) -> ApiResult<()> {
+    let kind = match status {
+        "open" => {
+            weaver_core::issue::reopen(&st.db, issue.id).await?;
+            "issue_reopened"
+        }
+        "closed" => {
+            weaver_core::issue::close(&st.db, issue.id).await?;
+            "issue_closed"
+        }
+        other => {
+            return Err(AppError::bad_request(format!(
+                "invalid status '{other}' (expected 'open' or 'closed')"
+            )))
+        }
+    };
+    tracing::info!(issue = issue.id, status, "issue status changed");
+    record_issue_event(st, issue, kind, json!({ "id": issue.id })).await;
+    Ok(())
+}
+
+async fn set_issue_tag_value(
+    st: &AppState,
+    issue: &Issue,
+    key: &str,
+    value: &str,
+    note: &str,
+    by: &str,
+) -> ApiResult<()> {
+    weaver_core::issue::set_tag(&st.db, issue.id, key, value, note, by).await?;
+    record_issue_event(
+        st,
+        issue,
+        "issue_tagged",
+        json!({ "id": issue.id, "key": key, "value": value }),
+    )
+    .await;
+    Ok(())
+}
+
+async fn clear_issue_tag_value(st: &AppState, issue: &Issue, key: &str) -> ApiResult<()> {
+    weaver_core::issue::clear_tag(&st.db, issue.id, key).await?;
+    record_issue_event(
+        st,
+        issue,
+        "issue_tagged",
+        json!({ "id": issue.id, "key": key, "value": "" }),
+    )
+    .await;
+    Ok(())
 }
 
 pub(super) async fn get_issue(
@@ -205,26 +299,7 @@ pub(super) async fn patch_issue(
         ));
     }
     if let Some(status) = req.status.as_deref() {
-        match status {
-            "open" => weaver_core::issue::reopen(&st.db, id).await?,
-            "closed" => weaver_core::issue::close(&st.db, id).await?,
-            other => {
-                return Err(AppError::bad_request(format!(
-                    "invalid status '{other}' (expected 'open' or 'closed')"
-                )));
-            }
-        }
-        tracing::info!(issue = id, status, "issue status changed");
-        let kind = if status == "open" {
-            "issue_reopened"
-        } else {
-            "issue_closed"
-        };
-        if let Some(branch_id) = issue_event_branch(&st.db, &existing).await {
-            events::record(&st.db, &st.bus, &branch_id, kind, json!({ "id": id }))
-                .await
-                .ok();
-        }
+        change_issue_status(&st, &existing, status).await?;
     }
     if req.title.is_some() || req.body.is_some() {
         let new_title = req.title.as_deref().unwrap_or(&existing.title);
@@ -297,18 +372,7 @@ pub(super) async fn set_issue_tag(
     }
     let by = author_or_manual(req.by.as_deref());
     let note = req.note.trim();
-    weaver_core::issue::set_tag(&st.db, id, key, value, note, &by).await?;
-    if let Some(branch_id) = issue_event_branch(&st.db, &issue).await {
-        events::record(
-            &st.db,
-            &st.bus,
-            &branch_id,
-            "issue_tagged",
-            json!({ "id": id, "key": key, "value": value }),
-        )
-        .await
-        .ok();
-    }
+    set_issue_tag_value(&st, &issue, key, value, note, &by).await?;
     let issue = weaver_core::issue::get(&st.db, id)
         .await?
         .ok_or_else(|| AppError::not_found("issue"))?;
@@ -324,18 +388,7 @@ pub(super) async fn clear_issue_tag(
     let issue = weaver_core::issue::get(&st.db, id)
         .await?
         .ok_or_else(|| AppError::not_found("issue"))?;
-    weaver_core::issue::clear_tag(&st.db, id, tag_key.trim()).await?;
-    if let Some(branch_id) = issue_event_branch(&st.db, &issue).await {
-        events::record(
-            &st.db,
-            &st.bus,
-            &branch_id,
-            "issue_tagged",
-            json!({ "id": id, "key": tag_key.trim(), "value": "" }),
-        )
-        .await
-        .ok();
-    }
+    clear_issue_tag_value(&st, &issue, tag_key.trim()).await?;
     let issue = weaver_core::issue::get(&st.db, id)
         .await?
         .ok_or_else(|| AppError::not_found("issue"))?;
@@ -352,6 +405,114 @@ pub(super) async fn delete_issue(
     weaver_core::issue::delete(&st.db, id).await?;
     tracing::info!(issue = id, "issue deleted");
     Ok(Json(json!({ "deleted": true })))
+}
+
+fn validate_issue_action(action: &IssueAction) -> ApiResult<()> {
+    let (key, value) = match action {
+        IssueAction::Tag { key, value, .. } => (Some(key.trim()), Some(value.trim())),
+        IssueAction::Untag { key } => (Some(key.trim()), None),
+        _ => (None, None),
+    };
+    if key.is_some_and(str::is_empty) {
+        return Err(AppError::bad_request("tag key is required"));
+    }
+    if value.is_some_and(str::is_empty) {
+        return Err(AppError::bad_request("tag value must be non-empty"));
+    }
+    Ok(())
+}
+
+fn domain_issue_action(action: &IssueAction) -> BulkIssueAction {
+    match action {
+        IssueAction::Close => BulkIssueAction::Close,
+        IssueAction::Reopen => BulkIssueAction::Reopen,
+        IssueAction::Tag {
+            key,
+            value,
+            note,
+            by,
+        } => BulkIssueAction::Tag {
+            key: key.trim().to_string(),
+            value: value.trim().to_string(),
+            note: note.trim().to_string(),
+            set_by: author_or_manual(by.as_deref()),
+        },
+        IssueAction::Untag { key } => BulkIssueAction::Untag {
+            key: key.trim().to_string(),
+        },
+        IssueAction::Delete => BulkIssueAction::Delete,
+    }
+}
+
+/// Validate an issue command and every target before applying the whole batch
+/// in one transaction. Invalid IDs and preconditions are returned together in
+/// structured error details; no requested issue changes.
+pub(super) async fn issue_actions(
+    State(st): State<AppState>,
+    Json(req): Json<IssueActionsReq>,
+) -> ApiResult<Json<IssueActionsResult>> {
+    if req.ids.is_empty() {
+        return Err(AppError::bad_request("at least one issue id is required"));
+    }
+    let mut seen = std::collections::HashSet::new();
+    if req.ids.iter().any(|id| !seen.insert(*id)) {
+        return Err(AppError::bad_request("issue ids must be unique"));
+    }
+    validate_issue_action(&req.action)?;
+
+    let action = domain_issue_action(&req.action);
+    let result = match weaver_core::issue::apply_bulk_action(&st.db, &req.ids, &action).await {
+        Ok(result) => result,
+        Err(error) => {
+            if let Some(validation) =
+                error.downcast_ref::<weaver_core::issue::IssueActionValidationError>()
+            {
+                let problems: Vec<IssueActionProblemView> = validation
+                    .problems
+                    .iter()
+                    .map(|problem| IssueActionProblemView {
+                        id: problem.id,
+                        code: problem.code.clone(),
+                        error: problem.error.clone(),
+                    })
+                    .collect();
+                let summary = problems
+                    .iter()
+                    .map(|problem| format!("#{} {}", problem.id, problem.error))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                return Err(AppError::conflict(format!("{} — {summary}", validation))
+                    .with_details(json!({
+                        "problems": problems,
+                    })));
+            }
+            return Err(error.into());
+        }
+    };
+
+    let event = match &req.action {
+        IssueAction::Close => Some(("issue_closed", json!({}))),
+        IssueAction::Reopen => Some(("issue_reopened", json!({}))),
+        IssueAction::Tag { key, value, .. } => Some((
+            "issue_tagged",
+            json!({ "key": key.trim(), "value": value.trim() }),
+        )),
+        IssueAction::Untag { key } => {
+            Some(("issue_tagged", json!({ "key": key.trim(), "value": "" })))
+        }
+        IssueAction::Delete => None,
+    };
+    if let Some((kind, fields)) = event {
+        for issue in &result.issues {
+            let mut payload = fields.clone();
+            payload["id"] = json!(issue.id);
+            record_issue_event(&st, issue, kind, payload).await;
+        }
+    }
+    Ok(Json(IssueActionsResult {
+        issues: issue_views(&st.db, result.issues).await?,
+        deleted_ids: result.deleted_ids,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -422,7 +583,8 @@ pub(super) async fn create_repo_issue(
     if req.repo_root.trim().is_empty() {
         return Err(AppError::bad_request("repo_root is required"));
     }
-    let issue = weaver_core::issue::add(
+    let tags = initial_issue_tags(req.tags)?;
+    let issue = weaver_core::issue::add_with_tags(
         &st.db,
         &weaver_core::issue::NewIssue {
             repo_root: req.repo_root.clone(),
@@ -432,6 +594,7 @@ pub(super) async fn create_repo_issue(
             github_issue: req.github_issue,
             ..Default::default()
         },
+        &tags,
     )
     .await?;
     // Attribute the add to the filing branch, when there is one, so its
@@ -490,6 +653,7 @@ mod tests {
                 body: String::new(),
                 github_issue: None,
                 source_branch: Some("weaver/a".to_string()),
+                tags: Vec::new(),
             }),
         )
         .await
@@ -587,5 +751,88 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(err.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn issue_actions_returns_one_aggregate_success() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let st = test_state(db.clone());
+        let first = weaver_core::issue::add(
+            &db,
+            &weaver_core::issue::NewIssue {
+                repo_root: "/r".to_string(),
+                title: "first".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let second = weaver_core::issue::add(
+            &db,
+            &weaver_core::issue::NewIssue {
+                repo_root: "/r".to_string(),
+                title: "second".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = issue_actions(
+            State(st),
+            Json(IssueActionsReq {
+                ids: vec![first.id, second.id],
+                action: IssueAction::Close,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        assert_eq!(result.issues.len(), 2);
+        assert!(result.issues.iter().all(|issue| issue.status == "closed"));
+        assert!(result.deleted_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn issue_actions_reports_invalid_ids_and_commits_nothing() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let st = test_state(db.clone());
+        let issue = weaver_core::issue::add(
+            &db,
+            &weaver_core::issue::NewIssue {
+                repo_root: "/r".to_string(),
+                title: "must stay open".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = issue_actions(
+            State(st),
+            Json(IssueActionsReq {
+                ids: vec![issue.id, 999_999],
+                action: IssueAction::Close,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.status(), axum::http::StatusCode::CONFLICT);
+        assert_eq!(
+            error.details.as_ref().unwrap()["problems"][0],
+            json!({
+                "id": 999_999,
+                "code": "not_found",
+                "error": "issue not found",
+            })
+        );
+        assert_eq!(
+            weaver_core::issue::get(&db, issue.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            "open"
+        );
     }
 }

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -16,6 +16,7 @@
 //!   session). `/api/branches/{id}` — GET / PATCH (goal / title / description).
 //! * `/api/branches/{id}/issues` — list / POST issues for a branch.
 //! * `/api/issues/{id}` — GET / PATCH / DELETE an issue by id.
+//! * `/api/issues/actions` — validate and atomically mutate a set of issues.
 //! * `/api/health` + `/api/health/live` are process-level liveness;
 //!   `/api/ready` checks the database and migration streams; `/metrics` exposes
 //!   bounded-label OpenMetrics; `/api/diagnostics` is the admin inventory.
@@ -736,6 +737,7 @@ pub fn router(state: AppState) -> Router {
         )
         // The cross-repo issue board (the loom Issues pane consumes this).
         .route("/issues", get(list_all_issues))
+        .route("/issues/actions", post(issue_actions))
         .route(
             "/issues/{id}",
             get(get_issue).patch(patch_issue).delete(delete_issue),

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -15,10 +15,11 @@ use crate::dto::{
     AutomationTokenView, BranchStatusReq, BranchView, CommentDto, CreateEventReq, CreateIssueReq,
     CreateRepoIssueReq, CreateReq, CreateTokenReq, CreateWatchReq, CreatedTokenView, CustomMcpReq,
     CustomMcpView, DeploymentReq, DeploymentView, DiagnosticsView, EffectiveProfileView,
-    FederationReq, FederationView, HandoffReq, HistoryPageView, IssueView, McpRegistryView,
-    NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileProbeView,
-    ProfileReq, ProfileView, PutProfileEnvReq, ReadinessView, RunReq, RunView, RunWatchReq,
-    SendReq, SessionView, SetTagsReq, SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
+    FederationReq, FederationView, HandoffReq, HistoryPageView, IssueActionsReq,
+    IssueActionsResult, IssueView, McpRegistryView, NewCommentBody, NewThreadBody, PatchIssueReq,
+    PatchSessionReq, PatchWatchReq, ProfileProbeView, ProfileReq, ProfileView, PutProfileEnvReq,
+    ReadinessView, RunReq, RunView, RunWatchReq, SendReq, SessionView, SetTagsReq,
+    SettingsEnvelope, TagReq, ThreadDto, TokenView, WatchView,
 };
 
 /// A client for one loom server, identified by its base URL.
@@ -696,6 +697,15 @@ impl Client {
     /// Patch an issue's title/body/status (`PATCH /api/issues/{id}`).
     pub async fn patch_issue(&self, id: i64, req: &PatchIssueReq) -> Result<IssueView> {
         self.send_typed(Method::PATCH, &format!("/api/issues/{id}"), Some(req))
+            .await
+    }
+
+    /// Apply one command to a set of issues (`POST /api/issues/actions`).
+    ///
+    /// The server validates every id and precondition before applying the
+    /// command atomically. Validation failure changes nothing.
+    pub async fn issue_actions(&self, req: &IssueActionsReq) -> Result<IssueActionsResult> {
+        self.send_typed(Method::POST, "/api/issues/actions", Some(req))
             .await
     }
 

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -863,6 +863,63 @@ pub struct IssueView {
     pub github_state: Option<GithubThreadState>,
 }
 
+/// One initial tag supplied while creating an issue.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IssueTagInput {
+    pub key: String,
+    pub value: String,
+    #[serde(default)]
+    pub note: String,
+    #[serde(default)]
+    pub by: Option<String>,
+}
+
+/// One command validated and applied atomically to every requested issue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum IssueAction {
+    Close,
+    Reopen,
+    Tag {
+        key: String,
+        value: String,
+        #[serde(default)]
+        note: String,
+        #[serde(default)]
+        by: Option<String>,
+    },
+    Untag {
+        key: String,
+    },
+    Delete,
+}
+
+/// Body for `POST /api/issues/actions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueActionsReq {
+    pub ids: Vec<i64>,
+    pub action: IssueAction,
+}
+
+/// One ID or precondition reported in an atomic action error's `details`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueActionProblem {
+    pub id: i64,
+    /// Stable machine-readable category such as `not_found`, `invalid_state`,
+    /// or `missing_tag`.
+    pub code: String,
+    pub error: String,
+}
+
+/// Aggregate outcome from a successful atomic `POST /api/issues/actions`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IssueActionsResult {
+    /// Updated issue views for close, reopen, tag, and untag.
+    pub issues: Vec<IssueView>,
+    /// Deleted IDs for delete. Empty for every other action.
+    pub deleted_ids: Vec<i64>,
+}
+
 /// The minimal live snapshot of a GitHub thread `weaver issue show` renders
 /// beside the weaver ledger: enough to notice "this was closed / re-titled
 /// while I worked". An agent that needs the discussion reads it with `gh`.
@@ -1423,6 +1480,8 @@ pub struct CreateIssueReq {
     pub body: String,
     #[serde(default)]
     pub github_issue: Option<i64>,
+    #[serde(default)]
+    pub tags: Vec<IssueTagInput>,
 }
 
 /// Body for `PATCH /api/issues/{id}`: every mutable field optional.
@@ -1476,6 +1535,8 @@ pub struct CreateRepoIssueReq {
     /// a live branch in this repo, an `issue_added` event is recorded there.
     #[serde(default)]
     pub source_branch: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<IssueTagInput>,
 }
 
 /// Body for `PUT /api/sessions/{id}/artifacts/{name}`: a user edit that appends

--- a/crates/weaver-core/src/issue.rs
+++ b/crates/weaver-core/src/issue.rs
@@ -14,6 +14,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use std::fmt;
 
 use crate::db::{now_iso, Db};
 use crate::tags::Tag;
@@ -48,8 +49,23 @@ pub struct NewIssue {
     pub github_issue: Option<i64>,
 }
 
+/// One tag to persist with a newly-created issue.
+#[derive(Debug, Clone)]
+pub struct NewIssueTag {
+    pub key: String,
+    pub value: String,
+    pub note: String,
+    pub set_by: String,
+}
+
 /// Create a new issue. Returns the persisted row.
 pub async fn add(db: &Db, new: &NewIssue) -> Result<Issue> {
+    add_with_tags(db, new, &[]).await
+}
+
+/// Create an issue and its initial tags in one transaction.
+pub async fn add_with_tags(db: &Db, new: &NewIssue, tags: &[NewIssueTag]) -> Result<Issue> {
+    let mut tx = crate::db::begin_immediate(db).await?;
     let now = now_iso();
     let row: (i64,) = sqlx::query_as(
         "INSERT INTO issues
@@ -66,13 +82,232 @@ pub async fn add(db: &Db, new: &NewIssue) -> Result<Issue> {
     .bind(new.github_issue)
     .bind(&now)
     .bind(&now)
-    .fetch_one(db)
+    .fetch_one(&mut *tx)
     .await?;
-    let issue = get(db, row.0)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("issue vanished after insert"))?;
+    for tag in tags {
+        sqlx::query(
+            "INSERT INTO issue_tags (issue_id, key, value, note, set_by, set_at)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(row.0)
+        .bind(&tag.key)
+        .bind(&tag.value)
+        .bind(&tag.note)
+        .bind(&tag.set_by)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await?;
+    }
+    let issue = sqlx::query_as::<_, Issue>("SELECT * FROM issues WHERE id = ?")
+        .bind(row.0)
+        .fetch_one(&mut *tx)
+        .await?;
+    tx.commit().await?;
     tracing::info!(issue = issue.id, title = %issue.title, "issue created");
     Ok(issue)
+}
+
+/// One bulk mutation supported by the issue command endpoint.
+#[derive(Debug, Clone)]
+pub enum BulkIssueAction {
+    Close,
+    Reopen,
+    Tag {
+        key: String,
+        value: String,
+        note: String,
+        set_by: String,
+    },
+    Untag {
+        key: String,
+    },
+    Delete,
+}
+
+/// One ID or precondition that makes a bulk issue action invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueActionProblem {
+    pub id: i64,
+    pub code: String,
+    pub error: String,
+}
+
+/// Validation failure from [`apply_bulk_action`]. No mutation has occurred.
+#[derive(Debug)]
+pub struct IssueActionValidationError {
+    pub problems: Vec<IssueActionProblem>,
+}
+
+impl fmt::Display for IssueActionValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "issue action validation failed for {} item{}",
+            self.problems.len(),
+            if self.problems.len() == 1 { "" } else { "s" }
+        )
+    }
+}
+
+impl std::error::Error for IssueActionValidationError {}
+
+/// Aggregate result from an atomic issue action. `issues` contains the updated
+/// rows for non-delete actions; deletes return their IDs in `deleted_ids`.
+#[derive(Debug)]
+pub struct BulkIssueActionResult {
+    pub issues: Vec<Issue>,
+    pub deleted_ids: Vec<i64>,
+}
+
+/// Validate every ID and action precondition, then apply the whole command in
+/// one transaction. Any validation or database failure leaves every issue
+/// unchanged.
+pub async fn apply_bulk_action(
+    db: &Db,
+    ids: &[i64],
+    action: &BulkIssueAction,
+) -> Result<BulkIssueActionResult> {
+    let mut tx = crate::db::begin_immediate(db).await?;
+    let mut issues = Vec::with_capacity(ids.len());
+    let mut problems = Vec::new();
+
+    for id in ids {
+        let issue = sqlx::query_as::<_, Issue>("SELECT * FROM issues WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&mut *tx)
+            .await?;
+        let Some(issue) = issue else {
+            problems.push(IssueActionProblem {
+                id: *id,
+                code: "not_found".to_string(),
+                error: "issue not found".to_string(),
+            });
+            continue;
+        };
+        let state_problem = match action {
+            BulkIssueAction::Close if issue.status != "open" => {
+                Some(("invalid_state", "issue is already closed"))
+            }
+            BulkIssueAction::Reopen if issue.status != "closed" => {
+                Some(("invalid_state", "issue is already open"))
+            }
+            BulkIssueAction::Untag { key } => {
+                let exists: Option<(i64,)> =
+                    sqlx::query_as("SELECT 1 FROM issue_tags WHERE issue_id = ? AND key = ?")
+                        .bind(issue.id)
+                        .bind(key)
+                        .fetch_optional(&mut *tx)
+                        .await?;
+                if exists.is_none() {
+                    Some(("missing_tag", "issue does not have this tag"))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if let Some((code, error)) = state_problem {
+            problems.push(IssueActionProblem {
+                id: *id,
+                code: code.to_string(),
+                error: error.to_string(),
+            });
+        }
+        issues.push(issue);
+    }
+
+    if !problems.is_empty() {
+        tx.rollback().await?;
+        return Err(IssueActionValidationError { problems }.into());
+    }
+
+    let now = now_iso();
+    for issue in &issues {
+        match action {
+            BulkIssueAction::Close => {
+                sqlx::query(
+                    "UPDATE issues SET status = 'closed', closed_at = ?, updated_at = ?
+                     WHERE id = ?",
+                )
+                .bind(&now)
+                .bind(&now)
+                .bind(issue.id)
+                .execute(&mut *tx)
+                .await?;
+            }
+            BulkIssueAction::Reopen => {
+                sqlx::query(
+                    "UPDATE issues SET status = 'open', closed_at = NULL, updated_at = ?
+                     WHERE id = ?",
+                )
+                .bind(&now)
+                .bind(issue.id)
+                .execute(&mut *tx)
+                .await?;
+            }
+            BulkIssueAction::Tag {
+                key,
+                value,
+                note,
+                set_by,
+            } => {
+                sqlx::query(
+                    "INSERT INTO issue_tags (issue_id, key, value, note, set_by, set_at)
+                     VALUES (?, ?, ?, ?, ?, ?)
+                     ON CONFLICT(issue_id, key) DO UPDATE SET
+                       value = excluded.value, note = excluded.note,
+                       set_by = excluded.set_by, set_at = excluded.set_at",
+                )
+                .bind(issue.id)
+                .bind(key)
+                .bind(value)
+                .bind(note)
+                .bind(set_by)
+                .bind(&now)
+                .execute(&mut *tx)
+                .await?;
+            }
+            BulkIssueAction::Untag { key } => {
+                sqlx::query("DELETE FROM issue_tags WHERE issue_id = ? AND key = ?")
+                    .bind(issue.id)
+                    .bind(key)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+            BulkIssueAction::Delete => {
+                sqlx::query("DELETE FROM issue_tags WHERE issue_id = ?")
+                    .bind(issue.id)
+                    .execute(&mut *tx)
+                    .await?;
+                sqlx::query("DELETE FROM issues WHERE id = ?")
+                    .bind(issue.id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+    }
+
+    let deleted_ids = if matches!(action, BulkIssueAction::Delete) {
+        ids.to_vec()
+    } else {
+        Vec::new()
+    };
+    let mut updated = Vec::new();
+    if deleted_ids.is_empty() {
+        for id in ids {
+            updated.push(
+                sqlx::query_as::<_, Issue>("SELECT * FROM issues WHERE id = ?")
+                    .bind(id)
+                    .fetch_one(&mut *tx)
+                    .await?,
+            );
+        }
+    }
+    tx.commit().await?;
+    Ok(BulkIssueActionResult {
+        issues: updated,
+        deleted_ids,
+    })
 }
 
 pub async fn get(db: &Db, id: i64) -> Result<Option<Issue>> {
@@ -600,5 +835,145 @@ mod tests {
         // Deleting the issue clears its remaining tags.
         delete(&db, i.id).await.unwrap();
         assert!(list_tags(&db, i.id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_with_tags_persists_the_issue_and_labels_together() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let issue = add_with_tags(
+            &db,
+            &claimed("/r", "feature", "tagged at creation"),
+            &[NewIssueTag {
+                key: "priority".to_string(),
+                value: "high".to_string(),
+                note: "ship first".to_string(),
+                set_by: "manual".to_string(),
+            }],
+        )
+        .await
+        .unwrap();
+
+        let tags = list_tags(&db, issue.id).await.unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].key, "priority");
+        assert_eq!(tags[0].value, "high");
+        assert_eq!(tags[0].note, "ship first");
+    }
+
+    #[tokio::test]
+    async fn create_with_tags_rolls_back_the_issue_if_a_tag_fails() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let duplicate = NewIssueTag {
+            key: "priority".to_string(),
+            value: "high".to_string(),
+            note: String::new(),
+            set_by: "manual".to_string(),
+        };
+        add_with_tags(
+            &db,
+            &claimed("/r", "feature", "must roll back"),
+            &[duplicate.clone(), duplicate],
+        )
+        .await
+        .unwrap_err();
+        assert!(list_for_repo(&db, "/r", true).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn bulk_actions_cover_close_reopen_tag_untag_and_delete() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let first = add(&db, &claimed("/r", "feature", "first")).await.unwrap();
+        let second = add(&db, &claimed("/r", "feature", "second")).await.unwrap();
+        let ids = [first.id, second.id];
+
+        let closed = apply_bulk_action(&db, &ids, &BulkIssueAction::Close)
+            .await
+            .unwrap();
+        assert!(closed.issues.iter().all(|issue| issue.status == "closed"));
+        let reopened = apply_bulk_action(&db, &ids, &BulkIssueAction::Reopen)
+            .await
+            .unwrap();
+        assert!(reopened.issues.iter().all(|issue| issue.status == "open"));
+
+        apply_bulk_action(
+            &db,
+            &ids,
+            &BulkIssueAction::Tag {
+                key: "area".to_string(),
+                value: "ui".to_string(),
+                note: String::new(),
+                set_by: "manual".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        for id in ids {
+            assert_eq!(list_tags(&db, id).await.unwrap()[0].value, "ui");
+        }
+
+        apply_bulk_action(
+            &db,
+            &ids,
+            &BulkIssueAction::Untag {
+                key: "area".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        for id in ids {
+            assert!(list_tags(&db, id).await.unwrap().is_empty());
+        }
+
+        let deleted = apply_bulk_action(&db, &ids, &BulkIssueAction::Delete)
+            .await
+            .unwrap();
+        assert_eq!(deleted.deleted_ids, ids);
+        assert!(list_for_repo(&db, "/r", true).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn bulk_action_invalid_id_rolls_back_every_mutation() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let issue = add(&db, &claimed("/r", "feature", "valid")).await.unwrap();
+
+        let error = apply_bulk_action(&db, &[issue.id, 999_999], &BulkIssueAction::Close)
+            .await
+            .unwrap_err();
+        let validation = error.downcast_ref::<IssueActionValidationError>().unwrap();
+        assert_eq!(
+            validation.problems,
+            vec![IssueActionProblem {
+                id: 999_999,
+                code: "not_found".to_string(),
+                error: "issue not found".to_string(),
+            }]
+        );
+        assert_eq!(get(&db, issue.id).await.unwrap().unwrap().status, "open");
+
+        apply_bulk_action(&db, &[issue.id, 999_999], &BulkIssueAction::Delete)
+            .await
+            .unwrap_err();
+        assert!(
+            get(&db, issue.id).await.unwrap().is_some(),
+            "a valid issue must survive when any delete target is invalid"
+        );
+    }
+
+    #[tokio::test]
+    async fn bulk_action_precondition_failure_rolls_back_every_mutation() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let open = add(&db, &claimed("/r", "feature", "open")).await.unwrap();
+        let closed = add(&db, &claimed("/r", "feature", "closed")).await.unwrap();
+        close(&db, closed.id).await.unwrap();
+
+        let error = apply_bulk_action(&db, &[open.id, closed.id], &BulkIssueAction::Close)
+            .await
+            .unwrap_err();
+        let validation = error.downcast_ref::<IssueActionValidationError>().unwrap();
+        assert_eq!(validation.problems.len(), 1);
+        assert_eq!(validation.problems[0].id, closed.id);
+        assert_eq!(validation.problems[0].code, "invalid_state");
+        assert_eq!(get(&db, open.id).await.unwrap().unwrap().status, "open");
+        assert_eq!(get(&db, closed.id).await.unwrap().unwrap().status, "closed");
     }
 }

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -1032,6 +1032,7 @@ async fn cmd_issue(cmd: IssueCmd) -> Result<()> {
                         body: body.unwrap_or_default(),
                         github_issue: github,
                         source_branch: Some(b.branch.clone()),
+                        tags: Vec::new(),
                     })
                     .await?
             } else {
@@ -1042,6 +1043,7 @@ async fn cmd_issue(cmd: IssueCmd) -> Result<()> {
                             title: title.clone(),
                             body: body.unwrap_or_default(),
                             github_issue: github,
+                            tags: Vec::new(),
                         },
                     )
                     .await?

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -295,6 +295,7 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET /api/branches` / `GET PATCH /api/branches/{id}` | list / inspect / edit tracked branches |
 | `GET POST /api/branches/{id}/issues` | issues claimed by the branch / create one |
 | `GET /api/issues?all=…` | the cross-repo issue board (every repo's issues; `all=true` includes closed, `automation=true` includes automation-class sessions' tracking issues, otherwise hidden) — what the loom Issues pane reads |
+| `POST /api/issues/actions` | atomically close, reopen, tag/untag, or delete a validated set of issue IDs; returns updated views/deleted IDs or structured precondition details with no mutation |
 | `GET PATCH DELETE /api/issues/{id}` | per-issue CRUD |
 | `PUT DELETE /api/issues/{id}/tags/{key}` | set (upsert) / clear a free-form issue label — quiet `(key, value)` pills, no loud `attention`/`triage` ladder |
 | `GET POST /api/repos/issues?repo_root=…` | repo-wide board (`scope=repo\|backlog`) / create a backlog item |

--- a/e2e/tests/issues.spec.ts
+++ b/e2e/tests/issues.spec.ts
@@ -12,7 +12,10 @@ test.describe('issues pane', () => {
     page,
     weaver,
   }) => {
-    const session = await weaver.seedSession({ goal: 'do the thing', name: 'feature' });
+    const session = await weaver.seedSession({
+      goal: 'do the thing',
+      name: 'feature',
+    });
     const issue = await weaver.seedIssue(session, 'wire up the routes');
     await weaver.tagIssue(issue.id, 'priority', 'high');
 
@@ -54,6 +57,192 @@ test.describe('issues pane', () => {
     expect(persisted.find((i) => i.id === issue.id)?.status).toBe('closed');
   });
 
+  test('keeps selection across filtering, pagination, and a kept-alive refresh', async ({
+    page,
+    weaver,
+  }) => {
+    const issues = [];
+    for (let index = 0; index < 27; index++) {
+      issues.push(
+        await weaver.seedBacklogIssue(
+          weaver.repoPath,
+          `triage item ${String(index).padStart(2, '0')}`,
+        ),
+      );
+    }
+
+    await page.goto(`${weaver.baseUrl}/issues`);
+    await expect(page.getByTestId('issues-pagination')).toBeVisible();
+    await page.getByTestId('issues-select-visible').click();
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('25 selected');
+
+    await page.getByTestId('issues-page-next').click();
+    const secondPageRows = page.getByTestId('issue-row');
+    await expect(secondPageRows).toHaveCount(2);
+    await secondPageRows.first().getByTestId('issue-select').click();
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('26 selected');
+
+    await page.getByTestId('issues-search').fill('triage item 26');
+    await expect(page.getByTestId('issue-row')).toHaveCount(1);
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('26 selected');
+    await page.getByTestId('issues-search').fill('');
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('26 selected');
+
+    // The remaining matching item can be added explicitly across the whole
+    // filtered result, not only the current page.
+    await page.getByTestId('issues-select-matching').click();
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('27 selected');
+
+    // Client-side navigation keeps Issues alive; activation performs a fresh
+    // API load without discarding the ID-based selection.
+    await page.getByRole('link', { name: 'loom home' }).click();
+    await page.getByRole('link', { name: 'Issues' }).click();
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('27 selected');
+    expect(issues).toHaveLength(27);
+  });
+
+  test('supports keyboard and shift-range additive selection', async ({ page, weaver }) => {
+    const issues = [];
+    for (let index = 0; index < 4; index++) {
+      issues.push(await weaver.seedBacklogIssue(weaver.repoPath, `range item ${index}`));
+    }
+
+    await page.goto(`${weaver.baseUrl}/issues`);
+    const first = page.locator(`[data-issue-id="${issues[0].id}"]`).getByTestId('issue-select');
+    await first.focus();
+    await page.keyboard.press('Space');
+    await page
+      .locator(`[data-issue-id="${issues[3].id}"]`)
+      .getByTestId('issue-select')
+      .click({ modifiers: ['Shift'] });
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('4 selected');
+
+    await page.locator(`[data-issue-id="${issues[1].id}"]`).getByTestId('issue-select').click();
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('3 selected');
+  });
+
+  test('bulk closes selected issues atomically and refreshes once', async ({ page, weaver }) => {
+    const first = await weaver.seedBacklogIssue(weaver.repoPath, 'bulk close first');
+    const second = await weaver.seedBacklogIssue(weaver.repoPath, 'bulk close second');
+    let issueRefreshes = 0;
+    page.on('request', (request) => {
+      if (request.method() === 'GET' && new URL(request.url()).pathname === '/api/issues') {
+        issueRefreshes++;
+      }
+    });
+
+    await page.goto(`${weaver.baseUrl}/issues`);
+    await expect(page.getByTestId('issue-row')).toHaveCount(2);
+    issueRefreshes = 0;
+    await page.locator(`[data-issue-id="${first.id}"]`).getByTestId('issue-select').click();
+    await page.locator(`[data-issue-id="${second.id}"]`).getByTestId('issue-select').click();
+    await page.getByTestId('issues-bulk-close').click();
+
+    await expect(page.getByTestId('issues-batch-feedback')).toContainText(
+      'Close applied to 2 issues.',
+    );
+    expect(issueRefreshes).toBe(1);
+    await expect(page.getByTestId('issue-row')).toHaveCount(0);
+    const persisted = await weaver.listIssues(true);
+    expect(persisted.find((issue) => issue.id === first.id)?.status).toBe('closed');
+    expect(persisted.find((issue) => issue.id === second.id)?.status).toBe('closed');
+  });
+
+  test('cancels and then confirms an accessible bulk delete dialog', async ({ page, weaver }) => {
+    const first = await weaver.seedBacklogIssue(weaver.repoPath, 'bulk delete first');
+    const second = await weaver.seedBacklogIssue(weaver.repoPath, 'bulk delete second');
+
+    await page.goto(`${weaver.baseUrl}/issues`);
+    await page.getByTestId('issues-select-visible').click();
+    const deleteButton = page.getByTestId('issues-bulk-delete');
+    await deleteButton.click();
+    const dialog = page.getByTestId('confirm-dialog');
+    await expect(dialog).toContainText('Permanently delete 2 selected issues');
+    await expect(dialog.getByTestId('confirm-dialog-cancel')).toBeFocused();
+    await page.keyboard.press('Shift+Tab');
+    await expect(dialog.getByTestId('confirm-dialog-confirm')).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+    await expect(deleteButton).toBeFocused();
+    await expect(page.getByTestId('issue-row')).toHaveCount(2);
+
+    await deleteButton.click();
+    await page.getByTestId('confirm-dialog-confirm').click();
+    await expect(page.getByTestId('issues-batch-feedback')).toContainText(
+      'Delete applied to 2 issues.',
+    );
+    await expect(page.getByTestId('issue-row')).toHaveCount(0);
+    const persisted = await weaver.listIssues(true);
+    expect(persisted.some((issue) => issue.id === first.id || issue.id === second.id)).toBe(false);
+  });
+
+  test('shows structured atomic failure details and changes nothing', async ({ page, weaver }) => {
+    const open = await weaver.seedBacklogIssue(weaver.repoPath, 'must stay open');
+    const closed = await weaver.seedBacklogIssue(weaver.repoPath, 'already closed');
+    const response = await page.request.patch(`${weaver.baseUrl}/api/issues/${closed.id}`, {
+      data: { status: 'closed' },
+    });
+    expect(response.ok()).toBe(true);
+
+    await page.goto(`${weaver.baseUrl}/issues`);
+    await page.getByTestId('issues-show-closed').check();
+    await page.locator(`[data-issue-id="${open.id}"]`).getByTestId('issue-select').click();
+    await page.locator(`[data-issue-id="${closed.id}"]`).getByTestId('issue-select').click();
+    await page.getByTestId('issues-bulk-close').click();
+
+    const feedback = page.getByTestId('issues-batch-feedback');
+    await expect(feedback).toHaveAttribute('role', 'alert');
+    await expect(feedback).toContainText('No issues were changed');
+    await expect(feedback).toContainText(`#${closed.id} — issue is already closed`);
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('2 selected');
+    const persisted = await weaver.listIssues(true);
+    expect(persisted.find((issue) => issue.id === open.id)?.status).toBe('open');
+    expect(persisted.find((issue) => issue.id === closed.id)?.status).toBe('closed');
+
+    await page.getByTestId('issues-remove-invalid').click();
+    await expect(page.getByTestId('issues-selected-count')).toHaveText('1 selected');
+    await page.getByTestId('issues-batch-retry').click();
+    await expect(page.getByTestId('issues-batch-feedback')).toContainText(
+      'Close applied to 1 issue.',
+    );
+    const retried = await weaver.listIssues(true);
+    expect(retried.find((issue) => issue.id === open.id)?.status).toBe('closed');
+  });
+
+  test('honors and clears URL-backed repository and branch scope', async ({ page, weaver }) => {
+    const firstSession = await weaver.seedSession({
+      goal: 'one',
+      name: 'scope-one',
+    });
+    const secondSession = await weaver.seedSession({
+      goal: 'two',
+      name: 'scope-two',
+    });
+    const first = await weaver.seedIssue(firstSession, 'first scoped issue');
+    const second = await weaver.seedIssue(secondSession, 'second scoped issue');
+    await weaver.seedBacklogIssue('/a/other-repo', 'outside the scoped repository');
+    const query = new URLSearchParams({
+      repo_root: firstSession.branch.repo_root,
+      branch: firstSession.branch.branch,
+    });
+
+    await page.goto(`${weaver.baseUrl}/issues?${query}`);
+    await expect(page.getByTestId('issues-active-scope')).toContainText('scope-one');
+    await expect(page.getByTestId('issues-open-count')).toHaveText('2 open');
+    await expect(page.locator(`[data-issue-id="${first.id}"]`)).toBeVisible();
+    await expect(page.locator(`[data-issue-id="${second.id}"]`)).toHaveCount(0);
+
+    await page.getByTestId('issue-create-toggle').click();
+    await expect(page.getByTestId('issue-create-repo')).toHaveValue(firstSession.branch.repo_root);
+    await page.getByTestId('issue-create-toggle').click();
+
+    await page.locator(`[data-issue-id="${first.id}"]`).getByTestId('issue-select').click();
+    await page.getByTestId('issues-clear-scope').click();
+    await expect(page.getByTestId('issues-active-scope')).toHaveCount(0);
+    await expect(page.getByTestId('issues-bulk-toolbar')).toHaveCount(0);
+    await expect(page.locator(`[data-issue-id="${second.id}"]`)).toBeVisible();
+  });
+
   test('edits an issue title through the inline editor', async ({ page, weaver }) => {
     const session = await weaver.seedSession({ goal: 'g', name: 'feature' });
     const issue = await weaver.seedIssue(session, 'old title');
@@ -86,7 +275,10 @@ test.describe('issues pane', () => {
     expect(persisted?.claimed_branch).toBeNull();
   });
 
-  test('changes and clears an issue GitHub mapping through the inline editor', async ({ page, weaver }) => {
+  test('changes and clears an issue GitHub mapping through the inline editor', async ({
+    page,
+    weaver,
+  }) => {
     const session = await weaver.seedSession({ goal: 'g', name: 'feature' });
     const issue = await weaver.seedIssue(session, 'remappable');
     await page.goto(`${weaver.baseUrl}/issues`);
@@ -136,16 +328,20 @@ test.describe('issues pane', () => {
     await page.goto(`${weaver.baseUrl}/issues`);
     const row = page.locator(`[data-issue-id="${issue.id}"]`);
 
-    // The delete path guards behind a confirm() — accept it.
-    page.on('dialog', (d) => d.accept());
     await row.getByTestId('issue-delete').click();
+    const dialog = page.getByTestId('confirm-dialog');
+    await expect(dialog).toContainText(`Delete issue #${issue.id}?`);
+    await dialog.getByTestId('confirm-dialog-confirm').click();
 
     await expect(row).toHaveCount(0);
     const persisted = await weaver.listIssues(true);
     expect(persisted.find((i) => i.id === issue.id)).toBeUndefined();
   });
 
-  test('creates a backlog issue with a tag through the New issue form', async ({ page, weaver }) => {
+  test('creates a backlog issue with a tag through the New issue form', async ({
+    page,
+    weaver,
+  }) => {
     // A seeded session puts exactly one repo on the board, so the form's repo
     // field is the static-label case and needs no selection.
     await weaver.seedSession({ goal: 'g', name: 'feature' });


### PR DESCRIPTION
## What

- Add one atomic issue-actions API for close, reopen, tag/untag, and delete, with create-with-tags and structured validation conflicts.
- Turn Issues into a dense, paged triage board with persistent keyboard-accessible selection, scoped URL filters, bulk controls, and retryable failure details.
- Add an accessible in-app confirmation primitive for issue deletion and expose the batch contract through `loom issue` commands.

## Why

Issue triage now scales beyond one-row-at-a-time edits without risking partial mutation or losing selection as the board is filtered and refreshed. Repository/branch deep links keep session-originated triage bounded and visible.
