### PR TITLE
fix(loom): keep custom launch snapshots private

### DIFF
--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -971,16 +971,6 @@ export interface ResolvedLaunchPolicy {
   mcp_policy: SessionMcpPolicy;
 }
 
-export interface ResolvedCustomAgent {
-  name: string;
-  label: string;
-  setup: string;
-  launch: string;
-  resume: string;
-  reports_status: boolean;
-  protocol: string;
-}
-
 export interface ResolvedLaunch {
   selection: LaunchSelection;
   profile_lifetime: number;
@@ -992,7 +982,6 @@ export interface ResolvedLaunch {
   protocol: string;
   mode: string;
   class: 'interactive' | 'automation';
-  custom_agent: ResolvedCustomAgent | null;
   locked_fields: string[];
   provenance: LaunchProvenance;
   capacity: LaunchCapacity;

--- a/crates/loom/src/backend.rs
+++ b/crates/loom/src/backend.rs
@@ -287,36 +287,12 @@ pub async fn kill_session(name: &str) -> Result<()> {
     Ok(())
 }
 
-static INJECTED_KILL_FAILURES: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashSet<String>>,
-> = std::sync::OnceLock::new();
-
-/// Inject one pre-teardown failure for an exact supervisor name. Integration
-/// barriers use this to prove lifecycle rollback without depending on timing a
-/// real socket failure.
-#[doc(hidden)]
-pub fn inject_kill_and_wait_failure(name: &str) {
-    INJECTED_KILL_FAILURES
-        .get_or_init(Default::default)
-        .lock()
-        .unwrap()
-        .insert(name.to_string());
-}
-
 /// Kill a session and wait until its supervisor has released the control socket.
 ///
 /// A kill request is acknowledged before the supervisor finishes teardown. A
 /// caller that immediately reuses the same name (provider handoff does this)
 /// must wait, or the replacement can connect to the dying supervisor.
 pub async fn kill_session_and_wait(name: &str) -> Result<()> {
-    if INJECTED_KILL_FAILURES
-        .get_or_init(Default::default)
-        .lock()
-        .unwrap()
-        .remove(name)
-    {
-        bail!("injected teardown failure for terminal {name}");
-    }
     kill_session(name).await?;
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     while has_session(name).await {

--- a/crates/loom/src/launch.rs
+++ b/crates/loom/src/launch.rs
@@ -7,10 +7,11 @@
 //! producers from growing subtly different launch rules.
 
 use anyhow::{anyhow, bail, Result};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use weaver_api::{
     LaunchCapacityView, LaunchOverrides, LaunchProvenanceView, LaunchSelection, ProfileEnvView,
-    ResolvedCustomAgentView, ResolvedLaunchPolicyView, ResolvedLaunchView, SessionMcpPolicyView,
+    ResolvedLaunchPolicyView, ResolvedLaunchView, SessionMcpPolicyView,
 };
 
 use crate::db::Db;
@@ -32,8 +33,8 @@ pub struct ResolveOptions {
     pub ignore_capacity: bool,
 }
 
-/// Exact server-side result. `view` is safe to return and persist;
-/// `profile`/`mcp_policy` retain the internal data provisioning needs.
+/// Exact server-side result. `view` is safe to return; the remaining fields
+/// retain the private data provisioning and persistence need.
 pub struct ResolvedLaunch {
     pub profile: Profile,
     pub mcp_policy: weaver_api::McpPolicySnapshot,
@@ -44,34 +45,79 @@ pub struct ResolvedLaunch {
     pub view: ResolvedLaunchView,
 }
 
-pub(crate) fn custom_agent_view(
-    custom: &crate::custom_agents::CustomAgent,
-) -> ResolvedCustomAgentView {
-    ResolvedCustomAgentView {
-        name: custom.name.clone(),
-        label: custom.label.clone(),
-        setup: custom.setup.clone(),
-        launch: custom.launch.clone(),
-        resume: custom.resume.clone(),
-        reports_status: custom.reports_status,
-        protocol: custom.protocol.clone(),
+/// Private extension of the public launch view stored in `sessions.launch_snapshot`.
+/// Flattening preserves the shape written before custom-agent commands were
+/// redacted from [`ResolvedLaunchView`], so existing rows remain readable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedLaunchSnapshot {
+    #[serde(flatten)]
+    view: ResolvedLaunchView,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    custom_agent: Option<PersistedCustomAgent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedCustomAgent {
+    name: String,
+    label: String,
+    setup: String,
+    launch: String,
+    resume: String,
+    reports_status: bool,
+    protocol: String,
+}
+
+impl From<&crate::custom_agents::CustomAgent> for PersistedCustomAgent {
+    fn from(custom: &crate::custom_agents::CustomAgent) -> Self {
+        Self {
+            name: custom.name.clone(),
+            label: custom.label.clone(),
+            setup: custom.setup.clone(),
+            launch: custom.launch.clone(),
+            resume: custom.resume.clone(),
+            reports_status: custom.reports_status,
+            protocol: custom.protocol.clone(),
+        }
     }
 }
 
-pub(crate) fn custom_agent_from_view(
-    custom: &ResolvedCustomAgentView,
-) -> crate::custom_agents::CustomAgent {
-    crate::custom_agents::CustomAgent {
-        name: custom.name.clone(),
-        label: custom.label.clone(),
-        setup: custom.setup.clone(),
-        launch: custom.launch.clone(),
-        resume: custom.resume.clone(),
-        reports_status: custom.reports_status,
-        protocol: custom.protocol.clone(),
-        created_at: String::new(),
-        updated_at: String::new(),
+impl From<PersistedCustomAgent> for crate::custom_agents::CustomAgent {
+    fn from(custom: PersistedCustomAgent) -> Self {
+        Self {
+            name: custom.name,
+            label: custom.label,
+            setup: custom.setup,
+            launch: custom.launch,
+            resume: custom.resume,
+            reports_status: custom.reports_status,
+            protocol: custom.protocol,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
     }
+}
+
+pub(crate) struct LaunchSnapshot {
+    pub view: ResolvedLaunchView,
+    pub custom_agent: Option<crate::custom_agents::CustomAgent>,
+}
+
+pub(crate) fn serialize_snapshot(
+    view: &ResolvedLaunchView,
+    custom_agent: Option<&crate::custom_agents::CustomAgent>,
+) -> serde_json::Result<String> {
+    serde_json::to_string(&PersistedLaunchSnapshot {
+        view: view.clone(),
+        custom_agent: custom_agent.map(PersistedCustomAgent::from),
+    })
+}
+
+pub(crate) fn deserialize_snapshot(snapshot: &str) -> serde_json::Result<LaunchSnapshot> {
+    let persisted: PersistedLaunchSnapshot = serde_json::from_str(snapshot)?;
+    Ok(LaunchSnapshot {
+        view: persisted.view,
+        custom_agent: persisted.custom_agent.map(Into::into),
+    })
 }
 
 fn selected(value: &Option<String>) -> Option<&str> {
@@ -316,7 +362,6 @@ pub async fn resolve(
         protocol,
         mode,
         class,
-        custom_agent: custom_agent.as_ref().map(custom_agent_view),
         locked_fields,
         provenance: LaunchProvenanceView {
             agent: if overrides.agent.is_some() {
@@ -540,9 +585,9 @@ mod tests {
         let mut custom = crate::custom_agents::CustomAgent {
             name: "reviewed-runtime".to_string(),
             label: "Reviewed runtime".to_string(),
-            setup: String::new(),
+            setup: "printf reviewed-setup".to_string(),
             launch: "printf old > reviewed-runtime.txt".to_string(),
-            resume: String::new(),
+            resume: "printf reviewed-resume".to_string(),
             reports_status: false,
             protocol: "terminal".to_string(),
             created_at: String::new(),
@@ -560,20 +605,48 @@ mod tests {
         let reviewed = resolve(&db, &selection, &ResolveOptions::default())
             .await
             .unwrap();
+        let public = serde_json::to_string(&reviewed.view).unwrap();
+        assert!(
+            !public.contains("custom_agent")
+                && [&custom.setup, &custom.launch, &custom.resume]
+                    .into_iter()
+                    .all(|command| !public.contains(command)),
+            "the public launch view must redact the private custom-agent envelope"
+        );
+        let persisted = serialize_snapshot(&reviewed.view, reviewed.custom_agent.as_ref()).unwrap();
+        let recovered = deserialize_snapshot(&persisted)
+            .unwrap()
+            .custom_agent
+            .unwrap();
+        let accepted = reviewed.custom_agent.as_ref().unwrap();
+        assert_eq!(
+            (
+                &recovered.name,
+                &recovered.label,
+                &recovered.setup,
+                &recovered.launch,
+                &recovered.resume,
+                recovered.reports_status,
+                &recovered.protocol,
+            ),
+            (
+                &accepted.name,
+                &accepted.label,
+                &accepted.setup,
+                &accepted.launch,
+                &accepted.resume,
+                accepted.reports_status,
+                &accepted.protocol,
+            ),
+            "the legacy flattened row shape must recover the exact accepted runtime"
+        );
+
         custom.launch = "printf new > reviewed-runtime.txt".to_string();
         crate::custom_agents::set(&db, &custom).await.unwrap();
         let fresh = resolve(&db, &selection, &ResolveOptions::default())
             .await
             .unwrap();
 
-        assert_eq!(
-            reviewed.custom_agent.as_ref().unwrap().launch,
-            "printf old > reviewed-runtime.txt"
-        );
-        assert_eq!(
-            fresh.custom_agent.as_ref().unwrap().launch,
-            "printf new > reviewed-runtime.txt"
-        );
         assert_ne!(
             reviewed.view.resolver_revision,
             fresh.view.resolver_revision

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -335,12 +335,14 @@ pub(crate) async fn session_view(
         None
     } else {
         Some(
-            serde_json::from_str(&session.launch_snapshot).map_err(|error| {
-                AppError::new(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("invalid session launch snapshot: {error}"),
-                )
-            })?,
+            crate::launch::deserialize_snapshot(&session.launch_snapshot)
+                .map_err(|error| {
+                    AppError::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("invalid session launch snapshot: {error}"),
+                    )
+                })?
+                .view,
         )
     };
     Ok(SessionView {

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -876,8 +876,9 @@ pub(crate) async fn provision_session(
     let protocol = resolved.view.protocol.clone();
     let mode = resolved.view.mode.clone();
     let class = resolved.view.class.clone();
-    let launch_snapshot = serde_json::to_string(&resolved.view)
-        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    let launch_snapshot =
+        crate::launch::serialize_snapshot(&resolved.view, resolved.custom_agent.as_ref())
+            .map_err(|error| AppError::bad_request(error.to_string()))?;
     if let Some(allowed) = actor.allowed_profiles() {
         if !allowed.iter().any(|name| name == &profile_name) {
             return Err(AppError::new(
@@ -2497,8 +2498,9 @@ pub(crate) async fn create_warm_session(
             "watch profile changed during warm launch; retry against a fresh resolution",
         ));
     }
-    let launch_snapshot = serde_json::to_string(&resolved.view)
-        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    let launch_snapshot =
+        crate::launch::serialize_snapshot(&resolved.view, resolved.custom_agent.as_ref())
+            .map_err(|error| AppError::bad_request(error.to_string()))?;
     let custom_agent = resolved.custom_agent.clone();
     let launch_profile = resolved.profile;
     let agent = resolved.view.agent;
@@ -2761,13 +2763,13 @@ fn stamped_custom_agent(session: &Session) -> ApiResult<Option<custom_agents::Cu
             session.id
         )));
     }
-    let snapshot: weaver_api::ResolvedLaunchView = serde_json::from_str(&session.launch_snapshot)
-        .map_err(|error| {
-        AppError::conflict(format!(
-            "session '{}' has an unreadable launch snapshot: {error}",
-            session.id
-        ))
-    })?;
+    let snapshot =
+        crate::launch::deserialize_snapshot(&session.launch_snapshot).map_err(|error| {
+            AppError::conflict(format!(
+                "session '{}' has an unreadable launch snapshot: {error}",
+                session.id
+            ))
+        })?;
     let custom = snapshot.custom_agent.ok_or_else(|| {
         AppError::conflict(format!(
             "session '{}' has no captured custom-agent definition; create a canonical replacement instead of consulting the mutable registry",
@@ -2780,7 +2782,7 @@ fn stamped_custom_agent(session: &Session) -> ApiResult<Option<custom_agents::Cu
             session.id, custom.name, session.agent_kind
         )));
     }
-    Ok(Some(crate::launch::custom_agent_from_view(&custom)))
+    Ok(Some(custom))
 }
 
 async fn require_resume_capacity(
@@ -3811,35 +3813,35 @@ fn legacy_handoff_snapshot(
     if session.launch_snapshot.trim().is_empty() {
         return Ok(String::new());
     }
-    let mut snapshot: weaver_api::ResolvedLaunchView =
-        serde_json::from_str(&session.launch_snapshot)
-            .map_err(|error| AppError::bad_request(error.to_string()))?;
-    snapshot.agent = target.to_string();
-    snapshot.model = model.to_string();
-    snapshot.effort = effort.to_string();
-    snapshot.protocol = "acp".to_string();
-    snapshot.mode = mode.to_string();
-    snapshot.custom_agent = custom_agent.map(crate::launch::custom_agent_view);
-    snapshot.selection.overrides.agent = Some(target.to_string());
-    snapshot.selection.overrides.model = Some(model.to_string());
-    snapshot.selection.overrides.effort = Some(effort.to_string());
-    snapshot.selection.overrides.mode = Some(mode.to_string());
-    snapshot.provenance.agent = "launch_override".to_string();
-    snapshot.provenance.model = if model.is_empty() {
+    let mut snapshot = crate::launch::deserialize_snapshot(&session.launch_snapshot)
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    snapshot.view.agent = target.to_string();
+    snapshot.view.model = model.to_string();
+    snapshot.view.effort = effort.to_string();
+    snapshot.view.protocol = "acp".to_string();
+    snapshot.view.mode = mode.to_string();
+    snapshot.custom_agent = custom_agent.cloned();
+    snapshot.view.selection.overrides.agent = Some(target.to_string());
+    snapshot.view.selection.overrides.model = Some(model.to_string());
+    snapshot.view.selection.overrides.effort = Some(effort.to_string());
+    snapshot.view.selection.overrides.mode = Some(mode.to_string());
+    snapshot.view.provenance.agent = "launch_override".to_string();
+    snapshot.view.provenance.model = if model.is_empty() {
         "agent_default"
     } else {
         "launch_override"
     }
     .to_string();
-    snapshot.provenance.effort = if effort.is_empty() {
+    snapshot.view.provenance.effort = if effort.is_empty() {
         "agent_default"
     } else {
         "launch_override"
     }
     .to_string();
-    snapshot.provenance.protocol = "agent_default".to_string();
-    snapshot.provenance.mode = "launch_override".to_string();
-    serde_json::to_string(&snapshot).map_err(|error| AppError::bad_request(error.to_string()))
+    snapshot.view.provenance.protocol = "agent_default".to_string();
+    snapshot.view.provenance.mode = "launch_override".to_string();
+    crate::launch::serialize_snapshot(&snapshot.view, snapshot.custom_agent.as_ref())
+        .map_err(|error| AppError::bad_request(error.to_string()))
 }
 
 async fn legacy_handoff_plan(
@@ -4038,8 +4040,9 @@ pub(super) async fn handoff_session(
         let profile_environment = crate::profile::env_pairs(&st.db, &resolved.profile.name)
             .await
             .map_err(|error| AppError::bad_request(error.to_string()))?;
-        let launch_snapshot = serde_json::to_string(&resolved.view)
-            .map_err(|error| AppError::bad_request(error.to_string()))?;
+        let launch_snapshot =
+            crate::launch::serialize_snapshot(&resolved.view, resolved.custom_agent.as_ref())
+                .map_err(|error| AppError::bad_request(error.to_string()))?;
         HandoffPlan {
             target: resolved.view.agent.clone(),
             model: resolved.view.model.clone(),

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -612,22 +612,8 @@ pub struct ResolvedLaunchPolicyView {
     pub mcp_policy: SessionMcpPolicyView,
 }
 
-/// Exact non-secret command/runtime definition accepted for a custom agent.
-/// Builtin agents omit this field. Persisting it makes adopt/recover use the
-/// reviewed runtime even if the mutable registry is later edited or deleted.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ResolvedCustomAgentView {
-    pub name: String,
-    pub label: String,
-    pub setup: String,
-    pub launch: String,
-    pub resume: String,
-    pub reports_status: bool,
-    pub protocol: String,
-}
-
-/// Concrete non-secret immutable launch snapshot returned by preview and
-/// stored with the created session (or replacement handoff runtime).
+/// Concrete source-redacted immutable launch snapshot returned by preview and
+/// exposed on the created session (or replacement handoff runtime).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedLaunchView {
     pub selection: LaunchSelection,
@@ -641,8 +627,6 @@ pub struct ResolvedLaunchView {
     pub protocol: String,
     pub mode: String,
     pub class: String,
-    #[serde(default)]
-    pub custom_agent: Option<ResolvedCustomAgentView>,
     pub locked_fields: Vec<String>,
     pub provenance: LaunchProvenanceView,
     pub capacity: LaunchCapacityView,


### PR DESCRIPTION
Keep each accepted custom-agent definition in a private flattened launch_snapshot envelope so adopt, recover, and handoff continue using the exact pinned commands while launch previews and SessionView expose only the source-redacted resolution. The envelope preserves the existing persisted row shape and requires no migration.

Remove the obsolete public DTO/frontend mirror and the unused kill-failure injection.

Weaver session: https://loom.rjp.io/s/pokzt086