### PR TITLE
fix(api): align client and UI contracts

### DIFF
--- a/crates/loom/frontend/src/components/AppearancePanel.vue
+++ b/crates/loom/frontend/src/components/AppearancePanel.vue
@@ -4,7 +4,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 import { get, patch } from '../api';
-import type { SettingView } from '../types';
+import type { SettingsEnvelope, SettingView } from '../types';
 import {
   FONT_CHOICES,
   fontStack,
@@ -78,8 +78,8 @@ function adopt(settings: SettingView[]) {
 
 async function load() {
   try {
-    const res = (await get('/settings')) as { settings?: SettingView[] };
-    adopt(res?.settings ?? []);
+    const res = (await get('/settings')) as SettingsEnvelope;
+    adopt(res.settings);
     error.value = '';
   } catch (e) {
     error.value = (e as Error).message;
@@ -97,8 +97,8 @@ async function commit(body: Record<string, string | null>, done: string) {
   error.value = '';
   notice.value = '';
   try {
-    const res = (await patch('/settings', body)) as { settings?: SettingView[] };
-    adopt(res?.settings ?? []);
+    const res = (await patch('/settings', body)) as SettingsEnvelope;
+    adopt(res.settings);
     notice.value = done;
   } catch (e) {
     error.value = (e as Error).message;

--- a/crates/loom/frontend/src/lib/sessionActions.ts
+++ b/crates/loom/frontend/src/lib/sessionActions.ts
@@ -2,7 +2,6 @@ import { ref } from 'vue';
 import {
   archiveSession,
   clearSessionTag,
-  del,
   patch,
   post,
   put,
@@ -113,7 +112,7 @@ export function useSessionActions(
         });
         notice.value = 'Automatic archive disabled for this session.';
       } else {
-        await del(path);
+        await clearSessionTag(getId(), AUTO_ARCHIVE_KEY);
         notice.value = 'Automatic archive enabled for this session.';
       }
       await reload();

--- a/crates/loom/frontend/src/lib/sessionActions.ts
+++ b/crates/loom/frontend/src/lib/sessionActions.ts
@@ -1,5 +1,15 @@
 import { ref } from 'vue';
-import { post, patch, put, del, regenerateSessionTitle, setSessionTitleGeneration } from '../api';
+import {
+  archiveSession,
+  clearSessionTag,
+  del,
+  patch,
+  post,
+  put,
+  regenerateSessionTitle,
+  removeSession,
+  setSessionTitleGeneration,
+} from '../api';
 import { confirmAction } from './confirmation';
 import { AUTO_ARCHIVE_DISABLED_VALUE, AUTO_ARCHIVE_KEY, type LifecycleVerb } from './sessionState';
 
@@ -88,7 +98,7 @@ export function useSessionActions(
   // calm (calm is the tag's absence — there is no stored `ok`).
   const clearTag = (key: string) =>
     act(`tag:${key}`, async () => {
-      await del(`/sessions/${getId()}/tags/${encodeURIComponent(key)}`);
+      await clearSessionTag(getId(), key);
       await reload();
     });
 
@@ -126,7 +136,7 @@ export function useSessionActions(
       action: async () => {
         error.value = '';
         notice.value = '';
-        const res = (await post(`/sessions/${getId()}/archive`)) as { branch: string };
+        const res = (await archiveSession(getId())) as { branch: string };
         notice.value = `Archived ${res.branch}.`;
         await reload();
       },
@@ -149,7 +159,7 @@ export function useSessionActions(
       action: async () => {
         error.value = '';
         notice.value = '';
-        await del(`/sessions/${getId()}`);
+        await removeSession(getId());
         if (removed) removed();
         else await reload();
       },

--- a/crates/loom/frontend/src/lib/terminalConfig.ts
+++ b/crates/loom/frontend/src/lib/terminalConfig.ts
@@ -6,7 +6,7 @@
 
 import type { ITheme } from '@xterm/xterm';
 import { get } from '../api';
-import type { SettingView } from '../types';
+import type { SettingsEnvelope, SettingView } from '../types';
 
 // Terminal palettes, selected by the `terminal.theme` setting. The dark palette
 // keeps xterm's own ANSI colours (they already assume a dark terminal) but sits
@@ -125,8 +125,8 @@ export function defaultTerminalConfig(): TerminalConfig {
 // defaults.
 export async function fetchTerminalConfig(): Promise<TerminalConfig> {
   try {
-    const res = (await get('/settings')) as { settings?: SettingView[] };
-    return resolveTerminalConfig(res?.settings ?? []);
+    const res = (await get('/settings')) as SettingsEnvelope;
+    return resolveTerminalConfig(res.settings);
   } catch {
     return defaultTerminalConfig();
   }

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -154,10 +154,6 @@ export interface Session {
   mcp_policy: SessionMcpPolicy;
   /** One canonical, shared workbench placement. */
   placement: SessionPlacement | null;
-  /** The ACP modes the adapter offers, when the server exposes them. Absent today
-   *  (SessionView carries only `current_mode`), so the mode chip falls back to the
-   *  well-known claude/codex mode set — see `AcpConversation`. */
-  available_modes?: string[];
   branch: Branch;
 }
 
@@ -1085,6 +1081,11 @@ export interface SettingView {
   options: string[];
   value: string;
   is_default: boolean;
+}
+
+/** Canonical reply from both GET and PATCH /api/settings. */
+export interface SettingsEnvelope {
+  settings: SettingView[];
 }
 
 // --- Authentication --------------------------------------------------------

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { get, patch, listAgents } from '../api';
-import type { CustomAgent, SettingView } from '../types';
+import type { CustomAgent, SettingsEnvelope, SettingView } from '../types';
 import ToggleSwitch from '../components/ToggleSwitch.vue';
 import TokensPanel from '../components/TokensPanel.vue';
 import AccountPanel from '../components/AccountPanel.vue';
@@ -17,11 +17,6 @@ import SettingFieldRow from '../components/SettingFieldRow.vue';
 
 const route = useRoute();
 const router = useRouter();
-
-// The server's canonical reply for both GET and PATCH /api/settings.
-interface SettingsEnvelope {
-  settings: SettingView[];
-}
 
 type Category =
   | 'agents'

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -56,7 +56,7 @@ enum Cmd {
         cmd: ServerCmd,
     },
 
-    /// Manage sessions: launch, ls, attach, poll, wait, send, break, preview.
+    /// Manage sessions: launch, ls, attach, poll, wait, send, interrupt, preview.
     ///
     /// The uniform surface for a child session — start one, list the fleet,
     /// watch one, and interact with its agent pane:
@@ -66,7 +66,7 @@ enum Cmd {
     ///     loom session poll weaver/health      # one-shot status
     ///     loom session wait weaver/health      # block until done / needs you
     ///     loom session send weaver/health "try the curl again"
-    ///     loom session break weaver/health     # interrupt the current turn
+    ///     loom session interrupt weaver/health # interrupt the current turn
     ///     loom session preview weaver/health   # peek at the terminal screen
     ///     loom session rename weaver/health "Health endpoint + test"
     ///
@@ -212,7 +212,7 @@ enum Cmd {
     /// List active sessions — shortcut for `loom session ls`.
     Ps,
     /// Attach your terminal to a session — shortcut for `loom session attach`.
-    Attach { branch: String },
+    Attach { session: String },
 
     /// Open the loom web UI in a browser.
     Open,
@@ -465,8 +465,9 @@ enum SessionCmd {
         #[arg(long)]
         no_enter: bool,
     },
-    /// Send a break (Escape) to a session — interrupt the agent's current turn.
-    Break {
+    /// Interrupt a session's current turn (sends Escape to terminal sessions).
+    #[command(visible_alias = "break")]
+    Interrupt {
         /// Session key: id, branch id, branch name, or `repo:branch`.
         session: String,
     },
@@ -551,18 +552,18 @@ enum SessionCmd {
         force: bool,
     },
     /// Show one session's details.
-    Show { branch: String },
+    Show { session: String },
     /// Attach your terminal to a session (also `loom attach`).
-    Attach { branch: String },
+    Attach { session: String },
     /// Archive a session or failed launch: tear down runtime, keep history.
     ///
     /// An unmatched automation launch is addressed by its reserved session id,
     /// the same id shown in the Interventions section/API.
-    Archive { branch: String },
+    Archive { session: String },
     /// Recreate the terminal session for an orphaned session.
-    Adopt { branch: String },
+    Adopt { session: String },
     /// Recover an archived session: rebuild its worktree and resume the agent.
-    Recover { branch: String },
+    Recover { session: String },
     /// Replace the provider behind a live ACP session, preserving its worktree
     /// and canonical conversation journal.
     Handoff {
@@ -589,7 +590,7 @@ enum SessionCmd {
     },
     /// Remove a session or unmatched launch attempt and its runtime.
     Rm {
-        branch: String,
+        session: String,
         #[arg(long)]
         keep_branch: bool,
     },
@@ -1300,7 +1301,7 @@ async fn run() -> Result<()> {
         Cmd::Config { cmd } => run_config(cmd).await,
         Cmd::Launch(opts) => cmd_launch(opts.into()).await,
         Cmd::Ps => cmd_ps(false, false, false, None, None, None).await,
-        Cmd::Attach { branch } => cmd_attach(branch).await,
+        Cmd::Attach { session } => cmd_attach(session).await,
         Cmd::Open => cmd_open().await,
         Cmd::Completions { shell } => {
             let mut cmd = Cli::command();
@@ -1562,7 +1563,7 @@ async fn run_review(cmd: ReviewCmd) -> Result<()> {
             comment_id,
         } => {
             let comment = client
-                .resolve_review_comment(review_id, comment_id, true)
+                .set_review_comment_resolution(review_id, comment_id, true)
                 .await?;
             println!("resolved comment {}", comment.id);
             Ok(())
@@ -1572,7 +1573,7 @@ async fn run_review(cmd: ReviewCmd) -> Result<()> {
             comment_id,
         } => {
             let comment = client
-                .resolve_review_comment(review_id, comment_id, false)
+                .set_review_comment_resolution(review_id, comment_id, false)
                 .await?;
             println!("reopened comment {}", comment.id);
             Ok(())
@@ -1659,7 +1660,7 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
             message,
             no_enter,
         } => cmd_session_send(session, message.join(" "), !no_enter).await,
-        SessionCmd::Break { session } => cmd_session_break(session).await,
+        SessionCmd::Interrupt { session } => cmd_session_interrupt(session).await,
         SessionCmd::Preview { session, lines } => cmd_session_preview(session, lines).await,
         SessionCmd::Changes { session } => {
             let changes = client::default()?.changes(&session).await?;
@@ -1685,11 +1686,11 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
             ensure,
             force,
         } => cmd_session_cue(session, ensure || force, force).await,
-        SessionCmd::Show { branch } => cmd_show(branch).await,
-        SessionCmd::Attach { branch } => cmd_attach(branch).await,
-        SessionCmd::Archive { branch } => cmd_archive(branch).await,
-        SessionCmd::Adopt { branch } => cmd_adopt(branch).await,
-        SessionCmd::Recover { branch } => cmd_recover(branch).await,
+        SessionCmd::Show { session } => cmd_show(session).await,
+        SessionCmd::Attach { session } => cmd_attach(session).await,
+        SessionCmd::Archive { session } => cmd_archive(session).await,
+        SessionCmd::Adopt { session } => cmd_adopt(session).await,
+        SessionCmd::Recover { session } => cmd_recover(session).await,
         SessionCmd::Handoff {
             session,
             profile,
@@ -1699,9 +1700,9 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
             mode,
         } => cmd_handoff(session, profile, agent, model, effort, mode).await,
         SessionCmd::Rm {
-            branch,
+            session,
             keep_branch,
-        } => cmd_rm(branch, keep_branch).await,
+        } => cmd_rm(session, keep_branch).await,
     }
 }
 
@@ -4086,8 +4087,8 @@ async fn cmd_session_send(key: String, message: String, submit: bool) -> Result<
     Ok(())
 }
 
-/// `loom session break` — send Escape to interrupt the agent's current turn.
-async fn cmd_session_break(key: String) -> Result<()> {
+/// `loom session interrupt` — interrupt the agent's current turn.
+async fn cmd_session_interrupt(key: String) -> Result<()> {
     let client = client::default()?;
     client
         .post(
@@ -4095,7 +4096,7 @@ async fn cmd_session_break(key: String) -> Result<()> {
             json!({}),
         )
         .await?;
-    println!("sent break (Escape) to {key}");
+    println!("interrupted {key}");
     Ok(())
 }
 
@@ -5324,6 +5325,16 @@ mod tests {
                 }
             } if session == "task-1"
         ));
+
+        for verb in ["interrupt", "break"] {
+            let parsed = Cli::try_parse_from(["loom", "session", verb, "task-1"]).unwrap();
+            assert!(matches!(
+                parsed.cmd,
+                Cmd::Session {
+                    cmd: SessionCmd::Interrupt { session }
+                } if session == "task-1"
+            ));
+        }
     }
 
     /// The scaffold must honor the contract it documents — at minimum, be

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -762,7 +762,8 @@ pub fn router(state: AppState) -> Router {
                 .post(upload_scratch)
                 .delete(delete_scratch),
         )
-        .route("/sessions/{id}/log", get(log_session))
+        // Compatibility alias for the branch-owned history endpoint below.
+        .route("/sessions/{id}/log", get(branch_events))
         .route("/sessions/{id}/conversation", get(conversation_session))
         .route("/sessions/{id}/history", get(session_history))
         .route("/sessions/{id}/history/search", get(search_session_history))
@@ -818,7 +819,10 @@ pub fn router(state: AppState) -> Router {
         // HTTP-only client of loom and these are its primary write path.
         .route("/branches/{id}/status", post(set_branch_status))
         .route("/branches/{id}/slack/reply", post(slack_reply))
-        .route("/branches/{id}/events", post(create_branch_event))
+        .route(
+            "/branches/{id}/events",
+            get(branch_events).post(create_branch_event),
+        )
         .route(
             "/branches/{id}/tags/{key}",
             axum::routing::put(set_branch_tag).delete(clear_branch_tag),

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2255,9 +2255,9 @@ pub(super) async fn raw_session(
         .into_response())
 }
 
-// Session log, conversation, and event-stream endpoints.
+// Branch history compatibility alias plus session conversation/event endpoints.
 
-pub(super) async fn log_session(
+pub(super) async fn branch_events(
     State(st): State<AppState>,
     Path(key): Path<String>,
 ) -> ApiResult<Json<Vec<Event>>> {

--- a/crates/loom/src/web/settings.rs
+++ b/crates/loom/src/web/settings.rs
@@ -1,5 +1,6 @@
 use axum::{extract::State, Json};
 use serde_json::{json, Value};
+use weaver_api::{SettingView, SettingsEnvelope};
 
 use crate::config;
 use crate::db::Db;
@@ -11,18 +12,23 @@ use super::{ApiResult, AppError, AppState};
 // Settings
 // ---------------------------------------------------------------------------
 
-async fn settings_envelope(db: &Db) -> ApiResult<Json<Value>> {
-    Ok(Json(json!({ "settings": config::describe(db).await? })))
+async fn settings_envelope(db: &Db) -> ApiResult<Json<SettingsEnvelope>> {
+    let settings = config::describe(db)
+        .await?
+        .into_iter()
+        .map(SettingView::from)
+        .collect();
+    Ok(Json(SettingsEnvelope { settings }))
 }
 
-pub(super) async fn get_settings(State(st): State<AppState>) -> ApiResult<Json<Value>> {
+pub(super) async fn get_settings(State(st): State<AppState>) -> ApiResult<Json<SettingsEnvelope>> {
     settings_envelope(&st.db).await
 }
 
 pub(super) async fn patch_settings(
     State(st): State<AppState>,
     Json(body): Json<serde_json::Map<String, Value>>,
-) -> ApiResult<Json<Value>> {
+) -> ApiResult<Json<SettingsEnvelope>> {
     let mut changes: Vec<config::Change> = Vec::with_capacity(body.len());
     let mut legacy_agent_changes: Vec<config::Change> = Vec::new();
     let mut errors = serde_json::Map::new();

--- a/crates/loom/src/web/settings.rs
+++ b/crates/loom/src/web/settings.rs
@@ -1,6 +1,6 @@
 use axum::{extract::State, Json};
 use serde_json::{json, Value};
-use weaver_api::{SettingView, SettingsEnvelope};
+use weaver_api::SettingsEnvelope;
 
 use crate::config;
 use crate::db::Db;
@@ -16,7 +16,7 @@ async fn settings_envelope(db: &Db) -> ApiResult<Json<SettingsEnvelope>> {
     let settings = config::describe(db)
         .await?
         .into_iter()
-        .map(SettingView::from)
+        .map(|setting| setting.into())
         .collect();
     Ok(Json(SettingsEnvelope { settings }))
 }

--- a/crates/loom/tests/integration/archive.rs
+++ b/crates/loom/tests/integration/archive.rs
@@ -217,15 +217,24 @@ async fn archive_keeps_branch_and_history() {
         weaver_core::git::branch_exists(ts.repo_path(), "weaver/archive-me").await,
         "archive must not delete the branch"
     );
-    // The branch event history survives the archive (unlike delete): the
-    // pre-archive manual attention event is still in the log.
-    let log = client
+    // The branch event history survives the archive (unlike delete). The typed
+    // client uses the branch-owned endpoint; the old session log remains an
+    // exact compatibility alias.
+    let branch_log = client.branch_log(&arch_id).await.unwrap();
+    let session_log = client
         .get(&format!("/api/sessions/{arch_id}/log"))
         .await
         .unwrap();
     assert!(
-        serde_json::to_string(&log).unwrap().contains("manual"),
+        serde_json::to_string(&branch_log)
+            .unwrap()
+            .contains("manual"),
         "branch history should survive archive"
+    );
+    assert_eq!(
+        serde_json::to_value(&branch_log).unwrap(),
+        session_log,
+        "the legacy session route must remain a compatibility alias"
     );
 
     // An archived session can still be fully removed afterwards.

--- a/crates/loom/tests/integration/branches.rs
+++ b/crates/loom/tests/integration/branches.rs
@@ -125,8 +125,9 @@ async fn branch_issues_and_repo_board() {
 }
 
 /// The cross-repo issue board (`GET /api/issues`) and issue tags: a label set
-/// via `PUT /api/issues/{id}/tags/{key}` surfaces on the issue's `tags`, and
-/// `DELETE` clears it. Closed issues only appear with `?all=true`.
+/// through the typed client surfaces on the issue's `tags`, including when its
+/// free-form key contains reserved URL characters, and clearing removes it.
+/// Closed issues only appear with `?all=true`.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cross_repo_board_and_issue_tags() {
@@ -165,39 +166,29 @@ async fn cross_repo_board_and_issue_tags() {
         "the new issue shows on the cross-repo board"
     );
 
-    // Set a free-form label; it surfaces on the issue's tags with attribution.
+    // Set a free-form label through the typed client. The key deliberately
+    // contains path/query delimiters so the client must encode it as one path
+    // segment instead of changing the route.
+    let tag_key = "priority / now?#";
     let tagged = client
-        .put(
-            &format!("/api/issues/{issue_id}/tags/priority"),
-            json!({ "value": "high", "note": "ship first", "by": "agent" }),
-        )
+        .set_issue_tag(issue_id, tag_key, "high", "ship first", "agent")
         .await
         .unwrap();
-    let tags = tagged["tags"].as_array().unwrap();
-    assert_eq!(tags.len(), 1);
-    assert_eq!(tags[0]["key"], "priority");
-    assert_eq!(tags[0]["value"], "high");
-    assert_eq!(tags[0]["note"], "ship first");
-    assert_eq!(tags[0]["set_by"], "agent");
+    assert_eq!(tagged.tags.len(), 1);
+    assert_eq!(tagged.tags[0].key, tag_key);
+    assert_eq!(tagged.tags[0].value, "high");
+    assert_eq!(tagged.tags[0].note, "ship first");
+    assert_eq!(tagged.tags[0].set_by, "agent");
 
     // An empty value is rejected (clear the tag instead).
     let bad = client
-        .put(
-            &format!("/api/issues/{issue_id}/tags/priority"),
-            json!({ "value": "" }),
-        )
+        .set_issue_tag(issue_id, tag_key, "", "", "agent")
         .await;
     assert!(bad.is_err(), "an empty issue-tag value is rejected");
 
     // Clearing removes the label.
-    let cleared = client
-        .delete(&format!("/api/issues/{issue_id}/tags/priority"))
-        .await
-        .unwrap();
-    assert!(
-        cleared["tags"].as_array().unwrap().is_empty(),
-        "clearing removes the label"
-    );
+    let cleared = client.clear_issue_tag(issue_id, tag_key).await.unwrap();
+    assert!(cleared.tags.is_empty(), "clearing removes the label");
 
     // Close the issue: it leaves the default board but returns with ?all=true.
     client

--- a/crates/loom/tests/integration/reviews.rs
+++ b/crates/loom/tests/integration/reviews.rs
@@ -375,14 +375,14 @@ async fn api_and_cli_share_the_private_optimistic_review_contract() {
     assert!(visible.iter().any(|review| review.id == submitted.id));
     let comment_id = submitted.comments[0].id;
     assert_eq!(
-        bob.resolve_review_comment(submitted.id, comment_id, true)
+        bob.set_review_comment_resolution(submitted.id, comment_id, true)
             .await
             .unwrap()
             .status,
         "resolved"
     );
     assert_eq!(
-        bob.resolve_review_comment(submitted.id, comment_id, false)
+        bob.set_review_comment_resolution(submitted.id, comment_id, false)
             .await
             .unwrap()
             .status,

--- a/crates/loom/tests/integration/typed_client.rs
+++ b/crates/loom/tests/integration/typed_client.rs
@@ -8,7 +8,8 @@
 
 use serial_test::serial;
 
-use weaver_api::CreateReq;
+use serde_json::{Map, Value};
+use weaver_api::{CreateReq, SettingKind};
 
 use crate::fixtures::TestServer;
 
@@ -88,4 +89,43 @@ async fn typed_create_list_get_and_mark() {
     );
 
     client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// Both settings methods share one rich typed envelope. Registry metadata must
+/// survive a PATCH reply just as it does the initial GET.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_settings_get_and_patch_share_the_rich_envelope() {
+    let ts = TestServer::start_api_only().await;
+    let client = &ts.client;
+
+    let initial = client.list_settings().await.unwrap();
+    let initial_setting = initial
+        .settings
+        .iter()
+        .find(|setting| setting.key == "server.auto_adopt")
+        .expect("server.auto_adopt is registered");
+    assert_eq!(initial_setting.kind, SettingKind::Bool);
+    assert!(!initial_setting.label.is_empty());
+    assert!(!initial_setting.description.is_empty());
+    assert_eq!(initial_setting.default, "false");
+    assert!(!initial_setting.group.is_empty());
+    assert!(initial_setting.options.is_empty());
+
+    let mut changes = Map::new();
+    changes.insert("server.auto_adopt".to_string(), Value::Bool(true));
+    let updated = client.patch_settings(changes).await.unwrap();
+    let updated_setting = updated
+        .settings
+        .iter()
+        .find(|setting| setting.key == "server.auto_adopt")
+        .expect("PATCH returns the full registry");
+    assert_eq!(updated_setting.kind, SettingKind::Bool);
+    assert_eq!(updated_setting.label, initial_setting.label);
+    assert_eq!(updated_setting.description, initial_setting.description);
+    assert_eq!(updated_setting.default, initial_setting.default);
+    assert_eq!(updated_setting.group, initial_setting.group);
+    assert_eq!(updated_setting.options, initial_setting.options);
+    assert_eq!(updated_setting.value, "true");
+    assert!(!updated_setting.is_default);
 }

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -156,7 +156,7 @@ impl Client {
 
     // -- Sessions ---------------------------------------------------------
 
-    /// List every active session (`GET /api/sessions`).
+    /// List active non-automation sessions (`GET /api/sessions`).
     pub async fn list_sessions(&self) -> Result<Vec<SessionView>> {
         self.get_typed("/api/sessions").await
     }

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -609,10 +609,10 @@ impl Client {
     }
 
     /// Recent events for a branch, newest first, capped at 200 server-side
-    /// (`GET /api/sessions/{key}/log`). Despite the URL, `key` may be a branch
-    /// id, `repo:branch`, or unambiguous id prefix — no live session required.
+    /// (`GET /api/branches/{key}/events`). `key` may be a branch id,
+    /// `repo:branch`, or unambiguous id prefix — no live session required.
     pub async fn branch_log(&self, key: &str) -> Result<Vec<weaver_core::events::Event>> {
-        self.get_typed(&format!("/api/sessions/{}/log", Self::seg(key)))
+        self.get_typed(&format!("/api/branches/{}/events", Self::seg(key)))
             .await
     }
 
@@ -996,7 +996,7 @@ impl Client {
         .await
     }
 
-    pub async fn resolve_review_comment(
+    pub async fn set_review_comment_resolution(
         &self,
         review_id: i64,
         comment_id: i64,
@@ -1008,6 +1008,17 @@ impl Client {
             Some(&ResolveReviewCommentReq { resolved }),
         )
         .await
+    }
+
+    /// Compatibility alias for [`Self::set_review_comment_resolution`].
+    pub async fn resolve_review_comment(
+        &self,
+        review_id: i64,
+        comment_id: i64,
+        resolved: bool,
+    ) -> Result<ReviewCommentDto> {
+        self.set_review_comment_resolution(review_id, comment_id, resolved)
+            .await
     }
 
     pub async fn retry_review_delivery(&self, review_id: i64) -> Result<ReviewDto> {
@@ -1098,7 +1109,7 @@ impl Client {
         };
         self.send_typed(
             Method::PUT,
-            &format!("/api/issues/{id}/tags/{key}"),
+            &format!("/api/issues/{id}/tags/{}", Self::seg(key)),
             Some(&req),
         )
         .await
@@ -1106,7 +1117,7 @@ impl Client {
 
     /// Clear a label on an issue (`DELETE /api/issues/{id}/tags/{key}`).
     pub async fn clear_issue_tag(&self, id: i64, key: &str) -> Result<IssueView> {
-        self.delete(&format!("/api/issues/{id}/tags/{key}"))
+        self.delete(&format!("/api/issues/{id}/tags/{}", Self::seg(key)))
             .await
             .and_then(|v| {
                 serde_json::from_value(v)
@@ -1278,8 +1289,12 @@ impl Client {
 
     /// Apply setting changes: a `null` value clears a key back to its default
     /// (`PATCH /api/settings`).
-    pub async fn patch_settings(&self, changes: serde_json::Map<String, Value>) -> Result<Value> {
-        self.patch("/api/settings", Value::Object(changes)).await
+    pub async fn patch_settings(
+        &self,
+        changes: serde_json::Map<String, Value>,
+    ) -> Result<SettingsEnvelope> {
+        self.send_typed(Method::PATCH, "/api/settings", Some(&changes))
+            .await
     }
 
     // -- Watches ------------------------------------------------------

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -2421,17 +2421,61 @@ pub struct CreateEventReq {
     pub data: Value,
 }
 
-/// One registered setting with its effective value, as `GET /api/settings`
-/// exposes it (a subset of the server's richer `SettingSpec` — key, value,
-/// and whether it's unset-and-defaulted are all a CLI needs).
+wire_enum!(SettingKind {
+    String => "string",
+    Int => "int",
+    Bool => "bool",
+    Enum => "enum",
+});
+
+impl From<weaver_core::config::SettingKind> for SettingKind {
+    fn from(kind: weaver_core::config::SettingKind) -> Self {
+        match kind {
+            weaver_core::config::SettingKind::String => Self::String,
+            weaver_core::config::SettingKind::Int => Self::Int,
+            weaver_core::config::SettingKind::Bool => Self::Bool,
+            weaver_core::config::SettingKind::Enum => Self::Enum,
+        }
+    }
+}
+
+/// One registered setting with all registry metadata and its effective value,
+/// as both `GET` and `PATCH /api/settings` return it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SettingView {
     pub key: String,
+    pub label: String,
+    pub description: String,
+    pub kind: SettingKind,
+    pub default: String,
+    pub group: String,
+    pub options: Vec<String>,
     pub value: String,
     pub is_default: bool,
 }
 
-/// The envelope `GET /api/settings` returns: `{ "settings": [...] }`.
+impl From<weaver_core::config::SettingView> for SettingView {
+    fn from(setting: weaver_core::config::SettingView) -> Self {
+        Self {
+            key: setting.spec.key.to_string(),
+            label: setting.spec.label.to_string(),
+            description: setting.spec.description.to_string(),
+            kind: setting.spec.kind.into(),
+            default: setting.spec.default.to_string(),
+            group: setting.spec.group.to_string(),
+            options: setting
+                .spec
+                .options
+                .iter()
+                .map(|option| (*option).to_string())
+                .collect(),
+            value: setting.value,
+            is_default: setting.is_default,
+        }
+    }
+}
+
+/// The envelope both `GET` and `PATCH /api/settings` return.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SettingsEnvelope {
     pub settings: Vec<SettingView>,

--- a/crates/weaver-py/python/weaver_py.pyi
+++ b/crates/weaver-py/python/weaver_py.pyi
@@ -42,7 +42,7 @@ class Client:
 
     # -- Reads (observe) --
     def sessions(self) -> list[dict[str, Any]]:
-        """Every active session, as a list of dicts. Each carries a nested
+        """Active non-automation sessions, as a list of dicts. Each carries a nested
         `branch` whose `tags` is a list of `{key, value, note, set_by, set_at}`
         (the well-known `attention`/`triage` keys plus any free-form key);
         absence of a key is the calm state."""

--- a/crates/weaver-py/src/lib.rs
+++ b/crates/weaver-py/src/lib.rs
@@ -152,7 +152,7 @@ impl Client {
 
     // -- Reads (observe) --------------------------------------------------
 
-    /// Every active session, as a list of dicts (`GET /api/sessions`).
+    /// Active non-automation sessions, as a list of dicts (`GET /api/sessions`).
     fn sessions(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let views = py
             .detach(|| self.rt.block_on(self.inner.list_sessions()))


### PR DESCRIPTION
Unify the remaining public API nouns and typed responses across loom, weaver-api, the CLI, and Vue.

Branch history now has a canonical branch-owned GET route while the prior session log remains compatible. Free-form issue tag keys are encoded as single path segments, settings GET/PATCH share one rich typed envelope, and review resolution has a setter name with the old client method delegating at the edge.

Make `loom session interrupt` primary with a visible `break` alias and accurate session argument help. Remove the speculative Vue session field and route lifecycle actions through the existing API helpers.

Part of #627