### PR TITLE
fix(loom): isolate Cargo targets across worktrees

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustc-wrapper = "sccache"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
 
 # Least-privilege GITHUB_TOKEN: every job below only checks out and builds/tests
 # — none writes to the repo, posts comments, or publishes — so the token is
@@ -33,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:
@@ -51,6 +53,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
       # clippy compiles loom (and runs build.rs → the SPA build), so Node is
       # needed here too.
@@ -69,6 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:
@@ -102,6 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates/weaver-py
@@ -119,6 +124,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # ---- build: loom + tapestry + weaver, plus the embedded Vue bundle ----
 FROM rust:1-bookworm AS build
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
+ && apt-get install -y --no-install-recommends nodejs sccache \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY . .
@@ -97,7 +97,7 @@ RUN set -eux; \
       unzip zip less wget vim tree \
       bubblewrap socat \
       sqlite3 openssh-client patch diffutils procps rsync file \
-      gettext-base shellcheck; \
+      gettext-base shellcheck sccache; \
     rm -rf /var/lib/apt/lists/*; \
     # Debian ships fd as `fdfind` to avoid a name clash; expose the conventional
     # `fd` name agents (and fd-aware tools) expect.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ written for it to run; do them yourself if you'd rather.
    the PATH; for example:
 
    ```sh
-   cargo install sccache --locked
+   CARGO_BUILD_RUSTC_WRAPPER= cargo install sccache --locked
    ```
 
 2. **Build the tooling.** From the repo root:

--- a/README.md
+++ b/README.md
@@ -26,11 +26,20 @@ this repo in Claude Code (or your agent of choice) and tell it to *"set weaver u
 for me — follow the Getting Started steps in the README."* The steps below are
 written for it to run; do them yourself if you'd rather.
 
-1. **Get a Rust toolchain.** If `cargo` isn't already on the PATH, install it
-   via [rustup](https://rustup.rs):
+1. **Get a Rust toolchain and sccache.** If `cargo` isn't already on the PATH,
+   install it via [rustup](https://rustup.rs):
 
    ```sh
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+
+   Weaver keeps Cargo artifacts isolated in each worktree and uses
+   [`sccache`](https://github.com/mozilla/sccache) to reuse compilation results
+   safely across them. Install `sccache` separately and ensure its binary is on
+   the PATH; for example:
+
+   ```sh
+   cargo install sccache --locked
    ```
 
 2. **Build the tooling.** From the repo root:
@@ -499,10 +508,6 @@ Notable settings:
   [MCP/profile design](docs/plans/mcp-profiles.md).
 - Profile environment values are write-only: API, CLI, and Settings responses
   expose names and update times, never secret values.
-- Ordinary sessions default `CARGO_TARGET_DIR` to the primary repository's
-  `target/` directory, so Rust builds are reused across its Weaver worktrees.
-  A profile, per-repo environment value, or committed `[env]` entry can override
-  it; restricted profiles receive no repository-derived defaults.
 - `server.auto_adopt` — adopt every recoverable session on daemon startup.
 - `github.poll` — poll GitHub (via `gh`) for each session's PR, review, and
   check status (on by default; a no-op without `gh` or a GitHub remote).

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -329,25 +329,8 @@ async fn launch_env_for_profile(
         repo_env::layer(&mut env, repo_pairs);
         repo_env::layer(&mut env, config_pairs);
     }
-    apply_repo_env_defaults(&mut env, repo_root);
     tracing::debug!(repo = %repo_root_str, profile = profile_name, strict, env_vars = env.len(), "layered launch environment");
     env
-}
-
-/// Defaults shared by every ordinary worktree for one repository. Cargo's
-/// normal worktree-local `target/` defeats incremental reuse across Weaver
-/// sessions; pinning it to the primary repository root gives every branch the
-/// same cache. An explicit profile, per-repo, or committed config value wins.
-///
-/// Restricted profiles deliberately skip repo-derived defaults along with the
-/// other repository environment layers.
-fn apply_repo_env_defaults(env: &mut Vec<(String, String)>, repo_root: &std::path::Path) {
-    if !env.iter().any(|(name, _)| name == "CARGO_TARGET_DIR") {
-        env.push((
-            "CARGO_TARGET_DIR".to_string(),
-            repo_root.join("target").display().to_string(),
-        ));
-    }
 }
 
 async fn automation_policy_defaults(db: &Db) -> (i64, i64) {
@@ -4128,42 +4111,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ordinary_environment_shares_cargo_target_at_the_repo_root() {
+    async fn ordinary_environment_keeps_cargo_target_worktree_local() {
         let db = crate::db::connect_in_memory().await.unwrap();
         let dir = tempfile::tempdir().unwrap();
-        let repo = dir.path();
         let cfg = weaver_core::repo_config::RepoConfig::default();
 
-        let env = launch_env_for_profile(&db, repo, &cfg, "default", false, false).await;
+        let env = launch_env_for_profile(&db, dir.path(), &cfg, "default", false, false).await;
 
-        assert!(env.iter().any(|(name, value)| {
-            name == "CARGO_TARGET_DIR" && value == &repo.join("target").display().to_string()
-        }));
-    }
-
-    #[tokio::test]
-    async fn explicit_cargo_target_overrides_the_repo_default() {
-        let db = crate::db::connect_in_memory().await.unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        let repo = dir.path();
-        crate::repo_env::set(
-            &db,
-            &repo.display().to_string(),
-            "CARGO_TARGET_DIR",
-            "/custom/cargo-target",
-        )
-        .await
-        .unwrap();
-        let cfg = weaver_core::repo_config::RepoConfig::default();
-
-        let env = launch_env_for_profile(&db, repo, &cfg, "default", false, false).await;
-        let targets: Vec<_> = env
-            .iter()
-            .filter(|(name, _)| name == "CARGO_TARGET_DIR")
-            .collect();
-
-        assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].1, "/custom/cargo-target");
+        assert!(!env.iter().any(|(name, _)| name == "CARGO_TARGET_DIR"));
     }
 
     #[test]


### PR DESCRIPTION
Stop setting `CARGO_TARGET_DIR` to the primary checkout for ordinary sessions. Each worktree now keeps its own Cargo artifacts, avoiding branch-incompatible artifacts in a shared target directory.

Use sccache as the repository Rust compiler wrapper so compilation outputs can still be reused across worktrees. CI and the production image install sccache, and the setup guide documents the local dependency.
