### PR TITLE
feat(loom): add canonical task metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ loom session send <session> "try the curl again"   # deliver now (steer ACP, or 
 loom session break <session>          # send Escape — interrupt the current turn
 loom session preview <session>        # print the recent terminal screen
 loom session url [<session>]          # its dashboard URL (yours by default) — the link to share
+loom session rename <session> "Short task label"
+loom session regenerate-title <session>       # refresh an eligible derived/generated label
+loom session title-generation <session> false # per-session generated-label opt-out
+loom session cue <session>                    # read the current source-linked cache
+loom session cue <session> --ensure           # generate only when inactivity says it is due
+loom session cue <session> --force            # explicit regeneration
 loom ps                               # list active sessions
 loom session show <branch>                    # session detail
 loom session layout show                      # spaces, groups, placements, defaults, revision
@@ -171,6 +177,14 @@ submitting it for a terminal agent; steering or restarting an ACP turn),
 `loom session break` interrupts the current turn, and `loom session preview`
 prints the recent terminal screen. Each takes a session key — an id, branch id,
 branch name, or `repo:branch`.
+
+The session title is one canonical, unqualified task label; fleet views add its
+Group only when they need a qualified `Group / Task` name. Loom records whether
+that label was deterministic, model-generated, human-authored, or issue-owned.
+Human and issue labels always take precedence: metadata generation can replace
+only an unchanged derived label, or an unchanged generated label after an
+explicit regenerate request. Renames use compare-and-swap so a stale tab cannot
+overwrite a newer label.
 
 `loom session url` prints a session's dashboard URL — the link to hand a person,
 resolved against loom's externally-visible address (the `auth.base_url` setting,
@@ -335,6 +349,9 @@ Loom serves a JSON API under `/api`; the Vue SPA is the primary consumer.
   (admin-only operational inventory used by Settings → Diagnostics)
 - `GET POST /api/sessions`, `GET /api/sessions/search`,
   `GET PATCH DELETE /api/sessions/{id}`,
+  `POST /api/sessions/{id}/title/regenerate`,
+  `PUT /api/sessions/{id}/title-generation`,
+  `GET POST /api/sessions/{id}/resumption-cue`,
   `POST /api/session-launches/resolve`,
   `GET /api/session-layout`, `POST /api/session-layout/{moves,reorder}`,
   and space/group/default CRUD under `/api/session-layout`,
@@ -473,6 +490,7 @@ weaver config ls
 loom profile ls
 loom profile show default
 loom profile show github_comment
+loom config set metadata.profile watch
 loom mcp ls
 loom mcp show mcp/github/comment@v1
 loom profile add ops --agent codex --mcp github,messaging
@@ -534,6 +552,17 @@ Notable settings:
   [MCP/profile design](docs/plans/mcp-profiles.md).
 - Profile environment values are write-only: API, CLI, and Settings responses
   expose names and update times, never secret values.
+- Optional metadata assistance uses one explicitly selected, active,
+  automation-safe ACP profile. An empty `metadata.profile` disables model-backed
+  assistance. Restricted-session excerpts remain blocked unless
+  `metadata.allow_restricted` is explicitly enabled, and failure to resolve any
+  configured secret source aborts generation rather than sending unredacted
+  content. Title generation is asynchronous and fenced by the exact
+  goal/title/provenance/profile source it read. Resumption cues are generated
+  only by an explicit request or an on-return ensure after
+  `metadata.resumption_inactivity_secs`; GET is model-free, and cached prose is
+  reused only while its bounded conversation/content fingerprint and immutable
+  artifact identities still match.
 - `server.auto_adopt` — adopt every recoverable session on daemon startup.
 - `github.poll` — poll GitHub (via `gh`) for each session's PR, review, and
   check status (on by default; a no-op without `gh` or a GitHub remote).

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -121,6 +121,18 @@ export const archiveSession = (id: string) => post(`/sessions/${encodeURICompone
 export const removeSession = (id: string) => del(`/sessions/${encodeURIComponent(id)}`);
 export const clearSessionTag = (id: string, key: string) =>
   del(`/sessions/${encodeURIComponent(id)}/tags/${encodeURIComponent(key)}`);
+export const regenerateSessionTitle = (id: string) =>
+  post(`/sessions/${encodeURIComponent(id)}/title/regenerate`) as Promise<Session>;
+export const setSessionTitleGeneration = (id: string, enabled: boolean) =>
+  put(`/sessions/${encodeURIComponent(id)}/title-generation`, { enabled }) as Promise<Session>;
+export const getResumptionCue = (id: string) =>
+  get(`/sessions/${encodeURIComponent(id)}/resumption-cue`) as Promise<
+    import('./types').ResumptionCue
+  >;
+export const ensureResumptionCue = (id: string, force = false) =>
+  post(`/sessions/${encodeURIComponent(id)}/resumption-cue`, { force }) as Promise<
+    import('./types').ResumptionCue
+  >;
 
 // --- Session layout ---------------------------------------------------------
 

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -18,36 +18,75 @@ const isAcp = computed(() => props.session.protocol === 'acp');
 const forwardCommand = (name: string, args: string) => emit('command', name, args);
 
 const cue = ref<ResumptionCue | null>(null);
-const cueBusy = ref(false);
+const cueOperation = ref<'' | 'checking' | 'generating'>('');
+const cueOpen = ref(false);
 const cueError = ref('');
+let cueEpoch = 0;
+
+function isCurrent(sessionId: string, epoch: number): boolean {
+  return props.session.id === sessionId && cueEpoch === epoch;
+}
+
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => window.setTimeout(resolve, milliseconds));
+
+async function followGeneration(sessionId: string, epoch: number) {
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    await wait(2_000);
+    if (!isCurrent(sessionId, epoch)) return;
+    const current = await getResumptionCue(sessionId);
+    if (!isCurrent(sessionId, epoch)) return;
+    cue.value = current;
+    if (current.status === 'generated') {
+      cueOpen.value = true;
+      return;
+    }
+    if (current.status !== 'generating') return;
+  }
+}
 
 async function loadCue(onReturn = false) {
-  if (cueBusy.value) return;
-  cueBusy.value = true;
+  if (cueOperation.value) return;
+  const sessionId = props.session.id;
+  const epoch = ++cueEpoch;
+  cueOperation.value = 'checking';
   cueError.value = '';
   try {
-    let current = await getResumptionCue(props.session.id);
+    let current = await getResumptionCue(sessionId);
+    let ensuredDue = false;
+    if (!isCurrent(sessionId, epoch)) return;
     if (onReturn && current.status === 'due') {
-      current = await ensureResumptionCue(props.session.id);
+      ensuredDue = true;
+      cueOperation.value = 'generating';
+      current = await ensureResumptionCue(sessionId);
+      if (!isCurrent(sessionId, epoch)) return;
     }
     cue.value = current;
+    if (ensuredDue && current.status === 'generated') cueOpen.value = true;
+    if (current.status === 'generating') await followGeneration(sessionId, epoch);
   } catch (error) {
-    cueError.value = (error as Error).message;
+    if (isCurrent(sessionId, epoch)) cueError.value = (error as Error).message;
   } finally {
-    cueBusy.value = false;
+    if (isCurrent(sessionId, epoch)) cueOperation.value = '';
   }
 }
 
 async function generateCue() {
-  if (cueBusy.value) return;
-  cueBusy.value = true;
+  if (cueOperation.value) return;
+  const sessionId = props.session.id;
+  const epoch = ++cueEpoch;
+  cueOperation.value = 'generating';
   cueError.value = '';
   try {
-    cue.value = await ensureResumptionCue(props.session.id, true);
+    const generated = await ensureResumptionCue(sessionId, true);
+    if (!isCurrent(sessionId, epoch)) return;
+    cue.value = generated;
+    if (generated.status === 'generated') cueOpen.value = true;
+    if (generated.status === 'generating') await followGeneration(sessionId, epoch);
   } catch (error) {
-    cueError.value = (error as Error).message;
+    if (isCurrent(sessionId, epoch)) cueError.value = (error as Error).message;
   } finally {
-    cueBusy.value = false;
+    if (isCurrent(sessionId, epoch)) cueOperation.value = '';
   }
 }
 
@@ -56,7 +95,11 @@ onActivated(() => loadCue(true));
 watch(
   () => props.session.id,
   () => {
+    cueEpoch += 1;
     cue.value = null;
+    cueOpen.value = false;
+    cueOperation.value = '';
+    cueError.value = '';
     void loadCue(true);
   },
 );
@@ -67,49 +110,64 @@ watch(
     <section
       v-if="cue?.status === 'generated' && cue.text"
       data-testid="resumption-cue"
-      class="mx-3 mt-2 rounded border border-line bg-subtle px-3 py-2 text-sm"
+      class="mx-3 mt-2 flex items-start gap-2 rounded border border-line bg-subtle px-3 py-2 text-sm"
       aria-label="Generated resumption cue"
     >
-      <div class="mb-1 flex flex-wrap items-center gap-2">
-        <strong class="text-xs">Generated resumption cue</strong>
-        <span v-if="cue.generated_at" class="font-mono text-2xs text-faint">
-          {{ new Date(cue.generated_at).toLocaleString() }}
-        </span>
-        <button
-          type="button"
-          class="ml-auto text-xs text-accent hover:underline disabled:opacity-60"
-          :disabled="cueBusy"
-          @click="generateCue"
-        >
-          {{ cueBusy ? 'Generating…' : 'Refresh' }}
-        </button>
-      </div>
-      <p class="whitespace-pre-wrap text-muted">{{ cue.text }}</p>
-      <nav v-if="cue.evidence.length" class="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
-        <router-link
-          v-for="evidence in cue.evidence"
-          :key="evidence.cursor"
-          :to="evidence.href"
-          class="text-accent hover:underline"
-          >{{ evidence.label }}</router-link
-        >
-      </nav>
+      <details
+        class="min-w-0 flex-1"
+        :open="cueOpen"
+        @toggle="cueOpen = ($event.target as HTMLDetailsElement).open"
+      >
+        <summary class="cursor-pointer text-xs font-medium text-fg">
+          Resume context
+          <span v-if="cue.generated_at" class="ml-1 font-mono text-2xs font-normal text-faint">
+            {{ new Date(cue.generated_at).toLocaleString() }}
+          </span>
+        </summary>
+        <p class="mt-1 whitespace-pre-wrap text-muted">{{ cue.text }}</p>
+        <nav v-if="cue.evidence.length" class="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+          <router-link
+            v-for="evidence in cue.evidence"
+            :key="evidence.cursor"
+            :to="evidence.href"
+            class="text-accent hover:underline"
+            >{{ evidence.label }}</router-link
+          >
+        </nav>
+      </details>
+      <button
+        type="button"
+        class="shrink-0 text-xs text-accent hover:underline disabled:opacity-60"
+        :disabled="!!cueOperation"
+        @click="generateCue"
+      >
+        {{ cueOperation === 'generating' ? 'Generating…' : 'Refresh' }}
+      </button>
     </section>
     <div
       v-else-if="cue?.status !== 'disabled'"
       class="mx-3 mt-1 flex items-center gap-2 text-2xs text-faint"
       role="status"
     >
-      <span v-if="cueBusy || cue?.status === 'generating'">Generating resumption cue…</span>
       <button
-        v-else-if="cue?.status !== 'unavailable'"
+        v-if="cue?.status !== 'unavailable'"
         type="button"
         data-testid="generate-resumption-cue"
-        class="text-accent hover:underline"
-        @click="generateCue"
+        class="text-accent hover:underline disabled:opacity-60"
+        :disabled="!!cueOperation"
+        @click="cue?.status === 'generating' ? loadCue() : generateCue()"
       >
-        Generate resumption cue
+        {{
+          cueOperation === 'checking'
+            ? 'Checking resumption cue…'
+            : cueOperation === 'generating'
+              ? 'Generating resumption cue…'
+              : cue?.status === 'generating'
+                ? 'Check resumption cue'
+                : 'Generate resumption cue'
+        }}
       </button>
+      <span v-else>No eligible metadata profile is available.</span>
       <span v-if="cueError" class="text-block" role="alert">{{ cueError }}</span>
     </div>
     <AcpConversation

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import type { Session, AcpCommand } from '../types';
+import { computed, onActivated, onMounted, ref, watch } from 'vue';
+import { ensureResumptionCue, getResumptionCue } from '../api';
+import type { Session, AcpCommand, ResumptionCue } from '../types';
 import TerminalConversation from './TerminalConversation.vue';
 import AcpConversation from './AcpConversation.vue';
 
@@ -15,14 +16,108 @@ const props = withDefaults(defineProps<{ session: Session; localCommands?: AcpCo
 const emit = defineEmits<{ command: [name: string, args: string] }>();
 const isAcp = computed(() => props.session.protocol === 'acp');
 const forwardCommand = (name: string, args: string) => emit('command', name, args);
+
+const cue = ref<ResumptionCue | null>(null);
+const cueBusy = ref(false);
+const cueError = ref('');
+
+async function loadCue(onReturn = false) {
+  if (cueBusy.value) return;
+  cueBusy.value = true;
+  cueError.value = '';
+  try {
+    let current = await getResumptionCue(props.session.id);
+    if (onReturn && current.status === 'due') {
+      current = await ensureResumptionCue(props.session.id);
+    }
+    cue.value = current;
+  } catch (error) {
+    cueError.value = (error as Error).message;
+  } finally {
+    cueBusy.value = false;
+  }
+}
+
+async function generateCue() {
+  if (cueBusy.value) return;
+  cueBusy.value = true;
+  cueError.value = '';
+  try {
+    cue.value = await ensureResumptionCue(props.session.id, true);
+  } catch (error) {
+    cueError.value = (error as Error).message;
+  } finally {
+    cueBusy.value = false;
+  }
+}
+
+onMounted(() => loadCue(true));
+onActivated(() => loadCue(true));
+watch(
+  () => props.session.id,
+  () => {
+    cue.value = null;
+    void loadCue(true);
+  },
+);
 </script>
 
 <template>
-  <AcpConversation
-    v-if="isAcp"
-    :session="session"
-    :local-commands="localCommands"
-    @command="forwardCommand"
-  />
-  <TerminalConversation v-else :session="session" />
+  <div class="flex min-h-0 flex-1 flex-col">
+    <section
+      v-if="cue?.status === 'generated' && cue.text"
+      data-testid="resumption-cue"
+      class="mx-3 mt-2 rounded border border-line bg-subtle px-3 py-2 text-sm"
+      aria-label="Generated resumption cue"
+    >
+      <div class="mb-1 flex flex-wrap items-center gap-2">
+        <strong class="text-xs">Generated resumption cue</strong>
+        <span v-if="cue.generated_at" class="font-mono text-2xs text-faint">
+          {{ new Date(cue.generated_at).toLocaleString() }}
+        </span>
+        <button
+          type="button"
+          class="ml-auto text-xs text-accent hover:underline disabled:opacity-60"
+          :disabled="cueBusy"
+          @click="generateCue"
+        >
+          {{ cueBusy ? 'Generating…' : 'Refresh' }}
+        </button>
+      </div>
+      <p class="whitespace-pre-wrap text-muted">{{ cue.text }}</p>
+      <nav v-if="cue.evidence.length" class="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+        <router-link
+          v-for="evidence in cue.evidence"
+          :key="evidence.cursor"
+          :to="evidence.href"
+          class="text-accent hover:underline"
+          >{{ evidence.label }}</router-link
+        >
+      </nav>
+    </section>
+    <div
+      v-else-if="cue?.status !== 'disabled'"
+      class="mx-3 mt-1 flex items-center gap-2 text-2xs text-faint"
+      role="status"
+    >
+      <span v-if="cueBusy || cue?.status === 'generating'">Generating resumption cue…</span>
+      <button
+        v-else-if="cue?.status !== 'unavailable'"
+        type="button"
+        data-testid="generate-resumption-cue"
+        class="text-accent hover:underline"
+        @click="generateCue"
+      >
+        Generate resumption cue
+      </button>
+      <span v-if="cueError" class="text-block" role="alert">{{ cueError }}</span>
+    </div>
+    <AcpConversation
+      v-if="isAcp"
+      :session="session"
+      :local-commands="localCommands"
+      @command="forwardCommand"
+    />
+    <TerminalConversation v-else :session="session" />
+  </div>
 </template>

--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -106,11 +106,11 @@ watch(
 </script>
 
 <template>
-  <div class="flex min-h-0 flex-1 flex-col">
+  <div class="flex h-full min-h-0 flex-1 flex-col">
     <section
       v-if="cue?.status === 'generated' && cue.text"
       data-testid="resumption-cue"
-      class="mx-3 mt-2 flex items-start gap-2 rounded border border-line bg-subtle px-3 py-2 text-sm"
+      class="mx-3 mt-2 flex shrink-0 items-start gap-2 rounded border border-line bg-subtle px-3 py-2 text-sm"
       aria-label="Generated resumption cue"
     >
       <details
@@ -146,7 +146,7 @@ watch(
     </section>
     <div
       v-else-if="cue?.status !== 'disabled'"
-      class="mx-3 mt-1 flex items-center gap-2 text-2xs text-faint"
+      class="mx-3 mt-1 flex shrink-0 items-center gap-2 text-2xs text-faint"
       role="status"
     >
       <button
@@ -172,10 +172,11 @@ watch(
     </div>
     <AcpConversation
       v-if="isAcp"
+      class="min-h-0 flex-1"
       :session="session"
       :local-commands="localCommands"
       @command="forwardCommand"
     />
-    <TerminalConversation v-else :session="session" />
+    <TerminalConversation v-else class="min-h-0 flex-1" :session="session" />
   </div>
 </template>

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -67,7 +67,17 @@ const actions = useSessionActions(
   () => emit('reload'),
   () => router.push(fleetHref.value),
 );
-const { busy, notice, error, rename, clearTag, setAutoArchiveDisabled, run } = actions;
+const {
+  busy,
+  notice,
+  error,
+  rename,
+  regenerateTitle,
+  setTitleGeneration,
+  clearTag,
+  setAutoArchiveDisabled,
+  run,
+} = actions;
 
 // The lifecycle verbs the ⋯ manage menu offers — the same policy the fleet
 // list's row menu renders, so the two surfaces can't drift.
@@ -117,7 +127,9 @@ function commit() {
   if (!editing.value) return;
   editing.value = false;
   const next = draft.value.trim();
-  if (next && next !== current()) rename(next);
+  if (next && next !== current()) {
+    rename(next, current(), props.ws.branch.title_provenance);
+  }
 }
 
 function cancel() {
@@ -407,6 +419,41 @@ async function submitHandoff() {
           <SessionDetailsPopover :ws="ws" :open="showDetails" @close="closeDetails">
             <template #actions>
               <div class="space-y-1">
+                <div
+                  data-testid="title-generation-state"
+                  class="rounded border border-line bg-input px-2 py-1.5"
+                >
+                  <p class="text-xs font-medium text-fg">
+                    Task label · {{ ws.branch.title_provenance }}
+                  </p>
+                  <p class="text-2xs text-faint">
+                    Metadata refresh: {{ ws.title_generation.status }}
+                  </p>
+                  <div class="mt-1 flex flex-wrap gap-2">
+                    <button
+                      v-if="
+                        ws.title_generation.enabled &&
+                        ['derived', 'generated'].includes(ws.branch.title_provenance)
+                      "
+                      type="button"
+                      data-testid="action-regenerate-title"
+                      class="text-xs text-accent hover:underline disabled:opacity-60"
+                      :disabled="!!busy"
+                      @click="regenerateTitle"
+                    >
+                      {{ busy === 'title-generate' ? 'Starting…' : 'Regenerate label' }}
+                    </button>
+                    <button
+                      type="button"
+                      data-testid="action-title-generation"
+                      class="text-xs text-accent hover:underline disabled:opacity-60"
+                      :disabled="!!busy"
+                      @click="setTitleGeneration(!ws.title_generation.enabled)"
+                    >
+                      {{ ws.title_generation.enabled ? 'Disable refresh' : 'Enable refresh' }}
+                    </button>
+                  </div>
+                </div>
                 <button
                   v-if="ideEnabled"
                   type="button"

--- a/crates/loom/frontend/src/lib/sessionActions.ts
+++ b/crates/loom/frontend/src/lib/sessionActions.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { post, patch, put, del } from '../api';
+import { post, patch, put, del, regenerateSessionTitle, setSessionTitleGeneration } from '../api';
 import { AUTO_ARCHIVE_DISABLED_VALUE, AUTO_ARCHIVE_KEY, type LifecycleVerb } from './sessionState';
 
 // The session's write surface, shared by every place that can act on a session:
@@ -45,10 +45,28 @@ export function useSessionActions(
     }
   }
 
-  const rename = (title: string) =>
+  const rename = (title: string, expectedTitle: string, expectedProvenance: string) =>
     act('title', async () => {
-      await patch(`/sessions/${getId()}`, { title });
+      await patch(`/sessions/${getId()}`, {
+        title,
+        expected_title: expectedTitle,
+        expected_title_provenance: expectedProvenance,
+      });
       notice.value = 'Title saved.';
+      await reload();
+    });
+
+  const regenerateTitle = () =>
+    act('title-generate', async () => {
+      await regenerateSessionTitle(getId());
+      notice.value = 'Task-label refresh started.';
+      await reload();
+    });
+
+  const setTitleGeneration = (enabled: boolean) =>
+    act('title-generation', async () => {
+      await setSessionTitleGeneration(getId(), enabled);
+      notice.value = `Generated task labels ${enabled ? 'enabled' : 'disabled'}.`;
       await reload();
     });
 
@@ -120,5 +138,15 @@ export function useSessionActions(
   // is the whole surface and the individual verbs stay internal.
   const run = (verb: LifecycleVerb) => ({ adopt, recover, archive, remove })[verb]();
 
-  return { busy, notice, error, rename, clearTag, setAutoArchiveDisabled, run };
+  return {
+    busy,
+    notice,
+    error,
+    rename,
+    regenerateTitle,
+    setTitleGeneration,
+    clearTag,
+    setAutoArchiveDisabled,
+    run,
+  };
 }

--- a/crates/loom/frontend/src/lib/sessionActions.ts
+++ b/crates/loom/frontend/src/lib/sessionActions.ts
@@ -58,8 +58,19 @@ export function useSessionActions(
 
   const regenerateTitle = () =>
     act('title-generate', async () => {
-      await regenerateSessionTitle(getId());
-      notice.value = 'Task-label refresh started.';
+      const updated = await regenerateSessionTitle(getId());
+      notice.value =
+        {
+          idle: 'Task-label refresh is idle.',
+          running: 'Task-label refresh started.',
+          generated: 'Task label refreshed.',
+          protected: 'Task label is protected by its human or issue source.',
+          unavailable: 'No eligible metadata profile is available.',
+          disabled: 'Generated task labels are disabled.',
+          stale: 'Task-label source changed; stale output was discarded.',
+          failed: 'Task-label refresh failed.',
+        }[updated.title_generation.status] ??
+        `Task-label refresh: ${updated.title_generation.status}.`;
       await reload();
     });
 

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -88,7 +88,15 @@ export interface Session {
   updated_at: string;
   title_generation: {
     enabled: boolean;
-    status: 'idle' | 'running' | 'generated' | 'protected' | 'disabled' | 'unavailable' | 'failed';
+    status:
+      | 'idle'
+      | 'running'
+      | 'generated'
+      | 'protected'
+      | 'disabled'
+      | 'unavailable'
+      | 'stale'
+      | 'failed';
   };
   /** Branch id of the session that launched this one (its parent in the session
    *  tree), or null for a top-level session. The dashboard groups the list into

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -25,6 +25,7 @@ export interface Branch {
   /** Short label: the branch name with the optional `weaver/` prefix stripped. */
   name: string;
   title: string;
+  title_provenance: 'derived' | 'generated' | 'user' | 'issue';
   goal: string;
   /** The agent's current-state message, set together with the `attention` tag
    *  via `weaver status` (e.g. "Wired up routes; tests pass"). Shown even
@@ -85,6 +86,10 @@ export interface Session {
   last_activity_at: string;
   created_at: string;
   updated_at: string;
+  title_generation: {
+    enabled: boolean;
+    status: 'idle' | 'running' | 'generated' | 'protected' | 'disabled' | 'unavailable' | 'failed';
+  };
   /** Branch id of the session that launched this one (its parent in the session
    *  tree), or null for a top-level session. The dashboard groups the list into
    *  threads by it; a child whose parent is absent (archived, or never tracked)
@@ -146,6 +151,21 @@ export interface Session {
    *  well-known claude/codex mode set — see `AcpConversation`. */
   available_modes?: string[];
   branch: Branch;
+}
+
+export interface ResumptionEvidence {
+  kind: 'conversation' | 'artifact';
+  label: string;
+  href: string;
+  cursor: string;
+}
+
+export interface ResumptionCue {
+  status: 'generated' | 'generating' | 'due' | 'not_due' | 'disabled' | 'unavailable';
+  source_cursor: string | null;
+  text: string | null;
+  generated_at: string | null;
+  evidence: ResumptionEvidence[];
 }
 
 export interface SessionPlacement {

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -257,7 +257,7 @@ function openStream() {
   // `tag` covers every status axis (the agent's attention, a watch's
   // triage, any free-form key); a tag write re-fetches the session so the
   // resolved badge and the pill row refresh.
-  for (const kind of ['status', 'tag', 'github', 'handoff']) {
+  for (const kind of ['status', 'tag', 'github', 'handoff', 'metadata']) {
     source.addEventListener(kind, (e) => {
       const ev = JSON.parse((e as MessageEvent).data) as WeaverEvent;
       events.value.push(ev);

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -44,8 +44,8 @@ const categories: CategoryItem[] = [
   {
     id: 'agents',
     label: 'Agents',
-    groups: ['Agents'],
-    summary: 'Runtime profiles, MCP capabilities, and custom agents for new work sessions.',
+    groups: ['Agents', 'Metadata'],
+    summary: 'Runtime profiles, MCP capabilities, custom agents, and bounded metadata assistance.',
   },
   {
     id: 'sessions',

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { get, patch, listAgents } from '../api';
-import type { CustomAgent, SettingView } from '../types';
+import { get, patch, listAgents, listProfiles } from '../api';
+import type { CustomAgent, Profile, SettingView } from '../types';
 import ToggleSwitch from '../components/ToggleSwitch.vue';
 import TokensPanel from '../components/TokensPanel.vue';
 import AccountPanel from '../components/AccountPanel.vue';
@@ -14,6 +14,7 @@ import McpPanel from '../components/McpPanel.vue';
 import CustomAgentsPanel from '../components/CustomAgentsPanel.vue';
 import AppearancePanel from '../components/AppearancePanel.vue';
 import SettingFieldRow from '../components/SettingFieldRow.vue';
+import ProfileSelector from '../components/ProfileSelector.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -99,6 +100,7 @@ function categoryFromQuery(q: unknown): Category {
 const category = ref<Category>(categoryFromQuery(route.query.tab));
 const settings = ref<SettingView[]>([]);
 const customAgents = ref<CustomAgent[]>([]);
+const profiles = ref<Profile[]>([]);
 const profilesKey = ref(0);
 const drafts = ref<Record<string, string>>({});
 const error = ref('');
@@ -138,6 +140,16 @@ const currentSettings = computed(() => {
     .sort((a, b) => a.label.localeCompare(b.label));
 });
 
+const metadataProfiles = computed(() =>
+  profiles.value.filter(
+    (profile) =>
+      profile.protocol === 'acp' &&
+      profile.class === 'automation' &&
+      profile.strict &&
+      profile.env_clear,
+  ),
+);
+
 function setting(key: string): SettingView | undefined {
   return settings.value.find((s) => s.key === key);
 }
@@ -160,15 +172,17 @@ function defaultText(value: string): string {
 
 async function load() {
   try {
-    const [res, agentRes] = await Promise.all([
+    const [res, agentRes, profileRes] = await Promise.all([
       get('/settings') as Promise<SettingsEnvelope>,
       listAgents(),
+      listProfiles(),
     ]);
     if (!Array.isArray(res?.settings)) {
       throw new Error('Unexpected /api/settings response — the server may be out of date.');
     }
     settings.value = res.settings;
     customAgents.value = agentRes.custom;
+    profiles.value = profileRes;
     drafts.value = Object.fromEntries(res.settings.map((s) => [s.key, s.value]));
     error.value = '';
   } catch (e) {
@@ -309,13 +323,12 @@ onMounted(load);
         <EnvPanel v-if="category === 'environment'" />
         <LogsPanel v-else-if="category === 'diagnostics'" />
 
-        <div v-else-if="category === 'agents'" class="space-y-4">
-          <ProfilesPanel :key="profilesKey" />
-          <McpPanel />
-          <CustomAgentsPanel :agents="customAgents" @reload="reloadAgents" />
-        </div>
-
         <div v-else class="space-y-3">
+          <template v-if="category === 'agents'">
+            <ProfilesPanel :key="profilesKey" />
+            <McpPanel />
+            <CustomAgentsPanel :agents="customAgents" @reload="reloadAgents" />
+          </template>
           <AccountPanel v-if="category === 'access'" />
           <TokensPanel v-if="category === 'access'" />
           <AppearancePanel v-if="category === 'workspace'" />
@@ -323,6 +336,7 @@ onMounted(load);
 
           <section
             v-if="currentSettings.length"
+            :data-testid="category === 'agents' ? 'metadata-settings' : undefined"
             class="overflow-hidden rounded-md border border-line bg-surface"
           >
             <SettingFieldRow
@@ -336,7 +350,32 @@ onMounted(load);
               @save="saveSetting(s)"
               @reset="resetSetting(s)"
             >
-              <div v-if="s.kind === 'bool'" class="flex min-w-0 flex-1 items-center gap-2">
+              <div
+                v-if="s.key === 'metadata.profile'"
+                data-testid="metadata-profile-selector"
+                class="min-w-0 flex-1 space-y-1"
+              >
+                <button
+                  type="button"
+                  class="w-full rounded border px-3 py-2 text-left text-xs"
+                  :class="
+                    drafts[s.key] === ''
+                      ? 'border-accent bg-accent/10 text-fg'
+                      : 'border-line bg-input text-muted hover:bg-subtle hover:text-fg'
+                  "
+                  @click="drafts[s.key] = ''"
+                >
+                  Disabled
+                </button>
+                <ProfileSelector
+                  :profiles="metadataProfiles"
+                  :model-value="drafts[s.key] ?? ''"
+                  layout="list"
+                  @update:model-value="drafts[s.key] = $event"
+                />
+              </div>
+
+              <div v-else-if="s.kind === 'bool'" class="flex min-w-0 flex-1 items-center gap-2">
                 <ToggleSwitch
                   :id="s.key"
                   :model-value="drafts[s.key] === 'true'"

--- a/crates/loom/migrations/0014_metadata_assistance.sql
+++ b/crates/loom/migrations/0014_metadata_assistance.sql
@@ -1,0 +1,10 @@
+CREATE TABLE session_metadata_assistance (
+    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    title_generation_enabled INTEGER NOT NULL DEFAULT 1,
+    title_generation_status TEXT NOT NULL DEFAULT 'idle',
+    cue_source_cursor TEXT,
+    cue_text TEXT,
+    cue_generated_at TEXT,
+    cue_evidence TEXT NOT NULL DEFAULT '[]',
+    updated_at TEXT NOT NULL
+);

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -527,6 +527,10 @@ enum SessionCmd {
         /// Session key: id, branch id, branch name, or `repo:branch`.
         session: String,
         /// Whether generated title refreshes are enabled.
+        #[arg(
+            value_parser = clap::value_parser!(bool),
+            action = clap::ArgAction::Set
+        )]
         enabled: bool,
     },
     /// Read the cached resumption cue, optionally ensuring one now.
@@ -5308,6 +5312,18 @@ mod tests {
     #[test]
     fn cli_is_well_formed() {
         Cli::command().debug_assert();
+        let parsed =
+            Cli::try_parse_from(["loom", "session", "title-generation", "task-1", "false"])
+                .unwrap();
+        assert!(matches!(
+            parsed.cmd,
+            Cmd::Session {
+                cmd: SessionCmd::TitleGeneration {
+                    session,
+                    enabled: false,
+                }
+            } if session == "task-1"
+        ));
     }
 
     /// The scaffold must honor the contract it documents — at minimum, be

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -517,6 +517,29 @@ enum SessionCmd {
         /// The new title. Multiple words are joined, so quoting is optional.
         title: Vec<String>,
     },
+    /// Ask the configured metadata profile to refresh an eligible task label.
+    RegenerateTitle {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+    },
+    /// Enable or disable automatic generated task labels for one session.
+    TitleGeneration {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+        /// Whether generated title refreshes are enabled.
+        enabled: bool,
+    },
+    /// Read the cached resumption cue, optionally ensuring one now.
+    Cue {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
+        /// Generate when inactivity says a cue is due.
+        #[arg(long)]
+        ensure: bool,
+        /// Explicitly generate regardless of the inactivity threshold.
+        #[arg(long)]
+        force: bool,
+    },
     /// Show one session's details.
     Show { branch: String },
     /// Attach your terminal to a session (also `loom attach`).
@@ -1638,6 +1661,15 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
         } => cmd_ps(archived, automation, managed, search, status, attention).await,
         SessionCmd::Layout { cmd } => run_session_layout(cmd).await,
         SessionCmd::Rename { session, title } => cmd_session_rename(session, title.join(" ")).await,
+        SessionCmd::RegenerateTitle { session } => cmd_session_regenerate_title(session).await,
+        SessionCmd::TitleGeneration { session, enabled } => {
+            cmd_session_title_generation(session, enabled).await
+        }
+        SessionCmd::Cue {
+            session,
+            ensure,
+            force,
+        } => cmd_session_cue(session, ensure || force, force).await,
         SessionCmd::Show { branch } => cmd_show(branch).await,
         SessionCmd::Attach { branch } => cmd_attach(branch).await,
         SessionCmd::Archive { branch } => cmd_archive(branch).await,
@@ -4238,10 +4270,17 @@ async fn cmd_session_rename(key: String, title: String) -> Result<()> {
         bail!("nothing to rename to — provide a new title");
     }
     let client = client::default()?;
+    let current = client
+        .get(&format!("/api/sessions/{}", enc_key(&key)))
+        .await?;
     let ws = client
         .patch(
             &format!("/api/sessions/{}", enc_key(&key)),
-            json!({ "title": title }),
+            json!({
+                "title": title,
+                "expected_title": branch_str(&current, "title"),
+                "expected_title_provenance": branch_str(&current, "title_provenance"),
+            }),
         )
         .await?;
     println!(
@@ -4252,13 +4291,82 @@ async fn cmd_session_rename(key: String, title: String) -> Result<()> {
     Ok(())
 }
 
+async fn cmd_session_regenerate_title(key: String) -> Result<()> {
+    let client = client::default()?;
+    let ws = client
+        .post(
+            &format!("/api/sessions/{}/title/regenerate", enc_key(&key)),
+            json!({}),
+        )
+        .await?;
+    println!(
+        "{} — {}",
+        branch_str(&ws, "title"),
+        str_field(ws.get("title_generation").unwrap_or(&Value::Null), "status")
+    );
+    Ok(())
+}
+
+async fn cmd_session_title_generation(key: String, enabled: bool) -> Result<()> {
+    let client = client::default()?;
+    let ws = client
+        .put(
+            &format!("/api/sessions/{}/title-generation", enc_key(&key)),
+            json!({ "enabled": enabled }),
+        )
+        .await?;
+    println!(
+        "title generation {} ({})",
+        if enabled { "enabled" } else { "disabled" },
+        str_field(ws.get("title_generation").unwrap_or(&Value::Null), "status")
+    );
+    Ok(())
+}
+
+async fn cmd_session_cue(key: String, ensure: bool, force: bool) -> Result<()> {
+    let client = client::default()?;
+    let path = format!("/api/sessions/{}/resumption-cue", enc_key(&key));
+    let cue = if ensure {
+        client.post(&path, json!({ "force": force })).await?
+    } else {
+        client.get(&path).await?
+    };
+    println!("status: {}", str_field(&cue, "status"));
+    if let Some(text) = cue.get("text").and_then(Value::as_str) {
+        println!("{text}");
+    }
+    if let Some(at) = cue.get("generated_at").and_then(Value::as_str) {
+        println!("generated: {at}");
+    }
+    Ok(())
+}
+
 fn print_session(ws: &Value) {
     println!(
         "session {}  ({})",
         str_field(ws, "id"),
         branch_str(ws, "name")
     );
-    println!("  title:    {}", branch_str(ws, "title"));
+    println!(
+        "  title:    {} ({})",
+        branch_str(ws, "title"),
+        branch_str(ws, "title_provenance")
+    );
+    if let Some(generation) = ws.get("title_generation") {
+        println!(
+            "  title AI: {} ({})",
+            if generation
+                .get("enabled")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            str_field(generation, "status")
+        );
+    }
     println!("  status:   {}", str_field(ws, "status"));
     if let Some(placement) = ws.get("placement").filter(|value| !value.is_null()) {
         println!(

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -3284,13 +3284,24 @@ async fn run_config(cmd: ConfigCmd) -> Result<()> {
 /// the settings pane's `PATCH /api/settings` against a running daemon — the
 /// form a deploy's boot sequence needs, since it must seed the auth settings
 /// *before* loom starts listening.
-async fn cmd_config_set(key: String, value: String) -> Result<()> {
+async fn cmd_config_set(key: String, mut value: String) -> Result<()> {
     if let Err(why) = weaver_core::config::validate(&key, &value) {
         bail!("{key}: {why}");
     }
     let db = loom::db::connect(&weaver_core::db::default_db_path())
         .await
         .context("opening loom's database")?;
+    if key == loom::metadata_assist::METADATA_PROFILE_KEY {
+        value = value.trim().to_string();
+        if !value.is_empty() {
+            let profile = loom::profile::get(&db, &value)
+                .await?
+                .ok_or_else(|| anyhow!("unknown or retired metadata profile '{value}'"))?;
+            if !loom::metadata_assist::metadata_profile_eligible(&profile) {
+                bail!("metadata profile '{value}' must be an active automation-safe ACP profile");
+            }
+        }
+    }
     weaver_core::config::apply(&db, &[(key.clone(), Some(value))])
         .await
         .with_context(|| format!("writing setting '{key}'"))?;

--- a/crates/loom/src/chatlog.rs
+++ b/crates/loom/src/chatlog.rs
@@ -524,6 +524,7 @@ mod tests {
             base_branch: "main".to_string(),
             goal: String::new(),
             title: String::new(),
+            title_provenance: weaver_core::branch::TitleProvenance::User,
             description: String::new(),
             created_at: String::new(),
             updated_at: String::new(),

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -414,7 +414,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn v12_database_adds_the_review_inbox_at_v13() {
+    async fn v12_database_adds_the_review_inbox_while_upgrading_to_latest() {
         let db = core_connect_in_memory().await.unwrap();
         LOOM_STREAM.ensure_indicator(&db).await.unwrap();
         for (version, name, migration) in LOOM_MIGRATIONS.iter().take(12) {
@@ -436,7 +436,10 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+        assert_eq!(
+            versions,
+            (1..=latest_migration_version()).collect::<Vec<_>>()
+        );
         assert!(!table_columns(&db, "review_conversation_inbox")
             .await
             .unwrap()
@@ -592,7 +595,10 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+        assert_eq!(
+            versions,
+            (1..=latest_migration_version()).collect::<Vec<_>>()
+        );
         assert!(
             crate::session_layout::placement(&db, "warm")
                 .await
@@ -748,7 +754,10 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+        assert_eq!(
+            versions,
+            (1..=latest_migration_version()).collect::<Vec<_>>()
+        );
         let index_sql: String = sqlx::query_scalar(
             "SELECT sql FROM sqlite_master
              WHERE type = 'index' AND name = 'idx_sessions_active_branch'",
@@ -822,7 +831,7 @@ mod tests {
             .fetch_one(&db)
             .await
             .unwrap();
-        assert_eq!(count, 13);
+        assert_eq!(count, latest_migration_version());
 
         // Adoption replaced the historical index predicate: archived history
         // no longer prevents a new active session from claiming the branch.

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -75,6 +75,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "review-inbox",
         include_str!("../migrations/0013_review_inbox.sql"),
     ),
+    (
+        14,
+        "metadata-assistance",
+        include_str!("../migrations/0014_metadata_assistance.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -307,7 +312,10 @@ mod tests {
                 .fetch_all(&db)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+        assert_eq!(
+            versions,
+            (1..=latest_migration_version()).collect::<Vec<_>>()
+        );
 
         let profile_columns = table_columns(&db, "profiles").await.unwrap();
         assert!(profile_columns.iter().any(|column| column == "retired"));
@@ -321,6 +329,10 @@ mod tests {
             .unwrap()
             .is_empty());
         assert!(!table_columns(&db, "session_placements")
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(!table_columns(&db, "session_metadata_assistance")
             .await
             .unwrap()
             .is_empty());

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -32,6 +32,7 @@ pub mod launch_gate;
 pub mod logs;
 pub mod loom_config;
 pub mod mcp;
+pub mod metadata_assist;
 pub mod monitor;
 pub mod profile;
 pub mod repo;

--- a/crates/loom/src/metadata_assist.rs
+++ b/crates/loom/src/metadata_assist.rs
@@ -1,0 +1,659 @@
+//! Bounded metadata assistance for task labels and on-return conversation cues.
+//!
+//! This is deliberately one small service over the existing profile-aware
+//! transient ACP prompt. It has no scheduler: launch may detach one title
+//! refresh, while resumption cues run only through an explicit ensure request.
+
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex as StdMutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use tokio::sync::{Mutex, Semaphore};
+use weaver_api::{ResumptionCueView, ResumptionEvidenceView, TitleGenerationView};
+use weaver_core::artifact;
+use weaver_core::branch::{self, Branch, TitleProvenance, TitleUpdate, MAX_GENERATED_TITLE_CHARS};
+
+use crate::agent::AgentManager;
+use crate::history::{self, PageOptions};
+use crate::profile::Profile;
+use crate::session::Session;
+use crate::{config, profile, repo_env, Db};
+
+pub const METADATA_PROFILE_KEY: &str = "metadata.profile";
+pub const TITLE_ENABLED_KEY: &str = "metadata.title_generation";
+pub const CUES_ENABLED_KEY: &str = "metadata.resumption_cues";
+pub const ALLOW_RESTRICTED_KEY: &str = "metadata.allow_restricted";
+pub const CUE_INACTIVITY_KEY: &str = "metadata.resumption_inactivity_secs";
+
+const PROMPT_TIMEOUT: Duration = Duration::from_secs(45);
+const TITLE_GOAL_CHARS: usize = 4_000;
+const CUE_SOURCE_CHARS: usize = 12_000;
+const CUE_OUTPUT_CHARS: usize = 1_200;
+const HISTORY_RECORDS: usize = 24;
+
+static PROMPT_SLOTS: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(2));
+static ACTIVE_CLAIMS: LazyLock<StdMutex<HashSet<String>>> =
+    LazyLock::new(|| StdMutex::new(HashSet::new()));
+// Prepare/commit and enable/disable transitions are short. Serializing them
+// closes the only in-process race without inventing a job framework.
+static STATE_GATE: Mutex<()> = Mutex::const_new(());
+
+struct PromptClaim(String);
+
+impl PromptClaim {
+    fn acquire(key: String) -> Option<Self> {
+        let inserted = ACTIVE_CLAIMS
+            .lock()
+            .expect("metadata claim mutex poisoned")
+            .insert(key.clone());
+        inserted.then_some(Self(key))
+    }
+}
+
+impl Drop for PromptClaim {
+    fn drop(&mut self) {
+        ACTIVE_CLAIMS
+            .lock()
+            .expect("metadata claim mutex poisoned")
+            .remove(&self.0);
+    }
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct AssistanceRow {
+    title_generation_enabled: bool,
+    title_generation_status: String,
+    cue_source_cursor: Option<String>,
+    cue_text: Option<String>,
+    cue_generated_at: Option<String>,
+    cue_evidence: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CueCursor {
+    history: String,
+    artifacts: Vec<(String, i64)>,
+}
+
+struct CueSource {
+    cursor: String,
+    prompt: String,
+    evidence: Vec<ResumptionEvidenceView>,
+}
+
+async fn row(db: &Db, session_id: &str) -> Result<AssistanceRow> {
+    sqlx::query(
+        "INSERT INTO session_metadata_assistance
+         (session_id, updated_at) VALUES (?, ?)
+         ON CONFLICT(session_id) DO NOTHING",
+    )
+    .bind(session_id)
+    .bind(weaver_core::db::now_iso())
+    .execute(db)
+    .await?;
+    sqlx::query_as(
+        "SELECT title_generation_enabled, title_generation_status,
+                cue_source_cursor, cue_text, cue_generated_at, cue_evidence
+         FROM session_metadata_assistance WHERE session_id = ?",
+    )
+    .bind(session_id)
+    .fetch_one(db)
+    .await
+    .context("reading session metadata assistance")
+}
+
+pub async fn title_view(
+    db: &Db,
+    session_id: &str,
+    provenance: TitleProvenance,
+) -> Result<TitleGenerationView> {
+    let row = row(db, session_id).await?;
+    let globally_enabled = config::get_bool(db, TITLE_ENABLED_KEY, true).await;
+    Ok(TitleGenerationView {
+        enabled: row.title_generation_enabled && globally_enabled,
+        status: if !row.title_generation_enabled || !globally_enabled {
+            "disabled".to_string()
+        } else if !provenance.can_generate(true) {
+            "protected".to_string()
+        } else {
+            row.title_generation_status
+        },
+    })
+}
+
+pub async fn set_title_enabled(db: &Db, session_id: &str, enabled: bool) -> Result<()> {
+    let _guard = STATE_GATE.lock().await;
+    row(db, session_id).await?;
+    sqlx::query(
+        "UPDATE session_metadata_assistance
+         SET title_generation_enabled = ?,
+             title_generation_status = ?,
+             updated_at = ?
+         WHERE session_id = ?",
+    )
+    .bind(enabled)
+    .bind(if enabled { "idle" } else { "disabled" })
+    .bind(weaver_core::db::now_iso())
+    .bind(session_id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+async fn selected_profile(db: &Db, session: &Session) -> Result<Option<Profile>> {
+    let name = config::get(db, METADATA_PROFILE_KEY)
+        .await
+        .unwrap_or_default();
+    let name = name.trim();
+    if name.is_empty() {
+        return Ok(None);
+    }
+    if !privacy_allows_metadata(
+        session.policy_restricted,
+        config::get_bool(db, ALLOW_RESTRICTED_KEY, false).await,
+    ) {
+        return Ok(None);
+    }
+    let Some(profile) = profile::get(db, name).await? else {
+        return Ok(None);
+    };
+    Ok(
+        (!profile.retired && profile.protocol == "acp" && profile.is_automation_safe())
+            .then_some(profile),
+    )
+}
+
+fn privacy_allows_metadata(restricted: bool, allow_restricted: bool) -> bool {
+    !restricted || allow_restricted
+}
+
+async fn known_secret_values(db: &Db, session: &Session, branch: &Branch) -> Vec<String> {
+    let mut values = profile::env_pairs(db, &session.profile)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(_, value)| value)
+        .collect::<Vec<_>>();
+    values.extend(
+        repo_env::pairs(db, &branch.repo_root)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(_, value)| value),
+    );
+    if let Ok(repo_config) = weaver_core::repo_config::load(std::path::Path::new(&branch.repo_root))
+    {
+        values.extend(repo_config.env.into_values());
+    }
+    values.retain(|value| value.chars().count() >= 4);
+    values.sort_by_key(|value| std::cmp::Reverse(value.len()));
+    values.dedup();
+    values
+}
+
+fn redact_known_secrets(mut text: String, secrets: &[String]) -> String {
+    for secret in secrets {
+        text = text.replace(secret, "<redacted>");
+    }
+    text
+}
+
+fn take_chars(value: &str, limit: usize) -> String {
+    let mut chars = value.chars();
+    let prefix: String = chars.by_ref().take(limit).collect();
+    if chars.next().is_some() {
+        format!("{prefix}…")
+    } else {
+        prefix
+    }
+}
+
+fn title_prompt(branch: &Branch, secrets: &[String]) -> String {
+    redact_known_secrets(
+        format!(
+            "Return only a plain-text task label, at most {MAX_GENERATED_TITLE_CHARS} characters. \
+             No quotes, markdown, prefix, explanation, group, or repository name.\n\n\
+             Current fallback: {}\nGoal:\n{}",
+            take_chars(&branch.title, MAX_GENERATED_TITLE_CHARS),
+            take_chars(&branch.goal, TITLE_GOAL_CHARS),
+        ),
+        secrets,
+    )
+}
+
+async fn mark_title_status(db: &Db, session_id: &str, status: &str) -> Result<()> {
+    row(db, session_id).await?;
+    sqlx::query(
+        "UPDATE session_metadata_assistance
+         SET title_generation_status = ?, updated_at = ? WHERE session_id = ?",
+    )
+    .bind(status)
+    .bind(weaver_core::db::now_iso())
+    .bind(session_id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Start one best-effort title refresh. The model call is detached; all
+/// eligibility and CAS checks are repeated at commit.
+pub async fn spawn_title_generation(
+    db: Db,
+    session: Session,
+    branch: Branch,
+    explicit: bool,
+) -> Result<bool> {
+    let claim;
+    {
+        let _guard = STATE_GATE.lock().await;
+        let state = row(&db, &session.id).await?;
+        if !state.title_generation_enabled || !config::get_bool(&db, TITLE_ENABLED_KEY, true).await
+        {
+            mark_title_status(&db, &session.id, "disabled").await?;
+            return Ok(false);
+        }
+        if !branch.title_provenance.can_generate(explicit) {
+            mark_title_status(&db, &session.id, "protected").await?;
+            return Ok(false);
+        }
+        if selected_profile(&db, &session).await?.is_none() {
+            mark_title_status(&db, &session.id, "unavailable").await?;
+            return Ok(false);
+        }
+        let Some(acquired) = PromptClaim::acquire(format!("title:{}", session.id)) else {
+            return Ok(false);
+        };
+        claim = acquired;
+        mark_title_status(&db, &session.id, "running").await?;
+    }
+
+    tokio::spawn(async move {
+        let _claim = claim;
+        if let Err(error) = generate_title(&db, &session, &branch).await {
+            tracing::warn!(session = %session.id, %error, "metadata title generation failed");
+            let _guard = STATE_GATE.lock().await;
+            let _ = mark_title_status(&db, &session.id, "failed").await;
+        }
+    });
+    Ok(true)
+}
+
+async fn generate_title(db: &Db, session: &Session, branch: &Branch) -> Result<()> {
+    let Some(metadata_profile) = selected_profile(db, session).await? else {
+        anyhow::bail!("metadata profile is unavailable");
+    };
+    let secrets = known_secret_values(db, session, branch).await;
+    let prompt = title_prompt(branch, &secrets);
+    let _permit = PROMPT_SLOTS.acquire().await?;
+    let output = AgentManager::new(db)
+        .run_oneshot(
+            &metadata_profile.agent_kind,
+            &prompt,
+            "",
+            "",
+            Some(&metadata_profile),
+            PROMPT_TIMEOUT,
+        )
+        .await
+        .and_then(|text| branch::sanitize_generated_title(&text))
+        .context("metadata agent returned no usable task label")?;
+    drop(_permit);
+
+    let _guard = STATE_GATE.lock().await;
+    let state = row(db, &session.id).await?;
+    if !state.title_generation_enabled {
+        mark_title_status(db, &session.id, "disabled").await?;
+        return Ok(());
+    }
+    match branch::replace_title(
+        db,
+        &branch.id,
+        &branch.title,
+        branch.title_provenance,
+        &output,
+        TitleProvenance::Generated,
+    )
+    .await?
+    {
+        TitleUpdate::Applied(_) => mark_title_status(db, &session.id, "generated").await?,
+        TitleUpdate::Stale(_) => mark_title_status(db, &session.id, "protected").await?,
+        TitleUpdate::Missing => mark_title_status(db, &session.id, "failed").await?,
+    }
+    Ok(())
+}
+
+fn sanitize_cue(input: &str) -> Option<String> {
+    let plain: String = input
+        .chars()
+        .filter(|ch| !ch.is_control() || matches!(ch, '\n' | '\t'))
+        .collect();
+    let trimmed = plain.trim();
+    (!trimmed.is_empty()).then(|| take_chars(trimmed, CUE_OUTPUT_CHARS))
+}
+
+async fn cue_source(db: &Db, session: &Session, branch: &Branch) -> Result<Option<CueSource>> {
+    let page = history::page(
+        db,
+        session,
+        branch,
+        PageOptions {
+            limit: Some(HISTORY_RECORDS),
+            ..Default::default()
+        },
+    )
+    .await
+    .map_err(|error| match error {
+        history::PageError::BadRequest(message) => anyhow::anyhow!(message),
+        history::PageError::Internal(error) => error,
+    })?;
+    let Some(last) = page.records.last() else {
+        return Ok(None);
+    };
+    let artifacts = artifact::list_for_session(db, &branch.repo_root, &branch.id).await?;
+    let cursor = CueCursor {
+        history: last.cursor.clone(),
+        artifacts: artifacts
+            .iter()
+            .map(|artifact| (artifact.name.clone(), artifact.rev))
+            .collect(),
+    };
+    let cursor = serde_json::to_string(&cursor)?;
+    let mut transcript = String::new();
+    for record in &page.records {
+        let label = record
+            .role
+            .as_deref()
+            .or(record.tool_name.as_deref())
+            .or(record.event_name.as_deref())
+            .unwrap_or(&record.kind);
+        let content = record.content.as_deref().unwrap_or_default();
+        transcript.push_str(&format!("[{}] {}: {}\n", record.cursor, label, content));
+    }
+    let artifact_lines = artifacts
+        .iter()
+        .map(|artifact| format!("- {} rev {}", artifact.name, artifact.rev))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let evidence = std::iter::once(ResumptionEvidenceView {
+        kind: "conversation".to_string(),
+        label: format!("Conversation through {}", last.cursor),
+        href: format!("/s/{}?tab=conversation", session.id),
+        cursor: last.cursor.clone(),
+    })
+    .chain(artifacts.iter().map(|artifact| ResumptionEvidenceView {
+        kind: "artifact".to_string(),
+        label: format!("{} rev {}", artifact.name, artifact.rev),
+        href: format!("/s/{}/artifacts/{}", session.id, artifact.name),
+        cursor: format!("artifact:{}:{}", artifact.name, artifact.rev),
+    }))
+    .collect();
+    let secrets = known_secret_values(db, session, branch).await;
+    let prompt = redact_known_secrets(
+        format!(
+            "Write a compact on-return cue for this work session. Cover current intent, \
+             completed work, blockers, changed/current artifacts, and the likely next step. \
+             Use only the evidence below; say when a category is unknown. Maximum 160 words. \
+             Do not present the cue as authoritative state.\n\nGoal:\n{}\n\n\
+             Recent source-linked conversation:\n{}\nArtifacts:\n{}",
+            take_chars(&branch.goal, TITLE_GOAL_CHARS),
+            take_chars(&transcript, CUE_SOURCE_CHARS),
+            artifact_lines,
+        ),
+        &secrets,
+    );
+    Ok(Some(CueSource {
+        cursor,
+        prompt,
+        evidence,
+    }))
+}
+
+fn inactivity_elapsed(last_activity_at: Option<&str>, threshold_secs: i64) -> bool {
+    let Some(last) = last_activity_at else {
+        return false;
+    };
+    DateTime::parse_from_rfc3339(last)
+        .map(|last| Utc::now().signed_duration_since(last).num_seconds() >= threshold_secs)
+        .unwrap_or(false)
+}
+
+fn cue_cache_matches(state: &AssistanceRow, source_cursor: &str) -> bool {
+    state.cue_source_cursor.as_deref() == Some(source_cursor) && state.cue_text.is_some()
+}
+
+fn view(
+    status: &str,
+    source_cursor: Option<String>,
+    text: Option<String>,
+    generated_at: Option<String>,
+    evidence: Vec<ResumptionEvidenceView>,
+) -> ResumptionCueView {
+    ResumptionCueView {
+        status: status.to_string(),
+        source_cursor,
+        text,
+        generated_at,
+        evidence,
+    }
+}
+
+/// Read the current cache and whether a bounded explicit ensure is due. This
+/// never invokes an agent.
+pub async fn current_cue(db: &Db, session: &Session, branch: &Branch) -> Result<ResumptionCueView> {
+    if !config::get_bool(db, CUES_ENABLED_KEY, true).await {
+        return Ok(view("disabled", None, None, None, Vec::new()));
+    }
+    let Some(source) = cue_source(db, session, branch).await? else {
+        return Ok(view("unavailable", None, None, None, Vec::new()));
+    };
+    let state = row(db, &session.id).await?;
+    if cue_cache_matches(&state, &source.cursor) {
+        let evidence = serde_json::from_str(&state.cue_evidence).unwrap_or_default();
+        return Ok(view(
+            "generated",
+            Some(source.cursor),
+            state.cue_text,
+            state.cue_generated_at,
+            evidence,
+        ));
+    }
+    if selected_profile(db, session).await?.is_none() {
+        return Ok(view(
+            "unavailable",
+            Some(source.cursor),
+            None,
+            None,
+            source.evidence,
+        ));
+    }
+    let threshold = config::get(db, CUE_INACTIVITY_KEY)
+        .await
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or(3_600)
+        .max(0);
+    Ok(view(
+        if inactivity_elapsed(session.last_activity_at.as_deref(), threshold) {
+            "due"
+        } else {
+            "not_due"
+        },
+        Some(source.cursor),
+        None,
+        None,
+        source.evidence,
+    ))
+}
+
+/// Generate or reuse one cue for the current source cursor. `force` is the
+/// explicit user action; an on-return caller leaves it false and respects the
+/// configured inactivity threshold.
+pub async fn ensure_cue(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+    force: bool,
+) -> Result<ResumptionCueView> {
+    let current = current_cue(db, session, branch).await?;
+    if (!force && current.status != "due")
+        || matches!(current.status.as_str(), "disabled" | "unavailable")
+    {
+        return Ok(current);
+    }
+    let Some(source) = cue_source(db, session, branch).await? else {
+        return Ok(view("unavailable", None, None, None, Vec::new()));
+    };
+    let Some(metadata_profile) = selected_profile(db, session).await? else {
+        return Ok(view("unavailable", None, None, None, Vec::new()));
+    };
+    let Some(_claim) = PromptClaim::acquire(format!("cue:{}:{}", session.id, source.cursor)) else {
+        return Ok(view(
+            "generating",
+            Some(source.cursor),
+            None,
+            None,
+            source.evidence,
+        ));
+    };
+    let _permit = PROMPT_SLOTS.acquire().await?;
+    let output = AgentManager::new(db)
+        .run_oneshot(
+            &metadata_profile.agent_kind,
+            &source.prompt,
+            "",
+            "",
+            Some(&metadata_profile),
+            PROMPT_TIMEOUT,
+        )
+        .await
+        .and_then(|text| sanitize_cue(&text));
+    drop(_permit);
+    let Some(text) = output else {
+        return Ok(view(
+            "unavailable",
+            Some(source.cursor),
+            None,
+            None,
+            source.evidence,
+        ));
+    };
+    // Conversation/artifact state may have advanced during the bounded model
+    // call. Never label stale prose with a newer cursor.
+    let Some(current_source) = cue_source(db, session, branch).await? else {
+        return Ok(view("unavailable", None, None, None, Vec::new()));
+    };
+    if current_source.cursor != source.cursor {
+        return Ok(view(
+            "due",
+            Some(current_source.cursor),
+            None,
+            None,
+            current_source.evidence,
+        ));
+    }
+    let generated_at = weaver_core::db::now_iso();
+    let evidence = serde_json::to_string(&source.evidence)?;
+    row(db, &session.id).await?;
+    sqlx::query(
+        "UPDATE session_metadata_assistance
+         SET cue_source_cursor = ?, cue_text = ?, cue_generated_at = ?,
+             cue_evidence = ?, updated_at = ?
+         WHERE session_id = ?",
+    )
+    .bind(&source.cursor)
+    .bind(&text)
+    .bind(&generated_at)
+    .bind(evidence)
+    .bind(&generated_at)
+    .bind(&session.id)
+    .execute(db)
+    .await?;
+    Ok(view(
+        "generated",
+        Some(source.cursor),
+        Some(text),
+        Some(generated_at),
+        source.evidence,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redaction_and_bounds_are_deterministic() {
+        assert_eq!(
+            redact_known_secrets(
+                "token=abcdefgh and abcdefghij".to_string(),
+                &["abcdefghij".to_string(), "abcdefgh".to_string()],
+            ),
+            "token=<redacted> and <redacted>"
+        );
+        assert_eq!(take_chars("abc", 3), "abc");
+        assert_eq!(take_chars("abcd", 3), "abc…");
+        assert_eq!(
+            sanitize_cue("\0  Continue\nnext  "),
+            Some("Continue\nnext".into())
+        );
+    }
+
+    #[test]
+    fn inactivity_is_bounded_by_the_configured_threshold() {
+        let recent = Utc::now().to_rfc3339();
+        assert!(!inactivity_elapsed(Some(&recent), 60));
+        let old = (Utc::now() - chrono::Duration::seconds(120)).to_rfc3339();
+        assert!(inactivity_elapsed(Some(&old), 60));
+        assert!(!inactivity_elapsed(None, 0));
+    }
+
+    #[test]
+    fn cursor_and_cache_identity_include_artifact_revisions() {
+        let cursor = CueCursor {
+            history: "iris:1:0".into(),
+            artifacts: vec![("goal".into(), 1)],
+        };
+        assert_eq!(
+            serde_json::to_string(&cursor).unwrap(),
+            r#"{"history":"iris:1:0","artifacts":[["goal",1]]}"#
+        );
+        let state = AssistanceRow {
+            title_generation_enabled: true,
+            title_generation_status: "idle".into(),
+            cue_source_cursor: Some(serde_json::to_string(&cursor).unwrap()),
+            cue_text: Some("Continue the focused work.".into()),
+            cue_generated_at: Some("2026-07-26T00:00:00Z".into()),
+            cue_evidence: "[]".into(),
+        };
+        let current = state.cue_source_cursor.as_deref().unwrap();
+        assert!(cue_cache_matches(&state, current));
+        let advanced = CueCursor {
+            artifacts: vec![("goal".into(), 2)],
+            ..cursor
+        };
+        assert!(!cue_cache_matches(
+            &state,
+            &serde_json::to_string(&advanced).unwrap()
+        ));
+    }
+
+    #[test]
+    fn restricted_sessions_require_an_explicit_metadata_opt_in() {
+        assert!(privacy_allows_metadata(false, false));
+        assert!(!privacy_allows_metadata(true, false));
+        assert!(privacy_allows_metadata(true, true));
+    }
+
+    #[test]
+    fn prompt_claims_are_keyed_single_flight_and_release_on_drop() {
+        let key = "metadata-domain-test:cue:session:cursor".to_string();
+        let first = PromptClaim::acquire(key.clone()).expect("first claimant");
+        assert!(PromptClaim::acquire(key.clone()).is_none());
+        assert!(PromptClaim::acquire(format!("{key}:other")).is_some());
+        drop(first);
+        assert!(PromptClaim::acquire(key).is_some());
+    }
+}

--- a/crates/loom/src/metadata_assist.rs
+++ b/crates/loom/src/metadata_assist.rs
@@ -23,7 +23,7 @@ use crate::agent::AgentManager;
 use crate::history::{self, PageOptions};
 use crate::profile::Profile;
 use crate::session::Session;
-use crate::{config, events, profile, repo_env, session, Db};
+use crate::{config, events, profile, repo_env, session, user_token, Db};
 
 pub const METADATA_PROFILE_KEY: &str = "metadata.profile";
 pub const TITLE_ENABLED_KEY: &str = "metadata.title_generation";
@@ -84,6 +84,7 @@ struct AssistanceRow {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct CueCursor {
+    source: String,
     history: String,
     fingerprint: String,
     artifacts: Vec<(i64, String, i64)>,
@@ -103,9 +104,10 @@ struct CueInputs {
 struct PreparedCue {
     identity: CueIdentity,
     prompt: String,
+    fence: CueFence,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 struct ProfileIdentity {
     name: String,
     lifetime: i64,
@@ -122,25 +124,50 @@ impl From<&Profile> for ProfileIdentity {
     }
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct MetadataSource {
+    goal: String,
+    restricted: bool,
+    allow_restricted: bool,
+    session_profile: ProfileIdentity,
+    source_profile: Option<ProfileIdentity>,
+    created_by: Option<String>,
+    creator_credential: (bool, Option<String>),
+    metadata_profile_name: String,
+    metadata_profile: Option<ProfileIdentity>,
+}
+
+struct MetadataRead {
+    session: Session,
+    branch: Branch,
+    profile: Option<Profile>,
+    source: MetadataSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CueFence {
+    source: MetadataSource,
+    cursor: String,
+    prompt_fingerprint: String,
+}
+
 #[derive(Debug, Clone)]
 struct TitleFence {
-    goal: String,
+    source: MetadataSource,
     title: String,
     provenance: TitleProvenance,
-    restricted: bool,
-    profile: ProfileIdentity,
 }
 
 struct CurrentTitleState<'a> {
-    goal: &'a str,
+    source: Option<&'a MetadataSource>,
     title: &'a str,
     provenance: TitleProvenance,
-    restricted: bool,
     session_enabled: bool,
     globally_enabled: bool,
-    allow_restricted: bool,
-    profile: Option<&'a ProfileIdentity>,
 }
+
+type TitlePreflight = std::result::Result<MetadataRead, &'static str>;
+type CueBoundaryCheck = std::result::Result<MetadataRead, ResumptionCueView>;
 
 async fn row(db: &Db, session_id: &str) -> Result<AssistanceRow> {
     sqlx::query(
@@ -202,24 +229,16 @@ pub async fn set_title_enabled(db: &Db, session_id: &str, enabled: bool) -> Resu
     Ok(())
 }
 
-async fn selected_profile(db: &Db, session: &Session) -> Result<Option<Profile>> {
+async fn configured_profile(db: &Db) -> Result<(String, Option<Profile>)> {
     let name = config::get(db, METADATA_PROFILE_KEY)
         .await
         .unwrap_or_default();
-    let name = name.trim();
+    let name = name.trim().to_string();
     if name.is_empty() {
-        return Ok(None);
+        return Ok((name, None));
     }
-    if !privacy_allows_metadata(
-        session.policy_restricted,
-        config::get_bool(db, ALLOW_RESTRICTED_KEY, false).await,
-    ) {
-        return Ok(None);
-    }
-    let Some(profile) = profile::get(db, name).await? else {
-        return Ok(None);
-    };
-    Ok(metadata_profile_eligible(&profile).then_some(profile))
+    let selected = profile::get(db, &name).await?;
+    Ok((name, selected))
 }
 
 pub fn metadata_profile_eligible(profile: &Profile) -> bool {
@@ -228,6 +247,90 @@ pub fn metadata_profile_eligible(profile: &Profile) -> bool {
 
 fn privacy_allows_metadata(restricted: bool, allow_restricted: bool) -> bool {
     !restricted || allow_restricted
+}
+
+fn serialized_fingerprint<T: Serialize>(value: &T) -> Result<String> {
+    Ok(hex::encode(Sha256::digest(serde_json::to_vec(value)?)))
+}
+
+async fn launching_user_token(db: &Db, created_by: Option<&str>) -> Result<Option<String>> {
+    let Some(username) = created_by else {
+        return Ok(None);
+    };
+    Ok(user_token::get(db, username)
+        .await?
+        .filter(|value| !value.trim().is_empty()))
+}
+
+async fn metadata_source(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+    allow_restricted: bool,
+    metadata_profile_name: String,
+    metadata_profile: Option<&Profile>,
+) -> Result<MetadataSource> {
+    let source_profile = profile::get(db, &session.profile)
+        .await?
+        .as_ref()
+        .map(ProfileIdentity::from);
+    let creator_credential = match session.created_by.as_deref() {
+        Some(username) => {
+            let status = user_token::status(db, username).await?;
+            (status.set, status.updated_at)
+        }
+        None => (false, None),
+    };
+    Ok(MetadataSource {
+        goal: branch.goal.clone(),
+        restricted: session.policy_restricted,
+        allow_restricted,
+        session_profile: ProfileIdentity {
+            name: session.profile.clone(),
+            lifetime: session.profile_lifetime,
+            revision: session.profile_revision,
+        },
+        source_profile,
+        created_by: session.created_by.clone(),
+        creator_credential,
+        metadata_profile_name,
+        metadata_profile: metadata_profile.map(ProfileIdentity::from),
+    })
+}
+
+async fn metadata_read(db: &Db, session_id: &str, branch_id: &str) -> Result<Option<MetadataRead>> {
+    let Some(session) = session::get(db, session_id).await? else {
+        return Ok(None);
+    };
+    let Some(branch) = branch::get(db, branch_id).await? else {
+        return Ok(None);
+    };
+    let allow_restricted = config::get_bool(db, ALLOW_RESTRICTED_KEY, false).await;
+    let (metadata_profile_name, profile) = configured_profile(db).await?;
+    let source = metadata_source(
+        db,
+        &session,
+        &branch,
+        allow_restricted,
+        metadata_profile_name,
+        profile.as_ref(),
+    )
+    .await?;
+    Ok(Some(MetadataRead {
+        session,
+        branch,
+        profile,
+        source,
+    }))
+}
+
+fn metadata_read_is_eligible(read: &MetadataRead) -> bool {
+    privacy_allows_metadata(read.source.restricted, read.source.allow_restricted)
+        && read.profile.as_ref().is_some_and(metadata_profile_eligible)
+}
+
+fn generation_profile(read: &MetadataRead) -> &Profile {
+    read.profile.as_ref().expect("eligible metadata profile")
 }
 
 fn collect_secret_sources(
@@ -264,7 +367,16 @@ async fn known_secret_values(
         .map(|pairs| pairs.into_iter().map(|(_, value)| value).collect());
     let repo_file = weaver_core::repo_config::load(std::path::Path::new(&branch.repo_root))
         .map(|config| config.env.into_values().collect());
-    collect_secret_sources([source_profile, metadata_profile, repo, repo_file])
+    let creator_token = launching_user_token(db, session.created_by.as_deref())
+        .await
+        .map(|value| value.into_iter().collect());
+    collect_secret_sources([
+        source_profile,
+        metadata_profile,
+        repo,
+        repo_file,
+        creator_token,
+    ])
 }
 
 fn redact_known_secrets(mut text: String, secrets: &[String]) -> String {
@@ -318,20 +430,48 @@ fn title_fence_status(fence: &TitleFence, current: &CurrentTitleState<'_>) -> Op
     if !current.provenance.can_generate(true) {
         return Some("protected");
     }
-    if !privacy_allows_metadata(current.restricted, current.allow_restricted) {
+    let Some(source) = current.source else {
+        return Some("unavailable");
+    };
+    if !privacy_allows_metadata(source.restricted, source.allow_restricted) {
         return Some("unavailable");
     }
-    if current.profile != Some(&fence.profile) {
+    if source.metadata_profile != fence.source.metadata_profile {
         return Some("unavailable");
     }
-    if current.restricted != fence.restricted
-        || current.goal != fence.goal
+    if source != &fence.source
         || current.title != fence.title
         || current.provenance != fence.provenance
     {
         return Some("stale");
     }
     None
+}
+
+async fn title_preflight(
+    db: &Db,
+    session_id: &str,
+    branch_id: &str,
+    fence: &TitleFence,
+) -> Result<TitlePreflight> {
+    let state = row(db, session_id).await?;
+    let globally_enabled = config::get_bool(db, TITLE_ENABLED_KEY, true).await;
+    let Some(read) = metadata_read(db, session_id, branch_id).await? else {
+        return Ok(Err("failed"));
+    };
+    let current_title = read.branch.title.clone();
+    let current_provenance = read.branch.title_provenance;
+    let current = CurrentTitleState {
+        source: metadata_read_is_eligible(&read).then_some(&read.source),
+        title: &current_title,
+        provenance: current_provenance,
+        session_enabled: state.title_generation_enabled,
+        globally_enabled,
+    };
+    if let Some(status) = title_fence_status(fence, &current) {
+        return Ok(Err(status));
+    }
+    Ok(Ok(read))
 }
 
 /// Start one best-effort title refresh. The model call is detached; all
@@ -348,29 +488,37 @@ pub async fn spawn_title_generation(
         mark_title_status(&db, &session.id, "disabled").await?;
         return Ok(());
     }
-    if !branch.title_provenance.can_generate(explicit) {
-        mark_title_status(&db, &session.id, "protected").await?;
-        return Ok(());
-    }
-    let Some(metadata_profile) = selected_profile(&db, &session).await? else {
+    let Some(snapshot) = metadata_read(&db, &session.id, &branch.id).await? else {
         mark_title_status(&db, &session.id, "unavailable").await?;
         return Ok(());
     };
+    if !snapshot.branch.title_provenance.can_generate(explicit) {
+        mark_title_status(&db, &snapshot.session.id, "protected").await?;
+        return Ok(());
+    }
+    if !metadata_read_is_eligible(&snapshot) {
+        mark_title_status(&db, &session.id, "unavailable").await?;
+        return Ok(());
+    }
+    let MetadataRead {
+        session,
+        branch,
+        source,
+        ..
+    } = snapshot;
     let Some(claim) = PromptClaim::acquire(title_claim_key(&session.id)) else {
         return Ok(());
     };
     let fence = TitleFence {
-        goal: branch.goal.clone(),
+        source,
         title: branch.title.clone(),
         provenance: branch.title_provenance,
-        restricted: session.policy_restricted,
-        profile: ProfileIdentity::from(&metadata_profile),
     };
     mark_title_status(&db, &session.id, "running").await?;
 
     tokio::spawn(async move {
         let _claim = claim;
-        let status = match generate_title(&db, &session, &branch, &metadata_profile, &fence).await {
+        let status = match generate_title(&db, &session, &branch, &fence).await {
             Ok(status) => status,
             Err(error) => {
                 tracing::warn!(session = %session.id, %error, "metadata title generation failed");
@@ -401,24 +549,36 @@ async fn generate_title(
     db: &Db,
     session: &Session,
     branch: &Branch,
-    metadata_profile: &Profile,
     fence: &TitleFence,
 ) -> Result<&'static str> {
     let _permit = PROMPT_SLOTS.acquire().await?;
+    let prepared = match title_preflight(db, &session.id, &branch.id, fence).await? {
+        Ok(snapshot) => snapshot,
+        Err(status) => return Ok(status),
+    };
     let secrets = tokio::time::timeout(
         PREPARATION_TIMEOUT,
-        known_secret_values(db, session, branch, metadata_profile),
+        known_secret_values(
+            db,
+            &prepared.session,
+            &prepared.branch,
+            generation_profile(&prepared),
+        ),
     )
     .await
     .context("metadata title preparation timed out")??;
-    let prompt = title_prompt(branch, &secrets);
+    let prompt = title_prompt(&prepared.branch, &secrets);
+    let run = match title_preflight(db, &session.id, &branch.id, fence).await? {
+        Ok(snapshot) => snapshot,
+        Err(status) => return Ok(status),
+    };
     let output = AgentManager::new(db)
         .run_oneshot(
-            &metadata_profile.agent_kind,
+            &generation_profile(&run).agent_kind,
             &prompt,
             "",
             "",
-            Some(metadata_profile),
+            Some(generation_profile(&run)),
             PROMPT_TIMEOUT,
         )
         .await
@@ -426,35 +586,15 @@ async fn generate_title(
         .context("metadata agent returned no usable task label")?;
     drop(_permit);
 
-    let Some(current_session) = session::get(db, &session.id).await? else {
-        return Ok("failed");
+    let _current = match title_preflight(db, &session.id, &branch.id, fence).await? {
+        Ok(snapshot) => snapshot,
+        Err(status) => return Ok(status),
     };
-    let Some(current_branch) = branch::get(db, &branch.id).await? else {
-        return Ok("failed");
-    };
-    let state = row(db, &session.id).await?;
-    let globally_enabled = config::get_bool(db, TITLE_ENABLED_KEY, true).await;
-    let allow_restricted = config::get_bool(db, ALLOW_RESTRICTED_KEY, false).await;
-    let current_profile = selected_profile(db, &current_session).await?;
-    let current_profile = current_profile.as_ref().map(ProfileIdentity::from);
-    let current = CurrentTitleState {
-        goal: &current_branch.goal,
-        title: &current_branch.title,
-        provenance: current_branch.title_provenance,
-        restricted: current_session.policy_restricted,
-        session_enabled: state.title_generation_enabled,
-        globally_enabled,
-        allow_restricted,
-        profile: current_profile.as_ref(),
-    };
-    if let Some(status) = title_fence_status(fence, &current) {
-        return Ok(status);
-    }
     Ok(
         match branch::replace_title_from_goal(
             db,
             &branch.id,
-            &fence.goal,
+            &fence.source.goal,
             &fence.title,
             fence.provenance,
             &output,
@@ -515,16 +655,11 @@ async fn cue_inputs(db: &Db, session: &Session, branch: &Branch) -> Result<Optio
     Ok(Some(CueInputs { page, artifacts }))
 }
 
-fn source_fingerprint<T: Serialize>(
-    source: &str,
-    records: &T,
-    artifacts: &[(i64, String, i64)],
-) -> Result<String> {
-    let encoded = serde_json::to_vec(&(source, records, artifacts))?;
-    Ok(hex::encode(Sha256::digest(encoded)))
-}
-
-fn cue_identity_from(session: &Session, inputs: &CueInputs) -> Result<CueIdentity> {
+fn cue_identity_from(
+    session: &Session,
+    inputs: &CueInputs,
+    source: &MetadataSource,
+) -> Result<CueIdentity> {
     let last = inputs
         .page
         .records
@@ -536,12 +671,13 @@ fn cue_identity_from(session: &Session, inputs: &CueInputs) -> Result<CueIdentit
         .map(|artifact| (artifact.id, artifact.name.clone(), artifact.rev))
         .collect::<Vec<_>>();
     let cursor = CueCursor {
+        source: serialized_fingerprint(source)?,
         history: last.cursor.clone(),
-        fingerprint: source_fingerprint(
+        fingerprint: serialized_fingerprint(&(
             &inputs.page.source,
             &inputs.page.records,
             &artifact_versions,
-        )?,
+        ))?,
         artifacts: artifact_versions,
     };
     let cursor = serde_json::to_string(&cursor)?;
@@ -571,9 +707,14 @@ fn cue_identity_from(session: &Session, inputs: &CueInputs) -> Result<CueIdentit
     Ok(CueIdentity { cursor, evidence })
 }
 
-async fn cue_identity(db: &Db, session: &Session, branch: &Branch) -> Result<Option<CueIdentity>> {
+async fn cue_identity(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+    source: &MetadataSource,
+) -> Result<Option<CueIdentity>> {
     Ok(match cue_inputs(db, session, branch).await? {
-        Some(inputs) => Some(cue_identity_from(session, &inputs)?),
+        Some(inputs) => Some(cue_identity_from(session, &inputs, source)?),
         None => None,
     })
 }
@@ -611,16 +752,11 @@ fn recent_transcript(page: &HistoryPageView) -> String {
     take_tail_chars(&transcript, CUE_SOURCE_CHARS)
 }
 
-async fn prepare_cue(
-    db: &Db,
-    session: &Session,
-    branch: &Branch,
-    metadata_profile: &Profile,
-) -> Result<Option<PreparedCue>> {
-    let Some(inputs) = cue_inputs(db, session, branch).await? else {
+async fn prepare_cue(db: &Db, snapshot: &MetadataRead) -> Result<Option<PreparedCue>> {
+    let Some(inputs) = cue_inputs(db, &snapshot.session, &snapshot.branch).await? else {
         return Ok(None);
     };
-    let identity = cue_identity_from(session, &inputs)?;
+    let identity = cue_identity_from(&snapshot.session, &inputs, &snapshot.source)?;
     let artifact_lines = inputs
         .artifacts
         .iter()
@@ -634,7 +770,13 @@ async fn prepare_cue(
         })
         .collect::<Vec<_>>()
         .join("\n");
-    let secrets = known_secret_values(db, session, branch, metadata_profile).await?;
+    let secrets = known_secret_values(
+        db,
+        &snapshot.session,
+        &snapshot.branch,
+        generation_profile(snapshot),
+    )
+    .await?;
     let prompt = redact_known_secrets(
         format!(
             "Write a compact on-return cue for this work session. Cover current intent, \
@@ -642,13 +784,22 @@ async fn prepare_cue(
              Use only the evidence below; say when a category is unknown. Maximum 160 words. \
              Do not present the cue as authoritative state.\n\nGoal:\n{}\n\n\
              Recent source-linked conversation:\n{}\nArtifacts:\n{}",
-            take_chars(&branch.goal, TITLE_GOAL_CHARS),
+            take_chars(&snapshot.branch.goal, TITLE_GOAL_CHARS),
             recent_transcript(&inputs.page),
             artifact_lines,
         ),
         &secrets,
     );
-    Ok(Some(PreparedCue { identity, prompt }))
+    let fence = CueFence {
+        source: snapshot.source.clone(),
+        cursor: identity.cursor.clone(),
+        prompt_fingerprint: serialized_fingerprint(&prompt)?,
+    };
+    Ok(Some(PreparedCue {
+        identity,
+        prompt,
+        fence,
+    }))
 }
 
 fn inactivity_elapsed(last_activity_at: Option<&str>, threshold_secs: i64) -> bool {
@@ -658,6 +809,50 @@ fn inactivity_elapsed(last_activity_at: Option<&str>, threshold_secs: i64) -> bo
     DateTime::parse_from_rfc3339(last)
         .map(|last| Utc::now().signed_duration_since(last).num_seconds() >= threshold_secs)
         .unwrap_or(false)
+}
+
+async fn cue_inactivity_threshold(db: &Db) -> i64 {
+    config::get(db, CUE_INACTIVITY_KEY)
+        .await
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or(3_600)
+        .max(0)
+}
+
+async fn cue_is_due(db: &Db, session: &Session) -> bool {
+    inactivity_elapsed(
+        session.last_activity_at.as_deref(),
+        cue_inactivity_threshold(db).await,
+    )
+}
+
+async fn bounded_prepare_cue(db: &Db, snapshot: &MetadataRead) -> Result<Option<PreparedCue>> {
+    tokio::time::timeout(PREPARATION_TIMEOUT, prepare_cue(db, snapshot))
+        .await
+        .context("resumption cue preparation timed out")?
+}
+
+fn cue_fence_status(expected: &CueFence, current: &CueFence) -> Option<&'static str> {
+    cue_boundary_status(expected, &current.source, &current.cursor)
+        .or_else(|| (current.prompt_fingerprint != expected.prompt_fingerprint).then_some("due"))
+}
+
+fn cue_boundary_status(
+    expected: &CueFence,
+    source: &MetadataSource,
+    cursor: &str,
+) -> Option<&'static str> {
+    if source.metadata_profile != expected.source.metadata_profile {
+        Some("unavailable")
+    } else if source != &expected.source || cursor != expected.cursor {
+        Some("due")
+    } else {
+        None
+    }
+}
+
+fn prepared_view(status: &str, prepared: &PreparedCue) -> ResumptionCueView {
+    identity_view(status, &prepared.identity)
 }
 
 fn cue_cache_matches(state: &AssistanceRow, source_cursor: &str) -> bool {
@@ -688,16 +883,59 @@ fn view(
     }
 }
 
+fn identity_view(status: &str, identity: &CueIdentity) -> ResumptionCueView {
+    view(
+        status,
+        Some(identity.cursor.clone()),
+        None,
+        None,
+        identity.evidence.clone(),
+    )
+}
+
+async fn checked_cue_boundary(
+    db: &Db,
+    session_id: &str,
+    branch_id: &str,
+    force: bool,
+    expected: &PreparedCue,
+) -> Result<CueBoundaryCheck> {
+    let enabled = config::get_bool(db, CUES_ENABLED_KEY, true).await;
+    let threshold = cue_inactivity_threshold(db).await;
+    let snapshot = match metadata_read(db, session_id, branch_id).await? {
+        Some(snapshot) if metadata_read_is_eligible(&snapshot) => snapshot,
+        _ => return Ok(Err(prepared_view("unavailable", expected))),
+    };
+    let Some(identity) =
+        cue_identity(db, &snapshot.session, &snapshot.branch, &snapshot.source).await?
+    else {
+        return Ok(Err(prepared_view("unavailable", expected)));
+    };
+    if !enabled {
+        return Ok(Err(view("disabled", None, None, None, Vec::new())));
+    }
+    if !force && !inactivity_elapsed(snapshot.session.last_activity_at.as_deref(), threshold) {
+        return Ok(Err(identity_view("not_due", &identity)));
+    }
+    if let Some(status) = cue_boundary_status(&expected.fence, &snapshot.source, &identity.cursor) {
+        return Ok(Err(identity_view(status, &identity)));
+    }
+    Ok(Ok(snapshot))
+}
+
 /// Read the current cache and whether a bounded explicit ensure is due. This
 /// never invokes an agent.
 pub async fn current_cue(db: &Db, session: &Session, branch: &Branch) -> Result<ResumptionCueView> {
     if !config::get_bool(db, CUES_ENABLED_KEY, true).await {
         return Ok(view("disabled", None, None, None, Vec::new()));
     }
-    let Some(identity) = cue_identity(db, session, branch).await? else {
+    let Some(read) = metadata_read(db, &session.id, &branch.id).await? else {
         return Ok(view("unavailable", None, None, None, Vec::new()));
     };
-    let state = row(db, &session.id).await?;
+    let Some(identity) = cue_identity(db, &read.session, &read.branch, &read.source).await? else {
+        return Ok(view("unavailable", None, None, None, Vec::new()));
+    };
+    let state = row(db, &read.session.id).await?;
     if cue_cache_matches(&state, &identity.cursor) {
         let evidence = serde_json::from_str(&state.cue_evidence).unwrap_or_default();
         return Ok(view(
@@ -708,39 +946,19 @@ pub async fn current_cue(db: &Db, session: &Session, branch: &Branch) -> Result<
             evidence,
         ));
     }
-    if PromptClaim::active(&cue_claim_key(&session.id)) {
-        return Ok(view(
-            "generating",
-            Some(identity.cursor),
-            None,
-            None,
-            identity.evidence,
-        ));
+    if PromptClaim::active(&cue_claim_key(&read.session.id)) {
+        return Ok(identity_view("generating", &identity));
     }
-    if selected_profile(db, session).await?.is_none() {
-        return Ok(view(
-            "unavailable",
-            Some(identity.cursor),
-            None,
-            None,
-            identity.evidence,
-        ));
+    if !metadata_read_is_eligible(&read) {
+        return Ok(identity_view("unavailable", &identity));
     }
-    let threshold = config::get(db, CUE_INACTIVITY_KEY)
-        .await
-        .and_then(|value| value.parse::<i64>().ok())
-        .unwrap_or(3_600)
-        .max(0);
-    Ok(view(
-        if inactivity_elapsed(session.last_activity_at.as_deref(), threshold) {
+    Ok(identity_view(
+        if cue_is_due(db, &read.session).await {
             "due"
         } else {
             "not_due"
         },
-        Some(identity.cursor),
-        None,
-        None,
-        identity.evidence,
+        &identity,
     ))
 }
 
@@ -769,84 +987,74 @@ pub async fn ensure_cue(
             current.evidence,
         ));
     };
-    let Some(metadata_profile) = selected_profile(db, session).await? else {
-        return Ok(view("unavailable", None, None, None, Vec::new()));
-    };
-    let profile_identity = ProfileIdentity::from(&metadata_profile);
     let _permit = PROMPT_SLOTS.acquire().await?;
-    let Some(prepared) = tokio::time::timeout(
-        PREPARATION_TIMEOUT,
-        prepare_cue(db, session, branch, &metadata_profile),
-    )
-    .await
-    .context("resumption cue preparation timed out")??
-    else {
+    if !config::get_bool(db, CUES_ENABLED_KEY, true).await {
+        return Ok(view("disabled", None, None, None, Vec::new()));
+    }
+    let Some(snapshot) = metadata_read(db, &session.id, &branch.id).await? else {
         return Ok(view("unavailable", None, None, None, Vec::new()));
     };
+    if !metadata_read_is_eligible(&snapshot) {
+        return Ok(view("unavailable", None, None, None, Vec::new()));
+    };
+    let Some(prepared) = bounded_prepare_cue(db, &snapshot).await? else {
+        return Ok(view("unavailable", None, None, None, Vec::new()));
+    };
+
+    // Reload the semantic source and evidence identity after the complete
+    // bounded preparation. This is the final awaited operation before crossing
+    // the model boundary; only synchronous eligibility/fence comparisons
+    // follow it, and no lock or transaction spans the prompt.
+    let run_snapshot =
+        match checked_cue_boundary(db, &session.id, &branch.id, force, &prepared).await? {
+            Ok(snapshot) => snapshot,
+            Err(view) => return Ok(view),
+        };
     let output = AgentManager::new(db)
         .run_oneshot(
-            &metadata_profile.agent_kind,
+            &generation_profile(&run_snapshot).agent_kind,
             &prepared.prompt,
             "",
             "",
-            Some(&metadata_profile),
+            Some(generation_profile(&run_snapshot)),
             PROMPT_TIMEOUT,
         )
         .await
         .and_then(|text| sanitize_cue(&text));
-    drop(_permit);
     let Some(text) = output else {
-        return Ok(view(
-            "unavailable",
-            Some(prepared.identity.cursor),
-            None,
-            None,
-            prepared.identity.evidence,
-        ));
+        return Ok(prepared_view("unavailable", &prepared));
     };
-    // Conversation/artifact state may have advanced during the bounded model
-    // call. Recompute the content fingerprint and never label stale prose with
-    // a newer cursor.
-    let Some(current_identity) = cue_identity(db, session, branch).await? else {
+
+    // Recompute from newly loaded rows after the model returns. Goal, policy,
+    // selected profile, redaction inputs, conversation, and artifacts must all
+    // still identify the exact prompt that ran.
+    let Some(current_snapshot) = metadata_read(db, &session.id, &branch.id).await? else {
+        return Ok(prepared_view("unavailable", &prepared));
+    };
+    if !metadata_read_is_eligible(&current_snapshot) {
+        return Ok(prepared_view("unavailable", &prepared));
+    };
+    let Some(current_prepared) = bounded_prepare_cue(db, &current_snapshot).await? else {
         return Ok(view("unavailable", None, None, None, Vec::new()));
     };
-    if current_identity.cursor != prepared.identity.cursor {
-        return Ok(view(
-            "due",
-            Some(current_identity.cursor),
-            None,
-            None,
-            current_identity.evidence,
-        ));
+    if let Some(status) = cue_fence_status(&prepared.fence, &current_prepared.fence) {
+        return Ok(prepared_view(status, &current_prepared));
     }
-    if !config::get_bool(db, CUES_ENABLED_KEY, true).await {
-        return Ok(view("disabled", None, None, None, Vec::new()));
-    }
-    if selected_profile(db, session)
-        .await?
-        .as_ref()
-        .map(ProfileIdentity::from)
-        .as_ref()
-        != Some(&profile_identity)
+    row(db, &session.id).await?;
+    if let Err(view) =
+        checked_cue_boundary(db, &session.id, &branch.id, force, &current_prepared).await?
     {
-        return Ok(view(
-            "unavailable",
-            Some(prepared.identity.cursor),
-            None,
-            None,
-            prepared.identity.evidence,
-        ));
+        return Ok(view);
     }
     let generated_at = weaver_core::db::now_iso();
-    let evidence = serde_json::to_string(&prepared.identity.evidence)?;
-    row(db, &session.id).await?;
+    let evidence = serde_json::to_string(&current_prepared.identity.evidence)?;
     sqlx::query(
         "UPDATE session_metadata_assistance
          SET cue_source_cursor = ?, cue_text = ?, cue_generated_at = ?,
              cue_evidence = ?, updated_at = ?
          WHERE session_id = ?",
     )
-    .bind(&prepared.identity.cursor)
+    .bind(&current_prepared.identity.cursor)
     .bind(&text)
     .bind(&generated_at)
     .bind(evidence)
@@ -856,16 +1064,50 @@ pub async fn ensure_cue(
     .await?;
     Ok(view(
         "generated",
-        Some(prepared.identity.cursor),
+        Some(current_prepared.identity.cursor),
         Some(text),
         Some(generated_at),
-        prepared.identity.evidence,
+        current_prepared.identity.evidence,
     ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn source() -> MetadataSource {
+        MetadataSource {
+            goal: "ship it".into(),
+            restricted: false,
+            allow_restricted: false,
+            session_profile: ProfileIdentity {
+                name: "default".into(),
+                lifetime: 1,
+                revision: 4,
+            },
+            source_profile: Some(ProfileIdentity {
+                name: "default".into(),
+                lifetime: 1,
+                revision: 9,
+            }),
+            created_by: Some("alice".into()),
+            creator_credential: (true, Some("2026-07-26T00:00:00Z".into())),
+            metadata_profile_name: "watch".into(),
+            metadata_profile: Some(ProfileIdentity {
+                name: "watch".into(),
+                lifetime: 1,
+                revision: 7,
+            }),
+        }
+    }
+
+    fn source_fingerprint<T: Serialize>(
+        source: &str,
+        records: &T,
+        artifacts: &[(i64, String, i64)],
+    ) -> Result<String> {
+        serialized_fingerprint(&(source, records, artifacts))
+    }
 
     #[test]
     fn redaction_and_bounds_are_deterministic() {
@@ -897,13 +1139,14 @@ mod tests {
     #[test]
     fn cursor_and_cache_identity_include_artifact_revisions() {
         let cursor = CueCursor {
+            source: "source-v1".into(),
             history: "iris:1:0".into(),
             fingerprint: "abc123".into(),
             artifacts: vec![(42, "goal".into(), 1)],
         };
         assert_eq!(
             serde_json::to_string(&cursor).unwrap(),
-            r#"{"history":"iris:1:0","fingerprint":"abc123","artifacts":[[42,"goal",1]]}"#
+            r#"{"source":"source-v1","history":"iris:1:0","fingerprint":"abc123","artifacts":[[42,"goal",1]]}"#
         );
         let state = AssistanceRow {
             title_generation_enabled: true,
@@ -961,146 +1204,256 @@ mod tests {
     }
 
     #[test]
+    fn durable_source_fingerprint_covers_semantic_prompt_inputs() {
+        let source = source();
+        let baseline = serialized_fingerprint(&source).unwrap();
+        let changed_sources = [
+            MetadataSource {
+                goal: "changed goal".into(),
+                ..source.clone()
+            },
+            MetadataSource {
+                restricted: true,
+                allow_restricted: true,
+                ..source.clone()
+            },
+            MetadataSource {
+                allow_restricted: true,
+                ..source.clone()
+            },
+            MetadataSource {
+                session_profile: ProfileIdentity {
+                    revision: 5,
+                    ..source.session_profile.clone()
+                },
+                ..source.clone()
+            },
+            MetadataSource {
+                source_profile: Some(ProfileIdentity {
+                    revision: 10,
+                    ..source.source_profile.clone().unwrap()
+                }),
+                ..source.clone()
+            },
+            MetadataSource {
+                created_by: Some("bob".into()),
+                ..source.clone()
+            },
+            MetadataSource {
+                creator_credential: (true, Some("2026-07-26T00:01:00Z".into())),
+                ..source.clone()
+            },
+            MetadataSource {
+                metadata_profile_name: String::new(),
+                metadata_profile: None,
+                ..source.clone()
+            },
+            MetadataSource {
+                metadata_profile: Some(ProfileIdentity {
+                    revision: 8,
+                    ..source.metadata_profile.clone().unwrap()
+                }),
+                ..source.clone()
+            },
+        ];
+        for changed in changed_sources {
+            assert_ne!(baseline, serialized_fingerprint(&changed).unwrap());
+        }
+    }
+
+    #[test]
     fn title_fence_rejects_every_source_and_eligibility_change() {
-        let profile = ProfileIdentity {
-            name: "watch".into(),
-            lifetime: 1,
-            revision: 7,
-        };
+        let source = source();
         let fence = TitleFence {
-            goal: "ship it".into(),
+            source: source.clone(),
             title: "ship it".into(),
             provenance: TitleProvenance::Derived,
-            restricted: false,
-            profile: profile.clone(),
         };
-        let status = |goal,
+        let status = |source: Option<&MetadataSource>,
                       title,
                       provenance,
-                      restricted,
                       session_enabled,
-                      global_enabled,
-                      allow_restricted,
-                      profile: Option<&ProfileIdentity>| {
+                      global_enabled| {
             let current = CurrentTitleState {
-                goal,
+                source,
                 title,
                 provenance,
-                restricted,
                 session_enabled,
                 globally_enabled: global_enabled,
-                allow_restricted,
-                profile,
             };
             title_fence_status(&fence, &current)
         };
         assert_eq!(
             status(
-                "ship it",
+                Some(&source),
                 "ship it",
                 TitleProvenance::Derived,
-                false,
                 true,
                 true,
-                false,
-                Some(&profile)
             ),
             None
         );
+        let changed_goal = MetadataSource {
+            goal: "changed".into(),
+            ..source.clone()
+        };
         assert_eq!(
             status(
-                "changed",
+                Some(&changed_goal),
                 "ship it",
                 TitleProvenance::Derived,
-                false,
                 true,
                 true,
-                false,
-                Some(&profile)
             ),
             Some("stale")
         );
         assert_eq!(
-            status(
-                "ship it",
-                "human",
-                TitleProvenance::User,
-                false,
-                true,
-                true,
-                false,
-                Some(&profile)
-            ),
+            status(Some(&source), "human", TitleProvenance::User, true, true,),
             Some("protected")
         );
         assert_eq!(
             status(
-                "ship it",
+                Some(&source),
                 "ship it",
                 TitleProvenance::Derived,
                 false,
-                false,
                 true,
-                false,
-                Some(&profile)
             ),
             Some("disabled")
         );
         assert_eq!(
             status(
-                "ship it",
+                Some(&source),
                 "ship it",
                 TitleProvenance::Derived,
-                false,
                 true,
                 false,
-                false,
-                Some(&profile)
             ),
             Some("disabled")
         );
         assert_eq!(
-            status(
-                "ship it",
-                "ship it",
-                TitleProvenance::Derived,
-                true,
-                true,
-                true,
-                false,
-                Some(&profile)
-            ),
+            status(None, "ship it", TitleProvenance::Derived, true, true,),
             Some("unavailable")
         );
-        assert_eq!(
-            status(
-                "ship it",
-                "ship it",
-                TitleProvenance::Derived,
-                true,
-                true,
-                true,
-                true,
-                Some(&profile)
-            ),
-            Some("stale"),
-            "a changed restricted-session policy invalidates the source fence"
-        );
-        let changed_profile = ProfileIdentity {
-            revision: 8,
-            ..profile.clone()
+        let revoked = MetadataSource {
+            restricted: true,
+            allow_restricted: false,
+            ..source.clone()
         };
         assert_eq!(
             status(
-                "ship it",
+                Some(&revoked),
                 "ship it",
                 TitleProvenance::Derived,
-                false,
                 true,
                 true,
-                false,
-                Some(&changed_profile)
             ),
+            Some("unavailable")
+        );
+        let changed_session_profile = MetadataSource {
+            session_profile: ProfileIdentity {
+                revision: 5,
+                ..source.session_profile.clone()
+            },
+            ..source.clone()
+        };
+        assert_eq!(
+            status(
+                Some(&changed_session_profile),
+                "ship it",
+                TitleProvenance::Derived,
+                true,
+                true,
+            ),
+            Some("stale"),
+            "a changed source-session profile invalidates the prompt fence"
+        );
+        let changed_profile = MetadataSource {
+            metadata_profile: Some(ProfileIdentity {
+                revision: 8,
+                ..source.metadata_profile.clone().unwrap()
+            }),
+            ..source.clone()
+        };
+        assert_eq!(
+            status(
+                Some(&changed_profile),
+                "ship it",
+                TitleProvenance::Derived,
+                true,
+                true,
+            ),
+            Some("unavailable")
+        );
+    }
+
+    #[test]
+    fn cue_fence_and_post_preparation_boundary_cover_every_prompt_source() {
+        let source = source();
+        let fence = CueFence {
+            source: source.clone(),
+            cursor: "cursor-v1".into(),
+            prompt_fingerprint: "prompt-v1".into(),
+        };
+        assert_eq!(cue_fence_status(&fence, &fence), None);
+        for changed in [
+            CueFence {
+                source: MetadataSource {
+                    goal: "changed goal".into(),
+                    ..source.clone()
+                },
+                ..fence.clone()
+            },
+            CueFence {
+                source: MetadataSource {
+                    creator_credential: (true, Some("2026-07-26T00:01:00Z".into())),
+                    ..source.clone()
+                },
+                ..fence.clone()
+            },
+            CueFence {
+                cursor: "cursor-v2".into(),
+                ..fence.clone()
+            },
+            CueFence {
+                prompt_fingerprint: "prompt-v2".into(),
+                ..fence.clone()
+            },
+        ] {
+            assert_eq!(cue_fence_status(&fence, &changed), Some("due"));
+        }
+        let changed_profile = CueFence {
+            source: MetadataSource {
+                metadata_profile: Some(ProfileIdentity {
+                    revision: 8,
+                    ..source.metadata_profile.unwrap()
+                }),
+                ..source
+            },
+            ..fence.clone()
+        };
+        assert_eq!(
+            cue_fence_status(&fence, &changed_profile),
+            Some("unavailable")
+        );
+        assert_eq!(
+            cue_boundary_status(&fence, &fence.source, &fence.cursor),
+            None
+        );
+        let changed_goal = MetadataSource {
+            goal: "changed after preparation".into(),
+            ..fence.source.clone()
+        };
+        assert_eq!(
+            cue_boundary_status(&fence, &changed_goal, &fence.cursor),
+            Some("due")
+        );
+        assert_eq!(
+            cue_boundary_status(&fence, &fence.source, "cursor-v2"),
+            Some("due")
+        );
+        assert_eq!(
+            cue_boundary_status(&fence, &changed_profile.source, &fence.cursor),
             Some("unavailable")
         );
     }
@@ -1116,6 +1469,38 @@ mod tests {
             result.unwrap_err().to_string(),
             "secret backend unavailable"
         );
+    }
+
+    #[tokio::test]
+    async fn launching_user_token_is_a_fail_closed_secret_source() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        sqlx::query("INSERT INTO users (username) VALUES ('alice')")
+            .execute(&db)
+            .await
+            .unwrap();
+        user_token::set(&db, "alice", "github_pat_secret")
+            .await
+            .unwrap();
+        let status = user_token::status(&db, "alice").await.unwrap();
+        assert!(status.set);
+        assert!(status.updated_at.is_some());
+        assert!(!serde_json::to_string(&status)
+            .unwrap()
+            .contains("github_pat_secret"));
+        assert_eq!(
+            launching_user_token(&db, Some("alice")).await.unwrap(),
+            Some("github_pat_secret".into())
+        );
+        user_token::set(&db, "alice", "").await.unwrap();
+        assert_eq!(
+            launching_user_token(&db, Some("alice")).await.unwrap(),
+            None
+        );
+        sqlx::query("DROP TABLE user_github_tokens")
+            .execute(&db)
+            .await
+            .unwrap();
+        assert!(launching_user_token(&db, Some("alice")).await.is_err());
     }
 
     #[test]

--- a/crates/loom/src/metadata_assist.rs
+++ b/crates/loom/src/metadata_assist.rs
@@ -1,12 +1,8 @@
 //! Bounded metadata assistance for task labels and on-return conversation cues.
-//!
-//! This is deliberately one small service over the existing profile-aware
-//! transient ACP prompt. It has no scheduler: launch may detach one title
-//! refresh, while resumption cues run only through an explicit ensure request.
 
 use std::collections::HashSet;
 use std::sync::{LazyLock, Mutex as StdMutex};
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -133,6 +129,8 @@ struct MetadataSource {
     source_profile: Option<ProfileIdentity>,
     created_by: Option<String>,
     creator_credential: (bool, Option<String>),
+    repo_env_generation: Vec<(String, String)>,
+    repo_config_generation: Option<(u64, u64)>,
     metadata_profile_name: String,
     metadata_profile: Option<ProfileIdentity>,
 }
@@ -281,6 +279,26 @@ async fn metadata_source(
         }
         None => (false, None),
     };
+    let repo_env_generation = repo_env::list(db, &branch.repo_root)
+        .await?
+        .into_iter()
+        .map(|entry| (entry.name, entry.updated_at))
+        .collect();
+    let repo_config_path =
+        std::path::Path::new(&branch.repo_root).join(weaver_core::repo_config::CONFIG_REL_PATH);
+    let repo_config_generation = match std::fs::metadata(repo_config_path) {
+        Ok(metadata) => Some((
+            metadata.len(),
+            metadata
+                .modified()?
+                .duration_since(UNIX_EPOCH)?
+                .as_nanos()
+                .try_into()
+                .context("repo config modified time exceeds u64")?,
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
     Ok(MetadataSource {
         goal: branch.goal.clone(),
         restricted: session.policy_restricted,
@@ -293,6 +311,8 @@ async fn metadata_source(
         source_profile,
         created_by: session.created_by.clone(),
         creator_credential,
+        repo_env_generation,
+        repo_config_generation,
         metadata_profile_name,
         metadata_profile: metadata_profile.map(ProfileIdentity::from),
     })
@@ -474,8 +494,6 @@ async fn title_preflight(
     Ok(Ok(read))
 }
 
-/// Start one best-effort title refresh. The model call is detached; all
-/// eligibility and CAS checks are repeated at commit.
 pub async fn spawn_title_generation(
     db: Db,
     bus: EventBus,
@@ -923,8 +941,6 @@ async fn checked_cue_boundary(
     Ok(Ok(snapshot))
 }
 
-/// Read the current cache and whether a bounded explicit ensure is due. This
-/// never invokes an agent.
 pub async fn current_cue(db: &Db, session: &Session, branch: &Branch) -> Result<ResumptionCueView> {
     if !config::get_bool(db, CUES_ENABLED_KEY, true).await {
         return Ok(view("disabled", None, None, None, Vec::new()));
@@ -962,9 +978,6 @@ pub async fn current_cue(db: &Db, session: &Session, branch: &Branch) -> Result<
     ))
 }
 
-/// Generate or reuse one cue for the current source cursor. `force` is the
-/// explicit user action; an on-return caller leaves it false and respects the
-/// configured inactivity threshold.
 pub async fn ensure_cue(
     db: &Db,
     session: &Session,
@@ -1001,10 +1014,7 @@ pub async fn ensure_cue(
         return Ok(view("unavailable", None, None, None, Vec::new()));
     };
 
-    // Reload the semantic source and evidence identity after the complete
-    // bounded preparation. This is the final awaited operation before crossing
-    // the model boundary; only synchronous eligibility/fence comparisons
-    // follow it, and no lock or transaction spans the prompt.
+    // This boundary is the final await before the model call.
     let run_snapshot =
         match checked_cue_boundary(db, &session.id, &branch.id, force, &prepared).await? {
             Ok(snapshot) => snapshot,
@@ -1025,9 +1035,7 @@ pub async fn ensure_cue(
         return Ok(prepared_view("unavailable", &prepared));
     };
 
-    // Recompute from newly loaded rows after the model returns. Goal, policy,
-    // selected profile, redaction inputs, conversation, and artifacts must all
-    // still identify the exact prompt that ran.
+    // Recompute every prompt source after the model returns.
     let Some(current_snapshot) = metadata_read(db, &session.id, &branch.id).await? else {
         return Ok(prepared_view("unavailable", &prepared));
     };
@@ -1092,6 +1100,8 @@ mod tests {
             }),
             created_by: Some("alice".into()),
             creator_credential: (true, Some("2026-07-26T00:00:00Z".into())),
+            repo_env_generation: vec![("REGISTRY_TOKEN".into(), "2026-07-26T00:00:00Z".into())],
+            repo_config_generation: Some((128, 1_722_000_000_000_000_000)),
             metadata_profile_name: "watch".into(),
             metadata_profile: Some(ProfileIdentity {
                 name: "watch".into(),
@@ -1241,6 +1251,14 @@ mod tests {
             },
             MetadataSource {
                 creator_credential: (true, Some("2026-07-26T00:01:00Z".into())),
+                ..source.clone()
+            },
+            MetadataSource {
+                repo_env_generation: vec![("REGISTRY_TOKEN".into(), "2026-07-26T00:01:00Z".into())],
+                ..source.clone()
+            },
+            MetadataSource {
+                repo_config_generation: Some((129, 1_722_000_000_000_000_001)),
                 ..source.clone()
             },
             MetadataSource {

--- a/crates/loom/src/metadata_assist.rs
+++ b/crates/loom/src/metadata_assist.rs
@@ -11,17 +11,19 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use sqlx::FromRow;
-use tokio::sync::{Mutex, Semaphore};
-use weaver_api::{ResumptionCueView, ResumptionEvidenceView, TitleGenerationView};
-use weaver_core::artifact;
+use tokio::sync::Semaphore;
+use weaver_api::{HistoryPageView, ResumptionCueView, ResumptionEvidenceView, TitleGenerationView};
+use weaver_core::artifact::{self, Artifact};
 use weaver_core::branch::{self, Branch, TitleProvenance, TitleUpdate, MAX_GENERATED_TITLE_CHARS};
+use weaver_core::events::EventBus;
 
 use crate::agent::AgentManager;
 use crate::history::{self, PageOptions};
 use crate::profile::Profile;
 use crate::session::Session;
-use crate::{config, profile, repo_env, Db};
+use crate::{config, events, profile, repo_env, session, Db};
 
 pub const METADATA_PROFILE_KEY: &str = "metadata.profile";
 pub const TITLE_ENABLED_KEY: &str = "metadata.title_generation";
@@ -30,17 +32,17 @@ pub const ALLOW_RESTRICTED_KEY: &str = "metadata.allow_restricted";
 pub const CUE_INACTIVITY_KEY: &str = "metadata.resumption_inactivity_secs";
 
 const PROMPT_TIMEOUT: Duration = Duration::from_secs(45);
+const PREPARATION_TIMEOUT: Duration = Duration::from_secs(10);
 const TITLE_GOAL_CHARS: usize = 4_000;
 const CUE_SOURCE_CHARS: usize = 12_000;
 const CUE_OUTPUT_CHARS: usize = 1_200;
 const HISTORY_RECORDS: usize = 24;
+const CUE_ARTIFACTS: usize = 24;
+const ARTIFACT_LABEL_CHARS: usize = 120;
 
 static PROMPT_SLOTS: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(2));
 static ACTIVE_CLAIMS: LazyLock<StdMutex<HashSet<String>>> =
     LazyLock::new(|| StdMutex::new(HashSet::new()));
-// Prepare/commit and enable/disable transitions are short. Serializing them
-// closes the only in-process race without inventing a job framework.
-static STATE_GATE: Mutex<()> = Mutex::const_new(());
 
 struct PromptClaim(String);
 
@@ -51,6 +53,13 @@ impl PromptClaim {
             .expect("metadata claim mutex poisoned")
             .insert(key.clone());
         inserted.then_some(Self(key))
+    }
+
+    fn active(key: &str) -> bool {
+        ACTIVE_CLAIMS
+            .lock()
+            .expect("metadata claim mutex poisoned")
+            .contains(key)
     }
 }
 
@@ -76,13 +85,61 @@ struct AssistanceRow {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct CueCursor {
     history: String,
-    artifacts: Vec<(String, i64)>,
+    fingerprint: String,
+    artifacts: Vec<(i64, String, i64)>,
 }
 
-struct CueSource {
+#[derive(Clone)]
+struct CueIdentity {
     cursor: String,
-    prompt: String,
     evidence: Vec<ResumptionEvidenceView>,
+}
+
+struct CueInputs {
+    page: HistoryPageView,
+    artifacts: Vec<Artifact>,
+}
+
+struct PreparedCue {
+    identity: CueIdentity,
+    prompt: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProfileIdentity {
+    name: String,
+    lifetime: i64,
+    revision: i64,
+}
+
+impl From<&Profile> for ProfileIdentity {
+    fn from(profile: &Profile) -> Self {
+        Self {
+            name: profile.name.clone(),
+            lifetime: profile.lifetime,
+            revision: profile.revision,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TitleFence {
+    goal: String,
+    title: String,
+    provenance: TitleProvenance,
+    restricted: bool,
+    profile: ProfileIdentity,
+}
+
+struct CurrentTitleState<'a> {
+    goal: &'a str,
+    title: &'a str,
+    provenance: TitleProvenance,
+    restricted: bool,
+    session_enabled: bool,
+    globally_enabled: bool,
+    allow_restricted: bool,
+    profile: Option<&'a ProfileIdentity>,
 }
 
 async fn row(db: &Db, session_id: &str) -> Result<AssistanceRow> {
@@ -119,6 +176,8 @@ pub async fn title_view(
             "disabled".to_string()
         } else if !provenance.can_generate(true) {
             "protected".to_string()
+        } else if PromptClaim::active(&title_claim_key(session_id)) {
+            "running".to_string()
         } else {
             row.title_generation_status
         },
@@ -126,7 +185,6 @@ pub async fn title_view(
 }
 
 pub async fn set_title_enabled(db: &Db, session_id: &str, enabled: bool) -> Result<()> {
-    let _guard = STATE_GATE.lock().await;
     row(db, session_id).await?;
     sqlx::query(
         "UPDATE session_metadata_assistance
@@ -161,38 +219,52 @@ async fn selected_profile(db: &Db, session: &Session) -> Result<Option<Profile>>
     let Some(profile) = profile::get(db, name).await? else {
         return Ok(None);
     };
-    Ok(
-        (!profile.retired && profile.protocol == "acp" && profile.is_automation_safe())
-            .then_some(profile),
-    )
+    Ok(metadata_profile_eligible(&profile).then_some(profile))
+}
+
+pub fn metadata_profile_eligible(profile: &Profile) -> bool {
+    !profile.retired && profile.protocol == "acp" && profile.is_automation_safe()
 }
 
 fn privacy_allows_metadata(restricted: bool, allow_restricted: bool) -> bool {
     !restricted || allow_restricted
 }
 
-async fn known_secret_values(db: &Db, session: &Session, branch: &Branch) -> Vec<String> {
-    let mut values = profile::env_pairs(db, &session.profile)
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .map(|(_, value)| value)
-        .collect::<Vec<_>>();
-    values.extend(
-        repo_env::pairs(db, &branch.repo_root)
-            .await
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(_, value)| value),
-    );
-    if let Ok(repo_config) = weaver_core::repo_config::load(std::path::Path::new(&branch.repo_root))
-    {
-        values.extend(repo_config.env.into_values());
+fn collect_secret_sources(
+    sources: impl IntoIterator<Item = Result<Vec<String>>>,
+) -> Result<Vec<String>> {
+    let mut values = Vec::new();
+    for source in sources {
+        values.extend(source?);
     }
     values.retain(|value| value.chars().count() >= 4);
     values.sort_by_key(|value| std::cmp::Reverse(value.len()));
     values.dedup();
-    values
+    Ok(values)
+}
+
+async fn known_secret_values(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+    metadata_profile: &Profile,
+) -> Result<Vec<String>> {
+    let source_profile = profile::env_pairs(db, &session.profile)
+        .await
+        .map(|pairs| pairs.into_iter().map(|(_, value)| value).collect());
+    let metadata_profile = if metadata_profile.name == session.profile {
+        Ok(Vec::new())
+    } else {
+        profile::env_pairs(db, &metadata_profile.name)
+            .await
+            .map(|pairs| pairs.into_iter().map(|(_, value)| value).collect())
+    };
+    let repo = repo_env::pairs(db, &branch.repo_root)
+        .await
+        .map(|pairs| pairs.into_iter().map(|(_, value)| value).collect());
+    let repo_file = weaver_core::repo_config::load(std::path::Path::new(&branch.repo_root))
+        .map(|config| config.env.into_values().collect());
+    collect_secret_sources([source_profile, metadata_profile, repo, repo_file])
 }
 
 fn redact_known_secrets(mut text: String, secrets: &[String]) -> String {
@@ -239,63 +311,114 @@ async fn mark_title_status(db: &Db, session_id: &str, status: &str) -> Result<()
     Ok(())
 }
 
+fn title_fence_status(fence: &TitleFence, current: &CurrentTitleState<'_>) -> Option<&'static str> {
+    if !current.session_enabled || !current.globally_enabled {
+        return Some("disabled");
+    }
+    if !current.provenance.can_generate(true) {
+        return Some("protected");
+    }
+    if !privacy_allows_metadata(current.restricted, current.allow_restricted) {
+        return Some("unavailable");
+    }
+    if current.profile != Some(&fence.profile) {
+        return Some("unavailable");
+    }
+    if current.restricted != fence.restricted
+        || current.goal != fence.goal
+        || current.title != fence.title
+        || current.provenance != fence.provenance
+    {
+        return Some("stale");
+    }
+    None
+}
+
 /// Start one best-effort title refresh. The model call is detached; all
 /// eligibility and CAS checks are repeated at commit.
 pub async fn spawn_title_generation(
     db: Db,
+    bus: EventBus,
     session: Session,
     branch: Branch,
     explicit: bool,
-) -> Result<bool> {
-    let claim;
-    {
-        let _guard = STATE_GATE.lock().await;
-        let state = row(&db, &session.id).await?;
-        if !state.title_generation_enabled || !config::get_bool(&db, TITLE_ENABLED_KEY, true).await
-        {
-            mark_title_status(&db, &session.id, "disabled").await?;
-            return Ok(false);
-        }
-        if !branch.title_provenance.can_generate(explicit) {
-            mark_title_status(&db, &session.id, "protected").await?;
-            return Ok(false);
-        }
-        if selected_profile(&db, &session).await?.is_none() {
-            mark_title_status(&db, &session.id, "unavailable").await?;
-            return Ok(false);
-        }
-        let Some(acquired) = PromptClaim::acquire(format!("title:{}", session.id)) else {
-            return Ok(false);
-        };
-        claim = acquired;
-        mark_title_status(&db, &session.id, "running").await?;
+) -> Result<()> {
+    let state = row(&db, &session.id).await?;
+    if !state.title_generation_enabled || !config::get_bool(&db, TITLE_ENABLED_KEY, true).await {
+        mark_title_status(&db, &session.id, "disabled").await?;
+        return Ok(());
     }
+    if !branch.title_provenance.can_generate(explicit) {
+        mark_title_status(&db, &session.id, "protected").await?;
+        return Ok(());
+    }
+    let Some(metadata_profile) = selected_profile(&db, &session).await? else {
+        mark_title_status(&db, &session.id, "unavailable").await?;
+        return Ok(());
+    };
+    let Some(claim) = PromptClaim::acquire(title_claim_key(&session.id)) else {
+        return Ok(());
+    };
+    let fence = TitleFence {
+        goal: branch.goal.clone(),
+        title: branch.title.clone(),
+        provenance: branch.title_provenance,
+        restricted: session.policy_restricted,
+        profile: ProfileIdentity::from(&metadata_profile),
+    };
+    mark_title_status(&db, &session.id, "running").await?;
 
     tokio::spawn(async move {
         let _claim = claim;
-        if let Err(error) = generate_title(&db, &session, &branch).await {
-            tracing::warn!(session = %session.id, %error, "metadata title generation failed");
-            let _guard = STATE_GATE.lock().await;
-            let _ = mark_title_status(&db, &session.id, "failed").await;
+        let status = match generate_title(&db, &session, &branch, &metadata_profile, &fence).await {
+            Ok(status) => status,
+            Err(error) => {
+                tracing::warn!(session = %session.id, %error, "metadata title generation failed");
+                "failed"
+            }
+        };
+        if let Err(error) = mark_title_status(&db, &session.id, status).await {
+            tracing::warn!(
+                session = %session.id,
+                %error,
+                "failed to persist terminal metadata title status"
+            );
         }
+        events::emit(
+            &bus,
+            &branch.id,
+            "metadata",
+            serde_json::json!({
+                "session_id": session.id,
+                "title_generation": status,
+            }),
+        );
     });
-    Ok(true)
+    Ok(())
 }
 
-async fn generate_title(db: &Db, session: &Session, branch: &Branch) -> Result<()> {
-    let Some(metadata_profile) = selected_profile(db, session).await? else {
-        anyhow::bail!("metadata profile is unavailable");
-    };
-    let secrets = known_secret_values(db, session, branch).await;
-    let prompt = title_prompt(branch, &secrets);
+async fn generate_title(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+    metadata_profile: &Profile,
+    fence: &TitleFence,
+) -> Result<&'static str> {
     let _permit = PROMPT_SLOTS.acquire().await?;
+    let secrets = tokio::time::timeout(
+        PREPARATION_TIMEOUT,
+        known_secret_values(db, session, branch, metadata_profile),
+    )
+    .await
+    .context("metadata title preparation timed out")??;
+    let prompt = title_prompt(branch, &secrets);
     let output = AgentManager::new(db)
         .run_oneshot(
             &metadata_profile.agent_kind,
             &prompt,
             "",
             "",
-            Some(&metadata_profile),
+            Some(metadata_profile),
             PROMPT_TIMEOUT,
         )
         .await
@@ -303,27 +426,49 @@ async fn generate_title(db: &Db, session: &Session, branch: &Branch) -> Result<(
         .context("metadata agent returned no usable task label")?;
     drop(_permit);
 
-    let _guard = STATE_GATE.lock().await;
+    let Some(current_session) = session::get(db, &session.id).await? else {
+        return Ok("failed");
+    };
+    let Some(current_branch) = branch::get(db, &branch.id).await? else {
+        return Ok("failed");
+    };
     let state = row(db, &session.id).await?;
-    if !state.title_generation_enabled {
-        mark_title_status(db, &session.id, "disabled").await?;
-        return Ok(());
+    let globally_enabled = config::get_bool(db, TITLE_ENABLED_KEY, true).await;
+    let allow_restricted = config::get_bool(db, ALLOW_RESTRICTED_KEY, false).await;
+    let current_profile = selected_profile(db, &current_session).await?;
+    let current_profile = current_profile.as_ref().map(ProfileIdentity::from);
+    let current = CurrentTitleState {
+        goal: &current_branch.goal,
+        title: &current_branch.title,
+        provenance: current_branch.title_provenance,
+        restricted: current_session.policy_restricted,
+        session_enabled: state.title_generation_enabled,
+        globally_enabled,
+        allow_restricted,
+        profile: current_profile.as_ref(),
+    };
+    if let Some(status) = title_fence_status(fence, &current) {
+        return Ok(status);
     }
-    match branch::replace_title(
-        db,
-        &branch.id,
-        &branch.title,
-        branch.title_provenance,
-        &output,
-        TitleProvenance::Generated,
+    Ok(
+        match branch::replace_title_from_goal(
+            db,
+            &branch.id,
+            &fence.goal,
+            &fence.title,
+            fence.provenance,
+            &output,
+        )
+        .await?
+        {
+            TitleUpdate::Applied(_) => "generated",
+            TitleUpdate::Stale(current) if !current.title_provenance.can_generate(true) => {
+                "protected"
+            }
+            TitleUpdate::Stale(_) => "stale",
+            TitleUpdate::Missing => "failed",
+        },
     )
-    .await?
-    {
-        TitleUpdate::Applied(_) => mark_title_status(db, &session.id, "generated").await?,
-        TitleUpdate::Stale(_) => mark_title_status(db, &session.id, "protected").await?,
-        TitleUpdate::Missing => mark_title_status(db, &session.id, "failed").await?,
-    }
-    Ok(())
 }
 
 fn sanitize_cue(input: &str) -> Option<String> {
@@ -335,7 +480,19 @@ fn sanitize_cue(input: &str) -> Option<String> {
     (!trimmed.is_empty()).then(|| take_chars(trimmed, CUE_OUTPUT_CHARS))
 }
 
-async fn cue_source(db: &Db, session: &Session, branch: &Branch) -> Result<Option<CueSource>> {
+fn recent_artifacts(mut artifacts: Vec<Artifact>) -> Vec<Artifact> {
+    artifacts.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    artifacts.truncate(CUE_ARTIFACTS);
+    artifacts.sort_by(|left, right| left.name.cmp(&right.name));
+    artifacts
+}
+
+async fn cue_inputs(db: &Db, session: &Session, branch: &Branch) -> Result<Option<CueInputs>> {
     let page = history::page(
         db,
         session,
@@ -350,18 +507,87 @@ async fn cue_source(db: &Db, session: &Session, branch: &Branch) -> Result<Optio
         history::PageError::BadRequest(message) => anyhow::anyhow!(message),
         history::PageError::Internal(error) => error,
     })?;
-    let Some(last) = page.records.last() else {
+    if page.records.is_empty() {
         return Ok(None);
-    };
-    let artifacts = artifact::list_for_session(db, &branch.repo_root, &branch.id).await?;
+    }
+    let artifacts =
+        recent_artifacts(artifact::list_for_session(db, &branch.repo_root, &branch.id).await?);
+    Ok(Some(CueInputs { page, artifacts }))
+}
+
+fn source_fingerprint<T: Serialize>(
+    source: &str,
+    records: &T,
+    artifacts: &[(i64, String, i64)],
+) -> Result<String> {
+    let encoded = serde_json::to_vec(&(source, records, artifacts))?;
+    Ok(hex::encode(Sha256::digest(encoded)))
+}
+
+fn cue_identity_from(session: &Session, inputs: &CueInputs) -> Result<CueIdentity> {
+    let last = inputs
+        .page
+        .records
+        .last()
+        .expect("cue inputs require at least one history record");
+    let artifact_versions = inputs
+        .artifacts
+        .iter()
+        .map(|artifact| (artifact.id, artifact.name.clone(), artifact.rev))
+        .collect::<Vec<_>>();
     let cursor = CueCursor {
         history: last.cursor.clone(),
-        artifacts: artifacts
-            .iter()
-            .map(|artifact| (artifact.name.clone(), artifact.rev))
-            .collect(),
+        fingerprint: source_fingerprint(
+            &inputs.page.source,
+            &inputs.page.records,
+            &artifact_versions,
+        )?,
+        artifacts: artifact_versions,
     };
     let cursor = serde_json::to_string(&cursor)?;
+    let evidence = std::iter::once(ResumptionEvidenceView {
+        kind: "conversation".to_string(),
+        label: format!("Conversation through {}", last.cursor),
+        href: format!("/s/{}?tab=conversation", session.id),
+        cursor: last.cursor.clone(),
+    })
+    .chain(inputs.artifacts.iter().map(|artifact| {
+        let name = percent_encoding::utf8_percent_encode(
+            &artifact.name,
+            percent_encoding::NON_ALPHANUMERIC,
+        );
+        ResumptionEvidenceView {
+            kind: "artifact".to_string(),
+            label: format!(
+                "{} rev {}",
+                take_chars(&artifact.name, ARTIFACT_LABEL_CHARS),
+                artifact.rev
+            ),
+            href: format!("/s/{}/artifacts/{name}", session.id),
+            cursor: format!("artifact:{}:{}", artifact.id, artifact.rev),
+        }
+    }))
+    .collect();
+    Ok(CueIdentity { cursor, evidence })
+}
+
+async fn cue_identity(db: &Db, session: &Session, branch: &Branch) -> Result<Option<CueIdentity>> {
+    Ok(match cue_inputs(db, session, branch).await? {
+        Some(inputs) => Some(cue_identity_from(session, &inputs)?),
+        None => None,
+    })
+}
+
+fn take_tail_chars(value: &str, limit: usize) -> String {
+    let count = value.chars().count();
+    if count <= limit {
+        return value.to_string();
+    }
+    let tail: String = value.chars().skip(count - (limit - 1)).collect();
+    format!("…{tail}")
+}
+
+fn recent_transcript(page: &HistoryPageView) -> String {
     let mut transcript = String::new();
     for record in &page.records {
         let label = record
@@ -370,28 +596,45 @@ async fn cue_source(db: &Db, session: &Session, branch: &Branch) -> Result<Optio
             .or(record.tool_name.as_deref())
             .or(record.event_name.as_deref())
             .unwrap_or(&record.kind);
-        let content = record.content.as_deref().unwrap_or_default();
+        let tool_input = record
+            .tool_input
+            .as_ref()
+            .and_then(|value| serde_json::to_string(value).ok())
+            .unwrap_or_default();
+        let content = record
+            .content
+            .as_deref()
+            .or(record.tool_status.as_deref())
+            .unwrap_or(&tool_input);
         transcript.push_str(&format!("[{}] {}: {}\n", record.cursor, label, content));
     }
-    let artifact_lines = artifacts
+    take_tail_chars(&transcript, CUE_SOURCE_CHARS)
+}
+
+async fn prepare_cue(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+    metadata_profile: &Profile,
+) -> Result<Option<PreparedCue>> {
+    let Some(inputs) = cue_inputs(db, session, branch).await? else {
+        return Ok(None);
+    };
+    let identity = cue_identity_from(session, &inputs)?;
+    let artifact_lines = inputs
+        .artifacts
         .iter()
-        .map(|artifact| format!("- {} rev {}", artifact.name, artifact.rev))
+        .map(|artifact| {
+            format!(
+                "- {} rev {}: {}",
+                take_chars(&artifact.name, ARTIFACT_LABEL_CHARS),
+                artifact.rev,
+                take_chars(&artifact.title, ARTIFACT_LABEL_CHARS)
+            )
+        })
         .collect::<Vec<_>>()
         .join("\n");
-    let evidence = std::iter::once(ResumptionEvidenceView {
-        kind: "conversation".to_string(),
-        label: format!("Conversation through {}", last.cursor),
-        href: format!("/s/{}?tab=conversation", session.id),
-        cursor: last.cursor.clone(),
-    })
-    .chain(artifacts.iter().map(|artifact| ResumptionEvidenceView {
-        kind: "artifact".to_string(),
-        label: format!("{} rev {}", artifact.name, artifact.rev),
-        href: format!("/s/{}/artifacts/{}", session.id, artifact.name),
-        cursor: format!("artifact:{}:{}", artifact.name, artifact.rev),
-    }))
-    .collect();
-    let secrets = known_secret_values(db, session, branch).await;
+    let secrets = known_secret_values(db, session, branch, metadata_profile).await?;
     let prompt = redact_known_secrets(
         format!(
             "Write a compact on-return cue for this work session. Cover current intent, \
@@ -400,16 +643,12 @@ async fn cue_source(db: &Db, session: &Session, branch: &Branch) -> Result<Optio
              Do not present the cue as authoritative state.\n\nGoal:\n{}\n\n\
              Recent source-linked conversation:\n{}\nArtifacts:\n{}",
             take_chars(&branch.goal, TITLE_GOAL_CHARS),
-            take_chars(&transcript, CUE_SOURCE_CHARS),
+            recent_transcript(&inputs.page),
             artifact_lines,
         ),
         &secrets,
     );
-    Ok(Some(CueSource {
-        cursor,
-        prompt,
-        evidence,
-    }))
+    Ok(Some(PreparedCue { identity, prompt }))
 }
 
 fn inactivity_elapsed(last_activity_at: Option<&str>, threshold_secs: i64) -> bool {
@@ -423,6 +662,14 @@ fn inactivity_elapsed(last_activity_at: Option<&str>, threshold_secs: i64) -> bo
 
 fn cue_cache_matches(state: &AssistanceRow, source_cursor: &str) -> bool {
     state.cue_source_cursor.as_deref() == Some(source_cursor) && state.cue_text.is_some()
+}
+
+fn cue_claim_key(session_id: &str) -> String {
+    format!("cue:{session_id}")
+}
+
+fn title_claim_key(session_id: &str) -> String {
+    format!("title:{session_id}")
 }
 
 fn view(
@@ -447,27 +694,36 @@ pub async fn current_cue(db: &Db, session: &Session, branch: &Branch) -> Result<
     if !config::get_bool(db, CUES_ENABLED_KEY, true).await {
         return Ok(view("disabled", None, None, None, Vec::new()));
     }
-    let Some(source) = cue_source(db, session, branch).await? else {
+    let Some(identity) = cue_identity(db, session, branch).await? else {
         return Ok(view("unavailable", None, None, None, Vec::new()));
     };
     let state = row(db, &session.id).await?;
-    if cue_cache_matches(&state, &source.cursor) {
+    if cue_cache_matches(&state, &identity.cursor) {
         let evidence = serde_json::from_str(&state.cue_evidence).unwrap_or_default();
         return Ok(view(
             "generated",
-            Some(source.cursor),
+            Some(identity.cursor),
             state.cue_text,
             state.cue_generated_at,
             evidence,
         ));
     }
+    if PromptClaim::active(&cue_claim_key(&session.id)) {
+        return Ok(view(
+            "generating",
+            Some(identity.cursor),
+            None,
+            None,
+            identity.evidence,
+        ));
+    }
     if selected_profile(db, session).await?.is_none() {
         return Ok(view(
             "unavailable",
-            Some(source.cursor),
+            Some(identity.cursor),
             None,
             None,
-            source.evidence,
+            identity.evidence,
         ));
     }
     let threshold = config::get(db, CUE_INACTIVITY_KEY)
@@ -481,10 +737,10 @@ pub async fn current_cue(db: &Db, session: &Session, branch: &Branch) -> Result<
         } else {
             "not_due"
         },
-        Some(source.cursor),
+        Some(identity.cursor),
         None,
         None,
-        source.evidence,
+        identity.evidence,
     ))
 }
 
@@ -503,26 +759,34 @@ pub async fn ensure_cue(
     {
         return Ok(current);
     }
-    let Some(source) = cue_source(db, session, branch).await? else {
-        return Ok(view("unavailable", None, None, None, Vec::new()));
+    let claim_key = cue_claim_key(&session.id);
+    let Some(_claim) = PromptClaim::acquire(claim_key) else {
+        return Ok(view(
+            "generating",
+            current.source_cursor,
+            None,
+            None,
+            current.evidence,
+        ));
     };
     let Some(metadata_profile) = selected_profile(db, session).await? else {
         return Ok(view("unavailable", None, None, None, Vec::new()));
     };
-    let Some(_claim) = PromptClaim::acquire(format!("cue:{}:{}", session.id, source.cursor)) else {
-        return Ok(view(
-            "generating",
-            Some(source.cursor),
-            None,
-            None,
-            source.evidence,
-        ));
-    };
+    let profile_identity = ProfileIdentity::from(&metadata_profile);
     let _permit = PROMPT_SLOTS.acquire().await?;
+    let Some(prepared) = tokio::time::timeout(
+        PREPARATION_TIMEOUT,
+        prepare_cue(db, session, branch, &metadata_profile),
+    )
+    .await
+    .context("resumption cue preparation timed out")??
+    else {
+        return Ok(view("unavailable", None, None, None, Vec::new()));
+    };
     let output = AgentManager::new(db)
         .run_oneshot(
             &metadata_profile.agent_kind,
-            &source.prompt,
+            &prepared.prompt,
             "",
             "",
             Some(&metadata_profile),
@@ -534,28 +798,47 @@ pub async fn ensure_cue(
     let Some(text) = output else {
         return Ok(view(
             "unavailable",
-            Some(source.cursor),
+            Some(prepared.identity.cursor),
             None,
             None,
-            source.evidence,
+            prepared.identity.evidence,
         ));
     };
     // Conversation/artifact state may have advanced during the bounded model
-    // call. Never label stale prose with a newer cursor.
-    let Some(current_source) = cue_source(db, session, branch).await? else {
+    // call. Recompute the content fingerprint and never label stale prose with
+    // a newer cursor.
+    let Some(current_identity) = cue_identity(db, session, branch).await? else {
         return Ok(view("unavailable", None, None, None, Vec::new()));
     };
-    if current_source.cursor != source.cursor {
+    if current_identity.cursor != prepared.identity.cursor {
         return Ok(view(
             "due",
-            Some(current_source.cursor),
+            Some(current_identity.cursor),
             None,
             None,
-            current_source.evidence,
+            current_identity.evidence,
+        ));
+    }
+    if !config::get_bool(db, CUES_ENABLED_KEY, true).await {
+        return Ok(view("disabled", None, None, None, Vec::new()));
+    }
+    if selected_profile(db, session)
+        .await?
+        .as_ref()
+        .map(ProfileIdentity::from)
+        .as_ref()
+        != Some(&profile_identity)
+    {
+        return Ok(view(
+            "unavailable",
+            Some(prepared.identity.cursor),
+            None,
+            None,
+            prepared.identity.evidence,
         ));
     }
     let generated_at = weaver_core::db::now_iso();
-    let evidence = serde_json::to_string(&source.evidence)?;
+    let evidence = serde_json::to_string(&prepared.identity.evidence)?;
     row(db, &session.id).await?;
     sqlx::query(
         "UPDATE session_metadata_assistance
@@ -563,7 +846,7 @@ pub async fn ensure_cue(
              cue_evidence = ?, updated_at = ?
          WHERE session_id = ?",
     )
-    .bind(&source.cursor)
+    .bind(&prepared.identity.cursor)
     .bind(&text)
     .bind(&generated_at)
     .bind(evidence)
@@ -573,10 +856,10 @@ pub async fn ensure_cue(
     .await?;
     Ok(view(
         "generated",
-        Some(source.cursor),
+        Some(prepared.identity.cursor),
         Some(text),
         Some(generated_at),
-        source.evidence,
+        prepared.identity.evidence,
     ))
 }
 
@@ -595,6 +878,7 @@ mod tests {
         );
         assert_eq!(take_chars("abc", 3), "abc");
         assert_eq!(take_chars("abcd", 3), "abc…");
+        assert_eq!(take_tail_chars("abcdef", 4), "…def");
         assert_eq!(
             sanitize_cue("\0  Continue\nnext  "),
             Some("Continue\nnext".into())
@@ -614,11 +898,12 @@ mod tests {
     fn cursor_and_cache_identity_include_artifact_revisions() {
         let cursor = CueCursor {
             history: "iris:1:0".into(),
-            artifacts: vec![("goal".into(), 1)],
+            fingerprint: "abc123".into(),
+            artifacts: vec![(42, "goal".into(), 1)],
         };
         assert_eq!(
             serde_json::to_string(&cursor).unwrap(),
-            r#"{"history":"iris:1:0","artifacts":[["goal",1]]}"#
+            r#"{"history":"iris:1:0","fingerprint":"abc123","artifacts":[[42,"goal",1]]}"#
         );
         let state = AssistanceRow {
             title_generation_enabled: true,
@@ -631,7 +916,7 @@ mod tests {
         let current = state.cue_source_cursor.as_deref().unwrap();
         assert!(cue_cache_matches(&state, current));
         let advanced = CueCursor {
-            artifacts: vec![("goal".into(), 2)],
+            artifacts: vec![(42, "goal".into(), 2)],
             ..cursor
         };
         assert!(!cue_cache_matches(
@@ -648,11 +933,197 @@ mod tests {
     }
 
     #[test]
-    fn prompt_claims_are_keyed_single_flight_and_release_on_drop() {
-        let key = "metadata-domain-test:cue:session:cursor".to_string();
+    fn source_fingerprint_covers_content_and_immutable_artifact_identity() {
+        let artifacts = vec![(42, "goal".to_string(), 1)];
+        let before = source_fingerprint(
+            "acp",
+            &serde_json::json!([{"cursor":"acp:1:2","text":"old"}]),
+            &artifacts,
+        )
+        .unwrap();
+        let updated = source_fingerprint(
+            "acp",
+            &serde_json::json!([{"cursor":"acp:1:2","text":"new"}]),
+            &artifacts,
+        )
+        .unwrap();
+        let recreated = source_fingerprint(
+            "acp",
+            &serde_json::json!([{"cursor":"acp:1:2","text":"old"}]),
+            &[(99, "goal".to_string(), 1)],
+        )
+        .unwrap();
+        assert_ne!(before, updated, "in-place ACP updates change identity");
+        assert_ne!(
+            before, recreated,
+            "delete/recreate changes immutable artifact identity"
+        );
+    }
+
+    #[test]
+    fn title_fence_rejects_every_source_and_eligibility_change() {
+        let profile = ProfileIdentity {
+            name: "watch".into(),
+            lifetime: 1,
+            revision: 7,
+        };
+        let fence = TitleFence {
+            goal: "ship it".into(),
+            title: "ship it".into(),
+            provenance: TitleProvenance::Derived,
+            restricted: false,
+            profile: profile.clone(),
+        };
+        let status = |goal,
+                      title,
+                      provenance,
+                      restricted,
+                      session_enabled,
+                      global_enabled,
+                      allow_restricted,
+                      profile: Option<&ProfileIdentity>| {
+            let current = CurrentTitleState {
+                goal,
+                title,
+                provenance,
+                restricted,
+                session_enabled,
+                globally_enabled: global_enabled,
+                allow_restricted,
+                profile,
+            };
+            title_fence_status(&fence, &current)
+        };
+        assert_eq!(
+            status(
+                "ship it",
+                "ship it",
+                TitleProvenance::Derived,
+                false,
+                true,
+                true,
+                false,
+                Some(&profile)
+            ),
+            None
+        );
+        assert_eq!(
+            status(
+                "changed",
+                "ship it",
+                TitleProvenance::Derived,
+                false,
+                true,
+                true,
+                false,
+                Some(&profile)
+            ),
+            Some("stale")
+        );
+        assert_eq!(
+            status(
+                "ship it",
+                "human",
+                TitleProvenance::User,
+                false,
+                true,
+                true,
+                false,
+                Some(&profile)
+            ),
+            Some("protected")
+        );
+        assert_eq!(
+            status(
+                "ship it",
+                "ship it",
+                TitleProvenance::Derived,
+                false,
+                false,
+                true,
+                false,
+                Some(&profile)
+            ),
+            Some("disabled")
+        );
+        assert_eq!(
+            status(
+                "ship it",
+                "ship it",
+                TitleProvenance::Derived,
+                false,
+                true,
+                false,
+                false,
+                Some(&profile)
+            ),
+            Some("disabled")
+        );
+        assert_eq!(
+            status(
+                "ship it",
+                "ship it",
+                TitleProvenance::Derived,
+                true,
+                true,
+                true,
+                false,
+                Some(&profile)
+            ),
+            Some("unavailable")
+        );
+        assert_eq!(
+            status(
+                "ship it",
+                "ship it",
+                TitleProvenance::Derived,
+                true,
+                true,
+                true,
+                true,
+                Some(&profile)
+            ),
+            Some("stale"),
+            "a changed restricted-session policy invalidates the source fence"
+        );
+        let changed_profile = ProfileIdentity {
+            revision: 8,
+            ..profile.clone()
+        };
+        assert_eq!(
+            status(
+                "ship it",
+                "ship it",
+                TitleProvenance::Derived,
+                false,
+                true,
+                true,
+                false,
+                Some(&changed_profile)
+            ),
+            Some("unavailable")
+        );
+    }
+
+    #[test]
+    fn secret_resolution_fails_closed_on_any_source_error() {
+        let result = collect_secret_sources([
+            Ok(vec!["first-secret".into()]),
+            Err(anyhow::anyhow!("secret backend unavailable")),
+            Ok(vec!["later-secret".into()]),
+        ]);
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "secret backend unavailable"
+        );
+    }
+
+    #[test]
+    fn prompt_claims_are_per_session_single_flight_and_release_on_drop() {
+        let key = cue_claim_key("metadata-domain-test-session");
         let first = PromptClaim::acquire(key.clone()).expect("first claimant");
         assert!(PromptClaim::acquire(key.clone()).is_none());
-        assert!(PromptClaim::acquire(format!("{key}:other")).is_some());
+        assert!(PromptClaim::acquire(cue_claim_key("another-session")).is_some());
         drop(first);
         assert!(PromptClaim::acquire(key).is_some());
     }

--- a/crates/loom/src/web/branches.rs
+++ b/crates/loom/src/web/branches.rs
@@ -5,6 +5,7 @@ use axum::{
 use serde::Deserialize;
 use serde_json::json;
 use weaver_api::{BranchStatusReq, BranchView, CreateEventReq, TagReq};
+use weaver_core::branch::{TitleProvenance, TitleUpdate};
 use weaver_core::{branch as branch_mod, tags};
 
 use crate::{events, session as session_mod};
@@ -38,6 +39,8 @@ pub(super) async fn get_branch(
 #[derive(Debug, Deserialize)]
 pub(super) struct PatchBranchReq {
     title: Option<String>,
+    expected_title: Option<String>,
+    expected_title_provenance: Option<String>,
     goal: Option<String>,
     description: Option<String>,
 }
@@ -76,7 +79,40 @@ pub(super) async fn patch_branch(
         ));
     }
     if let Some(title) = &req.title {
-        branch_mod::set_title(&st.db, &branch.id, title).await?;
+        let title = branch_mod::sanitize_user_title(title)
+            .ok_or_else(|| AppError::bad_request("title must not be empty"))?;
+        let expected_title = req.expected_title.as_deref().ok_or_else(|| {
+            AppError::bad_request("expected_title is required when renaming a branch")
+        })?;
+        let expected_provenance = req
+            .expected_title_provenance
+            .as_deref()
+            .ok_or_else(|| {
+                AppError::bad_request(
+                    "expected_title_provenance is required when renaming a branch",
+                )
+            })?
+            .parse::<TitleProvenance>()
+            .map_err(AppError::bad_request)?;
+        match branch_mod::replace_title(
+            &st.db,
+            &branch.id,
+            expected_title,
+            expected_provenance,
+            &title,
+            TitleProvenance::User,
+        )
+        .await?
+        {
+            TitleUpdate::Applied(_) => {}
+            TitleUpdate::Stale(current) => {
+                return Err(AppError::conflict(
+                    "the task label changed while it was being edited; review it and retry",
+                )
+                .with_fields(json!({ "branch": super::branch_view(&st.db, &current).await? })));
+            }
+            TitleUpdate::Missing => return Err(AppError::not_found("branch")),
+        }
     }
     if let Some(goal) = &req.goal {
         branch_mod::set_goal(&st.db, &branch.id, goal, "user").await?;

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -354,6 +354,8 @@ pub(crate) async fn session_view(
         (placement.group_system_key.as_deref() == Some("later")).then_some("parked".to_string())
     });
     let legacy_sort_order = placement.as_ref().map(|placement| placement.rank as f64);
+    let title_generation =
+        crate::metadata_assist::title_view(db, &session.id, branch.title_provenance).await?;
     Ok(SessionView {
         id: session.id.clone(),
         status: session.status.clone(),
@@ -370,6 +372,7 @@ pub(crate) async fn session_view(
             .unwrap_or_else(|| branch.updated_at.clone()),
         created_at: session.created_at.clone(),
         updated_at: branch.updated_at.clone(),
+        title_generation,
         parent_id: session.parent_branch_id.clone(),
         parent_session_id: session.parent_session_id.clone(),
         created_by: session.created_by.clone(),
@@ -663,6 +666,18 @@ pub fn router(state: AppState) -> Router {
         )
         // The session's own dashboard URL — the link an agent hands a human.
         .route("/sessions/{id}/url", get(session_url_route))
+        .route(
+            "/sessions/{id}/title/regenerate",
+            post(regenerate_session_title),
+        )
+        .route(
+            "/sessions/{id}/title-generation",
+            axum::routing::put(set_session_title_generation),
+        )
+        .route(
+            "/sessions/{id}/resumption-cue",
+            get(get_resumption_cue).post(ensure_resumption_cue),
+        )
         .route("/sessions/{id}/archive", post(archive_session))
         .route(
             "/sessions/{id}/restricted-github/{tool}",

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1198,14 +1198,11 @@ pub(crate) async fn provision_session(
 
     // Build title/goal/description; an optional GitHub issue seeds all three.
     let mut goal = req.goal.unwrap_or_default().trim().to_string();
-    let title_was_explicit = req
-        .title
-        .as_deref()
-        .is_some_and(|title| !title.trim().is_empty());
     let mut title = req
         .title
         .as_deref()
         .and_then(branch_mod::sanitize_user_title);
+    let title_was_explicit = title.is_some();
     let mut description = String::new();
     let mut github_repo = None;
     let mut github_issue: Option<i64> = None;
@@ -1279,7 +1276,9 @@ pub(crate) async fn provision_session(
     } else {
         TitleProvenance::Derived
     };
-    let mut title = title.unwrap_or_else(|| branch_mod::derive_title(&goal));
+    let mut title = title
+        .and_then(|title| branch_mod::sanitize_user_title(&title))
+        .unwrap_or_else(|| branch_mod::derive_title(&goal));
 
     let existing = req
         .existing_branch
@@ -1833,6 +1832,7 @@ pub(crate) async fn provision_session(
 
     crate::metadata_assist::spawn_title_generation(
         st.db.clone(),
+        st.bus.clone(),
         session.clone(),
         branch.clone(),
         false,
@@ -2244,8 +2244,14 @@ pub(super) async fn regenerate_session_title(
     Path(key): Path<String>,
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
-    crate::metadata_assist::spawn_title_generation(st.db.clone(), session.clone(), branch, true)
-        .await?;
+    crate::metadata_assist::spawn_title_generation(
+        st.db.clone(),
+        st.bus.clone(),
+        session.clone(),
+        branch,
+        true,
+    )
+    .await?;
     let (session, branch) = require_session(&st.db, &session.id).await?;
     Ok(Json(session_view(&st.db, &session, &branch).await?))
 }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -26,12 +26,13 @@ use crate::{
     setup,
 };
 use weaver_api::{
-    CreateReq, HandoffReq, HistoryPageView, LaunchOverrides, LaunchSelection, PatchSessionReq,
-    SearchSessionsOptions, SendReq, SessionSearchAttention, SessionSearchStatus, SessionView,
-    SetTagsReq, TagReq,
+    CreateReq, EnsureResumptionCueReq, HandoffReq, HistoryPageView, LaunchOverrides,
+    LaunchSelection, PatchSessionReq, ResumptionCueView, SearchSessionsOptions, SendReq,
+    SessionSearchAttention, SessionSearchStatus, SessionView, SetTagsReq, SetTitleGenerationReq,
+    TagReq,
 };
 use weaver_core::branch as branch_mod;
-use weaver_core::branch::Branch;
+use weaver_core::branch::{Branch, TitleProvenance, TitleUpdate};
 use weaver_core::tags;
 use weaver_core::watch::{self as watch_store, Watch};
 
@@ -1197,10 +1198,14 @@ pub(crate) async fn provision_session(
 
     // Build title/goal/description; an optional GitHub issue seeds all three.
     let mut goal = req.goal.unwrap_or_default().trim().to_string();
+    let title_was_explicit = req
+        .title
+        .as_deref()
+        .is_some_and(|title| !title.trim().is_empty());
     let mut title = req
         .title
-        .map(|t| t.trim().to_string())
-        .filter(|t| !t.is_empty());
+        .as_deref()
+        .and_then(branch_mod::sanitize_user_title);
     let mut description = String::new();
     let mut github_repo = None;
     let mut github_issue: Option<i64> = None;
@@ -1261,13 +1266,20 @@ pub(crate) async fn provision_session(
         }
         claimed_issue_id = Some(issue_id);
     }
-    let title = title.unwrap_or_else(|| {
-        if goal.is_empty() {
-            "Untitled session".to_string()
+    let issue_owned_title =
+        req.issue.is_some() || req.github_issue.is_some() || req.claim_issue.is_some();
+    let title_provenance = if title_was_explicit {
+        if issue_owned_title && origin == "github" {
+            TitleProvenance::Issue
         } else {
-            branch_mod::derive_title(&goal)
+            TitleProvenance::User
         }
-    });
+    } else if issue_owned_title {
+        TitleProvenance::Issue
+    } else {
+        TitleProvenance::Derived
+    };
+    let mut title = title.unwrap_or_else(|| branch_mod::derive_title(&goal));
 
     let existing = req
         .existing_branch
@@ -1379,7 +1391,18 @@ pub(crate) async fn provision_session(
     // Get-or-create the branch row, then stamp its title/goal/description.
     let branch = branch_mod::upsert(&st.db, &repo_root_str, &branch_name, &base).await?;
     tracing::debug!(branch = %branch.id, branch_name = %branch_name, "upserted branch row");
-    branch_mod::set_title(&st.db, &branch.id, &title).await?;
+    // A plain relaunch of an existing branch resumes its human-owned identity;
+    // only new task input intentionally replaces it.
+    let preserve_existing_title = existing.is_some()
+        && !title_was_explicit
+        && !issue_owned_title
+        && goal.is_empty()
+        && !branch.title.is_empty();
+    if preserve_existing_title {
+        title.clone_from(&branch.title);
+    } else {
+        branch_mod::set_title(&st.db, &branch.id, &title, title_provenance).await?;
+    }
     if !goal.is_empty() {
         branch_mod::set_goal(&st.db, &branch.id, &goal, "user").await?;
     }
@@ -1808,6 +1831,14 @@ pub(crate) async fn provision_session(
         "session created"
     );
 
+    crate::metadata_assist::spawn_title_generation(
+        st.db.clone(),
+        session.clone(),
+        branch.clone(),
+        false,
+    )
+    .await
+    .ok();
     session_view(&st.db, &session, &branch).await
 }
 
@@ -2144,7 +2175,40 @@ pub(super) async fn patch_session(
         ));
     };
     if let Some(title) = &req.title {
-        branch_mod::set_title(&st.db, &branch.id, title).await?;
+        let title = branch_mod::sanitize_user_title(title)
+            .ok_or_else(|| AppError::bad_request("title must not be empty"))?;
+        let expected_title = req.expected_title.as_deref().ok_or_else(|| {
+            AppError::bad_request("expected_title is required when renaming a session")
+        })?;
+        let expected_provenance = req
+            .expected_title_provenance
+            .as_deref()
+            .ok_or_else(|| {
+                AppError::bad_request(
+                    "expected_title_provenance is required when renaming a session",
+                )
+            })?
+            .parse::<TitleProvenance>()
+            .map_err(AppError::bad_request)?;
+        match branch_mod::replace_title(
+            &st.db,
+            &branch.id,
+            expected_title,
+            expected_provenance,
+            &title,
+            TitleProvenance::User,
+        )
+        .await?
+        {
+            TitleUpdate::Applied(_) => {}
+            TitleUpdate::Stale(current) => {
+                return Err(AppError::conflict(
+                    "the task label changed while it was being edited; review it and retry",
+                )
+                .with_fields(json!({ "branch": super::branch_view(&st.db, &current).await? })));
+            }
+            TitleUpdate::Missing => return Err(AppError::not_found("branch")),
+        }
     }
     if let Some(goal) = &req.goal {
         branch_mod::set_goal(&st.db, &branch.id, goal, "user").await?;
@@ -2173,6 +2237,49 @@ pub(super) async fn patch_session(
     }
     let (session, branch) = require_session(&st.db, &session.id).await?;
     Ok(Json(session_view(&st.db, &session, &branch).await?))
+}
+
+pub(super) async fn regenerate_session_title(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<SessionView>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    crate::metadata_assist::spawn_title_generation(st.db.clone(), session.clone(), branch, true)
+        .await?;
+    let (session, branch) = require_session(&st.db, &session.id).await?;
+    Ok(Json(session_view(&st.db, &session, &branch).await?))
+}
+
+pub(super) async fn set_session_title_generation(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Json(req): Json<SetTitleGenerationReq>,
+) -> ApiResult<Json<SessionView>> {
+    let (session, _) = require_session(&st.db, &key).await?;
+    crate::metadata_assist::set_title_enabled(&st.db, &session.id, req.enabled).await?;
+    let (session, branch) = require_session(&st.db, &session.id).await?;
+    Ok(Json(session_view(&st.db, &session, &branch).await?))
+}
+
+pub(super) async fn get_resumption_cue(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<ResumptionCueView>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    Ok(Json(
+        crate::metadata_assist::current_cue(&st.db, &session, &branch).await?,
+    ))
+}
+
+pub(super) async fn ensure_resumption_cue(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Json(req): Json<EnsureResumptionCueReq>,
+) -> ApiResult<Json<ResumptionCueView>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    Ok(Json(
+        crate::metadata_assist::ensure_cue(&st.db, &session, &branch, req.force).await?,
+    ))
 }
 
 #[derive(Debug, Deserialize)]
@@ -2704,7 +2811,13 @@ pub(crate) async fn create_warm_session(
         .map_err(|e| AppError::bad_request(e.to_string()))?;
 
     let branch = branch_mod::upsert(&st.db, &repo_root_str, &branch_name, &base).await?;
-    branch_mod::set_title(&st.db, &branch.id, &format!("watch {}", watch.name)).await?;
+    branch_mod::set_title(
+        &st.db,
+        &branch.id,
+        &format!("watch {}", watch.name),
+        TitleProvenance::Derived,
+    )
+    .await?;
     tracing::debug!(watch = %watch.id, branch = %branch.id, "upserted warm session branch row");
 
     let session_id = branch_mod::new_id();

--- a/crates/loom/src/web/settings.rs
+++ b/crates/loom/src/web/settings.rs
@@ -36,7 +36,7 @@ pub(super) async fn patch_settings(
             errors.insert(key, json!("unknown setting"));
             continue;
         }
-        let value = match raw {
+        let mut value = match raw {
             Value::Null => None,
             Value::String(s) => Some(s),
             Value::Bool(b) => Some(b.to_string()),
@@ -49,6 +49,9 @@ pub(super) async fn patch_settings(
                 continue;
             }
         };
+        if key == crate::metadata_assist::METADATA_PROFILE_KEY {
+            value = value.map(|value| value.trim().to_string());
+        }
         if !legacy_agent {
             if let Some(value) = &value {
                 if let Err(why) = config::validate(&key, value) {
@@ -61,6 +64,32 @@ pub(super) async fn patch_settings(
             legacy_agent_changes.push((key, value));
         } else {
             changes.push((key, value));
+        }
+    }
+
+    if errors.is_empty() {
+        if let Some((_, Some(name))) = changes
+            .iter()
+            .find(|(key, _)| key == crate::metadata_assist::METADATA_PROFILE_KEY)
+        {
+            if !name.is_empty() {
+                match profile::get(&st.db, name).await? {
+                    Some(candidate)
+                        if crate::metadata_assist::metadata_profile_eligible(&candidate) => {}
+                    Some(_) => {
+                        errors.insert(
+                            crate::metadata_assist::METADATA_PROFILE_KEY.to_string(),
+                            json!("profile must be an active automation-safe ACP profile"),
+                        );
+                    }
+                    None => {
+                        errors.insert(
+                            crate::metadata_assist::METADATA_PROFILE_KEY.to_string(),
+                            json!("unknown or retired profile"),
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/crates/loom/tests/integration/conversation.rs
+++ b/crates/loom/tests/integration/conversation.rs
@@ -95,9 +95,10 @@ async fn conversation_endpoint_returns_the_iris_log() {
     let source_cursor = unavailable["source_cursor"].as_str().unwrap();
     let evidence = unavailable["evidence"].as_array().unwrap();
     assert!(evidence.iter().any(|item| item["kind"] == "conversation"));
-    assert!(evidence
-        .iter()
-        .any(|item| item["cursor"] == "artifact:goal:1"));
+    assert!(evidence.iter().any(|item| item["kind"] == "artifact"
+        && item["cursor"]
+            .as_str()
+            .is_some_and(|cursor| cursor.ends_with(":1"))));
 
     // Seed the persisted result a completed one-shot would commit. GET and an
     // on-return ensure both reuse it while the source cursor is unchanged.
@@ -147,7 +148,10 @@ async fn conversation_endpoint_returns_the_iris_log() {
         .as_array()
         .unwrap()
         .iter()
-        .any(|item| item["cursor"] == "artifact:goal:2"));
+        .any(|item| item["kind"] == "artifact"
+            && item["cursor"]
+                .as_str()
+                .is_some_and(|cursor| cursor.ends_with(":2"))));
 }
 
 /// The ACP endpoint opens at a bounded tail and pages backward with an exclusive

--- a/crates/loom/tests/integration/conversation.rs
+++ b/crates/loom/tests/integration/conversation.rs
@@ -83,6 +83,71 @@ async fn conversation_endpoint_returns_the_iris_log() {
         .unwrap();
     assert_eq!(search["records"].as_array().unwrap().len(), 1);
     assert_eq!(search["records"][0]["role"], "assistant");
+
+    // A cue read is source-linked but never invokes a model. With no metadata
+    // profile configured it exposes an API-ready unavailable boundary and the
+    // exact conversation/artifact cursor that a later ensure would summarize.
+    let unavailable = client
+        .get(&format!("/api/sessions/{id}/resumption-cue"))
+        .await
+        .unwrap();
+    assert_eq!(unavailable["status"], "unavailable");
+    let source_cursor = unavailable["source_cursor"].as_str().unwrap();
+    let evidence = unavailable["evidence"].as_array().unwrap();
+    assert!(evidence.iter().any(|item| item["kind"] == "conversation"));
+    assert!(evidence
+        .iter()
+        .any(|item| item["cursor"] == "artifact:goal:1"));
+
+    // Seed the persisted result a completed one-shot would commit. GET and an
+    // on-return ensure both reuse it while the source cursor is unchanged.
+    sqlx::query(
+        "UPDATE session_metadata_assistance
+         SET cue_source_cursor = ?, cue_text = ?, cue_generated_at = ?,
+             cue_evidence = ?, updated_at = ?
+         WHERE session_id = ?",
+    )
+    .bind(source_cursor)
+    .bind("Continue from the verified transcript.")
+    .bind("2026-07-26T00:00:00Z")
+    .bind(serde_json::to_string(evidence).unwrap())
+    .bind("2026-07-26T00:00:00Z")
+    .bind(&id)
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+    let cached = client
+        .get(&format!("/api/sessions/{id}/resumption-cue"))
+        .await
+        .unwrap();
+    assert_eq!(cached["status"], "generated");
+    assert_eq!(cached["text"], "Continue from the verified transcript.");
+    let ensured = client
+        .post(
+            &format!("/api/sessions/{id}/resumption-cue"),
+            json!({ "force": false }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ensured, cached);
+
+    // Advancing an artifact revision invalidates the cached cue even though the
+    // terminal transcript itself is unchanged.
+    let branch_id = sess["branch"]["id"].as_str().unwrap();
+    weaver_core::branch::set_goal(&ts.state.db, branch_id, "chat me, revised", "user")
+        .await
+        .unwrap();
+    let advanced = client
+        .get(&format!("/api/sessions/{id}/resumption-cue"))
+        .await
+        .unwrap();
+    assert_eq!(advanced["status"], "unavailable");
+    assert_ne!(advanced["source_cursor"], cached["source_cursor"]);
+    assert!(advanced["evidence"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["cursor"] == "artifact:goal:2"));
 }
 
 /// The ACP endpoint opens at a bounded tail and pages backward with an exclusive

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -256,8 +256,9 @@ async fn settings_validate_agent_model_effort_against_registry() {
 /// The active fleet and archived history remain disjoint at the REST boundary:
 /// the default (and therefore `loom session ls`) contains only actionable work,
 /// while inventory callers can opt into both with `?archived=true`. Search
-/// narrows the selected set over title, branch, and goal; a title PATCH is
-/// reflected in that search.
+/// narrows the selected set over qualified Group / Task names and other fleet
+/// metadata. Renames use provenance-aware compare-and-swap and become
+/// user-owned labels.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn list_keeps_active_fleet_disjoint_from_archived_history_and_searches() {
@@ -272,6 +273,8 @@ async fn list_keeps_active_fleet_disjoint_from_archived_history_and_searches() {
         .await
         .unwrap();
     let alpha_id = alpha["id"].as_str().unwrap().to_string();
+    assert_eq!(alpha["branch"]["title"], "alpha search target");
+    assert_eq!(alpha["branch"]["title_provenance"], "derived");
 
     let beta = client
         .post(
@@ -341,21 +344,47 @@ async fn list_keeps_active_fleet_disjoint_from_archived_history_and_searches() {
         "archived search opt-in finds beta"
     );
 
-    // Renaming a session (the title PATCH the `loom session rename` CLI wraps) is
-    // reflected in the search.
-    client
+    // Renaming a session (the title PATCH the `loom session rename` CLI wraps)
+    // claims the label for the user and is reflected in qualified fleet search.
+    let renamed_view = client
         .patch(
             &format!("/api/sessions/{alpha_id}"),
-            json!({ "title": "renamed-zeta" }),
+            json!({
+                "title": "renamed-zeta",
+                "expected_title": "alpha search target",
+                "expected_title_provenance": "derived",
+            }),
         )
         .await
         .unwrap();
-    let renamed = client.get("/api/sessions?q=zeta").await.unwrap();
+    assert_eq!(renamed_view["branch"]["title_provenance"], "user");
+    assert_eq!(renamed_view["title_generation"]["status"], "protected");
+    let renamed = client
+        .get("/api/sessions/search?q=Inbox%20%2F%20renamed-zeta")
+        .await
+        .unwrap();
     assert_eq!(
         renamed.as_array().unwrap().len(),
         1,
-        "rename is reflected in search"
+        "qualified Group / Task search follows the canonical label"
     );
+    assert_eq!(renamed[0]["placement"]["group_name"], "Inbox");
+
+    // A second tab editing the old value cannot overwrite the user-owned title.
+    let stale = reqwest::Client::new()
+        .patch(format!("http://{}/api/sessions/{alpha_id}", ts.addr))
+        .json(&json!({
+            "title": "late-overwrite",
+            "expected_title": "alpha search target",
+            "expected_title_provenance": "derived",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(stale.status(), reqwest::StatusCode::CONFLICT);
+    let stale: serde_json::Value = stale.json().await.unwrap();
+    assert_eq!(stale["branch"]["title"], "renamed-zeta");
+    assert_eq!(stale["branch"]["title_provenance"], "user");
 
     client
         .delete(&format!("/api/sessions/{alpha_id}"))

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -16,16 +16,17 @@ use crate::dto::{
     CommentDto, CreateEventReq, CreateIssueReq, CreateRepoIssueReq, CreateReq, CreateReviewReq,
     CreateSessionGroupReq, CreateSessionSpaceReq, CreateTokenReq, CreateWatchReq, CreatedTokenView,
     CustomMcpReq, CustomMcpView, DeleteSessionGroupReq, DeleteSessionSpaceReq, DeploymentReq,
-    DeploymentView, DiagnosticsView, EffectiveProfileView, ExpectedReviewRevisionReq,
-    FederationReq, FederationView, HandoffReq, HistoryPageView, IssueActionsReq,
-    IssueActionsResult, IssueView, McpRegistryView, MoveSessionsReq, NewCommentBody, NewThreadBody,
-    PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileProbeView, ProfileReq, ProfileView,
-    PutProfileEnvReq, ReadinessView, ReorderSessionLayoutReq, ResolveLaunchReq,
-    ResolveReviewCommentReq, ResolvedLaunchView, RestoreSessionGroupsReq, ReviewCommentDto,
-    ReviewDto, RunReq, RunView, RunWatchReq, ScratchLimitsView, SearchSessionsOptions, SendReq,
-    SessionGroupPreferenceReq, SessionLayoutView, SessionPlacementSelectorKind, SessionView,
-    SetSessionPlacementDefaultReq, SetTagsReq, SettingsEnvelope, SubmitReviewReq, TagReq,
-    ThreadDto, TokenView, UpdateReviewCommentReq, UpdateReviewReq, UpdateSessionGroupReq,
+    DeploymentView, DiagnosticsView, EffectiveProfileView, EnsureResumptionCueReq,
+    ExpectedReviewRevisionReq, FederationReq, FederationView, HandoffReq, HistoryPageView,
+    IssueActionsReq, IssueActionsResult, IssueView, McpRegistryView, MoveSessionsReq,
+    NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileProbeView,
+    ProfileReq, ProfileView, PutProfileEnvReq, ReadinessView, ReorderSessionLayoutReq,
+    ResolveLaunchReq, ResolveReviewCommentReq, ResolvedLaunchView, RestoreSessionGroupsReq,
+    ResumptionCueView, ReviewCommentDto, ReviewDto, RunReq, RunView, RunWatchReq,
+    ScratchLimitsView, SearchSessionsOptions, SendReq, SessionGroupPreferenceReq,
+    SessionLayoutView, SessionPlacementSelectorKind, SessionView, SetSessionPlacementDefaultReq,
+    SetTagsReq, SetTitleGenerationReq, SettingsEnvelope, SubmitReviewReq, TagReq, ThreadDto,
+    TokenView, UpdateReviewCommentReq, UpdateReviewReq, UpdateSessionGroupReq,
     UpdateSessionSpaceReq, WatchView,
 };
 
@@ -419,6 +420,50 @@ impl Client {
         self.send_typed(
             Method::PATCH,
             &format!("/api/sessions/{}", Self::seg(key)),
+            Some(req),
+        )
+        .await
+    }
+
+    pub async fn regenerate_session_title(&self, key: &str) -> Result<SessionView> {
+        self.send_typed::<(), _>(
+            Method::POST,
+            &format!("/api/sessions/{}/title/regenerate", Self::seg(key)),
+            None,
+        )
+        .await
+    }
+
+    pub async fn set_session_title_generation(
+        &self,
+        key: &str,
+        req: &SetTitleGenerationReq,
+    ) -> Result<SessionView> {
+        self.send_typed(
+            Method::PUT,
+            &format!("/api/sessions/{}/title-generation", Self::seg(key)),
+            Some(req),
+        )
+        .await
+    }
+
+    pub async fn get_resumption_cue(&self, key: &str) -> Result<ResumptionCueView> {
+        self.send_typed::<(), _>(
+            Method::GET,
+            &format!("/api/sessions/{}/resumption-cue", Self::seg(key)),
+            None,
+        )
+        .await
+    }
+
+    pub async fn ensure_resumption_cue(
+        &self,
+        key: &str,
+        req: &EnsureResumptionCueReq,
+    ) -> Result<ResumptionCueView> {
+        self.send_typed(
+            Method::POST,
+            &format!("/api/sessions/{}/resumption-cue", Self::seg(key)),
             Some(req),
         )
         .await

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -93,6 +93,10 @@ pub struct BranchView {
     /// Short label: the branch name with the optional `weaver/` prefix stripped.
     pub name: String,
     pub title: String,
+    /// Ownership of the unqualified task label: `derived`, `generated`,
+    /// `user`, or `issue`.
+    #[serde(default = "default_title_provenance")]
+    pub title_provenance: String,
     pub goal: String,
     /// The agent's current-state message, set via `weaver status`, shown even
     /// when the branch is calm. The attention *level* is the `attention` tag.
@@ -137,6 +141,7 @@ impl BranchView {
             id: branch.id.clone(),
             name,
             title: branch.title.clone(),
+            title_provenance: branch.title_provenance.as_str().to_string(),
             goal: branch.goal.clone(),
             description: branch.description.clone(),
             tags: tags.iter().map(TagView::from).collect(),
@@ -171,6 +176,9 @@ pub struct SessionView {
     pub last_activity_at: String,
     pub created_at: String,
     pub updated_at: String,
+    /// Optional metadata-agent state for the task label.
+    #[serde(default)]
+    pub title_generation: TitleGenerationView,
     /// Branch id of the session that **launched** this one — the parent in the
     /// dashboard's session tree — or `null` for a top-level session.
     pub parent_id: Option<String>,
@@ -257,6 +265,51 @@ pub struct SessionView {
     #[serde(default)]
     pub placement: Option<SessionPlacementView>,
     pub branch: BranchView,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TitleGenerationView {
+    pub enabled: bool,
+    /// `idle`, `running`, `generated`, `protected`, `disabled`, `unavailable`,
+    /// or `failed`.
+    pub status: String,
+}
+
+impl Default for TitleGenerationView {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            status: "idle".to_string(),
+        }
+    }
+}
+
+fn default_title_provenance() -> String {
+    "user".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResumptionEvidenceView {
+    /// `conversation` or `artifact`.
+    pub kind: String,
+    pub label: String,
+    pub href: String,
+    /// Source-stable history cursor or artifact name/revision cursor.
+    pub cursor: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResumptionCueView {
+    /// `generated`, `due`, `not_due`, `disabled`, or `unavailable`.
+    pub status: String,
+    #[serde(default)]
+    pub source_cursor: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub generated_at: Option<String>,
+    #[serde(default)]
+    pub evidence: Vec<ResumptionEvidenceView>,
 }
 
 wire_enum!(SessionSearchStatus {
@@ -1826,6 +1879,11 @@ pub struct PatchSessionReq {
     pub status: Option<String>,
     #[serde(default)]
     pub title: Option<String>,
+    /// Required with `title`: the label/provenance the caller observed.
+    #[serde(default)]
+    pub expected_title: Option<String>,
+    #[serde(default)]
+    pub expected_title_provenance: Option<String>,
     #[serde(default)]
     pub goal: Option<String>,
     /// The agent's current-state message — the prose shown beside the level.
@@ -1839,6 +1897,19 @@ pub struct PatchSessionReq {
     /// must use the revisioned session-layout move API.
     #[serde(default)]
     pub sort_order: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetTitleGenerationReq {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EnsureResumptionCueReq {
+    /// Explicit user request. False is the on-return path and respects the
+    /// configured inactivity threshold.
+    #[serde(default)]
+    pub force: bool,
 }
 
 /// Create a space and its useful empty Inbox group.

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -271,7 +271,7 @@ pub struct SessionView {
 pub struct TitleGenerationView {
     pub enabled: bool,
     /// `idle`, `running`, `generated`, `protected`, `disabled`, `unavailable`,
-    /// or `failed`.
+    /// `stale`, or `failed`.
     pub status: String,
 }
 
@@ -294,13 +294,14 @@ pub struct ResumptionEvidenceView {
     pub kind: String,
     pub label: String,
     pub href: String,
-    /// Source-stable history cursor or artifact name/revision cursor.
+    /// Source-stable history cursor or immutable artifact id/revision cursor.
     pub cursor: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResumptionCueView {
-    /// `generated`, `due`, `not_due`, `disabled`, or `unavailable`.
+    /// `generated`, `generating`, `due`, `not_due`, `disabled`, or
+    /// `unavailable`.
     pub status: String,
     #[serde(default)]
     pub source_cursor: Option<String>,

--- a/crates/weaver-core/migrations/0017_title_provenance.sql
+++ b/crates/weaver-core/migrations/0017_title_provenance.sql
@@ -1,0 +1,13 @@
+ALTER TABLE branches
+ADD COLUMN title_provenance TEXT NOT NULL DEFAULT 'user'
+CHECK (title_provenance IN ('derived', 'generated', 'user', 'issue'));
+
+-- Existing titles are human-owned unless the stored goal proves the exact
+-- deterministic derivation without having to reproduce Unicode truncation in
+-- SQLite. This deliberately conservative subset is safe to auto-replace.
+UPDATE branches
+SET title_provenance = 'derived'
+WHERE instr(goal, char(10)) = 0
+  AND instr(goal, char(13)) = 0
+  AND length(trim(goal)) BETWEEN 1 AND 72
+  AND title = trim(goal);

--- a/crates/weaver-core/src/branch.rs
+++ b/crates/weaver-core/src/branch.rs
@@ -371,6 +371,39 @@ pub async fn replace_title(
     })
 }
 
+/// Replace a generated title only while its goal and observed label ownership
+/// still match the prompt source. Goal edits invalidate model output even when
+/// the deterministic fallback title itself has not changed.
+pub async fn replace_title_from_goal(
+    db: &Db,
+    id: &str,
+    expected_goal: &str,
+    expected_title: &str,
+    expected_provenance: TitleProvenance,
+    title: &str,
+) -> Result<TitleUpdate> {
+    let result = sqlx::query(
+        "UPDATE branches
+         SET title = ?, title_provenance = ?, updated_at = ?
+         WHERE id = ? AND goal = ? AND title = ? AND title_provenance = ?",
+    )
+    .bind(title)
+    .bind(TitleProvenance::Generated)
+    .bind(now_iso())
+    .bind(id)
+    .bind(expected_goal)
+    .bind(expected_title)
+    .bind(expected_provenance)
+    .execute(db)
+    .await?;
+    let current = get(db, id).await?;
+    Ok(match (result.rows_affected(), current) {
+        (1, Some(branch)) => TitleUpdate::Applied(branch),
+        (_, Some(branch)) => TitleUpdate::Stale(branch),
+        (_, None) => TitleUpdate::Missing,
+    })
+}
+
 pub async fn set_description(db: &Db, id: &str, description: &str) -> Result<()> {
     sqlx::query("UPDATE branches SET description = ?, updated_at = ? WHERE id = ?")
         .bind(description)
@@ -581,6 +614,24 @@ mod tests {
             panic!("expected stale title");
         };
         assert_eq!(current.title, "Generated");
+
+        set_title(&db, &branch.id, "Fallback", TitleProvenance::Derived)
+            .await
+            .unwrap();
+        set_goal(&db, &branch.id, "new goal", "user").await.unwrap();
+        let TitleUpdate::Stale(current) = replace_title_from_goal(
+            &db,
+            &branch.id,
+            "old goal",
+            "Fallback",
+            TitleProvenance::Derived,
+            "Stale generation",
+        )
+        .await
+        .unwrap() else {
+            panic!("expected goal fence to reject stale output");
+        };
+        assert_eq!(current.title, "Fallback");
     }
 
     #[test]

--- a/crates/weaver-core/src/branch.rs
+++ b/crates/weaver-core/src/branch.rs
@@ -9,6 +9,48 @@ use std::path::{Path, PathBuf};
 use crate::artifact::{self, NewRevision};
 use crate::db::{now_iso, Db};
 
+pub const MAX_TASK_TITLE_CHARS: usize = 72;
+pub const MAX_GENERATED_TITLE_CHARS: usize = 48;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[serde(rename_all = "lowercase")]
+#[sqlx(type_name = "TEXT", rename_all = "lowercase")]
+pub enum TitleProvenance {
+    Derived,
+    Generated,
+    User,
+    Issue,
+}
+
+impl TitleProvenance {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Derived => "derived",
+            Self::Generated => "generated",
+            Self::User => "user",
+            Self::Issue => "issue",
+        }
+    }
+
+    pub const fn can_generate(self, explicit: bool) -> bool {
+        matches!(self, Self::Derived) || (explicit && matches!(self, Self::Generated))
+    }
+}
+
+impl std::str::FromStr for TitleProvenance {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value {
+            "derived" => Ok(Self::Derived),
+            "generated" => Ok(Self::Generated),
+            "user" => Ok(Self::User),
+            "issue" => Ok(Self::Issue),
+            _ => Err(format!("unknown title provenance '{value}'")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Branch {
     pub id: String,
@@ -17,6 +59,7 @@ pub struct Branch {
     pub base_branch: String,
     pub goal: String,
     pub title: String,
+    pub title_provenance: TitleProvenance,
     /// The agent's current-state message, set via `weaver status`. Free-form
     /// ("Wired up routes; tests pass"), shown even when the branch is calm. The
     /// attention *level* is a separate [`crate::tags`] tag.
@@ -46,12 +89,73 @@ pub fn derive_title(goal: &str) -> String {
     if first.is_empty() {
         return "Untitled".to_string();
     }
-    if first.chars().count() > 72 {
-        let t: String = first.chars().take(71).collect();
+    if first.chars().count() > MAX_TASK_TITLE_CHARS {
+        let t: String = first.chars().take(MAX_TASK_TITLE_CHARS - 1).collect();
         format!("{t}…")
     } else {
         first.to_string()
     }
+}
+
+/// Sanitize untrusted generated output into a single plain-text task label.
+/// Manual titles keep their punctuation; model-authored labels additionally
+/// lose common Markdown wrappers so no client has to interpret markup.
+pub fn sanitize_generated_title(input: &str) -> Option<String> {
+    let first = input.lines().map(str::trim).find(|line| !line.is_empty())?;
+    let first = first
+        .strip_prefix("Title:")
+        .or_else(|| first.strip_prefix("Task:"))
+        .unwrap_or(first)
+        .trim()
+        .trim_matches(['`', '"', '\'', '*', '_', '#']);
+    let plain: String = first
+        .chars()
+        .map(|ch| {
+            if ch.is_control() || matches!(ch, '<' | '>' | '`') {
+                ' '
+            } else {
+                ch
+            }
+        })
+        .collect();
+    let collapsed = plain.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    if collapsed.chars().count() <= MAX_GENERATED_TITLE_CHARS {
+        return Some(collapsed);
+    }
+    let prefix: String = collapsed
+        .chars()
+        .take(MAX_GENERATED_TITLE_CHARS - 1)
+        .collect();
+    Some(format!("{prefix}…"))
+}
+
+/// Normalize a human-authored task label without interpreting its punctuation.
+pub fn sanitize_user_title(input: &str) -> Option<String> {
+    let collapsed = input
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    if collapsed.chars().count() <= MAX_TASK_TITLE_CHARS {
+        return Some(collapsed);
+    }
+    let prefix: String = collapsed.chars().take(MAX_TASK_TITLE_CHARS - 1).collect();
+    Some(format!("{prefix}…"))
+}
+
+#[derive(Debug, Clone)]
+pub enum TitleUpdate {
+    Applied(Branch),
+    Stale(Branch),
+    Missing,
 }
 
 /// Turn free text into a short kebab-case slug suitable for a branch name.
@@ -221,14 +325,50 @@ pub async fn current_goal(db: &Db, branch: &Branch) -> Result<String> {
     Ok(branch.goal.clone())
 }
 
-pub async fn set_title(db: &Db, id: &str, title: &str) -> Result<()> {
-    sqlx::query("UPDATE branches SET title = ?, updated_at = ? WHERE id = ?")
-        .bind(title)
-        .bind(now_iso())
-        .bind(id)
-        .execute(db)
-        .await?;
+pub async fn set_title(db: &Db, id: &str, title: &str, provenance: TitleProvenance) -> Result<()> {
+    sqlx::query(
+        "UPDATE branches
+         SET title = ?, title_provenance = ?, updated_at = ?
+         WHERE id = ?",
+    )
+    .bind(title)
+    .bind(provenance)
+    .bind(now_iso())
+    .bind(id)
+    .execute(db)
+    .await?;
     Ok(())
+}
+
+/// Replace a title only while both the observed label and its ownership still
+/// match. Human rename and generated refresh use this same domain operation.
+pub async fn replace_title(
+    db: &Db,
+    id: &str,
+    expected_title: &str,
+    expected_provenance: TitleProvenance,
+    title: &str,
+    provenance: TitleProvenance,
+) -> Result<TitleUpdate> {
+    let result = sqlx::query(
+        "UPDATE branches
+         SET title = ?, title_provenance = ?, updated_at = ?
+         WHERE id = ? AND title = ? AND title_provenance = ?",
+    )
+    .bind(title)
+    .bind(provenance)
+    .bind(now_iso())
+    .bind(id)
+    .bind(expected_title)
+    .bind(expected_provenance)
+    .execute(db)
+    .await?;
+    let current = get(db, id).await?;
+    Ok(match (result.rows_affected(), current) {
+        (1, Some(branch)) => TitleUpdate::Applied(branch),
+        (_, Some(branch)) => TitleUpdate::Stale(branch),
+        (_, None) => TitleUpdate::Missing,
+    })
 }
 
 pub async fn set_description(db: &Db, id: &str, description: &str) -> Result<()> {
@@ -387,6 +527,60 @@ mod tests {
         assert_eq!(derive_title("\n\nFix the bug\nmore detail"), "Fix the bug");
         assert_eq!(derive_title("   "), "Untitled");
         assert!(derive_title(&"x".repeat(200)).chars().count() <= 72);
+    }
+
+    #[test]
+    fn generated_titles_are_plain_single_line_and_bounded() {
+        assert_eq!(
+            sanitize_generated_title("  **Title: `Fix <auth>\\nflow`**\nextra"),
+            Some("Title: Fix auth \\nflow".to_string())
+        );
+        let title = sanitize_generated_title(&"x".repeat(100)).unwrap();
+        assert_eq!(title.chars().count(), MAX_GENERATED_TITLE_CHARS);
+        assert!(title.ends_with('…'));
+        assert_eq!(sanitize_generated_title("\n\t"), None);
+        assert_eq!(
+            sanitize_user_title("  Fix <auth>\n flow  "),
+            Some("Fix <auth> flow".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn title_replace_is_provenance_aware_compare_and_swap() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let branch = insert(&db, "b1", "/repo", "weaver/task", "main")
+            .await
+            .unwrap();
+        set_title(&db, &branch.id, "Initial", TitleProvenance::Derived)
+            .await
+            .unwrap();
+        let TitleUpdate::Applied(updated) = replace_title(
+            &db,
+            &branch.id,
+            "Initial",
+            TitleProvenance::Derived,
+            "Generated",
+            TitleProvenance::Generated,
+        )
+        .await
+        .unwrap() else {
+            panic!("expected applied title");
+        };
+        assert_eq!(updated.title_provenance, TitleProvenance::Generated);
+
+        let TitleUpdate::Stale(current) = replace_title(
+            &db,
+            &branch.id,
+            "Initial",
+            TitleProvenance::Derived,
+            "Late",
+            TitleProvenance::Generated,
+        )
+        .await
+        .unwrap() else {
+            panic!("expected stale title");
+        };
+        assert_eq!(current.title, "Generated");
     }
 
     #[test]

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -442,6 +442,56 @@ pub const REGISTRY: &[SettingSpec] = &[
         group: "Sessions",
         options: &[],
     },
+    SettingSpec {
+        key: "metadata.profile",
+        label: "Metadata profile",
+        description: "Automation-safe ACP profile used for optional generated task labels and \
+            resumption cues. Empty disables model-backed metadata assistance.",
+        kind: SettingKind::String,
+        default: "",
+        group: "Metadata",
+        options: &[],
+    },
+    SettingSpec {
+        key: "metadata.title_generation",
+        label: "Generate task labels",
+        description: "Asynchronously replace eligible deterministic task labels through the \
+            configured metadata profile. Launch never waits for this.",
+        kind: SettingKind::Bool,
+        default: "true",
+        group: "Metadata",
+        options: &[],
+    },
+    SettingSpec {
+        key: "metadata.resumption_cues",
+        label: "Generate resumption cues",
+        description: "Allow explicit or inactivity-based on-return cues in Conversation. \
+            Cues are cached by their conversation and artifact cursor.",
+        kind: SettingKind::Bool,
+        default: "true",
+        group: "Metadata",
+        options: &[],
+    },
+    SettingSpec {
+        key: "metadata.resumption_inactivity_secs",
+        label: "Cue inactivity (seconds)",
+        description: "Minimum session inactivity before an on-return cue is due. Explicit \
+            Generate requests do not wait for this threshold.",
+        kind: SettingKind::Int,
+        default: "3600",
+        group: "Metadata",
+        options: &[],
+    },
+    SettingSpec {
+        key: "metadata.allow_restricted",
+        label: "Allow restricted metadata",
+        description: "Explicitly permit bounded title/cue excerpts from restricted sessions \
+            to cross into the configured metadata profile. Off by default.",
+        kind: SettingKind::Bool,
+        default: "false",
+        group: "Metadata",
+        options: &[],
+    },
 ];
 
 /// Whether the Watch engine master switch is on. On by default.

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -484,6 +484,8 @@ mod tests {
         );
     }
 
+    /// Review migration 16 shipped the final review shape; later unrelated
+    /// migrations must preserve those columns and indexes.
     #[tokio::test]
     async fn review_schema_is_final_when_v16_first_ships() {
         let pool = empty_pool().await;
@@ -509,7 +511,7 @@ mod tests {
                 .fetch_all(&pool)
                 .await
                 .unwrap();
-        assert_eq!(versions, (1..=16).collect::<Vec<_>>());
+        assert_eq!(versions, all_versions());
         let review_columns = table_columns(&pool, "reviews").await.unwrap();
         assert!(review_columns.iter().any(|column| column == "subject_id"));
         assert!(review_columns

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -103,6 +103,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "reviews",
         include_str!("../migrations/0016_reviews.sql"),
     ),
+    (
+        17,
+        "title_provenance",
+        include_str!("../migrations/0017_title_provenance.sql"),
+    ),
 ];
 
 /// Latest core schema version compiled into this binary.
@@ -1000,5 +1005,64 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(versions, 1);
+    }
+
+    #[tokio::test]
+    async fn title_provenance_migration_only_preserves_provable_derivations() {
+        let pool = empty_pool().await;
+        STREAM.ensure_indicator(&pool).await.unwrap();
+        let migration_index = MIGRATIONS
+            .iter()
+            .position(|(_, name, _)| *name == "title_provenance")
+            .unwrap();
+        for (version, name, sql) in &MIGRATIONS[..migration_index] {
+            for stmt in split_statements(sql) {
+                sqlx::query(&stmt).execute(&pool).await.unwrap();
+            }
+            sqlx::query(
+                "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)",
+            )
+            .bind(version)
+            .bind(*name)
+            .bind("2026-01-01T00:00:00.000Z")
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        for (id, goal, title) in [
+            ("exact", "Ship the thing", "Ship the thing"),
+            ("edited", "Ship the thing", "Release carefully"),
+            ("multiline", "\nShip the thing\nDetails", "Ship the thing"),
+            ("empty", "", "Untitled session"),
+        ] {
+            sqlx::query(
+                "INSERT INTO branches (id, repo_root, branch, goal, title)
+                 VALUES (?, '/repo', ?, ?, ?)",
+            )
+            .bind(id)
+            .bind(id)
+            .bind(goal)
+            .bind(title)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        run(&pool).await.unwrap();
+
+        let rows: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, title_provenance FROM branches ORDER BY id")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("edited".into(), "user".into()),
+                ("empty".into(), "user".into()),
+                ("exact".into(), "derived".into()),
+                ("multiline".into(), "user".into()),
+            ]
+        );
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,6 +180,9 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
     [chat journal](#rest-api): one row per `(session_id, turn, seq)` block),
     `session_acp_metadata` (the latest provider-advertised composer controls,
     retained when its live task exits or Loom restarts),
+    `session_metadata_assistance` (per-session generated-title enable/status and
+    the cached resumption cue keyed by a bounded conversation/content +
+    immutable-artifact fingerprint),
     and the auth tables `users` (the approved-operator allowlist, seeded with
     the owner), `api_tokens` (hashed bearer tokens), and `auth_sessions`
     (hashed login cookies). See [Authentication](#authentication). Loom-owned
@@ -283,6 +286,8 @@ All routes live under `/api`. The Vue SPA is the primary consumer.
 | `GET POST /api/runs`; `GET /api/runs/{id}` | durable, subject-scoped automation runs with idempotency reservation; an optional channel routes distinct deliveries through one live ACP session, and verified GitHub callers may provide a validated deterministic key or use the workflow run/attempt |
 | `POST /api/sessions/{id}/restricted-github/{tool}` | session-token-scoped fixed GitHub operations for a restricted session; checks stamped tool policy, fixes the target repository and thread from the session, and resolves a GitHub App token or explicit App-less profile token server-side |
 | `GET PATCH DELETE /api/sessions/{id}` | session CRUD (status, title, goal, description); legacy `park`/`sort_order` reads are derived from canonical placement and writes are rejected; DELETE also accepts an unmatched automation run's reserved session id, tearing down and removing the failed launch attempt |
+| `POST /api/sessions/{id}/title/regenerate`; `PUT /api/sessions/{id}/title-generation` | explicit provenance-aware title regeneration / per-session opt-out; generation uses the selected automation-safe ACP metadata profile, commits through a goal/title/provenance CAS, and emits a session `metadata` invalidation at terminal completion |
+| `GET POST /api/sessions/{id}/resumption-cue` | model-free current cue/cache read / explicit or inactivity-gated ensure; one in-process flight per session, with bounded lazy prompt preparation and a content + immutable-artifact source fingerprint |
 | `PUT DELETE /api/sessions/{id}/tags/{key}` | set (upsert) / clear one branch tag — the well-known `attention` and `triage` keys plus any free-form key |
 | `PUT /api/sessions/{id}/tags` | atomically replace one author's complete tag set, with optional exact `(key, value)` clears for lifecycle marks; the watch-safe write path |
 | `GET /api/sessions/{id}/url` | the session's dashboard URL as `{url}`, built from the externally-visible origin (`auth.base_url`, else the request's own Host) — what `loom session url` prints, so an agent can link a PR back to its session without inventing a loopback link |

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -208,5 +208,24 @@ for line in sys.stdin:
       page.getByRole("button", { name: "Account", exact: true }),
     ).toHaveCount(0);
     await expect(page.locator('[data-rail="chat"]')).toHaveCount(0);
+    expect(
+      await page.getByTestId("metadata-settings").evaluate((section) => ({
+        settingsVisible: [
+          "metadata.profile",
+          "metadata.title_generation",
+          "metadata.resumption_cues",
+          "metadata.resumption_inactivity_secs",
+          "metadata.allow_restricted",
+        ].every((key) => section.textContent?.includes(key)),
+        selectableProfiles: Array.from(
+          section.querySelectorAll('[data-testid^="profile-option-"]'),
+        ).map((option) =>
+          option.getAttribute("data-testid")?.replace("profile-option-", ""),
+        ),
+      })),
+    ).toEqual({
+      settingsVisible: true,
+      selectableProfiles: ["github_comment", "watch"],
+    });
   });
 });


### PR DESCRIPTION
Add provenance-aware canonical task labels with compare-and-swap protection for human and issue ownership, plus optional asynchronous refreshes through an explicitly selected automation-safe ACP profile.

Add model-free source-linked resumption cue reads and explicit or inactivity-gated ensures. Preparation and model calls are bounded, secret resolution fails closed, per-session claims prevent duplicate model cost, and conversation/artifact fingerprints reject stale output.

Expose the controls through typed REST, the loom CLI, Settings, and session progressive disclosure. The migrations continue the landed streams at core 0017 and Loom 0014, and the production diff remains below the agreed cap.

The substantive branch lint-review completed with no blocking findings. A second lint-review was skipped for the CI follow-up because it only replaced stale numeric migration-test expectations with the existing latest-version helper.