### PR TITLE
refactor(api): tighten client contract seams

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -233,6 +233,12 @@ import type {
   RepoEnvVar,
   ScratchFile,
   ScratchLimits,
+  Watch,
+  WatchCreateInput,
+  WatchRun,
+  WatchRunResult,
+  WatchUpdateInput,
+  ProgramView,
 } from './types';
 
 // --- Managed repos ---------------------------------------------------------
@@ -700,6 +706,22 @@ export const setGithubConfig = (clientId: string, clientSecret?: string) =>
     client_id: clientId,
     ...(clientSecret !== undefined ? { client_secret: clientSecret } : {}),
   }) as Promise<GithubConfig>;
+
+// --- Watches ---------------------------------------------------------------
+
+export const listWatches = () => get('/watches') as Promise<Watch[]>;
+export const getWatch = (id: string) => get(`/watches/${encodeURIComponent(id)}`) as Promise<Watch>;
+export const createWatch = (body: WatchCreateInput) => post('/watches', body) as Promise<Watch>;
+export const updateWatch = (id: string, body: WatchUpdateInput) =>
+  patch(`/watches/${encodeURIComponent(id)}`, body) as Promise<Watch>;
+export const deleteWatch = (id: string) => del(`/watches/${encodeURIComponent(id)}`);
+export const listWatchPrograms = () => get('/watches/programs') as Promise<ProgramView[]>;
+export const listWatchRuns = (id: string, limit = 50) =>
+  get(`/watches/${encodeURIComponent(id)}/runs?limit=${limit}`) as Promise<WatchRun[]>;
+export const runWatch = (id: string, dryRun = false) =>
+  post(`/watches/${encodeURIComponent(id)}/run`, {
+    dry_run: dryRun,
+  }) as Promise<WatchRunResult>;
 
 // --- Slack -------------------------------------------------------------
 

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -983,6 +983,24 @@ export interface Watch {
   updated_at: string;
 }
 
+/** Create payload for `POST /api/watches`. */
+export interface WatchCreateInput {
+  name: string;
+  trigger?: WatchTrigger;
+  scope?: WatchScope;
+  program?: string;
+  params?: Record<string, unknown>;
+  capabilities?: string[];
+  profile?: string;
+  model?: string;
+  effort?: string;
+  cooldown_secs?: number;
+  enabled?: boolean;
+}
+
+/** Mutable fields accepted by `PATCH /api/watches/{id}`. */
+export type WatchUpdateInput = Partial<Omit<WatchCreateInput, 'name'>>;
+
 /** One action a round recorded — a mark, nudge, interrupt, or a stubbed
  *  "would do X" from a dry-run. The shape is loose (the engine writes free-form
  *  JSON); these are the fields the panel renders when present. */

--- a/crates/loom/frontend/src/views/Watches.vue
+++ b/crates/loom/frontend/src/views/Watches.vue
@@ -1,8 +1,27 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch as watchEffect, onMounted, onActivated } from 'vue';
 import { useRouter } from 'vue-router';
-import { get, post, patch, del } from '../api';
-import type { Watch, WatchRun, WatchRunResult, ProgramView, Profile } from '../types';
+import {
+  createWatch,
+  deleteWatch,
+  getWatch,
+  listProfiles,
+  listWatchPrograms,
+  listWatchRuns,
+  listWatches,
+  runWatch,
+  updateWatch,
+} from '../api';
+import type {
+  ProgramView,
+  Profile,
+  Watch,
+  WatchCreateInput,
+  WatchRun,
+  WatchScope,
+  WatchTrigger,
+  WatchUpdateInput,
+} from '../types';
 import OutcomeBadge from '../components/OutcomeBadge.vue';
 import AgentTerminal from '../components/AgentTerminal.vue';
 import ToggleSwitch from '../components/ToggleSwitch.vue';
@@ -75,7 +94,7 @@ const watchProfiles = computed(() =>
 // ── Loading ─────────────────────────────────────────────────────────────────
 async function load() {
   try {
-    watches.value = (await get('/watches')) as Watch[];
+    watches.value = await listWatches();
     error.value = '';
     // Adopt the route's id, else fall back to the first watch so the pane is
     // never pointlessly empty.
@@ -91,7 +110,7 @@ async function load() {
 
 async function loadPrograms() {
   try {
-    programs.value = (await get('/watches/programs')) as ProgramView[];
+    programs.value = await listWatchPrograms();
   } catch {
     // Supplementary: without the registry a program still shows as its ref.
   }
@@ -99,7 +118,7 @@ async function loadPrograms() {
 
 async function loadProfiles() {
   try {
-    profiles.value = (await get('/profiles')) as Profile[];
+    profiles.value = await listProfiles();
   } catch {
     // Supplementary: the stored profile name remains editable as plain data.
   }
@@ -120,7 +139,7 @@ const lastRun = ref<{ outcome: string; summary: string; dry: boolean } | null>(n
 async function loadRuns() {
   if (!selectedId.value) return;
   try {
-    runs.value = (await get(`/watches/${selectedId.value}/runs?limit=50`)) as WatchRun[];
+    runs.value = await listWatchRuns(selectedId.value);
     runsError.value = '';
   } catch (e) {
     runsError.value = (e as Error).message;
@@ -144,7 +163,7 @@ async function toggleEnabled(w: Watch) {
   busy.value = true;
   error.value = '';
   try {
-    adopt((await patch(`/watches/${w.id}`, { enabled: !w.enabled })) as Watch);
+    adopt(await updateWatch(w.id, { enabled: !w.enabled }));
   } catch (e) {
     error.value = (e as Error).message;
   } finally {
@@ -157,12 +176,10 @@ async function run(dry: boolean) {
   busy.value = true;
   error.value = '';
   try {
-    const res = (await post(`/watches/${selected.value.id}/run`, {
-      dry_run: dry,
-    })) as WatchRunResult;
+    const res = await runWatch(selected.value.id, dry);
     lastRun.value = { outcome: res.outcome, summary: res.summary, dry };
     tab.value = 'activity';
-    adopt((await get(`/watches/${selected.value.id}`)) as Watch);
+    adopt(await getWatch(selected.value.id));
     await loadRuns();
     // Surface the fresh round's log without an extra click.
     if (runs.value.length) expanded[runs.value[0].id] = true;
@@ -185,7 +202,7 @@ async function remove() {
       busy.value = true;
       error.value = '';
       try {
-        await del(`/watches/${w.id}`);
+        await deleteWatch(w.id);
         watches.value = watches.value.filter((x) => x.id !== w.id);
         selectedId.value = watches.value[0]?.id ?? '';
         await router.replace(selectedId.value ? `/watches/${selectedId.value}` : '/watches');
@@ -235,7 +252,7 @@ async function saveConfig() {
   error.value = '';
   notice.value = '';
   try {
-    const body: Record<string, unknown> = {
+    const body: WatchUpdateInput = {
       params: draft.prompt.trim() ? { prompt: draft.prompt.trim() } : {},
       capabilities: capabilitiesFrom(draft.capabilities),
       profile: draft.profile.trim() || 'watch',
@@ -243,7 +260,7 @@ async function saveConfig() {
       effort: draft.effort,
       cooldown_secs: Number(draft.cooldown) || 0,
     };
-    adopt((await patch(`/watches/${w.id}`, body)) as Watch);
+    adopt(await updateWatch(w.id, body));
     editing.value = false;
     notice.value = 'Saved.';
   } catch (e) {
@@ -324,9 +341,9 @@ async function create() {
     // `auto` omits the trigger entirely so the server reconciles it from the
     // script's manifest; the explicit kinds build the trigger here. (A repo pin
     // rides on `scope` below either way, so `auto` keeps repo scoping.)
-    let trigger: Record<string, unknown> | undefined;
+    let trigger: WatchTrigger | undefined;
     if (form.triggerKind !== 'auto') {
-      const t: Record<string, unknown> = {};
+      const t: WatchTrigger = {};
       if (form.triggerKind === 'cron' && form.cron.trim()) t.cron = form.cron.trim();
       else if (form.triggerKind === 'every' && form.every.trim()) t.every = form.every.trim();
       else if (form.triggerKind === 'on' && form.on.trim()) {
@@ -339,10 +356,10 @@ async function create() {
       // Only override the manifest when the user actually gave a firing
       // condition — a blank explicit kind would create a dead, manual-only
       // watch; fall back to `auto` (server reconciles) instead.
-      if (t.cron || t.every || (Array.isArray(t.on) && t.on.length)) trigger = t;
+      if (t.cron || t.every || t.on?.length) trigger = t;
     }
 
-    const scope: Record<string, string> = {};
+    const scope: WatchScope = {};
     if (form.scopeAttention.trim()) scope.attention = form.scopeAttention.trim();
     if (form.repo.trim()) scope.repo = form.repo.trim();
 
@@ -352,7 +369,7 @@ async function create() {
     const params: Record<string, unknown> = { ...(chosen?.defaults?.params ?? {}) };
     if (form.prompt.trim()) params.prompt = form.prompt.trim();
 
-    const body: Record<string, unknown> = {
+    const body: WatchCreateInput = {
       name: form.name.trim(),
       scope,
       program: programRef || 'builtin:status',
@@ -363,7 +380,7 @@ async function create() {
       enabled: true,
     };
     if (trigger !== undefined) body.trigger = trigger;
-    const made = (await post('/watches', body)) as Watch;
+    const made = await createWatch(body);
     creatingNew.value = false;
     await load();
     selectedId.value = made.id;

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -602,14 +602,6 @@ impl Client {
             .to_string())
     }
 
-    /// The worktree file tree + change map vs the diff base
-    /// (`GET /api/sessions/{key}/tree`). Returned as raw JSON — the shape is a
-    /// loose `{files, changed, base}` the dashboard assembles client-side.
-    pub async fn diff(&self, key: &str) -> Result<Value> {
-        self.get(&format!("/api/sessions/{}/tree", Self::seg(key)))
-            .await
-    }
-
     /// Typed, bounded worktree changes relative to the session's local base.
     pub async fn changes(&self, key: &str) -> Result<crate::ChangeSetDto> {
         self.get_typed(&format!("/api/sessions/{}/changes", Self::seg(key)))

--- a/crates/weaver-py/README.md
+++ b/crates/weaver-py/README.md
@@ -45,7 +45,7 @@ for s in c.sessions():
 
 s = c.session("abc123")            # by id, branch id, branch name, or repo:branch
 screen = c.preview("abc123", 200)  # terminal as text, 200 lines of scrollback
-tree = c.diff("abc123")            # worktree file tree + change map
+changes = c.changes("abc123")      # typed, bounded worktree changes
 
 c.set_tag("abc123", "triage", "attention", note="stuck on tests")  # needs "mark"
 c.clear_tag("abc123", "triage")                          # back to calm; needs "mark"

--- a/crates/weaver-py/python/weaver_py.pyi
+++ b/crates/weaver-py/python/weaver_py.pyi
@@ -53,8 +53,8 @@ class Client:
     def preview(self, key: str, lines: int = ...) -> str:
         """The session's tmux pane as text, with `lines` of extra scrollback."""
 
-    def diff(self, key: str) -> dict[str, Any]:
-        """The worktree file tree + change map vs the diff base."""
+    def changes(self, key: str) -> dict[str, Any]:
+        """Typed, bounded worktree changes relative to the session's local base."""
 
     # -- Writes (capability-gated) --
     def set_tag(

--- a/crates/weaver-py/src/lib.rs
+++ b/crates/weaver-py/src/lib.rs
@@ -177,11 +177,11 @@ impl Client {
             .map_err(api_err)
     }
 
-    /// The worktree file tree + change map vs the diff base, as a dict
-    /// (`GET /api/sessions/{key}/tree`).
-    fn diff(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+    /// Typed, bounded worktree changes relative to the session's local base
+    /// (`GET /api/sessions/{key}/changes`).
+    fn changes(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
         let value = py
-            .detach(|| self.rt.block_on(self.inner.diff(key)))
+            .detach(|| self.rt.block_on(self.inner.changes(key)))
             .map_err(api_err)?;
         to_py(py, &value)
     }

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -378,9 +378,9 @@ class Client:
         reply = self._request("GET", f"/sessions/{key}/preview?lines={lines}")
         return (reply or {}).get("screen", "")
 
-    def diff(self, key):
-        """The worktree file tree + change map vs the diff base."""
-        return self._request("GET", f"/sessions/{key}/tree")
+    def changes(self, key):
+        """Typed, bounded worktree changes relative to the session's local base."""
+        return self._request("GET", f"/sessions/{key}/changes")
 
     def programs(self):
         """The builtin watch program registry."""

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -110,6 +110,13 @@ class StubClient(Client):
         return self.replies.get(path)
 
 
+def test_changes_uses_the_canonical_typed_changes_route():
+    client = StubClient(replies={"/sessions/s1/changes": {"files": []}})
+
+    assert client.changes("s1") == {"files": []}
+    assert client.requests == [("GET", "/sessions/s1/changes", None)]
+
+
 def test_profile_scoped_run_is_capability_gated_and_preserves_idempotency():
     session_request = {
         "repo": "marin-community/marin",


### PR DESCRIPTION
Remove the dead `/sessions/{id}/tree` client surface and expose the existing typed changes contract consistently through both Python clients.

Give the Watches view named, typed API methods for its existing REST resources so route construction stays in `api.ts` and matches the Rust client and CLI contract.

Session: `uxymvk54` (the restricted session credential cannot resolve `loom session url`).