### PR TITLE
feat(loom): add bounded changes review surface

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -220,6 +220,7 @@ import type {
   AddReviewCommentBody,
   UpdateReviewCommentBody,
   UpdateReviewBody,
+  ChangeSet,
   IdeInfo,
   AgentMetadata,
   CustomAgent,
@@ -439,8 +440,15 @@ export const listArtifactReviews = (id: string, name: string) =>
     `/sessions/${id}/reviews?subject_kind=artifact&subject_key=${encodeURIComponent(name)}`,
   ) as Promise<Review[]>;
 
-export const createArtifactReview = (id: string, body: CreateReviewBody) =>
+export const getChanges = (id: string) => get(`/sessions/${id}/changes`) as Promise<ChangeSet>;
+
+export const listChangesReviews = (id: string) =>
+  get(`/sessions/${id}/reviews?subject_kind=changes&subject_key=changes`) as Promise<Review[]>;
+
+export const createReview = (id: string, body: CreateReviewBody) =>
   post(`/sessions/${id}/reviews`, body) as Promise<Review>;
+
+export const createArtifactReview = (id: string, body: CreateReviewBody) => createReview(id, body);
 
 export const addReviewComment = (reviewId: number, body: AddReviewCommentBody) =>
   post(`/reviews/${reviewId}/comments`, body) as Promise<Review>;

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -448,8 +448,6 @@ export const listChangesReviews = (id: string) =>
 export const createReview = (id: string, body: CreateReviewBody) =>
   post(`/sessions/${id}/reviews`, body) as Promise<Review>;
 
-export const createArtifactReview = (id: string, body: CreateReviewBody) => createReview(id, body);
-
 export const addReviewComment = (reviewId: number, body: AddReviewCommentBody) =>
   post(`/reviews/${reviewId}/comments`, body) as Promise<Review>;
 

--- a/crates/loom/frontend/src/components/ArtifactDocument.vue
+++ b/crates/loom/frontend/src/components/ArtifactDocument.vue
@@ -16,7 +16,7 @@ import { useMarkdownDoc, routeDocLink } from '../lib/markdownDoc';
 import type { Anchor, IssueRefStatus, Review, ReviewComment } from '../types';
 import {
   addReviewComment,
-  createArtifactReview,
+  createReview,
   deleteReviewComment,
   discardReview,
   listArtifactReviews,
@@ -246,7 +246,7 @@ const draftController = new ReviewDraftController<Review>({
     let current = item;
     if (!current) {
       if (!summary.trim()) return null;
-      current = await createArtifactReview(props.id, {
+      current = await createReview(props.id, {
         subject_kind: 'artifact',
         subject_key: props.artifactName,
         subject_version: String(props.rev),
@@ -633,7 +633,7 @@ async function createPendingComment() {
     const updated = await draftController.command(async (current) => {
       const review =
         current ??
-        (await createArtifactReview(props.id, {
+        (await createReview(props.id, {
           subject_kind: 'artifact',
           subject_key: props.artifactName,
           subject_version: pendingComment.subjectVersion,

--- a/crates/loom/frontend/src/components/ArtifactDocument.vue
+++ b/crates/loom/frontend/src/components/ArtifactDocument.vue
@@ -13,7 +13,7 @@ import {
 import { useRouter } from 'vue-router';
 import { renderTokens } from '../markdown-render';
 import { useMarkdownDoc, routeDocLink } from '../lib/markdownDoc';
-import type { IssueRefStatus, Review, ReviewComment } from '../types';
+import type { Anchor, IssueRefStatus, Review, ReviewComment } from '../types';
 import {
   addReviewComment,
   createArtifactReview,
@@ -39,8 +39,8 @@ import {
   type TextAnchor,
 } from '../discussion-anchor';
 import { ReviewDraftController } from '../lib/reviewDraftController';
-import InlineConfirm from './InlineConfirm.vue';
 import ReviewCommentCard from './ReviewCommentCard.vue';
+import ReviewTray from './ReviewTray.vue';
 
 // Dock/pop swaps mounts of the same document. Keep a small in-memory scroll
 // ledger keyed by session + artifact + revision so the document remains where
@@ -177,26 +177,9 @@ let layoutReturnFocus: HTMLElement | null = null;
 const reanchorCommentId = ref<number | null>(null);
 
 const draft = computed(() => reviews.value.find((review) => review.status === 'draft') ?? null);
-const recentSubmitted = computed(
-  () =>
-    [...reviews.value]
-      .filter((review) => review.status === 'submitted' && !review.legacy)
-      .sort((a, b) => b.id - a.id)[0] ?? null,
-);
-const failedSubmissions = computed(() =>
-  [...reviews.value]
-    .filter(
-      (review) =>
-        review.status === 'submitted' && !review.legacy && review.delivery_state === 'failed',
-    )
-    .sort((a, b) => b.id - a.id),
-);
 const draftEntries = computed<ReviewEntry[]>(() =>
   (draft.value?.comments ?? []).map((comment) => ({ review: draft.value!, comment })),
 );
-const feedbackPreview = computed(() => {
-  return draft.value?.message ?? '';
-});
 const allEntries = computed<ReviewEntry[]>(() => {
   const entries: ReviewEntry[] = [];
   for (const review of reviews.value) {
@@ -308,8 +291,7 @@ async function loadReviews() {
   locateCycle();
 }
 
-function editOverallNote(event: Event) {
-  const summary = (event.target as HTMLTextAreaElement).value;
+function editOverallValue(summary: string) {
   draftController.editSummary(summary);
   if (!draftController.draft && !summary.trim()) return;
   if (summarySaveTimer) clearTimeout(summarySaveTimer);
@@ -346,7 +328,8 @@ function locateCycle() {
   const located: { entry: ReviewEntry; range: Range; block: number }[] = [];
   const unlocated: ReviewEntry[] = [];
   for (const entry of allEntries.value) {
-    const range = locate(root, entry.comment.anchor);
+    const anchor = entry.comment.anchor as Anchor;
+    const range = locate(root, anchor);
     if (!range) {
       unlocated.push(entry);
       continue;
@@ -354,7 +337,7 @@ function locateCycle() {
     const element =
       blockContaining(root, range.endContainer) ?? blockContaining(root, range.startContainer);
     const attr = element?.getAttribute('data-block');
-    const capturedBlock = entry.comment.anchor.block_index;
+    const capturedBlock = anchor.block_index;
     const block =
       attr != null ? Number(attr) : typeof capturedBlock === 'number' ? capturedBlock : -1;
     located.push({ entry, range, block });
@@ -400,7 +383,7 @@ const selectionButton = ref<{
   left: number;
 } | null>(null);
 const buttonEl = ref<HTMLElement | null>(null);
-const trayToggleEl = ref<HTMLButtonElement | null>(null);
+const reviewTrayRef = ref<InstanceType<typeof ReviewTray> | null>(null);
 
 function updateSelectionButton() {
   const root = body.value;
@@ -683,7 +666,7 @@ function cancelPendingComment() {
   pendingRange = null;
   pendingDraft.value = '';
   locateCycle();
-  void nextTick(() => trayToggleEl.value?.focus());
+  void nextTick(() => reviewTrayRef.value?.focusToggle());
 }
 
 async function editComment(payload: { commentId: number; body: string }) {
@@ -716,7 +699,7 @@ async function removeComment(commentId: number) {
     reviewNotice.value = 'Pending comment deleted.';
     await nextTick();
     locateCycle();
-    trayToggleEl.value?.focus();
+    reviewTrayRef.value?.focusToggle();
   } catch (e) {
     throw new Error(setCommentMutationError(commentId, e));
   }
@@ -774,7 +757,7 @@ async function discardDraft() {
     reviewNotice.value = 'Draft review discarded.';
     await nextTick();
     locateCycle();
-    trayToggleEl.value?.focus();
+    reviewTrayRef.value?.focusToggle();
   } catch (e) {
     const message = mutationMessage(e);
     trayError.value = message;
@@ -1141,249 +1124,31 @@ const DocBody = () => {
       {{ reanchorCommentId == null ? '＋ Add comment' : '↪ Re-anchor selection' }}
     </button>
 
-    <aside
-      class="absolute bottom-3 right-3 z-20 w-[min(28rem,calc(100%-1.5rem))] rounded-lg border border-line bg-surface shadow-xl"
-      data-testid="review-tray"
-      aria-label="Review tray"
-    >
-      <div class="flex min-h-10 items-center gap-1.5 px-2">
-        <button
-          ref="trayToggleEl"
-          type="button"
-          class="min-w-0 flex-1 px-1 py-2 text-left text-xs font-semibold text-fg"
-          data-testid="review-tray-toggle"
-          :aria-expanded="trayOpen"
-          @click="trayOpen = !trayOpen"
-        >
-          <template v-if="draft">
-            Review · {{ draft.comments.length }} pending
-            <span v-if="draft.outdated" class="ml-1 text-block">· stale</span>
-            <span v-if="failedSubmissions.length" class="ml-1 text-block">
-              · {{ failedSubmissions.length }} delivery failed
-            </span>
-          </template>
-          <template v-else-if="failedSubmissions.length">
-            Review delivery · {{ failedSubmissions.length }} failed
-          </template>
-          <template v-else-if="recentSubmitted">
-            Review submitted · {{ recentSubmitted.delivery_state }}
-          </template>
-          <template v-else>Review artifact</template>
-        </button>
-        <template v-if="draft?.comments.length">
-          <button
-            type="button"
-            class="btn-secondary px-2 py-1 text-xs"
-            aria-label="Previous pending comment"
-            @click="navigateDraft(-1)"
-          >
-            ↑
-          </button>
-          <button
-            type="button"
-            class="btn-secondary px-2 py-1 text-xs"
-            aria-label="Next pending comment"
-            @click="navigateDraft(1)"
-          >
-            ↓
-          </button>
-        </template>
-        <button
-          type="button"
-          class="btn-secondary px-2 py-1 text-xs"
-          :aria-label="trayOpen ? 'Collapse review tray' : 'Expand review tray'"
-          @click="trayOpen = !trayOpen"
-        >
-          {{ trayOpen ? '▾' : '▴' }}
-        </button>
-      </div>
-
-      <div v-if="trayOpen" class="max-h-[min(60vh,34rem)] overflow-auto border-t border-line p-3">
-        <div
-          v-if="failedSubmissions.length"
-          class="mb-3 space-y-2"
-          aria-label="Failed review deliveries"
-        >
-          <div
-            v-for="item in failedSubmissions"
-            :key="`failed-${item.id}`"
-            class="rounded border border-block-line bg-block-soft p-2 text-xs"
-            :data-testid="`failed-review-delivery-${item.id}`"
-          >
-            <p class="font-medium text-block">Review {{ item.id }} delivery failed</p>
-            <p v-if="item.delivery_error" class="mt-1 text-block">{{ item.delivery_error }}</p>
-            <button
-              type="button"
-              class="btn-primary mt-2 px-2 py-1 text-xs"
-              @click="retryDelivery(item)"
-            >
-              Retry delivery
-            </button>
-            <p
-              v-if="deliveryErrors[item.id]"
-              class="mt-2 rounded bg-surface/70 px-2 py-1 text-2xs text-block"
-              role="alert"
-            >
-              {{ deliveryErrors[item.id] }}
-            </p>
-          </div>
-        </div>
-
-        <template v-if="draft">
-          <p
-            v-if="draft.outdated"
-            class="mb-3 rounded border border-block-line bg-block-soft p-2 text-xs text-block"
-            data-testid="review-stale-warning"
-          >
-            This artifact is now revision {{ draft.subject.current_version }}. Stale anchors are
-            preserved; re-anchor them, or acknowledge the older context before submitting.
-          </p>
-          <button
-            v-if="draft.outdated && !draft.comments.length"
-            type="button"
-            class="btn-secondary mb-3 px-2 py-1 text-xs"
-            data-testid="review-retarget-current"
-            :disabled="summarySaving"
-            @click="retargetDraft"
-          >
-            Move review target to revision {{ draft.subject.current_version }}
-          </button>
-
-          <div class="space-y-1.5" aria-label="Pending comments">
-            <button
-              v-for="(entry, index) in draftEntries"
-              :key="entry.comment.id"
-              type="button"
-              class="flex w-full items-center gap-2 rounded border border-line px-2 py-1.5 text-left text-xs hover:border-accent"
-              @click="focusComment(entry.comment.id)"
-            >
-              <span class="shrink-0 font-mono text-2xs text-faint">{{ index + 1 }}</span>
-              <span class="min-w-0 flex-1 truncate text-fg">{{ entry.comment.body }}</span>
-              <span
-                v-if="entry.comment.subject_version !== draft.subject.current_version"
-                class="shrink-0 text-2xs text-block"
-              >
-                rev {{ entry.comment.subject_version }}
-              </span>
-            </button>
-          </div>
-
-          <label class="mt-3 block text-xs font-medium text-muted" for="review-overall-note">
-            Overall note <span class="font-normal text-faint">(optional)</span>
-          </label>
-          <textarea
-            id="review-overall-note"
-            :value="overallNote"
-            rows="3"
-            class="mt-1 w-full resize-y rounded border border-line bg-input p-2 text-xs text-fg outline-none focus:border-accent"
-            placeholder="Feedback that applies to the artifact as a whole…"
-            data-testid="review-overall-note"
-            :disabled="layoutBusy || submitting || discarding"
-            @input="editOverallNote"
-            @blur="saveOverallNote"
-          ></textarea>
-          <p v-if="summarySaving" class="mt-1 text-2xs text-faint" aria-live="polite">
-            Saving overall note…
-          </p>
-
-          <label
-            v-if="draft.outdated"
-            class="mt-2 flex cursor-pointer items-start gap-2 rounded bg-subtle/50 p-2 text-xs text-muted"
-          >
-            <input
-              v-model="acknowledgeOutdated"
-              type="checkbox"
-              class="mt-0.5"
-              data-testid="review-stale-ack"
-            />
-            Submit against the captured revision context intentionally.
-          </label>
-
-          <div class="mt-3 border-t border-line pt-3">
-            <p class="mb-2 text-2xs font-semibold uppercase tracking-wide text-faint">
-              Conversation feedback preview
-            </p>
-            <pre
-              class="max-h-32 overflow-auto whitespace-pre-wrap rounded bg-code p-2 text-xs text-code-fg"
-              >{{ feedbackPreview }}</pre>
-          </div>
-
-          <div class="mt-3 flex flex-wrap items-center gap-2">
-            <p
-              v-if="trayError"
-              class="w-full rounded bg-block-soft px-2 py-1 text-2xs text-block"
-              role="alert"
-            >
-              {{ trayError }}
-            </p>
-            <InlineConfirm
-              label="Discard draft"
-              :message="`Discard the overall note and all ${draft.comments.length} pending comment${draft.comments.length === 1 ? '' : 's'}?`"
-              confirm-label="Discard draft"
-              danger
-              :disabled="layoutBusy || submitting || discarding"
-              :action="discardDraft"
-            />
-            <button
-              type="button"
-              class="btn-primary ml-auto px-3 py-1.5 text-xs"
-              data-testid="submit-review"
-              :disabled="
-                submitting ||
-                layoutBusy ||
-                discarding ||
-                summarySaving ||
-                (!draft.comments.length && !overallNote.trim()) ||
-                (draft.outdated && !acknowledgeOutdated)
-              "
-              @click="submitDraft"
-            >
-              {{ submitting ? 'Submitting…' : 'Submit review' }}
-            </button>
-          </div>
-        </template>
-
-        <template v-else>
-          <div
-            v-if="
-              recentSubmitted &&
-              !failedSubmissions.some((review) => review.id === recentSubmitted?.id)
-            "
-            class="mb-3 text-xs text-muted"
-          >
-            <p class="font-medium text-fg">Review {{ recentSubmitted.id }} submitted</p>
-            <p class="mt-1">
-              Delivery:
-              <span class="text-accent">{{ recentSubmitted.delivery_state }}</span>
-            </p>
-          </div>
-          <label class="block text-xs font-medium text-muted" for="review-new-overall-note">
-            Start a new review with an overall note
-          </label>
-          <textarea
-            id="review-new-overall-note"
-            :value="overallNote"
-            rows="3"
-            class="mt-1 w-full resize-y rounded border border-line bg-input p-2 text-xs text-fg outline-none focus:border-accent"
-            placeholder="Feedback that applies to the artifact as a whole…"
-            data-testid="review-overall-note"
-            :disabled="layoutBusy || submitting || discarding"
-            @input="editOverallNote"
-            @blur="saveOverallNote"
-          ></textarea>
-          <p v-if="summarySaving" class="mt-1 text-2xs text-faint" aria-live="polite">
-            Saving overall note…
-          </p>
-          <p
-            v-if="trayError"
-            class="mt-2 rounded bg-block-soft px-2 py-1 text-2xs text-block"
-            role="alert"
-          >
-            {{ trayError }}
-          </p>
-        </template>
-      </div>
-    </aside>
+    <ReviewTray
+      ref="reviewTrayRef"
+      :reviews="reviews"
+      :draft="draft"
+      :open="trayOpen"
+      :overall-note="overallNote"
+      :summary-saving="summarySaving"
+      :acknowledge-outdated="acknowledgeOutdated"
+      :error="trayError"
+      :layout-busy="layoutBusy"
+      :submitting="submitting"
+      :discarding="discarding"
+      :delivery-errors="deliveryErrors"
+      subject-label="artifact"
+      :discard-action="discardDraft"
+      @update:open="trayOpen = $event"
+      @update:overall-note="editOverallValue"
+      @update:acknowledge-outdated="acknowledgeOutdated = $event"
+      @navigate="navigateDraft"
+      @focus-comment="focusComment"
+      @save-overall="saveOverallNote"
+      @retarget="retargetDraft"
+      @submit="submitDraft"
+      @retry="retryDelivery"
+    />
 
     <div
       v-if="reviewNotice"

--- a/crates/loom/frontend/src/components/ChangesPanel.vue
+++ b/crates/loom/frontend/src/components/ChangesPanel.vue
@@ -39,7 +39,7 @@ const acknowledgeOutdated = ref(false);
 const submitting = ref(false);
 const discarding = ref(false);
 
-type Pending = { anchor: ChangeAnchor; body: string };
+type Pending = { anchor: ChangeAnchor; body: string; version: string };
 const pending = ref<Pending | null>(null);
 const savingComment = ref(false);
 const composerInput = ref<HTMLTextAreaElement | null>(null);
@@ -54,11 +54,19 @@ function replaceReview(next: Review) {
 
 function conflictReview(cause: unknown): Review | null {
   if (!(cause instanceof ApiError) || cause.status !== 409) return null;
-  const fresh = (cause.body.details as { review?: Review } | undefined)?.review;
-  if (!fresh) return null;
-  replaceReview(fresh);
-  if (fresh.status === 'draft') controller.reconcile(fresh);
-  return fresh;
+  const details = cause.body.details;
+  if (!details || typeof details !== 'object') return null;
+  const fresh = (details as { review?: unknown }).review;
+  if (!fresh || typeof fresh !== 'object' || typeof (fresh as Review).id !== 'number') return null;
+  const review = fresh as Review;
+  if (review.status === 'draft') controller.reconcile(review);
+  else {
+    replaceReview(review);
+    controller.clearOwnership();
+    activeComment.value = null;
+    reanchorComment.value = null;
+  }
+  return review;
 }
 
 function mutationMessage(cause: unknown): string {
@@ -101,12 +109,10 @@ async function load() {
       getChanges(props.id),
       listChangesReviews(props.id),
     ]);
+    const nextDraft = nextReviews.find((review) => review.status === 'draft') ?? null;
+    if (!controller.acceptRefresh(epoch, nextDraft)) return;
     changes.value = nextChanges;
     reviews.value = nextReviews;
-    controller.acceptRefresh(
-      epoch,
-      nextReviews.find((review) => review.status === 'draft') ?? null,
-    );
     error.value = '';
   } catch (cause) {
     error.value = (cause as Error).message;
@@ -142,7 +148,7 @@ function anchorFor(
   const side = lineSide(line);
   const start = lineNumber(line, side);
   const end = lineNumber(last, side);
-  if (start == null || end == null || lineSide(last) !== side) return null;
+  if (start == null || end == null) return null;
   const low = Math.min(start, end);
   const high = Math.max(start, end);
   const eligible = hunk.lines.filter((line) => lineNumber(line, side) != null);
@@ -166,6 +172,8 @@ function anchorFor(
 }
 
 function selectLine(file: ChangeFile, hunk: ChangeHunk, line: ChangeLine) {
+  const version = changes.value?.version;
+  if (!version) return;
   const next = anchorFor(file, hunk, line);
   if (!next) return;
   if (reanchorComment.value != null) {
@@ -174,6 +182,7 @@ function selectLine(file: ChangeFile, hunk: ChangeHunk, line: ChangeLine) {
   }
   const current = pending.value?.anchor;
   if (
+    pending.value?.version === version &&
     current?.path.bytes === file.path.bytes &&
     current.side === next.side &&
     current.hunk_header === hunk.header
@@ -187,15 +196,58 @@ function selectLine(file: ChangeFile, hunk: ChangeHunk, line: ChangeLine) {
       return;
     }
   }
-  pending.value = { anchor: next, body: '' };
+  pending.value = { anchor: next, body: pending.value?.body ?? '', version };
   void nextTick(() => composerInput.value?.focus());
 }
 
-async function saveComment() {
-  const body = pending.value?.body.trim();
+function extendSelection(file: ChangeFile, hunk: ChangeHunk, line: ChangeLine, direction: -1 | 1) {
   const version = changes.value?.version;
-  if (!pending.value || !body || !version || savingComment.value) return;
+  if (!version) return;
+  const side = lineSide(line);
+  const eligible = hunk.lines.filter((candidate) => lineNumber(candidate, side) != null);
+  const current = pending.value;
+  const sameRange =
+    current?.version === version &&
+    current.anchor.path.bytes === file.path.bytes &&
+    current.anchor.side === side &&
+    current.anchor.hunk_header === hunk.header;
+  const boundary = sameRange
+    ? direction < 0
+      ? current!.anchor.start_line
+      : current!.anchor.end_line
+    : lineNumber(line, side);
+  const boundaryIndex = eligible.findIndex((candidate) => lineNumber(candidate, side) === boundary);
+  const target = eligible[boundaryIndex + direction];
+  if (boundaryIndex < 0 || !target) return;
+  let range: ChangeAnchor | null;
+  if (!sameRange) {
+    range =
+      direction < 0 ? anchorFor(file, hunk, target, line) : anchorFor(file, hunk, line, target);
+  } else {
+    const first = hunk.lines.find(
+      (candidate) => lineNumber(candidate, side) === current!.anchor.start_line,
+    );
+    const last =
+      direction < 0
+        ? hunk.lines.find((candidate) => lineNumber(candidate, side) === current!.anchor.end_line)
+        : target;
+    range =
+      first && last && direction < 0
+        ? anchorFor(file, hunk, target, last)
+        : first && last
+          ? anchorFor(file, hunk, first, target)
+          : null;
+  }
+  if (!range) return;
+  pending.value = { anchor: range, body: current?.body ?? '', version };
+}
+
+async function saveComment() {
+  const capture = pending.value;
+  const body = capture?.body.trim();
+  if (!capture || !body || savingComment.value) return;
   savingComment.value = true;
+  trayError.value = '';
   try {
     const updated = await controller.command(async (current) => {
       const review =
@@ -203,13 +255,13 @@ async function saveComment() {
         (await createReview(props.id, {
           subject_kind: 'changes',
           subject_key: 'changes',
-          subject_version: version,
+          subject_version: capture.version,
         }));
       return addReviewComment(review.id, {
         expected_revision: review.draft_revision,
-        subject_version: version,
+        subject_version: capture.version,
         anchor_kind: 'change',
-        anchor: pending.value!.anchor,
+        anchor: capture.anchor,
         body,
       });
     });
@@ -429,6 +481,8 @@ onMounted(load);
               }"
               :aria-label="`Comment on ${file.path.display} ${lineSide(line)} line ${lineNumber(line, lineSide(line))}`"
               @click="selectLine(file, hunk, line)"
+              @keydown.shift.up.prevent="extendSelection(file, hunk, line, -1)"
+              @keydown.shift.down.prevent="extendSelection(file, hunk, line, 1)"
             >
               <span class="select-none px-1 text-right text-faint">{{ line.old_line }}</span>
               <span class="select-none px-1 text-right text-faint">{{ line.new_line }}</span>

--- a/crates/loom/frontend/src/components/ChangesPanel.vue
+++ b/crates/loom/frontend/src/components/ChangesPanel.vue
@@ -1,0 +1,523 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, reactive, ref } from 'vue';
+import {
+  addReviewComment,
+  createReview,
+  deleteReviewComment,
+  discardReview,
+  getChanges,
+  listChangesReviews,
+  retryReviewDelivery,
+  retargetReviewToCurrent,
+  submitReview,
+  updateReview,
+  updateReviewComment,
+  ApiError,
+} from '../api';
+import type { ChangeAnchor, ChangeFile, ChangeHunk, ChangeLine, ChangeSet, Review } from '../types';
+import { ReviewDraftController } from '../lib/reviewDraftController';
+import ReviewCommentCard from './ReviewCommentCard.vue';
+import ReviewTray from './ReviewTray.vue';
+
+const props = defineProps<{ id: string }>();
+const changes = ref<ChangeSet | null>(null);
+const reviews = ref<Review[]>([]);
+const loading = ref(false);
+const error = ref('');
+const notice = ref('');
+const expanded = reactive(new Set<string>());
+const activeComment = ref<number | null>(null);
+const reanchorComment = ref<number | null>(null);
+const commentErrors = reactive<Record<number, string>>({});
+const deliveryErrors = reactive<Record<number, string>>({});
+const trayOpen = ref(false);
+const trayError = ref('');
+const overallNote = ref('');
+const summaryDirty = ref(false);
+const summarySaving = ref(false);
+const acknowledgeOutdated = ref(false);
+const submitting = ref(false);
+const discarding = ref(false);
+
+type Pending = { anchor: ChangeAnchor; body: string };
+const pending = ref<Pending | null>(null);
+const savingComment = ref(false);
+const composerInput = ref<HTMLTextAreaElement | null>(null);
+
+const draft = computed(() => reviews.value.find((review) => review.status === 'draft') ?? null);
+
+function replaceReview(next: Review) {
+  const index = reviews.value.findIndex((review) => review.id === next.id);
+  if (index < 0) reviews.value = [next, ...reviews.value];
+  else reviews.value.splice(index, 1, next);
+}
+
+function conflictReview(cause: unknown): Review | null {
+  if (!(cause instanceof ApiError) || cause.status !== 409) return null;
+  const fresh = (cause.body.details as { review?: Review } | undefined)?.review;
+  if (!fresh) return null;
+  replaceReview(fresh);
+  if (fresh.status === 'draft') controller.reconcile(fresh);
+  return fresh;
+}
+
+function mutationMessage(cause: unknown): string {
+  if (conflictReview(cause)) {
+    return 'This draft changed elsewhere. The latest version is loaded; review it before retrying.';
+  }
+  return (cause as Error).message;
+}
+
+const controller = new ReviewDraftController<Review>({
+  saveSummary: async (current, summary) => {
+    const version = changes.value?.version;
+    if (!version) throw new Error('The change-set version is unavailable.');
+    const review =
+      current ??
+      (await createReview(props.id, {
+        subject_kind: 'changes',
+        subject_key: 'changes',
+        subject_version: version,
+      }));
+    return updateReview(review.id, {
+      expected_revision: review.draft_revision,
+      summary,
+    });
+  },
+  onDraft: (next) => {
+    if (next) replaceReview(next);
+  },
+  onSummary: (summary, dirty) => {
+    overallNote.value = summary;
+    summaryDirty.value = dirty;
+  },
+});
+
+async function load() {
+  const epoch = controller.beginRefresh();
+  loading.value = true;
+  try {
+    const [nextChanges, nextReviews] = await Promise.all([
+      getChanges(props.id),
+      listChangesReviews(props.id),
+    ]);
+    changes.value = nextChanges;
+    reviews.value = nextReviews;
+    controller.acceptRefresh(
+      epoch,
+      nextReviews.find((review) => review.status === 'draft') ?? null,
+    );
+    error.value = '';
+  } catch (cause) {
+    error.value = (cause as Error).message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function fileKey(file: ChangeFile): string {
+  return file.path.bytes;
+}
+
+function toggleFile(file: ChangeFile) {
+  const key = fileKey(file);
+  if (expanded.has(key)) expanded.delete(key);
+  else expanded.add(key);
+}
+
+function lineSide(line: ChangeLine): 'old' | 'new' {
+  return line.kind === 'deletion' ? 'old' : 'new';
+}
+
+function lineNumber(line: ChangeLine, side: 'old' | 'new'): number | null {
+  return side === 'old' ? line.old_line : line.new_line;
+}
+
+function anchorFor(
+  file: ChangeFile,
+  hunk: ChangeHunk,
+  line: ChangeLine,
+  last = line,
+): ChangeAnchor | null {
+  const side = lineSide(line);
+  const start = lineNumber(line, side);
+  const end = lineNumber(last, side);
+  if (start == null || end == null || lineSide(last) !== side) return null;
+  const low = Math.min(start, end);
+  const high = Math.max(start, end);
+  const eligible = hunk.lines.filter((line) => lineNumber(line, side) != null);
+  const selected = eligible.filter((line) => {
+    const number = lineNumber(line, side)!;
+    return number >= low && number <= high;
+  });
+  if (selected.length !== high - low + 1) return null;
+  const first = eligible.indexOf(selected[0]);
+  const lastIndex = eligible.indexOf(selected.at(-1)!);
+  return {
+    path: file.path,
+    side,
+    start_line: low,
+    end_line: high,
+    hunk_header: hunk.header,
+    context_before: eligible.slice(Math.max(0, first - 2), first).map((line) => line.text),
+    selected: selected.map((line) => line.text),
+    context_after: eligible.slice(lastIndex + 1, lastIndex + 3).map((line) => line.text),
+  };
+}
+
+function selectLine(file: ChangeFile, hunk: ChangeHunk, line: ChangeLine) {
+  const next = anchorFor(file, hunk, line);
+  if (!next) return;
+  if (reanchorComment.value != null) {
+    void applyReanchor(reanchorComment.value, next);
+    return;
+  }
+  const current = pending.value?.anchor;
+  if (
+    current?.path.bytes === file.path.bytes &&
+    current.side === next.side &&
+    current.hunk_header === hunk.header
+  ) {
+    const first = hunk.lines.find(
+      (candidate) => lineNumber(candidate, current.side) === current.start_line,
+    );
+    const range = first && anchorFor(file, hunk, first, line);
+    if (range) {
+      pending.value = { ...pending.value!, anchor: range };
+      return;
+    }
+  }
+  pending.value = { anchor: next, body: '' };
+  void nextTick(() => composerInput.value?.focus());
+}
+
+async function saveComment() {
+  const body = pending.value?.body.trim();
+  const version = changes.value?.version;
+  if (!pending.value || !body || !version || savingComment.value) return;
+  savingComment.value = true;
+  try {
+    const updated = await controller.command(async (current) => {
+      const review =
+        current ??
+        (await createReview(props.id, {
+          subject_kind: 'changes',
+          subject_key: 'changes',
+          subject_version: version,
+        }));
+      return addReviewComment(review.id, {
+        expected_revision: review.draft_revision,
+        subject_version: version,
+        anchor_kind: 'change',
+        anchor: pending.value!.anchor,
+        body,
+      });
+    });
+    activeComment.value = updated.comments.at(-1)?.id ?? null;
+    pending.value = null;
+    trayOpen.value = true;
+    notice.value = 'Pending comment saved.';
+  } catch (cause) {
+    trayError.value = mutationMessage(cause);
+  } finally {
+    savingComment.value = false;
+  }
+}
+
+async function editComment(payload: { commentId: number; body: string }) {
+  try {
+    await controller.command((current) => {
+      if (!current) throw new Error('Review draft is unavailable.');
+      return updateReviewComment(current.id, payload.commentId, {
+        expected_revision: current.draft_revision,
+        body: payload.body,
+      });
+    });
+  } catch (cause) {
+    commentErrors[payload.commentId] = mutationMessage(cause);
+  }
+}
+
+async function removeComment(commentId: number) {
+  try {
+    await controller.command((current) => {
+      if (!current) throw new Error('Review draft is unavailable.');
+      return deleteReviewComment(current.id, commentId, current.draft_revision);
+    });
+    activeComment.value = null;
+  } catch (cause) {
+    throw new Error(mutationMessage(cause));
+  }
+}
+
+async function applyReanchor(commentId: number, anchor: ChangeAnchor) {
+  const version = changes.value?.version;
+  if (!version) return;
+  try {
+    await controller.command((current) => {
+      if (!current) throw new Error('Review draft is unavailable.');
+      return updateReviewComment(current.id, commentId, {
+        expected_revision: current.draft_revision,
+        subject_version: version,
+        anchor_kind: 'change',
+        anchor,
+      });
+    });
+    reanchorComment.value = null;
+    notice.value = 'Comment re-anchored to the current changes.';
+  } catch (cause) {
+    commentErrors[commentId] = mutationMessage(cause);
+  }
+}
+
+function editOverall(summary: string) {
+  controller.editSummary(summary);
+}
+
+async function saveOverall() {
+  summarySaving.value = true;
+  try {
+    await controller.flush();
+  } catch (cause) {
+    trayError.value = mutationMessage(cause);
+  } finally {
+    summarySaving.value = false;
+  }
+}
+
+async function discardDraft() {
+  discarding.value = true;
+  try {
+    const id = await controller.freeze(async (current) => {
+      if (!current) throw new Error('Review draft is unavailable.');
+      await discardReview(current.id, current.draft_revision);
+      return { draft: null, result: current.id };
+    });
+    reviews.value = reviews.value.filter((review) => review.id !== id);
+    trayOpen.value = false;
+  } finally {
+    discarding.value = false;
+  }
+}
+
+async function retarget() {
+  if (!draft.value || draft.value.comments.length) return;
+  try {
+    await controller.command((current) => {
+      if (!current) throw new Error('Review draft is unavailable.');
+      return retargetReviewToCurrent(current.id, current.draft_revision);
+    });
+  } catch (cause) {
+    trayError.value = mutationMessage(cause);
+  }
+}
+
+async function submit() {
+  submitting.value = true;
+  try {
+    const submitted = await controller.freeze(async (current) => {
+      if (!current) throw new Error('Review draft is unavailable.');
+      const result = await submitReview(current.id, {
+        expected_revision: current.draft_revision,
+        acknowledge_outdated: acknowledgeOutdated.value,
+      });
+      replaceReview(result);
+      return { draft: null, result };
+    });
+    notice.value = `Review submitted · ${submitted.delivery_state}.`;
+  } catch (cause) {
+    trayError.value = mutationMessage(cause);
+  } finally {
+    submitting.value = false;
+  }
+}
+
+async function retryDelivery(item: Review) {
+  try {
+    replaceReview(await retryReviewDelivery(item.id));
+  } catch (cause) {
+    deliveryErrors[item.id] = (cause as Error).message;
+  }
+}
+
+function navigate(direction: number) {
+  const comments = draft.value?.comments ?? [];
+  if (!comments.length) return;
+  const current = comments.findIndex((comment) => comment.id === activeComment.value);
+  activeComment.value = comments[(current + direction + comments.length) % comments.length].id;
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <section
+    class="relative flex h-full min-h-0 flex-col overflow-hidden"
+    data-testid="changes-panel"
+  >
+    <header class="flex flex-wrap items-center gap-2 border-b border-line px-3 py-2">
+      <div class="min-w-0 flex-1">
+        <h2 class="text-sm font-semibold text-fg">Changes</h2>
+        <p
+          v-if="changes?.base.state === 'available'"
+          class="truncate font-mono text-2xs text-faint"
+        >
+          {{ changes.base.reference }} · {{ changes.base.oid.slice(0, 10) }}
+        </p>
+      </div>
+      <span v-if="changes" class="text-xs text-muted">
+        {{ changes.totals.files }} files · +{{ changes.totals.additions }} −{{
+          changes.totals.deletions
+        }}
+      </span>
+      <button type="button" class="btn-secondary px-2 py-1 text-xs" @click="load">Refresh</button>
+    </header>
+
+    <p v-if="error" class="m-3 rounded bg-block-soft p-2 text-xs text-block" role="alert">
+      {{ error }}
+    </p>
+    <p
+      v-else-if="changes?.base.state === 'unavailable'"
+      class="m-3 rounded border border-line p-3 text-sm text-muted"
+    >
+      Changes unavailable: {{ changes.base.reason.replaceAll('_', ' ') }} for local
+      <code>{{ changes.base.reference }}</code
+      >.
+    </p>
+    <div v-else class="min-h-0 flex-1 overflow-auto">
+      <p v-if="loading && !changes" class="p-3 text-sm text-muted">Loading changes…</p>
+      <p v-else-if="changes && !changes.files.length" class="p-3 text-sm text-muted">
+        No branch or worktree changes.
+      </p>
+      <p v-if="changes?.truncated" class="m-3 rounded bg-block-soft p-2 text-xs text-block">
+        This response reached its explicit display bounds. Refresh after narrowing the change set;
+        the version still covers all final bytes when available.
+      </p>
+
+      <article v-for="file in changes?.files" :key="file.path.bytes" class="border-b border-line">
+        <button
+          type="button"
+          class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-subtle"
+          :aria-expanded="expanded.has(fileKey(file))"
+          @click="toggleFile(file)"
+        >
+          <span class="w-4 text-faint">{{ expanded.has(fileKey(file)) ? '▾' : '▸' }}</span>
+          <span class="rounded bg-subtle px-1.5 py-0.5 text-2xs uppercase text-muted">
+            {{ file.status }}
+          </span>
+          <code class="min-w-0 flex-1 truncate text-xs">{{ file.path.display }}</code>
+          <span class="text-2xs text-faint">{{ file.sources.join(' · ') }}</span>
+          <span class="font-mono text-2xs text-muted"
+            >+{{ file.additions ?? '–' }} −{{ file.deletions ?? '–' }}</span
+          >
+        </button>
+
+        <div v-if="expanded.has(fileKey(file))" class="overflow-x-auto bg-code font-mono text-xs">
+          <p v-if="file.content !== 'text'" class="px-4 py-3 text-muted">
+            {{ file.content }} content is not rendered.
+          </p>
+          <div v-for="hunk in file.hunks" :key="hunk.header">
+            <p class="sticky left-0 bg-subtle px-3 py-1 text-accent">{{ hunk.header }}</p>
+            <button
+              v-for="line in hunk.lines"
+              :key="`${line.old_line}:${line.new_line}:${line.kind}`"
+              type="button"
+              class="grid min-w-full grid-cols-[3rem_3rem_1rem_1fr] text-left hover:bg-subtle focus:bg-subtle"
+              :class="{
+                'bg-green-950/20': line.kind === 'addition',
+                'bg-red-950/20': line.kind === 'deletion',
+              }"
+              :aria-label="`Comment on ${file.path.display} ${lineSide(line)} line ${lineNumber(line, lineSide(line))}`"
+              @click="selectLine(file, hunk, line)"
+            >
+              <span class="select-none px-1 text-right text-faint">{{ line.old_line }}</span>
+              <span class="select-none px-1 text-right text-faint">{{ line.new_line }}</span>
+              <span class="select-none text-center">{{
+                line.kind === 'addition' ? '+' : line.kind === 'deletion' ? '−' : ' '
+              }}</span>
+              <span class="whitespace-pre px-1">{{ line.text || ' ' }}</span>
+            </button>
+          </div>
+        </div>
+      </article>
+
+      <div v-if="draft?.comments.length" class="space-y-1 p-3">
+        <template v-if="draft">
+          <ReviewCommentCard
+            v-for="comment in draft.comments"
+            :key="comment.id"
+            :review="draft"
+            :comment="comment"
+            :active="activeComment === comment.id"
+            :reanchoring="reanchorComment === comment.id"
+            :error="commentErrors[comment.id] ?? ''"
+            :delete-action="removeComment"
+            @focus="activeComment = $event"
+            @close="activeComment = null"
+            @edit="editComment"
+            @reanchor="reanchorComment = $event"
+            @cancel-reanchor="reanchorComment = null"
+          />
+        </template>
+      </div>
+    </div>
+
+    <form
+      v-if="pending"
+      class="absolute bottom-14 left-3 z-30 w-[min(30rem,calc(100%-1.5rem))] rounded border border-accent bg-surface p-2 shadow-xl"
+      data-testid="change-comment-composer"
+      @submit.prevent="saveComment"
+    >
+      <p class="mb-1 text-2xs font-semibold uppercase text-accent">
+        {{ pending.anchor.path.display }} · {{ pending.anchor.side }}
+        {{ pending.anchor.start_line }}–{{ pending.anchor.end_line }}
+      </p>
+      <textarea
+        ref="composerInput"
+        v-model="pending.body"
+        rows="3"
+        class="w-full rounded border border-line bg-input p-2 text-xs"
+      ></textarea>
+      <div class="mt-2 flex justify-end gap-2">
+        <button type="button" class="btn-secondary px-2 py-1 text-xs" @click="pending = null">
+          Cancel
+        </button>
+        <button
+          type="submit"
+          class="btn-primary px-2 py-1 text-xs"
+          :disabled="!pending.body.trim() || savingComment"
+        >
+          {{ savingComment ? 'Saving…' : 'Add pending comment' }}
+        </button>
+      </div>
+    </form>
+
+    <ReviewTray
+      :reviews="reviews"
+      :draft="draft"
+      :open="trayOpen"
+      :overall-note="overallNote"
+      :summary-saving="summarySaving || summaryDirty"
+      :acknowledge-outdated="acknowledgeOutdated"
+      :error="trayError"
+      :layout-busy="false"
+      :submitting="submitting"
+      :discarding="discarding"
+      :delivery-errors="deliveryErrors"
+      subject-label="changes"
+      :discard-action="discardDraft"
+      @update:open="trayOpen = $event"
+      @update:overall-note="editOverall"
+      @update:acknowledge-outdated="acknowledgeOutdated = $event"
+      @navigate="navigate"
+      @focus-comment="activeComment = $event"
+      @save-overall="saveOverall"
+      @retarget="retarget"
+      @submit="submit"
+      @retry="retryDelivery"
+    />
+    <p v-if="notice" class="absolute bottom-1 left-3 text-2xs text-accent" role="status">
+      {{ notice }}
+    </p>
+  </section>
+</template>

--- a/crates/loom/frontend/src/components/ChangesPanel.vue
+++ b/crates/loom/frontend/src/components/ChangesPanel.vue
@@ -61,8 +61,10 @@ function conflictReview(cause: unknown): Review | null {
   const review = fresh as Review;
   if (review.status === 'draft') controller.reconcile(review);
   else {
+    const dirtySummary = controller.summaryDirty ? overallNote.value : null;
     replaceReview(review);
     controller.clearOwnership();
+    if (dirtySummary != null) controller.editSummary(dirtySummary);
     activeComment.value = null;
     reanchorComment.value = null;
   }

--- a/crates/loom/frontend/src/components/ReviewCommentCard.vue
+++ b/crates/loom/frontend/src/components/ReviewCommentCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue';
-import type { Review, ReviewComment } from '../types';
+import { computed, nextTick, ref, watch } from 'vue';
+import type { Anchor, ChangeAnchor, Review, ReviewComment } from '../types';
 import InlineConfirm from './InlineConfirm.vue';
 
 const props = defineProps<{
@@ -28,6 +28,17 @@ const editEl = ref<HTMLButtonElement | null>(null);
 const resolutionEl = ref<HTMLButtonElement | null>(null);
 const closeEl = ref<HTMLButtonElement | null>(null);
 const textareaEl = ref<HTMLTextAreaElement | null>(null);
+const anchorLabel = computed(() => {
+  if (props.comment.anchor_kind === 'change') {
+    const anchor = props.comment.anchor as ChangeAnchor;
+    const range =
+      anchor.start_line === anchor.end_line
+        ? `${anchor.side} ${anchor.start_line}`
+        : `${anchor.side} ${anchor.start_line}–${anchor.end_line}`;
+    return `${anchor.path.display}:${range}`;
+  }
+  return (props.comment.anchor as Anchor).quote;
+});
 
 watch(
   () => props.comment.body,
@@ -152,8 +163,8 @@ function cancelEdit() {
     @keydown.esc.stop.prevent="reanchoring ? emit('cancelReanchor') : emit('close', comment.id)"
   >
     <div class="mb-1.5 flex items-start gap-2">
-      <div class="min-w-0 flex-1 truncate italic text-muted" :title="comment.anchor.quote">
-        &ldquo;{{ comment.anchor.quote }}&rdquo;
+      <div class="min-w-0 flex-1 truncate italic text-muted" :title="anchorLabel">
+        {{ comment.anchor_kind === 'text' ? `“${anchorLabel}”` : anchorLabel }}
       </div>
       <span
         v-if="comment.subject_version !== review.subject.current_version"
@@ -269,7 +280,11 @@ function cancelEdit() {
       {{ error }}
     </p>
     <p v-if="reanchoring" class="mt-2 rounded bg-subtle px-2 py-1 text-2xs text-accent">
-      Select the replacement text in this artifact, then choose Re-anchor selection.
+      {{
+        comment.anchor_kind === 'change'
+          ? 'Choose the replacement line in the current changes.'
+          : 'Select the replacement text in this artifact, then choose Re-anchor selection.'
+      }}
     </p>
   </div>
 </template>

--- a/crates/loom/frontend/src/components/ReviewTray.vue
+++ b/crates/loom/frontend/src/components/ReviewTray.vue
@@ -1,0 +1,285 @@
+<script setup lang="ts">
+import { computed, ref, useId } from 'vue';
+import type { Review } from '../types';
+import InlineConfirm from './InlineConfirm.vue';
+
+const props = defineProps<{
+  reviews: Review[];
+  draft: Review | null;
+  open: boolean;
+  overallNote: string;
+  summarySaving: boolean;
+  acknowledgeOutdated: boolean;
+  error: string;
+  layoutBusy: boolean;
+  submitting: boolean;
+  discarding: boolean;
+  deliveryErrors: Record<number, string>;
+  subjectLabel: string;
+  discardAction: () => Promise<void>;
+}>();
+const emit = defineEmits<{
+  'update:open': [value: boolean];
+  'update:overallNote': [value: string];
+  'update:acknowledgeOutdated': [value: boolean];
+  navigate: [direction: number];
+  focusComment: [commentId: number];
+  saveOverall: [];
+  retarget: [];
+  submit: [];
+  retry: [review: Review];
+}>();
+const toggleEl = ref<HTMLButtonElement | null>(null);
+const overallId = `review-overall-${useId()}`;
+defineExpose({ focusToggle: () => toggleEl.value?.focus() });
+
+const failed = computed(() =>
+  props.reviews.filter(
+    (review) =>
+      review.status === 'submitted' && !review.legacy && review.delivery_state === 'failed',
+  ),
+);
+const recent = computed(
+  () =>
+    [...props.reviews]
+      .filter((review) => review.status === 'submitted' && !review.legacy)
+      .sort((a, b) => b.id - a.id)[0] ?? null,
+);
+</script>
+
+<template>
+  <aside
+    class="absolute bottom-3 right-3 z-20 w-[min(28rem,calc(100%-1.5rem))] rounded-lg border border-line bg-surface shadow-xl"
+    data-testid="review-tray"
+    aria-label="Review tray"
+  >
+    <div class="flex min-h-10 items-center gap-1.5 px-2">
+      <button
+        ref="toggleEl"
+        type="button"
+        class="min-w-0 flex-1 px-1 py-2 text-left text-xs font-semibold text-fg"
+        data-testid="review-tray-toggle"
+        :aria-expanded="open"
+        @click="emit('update:open', !open)"
+      >
+        <template v-if="draft">
+          Review · {{ draft.comments.length }} pending
+          <span v-if="draft.outdated" class="ml-1 text-block">· stale</span>
+          <span v-if="failed.length" class="ml-1 text-block">
+            · {{ failed.length }} delivery failed
+          </span>
+        </template>
+        <template v-else-if="failed.length">Review delivery · {{ failed.length }} failed</template>
+        <template v-else-if="recent">Review submitted · {{ recent.delivery_state }}</template>
+        <template v-else>Review {{ subjectLabel }}</template>
+      </button>
+      <template v-if="draft?.comments.length">
+        <button
+          type="button"
+          class="btn-secondary px-2 py-1 text-xs"
+          aria-label="Previous pending comment"
+          @click="emit('navigate', -1)"
+        >
+          ↑
+        </button>
+        <button
+          type="button"
+          class="btn-secondary px-2 py-1 text-xs"
+          aria-label="Next pending comment"
+          @click="emit('navigate', 1)"
+        >
+          ↓
+        </button>
+      </template>
+      <button
+        type="button"
+        class="btn-secondary px-2 py-1 text-xs"
+        :aria-label="open ? 'Collapse review tray' : 'Expand review tray'"
+        @click="emit('update:open', !open)"
+      >
+        {{ open ? '▾' : '▴' }}
+      </button>
+    </div>
+
+    <div v-if="open" class="max-h-[min(60vh,34rem)] overflow-auto border-t border-line p-3">
+      <div v-if="failed.length" class="mb-3 space-y-2" aria-label="Failed review deliveries">
+        <div
+          v-for="item in failed"
+          :key="item.id"
+          class="rounded border border-block-line bg-block-soft p-2 text-xs"
+          :data-testid="`failed-review-delivery-${item.id}`"
+        >
+          <p class="font-medium text-block">Review {{ item.id }} delivery failed</p>
+          <p v-if="item.delivery_error" class="mt-1 text-block">{{ item.delivery_error }}</p>
+          <button
+            type="button"
+            class="btn-primary mt-2 px-2 py-1 text-xs"
+            @click="emit('retry', item)"
+          >
+            Retry delivery
+          </button>
+          <p
+            v-if="deliveryErrors[item.id]"
+            class="mt-2 rounded bg-surface/70 px-2 py-1 text-2xs text-block"
+            role="alert"
+          >
+            {{ deliveryErrors[item.id] }}
+          </p>
+        </div>
+      </div>
+
+      <template v-if="draft">
+        <p
+          v-if="draft.outdated"
+          class="mb-3 rounded border border-block-line bg-block-soft p-2 text-xs text-block"
+          data-testid="review-stale-warning"
+        >
+          This {{ subjectLabel }} changed to {{ draft.subject.current_version }}. Captured anchors
+          are preserved; re-anchor them, or acknowledge the older context before submitting.
+        </p>
+        <button
+          v-if="draft.outdated && !draft.comments.length"
+          type="button"
+          class="btn-secondary mb-3 px-2 py-1 text-xs"
+          data-testid="review-retarget-current"
+          :disabled="summarySaving"
+          @click="emit('retarget')"
+        >
+          Move review to current {{ subjectLabel }}
+        </button>
+
+        <div class="space-y-1.5" aria-label="Pending comments">
+          <button
+            v-for="(comment, index) in draft.comments"
+            :key="comment.id"
+            type="button"
+            class="flex w-full items-center gap-2 rounded border border-line px-2 py-1.5 text-left text-xs hover:border-accent"
+            @click="emit('focusComment', comment.id)"
+          >
+            <span class="shrink-0 font-mono text-2xs text-faint">{{ index + 1 }}</span>
+            <span class="min-w-0 flex-1 truncate text-fg">{{ comment.body }}</span>
+            <span
+              v-if="comment.subject_version !== draft.subject.current_version"
+              class="shrink-0 text-2xs text-block"
+            >
+              stale
+            </span>
+          </button>
+        </div>
+
+        <label class="mt-3 block text-xs font-medium text-muted" :for="overallId">
+          Overall note <span class="font-normal text-faint">(optional)</span>
+        </label>
+        <textarea
+          :id="overallId"
+          :value="overallNote"
+          rows="3"
+          class="mt-1 w-full resize-y rounded border border-line bg-input p-2 text-xs text-fg outline-none focus:border-accent"
+          :placeholder="`Feedback that applies to the ${subjectLabel} as a whole…`"
+          data-testid="review-overall-note"
+          :disabled="layoutBusy || submitting || discarding"
+          @input="emit('update:overallNote', ($event.target as HTMLTextAreaElement).value)"
+          @blur="emit('saveOverall')"
+        ></textarea>
+        <p v-if="summarySaving" class="mt-1 text-2xs text-faint" aria-live="polite">
+          Saving overall note…
+        </p>
+
+        <label
+          v-if="draft.outdated"
+          class="mt-2 flex cursor-pointer items-start gap-2 rounded bg-subtle/50 p-2 text-xs text-muted"
+        >
+          <input
+            :checked="acknowledgeOutdated"
+            type="checkbox"
+            class="mt-0.5"
+            data-testid="review-stale-ack"
+            @change="
+              emit('update:acknowledgeOutdated', ($event.target as HTMLInputElement).checked)
+            "
+          />
+          Submit against the captured version intentionally.
+        </label>
+
+        <div class="mt-3 border-t border-line pt-3">
+          <p class="mb-2 text-2xs font-semibold uppercase tracking-wide text-faint">
+            Conversation feedback preview
+          </p>
+          <pre
+            class="max-h-32 overflow-auto whitespace-pre-wrap rounded bg-code p-2 text-xs text-code-fg"
+            >{{ draft.message }}</pre>
+        </div>
+
+        <div class="mt-3 flex flex-wrap items-center gap-2">
+          <p
+            v-if="error"
+            class="w-full rounded bg-block-soft px-2 py-1 text-2xs text-block"
+            role="alert"
+          >
+            {{ error }}
+          </p>
+          <InlineConfirm
+            label="Discard draft"
+            :message="`Discard the overall note and all ${draft.comments.length} pending comments?`"
+            confirm-label="Discard draft"
+            danger
+            :disabled="layoutBusy || submitting || discarding"
+            :action="discardAction"
+          />
+          <button
+            type="button"
+            class="btn-primary ml-auto px-3 py-1.5 text-xs"
+            data-testid="submit-review"
+            :disabled="
+              submitting ||
+              layoutBusy ||
+              discarding ||
+              summarySaving ||
+              (!draft.comments.length && !overallNote.trim()) ||
+              (draft.outdated && !acknowledgeOutdated)
+            "
+            @click="emit('submit')"
+          >
+            {{ submitting ? 'Submitting…' : 'Submit review' }}
+          </button>
+        </div>
+      </template>
+
+      <template v-else>
+        <div
+          v-if="recent && !failed.some((review) => review.id === recent?.id)"
+          class="mb-3 text-xs text-muted"
+        >
+          <p class="font-medium text-fg">Review {{ recent.id }} submitted</p>
+          <p class="mt-1">
+            Delivery: <span class="text-accent">{{ recent.delivery_state }}</span>
+          </p>
+        </div>
+        <label class="block text-xs font-medium text-muted" :for="overallId">
+          Start a new review with an overall note
+        </label>
+        <textarea
+          :id="overallId"
+          :value="overallNote"
+          rows="3"
+          class="mt-1 w-full resize-y rounded border border-line bg-input p-2 text-xs text-fg outline-none focus:border-accent"
+          :placeholder="`Feedback that applies to the ${subjectLabel} as a whole…`"
+          data-testid="review-overall-note"
+          :disabled="layoutBusy || submitting || discarding"
+          @input="emit('update:overallNote', ($event.target as HTMLTextAreaElement).value)"
+          @blur="emit('saveOverall')"
+        ></textarea>
+        <p v-if="summarySaving" class="mt-1 text-2xs text-faint" aria-live="polite">
+          Saving overall note…
+        </p>
+        <p
+          v-if="error"
+          class="mt-2 rounded bg-block-soft px-2 py-1 text-2xs text-block"
+          role="alert"
+        >
+          {{ error }}
+        </p>
+      </template>
+    </div>
+  </aside>
+</template>

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -454,18 +454,20 @@ async function submitHandoff() {
                     </button>
                   </div>
                 </div>
-                <button
-                  v-if="ideEnabled"
-                  type="button"
-                  data-testid="action-open-editor"
-                  class="block w-full rounded px-2 py-1.5 text-left text-fg transition-colors hover:bg-subtle"
-                  @click="openEditor"
-                >
-                  <span class="block text-xs font-medium">Open editor</span>
-                  <span class="block text-2xs text-faint"
-                    >Open the worktree in the side panel.</span
+                <details v-if="ideEnabled" class="rounded border border-line bg-input">
+                  <summary class="cursor-pointer px-2 py-1.5 text-xs text-muted">Advanced</summary>
+                  <button
+                    type="button"
+                    data-testid="action-open-editor"
+                    class="block w-full border-t border-line px-2 py-1.5 text-left text-fg transition-colors hover:bg-subtle"
+                    @click="openEditor"
                   >
-                </button>
+                    <span class="block text-xs font-medium">Open editor</span>
+                    <span class="block text-2xs text-faint"
+                      >Open the worktree in the side panel.</span
+                    >
+                  </button>
+                </details>
                 <button
                   v-if="canHandoff"
                   type="button"

--- a/crates/loom/frontend/src/components/SessionTabs.vue
+++ b/crates/loom/frontend/src/components/SessionTabs.vue
@@ -11,7 +11,7 @@ import { computed } from 'vue';
 // live Agent surface; an ACP session leads with Conversation. Artifacts remains
 // route-backed and deep-linkable. Overview was a duplicate of these operational
 // surfaces and is deliberately absent.
-type Tab = 'terminal' | 'conversation' | 'artifacts' | 'shells';
+type Tab = 'terminal' | 'conversation' | 'review' | 'shells';
 
 const props = defineProps<{
   tab: Tab;
@@ -25,12 +25,12 @@ defineEmits<{ select: [Tab] }>();
 const TERMINAL_TABS: { key: Tab; label: string }[] = [
   { key: 'terminal', label: 'Agent' },
   { key: 'conversation', label: 'Conversation' },
-  { key: 'artifacts', label: 'Artifacts' },
+  { key: 'review', label: 'Review' },
 ];
 const ACP_TABS: { key: Tab; label: string }[] = [
   { key: 'conversation', label: 'Conversation' },
   { key: 'shells', label: 'Shells' },
-  { key: 'artifacts', label: 'Artifacts' },
+  { key: 'review', label: 'Review' },
 ];
 const tabs = computed(() => (props.protocol === 'acp' ? ACP_TABS : TERMINAL_TABS));
 </script>
@@ -38,15 +38,20 @@ const tabs = computed(() => (props.protocol === 'acp' ? ACP_TABS : TERMINAL_TABS
 <template>
   <!-- pl-0.5 mirrors the header's 2px left wash border so tab labels align
        with the title above. -->
-  <nav class="mb-1.5 flex items-center gap-0.5 border-b border-line pl-0.5 text-xs">
+  <nav
+    class="mb-1.5 flex items-center gap-0.5 border-b border-line pl-0.5 text-xs"
+    aria-label="Session surfaces"
+  >
     <button
       v-for="t in tabs"
       :key="t.key"
       type="button"
+      role="tab"
       :data-tab="t.key"
+      :aria-selected="tab === t.key"
       class="-mb-px border-b-2 px-2 py-1"
       :class="
-        tab === t.key || (t.key === 'artifacts' && artifactsPopped)
+        tab === t.key || (t.key === 'review' && artifactsPopped)
           ? 'border-accent text-fg font-medium'
           : 'border-transparent text-muted hover:text-fg'
       "
@@ -56,7 +61,7 @@ const tabs = computed(() => (props.protocol === 'acp' ? ACP_TABS : TERMINAL_TABS
       <!-- When popped out, the Artifacts surface lives in the rail, not here —
            a small glyph marks it open without claiming the work area. -->
       <span
-        v-if="t.key === 'artifacts' && artifactsPopped"
+        v-if="t.key === 'review' && artifactsPopped"
         class="ml-1 text-faint"
         title="Open in the side panel"
         >⤢</span

--- a/crates/loom/frontend/src/main.ts
+++ b/crates/loom/frontend/src/main.ts
@@ -48,6 +48,7 @@ const router = createRouter({
     // the same SessionDetail instance and stay deep-linkable.
     { path: '/s/:id/artifacts', component: SessionDetail, props: true },
     { path: '/s/:id/artifacts/:name', component: SessionDetail, props: true },
+    { path: '/s/:id/changes', component: SessionDetail, props: true },
     { path: '/issues', component: Issues, meta: { title: 'Issues' } },
     { path: '/watches', component: Watches, meta: { title: 'Watches' } },
     { path: '/watches/:id', component: Watches, props: true, meta: { title: 'Watches' } },

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -705,7 +705,7 @@ export interface NewCommentBody {
 // --- Staged reviews --------------------------------------------------------
 
 export interface ReviewSubject {
-  kind: string;
+  kind: 'artifact' | 'changes';
   /** Stable internal subject id. */
   id: string;
   /** Public round-trippable key; artifact reviews use the artifact name. */
@@ -718,8 +718,8 @@ export interface ReviewSubject {
 export interface ReviewComment {
   id: number;
   subject_version: string;
-  anchor_kind: string;
-  anchor: Anchor;
+  anchor_kind: 'text' | 'change';
+  anchor: Anchor | ChangeAnchor;
   body: string;
   status: string;
   created_at: string;
@@ -752,7 +752,7 @@ export interface Review {
 }
 
 export interface CreateReviewBody {
-  subject_kind: 'artifact';
+  subject_kind: 'artifact' | 'changes';
   subject_key: string;
   subject_version: string;
 }
@@ -760,16 +760,16 @@ export interface CreateReviewBody {
 export interface AddReviewCommentBody {
   expected_revision: number;
   subject_version: string;
-  anchor_kind: 'text';
-  anchor: Anchor;
+  anchor_kind: 'text' | 'change';
+  anchor: Anchor | ChangeAnchor;
   body: string;
 }
 
 export interface UpdateReviewCommentBody {
   expected_revision: number;
   subject_version?: string;
-  anchor_kind?: 'text';
-  anchor?: Anchor;
+  anchor_kind?: 'text' | 'change';
+  anchor?: Anchor | ChangeAnchor;
   body?: string;
 }
 
@@ -777,6 +777,80 @@ export interface UpdateReviewBody {
   expected_revision: number;
   summary?: string;
   subject_version?: string;
+}
+
+// --- Changes ---------------------------------------------------------------
+
+export type ChangeFileStatus =
+  'added' | 'modified' | 'deleted' | 'renamed' | 'copied' | 'type_changed' | 'untracked';
+export type ChangeSource = 'committed' | 'staged' | 'unstaged' | 'untracked';
+export type ChangeContent = 'text' | 'binary' | 'oversize' | 'unsupported';
+export type ChangeLineKind = 'context' | 'addition' | 'deletion';
+export type ChangeSide = 'old' | 'new';
+
+export interface ChangePath {
+  bytes: string;
+  display: string;
+}
+
+export interface ChangeLine {
+  kind: ChangeLineKind;
+  old_line: number | null;
+  new_line: number | null;
+  text: string;
+}
+
+export interface ChangeHunk {
+  header: string;
+  lines: ChangeLine[];
+  truncated: boolean;
+}
+
+export interface ChangeFile {
+  status: ChangeFileStatus;
+  path: ChangePath;
+  old_path: ChangePath | null;
+  sources: ChangeSource[];
+  additions: number | null;
+  deletions: number | null;
+  content: ChangeContent;
+  hunks: ChangeHunk[];
+  truncated: boolean;
+}
+
+export type ChangeBase =
+  | { state: 'available'; reference: string; oid: string }
+  | {
+      state: 'unavailable';
+      reference: string;
+      reason: 'unborn_head' | 'missing_base' | 'no_merge_base';
+    };
+
+export interface ChangeSet {
+  version: string | null;
+  base: ChangeBase;
+  head_oid: string | null;
+  totals: { files: number; additions: number; deletions: number; truncated: boolean };
+  files: ChangeFile[];
+  truncated: boolean;
+  limits: {
+    max_files: number;
+    max_hunks_per_file: number;
+    max_lines_per_file: number;
+    max_total_lines: number;
+    max_line_bytes: number;
+  };
+}
+
+export interface ChangeAnchor {
+  path: ChangePath;
+  side: ChangeSide;
+  start_line: number;
+  end_line: number;
+  hunk_header: string;
+  context_before: string[];
+  selected: string[];
+  context_after: string[];
 }
 
 export interface RecentRepo {

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -20,6 +20,7 @@ import SessionPageHeader from '../components/SessionPageHeader.vue';
 import SessionTabs from '../components/SessionTabs.vue';
 import SessionConversation from '../components/SessionConversation.vue';
 import ArtifactsPanel from '../components/ArtifactsPanel.vue';
+import ChangesPanel from '../components/ChangesPanel.vue';
 import { useFleet } from '../lib/sessionsStore';
 import { cancelSessionBacktrack, completeSessionOpen } from '../lib/workbenchMetrics';
 
@@ -53,7 +54,7 @@ const error = ref('');
 // Conversation and demotes the worktree shells to a slim Shells tab. `defaultTab`
 // resolves whichever leads when the user hasn't picked one.
 type LocalTab = 'terminal' | 'conversation' | 'shells';
-type WorkTab = LocalTab | 'artifacts';
+type WorkTab = LocalTab | 'review';
 const isAcp = computed(() => ws.value?.protocol === 'acp');
 const defaultTab = computed<LocalTab>(() => (isAcp.value ? 'conversation' : 'terminal'));
 
@@ -77,11 +78,16 @@ const effectiveLocalTab = computed<LocalTab>(() => localTab.value ?? defaultTab.
 
 // The artifacts surface is open whenever the path is under `…/artifacts`.
 const artifactsActive = computed(() => route.path.startsWith(`/s/${props.id}/artifacts`));
+const changesActive = computed(() => route.path === `/s/${props.id}/changes`);
+const reviewActive = computed(() => artifactsActive.value || changesActive.value);
 
 // Popped out into the rail beside the work area vs docked as the work-area tab.
 // Transient (defaults docked on a fresh open); only the rail *width* persists.
 const poppedOut = ref(false);
 const artifactsDocked = computed(() => artifactsActive.value && !poppedOut.value);
+const reviewDocked = computed(
+  () => (artifactsActive.value && !poppedOut.value) || changesActive.value,
+);
 const railOpen = computed(() => artifactsActive.value && poppedOut.value);
 const dockedArtifactsRef = ref<InstanceType<typeof ArtifactsPanel> | null>(null);
 const railArtifactsRef = ref<InstanceType<typeof ArtifactsPanel> | null>(null);
@@ -93,9 +99,7 @@ function activeArtifactsPanel(): InstanceType<typeof ArtifactsPanel> | null {
 
 // The pane the work area shows: the artifacts panel when docked, else the
 // effective local tab (so a popped-out artifact leaves the work pane in place).
-const workTab = computed<WorkTab>(() =>
-  artifactsDocked.value ? 'artifacts' : effectiveLocalTab.value,
-);
+const workTab = computed<WorkTab>(() => (reviewDocked.value ? 'review' : effectiveLocalTab.value));
 
 // Lazy-mount panes on first visit, then keep them (v-show) so re-selecting is
 // instant. The terminal is always mounted; the rest start cold so a session-open
@@ -106,6 +110,7 @@ const mounted = reactive({
   conversation: false,
   shells: false,
   artifacts: artifactsActive.value,
+  changes: changesActive.value,
 });
 watch(
   workTab,
@@ -118,6 +123,13 @@ watch(
   artifactsActive,
   (on) => {
     if (on) mounted.artifacts = true;
+  },
+  { immediate: true },
+);
+watch(
+  changesActive,
+  (on) => {
+    if (on) mounted.changes = true;
   },
   { immediate: true },
 );
@@ -137,12 +149,12 @@ async function guardedArtifactLayout(change: () => void | Promise<void>): Promis
 }
 
 async function selectTab(t: WorkTab) {
-  if (t === 'artifacts') {
-    // The Artifacts tab is the docked view: bring the surface into the work
-    // area (docking it if it was popped out), opening it if it was closed.
+  if (t === 'review') {
+    // Review owns the deep-linked Artifacts / Changes choice. Reopening it
+    // preserves the current choice and otherwise defaults to Artifacts.
     await guardedArtifactLayout(async () => {
       poppedOut.value = false;
-      if (!artifactsActive.value) await router.push(`/s/${props.id}/artifacts`);
+      if (!reviewActive.value) await router.push(`/s/${props.id}/artifacts`);
     });
     return;
   }
@@ -151,7 +163,7 @@ async function selectTab(t: WorkTab) {
   // Leaving a docked artifacts surface for a local tab closes it (back to the
   // plain session URL); when it's popped out the rail stays and we just swap the
   // work-area pane.
-  if (artifactsDocked.value) {
+  if (reviewDocked.value) {
     await guardedArtifactLayout(async () => {
       await router.push(`/s/${props.id}`);
     });
@@ -374,18 +386,41 @@ onUnmounted(() => {
           <SessionConversation :session="ws" />
         </div>
 
-        <!-- Artifacts (docked) — fills the work area as a tab. Lazily mounted on
-             first open, then kept (hidden via v-show) so flipping terminal ⇄
-             artifacts is instant. Unmounts only when popped out, where the rail
-             copy below takes over. -->
-        <div v-if="mounted.artifacts && !railOpen" v-show="artifactsDocked" class="h-full">
-          <ArtifactsPanel
-            ref="dockedArtifactsRef"
-            :id="props.id"
-            :name="props.name"
-            :active="artifactsActive"
-            @toggle-pop="togglePop"
-          />
+        <!-- Review is the one route owner for the kept-alive Artifacts and
+             Changes renderers. Existing artifact deep links stay canonical. -->
+        <div
+          v-if="(mounted.artifacts || mounted.changes) && !railOpen"
+          v-show="reviewDocked"
+          class="flex h-full min-h-0 flex-col"
+        >
+          <nav class="flex shrink-0 gap-1 border-b border-line px-2 text-xs" aria-label="Review">
+            <router-link
+              :to="`/s/${props.id}/artifacts`"
+              class="border-b-2 px-2 py-1.5"
+              :class="artifactsActive ? 'border-accent text-fg' : 'border-transparent text-muted'"
+            >
+              Artifacts
+            </router-link>
+            <router-link
+              :to="`/s/${props.id}/changes`"
+              class="border-b-2 px-2 py-1.5"
+              :class="changesActive ? 'border-accent text-fg' : 'border-transparent text-muted'"
+            >
+              Changes
+            </router-link>
+          </nav>
+          <div v-if="mounted.artifacts" v-show="artifactsDocked" class="min-h-0 flex-1">
+            <ArtifactsPanel
+              ref="dockedArtifactsRef"
+              :id="props.id"
+              :name="props.name"
+              :active="artifactsActive"
+              @toggle-pop="togglePop"
+            />
+          </div>
+          <div v-if="mounted.changes" v-show="changesActive" class="min-h-0 flex-1">
+            <ChangesPanel :id="props.id" />
+          </div>
         </div>
       </div>
     </div>

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -85,9 +85,7 @@ const reviewActive = computed(() => artifactsActive.value || changesActive.value
 // Transient (defaults docked on a fresh open); only the rail *width* persists.
 const poppedOut = ref(false);
 const artifactsDocked = computed(() => artifactsActive.value && !poppedOut.value);
-const reviewDocked = computed(
-  () => (artifactsActive.value && !poppedOut.value) || changesActive.value,
-);
+const reviewDocked = computed(() => artifactsDocked.value || changesActive.value);
 const railOpen = computed(() => artifactsActive.value && poppedOut.value);
 const dockedArtifactsRef = ref<InstanceType<typeof ArtifactsPanel> | null>(null);
 const railArtifactsRef = ref<InstanceType<typeof ArtifactsPanel> | null>(null);

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -13,7 +13,8 @@ use weaver_api::{
     AddReviewCommentReq, ArtifactTextAnchorDto, CreateReviewReq, CreateSessionGroupReq,
     CreateSessionSpaceReq, DeleteSessionGroupReq, DeleteSessionSpaceReq, IssueAction,
     IssueActionsReq, MoveSessionsReq, ReorderSessionLayoutReq, RestoreSessionGroupsReq,
-    SearchSessionsOptions, SessionGroupPreferenceReq, SessionLayoutItemKind, SessionLayoutView,
+    ReviewAnchorDto, ReviewAnchorKindDto, ReviewSubjectKindDto, SearchSessionsOptions,
+    SessionGroupPreferenceReq, SessionLayoutItemKind, SessionLayoutView,
     SessionPlacementSelectorKind, SessionSearchAttention, SessionSearchStatus,
     SetSessionPlacementDefaultReq, SubmitReviewReq, UpdateReviewCommentReq, UpdateReviewReq,
     UpdateSessionGroupReq, UpdateSessionSpaceReq,
@@ -476,6 +477,11 @@ enum SessionCmd {
         /// Extra scrollback lines above the visible screen (0 = visible only).
         #[arg(long, default_value = "0")]
         lines: usize,
+    },
+    /// Print the typed, bounded worktree changes relative to the local base.
+    Changes {
+        /// Session key: id, branch id, branch name, or `repo:branch`.
+        session: String,
     },
     /// List active sessions (also `loom ps`).
     ///
@@ -1406,7 +1412,7 @@ async fn run_review(cmd: ReviewCmd) -> Result<()> {
                 .create_session_review(
                     &session,
                     &CreateReviewReq {
-                        subject_kind: "artifact".to_string(),
+                        subject_kind: ReviewSubjectKindDto::Artifact,
                         subject_key: artifact,
                         subject_version: rev.to_string(),
                     },
@@ -1418,13 +1424,13 @@ async fn run_review(cmd: ReviewCmd) -> Result<()> {
                     &AddReviewCommentReq {
                         expected_revision: draft.draft_revision,
                         subject_version: rev.to_string(),
-                        anchor_kind: "text".to_string(),
-                        anchor: ArtifactTextAnchorDto {
+                        anchor_kind: ReviewAnchorKindDto::Text,
+                        anchor: ReviewAnchorDto::Text(ArtifactTextAnchorDto {
                             quote,
                             prefix,
                             suffix,
                             block_index: block,
-                        },
+                        }),
                         body,
                     },
                 )
@@ -1484,13 +1490,13 @@ async fn run_review(cmd: ReviewCmd) -> Result<()> {
                     &UpdateReviewCommentReq {
                         expected_revision: revision,
                         subject_version: Some(rev.to_string()),
-                        anchor_kind: Some("text".to_string()),
-                        anchor: Some(ArtifactTextAnchorDto {
+                        anchor_kind: Some(ReviewAnchorKindDto::Text),
+                        anchor: Some(ReviewAnchorDto::Text(ArtifactTextAnchorDto {
                             quote,
                             prefix,
                             suffix,
                             block_index: block,
-                        }),
+                        })),
                         body: None,
                     },
                 )
@@ -1515,7 +1521,7 @@ async fn run_review(cmd: ReviewCmd) -> Result<()> {
                 .create_session_review(
                     &session,
                     &CreateReviewReq {
-                        subject_kind: "artifact".to_string(),
+                        subject_kind: ReviewSubjectKindDto::Artifact,
                         subject_key: artifact,
                         subject_version: rev.to_string(),
                     },
@@ -1655,6 +1661,11 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
         } => cmd_session_send(session, message.join(" "), !no_enter).await,
         SessionCmd::Break { session } => cmd_session_break(session).await,
         SessionCmd::Preview { session, lines } => cmd_session_preview(session, lines).await,
+        SessionCmd::Changes { session } => {
+            let changes = client::default()?.changes(&session).await?;
+            println!("{}", serde_json::to_string_pretty(&changes)?);
+            Ok(())
+        }
         SessionCmd::Ls {
             archived,
             automation,

--- a/crates/loom/src/changes.rs
+++ b/crates/loom/src/changes.rs
@@ -35,6 +35,7 @@ const MAX_PATCH_BYTES: usize = 2 * 1024 * 1024;
 const MAX_UNTRACKED_RENDER_BYTES: u64 = 512 * 1024;
 const MAX_IDENTITY_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_EXCLUDE_BYTES: u64 = 256 * 1024;
+const MAX_SAFE_CONFIG_BYTES: usize = 4 * 1024;
 const MAX_INDEX_BYTES: u64 = 16 * 1024 * 1024;
 const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 const GIT_CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
@@ -286,6 +287,64 @@ async fn bootstrap_text(work_dir: &Path, args: &[&str]) -> Result<Option<String>
     Ok((!value.is_empty()).then_some(value))
 }
 
+fn git_bool(value: &str) -> Option<&'static str> {
+    match value {
+        "" | "1" | "yes" | "on" | "true" => Some("true"),
+        "0" | "no" | "off" | "false" => Some("false"),
+        _ => None,
+    }
+}
+
+async fn bootstrap_safe_config(work_dir: &Path) -> Result<String> {
+    let (capture, success) = capture_git_status(
+        hardened_git(work_dir),
+        &[
+            "config",
+            "--includes",
+            "--null",
+            "--get-regexp",
+            r"^core\.(filemode|ignorecase|symlinks|precomposeunicode|autocrlf|eol|safecrlf)$",
+        ],
+        MAX_SAFE_CONFIG_BYTES,
+    )
+    .await?;
+    if capture.timed_out || capture.truncated || (!success && !capture.bytes.is_empty()) {
+        bail!("safe Git configuration could not be bounded");
+    }
+    let mut values = BTreeMap::new();
+    for record in nul_records(&capture.bytes) {
+        let record = std::str::from_utf8(record).context("safe Git configuration was not UTF-8")?;
+        let (key, value) = record
+            .split_once('\n')
+            .context("safe Git configuration record was malformed")?;
+        let key = key.to_ascii_lowercase();
+        let value = value.to_ascii_lowercase();
+        let normalized = match key.as_str() {
+            "core.filemode" | "core.ignorecase" | "core.symlinks" | "core.precomposeunicode" => {
+                git_bool(&value)
+            }
+            "core.autocrlf" if value == "input" => Some("input"),
+            "core.autocrlf" => git_bool(&value),
+            "core.eol" if matches!(value.as_str(), "lf" | "crlf" | "native") => {
+                Some(value.as_str())
+            }
+            "core.safecrlf" if value == "warn" => Some("warn"),
+            "core.safecrlf" => git_bool(&value),
+            _ => None,
+        }
+        .with_context(|| format!("invalid safe Git configuration {key}"))?;
+        values.insert(key, normalized.to_string());
+    }
+    let mut config = String::new();
+    for (key, value) in values {
+        config.push_str(key.strip_prefix("core.").expect("validated core key"));
+        config.push_str(" = ");
+        config.push_str(&value);
+        config.push('\n');
+    }
+    Ok(config)
+}
+
 fn absolute_git_path(work_tree: &Path, path: String) -> PathBuf {
     let path = PathBuf::from(path);
     if path.is_absolute() {
@@ -337,17 +396,22 @@ impl GitBoundary {
             bootstrap_text(&work_tree, &["rev-parse", "--show-object-format=storage"])
                 .await?
                 .context("Git object format is unavailable")?;
-        let config = match object_format.as_str() {
-            "sha1" => "[core]\nrepositoryformatversion = 0\nbare = false\n",
-            "sha256" => {
-                "[core]\nrepositoryformatversion = 1\nbare = false\n\
-                         [extensions]\nobjectFormat = sha256\n"
-            }
+        let mut config = match object_format.as_str() {
+            "sha1" => "[core]\nrepositoryformatversion = 0\nbare = false\n".to_string(),
+            "sha256" => "[core]\nrepositoryformatversion = 1\nbare = false\n".to_string(),
             format => bail!("unsupported Git object format {format}"),
         };
+        config.push_str(&bootstrap_safe_config(&work_tree).await?);
+        if object_format == "sha256" {
+            config.push_str("[extensions]\nobjectFormat = sha256\n");
+        }
         let common_dir = tempfile::tempdir().context("creating bounded Git common directory")?;
         let info_dir = common_dir.path().join("info");
         std::fs::create_dir(&info_dir).context("creating bounded Git info directory")?;
+        std::fs::create_dir_all(common_dir.path().join("refs/heads"))
+            .context("creating bounded Git heads directory")?;
+        std::fs::create_dir(common_dir.path().join("refs/tags"))
+            .context("creating bounded Git tags directory")?;
         std::fs::write(common_dir.path().join("config"), config)
             .context("writing bounded Git configuration")?;
         std::fs::write(info_dir.join("attributes"), b"* !filter !diff\n")

--- a/crates/loom/src/changes.rs
+++ b/crates/loom/src/changes.rs
@@ -34,9 +34,10 @@ const MAX_INVENTORY_BYTES: usize = 8 * 1024 * 1024;
 const MAX_PATCH_BYTES: usize = 2 * 1024 * 1024;
 const MAX_UNTRACKED_RENDER_BYTES: u64 = 512 * 1024;
 const MAX_IDENTITY_BYTES: u64 = 64 * 1024 * 1024;
-const MAX_CONFIG_BYTES: usize = 256 * 1024;
+const MAX_EXCLUDE_BYTES: u64 = 256 * 1024;
 const MAX_INDEX_BYTES: u64 = 16 * 1024 * 1024;
 const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const GIT_CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
 struct Capture {
@@ -50,6 +51,7 @@ struct RawFile {
     status: ChangeFileStatusDto,
     path: Vec<u8>,
     old_path: Option<Vec<u8>>,
+    gitlink: bool,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -58,12 +60,71 @@ struct NumStat {
     deletions: Option<u32>,
 }
 
-#[derive(Debug, Default)]
-struct GitReadPolicy {
-    filter_drivers: Vec<String>,
+struct GitBoundary {
+    common_dir: tempfile::TempDir,
+    work_tree: PathBuf,
+    git_dir: PathBuf,
+    object_dir: PathBuf,
+    index_path: PathBuf,
 }
 
-fn hardened_git(work_dir: &Path, policy: &GitReadPolicy) -> Command {
+struct GitProcessGroup {
+    child: Option<tokio::process::Child>,
+    pgid: Option<i32>,
+}
+
+impl GitProcessGroup {
+    fn new(child: tokio::process::Child) -> Self {
+        let pgid = child.id().and_then(|pid| i32::try_from(pid).ok());
+        Self {
+            child: Some(child),
+            pgid,
+        }
+    }
+
+    fn child(&mut self) -> &mut tokio::process::Child {
+        self.child.as_mut().expect("Git child is present")
+    }
+
+    fn kill(&self) {
+        if let Some(pgid) = self.pgid {
+            // SAFETY: Git was spawned with process_group(0), so its pid is the
+            // pgid and a negative target kills Git plus any helper descendants.
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+    }
+
+    async fn kill_and_reap(&mut self) {
+        self.kill();
+        if let Some(child) = self.child.as_mut() {
+            let _ = tokio::time::timeout(GIT_CLEANUP_TIMEOUT, child.wait()).await;
+        }
+        self.disarm();
+    }
+
+    fn disarm(&mut self) {
+        self.pgid = None;
+        self.child = None;
+    }
+}
+
+impl Drop for GitProcessGroup {
+    fn drop(&mut self) {
+        self.kill();
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _ = tokio::time::timeout(GIT_CLEANUP_TIMEOUT, child.wait()).await;
+            });
+        }
+    }
+}
+
+fn hardened_git(work_dir: &Path) -> Command {
     let mut command = Command::new("git");
     command
         .arg("-C")
@@ -77,49 +138,71 @@ fn hardened_git(work_dir: &Path, policy: &GitReadPolicy) -> Command {
             "core.fsmonitor=false",
             "-c",
             "submodule.recurse=false",
+            "-c",
+            "diff.submodule=short",
         ])
         .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_NO_LAZY_FETCH", "1")
+        .env("GIT_NO_REPLACE_OBJECTS", "1")
         .env("GIT_CONFIG_COUNT", "0")
         .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_ATTR_NOSYSTEM", "1")
+        .env("GIT_PROTOCOL_FROM_USER", "0")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env_remove("GIT_CONFIG")
+        .env_remove("GIT_CONFIG_PARAMETERS")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env_remove("GIT_REPLACE_REF_BASE")
+        .env_remove("GIT_NAMESPACE")
+        .env_remove("GIT_SHALLOW_FILE")
+        .env_remove("GIT_GRAFT_FILE")
+        .env_remove("GIT_CEILING_DIRECTORIES")
         .env_remove("GIT_EXTERNAL_DIFF")
         .env_remove("GIT_DIFF_OPTS")
         .stdin(Stdio::null())
         .stderr(Stdio::null())
-        .kill_on_drop(true);
-    for driver in &policy.filter_drivers {
-        command
-            .arg("-c")
-            .arg(format!("filter.{driver}.clean="))
-            .arg("-c")
-            .arg(format!("filter.{driver}.process="))
-            .arg("-c")
-            .arg(format!("filter.{driver}.smudge="))
-            .arg("-c")
-            .arg(format!("filter.{driver}.required=false"));
-    }
+        .kill_on_drop(true)
+        .process_group(0);
     command
 }
 
+impl GitBoundary {
+    fn command(&self) -> Command {
+        let mut command = hardened_git(&self.work_tree);
+        command
+            .env("GIT_DIR", &self.git_dir)
+            .env("GIT_COMMON_DIR", self.common_dir.path())
+            .env("GIT_WORK_TREE", &self.work_tree)
+            .env("GIT_OBJECT_DIRECTORY", &self.object_dir)
+            .env("GIT_INDEX_FILE", &self.index_path);
+        command
+    }
+}
+
 async fn capture_git_status(
-    work_dir: &Path,
-    policy: &GitReadPolicy,
+    mut command: Command,
     args: &[&str],
     retain: usize,
 ) -> Result<(Capture, bool)> {
-    let mut child = hardened_git(work_dir, policy)
+    let mut child = command
         .args(args)
         .stdout(Stdio::piped())
         .spawn()
         .with_context(|| format!("spawning git {}", args.join(" ")))?;
     let stdout = child.stdout.take().context("capturing git stdout")?;
+    let mut group = GitProcessGroup::new(child);
     let mut reader = BufReader::new(stdout);
     let mut bytes = Vec::with_capacity(retain.min(64 * 1024));
     let mut chunk = vec![0_u8; 32 * 1024];
     let deadline = Instant::now() + GIT_COMMAND_TIMEOUT;
     let result = tokio::time::timeout_at(deadline, async {
-        let mut truncated = false;
         loop {
             let read = reader.read(&mut chunk).await?;
             if read == 0 {
@@ -128,78 +211,67 @@ async fn capture_git_status(
             let room = retain.saturating_sub(bytes.len());
             bytes.extend_from_slice(&chunk[..read.min(room)]);
             if read > room {
-                truncated = true;
-                child.start_kill().context("stopping bounded git capture")?;
-                break;
+                return Ok::<_, anyhow::Error>(None);
             }
         }
-        let status = child.wait().await?;
-        Ok::<_, anyhow::Error>((status.success(), truncated))
+        let status = group.child().wait().await?;
+        Ok::<_, anyhow::Error>(Some(status.success()))
     })
     .await;
+    let timed_out = result.is_err();
     match result {
-        Ok(result) => {
-            let (success, truncated) = result?;
+        Ok(Ok(Some(success))) => {
+            group.disarm();
             Ok((
                 Capture {
                     bytes,
-                    truncated,
+                    truncated: false,
                     timed_out: false,
                 },
                 success,
             ))
         }
-        Err(_) => {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
+        Ok(Ok(None)) | Err(_) => {
+            group.kill_and_reap().await;
             Ok((
                 Capture {
                     bytes,
                     truncated: true,
-                    timed_out: true,
+                    timed_out,
                 },
                 false,
             ))
         }
+        Ok(Err(error)) => {
+            group.kill_and_reap().await;
+            Err(error)
+        }
     }
 }
 
-async fn capture_git(
-    work_dir: &Path,
-    policy: &GitReadPolicy,
-    args: &[&str],
-    retain: usize,
-) -> Result<Capture> {
-    let (capture, success) = capture_git_status(work_dir, policy, args, retain).await?;
+async fn capture_git(boundary: &GitBoundary, args: &[&str], retain: usize) -> Result<Capture> {
+    let (capture, success) = capture_git_status(boundary.command(), args, retain).await?;
     if !success && !capture.truncated {
         bail!("git {} failed", args.join(" "));
     }
     Ok(capture)
 }
 
-async fn capture_diff(
-    work_dir: &Path,
-    policy: &GitReadPolicy,
-    args: &[&str],
-    retain: usize,
-) -> Result<Capture> {
+async fn capture_diff(boundary: &GitBoundary, args: &[&str], retain: usize) -> Result<Capture> {
     let mut full = vec![
         "diff",
         "--no-ext-diff",
         "--no-textconv",
         "--no-color",
-        "--ignore-submodules=all",
+        "--ignore-submodules=dirty",
+        "--submodule=short",
     ];
     full.extend_from_slice(args);
-    capture_git(work_dir, policy, &full, retain).await
+    capture_git(boundary, &full, retain).await
 }
 
-async fn git_text(
-    work_dir: &Path,
-    policy: &GitReadPolicy,
-    args: &[&str],
-) -> Result<Option<String>> {
-    let (capture, success) = capture_git_status(work_dir, policy, args, 4 * 1024).await?;
+async fn bootstrap_text(work_dir: &Path, args: &[&str]) -> Result<Option<String>> {
+    let (capture, success) = capture_git_status(hardened_git(work_dir), args, 4 * 1024).await?;
     if capture.timed_out {
         bail!("git {} exceeded its deadline", args.join(" "));
     }
@@ -214,35 +286,101 @@ async fn git_text(
     Ok((!value.is_empty()).then_some(value))
 }
 
-impl GitReadPolicy {
+fn absolute_git_path(work_tree: &Path, path: String) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else {
+        work_tree.join(path)
+    }
+}
+
+impl GitBoundary {
     async fn load(work_dir: &Path) -> Result<Self> {
-        let empty = Self::default();
-        let capture = capture_git(
-            work_dir,
-            &empty,
-            &["config", "--includes", "--null", "--name-only", "--list"],
-            MAX_CONFIG_BYTES,
-        )
-        .await?;
-        if capture.truncated {
-            bail!("git configuration exceeded its safe read bound");
-        }
-        let mut filter_drivers = Vec::new();
-        for raw in nul_records(&capture.bytes) {
-            let key = std::str::from_utf8(raw).context("git configuration key was not UTF-8")?;
-            let Some((driver, setting)) =
-                key.strip_prefix("filter.").and_then(|v| v.rsplit_once('.'))
-            else {
-                continue;
-            };
-            if !driver.is_empty() && matches!(setting, "clean" | "process" | "required" | "smudge")
-            {
-                filter_drivers.push(driver.to_string());
+        let work_tree = std::fs::canonicalize(work_dir).context("resolving Git worktree")?;
+        let git_dir = bootstrap_text(&work_tree, &["rev-parse", "--absolute-git-dir"])
+            .await?
+            .map(PathBuf::from)
+            .context("Git directory is unavailable")?;
+        let git_dir = std::fs::canonicalize(git_dir).context("resolving Git directory")?;
+        let real_common = bootstrap_text(&work_tree, &["rev-parse", "--git-common-dir"])
+            .await?
+            .map(|path| absolute_git_path(&work_tree, path))
+            .context("Git common directory is unavailable")?;
+        let real_common =
+            std::fs::canonicalize(real_common).context("resolving Git common directory")?;
+        let object_dir = bootstrap_text(&work_tree, &["rev-parse", "--git-path", "objects"])
+            .await?
+            .map(|path| absolute_git_path(&work_tree, path))
+            .context("Git object directory is unavailable")?;
+        let object_dir =
+            std::fs::canonicalize(object_dir).context("resolving Git object directory")?;
+        let index_path = bootstrap_text(&work_tree, &["rev-parse", "--git-path", "index"])
+            .await?
+            .map(|path| absolute_git_path(&work_tree, path))
+            .context("Git index path is unavailable")?;
+        let index_path = match std::fs::canonicalize(&index_path) {
+            Ok(path) => path,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                let parent = index_path.parent().context("Git index has no parent")?;
+                std::fs::canonicalize(parent)
+                    .context("resolving Git index parent")?
+                    .join(
+                        index_path
+                            .file_name()
+                            .context("Git index has no file name")?,
+                    )
             }
+            Err(error) => return Err(error).context("resolving Git index"),
+        };
+        let object_format =
+            bootstrap_text(&work_tree, &["rev-parse", "--show-object-format=storage"])
+                .await?
+                .context("Git object format is unavailable")?;
+        let config = match object_format.as_str() {
+            "sha1" => "[core]\nrepositoryformatversion = 0\nbare = false\n",
+            "sha256" => {
+                "[core]\nrepositoryformatversion = 1\nbare = false\n\
+                         [extensions]\nobjectFormat = sha256\n"
+            }
+            format => bail!("unsupported Git object format {format}"),
+        };
+        let common_dir = tempfile::tempdir().context("creating bounded Git common directory")?;
+        let info_dir = common_dir.path().join("info");
+        std::fs::create_dir(&info_dir).context("creating bounded Git info directory")?;
+        std::fs::write(common_dir.path().join("config"), config)
+            .context("writing bounded Git configuration")?;
+        std::fs::write(info_dir.join("attributes"), b"* !filter !diff\n")
+            .context("writing bounded Git attributes")?;
+        match safe_file(&real_common, b"info/exclude")? {
+            Some((file, initial)) => {
+                if initial.len() > MAX_EXCLUDE_BYTES {
+                    bail!("Git info/exclude exceeded its safe read bound");
+                }
+                let mut file = tokio::fs::File::from_std(file);
+                let mut bytes = vec![0_u8; initial.len() as usize];
+                file.read_exact(&mut bytes).await?;
+                let mut extra = [0_u8; 1];
+                if file.read(&mut extra).await? != 0
+                    || !same_metadata(&initial, &file.metadata().await?)
+                {
+                    bail!("Git info/exclude changed while being read");
+                }
+                std::fs::write(info_dir.join("exclude"), bytes)
+                    .context("copying bounded Git excludes")?;
+            }
+            None if real_common.join("info/exclude").try_exists()? => {
+                bail!("Git info/exclude is not a safe regular file");
+            }
+            None => {}
         }
-        filter_drivers.sort();
-        filter_drivers.dedup();
-        Ok(Self { filter_drivers })
+        Ok(Self {
+            common_dir,
+            work_tree,
+            git_dir,
+            object_dir,
+            index_path,
+        })
     }
 }
 
@@ -391,10 +529,15 @@ fn parse_raw_files(bytes: &[u8]) -> Vec<RawFile> {
             b'T' => ChangeFileStatusDto::TypeChanged,
             _ => ChangeFileStatusDto::Modified,
         };
+        let gitlink = header
+            .split(|byte| *byte == b' ')
+            .nth(1)
+            .is_some_and(|mode| mode == b"160000");
         files.push(RawFile {
             status,
             path,
             old_path,
+            gitlink,
         });
     }
     files
@@ -759,16 +902,14 @@ struct StateCapture {
 }
 
 async fn capture_state(
-    work_dir: &Path,
-    policy: &GitReadPolicy,
+    boundary: &GitBoundary,
     base_reference: &str,
     base_oid: &str,
     head_oid: &str,
-    index_path: &Path,
 ) -> Result<StateCapture> {
     macro_rules! diff {
         ($args:expr) => {
-            async { capture_diff(work_dir, policy, $args, MAX_INVENTORY_BYTES).await }
+            async { capture_diff(boundary, $args, MAX_INVENTORY_BYTES).await }
         };
     }
     let (final_raw, numstat, committed, staged, unstaged, untracked) = tokio::try_join!(
@@ -799,8 +940,7 @@ async fn capture_state(
         ]),
         diff!(&["--name-only", "--find-renames", "-z", "--"]),
         capture_git(
-            work_dir,
-            policy,
+            boundary,
             &["ls-files", "--others", "--exclude-standard", "-z", "--"],
             MAX_INVENTORY_BYTES,
         ),
@@ -831,20 +971,20 @@ async fn capture_state(
         ] {
             hash_record(&mut hasher, tag, &capture.bytes);
         }
-        let mut complete = hash_index(index_path, &mut hasher).await?;
+        let mut complete = hash_index(&boundary.index_path, &mut hasher).await?;
         let mut remaining = MAX_IDENTITY_BYTES;
         let raw_files = parse_raw_files(&final_raw.bytes);
         for file in raw_files
             .iter()
-            .filter(|file| file.status != ChangeFileStatusDto::Deleted)
+            .filter(|file| file.status != ChangeFileStatusDto::Deleted && !file.gitlink)
         {
-            match hash_path(work_dir, &file.path, &mut hasher, &mut remaining).await? {
+            match hash_path(&boundary.work_tree, &file.path, &mut hasher, &mut remaining).await? {
                 HashPathResult::Complete(_) => {}
                 HashPathResult::Incomplete => complete = false,
             }
         }
         for path in &untracked_paths {
-            match hash_path(work_dir, path, &mut hasher, &mut remaining).await? {
+            match hash_path(&boundary.work_tree, path, &mut hasher, &mut remaining).await? {
                 HashPathResult::Complete(Some(lines)) => {
                     untracked_additions += lines;
                 }
@@ -897,13 +1037,9 @@ fn unavailable(
     }
 }
 
-async fn load_once(
-    work_dir: &Path,
-    policy: &GitReadPolicy,
-    base_reference: &str,
-) -> Result<(ChangeSetDto, bool)> {
-    let Some(head_oid) = git_text(work_dir, policy, &["rev-parse", "--verify", "HEAD"]).await?
-    else {
+async fn load_once(boundary: &GitBoundary, base_reference: &str) -> Result<(ChangeSetDto, bool)> {
+    let work_dir = &boundary.work_tree;
+    let Some(head_oid) = bootstrap_text(work_dir, &["rev-parse", "--verify", "HEAD"]).await? else {
         return Ok((
             unavailable(
                 base_reference,
@@ -919,7 +1055,7 @@ async fn load_once(
         format!("refs/heads/{base_reference}")
     };
     let base_spec = format!("{local_base}^{{commit}}");
-    let Some(base_tip) = git_text(work_dir, policy, &["rev-parse", "--verify", &base_spec]).await?
+    let Some(base_tip) = bootstrap_text(work_dir, &["rev-parse", "--verify", &base_spec]).await?
     else {
         return Ok((
             unavailable(
@@ -930,7 +1066,7 @@ async fn load_once(
             true,
         ));
     };
-    let Some(base_oid) = git_text(work_dir, policy, &["merge-base", &head_oid, &base_tip]).await?
+    let Some(base_oid) = bootstrap_text(work_dir, &["merge-base", &head_oid, &base_tip]).await?
     else {
         return Ok((
             unavailable(
@@ -941,29 +1077,11 @@ async fn load_once(
             true,
         ));
     };
-    let index_path = git_text(work_dir, policy, &["rev-parse", "--git-path", "index"])
-        .await?
-        .map(PathBuf::from)
-        .context("git index path is unavailable")?;
-    let index_path = if index_path.is_absolute() {
-        index_path
-    } else {
-        work_dir.join(index_path)
-    };
-    let state = capture_state(
-        work_dir,
-        policy,
-        base_reference,
-        &base_oid,
-        &head_oid,
-        &index_path,
-    )
-    .await?;
+    let state = capture_state(boundary, base_reference, &base_oid, &head_oid).await?;
     let mut raw_files = parse_raw_files(&state.final_raw.bytes);
 
     let patch = capture_diff(
-        work_dir,
-        policy,
+        boundary,
         &["--patch", "--find-renames", "--unified=3", &base_oid, "--"],
         MAX_PATCH_BYTES,
     )
@@ -981,6 +1099,7 @@ async fn load_once(
                 status: ChangeFileStatusDto::Untracked,
                 path: path.clone(),
                 old_path: None,
+                gitlink: false,
             });
         }
     }
@@ -1049,17 +1168,9 @@ async fn load_once(
         return Ok((changes, true));
     };
 
-    let post = capture_state(
-        work_dir,
-        policy,
-        base_reference,
-        &base_oid,
-        &head_oid,
-        &index_path,
-    )
-    .await?;
-    let head_after = git_text(work_dir, policy, &["rev-parse", "--verify", "HEAD"]).await?;
-    let base_after = git_text(work_dir, policy, &["rev-parse", "--verify", &base_spec]).await?;
+    let post = capture_state(boundary, base_reference, &base_oid, &head_oid).await?;
+    let head_after = bootstrap_text(work_dir, &["rev-parse", "--verify", "HEAD"]).await?;
+    let base_after = bootstrap_text(work_dir, &["rev-parse", "--verify", &base_spec]).await?;
     let stable = post.identity == Some(identity)
         && head_after.as_deref() == Some(head_oid.as_str())
         && base_after.as_deref() == Some(base_tip.as_str());
@@ -1079,9 +1190,9 @@ async fn load_once(
 
 /// Read one session worktree without fetching or changing Git state.
 pub async fn load(work_dir: &Path, base_reference: &str) -> Result<ChangeSetDto> {
-    let policy = GitReadPolicy::load(work_dir).await?;
+    let boundary = GitBoundary::load(work_dir).await?;
     for attempt in 0..2 {
-        let (mut changes, stable) = load_once(work_dir, &policy, base_reference).await?;
+        let (mut changes, stable) = load_once(&boundary, base_reference).await?;
         if stable {
             return Ok(changes);
         }

--- a/crates/loom/src/changes.rs
+++ b/crates/loom/src/changes.rs
@@ -1,0 +1,839 @@
+//! Bounded, typed worktree changes relative to a session's local branch base.
+//!
+//! Git supplies inventories and a no-driver patch. Parsing, bounds, path
+//! display, and anchor validation are deterministic and side-effect free.
+
+use anyhow::{bail, Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use sha2::{Digest as _, Sha256};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::ffi::OsString;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::path::{Component, Path, PathBuf};
+use std::process::Stdio;
+use tokio::io::{AsyncReadExt, BufReader};
+use tokio::process::Command;
+use weaver_api::{
+    ChangeAnchorDto, ChangeBaseDto, ChangeBaseUnavailableReasonDto, ChangeContentDto,
+    ChangeFileDto, ChangeFileStatusDto, ChangeHunkDto, ChangeLimitsDto, ChangeLineDto,
+    ChangeLineKindDto, ChangePathDto, ChangeSetDto, ChangeSideDto, ChangeSourceDto,
+    ChangeTotalsDto,
+};
+
+pub const MAX_FILES: usize = 100;
+pub const MAX_HUNKS_PER_FILE: usize = 50;
+pub const MAX_LINES_PER_FILE: usize = 1_000;
+pub const MAX_TOTAL_LINES: usize = 8_000;
+pub const MAX_LINE_BYTES: usize = 2_048;
+const MAX_INVENTORY_BYTES: usize = 8 * 1024 * 1024;
+const MAX_PATCH_BYTES: usize = 2 * 1024 * 1024;
+const MAX_UNTRACKED_RENDER_BYTES: u64 = 512 * 1024;
+
+#[derive(Debug)]
+struct Capture {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+#[derive(Debug)]
+struct RawFile {
+    status: ChangeFileStatusDto,
+    path: Vec<u8>,
+    old_path: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct NumStat {
+    additions: Option<u32>,
+    deletions: Option<u32>,
+}
+
+fn hardened_git(work_dir: &Path) -> Command {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(work_dir)
+        .args(["-c", "color.ui=false"])
+        .env_remove("GIT_EXTERNAL_DIFF")
+        .env_remove("GIT_DIFF_OPTS")
+        .stdin(Stdio::null())
+        .stderr(Stdio::null());
+    command
+}
+
+async fn capture_git(work_dir: &Path, args: &[&str], retain: usize) -> Result<Capture> {
+    let mut child = hardened_git(work_dir)
+        .args(args)
+        .stdout(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("spawning git {}", args.join(" ")))?;
+    let stdout = child.stdout.take().context("capturing git stdout")?;
+    let mut reader = BufReader::new(stdout);
+    let mut bytes = Vec::with_capacity(retain.min(64 * 1024));
+    let mut chunk = [0_u8; 32 * 1024];
+    let mut truncated = false;
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        let room = retain.saturating_sub(bytes.len());
+        bytes.extend_from_slice(&chunk[..read.min(room)]);
+        truncated |= read > room;
+    }
+    let status = child.wait().await?;
+    if !status.success() {
+        bail!("git {} failed", args.join(" "));
+    }
+    Ok(Capture { bytes, truncated })
+}
+
+async fn capture_diff(work_dir: &Path, args: &[&str], retain: usize) -> Result<Capture> {
+    let mut full = vec!["diff", "--no-ext-diff", "--no-textconv", "--no-color"];
+    full.extend_from_slice(args);
+    capture_git(work_dir, &full, retain).await
+}
+
+async fn git_text(work_dir: &Path, args: &[&str]) -> Result<Option<String>> {
+    let output = hardened_git(work_dir)
+        .args(args)
+        .output()
+        .await
+        .with_context(|| format!("spawning git {}", args.join(" ")))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    if output.stdout.len() > 4 * 1024 {
+        bail!("git identity output exceeded its bound");
+    }
+    let value = String::from_utf8(output.stdout).context("git identity was not UTF-8")?;
+    let value = value.trim().to_string();
+    Ok((!value.is_empty()).then_some(value))
+}
+
+fn path_dto(raw: &[u8]) -> ChangePathDto {
+    let mut display = String::new();
+    for byte in raw {
+        match byte {
+            b' '..=b'~' if *byte != b'\\' => display.push(*byte as char),
+            b'\\' => display.push_str("\\\\"),
+            _ => display.push_str(&format!("\\x{byte:02x}")),
+        }
+    }
+    ChangePathDto {
+        bytes: URL_SAFE_NO_PAD.encode(raw),
+        display,
+    }
+}
+
+fn decode_path(path: &ChangePathDto) -> Result<Vec<u8>> {
+    URL_SAFE_NO_PAD
+        .decode(&path.bytes)
+        .context("change path identity is not valid base64url")
+}
+
+fn worktree_path(work_dir: &Path, raw: &[u8]) -> Result<PathBuf> {
+    if raw.is_empty() || raw.contains(&0) {
+        bail!("change path is empty or contains NUL");
+    }
+    let relative = PathBuf::from(OsString::from_vec(raw.to_vec()));
+    if relative.is_absolute()
+        || relative.components().any(|part| {
+            matches!(
+                part,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        bail!("change path escapes the worktree");
+    }
+    Ok(work_dir.join(relative))
+}
+
+fn nul_records(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
+    bytes
+        .split(|byte| *byte == 0)
+        .filter(|item| !item.is_empty())
+}
+
+fn parse_raw_files(bytes: &[u8]) -> Vec<RawFile> {
+    let mut records = nul_records(bytes);
+    let mut files = Vec::new();
+    while let Some(header) = records.next() {
+        let Some(code) = header.rsplit(|byte| *byte == b' ').next() else {
+            continue;
+        };
+        let letter = code.first().copied().unwrap_or(b'M');
+        let Some(first_path) = records.next() else {
+            break;
+        };
+        let (old_path, path) = if matches!(letter, b'R' | b'C') {
+            let Some(new_path) = records.next() else {
+                break;
+            };
+            (Some(first_path.to_vec()), new_path.to_vec())
+        } else {
+            (None, first_path.to_vec())
+        };
+        let status = match letter {
+            b'A' => ChangeFileStatusDto::Added,
+            b'D' => ChangeFileStatusDto::Deleted,
+            b'R' => ChangeFileStatusDto::Renamed,
+            b'C' => ChangeFileStatusDto::Copied,
+            b'T' => ChangeFileStatusDto::TypeChanged,
+            _ => ChangeFileStatusDto::Modified,
+        };
+        files.push(RawFile {
+            status,
+            path,
+            old_path,
+        });
+    }
+    files
+}
+
+fn parse_numstat(bytes: &[u8]) -> BTreeMap<Vec<u8>, NumStat> {
+    let mut records = bytes.split(|byte| *byte == 0);
+    let mut result = BTreeMap::new();
+    while let Some(record) = records.next() {
+        if record.is_empty() {
+            continue;
+        }
+        let mut fields = record.splitn(3, |byte| *byte == b'\t');
+        let added = fields.next().unwrap_or_default();
+        let deleted = fields.next().unwrap_or_default();
+        let mut path = fields.next().unwrap_or_default();
+        if path.is_empty() {
+            // Rename/copy under `-z`: the following two records are old/new.
+            let _old = records.next();
+            path = records.next().unwrap_or_default();
+        }
+        result.insert(
+            path.to_vec(),
+            NumStat {
+                additions: std::str::from_utf8(added).ok().and_then(|v| v.parse().ok()),
+                deletions: std::str::from_utf8(deleted)
+                    .ok()
+                    .and_then(|v| v.parse().ok()),
+            },
+        );
+    }
+    result
+}
+
+fn source_paths(bytes: &[u8]) -> BTreeSet<Vec<u8>> {
+    nul_records(bytes).map(ToOwned::to_owned).collect()
+}
+
+fn sanitize_text(value: &str, limit: usize) -> (String, bool) {
+    let cleaned: String = value
+        .chars()
+        .map(|ch| {
+            if ch == '\t' || !ch.is_control() {
+                ch
+            } else {
+                '\u{fffd}'
+            }
+        })
+        .collect();
+    if cleaned.len() <= limit {
+        return (cleaned, false);
+    }
+    let mut end = limit;
+    while !cleaned.is_char_boundary(end) {
+        end -= 1;
+    }
+    (format!("{}…", &cleaned[..end]), true)
+}
+
+fn parse_range(value: &str) -> Option<(u32, u32)> {
+    let value = value.trim_start_matches(['-', '+']);
+    let mut parts = value.splitn(2, ',');
+    let start = parts.next()?.parse().ok()?;
+    let count = parts.next().and_then(|part| part.parse().ok()).unwrap_or(1);
+    Some((start, count))
+}
+
+fn parse_hunk_header(line: &str) -> Option<(u32, u32)> {
+    let rest = line.strip_prefix("@@ ")?;
+    let end = rest.find(" @@")?;
+    let mut ranges = rest[..end].split_whitespace();
+    let (old_start, _) = parse_range(ranges.next()?)?;
+    let (new_start, _) = parse_range(ranges.next()?)?;
+    Some((old_start, new_start))
+}
+
+fn patch_sections(patch: &[u8]) -> VecDeque<&[u8]> {
+    let marker = b"diff --git ";
+    let mut starts = Vec::new();
+    let mut offset = 0;
+    while let Some(index) = patch[offset..]
+        .windows(marker.len())
+        .position(|window| window == marker)
+    {
+        let start = offset + index;
+        if start == 0 || patch[start - 1] == b'\n' {
+            starts.push(start);
+        }
+        offset = start + marker.len();
+    }
+    let mut sections = VecDeque::new();
+    for (index, start) in starts.iter().enumerate() {
+        let end = starts.get(index + 1).copied().unwrap_or(patch.len());
+        sections.push_back(&patch[*start..end]);
+    }
+    sections
+}
+
+fn parse_hunks(
+    section: &[u8],
+    remaining_total: &mut usize,
+) -> (ChangeContentDto, Vec<ChangeHunkDto>, bool) {
+    let text = String::from_utf8_lossy(section);
+    if text.contains("\nBinary files ") || text.contains("\nGIT binary patch") {
+        return (ChangeContentDto::Binary, Vec::new(), false);
+    }
+    let mut hunks = Vec::new();
+    let mut current: Option<ChangeHunkDto> = None;
+    let mut old_line = 0;
+    let mut new_line = 0;
+    let mut file_lines = 0;
+    let mut truncated = false;
+    for line in text.lines() {
+        if let Some((old_start, new_start)) = parse_hunk_header(line) {
+            if let Some(hunk) = current.take() {
+                hunks.push(hunk);
+            }
+            if hunks.len() >= MAX_HUNKS_PER_FILE {
+                truncated = true;
+                break;
+            }
+            old_line = old_start;
+            new_line = new_start;
+            let (header, cut) = sanitize_text(line, MAX_LINE_BYTES);
+            truncated |= cut;
+            current = Some(ChangeHunkDto {
+                header,
+                lines: Vec::new(),
+                truncated: false,
+            });
+            continue;
+        }
+        let Some(hunk) = current.as_mut() else {
+            continue;
+        };
+        if line == "\\ No newline at end of file" {
+            continue;
+        }
+        let Some(prefix) = line.as_bytes().first().copied() else {
+            continue;
+        };
+        let (kind, old, new) = match prefix {
+            b'+' => {
+                let current_new = new_line;
+                new_line += 1;
+                (ChangeLineKindDto::Addition, None, Some(current_new))
+            }
+            b'-' => {
+                let current_old = old_line;
+                old_line += 1;
+                (ChangeLineKindDto::Deletion, Some(current_old), None)
+            }
+            b' ' => {
+                let current_old = old_line;
+                let current_new = new_line;
+                old_line += 1;
+                new_line += 1;
+                (
+                    ChangeLineKindDto::Context,
+                    Some(current_old),
+                    Some(current_new),
+                )
+            }
+            _ => continue,
+        };
+        if file_lines >= MAX_LINES_PER_FILE || *remaining_total == 0 {
+            hunk.truncated = true;
+            truncated = true;
+            break;
+        }
+        let body = line.get(1..).unwrap_or_default();
+        let (text, cut) = sanitize_text(body, MAX_LINE_BYTES);
+        hunk.truncated |= cut;
+        truncated |= cut;
+        hunk.lines.push(ChangeLineDto {
+            kind,
+            old_line: old,
+            new_line: new,
+            text,
+        });
+        file_lines += 1;
+        *remaining_total -= 1;
+    }
+    if let Some(hunk) = current {
+        hunks.push(hunk);
+    }
+    (ChangeContentDto::Text, hunks, truncated)
+}
+
+async fn hash_path(work_dir: &Path, raw: &[u8], hasher: &mut Sha256) -> Result<Option<u32>> {
+    let path = worktree_path(work_dir, raw)?;
+    let metadata = tokio::fs::symlink_metadata(&path).await?;
+    hasher.update(raw);
+    if metadata.file_type().is_symlink() {
+        hasher.update(b"symlink\0");
+        let target = tokio::fs::read_link(path).await?;
+        hasher.update(target.as_os_str().as_bytes());
+        Ok(None)
+    } else if metadata.is_file() {
+        hasher.update(b"file\0");
+        let mut file = tokio::fs::File::open(path).await?;
+        let mut chunk = [0_u8; 32 * 1024];
+        let mut bytes = 0_u64;
+        let mut lines = 0_u64;
+        let mut last = 0_u8;
+        let mut binary = false;
+        loop {
+            let read = file.read(&mut chunk).await?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&chunk[..read]);
+            bytes += read as u64;
+            lines += chunk[..read].iter().filter(|byte| **byte == b'\n').count() as u64;
+            binary |= chunk[..read].contains(&0);
+            last = chunk[read - 1];
+        }
+        if bytes > 0 && last != b'\n' {
+            lines += 1;
+        }
+        Ok((!binary).then_some(lines.min(u32::MAX as u64) as u32))
+    } else {
+        hasher.update(b"unsupported\0");
+        Ok(None)
+    }
+}
+
+async fn untracked_file(
+    work_dir: &Path,
+    raw: &[u8],
+    sources: Vec<ChangeSourceDto>,
+    remaining_total: &mut usize,
+) -> Result<ChangeFileDto> {
+    let path = worktree_path(work_dir, raw)?;
+    let metadata = tokio::fs::symlink_metadata(&path).await?;
+    let mut file = ChangeFileDto {
+        status: ChangeFileStatusDto::Untracked,
+        path: path_dto(raw),
+        old_path: None,
+        sources,
+        additions: None,
+        deletions: None,
+        content: ChangeContentDto::Unsupported,
+        hunks: Vec::new(),
+        truncated: false,
+    };
+    if !metadata.is_file() {
+        return Ok(file);
+    }
+    if metadata.len() > MAX_UNTRACKED_RENDER_BYTES {
+        file.content = ChangeContentDto::Oversize;
+        file.truncated = true;
+        return Ok(file);
+    }
+    let bytes = tokio::fs::read(path).await?;
+    if bytes.contains(&0) {
+        file.content = ChangeContentDto::Binary;
+        return Ok(file);
+    }
+    let text = String::from_utf8_lossy(&bytes);
+    let lines: Vec<&str> = text.lines().collect();
+    file.additions = Some(lines.len().min(u32::MAX as usize) as u32);
+    let mut rendered = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        if index >= MAX_LINES_PER_FILE || *remaining_total == 0 {
+            file.truncated = true;
+            break;
+        }
+        let (text, cut) = sanitize_text(line, MAX_LINE_BYTES);
+        file.truncated |= cut;
+        rendered.push(ChangeLineDto {
+            kind: ChangeLineKindDto::Addition,
+            old_line: None,
+            new_line: Some((index + 1) as u32),
+            text,
+        });
+        *remaining_total -= 1;
+    }
+    file.content = ChangeContentDto::Text;
+    if !rendered.is_empty() {
+        file.hunks.push(ChangeHunkDto {
+            header: format!("@@ -0,0 +1,{} @@", lines.len()),
+            lines: rendered,
+            truncated: file.truncated,
+        });
+    }
+    Ok(file)
+}
+
+fn limits() -> ChangeLimitsDto {
+    ChangeLimitsDto {
+        max_files: MAX_FILES as u32,
+        max_hunks_per_file: MAX_HUNKS_PER_FILE as u32,
+        max_lines_per_file: MAX_LINES_PER_FILE as u32,
+        max_total_lines: MAX_TOTAL_LINES as u32,
+        max_line_bytes: MAX_LINE_BYTES as u32,
+    }
+}
+
+fn unavailable(
+    reference: &str,
+    reason: ChangeBaseUnavailableReasonDto,
+    head_oid: Option<String>,
+) -> ChangeSetDto {
+    ChangeSetDto {
+        version: None,
+        base: ChangeBaseDto::Unavailable {
+            reference: reference.to_string(),
+            reason,
+        },
+        head_oid,
+        totals: ChangeTotalsDto::default(),
+        files: Vec::new(),
+        truncated: false,
+        limits: limits(),
+    }
+}
+
+/// Read one session worktree without fetching or changing Git state.
+pub async fn load(work_dir: &Path, base_reference: &str) -> Result<ChangeSetDto> {
+    let Some(head_oid) = git_text(work_dir, &["rev-parse", "--verify", "HEAD"]).await? else {
+        return Ok(unavailable(
+            base_reference,
+            ChangeBaseUnavailableReasonDto::UnbornHead,
+            None,
+        ));
+    };
+    let local_base = if base_reference.starts_with("refs/heads/") {
+        base_reference.to_string()
+    } else {
+        format!("refs/heads/{base_reference}")
+    };
+    let base_spec = format!("{local_base}^{{commit}}");
+    let Some(base_tip) = git_text(work_dir, &["rev-parse", "--verify", &base_spec]).await? else {
+        return Ok(unavailable(
+            base_reference,
+            ChangeBaseUnavailableReasonDto::MissingBase,
+            Some(head_oid),
+        ));
+    };
+    let Some(base_oid) = git_text(work_dir, &["merge-base", &head_oid, &base_tip]).await? else {
+        return Ok(unavailable(
+            base_reference,
+            ChangeBaseUnavailableReasonDto::NoMergeBase,
+            Some(head_oid),
+        ));
+    };
+
+    let final_raw = capture_diff(
+        work_dir,
+        &[
+            "--raw",
+            "--full-index",
+            "--find-renames",
+            "-z",
+            &base_oid,
+            "--",
+        ],
+        MAX_INVENTORY_BYTES,
+    )
+    .await?;
+    let numstat = capture_diff(
+        work_dir,
+        &["--numstat", "--find-renames", "-z", &base_oid, "--"],
+        MAX_INVENTORY_BYTES,
+    )
+    .await?;
+    let committed = capture_diff(
+        work_dir,
+        &[
+            "--name-only",
+            "--find-renames",
+            "-z",
+            &base_oid,
+            "HEAD",
+            "--",
+        ],
+        MAX_INVENTORY_BYTES,
+    )
+    .await?;
+    let staged = capture_diff(
+        work_dir,
+        &[
+            "--cached",
+            "--name-only",
+            "--find-renames",
+            "-z",
+            "HEAD",
+            "--",
+        ],
+        MAX_INVENTORY_BYTES,
+    )
+    .await?;
+    let unstaged = capture_diff(
+        work_dir,
+        &["--name-only", "--find-renames", "-z", "--"],
+        MAX_INVENTORY_BYTES,
+    )
+    .await?;
+    let untracked = capture_git(
+        work_dir,
+        &["ls-files", "--others", "--exclude-standard", "-z", "--"],
+        MAX_INVENTORY_BYTES,
+    )
+    .await?;
+    let inventory_truncated = [
+        &final_raw, &numstat, &committed, &staged, &unstaged, &untracked,
+    ]
+    .iter()
+    .any(|capture| capture.truncated);
+    let mut raw_files = parse_raw_files(&final_raw.bytes);
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"weaver-changes-v1\0");
+    hasher.update(base_oid.as_bytes());
+    hasher.update([0]);
+    hasher.update(head_oid.as_bytes());
+    hasher.update([0]);
+    hasher.update(&final_raw.bytes);
+    for capture in [&committed, &staged, &unstaged, &untracked] {
+        hasher.update([0]);
+        hasher.update(&capture.bytes);
+    }
+    let untracked_paths: Vec<Vec<u8>> = nul_records(&untracked.bytes)
+        .map(ToOwned::to_owned)
+        .collect();
+    let mut untracked_additions = BTreeMap::new();
+    if !inventory_truncated {
+        for file in raw_files
+            .iter()
+            .filter(|file| file.status != ChangeFileStatusDto::Deleted)
+        {
+            hash_path(work_dir, &file.path, &mut hasher).await?;
+        }
+        for path in &untracked_paths {
+            if let Some(lines) = hash_path(work_dir, path, &mut hasher).await? {
+                untracked_additions.insert(path.clone(), lines);
+            }
+        }
+    }
+    let version =
+        (!inventory_truncated).then(|| format!("changes-v1:{}", hex::encode(hasher.finalize())));
+
+    let patch = capture_diff(
+        work_dir,
+        &["--patch", "--find-renames", "--unified=3", &base_oid, "--"],
+        MAX_PATCH_BYTES,
+    )
+    .await?;
+    let mut sections = patch_sections(&patch.bytes);
+    let stats = parse_numstat(&numstat.bytes);
+    let committed = source_paths(&committed.bytes);
+    let staged = source_paths(&staged.bytes);
+    let unstaged = source_paths(&unstaged.bytes);
+    let untracked_set: BTreeSet<Vec<u8>> = untracked_paths.iter().cloned().collect();
+
+    for path in &untracked_paths {
+        if !raw_files.iter().any(|file| file.path == *path) {
+            raw_files.push(RawFile {
+                status: ChangeFileStatusDto::Untracked,
+                path: path.clone(),
+                old_path: None,
+            });
+        }
+    }
+    let total_files = raw_files.len().min(u32::MAX as usize) as u32;
+    let mut remaining_total = MAX_TOTAL_LINES;
+    let mut files = Vec::new();
+    for raw in raw_files.iter().take(MAX_FILES) {
+        let mut sources = Vec::new();
+        if committed.contains(&raw.path) {
+            sources.push(ChangeSourceDto::Committed);
+        }
+        if staged.contains(&raw.path) {
+            sources.push(ChangeSourceDto::Staged);
+        }
+        if unstaged.contains(&raw.path) {
+            sources.push(ChangeSourceDto::Unstaged);
+        }
+        if untracked_set.contains(&raw.path) {
+            sources.push(ChangeSourceDto::Untracked);
+        }
+        if raw.status == ChangeFileStatusDto::Untracked {
+            files.push(untracked_file(work_dir, &raw.path, sources, &mut remaining_total).await?);
+            continue;
+        }
+        let section = sections.pop_front().unwrap_or_default();
+        let (content, hunks, section_truncated) = parse_hunks(section, &mut remaining_total);
+        let stat = stats.get(&raw.path).copied().unwrap_or_default();
+        files.push(ChangeFileDto {
+            status: raw.status,
+            path: path_dto(&raw.path),
+            old_path: raw.old_path.as_deref().map(path_dto),
+            sources,
+            additions: stat.additions,
+            deletions: stat.deletions,
+            content,
+            hunks,
+            truncated: section_truncated || (patch.truncated && sections.is_empty()),
+        });
+    }
+    let totals = ChangeTotalsDto {
+        files: total_files,
+        additions: stats
+            .values()
+            .filter_map(|stat| stat.additions)
+            .chain(untracked_additions.values().copied())
+            .sum(),
+        deletions: stats.values().filter_map(|stat| stat.deletions).sum(),
+        truncated: numstat.truncated || inventory_truncated,
+    };
+    Ok(ChangeSetDto {
+        version,
+        base: ChangeBaseDto::Available {
+            reference: base_reference.to_string(),
+            oid: base_oid,
+        },
+        head_oid: Some(head_oid),
+        totals,
+        truncated: inventory_truncated
+            || patch.truncated
+            || raw_files.len() > MAX_FILES
+            || remaining_total == 0,
+        files,
+        limits: limits(),
+    })
+}
+
+/// Validate a mutable comment anchor against the exact snapshot on screen.
+pub fn validate_anchor(
+    changes: &ChangeSetDto,
+    version: &str,
+    anchor: &ChangeAnchorDto,
+) -> Result<()> {
+    if changes.version.as_deref() != Some(version) {
+        bail!("change-set version moved; refresh before anchoring");
+    }
+    if anchor.start_line == 0 || anchor.end_line < anchor.start_line {
+        bail!("change anchor range is invalid");
+    }
+    let identity = decode_path(&anchor.path)?;
+    let file = changes
+        .files
+        .iter()
+        .find(|file| decode_path(&file.path).ok().as_deref() == Some(identity.as_slice()))
+        .context("change anchor path is not present in this version")?;
+    let mut expected = anchor.start_line;
+    for line in file.hunks.iter().flat_map(|hunk| &hunk.lines) {
+        let (number, allowed) = match anchor.side {
+            ChangeSideDto::Old => (
+                line.old_line,
+                matches!(
+                    line.kind,
+                    ChangeLineKindDto::Deletion | ChangeLineKindDto::Context
+                ),
+            ),
+            ChangeSideDto::New => (
+                line.new_line,
+                matches!(
+                    line.kind,
+                    ChangeLineKindDto::Addition | ChangeLineKindDto::Context
+                ),
+            ),
+        };
+        if allowed && number == Some(expected) {
+            expected += 1;
+            if expected > anchor.end_line {
+                return Ok(());
+            }
+        }
+    }
+    bail!("change anchor does not name a contiguous visible line range")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_typed_hunks_and_enforces_side_ranges() {
+        let patch = b"diff --git a/src/a.rs b/src/a.rs\n--- a/src/a.rs\n+++ b/src/a.rs\n@@ -2,2 +2,3 @@ fn main() {\n same\n-old\n+new\n+next\n";
+        let mut remaining = 100;
+        let (content, hunks, truncated) =
+            parse_hunks(patch_sections(patch).pop_front().unwrap(), &mut remaining);
+        assert_eq!(content, ChangeContentDto::Text);
+        assert!(!truncated);
+        assert_eq!(hunks[0].lines[1].old_line, Some(3));
+        assert_eq!(hunks[0].lines[2].new_line, Some(3));
+
+        let path = path_dto(b"src/a.rs");
+        let changes = ChangeSetDto {
+            version: Some("changes-v1:test".to_string()),
+            base: ChangeBaseDto::Available {
+                reference: "main".to_string(),
+                oid: "base".to_string(),
+            },
+            head_oid: Some("head".to_string()),
+            totals: ChangeTotalsDto::default(),
+            files: vec![ChangeFileDto {
+                status: ChangeFileStatusDto::Modified,
+                path: path.clone(),
+                old_path: None,
+                sources: vec![ChangeSourceDto::Unstaged],
+                additions: Some(2),
+                deletions: Some(1),
+                content,
+                hunks,
+                truncated: false,
+            }],
+            truncated: false,
+            limits: limits(),
+        };
+        let anchor = ChangeAnchorDto {
+            path,
+            side: ChangeSideDto::New,
+            start_line: 3,
+            end_line: 4,
+            hunk_header: "@@ -2,2 +2,3 @@".to_string(),
+            context_before: vec![],
+            selected: vec!["new".to_string(), "next".to_string()],
+            context_after: vec![],
+        };
+        validate_anchor(&changes, "changes-v1:test", &anchor).unwrap();
+        let wrong_side = ChangeAnchorDto {
+            side: ChangeSideDto::Old,
+            ..anchor
+        };
+        assert!(validate_anchor(&changes, "changes-v1:test", &wrong_side).is_err());
+    }
+
+    #[test]
+    fn paths_round_trip_without_control_or_utf8_loss() {
+        let raw = b"bad\n\xff.rs";
+        let path = path_dto(raw);
+        assert_eq!(decode_path(&path).unwrap(), raw);
+        assert_eq!(path.display, "bad\\x0a\\xff.rs");
+    }
+
+    #[test]
+    fn bounds_long_lines_and_file_line_count() {
+        let long = "x".repeat(MAX_LINE_BYTES + 50);
+        let patch = format!("diff --git a/a b/a\n@@ -1 +1 @@\n-{long}\n+{long}\n");
+        let mut remaining = 1;
+        let (_, hunks, truncated) = parse_hunks(patch.as_bytes(), &mut remaining);
+        assert!(truncated);
+        assert!(hunks[0].truncated);
+        assert!(hunks[0].lines[0].text.ends_with('…'));
+        assert_eq!(hunks[0].lines.len(), 1);
+    }
+}

--- a/crates/loom/src/changes.rs
+++ b/crates/loom/src/changes.rs
@@ -14,8 +14,10 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Component, Path, PathBuf};
 use std::process::Stdio;
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, BufReader};
 use tokio::process::Command;
+use tokio::time::Instant;
 use weaver_api::{
     ChangeAnchorDto, ChangeBaseDto, ChangeBaseUnavailableReasonDto, ChangeContentDto,
     ChangeFileDto, ChangeFileStatusDto, ChangeHunkDto, ChangeLimitsDto, ChangeLineDto,
@@ -34,11 +36,13 @@ const MAX_UNTRACKED_RENDER_BYTES: u64 = 512 * 1024;
 const MAX_IDENTITY_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_CONFIG_BYTES: usize = 256 * 1024;
 const MAX_INDEX_BYTES: u64 = 16 * 1024 * 1024;
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 struct Capture {
     bytes: Vec<u8>,
     truncated: bool,
+    timed_out: bool,
 }
 
 #[derive(Debug)]
@@ -82,7 +86,8 @@ fn hardened_git(work_dir: &Path, policy: &GitReadPolicy) -> Command {
         .env_remove("GIT_EXTERNAL_DIFF")
         .env_remove("GIT_DIFF_OPTS")
         .stdin(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
     for driver in &policy.filter_drivers {
         command
             .arg("-c")
@@ -97,12 +102,12 @@ fn hardened_git(work_dir: &Path, policy: &GitReadPolicy) -> Command {
     command
 }
 
-async fn capture_git(
+async fn capture_git_status(
     work_dir: &Path,
     policy: &GitReadPolicy,
     args: &[&str],
     retain: usize,
-) -> Result<Capture> {
+) -> Result<(Capture, bool)> {
     let mut child = hardened_git(work_dir, policy)
         .args(args)
         .stdout(Stdio::piped())
@@ -112,25 +117,64 @@ async fn capture_git(
     let mut reader = BufReader::new(stdout);
     let mut bytes = Vec::with_capacity(retain.min(64 * 1024));
     let mut chunk = vec![0_u8; 32 * 1024];
-    let mut truncated = false;
-    loop {
-        let read = reader.read(&mut chunk).await?;
-        if read == 0 {
-            break;
+    let deadline = Instant::now() + GIT_COMMAND_TIMEOUT;
+    let result = tokio::time::timeout_at(deadline, async {
+        let mut truncated = false;
+        loop {
+            let read = reader.read(&mut chunk).await?;
+            if read == 0 {
+                break;
+            }
+            let room = retain.saturating_sub(bytes.len());
+            bytes.extend_from_slice(&chunk[..read.min(room)]);
+            if read > room {
+                truncated = true;
+                child.start_kill().context("stopping bounded git capture")?;
+                break;
+            }
         }
-        let room = retain.saturating_sub(bytes.len());
-        bytes.extend_from_slice(&chunk[..read.min(room)]);
-        if read > room {
-            truncated = true;
-            child.start_kill().context("stopping bounded git capture")?;
-            break;
+        let status = child.wait().await?;
+        Ok::<_, anyhow::Error>((status.success(), truncated))
+    })
+    .await;
+    match result {
+        Ok(result) => {
+            let (success, truncated) = result?;
+            Ok((
+                Capture {
+                    bytes,
+                    truncated,
+                    timed_out: false,
+                },
+                success,
+            ))
+        }
+        Err(_) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            Ok((
+                Capture {
+                    bytes,
+                    truncated: true,
+                    timed_out: true,
+                },
+                false,
+            ))
         }
     }
-    let status = child.wait().await?;
-    if !status.success() && !truncated {
+}
+
+async fn capture_git(
+    work_dir: &Path,
+    policy: &GitReadPolicy,
+    args: &[&str],
+    retain: usize,
+) -> Result<Capture> {
+    let (capture, success) = capture_git_status(work_dir, policy, args, retain).await?;
+    if !success && !capture.truncated {
         bail!("git {} failed", args.join(" "));
     }
-    Ok(Capture { bytes, truncated })
+    Ok(capture)
 }
 
 async fn capture_diff(
@@ -155,18 +199,17 @@ async fn git_text(
     policy: &GitReadPolicy,
     args: &[&str],
 ) -> Result<Option<String>> {
-    let output = hardened_git(work_dir, policy)
-        .args(args)
-        .output()
-        .await
-        .with_context(|| format!("spawning git {}", args.join(" ")))?;
-    if !output.status.success() {
-        return Ok(None);
+    let (capture, success) = capture_git_status(work_dir, policy, args, 4 * 1024).await?;
+    if capture.timed_out {
+        bail!("git {} exceeded its deadline", args.join(" "));
     }
-    if output.stdout.len() > 4 * 1024 {
+    if capture.truncated {
         bail!("git identity output exceeded its bound");
     }
-    let value = String::from_utf8(output.stdout).context("git identity was not UTF-8")?;
+    if !success {
+        return Ok(None);
+    }
+    let value = String::from_utf8(capture.bytes).context("git identity was not UTF-8")?;
     let value = value.trim().to_string();
     Ok((!value.is_empty()).then_some(value))
 }
@@ -252,8 +295,7 @@ fn validate_path(raw: &[u8]) -> Result<()> {
 
 fn safe_file(work_dir: &Path, raw: &[u8]) -> Result<Option<(std::fs::File, std::fs::Metadata)>> {
     validate_path(raw)?;
-    let relative = CString::new(raw)?;
-    let root = match std::fs::OpenOptions::new()
+    let mut directory = match std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open(work_dir)
@@ -261,31 +303,36 @@ fn safe_file(work_dir: &Path, raw: &[u8]) -> Result<Option<(std::fs::File, std::
         Ok(root) => root,
         Err(_) => return Ok(None),
     };
-    #[cfg(target_os = "linux")]
-    let fd = {
-        // SAFETY: open_how is a plain kernel ABI struct whose zero value is valid.
-        let mut how: libc::open_how = unsafe { std::mem::zeroed() };
-        how.flags = (libc::O_RDONLY | libc::O_NONBLOCK | libc::O_CLOEXEC) as u64;
-        how.resolve =
-            libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS | libc::RESOLVE_NO_SYMLINKS;
-        // SAFETY: root, CString, and open_how remain valid for the syscall.
-        unsafe {
-            libc::syscall(
-                libc::SYS_openat2,
-                root.as_raw_fd(),
-                relative.as_ptr(),
-                &how,
-                std::mem::size_of::<libc::open_how>(),
-            ) as i32
+    let mut components = Path::new(OsStr::from_bytes(raw))
+        .components()
+        .filter_map(|part| match part {
+            Component::Normal(value) => Some(value),
+            _ => None,
+        })
+        .peekable();
+    while let Some(component) = components.next() {
+        let component = CString::new(component.as_bytes())?;
+        let leaf = components.peek().is_none();
+        let flags = libc::O_RDONLY
+            | libc::O_NOFOLLOW
+            | libc::O_CLOEXEC
+            | if leaf {
+                libc::O_NONBLOCK
+            } else {
+                libc::O_DIRECTORY
+            };
+        // SAFETY: the owned directory descriptor and CString remain valid.
+        let fd = unsafe { libc::openat(directory.as_raw_fd(), component.as_ptr(), flags) };
+        if fd < 0 {
+            return Ok(None);
         }
-    };
-    #[cfg(not(target_os = "linux"))]
-    let fd = -1;
-    if fd >= 0 {
-        // SAFETY: a successful `openat` returns a new owned descriptor.
-        let file = unsafe { std::fs::File::from_raw_fd(fd) };
-        let metadata = file.metadata()?;
-        return Ok(metadata.is_file().then_some((file, metadata)));
+        // SAFETY: a successful openat returns a new owned descriptor.
+        let opened = unsafe { std::fs::File::from_raw_fd(fd) };
+        if leaf {
+            let metadata = opened.metadata()?;
+            return Ok(metadata.is_file().then_some((opened, metadata)));
+        }
+        directory = opened;
     }
     Ok(None)
 }
@@ -998,7 +1045,7 @@ async fn load_once(
         files,
         limits: limits(),
     };
-    let Some(identity) = state.identity else {
+    let Some(identity) = state.identity.filter(|_| !patch.timed_out) else {
         return Ok((changes, true));
     };
 

--- a/crates/loom/src/changes.rs
+++ b/crates/loom/src/changes.rs
@@ -7,8 +7,11 @@ use anyhow::{bail, Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use sha2::{Digest as _, Sha256};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::ffi::OsString;
-use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::ffi::{CString, OsStr};
+use std::io::ErrorKind;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Component, Path, PathBuf};
 use std::process::Stdio;
 use tokio::io::{AsyncReadExt, BufReader};
@@ -28,6 +31,9 @@ pub const MAX_LINE_BYTES: usize = 2_048;
 const MAX_INVENTORY_BYTES: usize = 8 * 1024 * 1024;
 const MAX_PATCH_BYTES: usize = 2 * 1024 * 1024;
 const MAX_UNTRACKED_RENDER_BYTES: u64 = 512 * 1024;
+const MAX_IDENTITY_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_CONFIG_BYTES: usize = 256 * 1024;
+const MAX_INDEX_BYTES: u64 = 16 * 1024 * 1024;
 
 #[derive(Debug)]
 struct Capture {
@@ -48,21 +54,56 @@ struct NumStat {
     deletions: Option<u32>,
 }
 
-fn hardened_git(work_dir: &Path) -> Command {
+#[derive(Debug, Default)]
+struct GitReadPolicy {
+    filter_drivers: Vec<String>,
+}
+
+fn hardened_git(work_dir: &Path, policy: &GitReadPolicy) -> Command {
     let mut command = Command::new("git");
     command
         .arg("-C")
         .arg(work_dir)
-        .args(["-c", "color.ui=false"])
+        .args([
+            "-c",
+            "color.ui=false",
+            "-c",
+            "diff.autoRefreshIndex=false",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "submodule.recurse=false",
+        ])
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_CONFIG_COUNT", "0")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_ATTR_NOSYSTEM", "1")
         .env_remove("GIT_EXTERNAL_DIFF")
         .env_remove("GIT_DIFF_OPTS")
         .stdin(Stdio::null())
         .stderr(Stdio::null());
+    for driver in &policy.filter_drivers {
+        command
+            .arg("-c")
+            .arg(format!("filter.{driver}.clean="))
+            .arg("-c")
+            .arg(format!("filter.{driver}.process="))
+            .arg("-c")
+            .arg(format!("filter.{driver}.smudge="))
+            .arg("-c")
+            .arg(format!("filter.{driver}.required=false"));
+    }
     command
 }
 
-async fn capture_git(work_dir: &Path, args: &[&str], retain: usize) -> Result<Capture> {
-    let mut child = hardened_git(work_dir)
+async fn capture_git(
+    work_dir: &Path,
+    policy: &GitReadPolicy,
+    args: &[&str],
+    retain: usize,
+) -> Result<Capture> {
+    let mut child = hardened_git(work_dir, policy)
         .args(args)
         .stdout(Stdio::piped())
         .spawn()
@@ -70,7 +111,7 @@ async fn capture_git(work_dir: &Path, args: &[&str], retain: usize) -> Result<Ca
     let stdout = child.stdout.take().context("capturing git stdout")?;
     let mut reader = BufReader::new(stdout);
     let mut bytes = Vec::with_capacity(retain.min(64 * 1024));
-    let mut chunk = [0_u8; 32 * 1024];
+    let mut chunk = vec![0_u8; 32 * 1024];
     let mut truncated = false;
     loop {
         let read = reader.read(&mut chunk).await?;
@@ -79,23 +120,42 @@ async fn capture_git(work_dir: &Path, args: &[&str], retain: usize) -> Result<Ca
         }
         let room = retain.saturating_sub(bytes.len());
         bytes.extend_from_slice(&chunk[..read.min(room)]);
-        truncated |= read > room;
+        if read > room {
+            truncated = true;
+            child.start_kill().context("stopping bounded git capture")?;
+            break;
+        }
     }
     let status = child.wait().await?;
-    if !status.success() {
+    if !status.success() && !truncated {
         bail!("git {} failed", args.join(" "));
     }
     Ok(Capture { bytes, truncated })
 }
 
-async fn capture_diff(work_dir: &Path, args: &[&str], retain: usize) -> Result<Capture> {
-    let mut full = vec!["diff", "--no-ext-diff", "--no-textconv", "--no-color"];
+async fn capture_diff(
+    work_dir: &Path,
+    policy: &GitReadPolicy,
+    args: &[&str],
+    retain: usize,
+) -> Result<Capture> {
+    let mut full = vec![
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-color",
+        "--ignore-submodules=all",
+    ];
     full.extend_from_slice(args);
-    capture_git(work_dir, &full, retain).await
+    capture_git(work_dir, policy, &full, retain).await
 }
 
-async fn git_text(work_dir: &Path, args: &[&str]) -> Result<Option<String>> {
-    let output = hardened_git(work_dir)
+async fn git_text(
+    work_dir: &Path,
+    policy: &GitReadPolicy,
+    args: &[&str],
+) -> Result<Option<String>> {
+    let output = hardened_git(work_dir, policy)
         .args(args)
         .output()
         .await
@@ -109,6 +169,46 @@ async fn git_text(work_dir: &Path, args: &[&str]) -> Result<Option<String>> {
     let value = String::from_utf8(output.stdout).context("git identity was not UTF-8")?;
     let value = value.trim().to_string();
     Ok((!value.is_empty()).then_some(value))
+}
+
+impl GitReadPolicy {
+    async fn load(work_dir: &Path) -> Result<Self> {
+        let empty = Self::default();
+        let capture = capture_git(
+            work_dir,
+            &empty,
+            &["config", "--includes", "--null", "--name-only", "--list"],
+            MAX_CONFIG_BYTES,
+        )
+        .await?;
+        if capture.truncated {
+            bail!("git configuration exceeded its safe read bound");
+        }
+        let mut filter_drivers = Vec::new();
+        for raw in nul_records(&capture.bytes) {
+            let key = std::str::from_utf8(raw).context("git configuration key was not UTF-8")?;
+            let Some((driver, setting)) =
+                key.strip_prefix("filter.").and_then(|v| v.rsplit_once('.'))
+            else {
+                continue;
+            };
+            if !driver.is_empty() && matches!(setting, "clean" | "process" | "required" | "smudge")
+            {
+                filter_drivers.push(driver.to_string());
+            }
+        }
+        filter_drivers.sort();
+        filter_drivers.dedup();
+        Ok(Self { filter_drivers })
+    }
+}
+
+fn hash_record(hasher: &mut Sha256, tag: &[u8], bytes: &[u8]) {
+    hasher.update(b"weaver-change-record-v1");
+    hasher.update((tag.len() as u64).to_be_bytes());
+    hasher.update(tag);
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
 }
 
 fn path_dto(raw: &[u8]) -> ChangePathDto {
@@ -132,11 +232,11 @@ fn decode_path(path: &ChangePathDto) -> Result<Vec<u8>> {
         .context("change path identity is not valid base64url")
 }
 
-fn worktree_path(work_dir: &Path, raw: &[u8]) -> Result<PathBuf> {
+fn validate_path(raw: &[u8]) -> Result<()> {
     if raw.is_empty() || raw.contains(&0) {
         bail!("change path is empty or contains NUL");
     }
-    let relative = PathBuf::from(OsString::from_vec(raw.to_vec()));
+    let relative = Path::new(OsStr::from_bytes(raw));
     if relative.is_absolute()
         || relative.components().any(|part| {
             matches!(
@@ -147,7 +247,68 @@ fn worktree_path(work_dir: &Path, raw: &[u8]) -> Result<PathBuf> {
     {
         bail!("change path escapes the worktree");
     }
-    Ok(work_dir.join(relative))
+    Ok(())
+}
+
+fn safe_file(work_dir: &Path, raw: &[u8]) -> Result<Option<(std::fs::File, std::fs::Metadata)>> {
+    validate_path(raw)?;
+    let relative = CString::new(raw)?;
+    let root = match std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(work_dir)
+    {
+        Ok(root) => root,
+        Err(_) => return Ok(None),
+    };
+    #[cfg(target_os = "linux")]
+    let fd = {
+        // SAFETY: open_how is a plain kernel ABI struct whose zero value is valid.
+        let mut how: libc::open_how = unsafe { std::mem::zeroed() };
+        how.flags = (libc::O_RDONLY | libc::O_NONBLOCK | libc::O_CLOEXEC) as u64;
+        how.resolve =
+            libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS | libc::RESOLVE_NO_SYMLINKS;
+        // SAFETY: root, CString, and open_how remain valid for the syscall.
+        unsafe {
+            libc::syscall(
+                libc::SYS_openat2,
+                root.as_raw_fd(),
+                relative.as_ptr(),
+                &how,
+                std::mem::size_of::<libc::open_how>(),
+            ) as i32
+        }
+    };
+    #[cfg(not(target_os = "linux"))]
+    let fd = -1;
+    if fd >= 0 {
+        // SAFETY: a successful `openat` returns a new owned descriptor.
+        let file = unsafe { std::fs::File::from_raw_fd(fd) };
+        let metadata = file.metadata()?;
+        return Ok(metadata.is_file().then_some((file, metadata)));
+    }
+    Ok(None)
+}
+
+fn metadata_identity(metadata: &std::fs::Metadata) -> Vec<u8> {
+    let fields = [
+        metadata.dev(),
+        metadata.ino(),
+        metadata.mode() as u64,
+        metadata.len(),
+        metadata.mtime() as u64,
+        metadata.mtime_nsec() as u64,
+        metadata.ctime() as u64,
+        metadata.ctime_nsec() as u64,
+    ];
+    fields
+        .iter()
+        .flat_map(|field| field.to_be_bytes())
+        .collect()
+}
+
+fn same_metadata(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    metadata_identity(left) == metadata_identity(right)
 }
 
 fn nul_records(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
@@ -376,41 +537,64 @@ fn parse_hunks(
     (ChangeContentDto::Text, hunks, truncated)
 }
 
-async fn hash_path(work_dir: &Path, raw: &[u8], hasher: &mut Sha256) -> Result<Option<u32>> {
-    let path = worktree_path(work_dir, raw)?;
-    let metadata = tokio::fs::symlink_metadata(&path).await?;
-    hasher.update(raw);
-    if metadata.file_type().is_symlink() {
-        hasher.update(b"symlink\0");
-        let target = tokio::fs::read_link(path).await?;
-        hasher.update(target.as_os_str().as_bytes());
-        Ok(None)
-    } else if metadata.is_file() {
-        hasher.update(b"file\0");
-        let mut file = tokio::fs::File::open(path).await?;
-        let mut chunk = [0_u8; 32 * 1024];
-        let mut bytes = 0_u64;
-        let mut lines = 0_u64;
-        let mut last = 0_u8;
-        let mut binary = false;
-        loop {
-            let read = file.read(&mut chunk).await?;
-            if read == 0 {
-                break;
+enum HashPathResult {
+    Complete(Option<u32>),
+    Incomplete,
+}
+
+async fn hash_path(
+    work_dir: &Path,
+    raw: &[u8],
+    hasher: &mut Sha256,
+    remaining: &mut u64,
+) -> Result<HashPathResult> {
+    hash_record(hasher, b"path", raw);
+    match safe_file(work_dir, raw)? {
+        None => Ok(HashPathResult::Incomplete),
+        Some((file, initial)) => {
+            if initial.len() > *remaining {
+                return Ok(HashPathResult::Incomplete);
             }
-            hasher.update(&chunk[..read]);
-            bytes += read as u64;
-            lines += chunk[..read].iter().filter(|byte| **byte == b'\n').count() as u64;
-            binary |= chunk[..read].contains(&0);
-            last = chunk[read - 1];
+            *remaining -= initial.len();
+            hash_record(hasher, b"kind", b"file");
+            hash_record(hasher, b"file-stat", &metadata_identity(&initial));
+            hash_record(hasher, b"content-length", &initial.len().to_be_bytes());
+
+            let mut file = tokio::fs::File::from_std(file);
+            let mut chunk = [0_u8; 32 * 1024];
+            let mut left = initial.len();
+            let mut lines = 0_u64;
+            let mut last = 0_u8;
+            let mut binary = false;
+            while left > 0 {
+                let wanted = left.min(chunk.len() as u64) as usize;
+                if file.read_exact(&mut chunk[..wanted]).await.is_err() {
+                    return Ok(HashPathResult::Incomplete);
+                }
+                hash_record(hasher, b"file-chunk", &chunk[..wanted]);
+                lines += chunk[..wanted]
+                    .iter()
+                    .filter(|byte| **byte == b'\n')
+                    .count() as u64;
+                binary |= chunk[..wanted].contains(&0);
+                last = chunk[wanted - 1];
+                left -= wanted as u64;
+            }
+            let mut extra = [0_u8; 1];
+            if file.read(&mut extra).await? != 0 {
+                return Ok(HashPathResult::Incomplete);
+            }
+            let final_metadata = file.metadata().await?;
+            if !same_metadata(&initial, &final_metadata) {
+                return Ok(HashPathResult::Incomplete);
+            }
+            if initial.len() > 0 && last != b'\n' {
+                lines += 1;
+            }
+            Ok(HashPathResult::Complete(
+                (!binary).then_some(lines.min(u32::MAX as u64) as u32),
+            ))
         }
-        if bytes > 0 && last != b'\n' {
-            lines += 1;
-        }
-        Ok((!binary).then_some(lines.min(u32::MAX as u64) as u32))
-    } else {
-        hasher.update(b"unsupported\0");
-        Ok(None)
     }
 }
 
@@ -420,8 +604,6 @@ async fn untracked_file(
     sources: Vec<ChangeSourceDto>,
     remaining_total: &mut usize,
 ) -> Result<ChangeFileDto> {
-    let path = worktree_path(work_dir, raw)?;
-    let metadata = tokio::fs::symlink_metadata(&path).await?;
     let mut file = ChangeFileDto {
         status: ChangeFileStatusDto::Untracked,
         path: path_dto(raw),
@@ -433,15 +615,26 @@ async fn untracked_file(
         hunks: Vec::new(),
         truncated: false,
     };
-    if !metadata.is_file() {
-        return Ok(file);
-    }
+    let (handle, metadata) = match safe_file(work_dir, raw)? {
+        Some(file) => file,
+        None => return Ok(file),
+    };
     if metadata.len() > MAX_UNTRACKED_RENDER_BYTES {
         file.content = ChangeContentDto::Oversize;
         file.truncated = true;
         return Ok(file);
     }
-    let bytes = tokio::fs::read(path).await?;
+    let mut handle = tokio::fs::File::from_std(handle);
+    let mut bytes = vec![0_u8; metadata.len() as usize];
+    if handle.read_exact(&mut bytes).await.is_err() {
+        file.truncated = true;
+        return Ok(file);
+    }
+    let mut extra = [0_u8; 1];
+    if handle.read(&mut extra).await? != 0 || !same_metadata(&metadata, &handle.metadata().await?) {
+        file.truncated = true;
+        return Ok(file);
+    }
     if bytes.contains(&0) {
         file.content = ChangeContentDto::Binary;
         return Ok(file);
@@ -476,6 +669,158 @@ async fn untracked_file(
     Ok(file)
 }
 
+async fn hash_index(path: &Path, hasher: &mut Sha256) -> Result<bool> {
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            hash_record(hasher, b"index-state", b"absent");
+            return Ok(true);
+        }
+        Err(_) => return Ok(false),
+    };
+    let initial = file.metadata()?;
+    if !initial.is_file() || initial.len() > MAX_INDEX_BYTES {
+        return Ok(false);
+    }
+    let mut file = tokio::fs::File::from_std(file);
+    let mut bytes = vec![0_u8; initial.len() as usize];
+    if file.read_exact(&mut bytes).await.is_err() {
+        return Ok(false);
+    }
+    let mut extra = [0_u8; 1];
+    if file.read(&mut extra).await? != 0 || !same_metadata(&initial, &file.metadata().await?) {
+        return Ok(false);
+    }
+    hash_record(hasher, b"index-stat", &metadata_identity(&initial));
+    hash_record(hasher, b"index-bytes", &bytes);
+    Ok(true)
+}
+
+struct StateCapture {
+    final_raw: Capture,
+    numstat: Capture,
+    committed: Capture,
+    staged: Capture,
+    unstaged: Capture,
+    untracked_paths: Vec<Vec<u8>>,
+    untracked_additions: u32,
+    identity: Option<[u8; 32]>,
+}
+
+async fn capture_state(
+    work_dir: &Path,
+    policy: &GitReadPolicy,
+    base_reference: &str,
+    base_oid: &str,
+    head_oid: &str,
+    index_path: &Path,
+) -> Result<StateCapture> {
+    macro_rules! diff {
+        ($args:expr) => {
+            async { capture_diff(work_dir, policy, $args, MAX_INVENTORY_BYTES).await }
+        };
+    }
+    let (final_raw, numstat, committed, staged, unstaged, untracked) = tokio::try_join!(
+        diff!(&[
+            "--raw",
+            "--full-index",
+            "--find-renames",
+            "-z",
+            base_oid,
+            "--"
+        ]),
+        diff!(&["--numstat", "--find-renames", "-z", base_oid, "--"]),
+        diff!(&[
+            "--name-only",
+            "--find-renames",
+            "-z",
+            base_oid,
+            head_oid,
+            "--"
+        ]),
+        diff!(&[
+            "--cached",
+            "--name-only",
+            "--find-renames",
+            "-z",
+            head_oid,
+            "--"
+        ]),
+        diff!(&["--name-only", "--find-renames", "-z", "--"]),
+        capture_git(
+            work_dir,
+            policy,
+            &["ls-files", "--others", "--exclude-standard", "-z", "--"],
+            MAX_INVENTORY_BYTES,
+        ),
+    )?;
+    let truncated = [
+        &final_raw, &numstat, &committed, &staged, &unstaged, &untracked,
+    ]
+    .iter()
+    .any(|capture| capture.truncated);
+    let untracked_paths: Vec<Vec<u8>> = nul_records(&untracked.bytes)
+        .map(ToOwned::to_owned)
+        .collect();
+    let mut untracked_additions = 0;
+    let mut identity = None;
+    if !truncated {
+        let mut hasher = Sha256::new();
+        hash_record(&mut hasher, b"schema", b"changes-state-v2");
+        hash_record(&mut hasher, b"base-reference", base_reference.as_bytes());
+        hash_record(&mut hasher, b"base-oid", base_oid.as_bytes());
+        hash_record(&mut hasher, b"head-oid", head_oid.as_bytes());
+        for (tag, capture) in [
+            (b"final-raw".as_slice(), &final_raw),
+            (b"numstat".as_slice(), &numstat),
+            (b"committed".as_slice(), &committed),
+            (b"staged".as_slice(), &staged),
+            (b"unstaged".as_slice(), &unstaged),
+            (b"untracked".as_slice(), &untracked),
+        ] {
+            hash_record(&mut hasher, tag, &capture.bytes);
+        }
+        let mut complete = hash_index(index_path, &mut hasher).await?;
+        let mut remaining = MAX_IDENTITY_BYTES;
+        let raw_files = parse_raw_files(&final_raw.bytes);
+        for file in raw_files
+            .iter()
+            .filter(|file| file.status != ChangeFileStatusDto::Deleted)
+        {
+            match hash_path(work_dir, &file.path, &mut hasher, &mut remaining).await? {
+                HashPathResult::Complete(_) => {}
+                HashPathResult::Incomplete => complete = false,
+            }
+        }
+        for path in &untracked_paths {
+            match hash_path(work_dir, path, &mut hasher, &mut remaining).await? {
+                HashPathResult::Complete(Some(lines)) => {
+                    untracked_additions += lines;
+                }
+                HashPathResult::Complete(None) => {}
+                HashPathResult::Incomplete => complete = false,
+            }
+        }
+        if complete {
+            identity = Some(hasher.finalize().into());
+        }
+    }
+    Ok(StateCapture {
+        final_raw,
+        numstat,
+        committed,
+        staged,
+        unstaged,
+        untracked_paths,
+        untracked_additions,
+        identity,
+    })
+}
+
 fn limits() -> ChangeLimitsDto {
     ChangeLimitsDto {
         max_files: MAX_FILES as u32,
@@ -505,13 +850,20 @@ fn unavailable(
     }
 }
 
-/// Read one session worktree without fetching or changing Git state.
-pub async fn load(work_dir: &Path, base_reference: &str) -> Result<ChangeSetDto> {
-    let Some(head_oid) = git_text(work_dir, &["rev-parse", "--verify", "HEAD"]).await? else {
-        return Ok(unavailable(
-            base_reference,
-            ChangeBaseUnavailableReasonDto::UnbornHead,
-            None,
+async fn load_once(
+    work_dir: &Path,
+    policy: &GitReadPolicy,
+    base_reference: &str,
+) -> Result<(ChangeSetDto, bool)> {
+    let Some(head_oid) = git_text(work_dir, policy, &["rev-parse", "--verify", "HEAD"]).await?
+    else {
+        return Ok((
+            unavailable(
+                base_reference,
+                ChangeBaseUnavailableReasonDto::UnbornHead,
+                None,
+            ),
+            true,
         ));
     };
     let local_base = if base_reference.starts_with("refs/heads/") {
@@ -520,130 +872,63 @@ pub async fn load(work_dir: &Path, base_reference: &str) -> Result<ChangeSetDto>
         format!("refs/heads/{base_reference}")
     };
     let base_spec = format!("{local_base}^{{commit}}");
-    let Some(base_tip) = git_text(work_dir, &["rev-parse", "--verify", &base_spec]).await? else {
-        return Ok(unavailable(
-            base_reference,
-            ChangeBaseUnavailableReasonDto::MissingBase,
-            Some(head_oid),
+    let Some(base_tip) = git_text(work_dir, policy, &["rev-parse", "--verify", &base_spec]).await?
+    else {
+        return Ok((
+            unavailable(
+                base_reference,
+                ChangeBaseUnavailableReasonDto::MissingBase,
+                Some(head_oid),
+            ),
+            true,
         ));
     };
-    let Some(base_oid) = git_text(work_dir, &["merge-base", &head_oid, &base_tip]).await? else {
-        return Ok(unavailable(
-            base_reference,
-            ChangeBaseUnavailableReasonDto::NoMergeBase,
-            Some(head_oid),
+    let Some(base_oid) = git_text(work_dir, policy, &["merge-base", &head_oid, &base_tip]).await?
+    else {
+        return Ok((
+            unavailable(
+                base_reference,
+                ChangeBaseUnavailableReasonDto::NoMergeBase,
+                Some(head_oid),
+            ),
+            true,
         ));
     };
-
-    let final_raw = capture_diff(
+    let index_path = git_text(work_dir, policy, &["rev-parse", "--git-path", "index"])
+        .await?
+        .map(PathBuf::from)
+        .context("git index path is unavailable")?;
+    let index_path = if index_path.is_absolute() {
+        index_path
+    } else {
+        work_dir.join(index_path)
+    };
+    let state = capture_state(
         work_dir,
-        &[
-            "--raw",
-            "--full-index",
-            "--find-renames",
-            "-z",
-            &base_oid,
-            "--",
-        ],
-        MAX_INVENTORY_BYTES,
+        policy,
+        base_reference,
+        &base_oid,
+        &head_oid,
+        &index_path,
     )
     .await?;
-    let numstat = capture_diff(
-        work_dir,
-        &["--numstat", "--find-renames", "-z", &base_oid, "--"],
-        MAX_INVENTORY_BYTES,
-    )
-    .await?;
-    let committed = capture_diff(
-        work_dir,
-        &[
-            "--name-only",
-            "--find-renames",
-            "-z",
-            &base_oid,
-            "HEAD",
-            "--",
-        ],
-        MAX_INVENTORY_BYTES,
-    )
-    .await?;
-    let staged = capture_diff(
-        work_dir,
-        &[
-            "--cached",
-            "--name-only",
-            "--find-renames",
-            "-z",
-            "HEAD",
-            "--",
-        ],
-        MAX_INVENTORY_BYTES,
-    )
-    .await?;
-    let unstaged = capture_diff(
-        work_dir,
-        &["--name-only", "--find-renames", "-z", "--"],
-        MAX_INVENTORY_BYTES,
-    )
-    .await?;
-    let untracked = capture_git(
-        work_dir,
-        &["ls-files", "--others", "--exclude-standard", "-z", "--"],
-        MAX_INVENTORY_BYTES,
-    )
-    .await?;
-    let inventory_truncated = [
-        &final_raw, &numstat, &committed, &staged, &unstaged, &untracked,
-    ]
-    .iter()
-    .any(|capture| capture.truncated);
-    let mut raw_files = parse_raw_files(&final_raw.bytes);
-
-    let mut hasher = Sha256::new();
-    hasher.update(b"weaver-changes-v1\0");
-    hasher.update(base_oid.as_bytes());
-    hasher.update([0]);
-    hasher.update(head_oid.as_bytes());
-    hasher.update([0]);
-    hasher.update(&final_raw.bytes);
-    for capture in [&committed, &staged, &unstaged, &untracked] {
-        hasher.update([0]);
-        hasher.update(&capture.bytes);
-    }
-    let untracked_paths: Vec<Vec<u8>> = nul_records(&untracked.bytes)
-        .map(ToOwned::to_owned)
-        .collect();
-    let mut untracked_additions = BTreeMap::new();
-    if !inventory_truncated {
-        for file in raw_files
-            .iter()
-            .filter(|file| file.status != ChangeFileStatusDto::Deleted)
-        {
-            hash_path(work_dir, &file.path, &mut hasher).await?;
-        }
-        for path in &untracked_paths {
-            if let Some(lines) = hash_path(work_dir, path, &mut hasher).await? {
-                untracked_additions.insert(path.clone(), lines);
-            }
-        }
-    }
-    let version =
-        (!inventory_truncated).then(|| format!("changes-v1:{}", hex::encode(hasher.finalize())));
+    let mut raw_files = parse_raw_files(&state.final_raw.bytes);
 
     let patch = capture_diff(
         work_dir,
+        policy,
         &["--patch", "--find-renames", "--unified=3", &base_oid, "--"],
         MAX_PATCH_BYTES,
     )
     .await?;
     let mut sections = patch_sections(&patch.bytes);
-    let stats = parse_numstat(&numstat.bytes);
-    let committed = source_paths(&committed.bytes);
-    let staged = source_paths(&staged.bytes);
-    let unstaged = source_paths(&unstaged.bytes);
-    let untracked_set: BTreeSet<Vec<u8>> = untracked_paths.iter().cloned().collect();
+    let stats = parse_numstat(&state.numstat.bytes);
+    let committed = source_paths(&state.committed.bytes);
+    let staged = source_paths(&state.staged.bytes);
+    let unstaged = source_paths(&state.unstaged.bytes);
+    let untracked_set: BTreeSet<Vec<u8>> = state.untracked_paths.iter().cloned().collect();
 
-    for path in &untracked_paths {
+    for path in &state.untracked_paths {
         if !raw_files.iter().any(|file| file.path == *path) {
             raw_files.push(RawFile {
                 status: ChangeFileStatusDto::Untracked,
@@ -693,26 +978,74 @@ pub async fn load(work_dir: &Path, base_reference: &str) -> Result<ChangeSetDto>
         additions: stats
             .values()
             .filter_map(|stat| stat.additions)
-            .chain(untracked_additions.values().copied())
+            .chain(std::iter::once(state.untracked_additions))
             .sum(),
         deletions: stats.values().filter_map(|stat| stat.deletions).sum(),
-        truncated: numstat.truncated || inventory_truncated,
+        truncated: state.identity.is_none(),
     };
-    Ok(ChangeSetDto {
-        version,
+    let mut changes = ChangeSetDto {
+        version: None,
         base: ChangeBaseDto::Available {
             reference: base_reference.to_string(),
-            oid: base_oid,
+            oid: base_oid.clone(),
         },
-        head_oid: Some(head_oid),
+        head_oid: Some(head_oid.clone()),
         totals,
-        truncated: inventory_truncated
+        truncated: state.identity.is_none()
             || patch.truncated
             || raw_files.len() > MAX_FILES
             || remaining_total == 0,
         files,
         limits: limits(),
-    })
+    };
+    let Some(identity) = state.identity else {
+        return Ok((changes, true));
+    };
+
+    let post = capture_state(
+        work_dir,
+        policy,
+        base_reference,
+        &base_oid,
+        &head_oid,
+        &index_path,
+    )
+    .await?;
+    let head_after = git_text(work_dir, policy, &["rev-parse", "--verify", "HEAD"]).await?;
+    let base_after = git_text(work_dir, policy, &["rev-parse", "--verify", &base_spec]).await?;
+    let stable = post.identity == Some(identity)
+        && head_after.as_deref() == Some(head_oid.as_str())
+        && base_after.as_deref() == Some(base_tip.as_str());
+    if !stable {
+        changes.truncated = true;
+        changes.totals.truncated = true;
+        return Ok((changes, false));
+    }
+
+    let rendered = serde_json::to_vec(&changes).context("serializing stable change response")?;
+    let mut hasher = Sha256::new();
+    hash_record(&mut hasher, b"state-identity", &identity);
+    hash_record(&mut hasher, b"rendered-response", &rendered);
+    changes.version = Some(format!("changes-v1:{}", hex::encode(hasher.finalize())));
+    Ok((changes, true))
+}
+
+/// Read one session worktree without fetching or changing Git state.
+pub async fn load(work_dir: &Path, base_reference: &str) -> Result<ChangeSetDto> {
+    let policy = GitReadPolicy::load(work_dir).await?;
+    for attempt in 0..2 {
+        let (mut changes, stable) = load_once(work_dir, &policy, base_reference).await?;
+        if stable {
+            return Ok(changes);
+        }
+        if attempt == 1 {
+            changes.version = None;
+            changes.truncated = true;
+            changes.totals.truncated = true;
+            return Ok(changes);
+        }
+    }
+    unreachable!("bounded change read always returns or retries once")
 }
 
 /// Validate a mutable comment anchor against the exact snapshot on screen.
@@ -720,7 +1053,7 @@ pub fn validate_anchor(
     changes: &ChangeSetDto,
     version: &str,
     anchor: &ChangeAnchorDto,
-) -> Result<()> {
+) -> Result<ChangeAnchorDto> {
     if changes.version.as_deref() != Some(version) {
         bail!("change-set version moved; refresh before anchoring");
     }
@@ -733,32 +1066,54 @@ pub fn validate_anchor(
         .iter()
         .find(|file| decode_path(&file.path).ok().as_deref() == Some(identity.as_slice()))
         .context("change anchor path is not present in this version")?;
-    let mut expected = anchor.start_line;
-    for line in file.hunks.iter().flat_map(|hunk| &hunk.lines) {
-        let (number, allowed) = match anchor.side {
-            ChangeSideDto::Old => (
-                line.old_line,
-                matches!(
-                    line.kind,
-                    ChangeLineKindDto::Deletion | ChangeLineKindDto::Context
-                ),
-            ),
-            ChangeSideDto::New => (
-                line.new_line,
-                matches!(
-                    line.kind,
-                    ChangeLineKindDto::Addition | ChangeLineKindDto::Context
-                ),
-            ),
+    let count = (anchor.end_line - anchor.start_line + 1) as usize;
+    for hunk in &file.hunks {
+        let eligible: Vec<_> = hunk
+            .lines
+            .iter()
+            .filter(|line| line_number(line, anchor.side).is_some())
+            .collect();
+        let Some(first) = eligible
+            .iter()
+            .position(|line| line_number(line, anchor.side) == Some(anchor.start_line))
+        else {
+            continue;
         };
-        if allowed && number == Some(expected) {
-            expected += 1;
-            if expected > anchor.end_line {
-                return Ok(());
-            }
+        let Some(selected) = eligible.get(first..first.saturating_add(count)) else {
+            continue;
+        };
+        let contiguous = selected.iter().enumerate().all(|(offset, line)| {
+            let expected = anchor.start_line.checked_add(offset as u32);
+            line_number(line, anchor.side) == expected
+        });
+        if contiguous {
+            return Ok(ChangeAnchorDto {
+                path: file.path.clone(),
+                side: anchor.side,
+                start_line: anchor.start_line,
+                end_line: anchor.end_line,
+                hunk_header: hunk.header.clone(),
+                context_before: eligible[first.saturating_sub(2)..first]
+                    .iter()
+                    .map(|line| line.text.clone())
+                    .collect(),
+                selected: selected.iter().map(|line| line.text.clone()).collect(),
+                context_after: eligible[first + count..]
+                    .iter()
+                    .take(2)
+                    .map(|line| line.text.clone())
+                    .collect(),
+            });
         }
     }
     bail!("change anchor does not name a contiguous visible line range")
+}
+
+fn line_number(line: &ChangeLineDto, side: ChangeSideDto) -> Option<u32> {
+    match side {
+        ChangeSideDto::Old => line.old_line,
+        ChangeSideDto::New => line.new_line,
+    }
 }
 
 #[cfg(test)]
@@ -800,16 +1155,24 @@ mod tests {
             limits: limits(),
         };
         let anchor = ChangeAnchorDto {
-            path,
+            path: ChangePathDto {
+                bytes: path.bytes,
+                display: "spoofed.rs".to_string(),
+            },
             side: ChangeSideDto::New,
             start_line: 3,
             end_line: 4,
-            hunk_header: "@@ -2,2 +2,3 @@".to_string(),
-            context_before: vec![],
-            selected: vec!["new".to_string(), "next".to_string()],
-            context_after: vec![],
+            hunk_header: "@@ spoofed @@".to_string(),
+            context_before: vec!["spoofed before".to_string()],
+            selected: vec!["spoofed selection".to_string()],
+            context_after: vec!["spoofed after".to_string()],
         };
-        validate_anchor(&changes, "changes-v1:test", &anchor).unwrap();
+        let canonical = validate_anchor(&changes, "changes-v1:test", &anchor).unwrap();
+        assert_eq!(canonical.path.display, "src/a.rs");
+        assert_eq!(canonical.hunk_header, "@@ -2,2 +2,3 @@ fn main() {");
+        assert_eq!(canonical.context_before, vec!["same"]);
+        assert_eq!(canonical.selected, vec!["new", "next"]);
+        assert!(canonical.context_after.is_empty());
         let wrong_side = ChangeAnchorDto {
             side: ChangeSideDto::Old,
             ..anchor
@@ -835,5 +1198,39 @@ mod tests {
         assert!(hunks[0].truncated);
         assert!(hunks[0].lines[0].text.ends_with('…'));
         assert_eq!(hunks[0].lines.len(), 1);
+    }
+
+    #[test]
+    fn framed_identity_separates_cross_file_boundaries() {
+        fn legacy(files: &[(&[u8], &[u8])]) -> Vec<u8> {
+            let mut bytes = Vec::new();
+            for (path, content) in files {
+                bytes.extend_from_slice(path);
+                bytes.extend_from_slice(b"file\0");
+                bytes.extend_from_slice(content);
+            }
+            bytes
+        }
+
+        fn framed(files: &[(&[u8], &[u8])]) -> Vec<u8> {
+            let mut hasher = Sha256::new();
+            for (path, content) in files {
+                hash_record(&mut hasher, b"path", path);
+                hash_record(&mut hasher, b"kind", b"file");
+                hash_record(
+                    &mut hasher,
+                    b"content-length",
+                    &(content.len() as u64).to_be_bytes(),
+                );
+                hash_record(&mut hasher, b"file-chunk", content);
+            }
+            hasher.finalize().to_vec()
+        }
+
+        let combined = b"xbfile\0y";
+        let split = [(b"a".as_slice(), b"x".as_slice()), (b"b", b"y")];
+        let joined = [(b"a".as_slice(), combined.as_slice())];
+        assert_eq!(legacy(&split), legacy(&joined));
+        assert_ne!(framed(&split), framed(&joined));
     }
 }

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -12,6 +12,7 @@ pub mod auth;
 pub mod automation;
 pub mod backend;
 pub mod builtins;
+pub mod changes;
 pub mod chat;
 pub mod chatlog;
 pub mod client;

--- a/crates/loom/src/web/changes.rs
+++ b/crates/loom/src/web/changes.rs
@@ -1,0 +1,18 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use std::path::Path as FsPath;
+use weaver_api::ChangeSetDto;
+
+use super::{require_session, ApiResult, AppState};
+
+pub(super) async fn get_session_changes(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+) -> ApiResult<Json<ChangeSetDto>> {
+    let (session, branch) = require_session(&st.db, &key).await?;
+    Ok(Json(
+        crate::changes::load(FsPath::new(&session.work_dir), &branch.base_branch).await?,
+    ))
+}

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -71,6 +71,7 @@ mod artifacts;
 mod auth;
 mod automation;
 mod branches;
+mod changes;
 mod deployment;
 mod diagnostics;
 mod discussion;
@@ -95,6 +96,7 @@ use artifacts::*;
 use auth::*;
 use automation::*;
 use branches::*;
+use changes::*;
 use deployment::*;
 use diagnostics::*;
 use discussion::*;
@@ -745,6 +747,7 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{id}/history", get(session_history))
         .route("/sessions/{id}/history/search", get(search_session_history))
         .route("/sessions/{id}/files", get(list_session_files))
+        .route("/sessions/{id}/changes", get(get_session_changes))
         .route("/sessions/{id}/events", get(events_sse))
         .route("/sessions/{id}/terminal", get(crate::terminal::terminal_ws))
         // Per-session worktree debug shells: `shells` lists the live ones (so the

--- a/crates/loom/src/web/reviews.rs
+++ b/crates/loom/src/web/reviews.rs
@@ -485,7 +485,7 @@ async fn require_anchor(
             let changes =
                 crate::changes::load(std::path::Path::new(&session.work_dir), &branch.base_branch)
                     .await?;
-            crate::changes::validate_anchor(&changes, subject_version, anchor)
+            let anchor = crate::changes::validate_anchor(&changes, subject_version, anchor)
                 .map_err(|error| AppError::conflict(error.to_string()))?;
             Ok((
                 review::ReviewAnchor::Change(review::ChangeLineAnchor {

--- a/crates/loom/src/web/reviews.rs
+++ b/crates/loom/src/web/reviews.rs
@@ -6,8 +6,9 @@ use axum::{
 use serde::Deserialize;
 use serde_json::{json, Value};
 use weaver_api::{
-    AddReviewCommentReq, ArtifactTextAnchorDto, CreateReviewReq, ExpectedReviewRevisionReq,
-    ResolveReviewCommentReq, ReviewCommentDto, ReviewDto, ReviewSubjectDto, SubmitReviewReq,
+    AddReviewCommentReq, ArtifactTextAnchorDto, ChangeAnchorDto, CreateReviewReq,
+    ExpectedReviewRevisionReq, ResolveReviewCommentReq, ReviewAnchorDto, ReviewAnchorKindDto,
+    ReviewCommentDto, ReviewDto, ReviewSubjectDto, ReviewSubjectKindDto, SubmitReviewReq,
     UpdateReviewCommentReq, UpdateReviewReq,
 };
 use weaver_core::artifact::{self, Artifact};
@@ -22,7 +23,7 @@ use super::{require_session, ApiResult, AppError, AppState};
 
 #[derive(Debug, Deserialize)]
 pub(super) struct ReviewListQuery {
-    pub subject_kind: String,
+    pub subject_kind: ReviewSubjectKindDto,
     pub subject_key: String,
 }
 
@@ -39,16 +40,42 @@ fn require_operator(principal: &Principal) -> ApiResult<()> {
 
 fn comment_dto(comment: &review::ReviewComment) -> ReviewCommentDto {
     let anchor = comment.anchor();
+    let (anchor_kind, anchor) = match anchor {
+        review::ReviewAnchor::Text(anchor) => (
+            ReviewAnchorKindDto::Text,
+            ReviewAnchorDto::Text(ArtifactTextAnchorDto {
+                quote: anchor.quote,
+                prefix: anchor.prefix,
+                suffix: anchor.suffix,
+                block_index: anchor.block_index,
+            }),
+        ),
+        review::ReviewAnchor::Change(anchor) => (
+            ReviewAnchorKindDto::Change,
+            ReviewAnchorDto::Change(ChangeAnchorDto {
+                path: weaver_api::ChangePathDto {
+                    bytes: anchor.path_bytes,
+                    display: anchor.path_display,
+                },
+                side: if anchor.side == "old" {
+                    weaver_api::ChangeSideDto::Old
+                } else {
+                    weaver_api::ChangeSideDto::New
+                },
+                start_line: anchor.start_line,
+                end_line: anchor.end_line,
+                hunk_header: anchor.hunk_header,
+                context_before: anchor.context_before,
+                selected: anchor.selected,
+                context_after: anchor.context_after,
+            }),
+        ),
+    };
     ReviewCommentDto {
         id: comment.id,
         subject_version: comment.subject_version.clone(),
-        anchor_kind: comment.anchor_kind.clone(),
-        anchor: ArtifactTextAnchorDto {
-            quote: anchor.quote,
-            prefix: anchor.prefix,
-            suffix: anchor.suffix,
-            block_index: anchor.block_index,
-        },
+        anchor_kind,
+        anchor,
         body: comment.body.clone(),
         status: comment.status.clone(),
         created_at: comment.created_at.clone(),
@@ -66,7 +93,11 @@ fn review_dto(review: &review::Review, current_version: &str) -> ReviewDto {
         id: review.id,
         session_id: review.session_id.clone(),
         subject: ReviewSubjectDto {
-            kind: review.subject_kind.clone(),
+            kind: if review.subject_kind == "changes" {
+                ReviewSubjectKindDto::Changes
+            } else {
+                ReviewSubjectKindDto::Artifact
+            },
             id: review.subject_id.clone(),
             key: review.subject_key.clone(),
             label: review.subject_label.clone(),
@@ -92,16 +123,37 @@ fn review_dto(review: &review::Review, current_version: &str) -> ReviewDto {
 }
 
 async fn durable_review_dto(st: &AppState, item: &review::Review) -> ApiResult<ReviewDto> {
-    let artifact_id = item
-        .subject_id
-        .parse::<i64>()
-        .map_err(|_| AppError::bad_request("invalid artifact review subject"))?;
-    let current_version = artifact::get_by_id(&st.db, artifact_id)
+    let current_version = current_review_version(st, item)
         .await?
-        .filter(|artifact| artifact.repo_root == item.repo_root)
-        .map(|artifact| artifact.rev.to_string())
         .unwrap_or_else(|| item.subject_version.clone());
     Ok(review_dto(item, &current_version))
+}
+
+async fn current_review_version(st: &AppState, item: &review::Review) -> ApiResult<Option<String>> {
+    match item.subject_kind.as_str() {
+        "artifact" => {
+            let artifact_id = item
+                .subject_id
+                .parse::<i64>()
+                .map_err(|_| AppError::bad_request("invalid artifact review subject"))?;
+            Ok(artifact::get_by_id(&st.db, artifact_id)
+                .await?
+                .filter(|artifact| artifact.repo_root == item.repo_root)
+                .map(|artifact| artifact.rev.to_string()))
+        }
+        "changes" => {
+            let (session, branch) = require_session(&st.db, &item.session_id).await?;
+            if item.subject_id != branch.id {
+                return Err(AppError::bad_request("invalid changes review subject"));
+            }
+            Ok(
+                crate::changes::load(std::path::Path::new(&session.work_dir), &branch.base_branch)
+                    .await?
+                    .version,
+            )
+        }
+        _ => Err(AppError::bad_request("unsupported review subject kind")),
+    }
 }
 
 fn legacy_review_dto(
@@ -115,13 +167,13 @@ fn legacy_review_dto(
         .map(|comment| ReviewCommentDto {
             id: -(thread.id.saturating_mul(10_000) + comment.seq),
             subject_version: thread.base_rev.to_string(),
-            anchor_kind: "text".to_string(),
-            anchor: ArtifactTextAnchorDto {
+            anchor_kind: ReviewAnchorKindDto::Text,
+            anchor: ReviewAnchorDto::Text(ArtifactTextAnchorDto {
                 quote: thread.anchor_quote.clone(),
                 prefix: thread.anchor_prefix.clone(),
                 suffix: thread.anchor_suffix.clone(),
                 block_index: None,
-            },
+            }),
             body: comment.body.clone(),
             status: thread.status.clone(),
             created_at: comment.created_at.clone(),
@@ -132,7 +184,7 @@ fn legacy_review_dto(
         id: -thread.id,
         session_id: session_id.to_string(),
         subject: ReviewSubjectDto {
-            kind: "artifact".to_string(),
+            kind: ReviewSubjectKindDto::Artifact,
             id: artifact.id.to_string(),
             key: artifact.name.clone(),
             label: artifact.name.clone(),
@@ -214,14 +266,33 @@ async fn list_for(
     branch: &Branch,
     q: &ReviewListQuery,
 ) -> ApiResult<Vec<ReviewDto>> {
-    if q.subject_kind != "artifact" {
-        return Err(AppError::bad_request(
-            "only artifact reviews are supported in this release",
-        ));
-    }
-    let artifact = artifact::get(&st.db, &branch.repo_root, &branch.id, &q.subject_key)
-        .await?
-        .ok_or_else(|| AppError::not_found("artifact"))?;
+    let (subject_kind, subject_id, current_version) = match q.subject_kind {
+        ReviewSubjectKindDto::Artifact => {
+            let artifact = artifact::get(&st.db, &branch.repo_root, &branch.id, &q.subject_key)
+                .await?
+                .ok_or_else(|| AppError::not_found("artifact"))?;
+            (
+                "artifact",
+                artifact.id.to_string(),
+                artifact.rev.to_string(),
+            )
+        }
+        ReviewSubjectKindDto::Changes => {
+            if q.subject_key != "changes" {
+                return Err(AppError::bad_request(
+                    "changes review subject_key must be 'changes'",
+                ));
+            }
+            let changes =
+                crate::changes::load(std::path::Path::new(&session.work_dir), &branch.base_branch)
+                    .await?;
+            (
+                "changes",
+                branch.id.clone(),
+                changes.version.unwrap_or_default(),
+            )
+        }
+    };
     // Session-scoped agent grants may inspect submitted compatibility feedback,
     // but never inherit their operator owner's private draft merely because the
     // username is the same.
@@ -234,17 +305,25 @@ async fn list_for(
         &st.db,
         &branch.id,
         &session.id,
-        "artifact",
-        &artifact.id.to_string(),
+        subject_kind,
+        &subject_id,
         viewer,
     )
     .await?;
     let mut out: Vec<ReviewDto> = reviews
         .iter()
-        .map(|item| review_dto(item, &artifact.rev.to_string()))
+        .map(|item| review_dto(item, &current_version))
         .collect();
-    for thread in discussion::list_for_artifact(&st.db, artifact.id, true).await? {
-        out.push(legacy_review_dto(&thread, &session.id, &artifact));
+    if q.subject_kind == ReviewSubjectKindDto::Artifact {
+        let artifact_id = subject_id
+            .parse()
+            .map_err(|_| AppError::bad_request("invalid artifact subject"))?;
+        let artifact = artifact::get_by_id(&st.db, artifact_id)
+            .await?
+            .ok_or_else(|| AppError::not_found("artifact"))?;
+        for thread in discussion::list_for_artifact(&st.db, artifact.id, true).await? {
+            out.push(legacy_review_dto(&thread, &session.id, &artifact));
+        }
     }
     Ok(out)
 }
@@ -269,29 +348,65 @@ async fn create_for(
     body: &CreateReviewReq,
 ) -> ApiResult<ReviewDto> {
     require_operator(principal)?;
-    if body.subject_kind != "artifact" {
-        return Err(AppError::bad_request(
-            "only artifact reviews are supported in this release",
-        ));
-    }
-    let (artifact, subject_version) =
-        artifact_subject(st, branch, &body.subject_key, &body.subject_version).await?;
+    let (subject_kind, subject_id, subject_key, subject_label, subject_version, current_version) =
+        match body.subject_kind {
+            ReviewSubjectKindDto::Artifact => {
+                let (artifact, subject_version) =
+                    artifact_subject(st, branch, &body.subject_key, &body.subject_version).await?;
+                (
+                    "artifact",
+                    artifact.id.to_string(),
+                    artifact.name.clone(),
+                    artifact.name,
+                    subject_version,
+                    artifact.rev.to_string(),
+                )
+            }
+            ReviewSubjectKindDto::Changes => {
+                if body.subject_key != "changes" {
+                    return Err(AppError::bad_request(
+                        "changes review subject_key must be 'changes'",
+                    ));
+                }
+                let changes = crate::changes::load(
+                    std::path::Path::new(&session.work_dir),
+                    &branch.base_branch,
+                )
+                .await?;
+                let version = changes.version.ok_or_else(|| {
+                    AppError::conflict("changes are unavailable until the branch base resolves")
+                })?;
+                if body.subject_version != version {
+                    return Err(AppError::conflict(
+                        "change-set version moved; refresh before starting a review",
+                    ));
+                }
+                (
+                    "changes",
+                    branch.id.clone(),
+                    "changes".to_string(),
+                    "Changes".to_string(),
+                    version.clone(),
+                    version,
+                )
+            }
+        };
     let review = review::get_or_create(
         &st.db,
         &review::NewReview {
             repo_root: &branch.repo_root,
             branch_id: &branch.id,
             session_id: &session.id,
-            subject_kind: "artifact",
-            subject_id: &artifact.id.to_string(),
-            subject_key: &artifact.name,
-            subject_label: &artifact.name,
+            subject_kind,
+            subject_id: &subject_id,
+            subject_key: &subject_key,
+            subject_label: &subject_label,
             subject_version: &subject_version,
             created_by: &principal.username,
         },
     )
     .await?;
-    Ok(review_dto(&review, &artifact.rev.to_string()))
+    Ok(review_dto(&review, &current_version))
 }
 
 pub(super) async fn create_session_review(
@@ -343,22 +458,61 @@ pub(super) async fn get_review(
     Ok(Json(durable_review_dto(&st, &item).await?))
 }
 
-fn text_anchor(anchor: &ArtifactTextAnchorDto) -> review::ArtifactTextAnchor {
-    review::ArtifactTextAnchor {
-        quote: anchor.quote.clone(),
-        prefix: anchor.prefix.clone(),
-        suffix: anchor.suffix.clone(),
-        block_index: anchor.block_index,
-    }
-}
-
-fn require_text_anchor_kind(kind: &str) -> ApiResult<()> {
-    if kind == "text" {
-        Ok(())
-    } else {
-        Err(AppError::bad_request(
-            "artifact review anchor_kind must be 'text'",
-        ))
+async fn require_anchor(
+    st: &AppState,
+    item: &review::Review,
+    subject_version: &str,
+    kind: ReviewAnchorKindDto,
+    anchor: &ReviewAnchorDto,
+) -> ApiResult<(review::ReviewAnchor, String)> {
+    match (item.subject_kind.as_str(), kind, anchor) {
+        ("artifact", ReviewAnchorKindDto::Text, ReviewAnchorDto::Text(anchor)) => {
+            let artifact = review_artifact(st, item).await?;
+            let version =
+                require_artifact_version(st, &artifact, subject_version, "comment").await?;
+            Ok((
+                review::ReviewAnchor::Text(review::ArtifactTextAnchor {
+                    quote: anchor.quote.clone(),
+                    prefix: anchor.prefix.clone(),
+                    suffix: anchor.suffix.clone(),
+                    block_index: anchor.block_index,
+                }),
+                version,
+            ))
+        }
+        ("changes", ReviewAnchorKindDto::Change, ReviewAnchorDto::Change(anchor)) => {
+            let (session, branch) = require_session(&st.db, &item.session_id).await?;
+            let changes =
+                crate::changes::load(std::path::Path::new(&session.work_dir), &branch.base_branch)
+                    .await?;
+            crate::changes::validate_anchor(&changes, subject_version, anchor)
+                .map_err(|error| AppError::conflict(error.to_string()))?;
+            Ok((
+                review::ReviewAnchor::Change(review::ChangeLineAnchor {
+                    path_bytes: anchor.path.bytes.clone(),
+                    path_display: anchor.path.display.clone(),
+                    side: match anchor.side {
+                        weaver_api::ChangeSideDto::Old => "old",
+                        weaver_api::ChangeSideDto::New => "new",
+                    }
+                    .to_string(),
+                    start_line: anchor.start_line,
+                    end_line: anchor.end_line,
+                    hunk_header: anchor.hunk_header.clone(),
+                    context_before: anchor.context_before.clone(),
+                    selected: anchor.selected.clone(),
+                    context_after: anchor.context_after.clone(),
+                }),
+                subject_version.to_string(),
+            ))
+        }
+        ("artifact", _, _) => Err(AppError::bad_request(
+            "artifact reviews require a text anchor",
+        )),
+        ("changes", _, _) => Err(AppError::bad_request(
+            "changes reviews require a change anchor",
+        )),
+        _ => Err(AppError::bad_request("unsupported review subject kind")),
     }
 }
 
@@ -376,10 +530,12 @@ async fn draft_mutation_error(
             .contains("draft changed while applying the mutation");
     if drift {
         let fresh = match review::get(&st.db, item.id).await {
-            Ok(Some(fresh)) => match review_artifact(st, &fresh).await {
-                Ok(artifact) => serde_json::to_value(review_dto(&fresh, &artifact.rev.to_string()))
-                    .unwrap_or(Value::Null),
+            Ok(Some(fresh)) => match current_review_version(st, &fresh).await {
+                Ok(Some(current)) => {
+                    serde_json::to_value(review_dto(&fresh, &current)).unwrap_or(Value::Null)
+                }
                 Err(_) => Value::Null,
+                Ok(None) => Value::Null,
             },
             _ => Value::Null,
         };
@@ -389,11 +545,9 @@ async fn draft_mutation_error(
 }
 
 async fn submitted_draft_conflict(st: &AppState, item: &review::Review) -> AppError {
-    let artifact = review_artifact(st, item).await.ok();
-    let fresh = artifact
-        .map(|artifact| {
-            serde_json::to_value(review_dto(item, &artifact.rev.to_string())).unwrap_or(Value::Null)
-        })
+    let current = current_review_version(st, item).await.ok().flatten();
+    let fresh = current
+        .map(|current| serde_json::to_value(review_dto(item, &current)).unwrap_or(Value::Null))
         .unwrap_or(Value::Null);
     AppError::conflict("submitted reviews are immutable").with_details(json!({ "review": fresh }))
 }
@@ -408,10 +562,14 @@ pub(super) async fn add_review_comment(
     if item.status != "draft" {
         return Err(submitted_draft_conflict(&st, &item).await);
     }
-    let artifact = review_artifact(&st, &item).await?;
-    let subject_version =
-        require_artifact_version(&st, &artifact, &body.subject_version, "comment").await?;
-    require_text_anchor_kind(&body.anchor_kind)?;
+    let (anchor, subject_version) = require_anchor(
+        &st,
+        &item,
+        &body.subject_version,
+        body.anchor_kind,
+        &body.anchor,
+    )
+    .await?;
     let updated = match review::add_comment(
         &st.db,
         item.id,
@@ -419,7 +577,7 @@ pub(super) async fn add_review_comment(
         body.expected_revision,
         &review::NewComment {
             subject_version: &subject_version,
-            anchor: &text_anchor(&body.anchor),
+            anchor: &anchor,
             body: &body.body,
         },
     )
@@ -428,7 +586,10 @@ pub(super) async fn add_review_comment(
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    Ok(Json(review_dto(&updated, &artifact.rev.to_string())))
+    let current = current_review_version(&st, &updated)
+        .await?
+        .unwrap_or_else(|| updated.subject_version.clone());
+    Ok(Json(review_dto(&updated, &current)))
 }
 
 pub(super) async fn update_review_comment(
@@ -441,15 +602,6 @@ pub(super) async fn update_review_comment(
     if item.status != "draft" {
         return Err(submitted_draft_conflict(&st, &item).await);
     }
-    let subject_version = if let Some(version) = &body.subject_version {
-        let artifact = review_artifact(&st, &item).await?;
-        Some(require_artifact_version(&st, &artifact, version, "comment").await?)
-    } else {
-        None
-    };
-    if let Some(kind) = &body.anchor_kind {
-        require_text_anchor_kind(kind)?;
-    }
     if body.body.is_none() && body.subject_version.is_none() && body.anchor.is_none() {
         return Err(AppError::bad_request("comment update is empty"));
     }
@@ -458,12 +610,26 @@ pub(super) async fn update_review_comment(
             "a replacement anchor is required when changing comment revision",
         ));
     }
-    if body.anchor.is_some() && body.anchor_kind.as_deref() != Some("text") {
+    if body.anchor.is_some() && body.anchor_kind.is_none() {
         return Err(AppError::bad_request(
-            "anchor_kind 'text' is required when replacing an anchor",
+            "anchor_kind is required when replacing an anchor",
         ));
     }
-    let anchor = body.anchor.as_ref().map(text_anchor);
+    let replacement = match (
+        body.subject_version.as_deref(),
+        body.anchor_kind,
+        body.anchor.as_ref(),
+    ) {
+        (Some(version), Some(kind), Some(anchor)) => {
+            Some(require_anchor(&st, &item, version, kind, anchor).await?)
+        }
+        (None, None, None) => None,
+        _ => {
+            return Err(AppError::bad_request(
+                "subject_version, anchor_kind, and anchor must be replaced together",
+            ))
+        }
+    };
     let updated = match review::patch_comment(
         &st.db,
         item.id,
@@ -471,8 +637,8 @@ pub(super) async fn update_review_comment(
         &principal.username,
         body.expected_revision,
         &review::CommentPatch {
-            subject_version: subject_version.as_deref(),
-            anchor: anchor.as_ref(),
+            subject_version: replacement.as_ref().map(|(_, version)| version.as_str()),
+            anchor: replacement.as_ref().map(|(anchor, _)| anchor),
             body: body.body.as_deref(),
         },
     )
@@ -481,8 +647,10 @@ pub(super) async fn update_review_comment(
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    let artifact = review_artifact(&st, &updated).await?;
-    Ok(Json(review_dto(&updated, &artifact.rev.to_string())))
+    let current = current_review_version(&st, &updated)
+        .await?
+        .unwrap_or_else(|| updated.subject_version.clone());
+    Ok(Json(review_dto(&updated, &current)))
 }
 
 pub(super) async fn delete_review_comment(
@@ -507,8 +675,10 @@ pub(super) async fn delete_review_comment(
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    let artifact = review_artifact(&st, &updated).await?;
-    Ok(Json(review_dto(&updated, &artifact.rev.to_string())))
+    let current = current_review_version(&st, &updated)
+        .await?
+        .unwrap_or_else(|| updated.subject_version.clone());
+    Ok(Json(review_dto(&updated, &current)))
 }
 
 pub(super) async fn resolve_review_comment(
@@ -547,9 +717,22 @@ pub(super) async fn update_review(
     if item.status != "draft" {
         return Err(submitted_draft_conflict(&st, &item).await);
     }
-    let artifact = review_artifact(&st, &item).await?;
     let subject_version = match &body.subject_version {
-        Some(version) => Some(require_artifact_version(&st, &artifact, version, "review").await?),
+        Some(version) if item.subject_kind == "artifact" => {
+            let artifact = review_artifact(&st, &item).await?;
+            Some(require_artifact_version(&st, &artifact, version, "review").await?)
+        }
+        Some(version) => {
+            let current = current_review_version(&st, &item)
+                .await?
+                .ok_or_else(|| AppError::conflict("current change-set version is unavailable"))?;
+            if version != &current {
+                return Err(AppError::conflict(
+                    "change-set version moved; refresh before retargeting",
+                ));
+            }
+            Some(current)
+        }
         None => None,
     };
     let updated = match review::update_draft(
@@ -567,7 +750,10 @@ pub(super) async fn update_review(
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    Ok(Json(review_dto(&updated, &artifact.rev.to_string())))
+    let current = current_review_version(&st, &updated)
+        .await?
+        .unwrap_or_else(|| updated.subject_version.clone());
+    Ok(Json(review_dto(&updated, &current)))
 }
 
 pub(super) async fn discard_review(
@@ -598,19 +784,35 @@ pub(super) async fn retarget_review_to_current(
     if item.status != "draft" {
         return Err(submitted_draft_conflict(&st, &item).await);
     }
-    let updated = match review::retarget_draft_to_current(
-        &st.db,
-        item.id,
-        &principal.username,
-        body.expected_revision,
-    )
-    .await
-    {
+    let current = current_review_version(&st, &item)
+        .await?
+        .ok_or_else(|| AppError::conflict("current review subject is unavailable"))?;
+    let result = if item.subject_kind == "artifact" {
+        review::retarget_draft_to_current(
+            &st.db,
+            item.id,
+            &principal.username,
+            body.expected_revision,
+        )
+        .await
+    } else {
+        review::update_draft(
+            &st.db,
+            item.id,
+            &principal.username,
+            body.expected_revision,
+            &review::DraftPatch {
+                summary: None,
+                subject_version: Some(&current),
+            },
+        )
+        .await
+    };
+    let updated = match result {
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    let artifact = review_artifact(&st, &updated).await?;
-    Ok(Json(review_dto(&updated, &artifact.rev.to_string())))
+    Ok(Json(review_dto(&updated, &current)))
 }
 
 pub(super) async fn submit_review(
@@ -620,15 +822,31 @@ pub(super) async fn submit_review(
     Json(body): Json<SubmitReviewReq>,
 ) -> ApiResult<Json<ReviewDto>> {
     let item = creator_review(&st, &principal, review_id).await?;
-    let submission = match review::submit(
-        &st.db,
-        item.id,
-        &principal.username,
-        body.expected_revision,
-        body.acknowledge_outdated,
-    )
-    .await
-    {
+    let current = current_review_version(&st, &item).await?;
+    let result = if item.subject_kind == "changes" {
+        let current = current
+            .as_deref()
+            .ok_or_else(|| AppError::conflict("current change-set version is unavailable"))?;
+        review::submit_at_version(
+            &st.db,
+            item.id,
+            &principal.username,
+            body.expected_revision,
+            body.acknowledge_outdated,
+            current,
+        )
+        .await
+    } else {
+        review::submit(
+            &st.db,
+            item.id,
+            &principal.username,
+            body.expected_revision,
+            body.acknowledge_outdated,
+        )
+        .await
+    };
+    let submission = match result {
         Ok(submission) => submission,
         Err(error) => {
             if error
@@ -636,9 +854,11 @@ pub(super) async fn submit_review(
                 .contains("acknowledge the reviewed revision")
             {
                 let fresh = review::get(&st.db, item.id).await?.unwrap_or(item);
-                let artifact = review_artifact(&st, &fresh).await?;
+                let current = current_review_version(&st, &fresh)
+                    .await?
+                    .unwrap_or_else(|| fresh.subject_version.clone());
                 return Err(AppError::conflict(error.to_string()).with_details(json!({
-                    "review": review_dto(&fresh, &artifact.rev.to_string()),
+                    "review": review_dto(&fresh, &current),
                 })));
             }
             return Err(draft_mutation_error(&st, &item, error).await);
@@ -653,8 +873,10 @@ pub(super) async fn submit_review(
     let refreshed = review::get(&st.db, item.id)
         .await?
         .ok_or_else(|| AppError::not_found("review"))?;
-    let artifact = review_artifact(&st, &refreshed).await?;
-    Ok(Json(review_dto(&refreshed, &artifact.rev.to_string())))
+    let current = current_review_version(&st, &refreshed)
+        .await?
+        .unwrap_or_else(|| refreshed.subject_version.clone());
+    Ok(Json(review_dto(&refreshed, &current)))
 }
 
 pub(super) async fn retry_review_delivery(

--- a/crates/loom/src/web/reviews.rs
+++ b/crates/loom/src/web/reviews.rs
@@ -586,10 +586,7 @@ pub(super) async fn add_review_comment(
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    let current = current_review_version(&st, &updated)
-        .await?
-        .unwrap_or_else(|| updated.subject_version.clone());
-    Ok(Json(review_dto(&updated, &current)))
+    Ok(Json(durable_review_dto(&st, &updated).await?))
 }
 
 pub(super) async fn update_review_comment(
@@ -647,10 +644,7 @@ pub(super) async fn update_review_comment(
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    let current = current_review_version(&st, &updated)
-        .await?
-        .unwrap_or_else(|| updated.subject_version.clone());
-    Ok(Json(review_dto(&updated, &current)))
+    Ok(Json(durable_review_dto(&st, &updated).await?))
 }
 
 pub(super) async fn delete_review_comment(
@@ -675,10 +669,7 @@ pub(super) async fn delete_review_comment(
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    let current = current_review_version(&st, &updated)
-        .await?
-        .unwrap_or_else(|| updated.subject_version.clone());
-    Ok(Json(review_dto(&updated, &current)))
+    Ok(Json(durable_review_dto(&st, &updated).await?))
 }
 
 pub(super) async fn resolve_review_comment(
@@ -750,10 +741,7 @@ pub(super) async fn update_review(
         Ok(updated) => updated,
         Err(error) => return Err(draft_mutation_error(&st, &item, error).await),
     };
-    let current = current_review_version(&st, &updated)
-        .await?
-        .unwrap_or_else(|| updated.subject_version.clone());
-    Ok(Json(review_dto(&updated, &current)))
+    Ok(Json(durable_review_dto(&st, &updated).await?))
 }
 
 pub(super) async fn discard_review(
@@ -873,10 +861,7 @@ pub(super) async fn submit_review(
     let refreshed = review::get(&st.db, item.id)
         .await?
         .ok_or_else(|| AppError::not_found("review"))?;
-    let current = current_review_version(&st, &refreshed)
-        .await?
-        .unwrap_or_else(|| refreshed.subject_version.clone());
-    Ok(Json(review_dto(&refreshed, &current)))
+    Ok(Json(durable_review_dto(&st, &refreshed).await?))
 }
 
 pub(super) async fn retry_review_delivery(

--- a/crates/loom/tests/integration/reviews.rs
+++ b/crates/loom/tests/integration/reviews.rs
@@ -565,9 +565,10 @@ async fn api_and_cli_share_the_private_optimistic_review_contract() {
         )
         .await
         .unwrap();
-    assert!(submitted
-        .message
-        .contains("\"path_bytes\":\"UkVBRE1FLm1k\""));
+    let ReviewAnchorDto::Change(anchor) = &submitted.comments[0].anchor else {
+        panic!("submitted changes review lost its typed anchor");
+    };
+    assert_eq!(anchor.path, readme.path);
     assert_eq!(submitted.delivery_state, "queued");
 }
 

--- a/crates/loom/tests/integration/reviews.rs
+++ b/crates/loom/tests/integration/reviews.rs
@@ -10,8 +10,9 @@ use serial_test::serial;
 use std::{process::Output, time::Duration};
 use tokio::process::Command;
 use weaver_api::{
-    AddReviewCommentReq, ArtifactTextAnchorDto, ArtifactUpsertReq, CreateReq, CreateReviewReq,
-    SubmitReviewReq, UpdateReviewCommentReq, UpdateReviewReq,
+    AddReviewCommentReq, ArtifactTextAnchorDto, ArtifactUpsertReq, ChangeAnchorDto, ChangeSideDto,
+    ChangeSourceDto, CreateReq, CreateReviewReq, ReviewAnchorDto, ReviewAnchorKindDto,
+    ReviewSubjectKindDto, SubmitReviewReq, UpdateReviewCommentReq, UpdateReviewReq,
 };
 
 use super::fixtures::TestServer;
@@ -65,7 +66,7 @@ async fn seed_artifact(ts: &TestServer, session: &weaver_api::SessionView) {
 
 fn new_review(version: &str) -> CreateReviewReq {
     CreateReviewReq {
-        subject_kind: "artifact".to_string(),
+        subject_kind: ReviewSubjectKindDto::Artifact,
         subject_key: "design".to_string(),
         subject_version: version.to_string(),
     }
@@ -75,13 +76,13 @@ fn comment(expected_revision: i64, version: &str, body: &str) -> AddReviewCommen
     AddReviewCommentReq {
         expected_revision,
         subject_version: version.to_string(),
-        anchor_kind: "text".to_string(),
-        anchor: ArtifactTextAnchorDto {
+        anchor_kind: ReviewAnchorKindDto::Text,
+        anchor: ReviewAnchorDto::Text(ArtifactTextAnchorDto {
             quote: "beta".to_string(),
             prefix: "Alpha ".to_string(),
             suffix: " gamma".to_string(),
             block_index: Some(1),
-        },
+        }),
         body: body.to_string(),
     }
 }
@@ -135,7 +136,19 @@ fn assert_cli_ok(output: &Output) {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn api_and_cli_share_the_private_optimistic_review_contract() {
-    let ts = TestServer::start_api_only().await;
+    let ts = TestServer::start().await;
+    super::fixtures::sh(ts.repo_path(), "git", &["switch", "-c", "weaver/reviewapi"]);
+    std::fs::write(ts.repo_path().join("committed.txt"), "committed\n").unwrap();
+    super::fixtures::sh(ts.repo_path(), "git", &["add", "committed.txt"]);
+    super::fixtures::sh(ts.repo_path(), "git", &["commit", "-m", "branch change"]);
+    std::fs::write(ts.repo_path().join("README.md"), "hello\nstaged\n").unwrap();
+    super::fixtures::sh(ts.repo_path(), "git", &["add", "README.md"]);
+    std::fs::write(
+        ts.repo_path().join("README.md"),
+        "hello\nstaged\nunstaged\n",
+    )
+    .unwrap();
+    std::fs::write(ts.repo_path().join("untracked.txt"), "untracked\n").unwrap();
     let session = insert_api_session(&ts, "reviewapi").await;
     seed_artifact(&ts, &session).await;
 
@@ -270,13 +283,13 @@ async fn api_and_cli_share_the_private_optimistic_review_contract() {
             &UpdateReviewCommentReq {
                 expected_revision: added.draft_revision,
                 subject_version: Some("02".to_string()),
-                anchor_kind: Some("text".to_string()),
-                anchor: Some(ArtifactTextAnchorDto {
+                anchor_kind: Some(ReviewAnchorKindDto::Text),
+                anchor: Some(ReviewAnchorDto::Text(ArtifactTextAnchorDto {
                     quote: "beta gamma, revised".to_string(),
                     prefix: "Alpha ".to_string(),
                     suffix: ".".to_string(),
                     block_index: Some(1),
-                }),
+                })),
                 body: None,
             },
         )
@@ -458,6 +471,104 @@ async fn api_and_cli_share_the_private_optimistic_review_contract() {
     assert_eq!(shown["comments"][0]["anchor"]["prefix"], "# Design\n\n");
     assert_eq!(shown["comments"][0]["anchor"]["suffix"], " revision.");
     assert_eq!(shown["comments"][0]["body"], "CLI anchored body");
+
+    let changes = ts.client.changes(&session.id).await.unwrap();
+    let version = changes.version.clone().unwrap();
+    let readme = changes
+        .files
+        .iter()
+        .find(|file| file.path.display == "README.md")
+        .unwrap();
+    assert_eq!(
+        readme.sources,
+        vec![ChangeSourceDto::Staged, ChangeSourceDto::Unstaged]
+    );
+    assert!(changes.files.iter().any(|file| {
+        file.path.display == "committed.txt" && file.sources == vec![ChangeSourceDto::Committed]
+    }));
+    assert!(changes.files.iter().any(|file| {
+        file.path.display == "untracked.txt" && file.sources == vec![ChangeSourceDto::Untracked]
+    }));
+    let cli_changes = loom_review_cli(&ts, &["session", "changes", &session.id]).await;
+    assert_cli_ok(&cli_changes);
+    let cli_changes: weaver_api::ChangeSetDto =
+        serde_json::from_slice(&cli_changes.stdout).unwrap();
+    assert_eq!(cli_changes.version.as_deref(), Some(version.as_str()));
+
+    let line = readme
+        .hunks
+        .iter()
+        .flat_map(|hunk| &hunk.lines)
+        .find(|line| line.new_line == Some(2))
+        .unwrap();
+    let change_draft = ts
+        .client
+        .create_session_review(
+            &session.id,
+            &CreateReviewReq {
+                subject_kind: ReviewSubjectKindDto::Changes,
+                subject_key: "changes".to_string(),
+                subject_version: version.clone(),
+            },
+        )
+        .await
+        .unwrap();
+    let change_draft = ts
+        .client
+        .add_review_comment(
+            change_draft.id,
+            &AddReviewCommentReq {
+                expected_revision: change_draft.draft_revision,
+                subject_version: version,
+                anchor_kind: ReviewAnchorKindDto::Change,
+                anchor: ReviewAnchorDto::Change(ChangeAnchorDto {
+                    path: readme.path.clone(),
+                    side: ChangeSideDto::New,
+                    start_line: 2,
+                    end_line: 2,
+                    hunk_header: readme.hunks[0].header.clone(),
+                    context_before: vec!["hello".to_string()],
+                    selected: vec![line.text.clone()],
+                    context_after: vec!["unstaged".to_string()],
+                }),
+                body: "Explain this staged line.".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    std::fs::write(
+        ts.repo_path().join("README.md"),
+        "hello\nstaged\nunstaged\nmoved\n",
+    )
+    .unwrap();
+    assert!(ts
+        .client
+        .submit_review(
+            change_draft.id,
+            &SubmitReviewReq {
+                expected_revision: change_draft.draft_revision,
+                acknowledge_outdated: false,
+            },
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("outdated"));
+    let submitted = ts
+        .client
+        .submit_review(
+            change_draft.id,
+            &SubmitReviewReq {
+                expected_revision: change_draft.draft_revision,
+                acknowledge_outdated: true,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(submitted
+        .message
+        .contains("\"path_bytes\":\"UkVBRE1FLm1k\""));
+    assert_eq!(submitted.delivery_state, "queued");
 }
 
 async fn poll_review_turn(ts: &TestServer, session_id: &str, payload: &str) -> Value {

--- a/crates/loom/tests/integration/reviews.rs
+++ b/crates/loom/tests/integration/reviews.rs
@@ -7,6 +7,7 @@
 use reqwest::StatusCode;
 use serde_json::{json, Value};
 use serial_test::serial;
+use std::os::unix::fs::MetadataExt;
 use std::{process::Output, time::Duration};
 use tokio::process::Command;
 use weaver_api::{
@@ -472,6 +473,9 @@ async fn api_and_cli_share_the_private_optimistic_review_contract() {
     assert_eq!(shown["comments"][0]["anchor"]["suffix"], " revision.");
     assert_eq!(shown["comments"][0]["body"], "CLI anchored body");
 
+    let index_path = ts.repo_path().join(".git/index");
+    let index_before = std::fs::read(&index_path).unwrap();
+    let index_stat_before = std::fs::metadata(&index_path).unwrap();
     let changes = ts.client.changes(&session.id).await.unwrap();
     let version = changes.version.clone().unwrap();
     let readme = changes
@@ -494,6 +498,31 @@ async fn api_and_cli_share_the_private_optimistic_review_contract() {
     let cli_changes: weaver_api::ChangeSetDto =
         serde_json::from_slice(&cli_changes.stdout).unwrap();
     assert_eq!(cli_changes.version.as_deref(), Some(version.as_str()));
+    let index_stat_after = std::fs::metadata(&index_path).unwrap();
+    assert_eq!(std::fs::read(&index_path).unwrap(), index_before);
+    assert_eq!(
+        (
+            index_stat_after.dev(),
+            index_stat_after.ino(),
+            index_stat_after.mode(),
+            index_stat_after.len(),
+            index_stat_after.mtime(),
+            index_stat_after.mtime_nsec(),
+            index_stat_after.ctime(),
+            index_stat_after.ctime_nsec(),
+        ),
+        (
+            index_stat_before.dev(),
+            index_stat_before.ino(),
+            index_stat_before.mode(),
+            index_stat_before.len(),
+            index_stat_before.mtime(),
+            index_stat_before.mtime_nsec(),
+            index_stat_before.ctime(),
+            index_stat_before.ctime_nsec(),
+        ),
+        "Changes reads must not refresh or rewrite the real index"
+    );
 
     let line = readme
         .hunks

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -610,6 +610,12 @@ impl Client {
             .await
     }
 
+    /// Typed, bounded worktree changes relative to the session's local base.
+    pub async fn changes(&self, key: &str) -> Result<crate::ChangeSetDto> {
+        self.get_typed(&format!("/api/sessions/{}/changes", Self::seg(key)))
+            .await
+    }
+
     /// Recent events for a branch, newest first, capped at 200 server-side
     /// (`GET /api/sessions/{key}/log`). Despite the URL, `key` may be a branch
     /// id, `repo:branch`, or unambiguous id prefix — no live session required.

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -1472,9 +1472,23 @@ pub struct NewCommentBody {
 // generic subject/anchor shapes are shared with the future changes viewer.
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewSubjectKindDto {
+    Artifact,
+    Changes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewAnchorKindDto {
+    Text,
+    Change,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewSubjectDto {
-    pub kind: String,
+    pub kind: ReviewSubjectKindDto,
     /// Stable internal artifact envelope id.
     pub id: String,
     /// Stable public subject key: the artifact name accepted by list/create.
@@ -1496,12 +1510,47 @@ pub struct ArtifactTextAnchorDto {
     pub block_index: Option<i64>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeSideDto {
+    Old,
+    New,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChangeAnchorDto {
+    pub path: ChangePathDto,
+    pub side: ChangeSideDto,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub hunk_header: String,
+    #[serde(default)]
+    pub context_before: Vec<String>,
+    pub selected: Vec<String>,
+    #[serde(default)]
+    pub context_after: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ReviewAnchorDto {
+    Text(ArtifactTextAnchorDto),
+    Change(ChangeAnchorDto),
+}
+
+impl From<ArtifactTextAnchorDto> for ReviewAnchorDto {
+    fn from(value: ArtifactTextAnchorDto) -> Self {
+        Self::Text(value)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewCommentDto {
     pub id: i64,
     pub subject_version: String,
-    pub anchor_kind: String,
-    pub anchor: ArtifactTextAnchorDto,
+    pub anchor_kind: ReviewAnchorKindDto,
+    pub anchor: ReviewAnchorDto,
     pub body: String,
     pub status: String,
     pub created_at: String,
@@ -1536,7 +1585,7 @@ pub struct ReviewDto {
 /// Create or recover the caller's one draft for a session/subject.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateReviewReq {
-    pub subject_kind: String,
+    pub subject_kind: ReviewSubjectKindDto,
     /// Artifact name for `subject_kind = "artifact"`.
     pub subject_key: String,
     pub subject_version: String,
@@ -1547,8 +1596,8 @@ pub struct CreateReviewReq {
 pub struct AddReviewCommentReq {
     pub expected_revision: i64,
     pub subject_version: String,
-    pub anchor_kind: String,
-    pub anchor: ArtifactTextAnchorDto,
+    pub anchor_kind: ReviewAnchorKindDto,
+    pub anchor: ReviewAnchorDto,
     pub body: String,
 }
 
@@ -1559,9 +1608,9 @@ pub struct UpdateReviewCommentReq {
     #[serde(default)]
     pub subject_version: Option<String>,
     #[serde(default)]
-    pub anchor_kind: Option<String>,
+    pub anchor_kind: Option<ReviewAnchorKindDto>,
     #[serde(default)]
-    pub anchor: Option<ArtifactTextAnchorDto>,
+    pub anchor: Option<ReviewAnchorDto>,
     #[serde(default)]
     pub body: Option<String>,
 }
@@ -1593,6 +1642,134 @@ pub struct ExpectedReviewRevisionReq {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolveReviewCommentReq {
     pub resolved: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Changes — one bounded, typed snapshot of the session worktree relative to
+// its real branch base.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeFileStatusDto {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+    Copied,
+    TypeChanged,
+    Untracked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeSourceDto {
+    Committed,
+    Staged,
+    Unstaged,
+    Untracked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeContentDto {
+    Text,
+    Binary,
+    Oversize,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeLineKindDto {
+    Context,
+    Addition,
+    Deletion,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangeLineDto {
+    pub kind: ChangeLineKindDto,
+    pub old_line: Option<u32>,
+    pub new_line: Option<u32>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangeHunkDto {
+    pub header: String,
+    pub lines: Vec<ChangeLineDto>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangeFileDto {
+    pub status: ChangeFileStatusDto,
+    pub path: ChangePathDto,
+    pub old_path: Option<ChangePathDto>,
+    pub sources: Vec<ChangeSourceDto>,
+    pub additions: Option<u32>,
+    pub deletions: Option<u32>,
+    pub content: ChangeContentDto,
+    pub hunks: Vec<ChangeHunkDto>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangePathDto {
+    /// URL-safe base64 of the exact repo-relative Git path bytes.
+    pub bytes: String,
+    /// Escaped, control-free display form; never used as identity.
+    pub display: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeBaseUnavailableReasonDto {
+    UnbornHead,
+    MissingBase,
+    NoMergeBase,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ChangeBaseDto {
+    Available {
+        reference: String,
+        oid: String,
+    },
+    Unavailable {
+        reference: String,
+        reason: ChangeBaseUnavailableReasonDto,
+    },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ChangeTotalsDto {
+    pub files: u32,
+    pub additions: u32,
+    pub deletions: u32,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangeLimitsDto {
+    pub max_files: u32,
+    pub max_hunks_per_file: u32,
+    pub max_lines_per_file: u32,
+    pub max_total_lines: u32,
+    pub max_line_bytes: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangeSetDto {
+    pub version: Option<String>,
+    pub base: ChangeBaseDto,
+    pub head_oid: Option<String>,
+    pub totals: ChangeTotalsDto,
+    pub files: Vec<ChangeFileDto>,
+    pub truncated: bool,
+    pub limits: ChangeLimitsDto,
 }
 
 /// One watch, as the API exposes it. The JSON-bearing columns

--- a/crates/weaver-core/src/review.rs
+++ b/crates/weaver-core/src/review.rs
@@ -24,7 +24,7 @@ pub const MAX_SUMMARY_BYTES: usize = 8 * 1024;
 pub const MAX_QUOTE_BYTES: usize = 4 * 1024;
 pub const MAX_CONTEXT_BYTES: usize = 1024;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ArtifactTextAnchor {
     pub quote: String,
     #[serde(default)]
@@ -33,6 +33,51 @@ pub struct ArtifactTextAnchor {
     pub suffix: String,
     #[serde(default)]
     pub block_index: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeLineAnchor {
+    pub path_bytes: String,
+    pub path_display: String,
+    pub side: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub hunk_header: String,
+    #[serde(default)]
+    pub context_before: Vec<String>,
+    pub selected: Vec<String>,
+    #[serde(default)]
+    pub context_after: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum ReviewAnchor {
+    Text(ArtifactTextAnchor),
+    Change(ChangeLineAnchor),
+}
+
+impl From<ArtifactTextAnchor> for ReviewAnchor {
+    fn from(value: ArtifactTextAnchor) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl ReviewAnchor {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Text(_) => "text",
+            Self::Change(_) => "change",
+        }
+    }
+
+    fn json(&self) -> Result<String> {
+        Ok(serde_json::to_string(self)?)
+    }
+
+    fn value(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
 }
 
 #[derive(Debug)]
@@ -93,13 +138,15 @@ pub struct ReviewComment {
 }
 
 impl ReviewComment {
-    pub fn anchor(&self) -> ArtifactTextAnchor {
-        serde_json::from_str(&self.anchor_json).unwrap_or(ArtifactTextAnchor {
-            quote: String::new(),
-            prefix: String::new(),
-            suffix: String::new(),
-            block_index: None,
-        })
+    pub fn anchor(&self) -> ReviewAnchor {
+        match self.anchor_kind.as_str() {
+            "change" => serde_json::from_str(&self.anchor_json)
+                .map(ReviewAnchor::Change)
+                .unwrap_or_else(|_| ReviewAnchor::Change(ChangeLineAnchor::default())),
+            _ => serde_json::from_str(&self.anchor_json)
+                .map(ReviewAnchor::Text)
+                .unwrap_or_else(|_| ReviewAnchor::Text(ArtifactTextAnchor::default())),
+        }
     }
 }
 
@@ -119,14 +166,14 @@ pub struct NewReview<'a> {
 #[derive(Debug, Clone)]
 pub struct NewComment<'a> {
     pub subject_version: &'a str,
-    pub anchor: &'a ArtifactTextAnchor,
+    pub anchor: &'a ReviewAnchor,
     pub body: &'a str,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct CommentPatch<'a> {
     pub subject_version: Option<&'a str>,
-    pub anchor: Option<&'a ArtifactTextAnchor>,
+    pub anchor: Option<&'a ReviewAnchor>,
     pub body: Option<&'a str>,
 }
 
@@ -166,26 +213,54 @@ const SELECT_REVIEW: &str = "SELECT id, repo_root, branch_id, session_id, subjec
 const SELECT_COMMENT: &str = "SELECT id, review_id, subject_version, anchor_kind, anchor_json, \
     body, status, created_at, updated_at FROM review_comments";
 
-fn validate_anchor(anchor: &ArtifactTextAnchor) -> Result<()> {
-    if anchor.quote.trim().is_empty() {
-        bail!("a non-empty text quote is required");
+fn validate_anchor(anchor: &ReviewAnchor) -> Result<()> {
+    match anchor {
+        ReviewAnchor::Text(anchor) => {
+            if anchor.quote.trim().is_empty() {
+                bail!("a non-empty text quote is required");
+            }
+            if anchor.quote.len() > MAX_QUOTE_BYTES {
+                bail!("anchor quote exceeds the 4 KiB limit");
+            }
+            if anchor.prefix.len() > MAX_CONTEXT_BYTES || anchor.suffix.len() > MAX_CONTEXT_BYTES {
+                bail!("anchor prefix and suffix are limited to 1 KiB each");
+            }
+            if anchor.block_index.is_some_and(|index| index < 0) {
+                bail!("anchor block_index must be non-negative");
+            }
+        }
+        ReviewAnchor::Change(anchor) => {
+            if anchor.path_bytes.is_empty() {
+                bail!("a change path identity is required");
+            }
+            if !matches!(anchor.side.as_str(), "old" | "new") {
+                bail!("change anchor side must be old or new");
+            }
+            if anchor.start_line == 0 || anchor.end_line < anchor.start_line {
+                bail!("change anchor range is invalid");
+            }
+            if anchor.selected.is_empty() {
+                bail!("change anchor selected context is required");
+            }
+            for line in anchor
+                .context_before
+                .iter()
+                .chain(&anchor.selected)
+                .chain(&anchor.context_after)
+            {
+                if line.len() > MAX_CONTEXT_BYTES {
+                    bail!("change anchor context lines are limited to 1 KiB");
+                }
+            }
+        }
     }
-    if anchor.quote.len() > MAX_QUOTE_BYTES {
-        bail!("anchor quote exceeds the 4 KiB limit");
-    }
-    if anchor.prefix.len() > MAX_CONTEXT_BYTES || anchor.suffix.len() > MAX_CONTEXT_BYTES {
-        bail!("anchor prefix and suffix are limited to 1 KiB each");
-    }
-    if anchor.block_index.is_some_and(|index| index < 0) {
-        bail!("anchor block_index must be non-negative");
-    }
-    if serde_json::to_string(anchor)?.len() > MAX_ANCHOR_BYTES {
+    if anchor.json()?.len() > MAX_ANCHOR_BYTES {
         bail!("comment anchor exceeds the 8 KiB limit");
     }
     Ok(())
 }
 
-fn validate_comment(body: &str, anchor: &ArtifactTextAnchor) -> Result<()> {
+fn validate_comment(body: &str, anchor: &ReviewAnchor) -> Result<()> {
     let body = body.trim();
     if body.is_empty() {
         bail!("comment body is required");
@@ -378,7 +453,7 @@ pub async fn add_comment(
 ) -> Result<Review> {
     validate_comment(new.body, new.anchor)?;
     let body = new.body.trim();
-    let anchor_json = serde_json::to_string(new.anchor)?;
+    let anchor_json = new.anchor.json()?;
     let mut tx = crate::db::begin_immediate(db).await?;
     require_creator_draft(&mut tx, review_id, creator, expected_revision).await?;
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM review_comments WHERE review_id = ?")
@@ -404,10 +479,11 @@ pub async fn add_comment(
     sqlx::query(
         "INSERT INTO review_comments
             (review_id, subject_version, anchor_kind, anchor_json, body, created_at, updated_at)
-         VALUES (?, ?, 'text', ?, ?, ?, ?)",
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(review_id)
     .bind(new.subject_version)
+    .bind(new.anchor.kind())
     .bind(anchor_json)
     .bind(body)
     .bind(&now)
@@ -455,12 +531,18 @@ pub async fn patch_comment(
     let subject_version = patch.subject_version.unwrap_or(&current.subject_version);
     let anchor_json = patch
         .anchor
-        .map(serde_json::to_string)
+        .map(ReviewAnchor::json)
         .transpose()?
         .unwrap_or(current.anchor_json);
     let body = patch.body.unwrap_or(&current.body).trim();
-    let anchor: ArtifactTextAnchor =
-        serde_json::from_str(&anchor_json).context("decoding stored review anchor")?;
+    let anchor = match current.anchor_kind.as_str() {
+        "change" => ReviewAnchor::Change(
+            serde_json::from_str(&anchor_json).context("decoding stored change anchor")?,
+        ),
+        _ => ReviewAnchor::Text(
+            serde_json::from_str(&anchor_json).context("decoding stored text anchor")?,
+        ),
+    };
     validate_comment(body, &anchor)?;
     let total_without: i64 = sqlx::query_scalar(
         "SELECT COALESCE(SUM(
@@ -478,10 +560,16 @@ pub async fn patch_comment(
     let now = now_iso();
     sqlx::query(
         "UPDATE review_comments
-         SET subject_version = ?, anchor_kind = 'text', anchor_json = ?, body = ?, updated_at = ?
+         SET subject_version = ?, anchor_kind = ?, anchor_json = ?, body = ?, updated_at = ?
          WHERE id = ? AND review_id = ?",
     )
     .bind(subject_version)
+    .bind(
+        patch
+            .anchor
+            .map(ReviewAnchor::kind)
+            .unwrap_or(&current.anchor_kind),
+    )
     .bind(anchor_json)
     .bind(body)
     .bind(&now)
@@ -701,6 +789,46 @@ pub async fn submit(
     expected_revision: i64,
     acknowledge_outdated: bool,
 ) -> Result<Submission> {
+    submit_inner(
+        db,
+        review_id,
+        creator,
+        expected_revision,
+        acknowledge_outdated,
+        None,
+    )
+    .await
+}
+
+/// Submit a non-database subject against the current version resolved by its
+/// authoritative handler immediately before this transaction.
+pub async fn submit_at_version(
+    db: &Db,
+    review_id: i64,
+    creator: &str,
+    expected_revision: i64,
+    acknowledge_outdated: bool,
+    current_version: &str,
+) -> Result<Submission> {
+    submit_inner(
+        db,
+        review_id,
+        creator,
+        expected_revision,
+        acknowledge_outdated,
+        Some(current_version),
+    )
+    .await
+}
+
+async fn submit_inner(
+    db: &Db,
+    review_id: i64,
+    creator: &str,
+    expected_revision: i64,
+    acknowledge_outdated: bool,
+    provided_current_version: Option<&str>,
+) -> Result<Submission> {
     let mut tx = crate::db::begin_immediate(db).await?;
     let mut review =
         sqlx::query_as::<_, Review>(&format!("{SELECT_REVIEW} WHERE id = ? AND created_by = ?"))
@@ -732,24 +860,28 @@ pub async fn submit(
     if comments.is_empty() && review.summary.trim().is_empty() {
         bail!("add a comment or overall note before submitting");
     }
-    if review.subject_kind != "artifact" {
-        bail!("unsupported review subject kind");
-    }
-    let artifact_id: i64 = review
-        .subject_id
-        .parse()
-        .context("invalid artifact review subject id")?;
-    // Artifact writes use the same immediate transaction discipline. Reading
-    // the current revision here makes the stale decision, immutable event, and
-    // outbox insertion one serializable decision with respect to a write.
-    let current_version = sqlx::query_scalar::<_, Option<i64>>(
-        "SELECT MAX(rev) FROM artifact_versions WHERE artifact_id = ?",
-    )
-    .bind(artifact_id)
-    .fetch_one(&mut *tx)
-    .await?
-    .ok_or_else(|| anyhow!("artifact review subject not found"))?
-    .to_string();
+    let current_version = match review.subject_kind.as_str() {
+        "artifact" => {
+            let artifact_id: i64 = review
+                .subject_id
+                .parse()
+                .context("invalid artifact review subject id")?;
+            // Artifact writes use the same immediate transaction discipline.
+            sqlx::query_scalar::<_, Option<i64>>(
+                "SELECT MAX(rev) FROM artifact_versions WHERE artifact_id = ?",
+            )
+            .bind(artifact_id)
+            .fetch_one(&mut *tx)
+            .await?
+            .ok_or_else(|| anyhow!("artifact review subject not found"))?
+            .to_string()
+        }
+        "changes" => provided_current_version
+            .filter(|version| !version.is_empty())
+            .context("current change-set version is unavailable")?
+            .to_string(),
+        _ => bail!("unsupported review subject kind"),
+    };
     let outdated = is_outdated(&review, &comments, &current_version);
     if outdated && !acknowledge_outdated {
         bail!("review is outdated; acknowledge the reviewed revision before submitting");
@@ -781,7 +913,7 @@ pub async fn submit(
                 "id": comment.id,
                 "revision": comment.subject_version,
                 "anchor_kind": comment.anchor_kind,
-                "anchor": comment.anchor(),
+                "anchor": comment.anchor().value(),
                 "body": comment.body,
             })
         })
@@ -1033,17 +1165,25 @@ pub async fn retry_delivery(db: &Db, review_id: i64) -> Result<()> {
 }
 
 pub fn structured_message(review: &Review) -> String {
-    let mut message = format!(
-        "The user submitted feedback on artifact `{}`, revision {}.",
-        review.subject_label, review.subject_version
-    );
+    let subject = if review.subject_kind == "changes" {
+        format!(
+            "The user submitted feedback on changes version `{}`.",
+            review.subject_version
+        )
+    } else {
+        format!(
+            "The user submitted feedback on artifact `{}`, revision {}.",
+            review.subject_label, review.subject_version
+        )
+    };
+    let mut message = subject;
     if !review.summary.trim().is_empty() {
         message.push_str("\n\nOverall:\n");
         message.push_str(review.summary.trim());
     }
     for (index, comment) in review.comments.iter().enumerate() {
         let anchor = comment.anchor();
-        let anchor_json = serde_json::to_string(&anchor).unwrap_or_else(|_| "{}".to_string());
+        let anchor_json = anchor.json().unwrap_or_else(|_| "{}".to_string());
         message.push_str(&format!(
             "\n\n{}. Revision {}, {} anchor {}:\n",
             index + 1,
@@ -1109,13 +1249,14 @@ mod tests {
         .unwrap()
     }
 
-    fn anchor(quote: &str) -> ArtifactTextAnchor {
+    fn anchor(quote: &str) -> ReviewAnchor {
         ArtifactTextAnchor {
             quote: quote.to_string(),
             prefix: "before".to_string(),
             suffix: "after".to_string(),
             block_index: Some(0),
         }
+        .into()
     }
 
     async fn add(db: &Db, draft: &Review, body: &str) -> Review {
@@ -1135,7 +1276,7 @@ mod tests {
         .unwrap()
     }
 
-    fn comment<'a>(body: &'a str, anchor: &'a ArtifactTextAnchor) -> NewComment<'a> {
+    fn comment<'a>(body: &'a str, anchor: &'a ReviewAnchor) -> NewComment<'a> {
         NewComment {
             subject_version: "1",
             anchor,
@@ -1453,12 +1594,13 @@ mod tests {
     async fn anchors_are_bounded_individually_and_in_the_review_total() {
         let (db, artifact) = seeded().await;
         let mut draft = draft(&db, &artifact, "alice").await;
-        let oversized = ArtifactTextAnchor {
+        let oversized: ReviewAnchor = ArtifactTextAnchor {
             quote: "x".repeat(MAX_QUOTE_BYTES + 1),
             prefix: String::new(),
             suffix: String::new(),
             block_index: None,
-        };
+        }
+        .into();
         let error = add_comment(
             &db,
             draft.id,
@@ -1471,12 +1613,13 @@ mod tests {
         assert!(error.to_string().contains("quote exceeds"));
 
         let body = "b".repeat(MAX_COMMENT_BYTES);
-        let near_limit = ArtifactTextAnchor {
+        let near_limit: ReviewAnchor = ArtifactTextAnchor {
             quote: "x".repeat(MAX_QUOTE_BYTES),
             prefix: "p".repeat(MAX_CONTEXT_BYTES),
             suffix: "s".repeat(MAX_CONTEXT_BYTES),
             block_index: Some(0),
-        };
+        }
+        .into();
         let mut inserted = 0;
         loop {
             match add_comment(

--- a/e2e/tests/changes-review.spec.ts
+++ b/e2e/tests/changes-review.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '../fixtures/weaver';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+test('reviews a worktree change from the shared Review surface', async ({ page, weaver }) => {
+  const session = await weaver.seedSession({
+    goal: 'review a small change',
+    name: 'changes-review',
+  });
+  const changedPath = join(session.work_dir, 'review.txt');
+  writeFileSync(changedPath, 'first\nsecond\n');
+
+  await page.goto(`${weaver.baseUrl}/s/${session.id}/changes`);
+  await expect(page.getByRole('tab', { name: 'Review' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  await expect(page.getByRole('navigation', { name: 'Review' })).toBeVisible();
+  await page.getByRole('button', { name: /review\.txt/ }).click();
+  await page.getByRole('button', { name: /Comment on review\.txt new line 2/ }).click();
+
+  const composer = page.getByTestId('change-comment-composer');
+  await expect(composer.locator('textarea')).toBeFocused();
+  await composer.locator('textarea').fill('Explain why this line belongs here.');
+  await composer.getByRole('button', { name: 'Add pending comment' }).click();
+
+  const tray = page.getByTestId('review-tray');
+  await expect(tray).toContainText('1 pending');
+  await expect(tray.locator('pre')).toContainText('Explain why this line belongs here.');
+
+  writeFileSync(changedPath, 'first\nsecond\nthird\n');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByTestId('review-stale-warning')).toBeVisible();
+  await page.getByTestId('review-stale-ack').check();
+  const submit = page.waitForRequest(
+    (request) =>
+      request.method() === 'POST' && /\/api\/reviews\/\d+\/submit$/.test(request.url()),
+  );
+  await page.getByTestId('submit-review').click();
+  await submit;
+  await expect(tray).toContainText('Review submitted');
+
+  await page.setViewportSize({ width: 390, height: 720 });
+  await expect(page.getByRole('link', { name: 'Artifacts', exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Changes', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: /Details/ }).click();
+  await page.getByText('Advanced', { exact: true }).click();
+  await expect(page.getByTestId('action-open-editor')).toBeVisible();
+});

--- a/e2e/tests/changes-review.spec.ts
+++ b/e2e/tests/changes-review.spec.ts
@@ -66,6 +66,53 @@ test('reviews a worktree change from the shared Review surface', async ({ page, 
   await submit;
   await expect(tray).toContainText('Review submitted');
 
+  const overall = page.getByTestId('review-overall-note');
+  const initialSave = page.waitForResponse(
+    (response) =>
+      response.ok() &&
+      response.request().method() === 'PATCH' &&
+      /\/api\/reviews\/\d+$/.test(response.url()),
+  );
+  await overall.fill('Shared overall note.');
+  await overall.press('Tab');
+  await initialSave;
+
+  const peer = await page.context().newPage();
+  await peer.goto(`${weaver.baseUrl}/s/${session.id}/changes`);
+  await peer.getByTestId('review-tray-toggle').click();
+  await overall.fill('Keep this local edit after the conflict.');
+  const peerSubmit = peer.waitForResponse(
+    (response) =>
+      response.ok() &&
+      response.request().method() === 'POST' &&
+      /\/api\/reviews\/\d+\/submit$/.test(response.url()),
+  );
+  await peer.getByTestId('submit-review').click();
+  await peerSubmit;
+
+  const saveConflict = page.waitForResponse(
+    (response) =>
+      response.status() === 409 &&
+      response.request().method() === 'PATCH' &&
+      /\/api\/reviews\/\d+$/.test(response.url()),
+  );
+  await overall.focus();
+  await overall.press('Tab');
+  await saveConflict;
+  await expect(overall).toHaveValue('Keep this local edit after the conflict.');
+
+  const retrySave = page.waitForResponse(
+    (response) =>
+      response.ok() &&
+      response.request().method() === 'PATCH' &&
+      /\/api\/reviews\/\d+$/.test(response.url()),
+  );
+  await overall.focus();
+  await overall.press('Tab');
+  await retrySave;
+  await expect(tray).toContainText('0 pending');
+  await peer.close();
+
   await page.setViewportSize({ width: 390, height: 720 });
   await expect(page.getByRole('link', { name: 'Artifacts', exact: true })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Changes', exact: true })).toBeVisible();

--- a/e2e/tests/changes-review.spec.ts
+++ b/e2e/tests/changes-review.spec.ts
@@ -8,7 +8,9 @@ test('reviews a worktree change from the shared Review surface', async ({ page, 
     name: 'changes-review',
   });
   const changedPath = join(session.work_dir, 'review.txt');
+  const otherPath = join(session.work_dir, 'other.txt');
   writeFileSync(changedPath, 'first\nsecond\n');
+  writeFileSync(otherPath, 'other\n');
 
   await page.goto(`${weaver.baseUrl}/s/${session.id}/changes`);
   await expect(page.getByRole('tab', { name: 'Review' })).toHaveAttribute(
@@ -17,18 +19,42 @@ test('reviews a worktree change from the shared Review surface', async ({ page, 
   );
   await expect(page.getByRole('navigation', { name: 'Review' })).toBeVisible();
   await page.getByRole('button', { name: /review\.txt/ }).click();
-  await page.getByRole('button', { name: /Comment on review\.txt new line 2/ }).click();
+  const firstLine = page.getByRole('button', {
+    name: /Comment on review\.txt new line 1/,
+  });
+  await firstLine.focus();
+  await page.keyboard.press('Shift+ArrowDown');
 
   const composer = page.getByTestId('change-comment-composer');
-  await expect(composer.locator('textarea')).toBeFocused();
+  await expect(firstLine).toBeFocused();
+  await expect(composer).toContainText('1–2');
   await composer.locator('textarea').fill('Explain why this line belongs here.');
+
+  writeFileSync(changedPath, 'first\nchanged\nthird\n');
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(composer.locator('textarea')).toHaveValue('Explain why this line belongs here.');
+  const staleSave = page.waitForResponse(
+    (response) =>
+      response.status() === 409 &&
+      response.request().method() === 'POST' &&
+      /\/api\/(?:sessions\/[^/]+\/reviews|reviews\/\d+\/comments)$/.test(response.url()),
+  );
+  await composer.getByRole('button', { name: 'Add pending comment' }).click();
+  await staleSave;
+  await expect(composer.locator('textarea')).toHaveValue('Explain why this line belongs here.');
+
+  await page.getByRole('button', { name: /other\.txt/ }).click();
+  await page.getByRole('button', { name: /Comment on other\.txt new line 1/ }).click();
+  await expect(composer.locator('textarea')).toHaveValue('Explain why this line belongs here.');
+  await page.getByRole('button', { name: /Comment on review\.txt new line 2/ }).click();
+  await expect(composer.locator('textarea')).toHaveValue('Explain why this line belongs here.');
   await composer.getByRole('button', { name: 'Add pending comment' }).click();
 
   const tray = page.getByTestId('review-tray');
   await expect(tray).toContainText('1 pending');
   await expect(tray.locator('pre')).toContainText('Explain why this line belongs here.');
 
-  writeFileSync(changedPath, 'first\nsecond\nthird\n');
+  writeFileSync(changedPath, 'first\nchanged\nthird\nfourth\n');
   await page.getByRole('button', { name: 'Refresh' }).click();
   await expect(page.getByTestId('review-stale-warning')).toBeVisible();
   await page.getByTestId('review-stale-ack').check();

--- a/e2e/tests/ide.spec.ts
+++ b/e2e/tests/ide.spec.ts
@@ -16,6 +16,7 @@ test.describe('embedded editor panel', () => {
 
     await expect(page.getByTestId('ide-open')).toHaveCount(0);
     await page.getByRole('button', { name: /Details/ }).click();
+    await page.getByText('Advanced', { exact: true }).click();
     await page.getByTestId('action-open-editor').click();
 
     // The panel mounts with its header…


### PR DESCRIPTION
Adds a typed, bounded Changes resource derived from the local merge-base without fetching or mutating the index. The version covers final tracked and untracked bytes, paths retain round-trip identity, source layers stay explicit, and server-side anchor validation binds comments to the exact visible version.

Extends the existing staged-review subject and anchor seams so Changes reuses the same private drafts, optimistic mutations, stale acknowledgement, immutable submit message, delivery outbox, tray, and comment shell. Review now owns deep-linked Artifacts and Changes surfaces, while code-server remains available under Details → Advanced instead of primary chrome.

Keeps the CLI a typed REST consumer and covers parser bounds, source-layer wiring, review submission, responsive routing, and editor demotion within the agreed journey budget.

Correction verification:
- cargo test -p loom changes::tests
- npm run typecheck in crates/loom/frontend
- npm test -- changes-review.spec.ts in e2e
- ./scripts/pre-commit.sh
- lint-review not rerun: focused coordinator follow-up on an already lint-reviewed branch.