### PR TITLE
feat(loom): expose deployed build identity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ COPY . .
 # `debug` (default) is far faster to compile — fine for local/standalone
 # try-outs; pass `release` for a production image (`CARGO_PROFILE=release`).
 ARG CARGO_PROFILE=debug
+# Immutable remote Git build contexts normally omit `.git`, so deployment
+# tooling can pass the resolved source SHA explicitly. Local contexts may leave
+# this empty and loom's build script discovers HEAD itself.
+ARG LOOM_BUILD_REVISION
 
 # BuildKit cache mounts persist the cargo registry/git and the target dir across
 # builds *without* baking them into the image, so an incremental rebuild only

--- a/crates/loom/build.rs
+++ b/crates/loom/build.rs
@@ -2,6 +2,53 @@ use std::path::Path;
 use std::process::Command;
 use std::time::SystemTime;
 
+fn command_output(command: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(command).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn valid_revision(value: &str) -> bool {
+    (7..=64).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// Stamp the source revision into the binary. Local cargo builds discover it
+/// from git; immutable/container builders can supply `LOOM_BUILD_REVISION`
+/// when their source context intentionally omits `.git`.
+fn emit_build_identity() {
+    println!("cargo:rerun-if-env-changed=LOOM_BUILD_REVISION");
+
+    // A commit moves without changing source-file mtimes when a cached target
+    // directory is reused. Watch HEAD, its loose ref, and packed refs so the
+    // embedded identity follows that move in ordinary repositories and
+    // worktrees.
+    for path in [
+        command_output("git", &["rev-parse", "--git-path", "HEAD"]),
+        command_output("git", &["rev-parse", "--git-path", "packed-refs"]),
+        command_output("git", &["symbolic-ref", "-q", "HEAD"])
+            .and_then(|reference| command_output("git", &["rev-parse", "--git-path", &reference])),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        println!("cargo:rerun-if-changed={path}");
+    }
+
+    let revision = std::env::var("LOOM_BUILD_REVISION")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| valid_revision(value))
+        .or_else(|| command_output("git", &["rev-parse", "--verify", "HEAD"]))
+        .filter(|value| valid_revision(value))
+        .unwrap_or_else(|| "unknown".to_string());
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=LOOM_BUILD_REVISION={revision}");
+    println!("cargo:rustc-env=LOOM_BUILD_PROFILE={profile}");
+}
+
 /// Modification time of `path`, or the epoch when it cannot be read (so a
 /// missing file always counts as "older" than anything that exists).
 fn mtime(path: &Path) -> SystemTime {
@@ -18,6 +65,8 @@ fn mtime(path: &Path) -> SystemTime {
 // Node-less, backend-only checkout), it degrades to a placeholder page instead
 // of failing the build.
 fn main() {
+    emit_build_identity();
+
     // Every file that feeds the frontend build: changing any of them reruns
     // this script (and therefore rspack). `frontend/src` covers the Vue/TS
     // sources and the HTML template; the rest are build-config inputs.

--- a/crates/loom/frontend/src/components/LogsPanel.vue
+++ b/crates/loom/frontend/src/components/LogsPanel.vue
@@ -193,6 +193,13 @@ const uptime = computed(() => {
   return h ? `${h}h ${m}m` : m ? `${m}m ${s}s` : `${s}s`;
 });
 
+const shortIdentity = (value: string): string => {
+  if (value === 'unknown') return value;
+  const digest = value.includes('@') ? value.slice(value.lastIndexOf('@') + 1) : value;
+  if (digest.startsWith('sha256:')) return `${digest.slice(0, 19)}…`;
+  return digest.slice(0, 12);
+};
+
 const currentSessionCount = computed(
   () =>
     diagnostics.value?.sessions
@@ -239,7 +246,7 @@ onUnmounted(() => {
   <div>
     <p v-if="error" class="mb-3 text-sm text-block">{{ error }}</p>
 
-    <!-- Status line: server identity, so a redeploy is visible (pid/start change). -->
+    <!-- Build + process identity, so a redeploy is visible and attributable. -->
     <div
       v-if="status"
       class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border border-line bg-surface px-3 py-2 font-mono text-2xs text-muted"
@@ -247,6 +254,15 @@ onUnmounted(() => {
       <span
         >v<span class="text-accent">{{ status.version }}</span></span
       >
+      <span :title="status.build_revision">
+        rev <span class="text-accent">{{ shortIdentity(status.build_revision) }}</span>
+      </span>
+      <span>
+        profile <span class="text-accent">{{ status.build_profile }}</span>
+      </span>
+      <span v-if="status.image" :title="status.image">
+        image <span class="text-accent">{{ shortIdentity(status.image) }}</span>
+      </span>
       <span
         >pid <span class="text-accent">{{ status.pid }}</span></span
       >

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -1450,6 +1450,9 @@ export interface LogLine {
 /** Build/runtime status of the server. Mirrors `loom::web::logview::ServerStatus`. */
 export interface ServerStatus {
   version: string;
+  build_revision: string;
+  build_profile: string;
+  image: string | null;
   pid: number;
   started_at: string;
 }

--- a/crates/loom/src/web/logview.rs
+++ b/crates/loom/src/web/logview.rs
@@ -44,20 +44,31 @@ pub(super) async fn logs_stream() -> Sse<impl Stream<Item = Result<sse::Event, I
     Sse::new(stream).keep_alive(KeepAlive::default())
 }
 
-/// A small "what am I looking at" status blob for the debug panel — enough to
-/// tell whether a redeploy landed (pid + start time change on restart).
+/// A small "what am I looking at" status blob for the debug panel: build and
+/// image identity plus process identity, so both deploys and restarts are
+/// attributable.
 #[derive(Debug, Serialize)]
 pub(super) struct ServerStatus {
     version: &'static str,
+    build_revision: &'static str,
+    build_profile: &'static str,
+    /// Digest-pinned image reference when a container deployment supplies one.
+    image: Option<String>,
     pid: u32,
     /// When this process started capturing logs (≈ process start), RFC3339.
     started_at: String,
 }
 
-/// `GET /api/status` — build version + pid + start time (operator-only).
+/// `GET /api/status` — build and process identity (operator-only).
 pub(super) async fn server_status() -> Json<ServerStatus> {
     Json(ServerStatus {
         version: env!("CARGO_PKG_VERSION"),
+        build_revision: env!("LOOM_BUILD_REVISION"),
+        build_profile: env!("LOOM_BUILD_PROFILE"),
+        image: std::env::var("LOOM_IMAGE")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
         pid: std::process::id(),
         started_at: logs::buffer().started_at().to_string(),
     })

--- a/crates/loom/tests/integration/logs.rs
+++ b/crates/loom/tests/integration/logs.rs
@@ -33,6 +33,22 @@ async fn status_and_logs_are_shaped_and_operator_only() {
         .await
         .unwrap();
     assert!(st["version"].as_str().is_some(), "status has a version");
+    assert!(
+        st["build_revision"]
+            .as_str()
+            .is_some_and(|revision| !revision.is_empty()),
+        "status has a build revision or the explicit unknown sentinel"
+    );
+    assert!(
+        st["build_profile"]
+            .as_str()
+            .is_some_and(|profile| !profile.is_empty()),
+        "status has a cargo build profile"
+    );
+    assert!(
+        st.get("image").is_some(),
+        "status has a nullable runtime image identity"
+    );
     assert!(st["pid"].as_u64().unwrap_or(0) > 0, "status has a pid");
     assert!(
         st["started_at"].as_str().unwrap_or("").len() >= 10,


### PR DESCRIPTION
Expose source revision, Cargo profile, and digest-pinned runtime image through the operator-only status endpoint, and render them in the Debug panel alongside PID and uptime. This makes stale or mis-targeted restarts attributable instead of relying on the unchanged package version. Local builds derive the Git revision automatically; release builds may inject it explicitly, while container deployments report the exact LOOM_IMAGE reference.