### PR TITLE
docs(lint): make agent review proportional

### DIFF
--- a/.agents/skills/pull-request.md
+++ b/.agents/skills/pull-request.md
@@ -1,13 +1,13 @@
 ---
 name: pull-request
-description: Commit cleanly, run proportional deterministic gates, decide whether the agent lint review is warranted, open or update the PR, then monitor it and answer comments until it merges. Use when committing, pushing, or creating/updating a weaver pull request.
+description: Commit cleanly, run proportional deterministic gates, decide whether the agent lint review is warranted, open or update the PR, then drive CI green and hand off to the final reviewer. Use when committing, pushing, or creating/updating a weaver pull request.
 ---
 
 # Skill: Pull Request
 
 Clean the branch, commit, apply the lint-review policy, open or update the PR,
-then stay with it until it merges. Commit before any review run — it reads the
-committed branch diff and only reports.
+then drive CI green and hand it to the coordinator/human final reviewer. Commit
+before any review run — it reads the committed branch diff and only reports.
 
 Weaver is solo: skip team ceremony, but the deterministic gates, the
 lint-review decision, and driving CI green are not optional.
@@ -25,7 +25,7 @@ WIP checkpoint: **1, 2, 4, 5, 7**, stop. Full list before opening/updating a PR.
    record why it was skipped.
 7. Push.
 8. Open or update the PR.
-9. Monitor — drive CI green, answer every comment, in a loop.
+9. Drive CI green, address comments already present, and hand off.
 
 ## 1. Self-review
 
@@ -70,14 +70,9 @@ Hook fails → fix and commit again.
 Run the agent lint review for a substantive initial implementation or a
 follow-up that materially changes the design or risk surface. Skip it for a
 small, low-risk PR. Once a branch has already had an agent lint review, also
-skip small review/CI follow-ups.
-
-A follow-up is not small/low-risk if it introduces or materially changes a
-migration, authentication/authorization, secrets handling, concurrency or
-lifecycle behavior, destructive persistence behavior, a public REST/wire
-contract, or CI/build/release behavior. Do not use raw line count as the sole
-criterion. Documentation-only changes and narrow review cleanups are typical
-skips when they do not touch those areas.
+skip small review/CI follow-ups. Use the [canonical detailed
+criteria](../../docs/lint.md#when-to-run), including its risk exclusions and
+instruction not to decide from raw line count alone.
 
 When a review is warranted, run:
 
@@ -130,11 +125,11 @@ a branch that already has a PR.
 - ≤500 words; Markdown sections only when a large change needs them.
 - No self-credit.
 
-## 9. Monitor — in a loop
+## 9. Drive CI green and hand off
 
 Opening the PR starts this step. **Local green ≠ CI green:** CI runs more than the
-local gate (Playwright `e2e/`, CodeQL, clean-checkout SPA build). Stay until it
-merges (or the user says stop). A summary message is not an exit condition.
+local gate (Playwright `e2e/`, CodeQL, clean-checkout SPA build). Stay through
+CI, then hand off to the coordinator/human final reviewer. Do not merge.
 
 Block on CI, don't re-poll:
 
@@ -142,25 +137,19 @@ Block on CI, don't re-poll:
 gh pr checks <N> --watch --fail-fast
 ```
 
-Green → poll comments/reviews on a backoff (`ScheduleWakeup` 270s, doubling, give
-up after a few idle hours). Each pass check **both**:
+Failure → read the job log and fix it. A failure in a file you didn't touch
+isn't automatically pre-existing — confirm it fails on `main` without your
+change first. Never silently absorb a failure.
 
-1. CI — `gh pr checks <N>`. Failure → read the job log, fix it. A failure in a
-   file you didn't touch isn't automatically pre-existing — confirm it fails on
-   `main` without your change first; if your change caused it, it's your
-   regression. Never silently absorb a failure.
-2. Comments/reviews — `gh pr view <N> --json reviews,comments` and `gh api
-   repos/<owner>/<repo>/pulls/<N>/comments`. Green CI ≠ nothing to do; people and
-   bots comment after CI passes.
+Once CI is green, address any comments already present. Fix clear comments in a
+new commit and reply in-thread; if one is genuinely unclear, raise `weaver
+status attention "<question>"`. Do not poll for future reviews or wait for
+them.
 
-Answer every comment: fix the clear ones (commit as a **new** commit, reply
-in-thread prefixed 🤖, resolve). Genuinely unclear → `weaver status attention
-"<question>"`, keep monitoring while you wait.
-
-Status tracks the loop: `ok` while CI runs or you await review; `weaver
-status attention "ready for review"` only once green and every comment is
-handled. Close the tracking issue when the PR is open and the work is genuinely
-done — not before.
+Keep status `ok` while CI runs. Once CI is green and comments already present
+are handled, raise `weaver status attention "ready for review"` and hand off.
+Close the tracking issue when the PR is open and the work is genuinely done —
+not before.
 
 ## Rules
 

--- a/.agents/skills/pull-request.md
+++ b/.agents/skills/pull-request.md
@@ -1,16 +1,16 @@
 ---
 name: pull-request
-description: Commit cleanly, run the gate, hand off to the agent lint review, open or update the PR, then monitor it and answer comments until it merges. Use when committing, pushing, or creating/updating a weaver pull request.
+description: Commit cleanly, run proportional deterministic gates, decide whether the agent lint review is warranted, open or update the PR, then monitor it and answer comments until it merges. Use when committing, pushing, or creating/updating a weaver pull request.
 ---
 
 # Skill: Pull Request
 
-Clean the branch, commit, run the lint review, open or update the PR, then stay
-with it until it merges. Commit before the review — it reads the committed branch
-diff and only reports.
+Clean the branch, commit, apply the lint-review policy, open or update the PR,
+then stay with it until it merges. Commit before any review run — it reads the
+committed branch diff and only reports.
 
-Weaver is solo: skip team ceremony, but the gate, the lint review, and driving CI
-green are not optional.
+Weaver is solo: skip team ceremony, but the deterministic gates, the
+lint-review decision, and driving CI green are not optional.
 
 ## Checklist
 
@@ -21,7 +21,8 @@ WIP checkpoint: **1, 2, 4, 5, 7**, stop. Full list before opening/updating a PR.
 3. Tests when warranted — `cargo test --workspace`; `cd e2e && npm test` for UI.
 4. Stage the specific files.
 5. Commit. ← clean checkpoint.
-6. Lint review — `scripts/lint-review.py`; fix or answer every finding.
+6. Lint-review decision — run `scripts/lint-review.py` when warranted; otherwise
+   record why it was skipped.
 7. Push.
 8. Open or update the PR.
 9. Monitor — drive CI green, answer every comment, in a loop.
@@ -64,7 +65,21 @@ Imperative, lower-case, ≤72 chars. The `(#NN)` suffix lands on merge, not from
 
 Hook fails → fix and commit again.
 
-## 6. Lint review
+## 6. Lint-review decision
+
+Run the agent lint review for a substantive initial implementation or a
+follow-up that materially changes the design or risk surface. Skip it for a
+small, low-risk PR. Once a branch has already had an agent lint review, also
+skip small review/CI follow-ups.
+
+A follow-up is not small/low-risk if it introduces or materially changes a
+migration, authentication/authorization, secrets handling, concurrency or
+lifecycle behavior, destructive persistence behavior, a public REST/wire
+contract, or CI/build/release behavior. Do not use raw line count as the sole
+criterion. Documentation-only changes and narrow review cleanups are typical
+skips when they do not touch those areas.
+
+When a review is warranted, run:
 
 ```bash
 scripts/lint-review.py         # the agent lint over the branch diff
@@ -77,6 +92,10 @@ they make the code better, not blindly.
 
 Deeper pass on a big change: `/code-review` (`ultra` = multi-agent cloud). On a
 solo PR, read its findings and fix — don't post them to your own PR.
+
+When skipping, add one concise sentence to the PR/testing notes explaining why,
+for example: `Agent lint review skipped: documentation-only workflow change
+with no runtime behavior.` Do not add a checklist or scoring framework.
 
 ## 7. Push
 
@@ -105,6 +124,8 @@ a branch that already has a PR.
 **Hard rules:**
 
 - Body is *what & why* — no "Testing"/"Validation" section, no "written by…".
+  A single unheaded testing sentence is allowed when recording why the agent
+  lint review was skipped.
 - No checkboxes, no emoji, no filler openers ("This PR…", "Summary of changes:").
 - ≤500 words; Markdown sections only when a large change needs them.
 - No self-credit.
@@ -143,7 +164,8 @@ done — not before.
 
 ## Rules
 
-- `./scripts/pre-commit.sh` is the gate; commit before `lint-review.py`.
+- `./scripts/pre-commit.sh` is the gate; make the lint-review decision after
+  committing.
 - Never merge or push to `main`; open a PR.
 - Force-push with `--force-with-lease`, e.g. after a rebase.
 - No self-attribution in commits or PR bodies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,15 +40,12 @@ enforces; wire it up as a hook with `git config core.hooksPath .githooks`. Keep
 compile, type, and relevant test checks proportional to the change, but always
 run the ones that apply.
 
-Separately, the [agent lint review](docs/lint.md) — `scripts/lint-review.py` — is
-required for substantive initial implementations and follow-ups that materially
-change the design or risk surface. Skip it for small, low-risk PRs, and for
-small review/CI follow-ups after the branch has already had an agent lint
-review. A follow-up is not low-risk if it introduces or materially changes a
-migration, authentication/authorization, secrets handling, concurrency or
-lifecycle behavior, destructive persistence behavior, a public REST/wire
-contract, or CI/build/release behavior. Do not decide from line count alone.
-When skipping, put one concise reason in the PR/testing notes.
+Separately, follow the canonical [agent lint-review
+policy](docs/lint.md#when-to-run): run `scripts/lint-review.py` for substantive
+initial implementations and design/risk-changing follow-ups; skip it for small,
+low-risk PRs and small review/CI follow-ups after the branch has already had a
+review. The linked policy defines the detailed risk criteria. When skipping,
+put one concise reason in the PR/testing notes.
 
 The review is kept out of the commit hook so a slow or flaky agent never sits
 in the commit path. Build/test internals and the Playwright setup live in
@@ -78,7 +75,8 @@ WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0
 
 ## Landing changes
 
-The full commit → lint review → PR → monitor flow is the **`pull-request` skill**
+The full commit → lint-review decision → PR → CI handoff flow is the
+**`pull-request` skill**
 ([.agents/skills/pull-request.md](.agents/skills/pull-request.md)) — invoke it
 when you're ready to land. The rules it enforces:
 
@@ -91,15 +89,10 @@ when you're ready to land. The rules it enforces:
 - **Keep the branch synced with `main`** when it falls behind or conflicts.
 - **Drive the PR to green, then hand off — local green is not CI green.** CI runs
   more than the local gate (Playwright `e2e/`, CodeQL, a clean-checkout SPA
-  build). After pushing, block on `gh pr checks <n> --watch --fail-fast`, answer
-  comments in-thread, and fix failures until green. Only **then** raise `weaver
-  status attention "ready for review"`; while CI runs you are `ok`, not done.
-- **Wait for the bot reviewers — they're slower than CI.** GitHub's Copilot/Codex
-  reviewers post inline comments minutes after the PR opens (not instantly, and
-  after the checks pass). Don't call a PR done the moment it's pushed: block for
-  their review, or check back after ~30 min — `gh pr view <n> --json reviews,comments`
-  plus `gh api repos/{owner}/{repo}/pulls/<n>/comments` for the inline threads —
-  then address or reply to each before handing off.
+  build). After pushing, block on `gh pr checks <n> --watch --fail-fast`, fix
+  failures until green, and address any comments already present. Only **then**
+  raise `weaver status attention "ready for review"` and hand off to the
+  coordinator/human final reviewer; while CI runs you are `ok`, not done.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,12 +36,22 @@ Test placement: pure program/module logic lives in pytest
 tests prove wiring against a live server — don't duplicate logic across them.
 
 Run `./scripts/pre-commit.sh` before committing — the fmt + clippy gate CI
-enforces; wire it up as a hook with `git config core.hooksPath .githooks`.
-Separately, as a step in the commit → PR flow (see the `pull-request` skill), run
-the [agent lint review](docs/lint.md) — `scripts/lint-review.py`, a headless
-`claude` sub-agent that errors on the slop fmt/clippy can't catch. It's kept out
-of the commit hook on purpose, so a slow or flaky agent never sits in the commit
-path. Build/test internals and the Playwright setup live in
+enforces; wire it up as a hook with `git config core.hooksPath .githooks`. Keep
+compile, type, and relevant test checks proportional to the change, but always
+run the ones that apply.
+
+Separately, the [agent lint review](docs/lint.md) — `scripts/lint-review.py` — is
+required for substantive initial implementations and follow-ups that materially
+change the design or risk surface. Skip it for small, low-risk PRs, and for
+small review/CI follow-ups after the branch has already had an agent lint
+review. A follow-up is not low-risk if it introduces or materially changes a
+migration, authentication/authorization, secrets handling, concurrency or
+lifecycle behavior, destructive persistence behavior, a public REST/wire
+contract, or CI/build/release behavior. Do not decide from line count alone.
+When skipping, put one concise reason in the PR/testing notes.
+
+The review is kept out of the commit hook so a slow or flaky agent never sits
+in the commit path. Build/test internals and the Playwright setup live in
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Don't disturb the user's live loom
@@ -72,10 +82,10 @@ The full commit → lint review → PR → monitor flow is the **`pull-request` 
 ([.agents/skills/pull-request.md](.agents/skills/pull-request.md)) — invoke it
 when you're ready to land. The rules it enforces:
 
-- **Open a PR; never push to or merge `main`.** Branch → `./scripts/pre-commit.sh`
-  + `cargo test --workspace` → `scripts/lint-review.py` → `gh pr create`. A weaver
-  worktree is already on its own branch; finishing means opening the PR, not
-  integrating it yourself.
+- **Open a PR; never push to or merge `main`.** Branch →
+  `./scripts/pre-commit.sh` + relevant tests → the documented lint-review
+  decision → `gh pr create`. A weaver worktree is already on its own branch;
+  finishing means opening the PR, not integrating it yourself.
 - **Write in the project's voice** — no self-attribution in commits or PRs
   ("Generated with…", "Co-Authored-By: <tool>", and the like).
 - **Keep the branch synced with `main`** when it falls behind or conflicts.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,10 +103,12 @@ print as advisory.
 
 It is **not** wired into the pre-commit hook. `scripts/pre-commit.sh` stays a
 fast fmt + clippy gate identical to CI; the lint review is a separate, explicit
-step in the commit → PR flow — agents run it via the `pull-request` skill after
+decision in the commit → PR flow. Agents apply the proportional
+[run/skip policy](lint.md#when-to-run) via the `pull-request` skill after
 committing and before opening the PR. Keeping the agent out of the commit path
-means a slow or flaky review never wedges a commit. Run `scripts/lint-review.py`
-to review the whole branch against its merge-base with `main`.
+means a slow or flaky review never wedges a commit. When warranted,
+`scripts/lint-review.py` reviews the whole branch against its merge-base with
+`main`.
 
 It **self-skips** (exit 0) when `claude` isn't on PATH, when there are no
 Rust/TS/Vue changes, or when the agent times out or errors — so a flaky or

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -777,6 +777,24 @@ impl FakeMonitor {
 
 For an agent running this catalog against a diff.
 
+### When to run
+
+Run `scripts/lint-review.py` for a substantive initial implementation or a
+follow-up that materially changes the design or risk surface. Skip it for a
+small, low-risk PR. Once a branch has already had an agent lint review, also
+skip small review/CI follow-ups.
+
+A follow-up is not small/low-risk if it introduces or materially changes a
+migration, authentication/authorization, secrets handling, concurrency or
+lifecycle behavior, destructive persistence behavior, a public REST/wire
+contract, or CI/build/release behavior. Do not use raw line count as the sole
+criterion. Documentation-only changes and narrow review cleanups are typical
+skips when they do not touch those areas.
+
+When skipping, record one concise sentence in the PR/testing notes explaining
+why. Do not add a checklist, scoring framework, or automation for this
+decision.
+
 ### Inputs
 
 Pick the diff that applies, typically the current branch versus its merge-base


### PR DESCRIPTION
Make agent lint review proportional to design and risk instead of requiring it for every PR. `docs/lint.md` now owns the detailed criteria, while the contributor guide, pull-request skill, and architecture docs link to one clear run/skip policy and preserve applicable deterministic gates. The landing workflow now ends at green CI plus any already-present comments before coordinator/human handoff, without review polling.

Agent lint review skipped: documentation-only workflow change with no runtime behavior.