### PR TITLE
fix(loom): streamline fleet UI and loading

### DIFF
--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -85,34 +85,32 @@ export const getScratchLimits = () => get('/scratch/limits') as Promise<ScratchL
 
 // --- Sessions ----------------------------------------------------------------
 
-/** Session inventory. The compatibility default excludes automation; fleet
- * workbenches opt in. `managed` is the admin-only warm-session escape hatch. */
-export const listSessions = (
-  opts: { archived?: boolean; automation?: boolean; managed?: boolean } = {},
+/** Compact fleet inventory/search. Full session context is fetched from the
+ * item endpoint only when a row or session page discloses it. */
+export const listSessionSummaries = (
+  opts: {
+    archived?: boolean;
+    archivedOnly?: boolean;
+    automation?: boolean;
+    query?: string;
+    status?: SessionSearchOptions['status'];
+    attention?: SessionSearchOptions['attention'];
+  } = {},
+  signal?: AbortSignal,
 ) => {
   const params = new URLSearchParams();
   if (opts.archived) params.set('archived', 'true');
-  if (opts.automation !== undefined) params.set('automation', String(opts.automation));
-  if (opts.managed) params.set('automation', 'true');
-  if (opts.managed) params.set('managed', 'true');
-  const qs = params.toString();
-  return get(`/sessions${qs ? `?${qs}` : ''}`) as Promise<Session[]>;
-};
-
-/** Server-visible fleet search. `history` widens an active search;
- * `archivedOnly` keeps the History route a disjoint archived projection. */
-export const searchSessions = (
-  query: string,
-  opts: SessionSearchOptions = {},
-  signal?: AbortSignal,
-) => {
-  const params = new URLSearchParams({ q: query });
-  if (opts.history) params.set('history', 'true');
   if (opts.archivedOnly) params.set('archived_only', 'true');
+  if (opts.automation !== undefined) params.set('automation', String(opts.automation));
+  if (opts.query) params.set('q', opts.query);
   if (opts.status) params.set('status', opts.status);
   if (opts.attention) params.set('attention', opts.attention);
-  return request(`/sessions/search?${params}`, { signal }) as Promise<Session[]>;
+  const qs = params.toString();
+  return request(`/sessions/summary${qs ? `?${qs}` : ''}`, { signal }) as Promise<SessionSummary[]>;
 };
+
+export const getSession = (id: string) =>
+  get(`/sessions/${encodeURIComponent(id)}`) as Promise<Session>;
 
 /** Durable automation launch reservations, including failures that never
  *  produced a usable session (`GET /api/runs`). */
@@ -206,6 +204,7 @@ import type {
   IssueActionsResult,
   IssueTagInput,
   Session,
+  SessionSummary,
   AutomationRun,
   SessionGroupOrder,
   SessionLayoutItemKind,

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -1686,6 +1686,7 @@ function goTo(anchor: string) {
         rows="4"
         :disabled="sending || editingQueued"
         :placeholder="commandHint || 'Message the agent…'"
+        autocomplete="off"
         data-testid="acp-composer-input"
         class="acp-input"
         @keydown="onComposerKeydown"

--- a/crates/loom/frontend/src/components/AgentRuntimePicker.vue
+++ b/crates/loom/frontend/src/components/AgentRuntimePicker.vue
@@ -25,7 +25,7 @@ const props = withDefaults(
     modelKey: '',
     effortKey: '',
     rawModelId: '',
-    rawModelAutocomplete: '',
+    rawModelAutocomplete: 'off',
   },
 );
 

--- a/crates/loom/frontend/src/components/GithubAssociations.vue
+++ b/crates/loom/frontend/src/components/GithubAssociations.vue
@@ -1,19 +1,32 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
 import type { Session } from '../types';
 import { clearSessionGithub, patchIssue, refreshSessionGithub, setSessionGithub } from '../api';
 
-// The two GitHub links a workstream accumulates: the issue it came from and the
-// PR it produces. Both pills remain visible when empty so association is a
-// discoverable operation rather than a setting hidden in the manage menu.
+// The two high-frequency GitHub destinations a workstream accumulates: the issue
+// it came from and the PR it produces. A mapped pill is a direct link; its
+// adjacent edit control owns reassociation. An empty pill opens that same editor,
+// keeping setup discoverable without making every follow a two-click action.
 const props = defineProps<{ ws: Session }>();
 const emit = defineEmits<{ reload: [] }>();
 
-const prOpen = ref(false);
+type Editor = 'pr' | 'issue';
+const root = ref<HTMLElement | null>(null);
+const prTrigger = ref<HTMLButtonElement | null>(null);
+const issueTrigger = ref<HTMLButtonElement | null>(null);
+const editor = ref<Editor | null>(null);
+const prOpen = computed(() => editor.value === 'pr');
+const issueOpen = computed(() => editor.value === 'issue');
+
 const prDraft = ref('');
 const prBusy = ref('');
 const prError = ref('');
 const prNumber = computed(() => props.ws.branch.github?.pr_number ?? props.ws.branch.github_pr);
+const prUrl = computed(() => {
+  if (props.ws.branch.github?.pr_url) return props.ws.branch.github.pr_url;
+  if (!props.ws.github_repo || !prNumber.value) return '';
+  return `https://github.com/${props.ws.github_repo}/pull/${prNumber.value}`;
+});
 const prStateClass = computed(() => {
   const state = props.ws.branch.github?.pr_state;
   return (
@@ -28,14 +41,31 @@ const prChecksClass = computed(() => {
   );
 });
 
-const issueOpen = ref(false);
 const issueDraft = ref('');
 const issueBusy = ref(false);
 const issueError = ref('');
+const issueUrl = computed(() => {
+  const issue = props.ws.github_issue;
+  return issue ? `https://github.com/${issue.repo}/issues/${issue.number}` : '';
+});
+
+function triggerFor(target: Editor): HTMLButtonElement | null {
+  return target === 'pr' ? prTrigger.value : issueTrigger.value;
+}
+
+function closeEditor(focusTrigger = false) {
+  const active = editor.value;
+  if (!active) return;
+  editor.value = null;
+  if (focusTrigger) void nextTick(() => triggerFor(active)?.focus());
+}
 
 function togglePrEditor() {
-  prOpen.value = !prOpen.value;
-  issueOpen.value = false;
+  if (prOpen.value) {
+    closeEditor(true);
+    return;
+  }
+  editor.value = 'pr';
   prError.value = '';
   prDraft.value = String(props.ws.branch.github_pr ?? props.ws.branch.github?.pr_number ?? '');
 }
@@ -53,7 +83,7 @@ async function updatePr(action: 'set' | 'auto' | 'refresh') {
     if (action === 'set') await setSessionGithub(props.ws.id, number);
     else if (action === 'auto') await clearSessionGithub(props.ws.id);
     else await refreshSessionGithub(props.ws.id);
-    prOpen.value = false;
+    closeEditor(true);
     emit('reload');
   } catch (e) {
     prError.value = (e as Error).message;
@@ -63,8 +93,11 @@ async function updatePr(action: 'set' | 'auto' | 'refresh') {
 }
 
 function toggleIssueEditor() {
-  issueOpen.value = !issueOpen.value;
-  prOpen.value = false;
+  if (issueOpen.value) {
+    closeEditor(true);
+    return;
+  }
+  editor.value = 'issue';
   issueError.value = '';
   issueDraft.value = props.ws.github_issue
     ? `${props.ws.github_issue.repo}#${props.ws.github_issue.number}`
@@ -81,7 +114,7 @@ async function updateIssue(clear = false) {
   issueError.value = '';
   try {
     await patchIssue(props.ws.tracking_issue, { github: clear ? '' : issueDraft.value.trim() });
-    issueOpen.value = false;
+    closeEditor(true);
     emit('reload');
   } catch (e) {
     issueError.value = (e as Error).message;
@@ -89,150 +122,223 @@ async function updateIssue(clear = false) {
     issueBusy.value = false;
   }
 }
+
+// Match the header's Details popover: outside pointer presses light-dismiss
+// without swallowing the target, while Escape closes and restores the trigger.
+function onOutsidePointerDown(event: PointerEvent) {
+  const target = event.target;
+  if (!(target instanceof Element) || root.value?.contains(target)) return;
+  closeEditor();
+}
+
+watch(editor, async (open) => {
+  document.removeEventListener('pointerdown', onOutsidePointerDown, true);
+  if (!open) return;
+  await nextTick();
+  if (editor.value) document.addEventListener('pointerdown', onOutsidePointerDown, true);
+});
+onBeforeUnmount(() => document.removeEventListener('pointerdown', onOutsidePointerDown, true));
 </script>
 
 <template>
-  <div class="relative shrink-0">
-    <button
-      type="button"
-      class="pill font-mono hover:border-accent hover:text-accent"
-      data-testid="pr-association-pill"
-      :aria-expanded="prOpen"
-      :title="prNumber ? 'Edit pull request association' : 'Associate a pull request'"
-      @click="togglePrEditor"
-    >
-      PR {{ prNumber ? `#${prNumber}` : '—' }}
-    </button>
-    <div
-      v-if="prOpen"
-      class="absolute left-0 top-full z-30 mt-1 w-64 rounded border border-line bg-surface p-3 shadow-lg"
-      data-testid="pr-mapping-popover"
-    >
-      <form class="space-y-2" data-testid="pr-mapping-form" @submit.prevent="updatePr('set')">
-        <div class="flex items-baseline justify-between gap-2">
-          <span class="text-2xs font-semibold uppercase tracking-wider text-muted"
-            >Pull request</span
-          >
-          <a
-            v-if="ws.branch.github"
-            :href="ws.branch.github.pr_url"
-            target="_blank"
-            rel="noopener"
-            class="text-2xs text-accent hover:underline"
-            >Open on GitHub ↗</a
-          >
-        </div>
-        <label class="block text-2xs text-muted">
-          PR number
-          <input
-            v-model="prDraft"
-            type="number"
-            min="1"
-            class="mt-1 block w-full rounded bg-input px-2 py-1.5 font-mono text-xs text-fg"
-          />
-        </label>
-        <p class="text-2xs text-faint">
-          {{ ws.branch.github_pr ? 'Pinned manually.' : 'Following the worktree branch.' }}
-        </p>
-        <p v-if="prError" class="text-xs text-block">{{ prError }}</p>
-        <div class="flex flex-wrap gap-1.5">
-          <button type="submit" class="btn-primary px-2 py-1 text-xs" :disabled="!!prBusy">
-            {{ prBusy === 'set' ? 'Saving…' : 'Pin PR' }}
-          </button>
-          <button
-            type="button"
-            class="btn-secondary px-2 py-1 text-xs"
-            :disabled="!!prBusy"
-            @click="updatePr('auto')"
-          >
-            Use current
-          </button>
-          <button
-            type="button"
-            class="btn-secondary px-2 py-1 text-xs"
-            :disabled="!!prBusy"
-            @click="updatePr('refresh')"
-          >
-            Refresh
-          </button>
-        </div>
-      </form>
+  <div
+    ref="root"
+    class="flex shrink-0 flex-wrap items-center justify-end gap-1.5 text-xs"
+    data-testid="github-associations"
+    @keydown.esc.stop.prevent="closeEditor(true)"
+  >
+    <div class="relative flex shrink-0 items-center gap-0.5">
+      <a
+        v-if="prUrl"
+        :href="prUrl"
+        target="_blank"
+        rel="noopener"
+        class="pill font-mono hover:border-accent hover:text-accent"
+        data-testid="pr-association-pill"
+        :title="`Open pull request #${prNumber} on GitHub`"
+      >
+        PR #{{ prNumber }}
+      </a>
+      <button
+        v-else
+        ref="prTrigger"
+        type="button"
+        class="pill font-mono hover:border-accent hover:text-accent"
+        data-testid="pr-association-pill"
+        :aria-expanded="prOpen"
+        :title="prNumber ? 'Edit pull request association' : 'Associate a pull request'"
+        @click="togglePrEditor"
+      >
+        PR {{ prNumber ? `#${prNumber}` : '—' }}
+      </button>
+      <template v-if="ws.branch.github">
+        <span :class="prStateClass" class="font-mono uppercase tracking-wide">
+          {{ ws.branch.github.pr_state.toLowerCase() }}
+        </span>
+        <span
+          v-if="ws.branch.github.checks"
+          :class="prChecksClass"
+          class="font-mono"
+          :title="`Checks ${ws.branch.github.checks}`"
+          >●</span
+        >
+      </template>
+      <button
+        v-if="prUrl"
+        ref="prTrigger"
+        type="button"
+        class="min-h-7 rounded px-1 text-faint hover:bg-subtle hover:text-fg"
+        data-testid="pr-association-edit"
+        :aria-expanded="prOpen"
+        title="Edit pull request association"
+        aria-label="Edit pull request association"
+        @click="togglePrEditor"
+      >
+        ✎
+      </button>
+      <div
+        v-if="prOpen"
+        class="absolute right-0 top-full z-30 mt-1 w-64 rounded border border-line bg-surface p-3 shadow-lg"
+        data-testid="pr-mapping-popover"
+      >
+        <form class="space-y-2" data-testid="pr-mapping-form" @submit.prevent="updatePr('set')">
+          <div class="flex items-baseline justify-between gap-2">
+            <span class="text-2xs font-semibold uppercase tracking-wider text-muted">
+              Pull request
+            </span>
+            <a
+              v-if="prUrl"
+              :href="prUrl"
+              target="_blank"
+              rel="noopener"
+              class="text-2xs text-accent hover:underline"
+              >Open on GitHub ↗</a
+            >
+          </div>
+          <label class="block text-2xs text-muted">
+            PR number
+            <input
+              v-model="prDraft"
+              type="number"
+              min="1"
+              autocomplete="off"
+              class="mt-1 block w-full rounded bg-input px-2 py-1.5 font-mono text-xs text-fg"
+            />
+          </label>
+          <p class="text-2xs text-faint">
+            {{ ws.branch.github_pr ? 'Pinned manually.' : 'Following the worktree branch.' }}
+          </p>
+          <p v-if="prError" class="text-xs text-block">{{ prError }}</p>
+          <div class="flex flex-wrap gap-1.5">
+            <button type="submit" class="btn-primary px-2 py-1 text-xs" :disabled="!!prBusy">
+              {{ prBusy === 'set' ? 'Saving…' : 'Pin PR' }}
+            </button>
+            <button
+              type="button"
+              class="btn-secondary px-2 py-1 text-xs"
+              :disabled="!!prBusy"
+              @click="updatePr('auto')"
+            >
+              Use current
+            </button>
+            <button
+              type="button"
+              class="btn-secondary px-2 py-1 text-xs"
+              :disabled="!!prBusy"
+              @click="updatePr('refresh')"
+            >
+              Refresh
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
-  </div>
-  <template v-if="ws.branch.github">
-    <span :class="prStateClass" class="font-mono uppercase tracking-wide">
-      {{ ws.branch.github.pr_state.toLowerCase() }}
-    </span>
-    <span
-      v-if="ws.branch.github.checks"
-      :class="prChecksClass"
-      class="font-mono"
-      :title="`Checks ${ws.branch.github.checks}`"
-      >●</span
-    >
-  </template>
 
-  <div class="relative shrink-0">
-    <button
-      type="button"
-      class="pill font-mono hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-60"
-      data-testid="issue-association-pill"
-      :aria-expanded="issueOpen"
-      :disabled="!ws.tracking_issue"
-      :title="
-        ws.tracking_issue
-          ? ws.github_issue
-            ? 'Edit GitHub issue association'
-            : 'Associate a GitHub issue'
-          : 'This session has no tracking issue'
-      "
-      @click="toggleIssueEditor"
-    >
-      Issue {{ ws.github_issue ? `#${ws.github_issue.number}` : '—' }}
-    </button>
-    <div
-      v-if="issueOpen"
-      class="absolute left-0 top-full z-30 mt-1 w-72 rounded border border-line bg-surface p-3 shadow-lg"
-      data-testid="issue-mapping-popover"
-    >
-      <form class="space-y-2" data-testid="issue-mapping-form" @submit.prevent="updateIssue()">
-        <div class="flex items-baseline justify-between gap-2">
-          <span class="text-2xs font-semibold uppercase tracking-wider text-muted"
-            >GitHub issue</span
-          >
-          <a
-            v-if="ws.github_issue"
-            :href="`https://github.com/${ws.github_issue.repo}/issues/${ws.github_issue.number}`"
-            target="_blank"
-            rel="noopener"
-            class="text-2xs text-accent hover:underline"
-            >Open on GitHub ↗</a
-          >
-        </div>
-        <label class="block text-2xs text-muted">
-          owner/repo#number
-          <input
-            v-model="issueDraft"
-            placeholder="acme/widgets#123"
-            class="mt-1 block w-full rounded bg-input px-2 py-1.5 font-mono text-xs text-fg"
-          />
-        </label>
-        <p v-if="issueError" class="text-xs text-block">{{ issueError }}</p>
-        <div class="flex gap-1.5">
-          <button type="submit" class="btn-primary px-2 py-1 text-xs" :disabled="issueBusy">
-            {{ issueBusy ? 'Saving…' : 'Save' }}
-          </button>
-          <button
-            v-if="ws.github_issue"
-            type="button"
-            class="btn-secondary px-2 py-1 text-xs"
-            :disabled="issueBusy"
-            @click="updateIssue(true)"
-          >
-            Clear
-          </button>
-        </div>
-      </form>
+    <div class="relative flex shrink-0 items-center gap-0.5">
+      <a
+        v-if="issueUrl"
+        :href="issueUrl"
+        target="_blank"
+        rel="noopener"
+        class="pill font-mono hover:border-accent hover:text-accent"
+        data-testid="issue-association-pill"
+        :title="`Open ${ws.github_issue?.repo} issue #${ws.github_issue?.number} on GitHub`"
+      >
+        Issue #{{ ws.github_issue?.number }}
+      </a>
+      <button
+        v-else
+        ref="issueTrigger"
+        type="button"
+        class="pill font-mono hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-60"
+        data-testid="issue-association-pill"
+        :aria-expanded="issueOpen"
+        :disabled="!ws.tracking_issue"
+        :title="
+          ws.tracking_issue ? 'Associate a GitHub issue' : 'This session has no tracking issue'
+        "
+        @click="toggleIssueEditor"
+      >
+        Issue —
+      </button>
+      <button
+        v-if="issueUrl"
+        ref="issueTrigger"
+        type="button"
+        class="min-h-7 rounded px-1 text-faint hover:bg-subtle hover:text-fg"
+        data-testid="issue-association-edit"
+        :aria-expanded="issueOpen"
+        title="Edit GitHub issue association"
+        aria-label="Edit GitHub issue association"
+        @click="toggleIssueEditor"
+      >
+        ✎
+      </button>
+      <div
+        v-if="issueOpen"
+        class="absolute right-0 top-full z-30 mt-1 w-72 rounded border border-line bg-surface p-3 shadow-lg"
+        data-testid="issue-mapping-popover"
+      >
+        <form class="space-y-2" data-testid="issue-mapping-form" @submit.prevent="updateIssue()">
+          <div class="flex items-baseline justify-between gap-2">
+            <span class="text-2xs font-semibold uppercase tracking-wider text-muted">
+              GitHub issue
+            </span>
+            <a
+              v-if="issueUrl"
+              :href="issueUrl"
+              target="_blank"
+              rel="noopener"
+              class="text-2xs text-accent hover:underline"
+              >Open on GitHub ↗</a
+            >
+          </div>
+          <label class="block text-2xs text-muted">
+            owner/repo#number
+            <input
+              v-model="issueDraft"
+              placeholder="acme/widgets#123"
+              autocomplete="off"
+              class="mt-1 block w-full rounded bg-input px-2 py-1.5 font-mono text-xs text-fg"
+            />
+          </label>
+          <p v-if="issueError" class="text-xs text-block">{{ issueError }}</p>
+          <div class="flex gap-1.5">
+            <button type="submit" class="btn-primary px-2 py-1 text-xs" :disabled="issueBusy">
+              {{ issueBusy ? 'Saving…' : 'Save' }}
+            </button>
+            <button
+              v-if="ws.github_issue"
+              type="button"
+              class="btn-secondary px-2 py-1 text-xs"
+              :disabled="issueBusy"
+              @click="updateIssue(true)"
+            >
+              Clear
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </template>

--- a/crates/loom/frontend/src/components/LaunchOverrides.vue
+++ b/crates/loom/frontend/src/components/LaunchOverrides.vue
@@ -83,6 +83,7 @@ function locked(field: keyof LaunchOverrides): boolean {
           :disabled="locked('model')"
           data-testid="override-model"
           list="launch-model-options"
+          autocomplete="off"
           placeholder="Agent default"
           class="w-full rounded bg-surface px-2 py-1.5 font-mono disabled:opacity-60"
           @input="set('model', ($event.target as HTMLInputElement).value)"

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -633,10 +633,10 @@ onActivated(() => void refreshLaunchData());
 
 <template>
   <!--
-    Autofill suppression: Chrome's address/payment classifier deliberately
-    ignores autocomplete="off". Unrecognized per-field tokens keep this workflow
-    out of contact/payment autofill while preserving the form's normal keyboard
-    behavior.
+    Loom owns repository/branch suggestions, while task fields should start
+    clean. Keep browser history completion off at both form and field level:
+    product-specific autocomplete tokens create Chrome history buckets instead
+    of suppressing them.
   -->
   <form
     class="mx-auto flex min-h-full w-full max-w-7xl flex-1 flex-col bg-canvas"
@@ -681,7 +681,7 @@ onActivated(() => void refreshLaunchData());
                 repoActiveOption >= 0 ? `launch-repository-option-${repoActiveOption}` : undefined
               "
               placeholder="owner/name or /home/you/code/project"
-              autocomplete="loom-repo"
+              autocomplete="off"
               spellcheck="false"
               class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
             />
@@ -750,7 +750,7 @@ onActivated(() => void refreshLaunchData());
               id="launch-title"
               v-model="title"
               placeholder="Health endpoint"
-              autocomplete="loom-title"
+              autocomplete="off"
               class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent"
             />
           </div>
@@ -763,7 +763,7 @@ onActivated(() => void refreshLaunchData());
               v-model="goal"
               rows="4"
               placeholder="Add a /health endpoint that returns 200"
-              autocomplete="loom-goal"
+              autocomplete="off"
               class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent resize-y"
             ></textarea>
           </div>
@@ -813,7 +813,7 @@ onActivated(() => void refreshLaunchData());
                   v-model="name"
                   @input="nameEdited = true"
                   placeholder="health-endpoint"
-                  autocomplete="loom-branch-name"
+                  autocomplete="off"
                   spellcheck="false"
                   class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
                 />
@@ -826,7 +826,7 @@ onActivated(() => void refreshLaunchData());
                   id="launch-base-branch"
                   v-model="base"
                   placeholder="origin/main (freshly fetched)"
-                  autocomplete="loom-base-branch"
+                  autocomplete="off"
                   spellcheck="false"
                   class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
                 />
@@ -855,7 +855,7 @@ onActivated(() => void refreshLaunchData());
                   branchActiveOption >= 0 ? `launch-branch-option-${branchActiveOption}` : undefined
                 "
                 placeholder="feature/foo"
-                autocomplete="loom-existing-branch"
+                autocomplete="off"
                 spellcheck="false"
                 class="w-full rounded bg-input px-2 py-1.5 text-sm outline-none focus:ring-1 ring-accent font-mono"
               />

--- a/crates/loom/frontend/src/components/ProfileEditor.vue
+++ b/crates/loom/frontend/src/components/ProfileEditor.vue
@@ -153,6 +153,7 @@ watch(
         data-testid="profile-model"
         :list="`${uid}-model-options`"
         :disabled="disabled"
+        autocomplete="off"
         placeholder="Agent default"
         class="min-w-0 rounded bg-input px-2 py-1.5"
       />

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -36,12 +36,13 @@ import ResolvedLaunchSummary from './ResolvedLaunchSummary.vue';
 // view and the file browser, so the "where am I / what is this" context never
 // vanishes when you cross into Files.
 //
-//   row 1  ← sessions · title · current state / freshness · signals · Details
+//   row 1  ← sessions · title · GitHub destinations · current state / freshness
+//          · signals · Details
 //   row 2  the agent's current-state message, when present
 //
-// Identity, launch metadata, associations, tags, status history, lifecycle
-// actions, and the optional editor live in Details instead of permanently
-// occupying the work surface.
+// Frequent destinations stay in the always-visible row. Identity, launch
+// metadata, tags, status history, lifecycle actions, and the optional editor
+// live in Details instead of permanently occupying the work surface.
 const props = withDefaults(
   defineProps<{ ws: Session; events?: WeaverEvent[]; ideEnabled?: boolean }>(),
   {
@@ -368,6 +369,11 @@ async function submitHandoff() {
       </div>
 
       <div class="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+        <!-- An issue/PR is a frequent work destination, not merely metadata.
+             Existing associations open directly; their adjacent edit affordance
+             and the empty states own configuration. -->
+        <GithubAssociations :ws="ws" @reload="emit('reload')" />
+
         <span
           data-testid="conversation-state"
           :class="toneClass"
@@ -623,8 +629,6 @@ async function submitHandoff() {
                     </li>
                   </ul>
                 </details>
-
-                <GithubAssociations :ws="ws" @reload="emit('reload')" />
 
                 <div v-if="quiet.length" class="flex flex-wrap items-center gap-1.5">
                   <TagPill

--- a/crates/loom/frontend/src/components/SessionRemedyButton.vue
+++ b/crates/loom/frontend/src/components/SessionRemedyButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { Session } from '../types';
+import type { SessionSummary } from '../types';
 import { remedyAction } from '../lib/sessionState';
 import { useSessionActions } from '../lib/sessionActions';
 
@@ -12,7 +12,7 @@ import { useSessionActions } from '../lib/sessionActions';
 // on every surface that shows one (the fleet-list row and the detail header), so
 // the cure travels with the diagnosis instead of hiding behind a menu. The same
 // verbs are still in the ⋯ menu for anyone who looks there.
-const props = defineProps<{ ws: Session }>();
+const props = defineProps<{ ws: SessionSummary }>();
 const emit = defineEmits<{ changed: []; error: [string] }>();
 
 const remedy = computed(() => remedyAction(props.ws));

--- a/crates/loom/frontend/src/components/SessionRowActions.vue
+++ b/crates/loom/frontend/src/components/SessionRowActions.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, useId, watch } from 'vue';
-import type { Session } from '../types';
+import type { SessionSummary } from '../types';
 import { autoArchiveDisabled, lifecycleActions } from '../lib/sessionState';
 import { useSessionActions } from '../lib/sessionActions';
 
-const props = defineProps<{ ws: Session }>();
+const props = defineProps<{ ws: SessionSummary }>();
 const emit = defineEmits<{ changed: []; error: [string] }>();
 
 const open = ref(false);

--- a/crates/loom/frontend/src/components/SessionWorkbenchRow.vue
+++ b/crates/loom/frontend/src/components/SessionWorkbenchRow.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, type PropType, useId, watch } from 'vue';
-import type { Session, SessionGroup, SessionSpace } from '../types';
+import type { Session, SessionGroup, SessionSpace, SessionSummary } from '../types';
 import AgentUsage from './AgentUsage.vue';
 import GithubStatus from './GithubStatus.vue';
 import SessionRemedyButton from './SessionRemedyButton.vue';
@@ -24,7 +24,10 @@ interface GroupOption {
 }
 
 const props = defineProps({
-  session: { type: Object as PropType<Session>, required: true },
+  session: { type: Object as PropType<SessionSummary>, required: true },
+  detail: { type: Object as PropType<Session | undefined>, default: undefined },
+  detailLoading: { type: Boolean, default: false },
+  detailError: { type: String, default: '' },
   qualified: { type: Boolean, default: false },
   selected: { type: Boolean, default: false },
   expanded: { type: Boolean, default: false },
@@ -32,8 +35,8 @@ const props = defineProps({
   destination: { type: String, default: '' },
   before: { type: String, default: '' },
   allGroups: { type: Array as PropType<GroupOption[]>, default: () => [] },
-  allSessions: { type: Array as PropType<Session[]>, default: () => [] },
-  parentSession: { type: Object as PropType<Session | undefined>, default: undefined },
+  allSessions: { type: Array as PropType<SessionSummary[]>, default: () => [] },
+  parentSession: { type: Object as PropType<SessionSummary | undefined>, default: undefined },
   dragging: { type: Boolean, default: false },
   dropBefore: { type: Boolean, default: false },
   clearingTag: { type: String, default: '' },
@@ -245,9 +248,11 @@ function onKeydown(event: KeyboardEvent) {
         <AgentUsage v-if="session.usage" :usage="session.usage" compact />
         <span v-if="session.origin !== 'user'" class="tag-pill">origin: {{ session.origin }}</span>
       </div>
-      <p v-if="session.branch.goal" class="mt-1 line-clamp-2 text-muted">
-        {{ session.branch.goal }}
+      <p v-if="detail?.branch.goal" class="mt-1 line-clamp-2 text-muted">
+        {{ detail.branch.goal }}
       </p>
+      <p v-else-if="detailLoading" class="mt-1 text-faint">Loading details…</p>
+      <p v-else-if="detailError" class="mt-1 text-block" role="alert">{{ detailError }}</p>
       <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 font-mono text-2xs text-faint">
         <span>{{ session.branch.repo_root }}</span>
         <span>{{ session.branch.branch }}</span>

--- a/crates/loom/frontend/src/lib/automationSessions.ts
+++ b/crates/loom/frontend/src/lib/automationSessions.ts
@@ -1,17 +1,17 @@
-import type { AutomationRun, Session } from '../types';
+import type { AutomationRun, SessionSummary } from '../types';
 import { effectiveAttention } from './sessionState';
 
 const ACTIVE = new Set(['created', 'running']);
 const HISTORY = new Set(['done', 'archived']);
 
-export function isAutomationHistory(session: Session): boolean {
+export function isAutomationHistory(session: SessionSummary): boolean {
   return HISTORY.has(session.status);
 }
 
 /** Lifecycle failures are operational exceptions even when no agent/watch has
  *  had a chance to stamp a loud tag. Unknown live states fail open into the
  *  intervention queue rather than disappearing. */
-export function needsAutomationIntervention(session: Session): boolean {
+export function needsAutomationIntervention(session: SessionSummary): boolean {
   if (isAutomationHistory(session)) return false;
   if (session.status === 'error' || session.status === 'orphaned') return true;
   if (!ACTIVE.has(session.status)) return true;
@@ -19,7 +19,7 @@ export function needsAutomationIntervention(session: Session): boolean {
 }
 
 /** Blocked first, then mechanical failures, then attention, then calm work. */
-export function automationPriority(session: Session): number {
+export function automationPriority(session: SessionSummary): number {
   const level = effectiveAttention(session).level;
   if (level === 'blocked') return 0;
   if (session.status === 'error' || session.status === 'orphaned') return 1;
@@ -27,7 +27,7 @@ export function automationPriority(session: Session): number {
   return 3;
 }
 
-export function byAutomationPriority(a: Session, b: Session): number {
+export function byAutomationPriority(a: SessionSummary, b: SessionSummary): number {
   return (
     automationPriority(a) - automationPriority(b) ||
     (b.last_activity_at || '').localeCompare(a.last_activity_at || '')
@@ -38,7 +38,7 @@ export function byAutomationPriority(a: Session, b: Session): number {
  *  whose preallocated session id is absent need their own operational row. */
 export function unmatchedAutomationRuns(
   runs: AutomationRun[],
-  sessions: Session[],
+  sessions: SessionSummary[],
 ): AutomationRun[] {
   const sessionIds = new Set(sessions.map((session) => session.id));
   return runs.filter((run) => !sessionIds.has(run.session_id));

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -1,4 +1,4 @@
-import type { Session, Tag } from '../types';
+import type { SessionSummary, Tag } from '../types';
 
 export type Attention = 'ok' | 'attention' | 'blocked';
 
@@ -19,7 +19,7 @@ export const AUTO_ARCHIVE_KEY = 'auto-archive';
 export const AUTO_ARCHIVE_DISABLED_VALUE = 'disabled';
 
 /** Whether this session carries the exact user-controlled retention opt-out. */
-export function autoArchiveDisabled(s: Session): boolean {
+export function autoArchiveDisabled(s: SessionSummary): boolean {
   return (s.branch.tags ?? []).some(
     (t) => t.key === AUTO_ARCHIVE_KEY && t.value === AUTO_ARCHIVE_DISABLED_VALUE,
   );
@@ -51,7 +51,7 @@ function isAgentTag(tag: Tag): boolean {
 
 // The current-state message (Branch.description). Suppressed for archived
 // sessions so torn-down workstreams don't show stale chatter.
-export function messageOf(s: Session): string {
+export function messageOf(s: SessionSummary): string {
   if (s.status === 'archived') return '';
   return s.branch.description ?? '';
 }
@@ -66,7 +66,7 @@ export function tagStale(tag: Tag | undefined, lastActivityAt: string): boolean 
 }
 
 // The loud tags on a session (value on the ladder), archived shown none.
-function loudTags(s: Session): Tag[] {
+function loudTags(s: SessionSummary): Tag[] {
   if (s.status === 'archived') return [];
   return (s.branch.tags ?? []).filter((t) => severityOf(t.value) > 0);
 }
@@ -102,7 +102,7 @@ function louder(a: Tag, b: Tag): number {
 // (by/raisedBy) and reason (note, with the agent's message as fallback).
 // effectiveAttention and signalChips both build on this so the rules stay in one
 // place; they differ only in how each treats staleness.
-function markOf(s: Session, tag: Tag): Omit<SignalChip, 'stale'> {
+function markOf(s: SessionSummary, tag: Tag): Omit<SignalChip, 'stale'> {
   const agent = isAgentTag(tag);
   return {
     key: tag.key,
@@ -117,7 +117,7 @@ function markOf(s: Session, tag: Tag): Omit<SignalChip, 'stale'> {
 // session's loud tags. A *non-stale* mark always beats a stale one (the session
 // has moved on past a stale mark); a stale mark surfaces, faded, only when it is
 // the lone signal — so an hour-old "looks stuck" fades rather than lies.
-export function effectiveAttention(s: Session): EffectiveAttention {
+export function effectiveAttention(s: SessionSummary): EffectiveAttention {
   const calm: EffectiveAttention = {
     level: 'ok',
     raisedBy: 'none',
@@ -177,7 +177,7 @@ export interface SignalChip {
 // order. Each loud tag renders as its own chip so any one can be cleared on its
 // own — which is the whole point: a stale mark is no longer a thing you "can't
 // resolve", it's just a chip with an × . Archived sessions show none.
-export function signalChips(s: Session): SignalChip[] {
+export function signalChips(s: SessionSummary): SignalChip[] {
   return loudTags(s)
     .slice()
     .sort(louder)
@@ -188,7 +188,7 @@ export function signalChips(s: Session): SignalChip[] {
 // These are free-form, deletable annotations (priority, needs-rebase, …). The
 // soothing `idle` mark is excluded — it is a lifecycle signal surfaced calmly by
 // idleTag/conversationState, not a free-form pill. Archived sessions show none.
-export function quietTags(s: Session): Tag[] {
+export function quietTags(s: SessionSummary): Tag[] {
   if (s.status === 'archived') return [];
   return (s.branch.tags ?? []).filter(
     (t) => severityOf(t.value) === 0 && t.key !== IDLE_KEY && !BOOKKEEPING_KEYS.includes(t.key),
@@ -219,11 +219,11 @@ const LIVE_STATUSES = new Set(['running']);
 // is gone (orphaned / done / error / archived), so the composer only shows while
 // the agent is running. Reuses LIVE_STATUSES: the same "the agent is here" notion
 // as the idle mark.
-export function canSend(s: Session): boolean {
+export function canSend(s: SessionSummary): boolean {
   return LIVE_STATUSES.has(s.status);
 }
 
-export function idleTag(s: Session): Tag | null {
+export function idleTag(s: SessionSummary): Tag | null {
   if (!LIVE_STATUSES.has(s.status)) return null;
   if (loudTags(s).length > 0) return null;
   return (s.branch.tags ?? []).find((t) => t.key === IDLE_KEY) ?? null;
@@ -240,7 +240,7 @@ export interface ConvState {
   tone: 'block' | 'attn' | 'ok' | 'info' | 'muted'; // which token family colors it
 }
 
-export function conversationState(s: Session): ConvState {
+export function conversationState(s: SessionSummary): ConvState {
   // Lifecycle first for the unambiguous mechanical states.
   if (s.status === 'archived') return { glyph: '◦', label: 'Archived', tone: 'muted' };
   if (s.status === 'orphaned') return { glyph: '●', label: 'Orphaned — detached', tone: 'attn' };
@@ -281,7 +281,7 @@ export const TONE_TEXT: Record<ConvState['tone'], string> = {
 // live, calm agent is green; anything terminal/detached (done, orphaned, error,
 // archived) recedes to faint. The dot is a quiet hairline tone, never the loud
 // chip fill, so it adds rhythm without competing with a real raised signal.
-export function lifecycleDot(s: Session): string {
+export function lifecycleDot(s: SessionSummary): string {
   const level = effectiveAttention(s).level;
   if (level === 'blocked') return 'bg-block-line';
   if (level === 'attention') return 'bg-attn-line';
@@ -339,7 +339,7 @@ const REMOVE: LifecycleAction = {
 // down, branch kept) is recovered. Surfaced next to the status badge that
 // announces the state, so the cure sits with the diagnosis rather than behind a
 // menu. Null for every healthy session — there is nothing to fix.
-export function remedyAction(s: Session): LifecycleAction | null {
+export function remedyAction(s: SessionSummary): LifecycleAction | null {
   if (s.status === 'orphaned') return ADOPT;
   if (s.status === 'archived') return RECOVER;
   return null;
@@ -347,7 +347,7 @@ export function remedyAction(s: Session): LifecycleAction | null {
 
 // Every lifecycle action available on a session, in menu order: its remedy (if
 // stuck), then archive (unless it already is), then the destructive remove.
-export function lifecycleActions(s: Session): LifecycleAction[] {
+export function lifecycleActions(s: SessionSummary): LifecycleAction[] {
   const actions: LifecycleAction[] = [];
   const remedy = remedyAction(s);
   if (remedy) actions.push(remedy);

--- a/crates/loom/frontend/src/lib/sessionsStore.ts
+++ b/crates/loom/frontend/src/lib/sessionsStore.ts
@@ -1,22 +1,23 @@
-import { ref } from 'vue';
-import { getSessionLayout, listRuns, listSessions } from '../api';
-import type { AutomationRun, Session, SessionLayout } from '../types';
+import { computed, ref } from 'vue';
+import { getSessionLayout, listRuns, listSessionSummaries } from '../api';
+import type { AutomationRun, SessionLayout, SessionSummary } from '../types';
 
 // One shared snapshot of the fleet. The session list, the status bar, and the
-// detail page all read from here instead of each polling `/api/sessions` on
-// their own. The payoff is snappiness: the data is fetched once per tick (not
-// three overlapping times), it's already present the instant any view mounts —
-// so returning to the fleet never flashes an empty state or re-runs an entrance
-// animation — and the detail page can paint from the cached row immediately
-// rather than showing "Loading…" while it refetches what the list already has.
+// detail-page tab title all read from here instead of each polling the fleet on
+// their own. This store intentionally holds SessionSummary rows, not full
+// Session resources: opening a page or row disclosure fetches its detail on
+// demand, so the three-second poll never transfers goals, launch snapshots, MCP
+// policy, runtime identifiers, or other detail-only fields.
 //
 // This is the thin-client pattern the rest of loom follows (docs/loom-ui.md):
 // the view is a projection of REST state, never a separate browser-local truth.
 
-const sessions = ref<Session[]>([]);
+const activeSessions = ref<SessionSummary[]>([]);
+const archivedSessions = ref<SessionSummary[]>([]);
+const sessions = computed(() => [...activeSessions.value, ...archivedSessions.value]);
 const runs = ref<AutomationRun[]>([]);
 const layout = ref<SessionLayout | null>(null);
-const resourceErrors = ref<Partial<Record<'sessions' | 'runs' | 'layout', string>>>({});
+const resourceErrors = ref<Partial<Record<'sessions' | 'history' | 'runs' | 'layout', string>>>({});
 // Last fetch reached the server? Drives the status bar's online dot; the cached
 // counts dim rather than vanish while the server is briefly unreachable.
 const online = ref(true);
@@ -24,18 +25,19 @@ const online = ref(true);
 let inflight: Promise<void> | null = null;
 let refreshRequested = false;
 
-// Pull the whole inventory, archived and automation-class sessions included —
-// the superset the Spaces, Attention, and explicit History views need. Concurrent
-// callers coalesce onto one in-flight loop. A request arriving while a
-// snapshot is loading marks the loop dirty and guarantees one trailing fetch.
-async function refresh(): Promise<void> {
+// Pull the compact active fleet only. Archived history is both much larger and
+// operationally cold, so `loadHistory` fetches it when that view is opened
+// instead of transferring it on every three-second tick. Concurrent callers
+// coalesce onto one in-flight loop. A request arriving while a snapshot is
+// loading marks the loop dirty and guarantees one trailing fetch.
+async function refreshActive(): Promise<void> {
   refreshRequested = true;
   if (inflight) return inflight;
   inflight = (async () => {
     while (refreshRequested) {
       refreshRequested = false;
       const results = await Promise.allSettled([
-        listSessions({ archived: true, automation: true }),
+        listSessionSummaries({ automation: true }),
         listRuns(),
         getSessionLayout(),
       ]);
@@ -48,7 +50,7 @@ async function refresh(): Promise<void> {
           return;
         }
         delete nextErrors[resource];
-        if (resource === 'sessions') sessions.value = result.value as Session[];
+        if (resource === 'sessions') activeSessions.value = result.value as SessionSummary[];
         if (resource === 'runs') runs.value = result.value as AutomationRun[];
         if (resource === 'layout') layout.value = result.value as SessionLayout;
       });
@@ -60,12 +62,48 @@ async function refresh(): Promise<void> {
     inflight = null;
     // Cover the promise-resolution microtask gap between the loop's final
     // condition check and this cleanup.
-    if (refreshRequested) void refresh();
+    if (refreshRequested) void refreshActive();
   });
   return inflight;
 }
 
-function sessionById(id: string): Session | undefined {
+let historyInflight: Promise<void> | null = null;
+let historyLoaded = false;
+async function loadHistory(): Promise<void> {
+  if (historyInflight) return historyInflight;
+  historyInflight = listSessionSummaries({
+    archived: true,
+    archivedOnly: true,
+    automation: true,
+  })
+    .then((history) => {
+      archivedSessions.value = history;
+      historyLoaded = true;
+      const errors = { ...resourceErrors.value };
+      delete errors.history;
+      resourceErrors.value = errors;
+    })
+    .catch((cause) => {
+      resourceErrors.value = {
+        ...resourceErrors.value,
+        history: (cause as Error).message,
+      };
+      throw cause;
+    })
+    .finally(() => {
+      historyInflight = null;
+    });
+  return historyInflight;
+}
+
+// Explicit mutations refresh any history snapshot the operator has disclosed;
+// the background timer below intentionally stays on the active projection.
+async function refresh(): Promise<void> {
+  await refreshActive();
+  if (historyLoaded) await loadHistory();
+}
+
+function sessionById(id: string): SessionSummary | undefined {
   return sessions.value.find((s) => s.id === id);
 }
 
@@ -78,10 +116,10 @@ const POLL_MS = 3000;
 
 function startFleetPoll(): void {
   if (timer !== undefined) return;
-  refresh();
-  timer = window.setInterval(refresh, POLL_MS);
+  refreshActive();
+  timer = window.setInterval(refreshActive, POLL_MS);
   layoutEvents = new EventSource('/api/session-layout/events');
-  layoutEvents.addEventListener('session_layout', () => void refresh());
+  layoutEvents.addEventListener('session_layout', () => void refreshActive());
 }
 
 function stopFleetPoll(): void {
@@ -100,6 +138,7 @@ export function useFleet() {
     resourceErrors,
     online,
     refresh,
+    loadHistory,
     sessionById,
     startFleetPoll,
     stopFleetPoll,

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -157,6 +157,41 @@ export interface Session {
   branch: Branch;
 }
 
+/** Compact branch projection used by the fleet polling/search endpoint. Large
+ * goal text and detail-only metadata remain on `Branch`. */
+export interface BranchSummary {
+  id: string;
+  name: string;
+  title: string;
+  description: string;
+  tags: Tag[];
+  repo_root: string;
+  branch: string;
+  github: GithubStatus | null;
+  github_pr: number | null;
+}
+
+/** Compact session projection returned by `GET /sessions/summary`. Opening a
+ * row or session follows with the full `Session` resource on demand. */
+export interface SessionSummary {
+  id: string;
+  status: string;
+  github_repo: string | null;
+  github_issue: { repo: string; number: number } | null;
+  last_activity_at: string;
+  created_at: string;
+  parent_id: string | null;
+  parent_session_id: string | null;
+  created_by: string | null;
+  origin: string;
+  class: string;
+  tracking_issue: number | null;
+  profile: string;
+  usage: AcpUsage | null;
+  placement: SessionPlacement | null;
+  branch: BranchSummary;
+}
+
 export interface ResumptionEvidence {
   kind: 'conversation' | 'artifact';
   label: string;

--- a/crates/loom/frontend/src/views/Issues.vue
+++ b/crates/loom/frontend/src/views/Issues.vue
@@ -3,7 +3,7 @@ import { ref, reactive, computed, nextTick, onMounted, onActivated, watch } from
 import { useRoute, useRouter } from 'vue-router';
 import {
   ApiError,
-  listSessions,
+  listSessionSummaries,
   listIssues,
   createRepoIssue,
   patchIssue,
@@ -13,7 +13,7 @@ import {
   clearIssueTag,
   launchSessionForIssue,
 } from '../api';
-import type { Issue, IssueAction, IssueActionProblem, Session, Tag } from '../types';
+import type { Issue, IssueAction, IssueActionProblem, SessionSummary, Tag } from '../types';
 import ConfirmDialog from '../components/ConfirmDialog.vue';
 import TagPill from '../components/TagPill.vue';
 import { timeAgo } from '../lib/time';
@@ -37,7 +37,7 @@ const route = useRoute();
 // from (`source`) — resolve to live session links from the session list.
 
 const issues = ref<Issue[]>([]);
-const sessions = ref<Session[]>([]);
+const sessions = ref<SessionSummary[]>([]);
 const loaded = ref(false);
 const error = ref('');
 
@@ -90,7 +90,7 @@ async function load() {
     // ask for both.
     const [iss, ses] = await Promise.all([
       listIssues({ all: true, automation: true }),
-      listSessions({ archived: true, automation: true }),
+      listSessionSummaries({ archived: true, automation: true }),
     ]);
     issues.value = iss;
     sessions.value = ses;
@@ -332,7 +332,7 @@ watch(scopeKey, (_next, previous) => {
 // runs several times per row, so the rebuilt-on-change index keeps rendering
 // off the O(issues × sessions) path.
 const sessionsByBranch = computed(() => {
-  const m = new Map<string, Session[]>();
+  const m = new Map<string, SessionSummary[]>();
   for (const s of sessions.value) {
     const k = `${s.branch.repo_root}\0${s.branch.branch}`;
     const arr = m.get(k);
@@ -350,7 +350,7 @@ function isAutomationClaimed(i: Issue): boolean {
   if (!i.claimed_branch) return false;
   const held = sessionsByBranch.value.get(`${i.repo_root}\0${i.claimed_branch}`) ?? [];
   const eligible = held.filter((s) => s.status !== 'archived');
-  const active = (s: Session) => !['done', 'error'].includes(s.status);
+  const active = (s: SessionSummary) => !['done', 'error'].includes(s.status);
   const holder = eligible.sort(
     (a, b) => Number(active(b)) - Number(active(a)) || b.created_at.localeCompare(a.created_at),
   )[0];
@@ -360,8 +360,8 @@ function isAutomationClaimed(i: Issue): boolean {
 // Sessions that reference an issue: the branch working it (claimed) and the
 // branch it came from (source), matched against the live session list by
 // repo + branch name. Claimed first, deduped, each tagged with its relation.
-function refsFor(i: Issue): { session: Session; rel: string }[] {
-  const out: { session: Session; rel: string }[] = [];
+function refsFor(i: Issue): { session: SessionSummary; rel: string }[] {
+  const out: { session: SessionSummary; rel: string }[] = [];
   const seen = new Set<string>();
   const match = (branch: string | null, rel: string) => {
     if (!branch) return;

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -11,7 +11,7 @@ import {
   nextTick,
 } from 'vue';
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router';
-import { get, ideInfo } from '../api';
+import { get, getSession, ideInfo } from '../api';
 import type { Session, WeaverEvent } from '../types';
 import SessionTerminals from '../components/SessionTerminals.vue';
 import IdeFrame from '../components/IdeFrame.vue';
@@ -21,7 +21,6 @@ import SessionTabs from '../components/SessionTabs.vue';
 import SessionConversation from '../components/SessionConversation.vue';
 import ArtifactsPanel from '../components/ArtifactsPanel.vue';
 import ChangesPanel from '../components/ChangesPanel.vue';
-import { useFleet } from '../lib/sessionsStore';
 import { cancelSessionBacktrack, completeSessionOpen } from '../lib/workbenchMetrics';
 
 // Named + keyed-by-id in App.vue's <keep-alive> so the page (and its live
@@ -34,11 +33,9 @@ const props = defineProps<{ id: string; name?: string }>();
 const route = useRoute();
 const router = useRouter();
 
-// Seed from the shared fleet snapshot so the page paints immediately with the
-// row the list already had — no "Loading…" gap while the per-session refetch is
-// in flight. loadAll() still refreshes it to the full per-session view.
-const { sessionById } = useFleet();
-const ws = ref<Session | null>(sessionById(props.id) ?? null);
+// The fleet cache is intentionally compact. A session page fetches the complete
+// resource on demand rather than pretending its summary is full detail.
+const ws = ref<Session | null>(null);
 const events = ref<WeaverEvent[]>([]);
 const error = ref('');
 
@@ -236,7 +233,7 @@ const ideOpen = ref(false);
 let source: EventSource | null = null;
 
 async function loadSession() {
-  ws.value = (await get(`/sessions/${props.id}`)) as Session;
+  ws.value = await getSession(props.id);
 }
 
 async function loadAll() {

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -6,6 +6,7 @@ import type {
   SessionGroup,
   SessionSearchAttention,
   SessionSearchStatus,
+  SessionSummary,
   SessionSpace,
 } from '../types';
 import AutomationRunRow from '../components/AutomationRunRow.vue';
@@ -18,10 +19,11 @@ import {
   createSessionSpace,
   deleteSessionGroup,
   deleteSessionSpace,
+  getSession,
+  listSessionSummaries,
   moveSessions,
   reorderSessionLayout,
   restoreSessionGroups,
-  searchSessions,
   setSessionGroupPreference,
   updateSessionGroup,
   updateSessionSpace,
@@ -36,7 +38,7 @@ defineOptions({ name: 'SessionList' });
 
 const route = useRoute();
 const router = useRouter();
-const { sessions, runs, layout, resourceErrors, refresh } = useFleet();
+const { sessions, runs, layout, resourceErrors, refresh, loadHistory } = useFleet();
 
 type WorkbenchView = 'space' | 'attention' | 'all' | 'history';
 
@@ -56,6 +58,13 @@ const view = computed<WorkbenchView>(() => {
   if (route.query.view === 'all') return 'all';
   return 'space';
 });
+watch(
+  view,
+  (next) => {
+    if (next === 'history') void loadHistory();
+  },
+  { immediate: true },
+);
 
 const activeSpace = computed<SessionSpace | undefined>(() => {
   const spaces = layout.value?.spaces ?? [];
@@ -121,7 +130,7 @@ function updateFilters() {
 
 const searchText = ref('');
 const includeHistory = ref(false);
-const searchResults = ref<Session[] | null>(null);
+const searchResults = ref<SessionSummary[] | null>(null);
 const searching = ref(false);
 const searchError = ref('');
 let searchTimer: number | undefined;
@@ -157,11 +166,12 @@ function queueSearch(clearResults: boolean) {
     searchAbort = controller;
     try {
       const archivedOnly = view.value === 'history';
-      const result = await searchSessions(
-        query,
+      const result = await listSessionSummaries(
         {
-          history: archivedOnly || includeHistory.value,
+          query,
+          archived: archivedOnly || includeHistory.value,
           archivedOnly,
+          automation: true,
           status: statusFilter.value || undefined,
           attention: attentionFilter.value || undefined,
         },
@@ -188,10 +198,11 @@ watch(
 watch([sessions, layout], () => queueSearch(false));
 onActivated(() => {
   recordSessionListReturn();
+  if (view.value === 'history') void loadHistory();
   queueSearch(true);
 });
 
-function matchesFilters(session: Session): boolean {
+function matchesFilters(session: SessionSummary): boolean {
   if (statusFilter.value && session.status !== statusFilter.value) return false;
   const attention = effectiveAttention(session).level;
   if (attentionFilter.value === 'needs' && attention === 'ok') return false;
@@ -204,9 +215,7 @@ function matchesFilters(session: Session): boolean {
 const baseSessions = computed(() => {
   if (searchResults.value) {
     const current = new Map(sessions.value.map((session) => [session.id, session]));
-    return searchResults.value
-      .map((result) => current.get(result.id))
-      .filter((session): session is Session => !!session);
+    return searchResults.value.map((result) => current.get(result.id) ?? result);
   }
   if (view.value === 'history') return historySessions.value;
   if (view.value === 'attention') return attentionSessions.value;
@@ -224,12 +233,12 @@ const sessionsByBranch = computed(() =>
     candidates.push(session);
     byBranch.set(session.branch.id, candidates);
     return byBranch;
-  }, new Map<string, Session[]>()),
+  }, new Map<string, SessionSummary[]>()),
 );
 const sessionsById = computed(
   () => new Map(sessions.value.map((session) => [session.id, session])),
 );
-function parentSessionOf(session: Session) {
+function parentSessionOf(session: SessionSummary) {
   if (session.parent_session_id) {
     return sessionsById.value.get(session.parent_session_id);
   }
@@ -242,7 +251,7 @@ const groupedSessions = computed(() =>
     group,
     sessions: group.session_ids
       .map((id) => visibleById.value.get(id))
-      .filter((session): session is Session => !!session),
+      .filter((session): session is SessionSummary => !!session),
   })),
 );
 const smartSessions = computed(() =>
@@ -302,13 +311,36 @@ const operationalRuns = computed(() =>
 );
 
 const expandedRows = ref(new Set<string>());
+const rowDetails = ref<Record<string, Session>>({});
+const rowDetailLoading = ref(new Set<string>());
+const rowDetailErrors = ref<Record<string, string>>({});
 function rowExpanded(id: string) {
   return expandedRows.value.has(id);
 }
+
+async function loadRowDetail(id: string) {
+  rowDetailLoading.value = new Set(rowDetailLoading.value).add(id);
+  const errors = { ...rowDetailErrors.value };
+  delete errors[id];
+  rowDetailErrors.value = errors;
+  try {
+    rowDetails.value = { ...rowDetails.value, [id]: await getSession(id) };
+  } catch (cause) {
+    rowDetailErrors.value = { ...rowDetailErrors.value, [id]: (cause as Error).message };
+  } finally {
+    const loading = new Set(rowDetailLoading.value);
+    loading.delete(id);
+    rowDetailLoading.value = loading;
+  }
+}
+
 function toggleRow(id: string) {
   const next = new Set(expandedRows.value);
   if (next.has(id)) next.delete(id);
-  else next.add(id);
+  else {
+    next.add(id);
+    void loadRowDetail(id);
+  }
   expandedRows.value = next;
 }
 
@@ -458,7 +490,7 @@ async function restoreMove() {
 const moveOpenId = ref('');
 const rowDestination = ref<Record<string, string>>({});
 const rowBefore = ref<Record<string, string>>({});
-function openMove(session: Session) {
+function openMove(session: SessionSummary) {
   moveOpenId.value = moveOpenId.value === session.id ? '' : session.id;
   rowDestination.value[session.id] =
     rowDestination.value[session.id] || session.placement?.group_id || allGroups.value[0]?.group.id;
@@ -1201,6 +1233,9 @@ function scrollSpaces(direction: number) {
           v-for="session in display.sessions"
           :key="session.id"
           :session="session"
+          :detail="rowDetails[session.id]"
+          :detail-loading="rowDetailLoading.has(session.id)"
+          :detail-error="rowDetailErrors[session.id]"
           :qualified="display.qualified"
           :selected="isSelected(session.id)"
           :expanded="rowExpanded(session.id)"

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -144,7 +144,10 @@ use crate::db::Db;
 use crate::github;
 use crate::session::{self as session_mod, Session};
 use crate::AppState;
-use weaver_api::{BranchView, McpPolicySnapshot, SessionMcpPolicyView, SessionView};
+use weaver_api::{
+    BranchSummaryView, BranchView, McpPolicySnapshot, SessionMcpPolicyView, SessionSummaryView,
+    SessionView,
+};
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::Branch;
 use weaver_core::tags;
@@ -423,6 +426,60 @@ pub(crate) async fn session_view(
     })
 }
 
+/// Build the compact fleet/search projection for a session + branch.
+///
+/// Unlike [`session_view`], this deliberately does not deserialize launch
+/// snapshots, MCP policy, or title-generation state. Large goal text remains
+/// available to server-side search through the source `Branch`, but crosses the
+/// wire only when a client follows with the session detail endpoint.
+pub(crate) async fn session_summary_view(
+    db: &Db,
+    session: &Session,
+    branch: &Branch,
+) -> ApiResult<SessionSummaryView> {
+    let branch = branch_view(db, branch).await?;
+    let github_issue = if let Some(id) = session.tracking_issue_id {
+        weaver_core::issue::get(db, id).await?.and_then(|issue| {
+            match (issue.github_repo, issue.github_issue) {
+                (Some(repo), Some(number)) => Some(weaver_api::GithubIssueRef { repo, number }),
+                _ => None,
+            }
+        })
+    } else {
+        None
+    };
+    let usage = if session.protocol == "acp" {
+        crate::chat::latest_usage(db, &session.id)
+            .await
+            .ok()
+            .flatten()
+    } else {
+        None
+    };
+    let placement = crate::session_layout::placement(db, &session.id).await?;
+    Ok(SessionSummaryView {
+        id: session.id.clone(),
+        status: session.status.clone(),
+        github_repo: session.github_repo.clone(),
+        github_issue,
+        last_activity_at: session
+            .last_activity_at
+            .clone()
+            .unwrap_or_else(|| branch.updated_at.clone()),
+        created_at: session.created_at.clone(),
+        parent_id: session.parent_branch_id.clone(),
+        parent_session_id: session.parent_session_id.clone(),
+        created_by: session.created_by.clone(),
+        origin: session.origin.clone(),
+        class: session.class.clone(),
+        tracking_issue: session.tracking_issue_id,
+        profile: session.profile.clone(),
+        usage,
+        placement,
+        branch: BranchSummaryView::from(&branch),
+    })
+}
+
 /// Resolve a session key (session id, branch id, branch name, or `repo:branch`)
 /// to `(Session, Branch)`. The session must exist and be active; clients hitting
 /// a branch with no live session get a 404.
@@ -681,6 +738,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/session-launches/resolve", post(resolve_session_launch))
         .route("/scratch/limits", get(scratch_limits))
+        .route("/sessions/summary", get(list_session_summaries))
         .route("/sessions/search", get(search_sessions))
         .route(
             "/sessions/{id}",

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -347,10 +347,7 @@ pub(crate) async fn session_view(
     // The latest usage block is a cheap indexed query; `None` for a terminal
     // session (or an ACP session before the agent reports usage).
     let usage = if session.protocol == "acp" {
-        crate::chat::latest_usage(db, &session.id)
-            .await
-            .ok()
-            .flatten()
+        crate::chat::latest_usage(db, &session.id).await?
     } else {
         None
     };
@@ -449,10 +446,7 @@ pub(crate) async fn session_summary_view(
         None
     };
     let usage = if session.protocol == "acp" {
-        crate::chat::latest_usage(db, &session.id)
-            .await
-            .ok()
-            .flatten()
+        crate::chat::latest_usage(db, &session.id).await?
     } else {
         None
     };

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -101,11 +101,11 @@ pub(super) async fn list_sessions(
     }
     collect_sessions(
         &st,
+        q.managed,
         SessionCollectionFilter {
             archived: q.archived,
             archived_only: false,
             automation: q.automation.unwrap_or(false),
-            managed: q.managed,
             search: q.q.as_deref(),
             status: None,
             attention: None,
@@ -148,7 +148,6 @@ pub(super) async fn list_session_summaries(
             archived: q.archived || q.archived_only,
             archived_only: q.archived_only,
             automation: q.automation,
-            managed: false,
             search: q.q.as_deref(),
             status: q.status,
             attention: q.attention,
@@ -167,11 +166,11 @@ pub(super) async fn search_sessions(
 ) -> ApiResult<Json<Vec<SessionView>>> {
     collect_sessions(
         &st,
+        false,
         SessionCollectionFilter {
             archived: q.history || q.archived_only,
             archived_only: q.archived_only,
             automation: true,
-            managed: false,
             search: Some(&q.query),
             status: q.status,
             attention: q.attention,
@@ -181,13 +180,13 @@ pub(super) async fn search_sessions(
     .map(Json)
 }
 
-fn view_attention(view: &SessionView) -> &str {
-    if view.status == "archived" {
+fn attention_level<'a>(status: &'a str, tags: &[weaver_api::TagView]) -> &'a str {
+    if status == "archived" {
         "ok"
-    } else if view.branch.tags.iter().any(|tag| tag.value == "blocked") {
+    } else if tags.iter().any(|tag| tag.value == "blocked") {
         "blocked"
-    } else if matches!(view.status.as_str(), "error" | "orphaned")
-        || view.branch.tags.iter().any(|tag| tag.value == "attention")
+    } else if matches!(status, "error" | "orphaned")
+        || tags.iter().any(|tag| tag.value == "attention")
     {
         "attention"
     } else {
@@ -195,17 +194,17 @@ fn view_attention(view: &SessionView) -> &str {
     }
 }
 
-fn summary_attention(view: &SessionSummaryView) -> &str {
-    if view.status == "archived" {
-        "ok"
-    } else if view.branch.tags.iter().any(|tag| tag.value == "blocked") {
-        "blocked"
-    } else if matches!(view.status.as_str(), "error" | "orphaned")
-        || view.branch.tags.iter().any(|tag| tag.value == "attention")
-    {
-        "attention"
-    } else {
-        "ok"
+fn matches_attention(
+    status: &str,
+    tags: &[weaver_api::TagView],
+    filter: SessionSearchAttention,
+) -> bool {
+    let level = attention_level(status, tags);
+    match filter {
+        SessionSearchAttention::Needs => level != "ok",
+        SessionSearchAttention::Ok => level == "ok",
+        SessionSearchAttention::Attention => level == "attention",
+        SessionSearchAttention::Blocked => level == "blocked",
     }
 }
 
@@ -214,41 +213,66 @@ fn append_search_field(haystack: &mut String, value: &str) {
     haystack.push_str(value);
 }
 
-fn search_haystack(view: &SessionView) -> String {
+struct SessionSearchFacets<'a> {
+    placement: Option<&'a weaver_api::SessionPlacementView>,
+    title: &'a str,
+    goal: &'a str,
+    description: &'a str,
+    repo_root: &'a str,
+    branch: &'a str,
+    name: &'a str,
+    base_branch: &'a str,
+    github_repo: Option<&'a str>,
+    status: &'a str,
+    profile: &'a str,
+    origin: &'a str,
+    class: &'a str,
+    created_by: Option<&'a str>,
+    parent_session_id: Option<&'a str>,
+    parent_id: Option<&'a str>,
+    github_issue: Option<&'a weaver_api::GithubIssueRef>,
+    tracking_issue: Option<i64>,
+    github: Option<&'a weaver_core::github::GithubStatus>,
+    github_pr: Option<i64>,
+    tags: &'a [weaver_api::TagView],
+}
+
+fn search_haystack(facets: SessionSearchFacets<'_>) -> String {
     let mut haystack = String::new();
-    if let Some(placement) = &view.placement {
+    if let Some(placement) = facets.placement {
         append_search_field(
             &mut haystack,
-            &format!("{} / {}", placement.group_name, view.branch.title.trim()),
+            &format!("{} / {}", placement.group_name, facets.title.trim()),
         );
         append_search_field(&mut haystack, &placement.group_name);
     }
     for field in [
-        view.branch.title.as_str(),
-        view.branch.goal.as_str(),
-        view.branch.description.as_str(),
-        view.github_repo.as_deref().unwrap_or_default(),
-        view.branch.repo_root.as_str(),
-        view.branch.branch.as_str(),
-        view.branch.name.as_str(),
-        view.status.as_str(),
-        view.profile.as_str(),
-        view.origin.as_str(),
-        view.class.as_str(),
-        view.created_by.as_deref().unwrap_or_default(),
-        view.parent_session_id.as_deref().unwrap_or_default(),
-        view.parent_id.as_deref().unwrap_or_default(),
+        facets.title,
+        facets.goal,
+        facets.description,
+        facets.repo_root,
+        facets.branch,
+        facets.name,
+        facets.base_branch,
+        facets.github_repo.unwrap_or_default(),
+        facets.status,
+        facets.profile,
+        facets.origin,
+        facets.class,
+        facets.created_by.unwrap_or_default(),
+        facets.parent_session_id.unwrap_or_default(),
+        facets.parent_id.unwrap_or_default(),
     ] {
         append_search_field(&mut haystack, field);
     }
-    if let Some(issue) = &view.github_issue {
+    if let Some(issue) = facets.github_issue {
         append_search_field(&mut haystack, &format!("{}#{}", issue.repo, issue.number));
         append_search_field(&mut haystack, &format!("#{}", issue.number));
     }
-    if let Some(issue) = view.tracking_issue {
+    if let Some(issue) = facets.tracking_issue {
         append_search_field(&mut haystack, &format!("#{issue}"));
     }
-    if let Some(pr) = &view.branch.github {
+    if let Some(pr) = facets.github {
         append_search_field(&mut haystack, &format!("#{}", pr.pr_number));
         for field in [
             pr.pr_url.as_str(),
@@ -259,10 +283,10 @@ fn search_haystack(view: &SessionView) -> String {
         ] {
             append_search_field(&mut haystack, field);
         }
-    } else if let Some(pr) = view.branch.github_pr {
+    } else if let Some(pr) = facets.github_pr {
         append_search_field(&mut haystack, &format!("#{pr}"));
     }
-    for tag in &view.branch.tags {
+    for tag in facets.tags {
         for field in [
             tag.key.as_str(),
             tag.value.as_str(),
@@ -275,80 +299,101 @@ fn search_haystack(view: &SessionView) -> String {
     haystack.to_lowercase()
 }
 
+fn view_search_haystack(view: &SessionView) -> String {
+    search_haystack(SessionSearchFacets {
+        placement: view.placement.as_ref(),
+        title: &view.branch.title,
+        goal: &view.branch.goal,
+        description: &view.branch.description,
+        repo_root: &view.branch.repo_root,
+        branch: &view.branch.branch,
+        name: &view.branch.name,
+        base_branch: &view.branch.base_branch,
+        github_repo: view.github_repo.as_deref(),
+        status: &view.status,
+        profile: &view.profile,
+        origin: &view.origin,
+        class: &view.class,
+        created_by: view.created_by.as_deref(),
+        parent_session_id: view.parent_session_id.as_deref(),
+        parent_id: view.parent_id.as_deref(),
+        github_issue: view.github_issue.as_ref(),
+        tracking_issue: view.tracking_issue,
+        github: view.branch.github.as_ref(),
+        github_pr: view.branch.github_pr,
+        tags: &view.branch.tags,
+    })
+}
+
 fn summary_search_haystack(view: &SessionSummaryView, branch: &Branch) -> String {
-    let mut haystack = String::new();
-    if let Some(placement) = &view.placement {
-        append_search_field(
-            &mut haystack,
-            &format!("{} / {}", placement.group_name, view.branch.title.trim()),
-        );
-        append_search_field(&mut haystack, &placement.group_name);
-    }
-    for field in [
-        view.branch.title.as_str(),
-        branch.goal.as_str(),
-        view.branch.description.as_str(),
-        view.branch.repo_root.as_str(),
-        view.branch.branch.as_str(),
-        view.branch.name.as_str(),
-        branch.base_branch.as_str(),
-        view.github_repo.as_deref().unwrap_or_default(),
-        view.status.as_str(),
-        view.profile.as_str(),
-        view.origin.as_str(),
-        view.class.as_str(),
-        view.created_by.as_deref().unwrap_or_default(),
-        view.parent_session_id.as_deref().unwrap_or_default(),
-        view.parent_id.as_deref().unwrap_or_default(),
-    ] {
-        append_search_field(&mut haystack, field);
-    }
-    if let Some(issue) = &view.github_issue {
-        append_search_field(&mut haystack, &format!("{}#{}", issue.repo, issue.number));
-        append_search_field(&mut haystack, &format!("#{}", issue.number));
-    }
-    if let Some(issue) = view.tracking_issue {
-        append_search_field(&mut haystack, &format!("#{issue}"));
-    }
-    if let Some(pr) = &view.branch.github {
-        append_search_field(&mut haystack, &format!("#{}", pr.pr_number));
-        for field in [
-            pr.pr_url.as_str(),
-            pr.pr_title.as_str(),
-            pr.pr_state.as_str(),
-            pr.review_decision.as_deref().unwrap_or_default(),
-            pr.checks.as_deref().unwrap_or_default(),
-        ] {
-            append_search_field(&mut haystack, field);
-        }
-    } else if let Some(pr) = view.branch.github_pr {
-        append_search_field(&mut haystack, &format!("#{pr}"));
-    }
-    for tag in &view.branch.tags {
-        for field in [
-            tag.key.as_str(),
-            tag.value.as_str(),
-            tag.note.as_str(),
-            tag.set_by.as_str(),
-        ] {
-            append_search_field(&mut haystack, field);
-        }
-    }
-    haystack.to_lowercase()
+    search_haystack(SessionSearchFacets {
+        placement: view.placement.as_ref(),
+        title: &view.branch.title,
+        goal: &branch.goal,
+        description: &view.branch.description,
+        repo_root: &view.branch.repo_root,
+        branch: &view.branch.branch,
+        name: &view.branch.name,
+        base_branch: &branch.base_branch,
+        github_repo: view.github_repo.as_deref(),
+        status: &view.status,
+        profile: &view.profile,
+        origin: &view.origin,
+        class: &view.class,
+        created_by: view.created_by.as_deref(),
+        parent_session_id: view.parent_session_id.as_deref(),
+        parent_id: view.parent_id.as_deref(),
+        github_issue: view.github_issue.as_ref(),
+        tracking_issue: view.tracking_issue,
+        github: view.branch.github.as_ref(),
+        github_pr: view.branch.github_pr,
+        tags: &view.branch.tags,
+    })
 }
 
 struct SessionCollectionFilter<'a> {
     archived: bool,
     archived_only: bool,
     automation: bool,
-    managed: bool,
     search: Option<&'a str>,
     status: Option<SessionSearchStatus>,
     attention: Option<SessionSearchAttention>,
 }
 
+fn search_needle(filter: &SessionCollectionFilter<'_>) -> Option<String> {
+    filter
+        .search
+        .map(str::trim)
+        .filter(|search| !search.is_empty())
+        .map(str::to_lowercase)
+}
+
+fn session_in_collection(
+    session: &Session,
+    warm: &HashSet<String>,
+    filter: &SessionCollectionFilter<'_>,
+    managed: bool,
+) -> bool {
+    (managed || !warm.contains(&session.id))
+        && (filter.archived || session.status != "archived")
+        && (!filter.archived_only || session.status == "archived")
+        && (filter.automation || session.class != "automation")
+}
+
+fn view_matches_filters(
+    status: &str,
+    tags: &[weaver_api::TagView],
+    filter: &SessionCollectionFilter<'_>,
+) -> bool {
+    filter.status.is_none_or(|wanted| status == wanted.as_str())
+        && filter
+            .attention
+            .is_none_or(|wanted| matches_attention(status, tags, wanted))
+}
+
 async fn collect_sessions(
     st: &AppState,
+    managed: bool,
     filter: SessionCollectionFilter<'_>,
 ) -> ApiResult<Vec<SessionView>> {
     // The fleet listing shows work, not infrastructure: engine-managed (warm)
@@ -364,46 +409,20 @@ async fn collect_sessions(
         .filter_map(|o| o.warm_session_id)
         .collect();
     // A blank `q` is no filter; otherwise match case-insensitively.
-    let needle = filter
-        .search
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_lowercase);
-    let sessions = if filter.managed {
+    let needle = search_needle(&filter);
+    let sessions = if managed {
         session_mod::list(&st.db).await?
     } else {
         session_mod::list_visible(&st.db).await?
     };
     let mut views: Vec<SessionView> = Vec::with_capacity(sessions.len());
     for s in sessions {
-        if !filter.managed && warm.contains(&s.id) {
-            continue;
-        }
-        // Archived sessions are torn down — hidden unless the caller opts in.
-        if !filter.archived && s.status == "archived" {
-            continue;
-        }
-        if filter.archived_only && s.status != "archived" {
-            continue;
-        }
-        // Explicit compatibility reads can still hide automation-class rows.
-        if !filter.automation && s.class == "automation" {
+        if !session_in_collection(&s, &warm, &filter, managed) {
             continue;
         }
         if let Some(branch) = branch_mod::get(&st.db, &s.branch_id).await? {
             let view = session_view(&st.db, &s, &branch).await?;
-            if filter
-                .status
-                .is_some_and(|status| view.status != status.as_str())
-            {
-                continue;
-            }
-            if filter.attention.is_some_and(|attention| match attention {
-                SessionSearchAttention::Needs => view_attention(&view) == "ok",
-                SessionSearchAttention::Ok => view_attention(&view) != "ok",
-                SessionSearchAttention::Attention => view_attention(&view) != "attention",
-                SessionSearchAttention::Blocked => view_attention(&view) != "blocked",
-            }) {
+            if !view_matches_filters(&view.status, &view.branch.tags, &filter) {
                 continue;
             }
             if let Some(needle) = &needle {
@@ -411,7 +430,7 @@ async fn collect_sessions(
                 // qualified placement, title/goal, repo/branch, issue/PR, tags,
                 // status, profile, and provenance. Searching only its values
                 // keeps that vocabulary synchronized without matching JSON keys.
-                let hay = search_haystack(&view);
+                let hay = view_search_haystack(&view);
                 if !hay.contains(needle) {
                     continue;
                 }
@@ -431,42 +450,18 @@ async fn collect_session_summaries(
         .into_iter()
         .filter_map(|watch| watch.warm_session_id)
         .collect();
-    let needle = filter
-        .search
-        .map(str::trim)
-        .filter(|search| !search.is_empty())
-        .map(str::to_lowercase);
+    let needle = search_needle(&filter);
     let sessions = session_mod::list_visible(&st.db).await?;
     let mut views = Vec::with_capacity(sessions.len());
     for session in sessions {
-        if warm.contains(&session.id) {
-            continue;
-        }
-        if !filter.archived && session.status == "archived" {
-            continue;
-        }
-        if filter.archived_only && session.status != "archived" {
-            continue;
-        }
-        if !filter.automation && session.class == "automation" {
+        if !session_in_collection(&session, &warm, &filter, false) {
             continue;
         }
         let Some(branch) = branch_mod::get(&st.db, &session.branch_id).await? else {
             continue;
         };
         let view = session_summary_view(&st.db, &session, &branch).await?;
-        if filter
-            .status
-            .is_some_and(|status| view.status != status.as_str())
-        {
-            continue;
-        }
-        if filter.attention.is_some_and(|attention| match attention {
-            SessionSearchAttention::Needs => summary_attention(&view) == "ok",
-            SessionSearchAttention::Ok => summary_attention(&view) != "ok",
-            SessionSearchAttention::Attention => summary_attention(&view) != "attention",
-            SessionSearchAttention::Blocked => summary_attention(&view) != "blocked",
-        }) {
+        if !view_matches_filters(&view.status, &view.branch.tags, &filter) {
             continue;
         }
         if let Some(needle) = &needle {

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -25,15 +25,17 @@ use crate::{agent, backend, config, custom_agents, db, events, git, github, repo
 use weaver_api::{
     CreateReq, EnsureResumptionCueReq, HandoffReq, HistoryPageView, LaunchOverrides,
     LaunchSelection, PatchSessionReq, ResumptionCueView, SearchSessionsOptions, SendReq,
-    SessionSearchAttention, SessionSearchStatus, SessionView, SetTagsReq, SetTitleGenerationReq,
-    TagReq,
+    SessionSearchAttention, SessionSearchStatus, SessionSummaryView, SessionView, SetTagsReq,
+    SetTitleGenerationReq, TagReq,
 };
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::{Branch, TitleProvenance, TitleUpdate};
 use weaver_core::tags;
 use weaver_core::watch::{self as watch_store, Watch};
 
-use super::{author_or_manual, require_branch, require_session, session_view};
+use super::{
+    author_or_manual, require_branch, require_session, session_summary_view, session_view,
+};
 use super::{ApiResult, AppError, AppState};
 use crate::runtime::{layer_launch_environment, repo_cfg_or_default, set_env};
 
@@ -113,6 +115,49 @@ pub(super) async fn list_sessions(
     .map(Json)
 }
 
+/// Compact fleet/search query for `GET /api/sessions/summary`.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct ListSessionSummariesQuery {
+    /// Include archived rows alongside active work.
+    #[serde(default)]
+    archived: bool,
+    /// Return only archived rows. Implies `archived=true`.
+    #[serde(default)]
+    archived_only: bool,
+    /// Include automation-class sessions.
+    #[serde(default)]
+    automation: bool,
+    /// Case-insensitive search over the same documented facets as fleet search.
+    #[serde(default)]
+    q: Option<String>,
+    #[serde(default)]
+    status: Option<SessionSearchStatus>,
+    #[serde(default)]
+    attention: Option<SessionSearchAttention>,
+}
+
+/// Compact polling/search contract for indexes. Full session context remains on
+/// `GET /api/sessions/{id}` and is fetched only when a row or page discloses it.
+pub(super) async fn list_session_summaries(
+    State(st): State<AppState>,
+    Query(q): Query<ListSessionSummariesQuery>,
+) -> ApiResult<Json<Vec<SessionSummaryView>>> {
+    collect_session_summaries(
+        &st,
+        SessionCollectionFilter {
+            archived: q.archived || q.archived_only,
+            archived_only: q.archived_only,
+            automation: q.automation,
+            managed: false,
+            search: q.q.as_deref(),
+            status: q.status,
+            attention: q.attention,
+        },
+    )
+    .await
+    .map(Json)
+}
+
 /// Search is an explicit fleet read so non-browser clients can find the same
 /// qualified sessions as the workbench. `history=true` widens the actionable
 /// result set; `archived_only=true` is the disjoint History projection.
@@ -150,6 +195,20 @@ fn view_attention(view: &SessionView) -> &str {
     }
 }
 
+fn summary_attention(view: &SessionSummaryView) -> &str {
+    if view.status == "archived" {
+        "ok"
+    } else if view.branch.tags.iter().any(|tag| tag.value == "blocked") {
+        "blocked"
+    } else if matches!(view.status.as_str(), "error" | "orphaned")
+        || view.branch.tags.iter().any(|tag| tag.value == "attention")
+    {
+        "attention"
+    } else {
+        "ok"
+    }
+}
+
 fn append_search_field(haystack: &mut String, value: &str) {
     haystack.push(' ');
     haystack.push_str(value);
@@ -172,6 +231,68 @@ fn search_haystack(view: &SessionView) -> String {
         view.branch.repo_root.as_str(),
         view.branch.branch.as_str(),
         view.branch.name.as_str(),
+        view.status.as_str(),
+        view.profile.as_str(),
+        view.origin.as_str(),
+        view.class.as_str(),
+        view.created_by.as_deref().unwrap_or_default(),
+        view.parent_session_id.as_deref().unwrap_or_default(),
+        view.parent_id.as_deref().unwrap_or_default(),
+    ] {
+        append_search_field(&mut haystack, field);
+    }
+    if let Some(issue) = &view.github_issue {
+        append_search_field(&mut haystack, &format!("{}#{}", issue.repo, issue.number));
+        append_search_field(&mut haystack, &format!("#{}", issue.number));
+    }
+    if let Some(issue) = view.tracking_issue {
+        append_search_field(&mut haystack, &format!("#{issue}"));
+    }
+    if let Some(pr) = &view.branch.github {
+        append_search_field(&mut haystack, &format!("#{}", pr.pr_number));
+        for field in [
+            pr.pr_url.as_str(),
+            pr.pr_title.as_str(),
+            pr.pr_state.as_str(),
+            pr.review_decision.as_deref().unwrap_or_default(),
+            pr.checks.as_deref().unwrap_or_default(),
+        ] {
+            append_search_field(&mut haystack, field);
+        }
+    } else if let Some(pr) = view.branch.github_pr {
+        append_search_field(&mut haystack, &format!("#{pr}"));
+    }
+    for tag in &view.branch.tags {
+        for field in [
+            tag.key.as_str(),
+            tag.value.as_str(),
+            tag.note.as_str(),
+            tag.set_by.as_str(),
+        ] {
+            append_search_field(&mut haystack, field);
+        }
+    }
+    haystack.to_lowercase()
+}
+
+fn summary_search_haystack(view: &SessionSummaryView, branch: &Branch) -> String {
+    let mut haystack = String::new();
+    if let Some(placement) = &view.placement {
+        append_search_field(
+            &mut haystack,
+            &format!("{} / {}", placement.group_name, view.branch.title.trim()),
+        );
+        append_search_field(&mut haystack, &placement.group_name);
+    }
+    for field in [
+        view.branch.title.as_str(),
+        branch.goal.as_str(),
+        view.branch.description.as_str(),
+        view.branch.repo_root.as_str(),
+        view.branch.branch.as_str(),
+        view.branch.name.as_str(),
+        branch.base_branch.as_str(),
+        view.github_repo.as_deref().unwrap_or_default(),
         view.status.as_str(),
         view.profile.as_str(),
         view.origin.as_str(),
@@ -297,6 +418,64 @@ async fn collect_sessions(
             }
             views.push(view);
         }
+    }
+    Ok(views)
+}
+
+async fn collect_session_summaries(
+    st: &AppState,
+    filter: SessionCollectionFilter<'_>,
+) -> ApiResult<Vec<SessionSummaryView>> {
+    let warm: HashSet<String> = watch_store::list(&st.db)
+        .await?
+        .into_iter()
+        .filter_map(|watch| watch.warm_session_id)
+        .collect();
+    let needle = filter
+        .search
+        .map(str::trim)
+        .filter(|search| !search.is_empty())
+        .map(str::to_lowercase);
+    let sessions = session_mod::list_visible(&st.db).await?;
+    let mut views = Vec::with_capacity(sessions.len());
+    for session in sessions {
+        if warm.contains(&session.id) {
+            continue;
+        }
+        if !filter.archived && session.status == "archived" {
+            continue;
+        }
+        if filter.archived_only && session.status != "archived" {
+            continue;
+        }
+        if !filter.automation && session.class == "automation" {
+            continue;
+        }
+        let Some(branch) = branch_mod::get(&st.db, &session.branch_id).await? else {
+            continue;
+        };
+        let view = session_summary_view(&st.db, &session, &branch).await?;
+        if filter
+            .status
+            .is_some_and(|status| view.status != status.as_str())
+        {
+            continue;
+        }
+        if filter.attention.is_some_and(|attention| match attention {
+            SessionSearchAttention::Needs => summary_attention(&view) == "ok",
+            SessionSearchAttention::Ok => summary_attention(&view) != "ok",
+            SessionSearchAttention::Attention => summary_attention(&view) != "attention",
+            SessionSearchAttention::Blocked => summary_attention(&view) != "blocked",
+        }) {
+            continue;
+        }
+        if let Some(needle) = &needle {
+            let haystack = summary_search_haystack(&view, &branch);
+            if !haystack.contains(needle) {
+                continue;
+            }
+        }
+        views.push(view);
     }
     Ok(views)
 }

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -318,6 +318,32 @@ async fn list_keeps_active_fleet_disjoint_from_archived_history_and_searches() {
     let beta_row = all.iter().find(|s| s["id"] == beta_id.as_str()).unwrap();
     assert_eq!(beta_row["status"], "archived");
 
+    // The SPA's polling contract carries only row-level fields. Large launch
+    // and goal context stays behind the per-session detail route.
+    let summaries = client
+        .get("/api/sessions/summary?archived=true")
+        .await
+        .unwrap();
+    let summaries = summaries.as_array().unwrap();
+    assert_eq!(summaries.len(), 2);
+    let alpha_summary = summaries
+        .iter()
+        .find(|session| session["id"] == alpha_id.as_str())
+        .unwrap();
+    assert_eq!(alpha_summary["branch"]["title"], "alpha search target");
+    assert!(
+        alpha_summary["branch"].get("goal").is_none(),
+        "fleet summaries must omit goal text"
+    );
+    assert!(
+        alpha_summary.get("resolved_launch").is_none(),
+        "fleet summaries must omit launch snapshots"
+    );
+    assert!(
+        alpha_summary.get("mcp_policy").is_none(),
+        "fleet summaries must omit MCP policy"
+    );
+
     // Search over title / branch / goal, on the live set.
     let hit = client.get("/api/sessions?q=alpha").await.unwrap();
     assert_eq!(
@@ -327,6 +353,16 @@ async fn list_keeps_active_fleet_disjoint_from_archived_history_and_searches() {
     );
     let miss = client.get("/api/sessions?q=nope-nothing").await.unwrap();
     assert!(miss.as_array().unwrap().is_empty(), "no match ⇒ empty");
+    let compact_hit = client
+        .get("/api/sessions/summary?q=alpha%20search%20target")
+        .await
+        .unwrap();
+    assert_eq!(
+        compact_hit.as_array().unwrap().len(),
+        1,
+        "compact search matches server-side goal text without returning it"
+    );
+    assert!(compact_hit[0]["branch"].get("goal").is_none());
 
     // An archived session is excluded from a default search, included when asked.
     let beta_hidden = client.get("/api/sessions?q=beta").await.unwrap();

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -157,6 +157,70 @@ impl BranchView {
     }
 }
 
+/// Compact branch projection embedded in [`SessionSummaryView`]. It carries
+/// only the identity, status, search, and GitHub fields fleet surfaces render;
+/// large goal text and detail-only metadata remain on [`BranchView`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchSummaryView {
+    pub id: String,
+    pub name: String,
+    pub title: String,
+    pub description: String,
+    pub tags: Vec<TagView>,
+    pub repo_root: String,
+    pub branch: String,
+    pub github: Option<GithubStatus>,
+    pub github_pr: Option<i64>,
+}
+
+impl From<&BranchView> for BranchSummaryView {
+    fn from(branch: &BranchView) -> Self {
+        Self {
+            id: branch.id.clone(),
+            name: branch.name.clone(),
+            title: branch.title.clone(),
+            description: branch.description.clone(),
+            tags: branch.tags.clone(),
+            repo_root: branch.repo_root.clone(),
+            branch: branch.branch.clone(),
+            github: branch.github.clone(),
+            github_pr: branch.github_pr,
+        }
+    }
+}
+
+/// Compact session projection returned by `GET /api/sessions/summary`.
+///
+/// This is the polling/search contract for fleet indexes. A client follows with
+/// `GET /api/sessions/{id}` only when it opens a session or discloses the row's
+/// complete context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSummaryView {
+    pub id: String,
+    pub status: String,
+    pub github_repo: Option<String>,
+    #[serde(default)]
+    pub github_issue: Option<GithubIssueRef>,
+    pub last_activity_at: String,
+    pub created_at: String,
+    pub parent_id: Option<String>,
+    #[serde(default)]
+    pub parent_session_id: Option<String>,
+    pub created_by: Option<String>,
+    #[serde(default = "default_origin")]
+    pub origin: String,
+    #[serde(default = "default_class")]
+    pub class: String,
+    pub tracking_issue: Option<i64>,
+    #[serde(default = "default_profile")]
+    pub profile: String,
+    #[serde(default)]
+    pub usage: Option<AcpUsage>,
+    #[serde(default)]
+    pub placement: Option<SessionPlacementView>,
+    pub branch: BranchSummaryView,
+}
+
 /// Session-scoped view returned by the `/api/sessions[/...]` endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionView {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -273,6 +273,7 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/diagnostics` | admin-only redacted counts, profile capacity, automation failures/staleness, orphan/error inventory, migration state, and non-secret federation metadata; backs Settings → Diagnostics |
 | `POST /api/session-launches/resolve` | resolve a canonical profile selection plus one-launch overrides into concrete selectors, provenance, policy, capacity, validation, and profile/resolver revisions without provisioning |
 | `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false` — `automation` — default `false` — and admin-only `managed` — default `false`; canonical create requires both revisions from resolve and returns 409 plus a fresh preview on drift/admission change; flattened selectors remain compatible; valid Scratch input is decoded before provisioning; visible creates atomically assign configured origin/profile placement while managed warm infrastructure has no placement or layout revision effect; create stamps `resolved_launch`, opens a tracking issue, and returns its id as `tracking_issue`) |
+| `GET /api/sessions/summary` | compact fleet row projection for polling and search; accepts `archived`, `archived_only`, `automation`, `q`, `status`, and `attention`, searches goal text server-side without returning goals, and omits launch/MCP/title-generation/runtime detail retained by `GET /api/sessions/{id}` |
 | `GET /api/sessions/search` | case-insensitive fleet search across qualified placement, title/prompt, repo/branch, issue/PR, tags, status, profile, and provenance; optional widening `history`, archived-only `archived_only`, `status`, and `attention` filters |
 | `GET /api/session-layout`; `GET /api/session-layout/events` | admin-only read of the ordered Spaces → Groups → Sessions model plus defaults/revision; SSE is invalidation-only and every membership/layout change emits one so clients reload canonical state |
 | `POST PATCH DELETE /api/session-layout/{spaces,groups}[/{id}]` | create/rename/delete spaces and groups; non-empty deletion requires a destination and moves sessions/defaults atomically |
@@ -692,7 +693,7 @@ number, URL, state (`OPEN`/`CLOSED`/`MERGED`), draft
 flag, `reviewDecision`, a rolled-up `checks` verdict (`passing`/`failing`/
 `pending`), and mergeability — is written to the loom-owned `branch_github`
 table (one row per branch, keyed `branch_id`) and served as `BranchView.github`.
-The dashboard renders it on the session list and compact session Details; `POST
+The dashboard renders it on the session list and session header; `POST
 /api/sessions/{id}/github` forces an immediate re-poll.
 
 The loop self-gates and degrades quietly: it is always spawned but does nothing
@@ -702,10 +703,12 @@ is logged at debug and skipped). So it is a no-op on non-GitHub repos rather
 than a failure.
 
 The session header always renders PR and issue association pills, including an
-empty state. The PR editor can pin an explicit number or return to live-branch
-discovery through `PUT` / `DELETE /api/sessions/{id}/github`; the issue editor
-patches the GitHub link on the session's weaver tracking issue, which remains
-the source of truth for that association.
+empty state. Existing associations are direct GitHub links; adjacent edit
+controls keep reassociation secondary. The PR editor can pin an explicit number
+or return to live-branch discovery through `PUT` / `DELETE
+/api/sessions/{id}/github`; the issue editor patches the GitHub link on the
+session's weaver tracking issue, which remains the source of truth for that
+association.
 
 **Archive on merge.** When a poll finds a branch's PR has merged and
 `github.archive_on_merge` is on (the default), loom archives the session

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -24,6 +24,12 @@ Search, moves, ordering, collapse preferences, and placement defaults all use
 the layout REST API. Selecting a row opens the session without changing its
 group, and returning to the workbench restores the current view.
 
+The shell polls a compact summary of active sessions. It fetches archived
+summaries only when History opens, and fetches full goal, launch, policy, and
+runtime context only when a session page or row disclosure needs it. Search
+still matches goal text on the server, so this transport hierarchy does not
+weaken discovery.
+
 ## Launch
 
 New Session chooses a repository, task, profile, and optional one-launch
@@ -65,8 +71,13 @@ layout changes that would discard it are stopped with a focused save-or-cancel
 choice. Submitted review history is immutable apart from comment resolution and
 delivery retry.
 
+The session header keeps current state and frequent destinations visible. A
+linked GitHub issue or pull request opens directly from its labelled pill;
+reassociation is an adjacent secondary action, and an empty pill remains a
+discoverable setup action.
+
 **Details** is a popover, not a work tab. It owns task and launch metadata,
-associations, lifecycle actions, handoff, auto-archive policy, and Scratch.
+status history, lifecycle actions, handoff, auto-archive policy, and Scratch.
 The embedded editor is an optional **Advanced → Open editor** escape hatch,
 loaded beside the work area only when requested.
 

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -694,6 +694,7 @@ test.describe('acp conversation', () => {
       name: 'acp-file-resource',
     });
     const input = page.getByTestId('acp-composer-input');
+    await expect(input).toHaveAttribute('autocomplete', 'off');
     await input.fill('resources|@READ');
     const menu = page.getByTestId('acp-file-menu');
     await expect(menu.getByText('@README.md', { exact: true })).toBeVisible();

--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -29,8 +29,15 @@ test.describe('creating a session via the UI form', () => {
     await page.goto(weaver.baseUrl);
     await page.getByRole('button', { name: 'New session' }).click();
 
-    await page.getByPlaceholder(repoPlaceholder).fill(weaver.repoPath);
-    await page.getByPlaceholder('Add a /health endpoint').fill('Investigate the attached trace');
+    const repo = page.getByPlaceholder(repoPlaceholder);
+    const title = page.getByLabel('Title', { exact: true });
+    const goal = page.getByPlaceholder('Add a /health endpoint');
+    await expect(repo).toHaveAttribute('autocomplete', 'off');
+    await expect(title).toHaveAttribute('autocomplete', 'off');
+    await expect(goal).toHaveAttribute('autocomplete', 'off');
+
+    await repo.fill(weaver.repoPath);
+    await goal.fill('Investigate the attached trace');
     await page.getByTestId('launch-profile-picker').selectOption('ui-launch');
     await page.getByTestId('override-mode').selectOption('plan');
     await expect(page.getByTestId('launch-settings')).toContainText('changed');

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -164,11 +164,33 @@ test.describe('session detail view', () => {
         json: { ...s, branch: { ...s.branch, github_pr: 37 } },
       });
     });
+    await page.route(`**/api/sessions/${s.id}`, async (route) => {
+      if (!requestBody) return route.fallback();
+      const response = await route.fetch();
+      const current = (await response.json()) as typeof s;
+      await route.fulfill({
+        response,
+        json: {
+          ...current,
+          github_repo: current.github_repo ?? 'acme/widgets',
+          branch: {
+            ...current.branch,
+            github_pr: 37,
+            github: {
+              pr_number: 37,
+              pr_url: 'https://github.com/acme/widgets/pull/37',
+              pr_state: 'OPEN',
+              checks: 'passing',
+            },
+          },
+        },
+      });
+    });
 
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);
-    await page.getByRole('button', { name: /Details/ }).click();
     const prPill = page.getByTestId('pr-association-pill');
     const issuePill = page.getByTestId('issue-association-pill');
+    await expect(page.getByTestId('github-associations')).toBeVisible();
     await expect(prPill).toHaveText('PR —');
     await expect(issuePill).toHaveText('Issue —');
 
@@ -179,6 +201,17 @@ test.describe('session detail view', () => {
 
     await expect.poll(() => requestBody).toEqual({ pr_number: 37 });
     await expect(form).toBeHidden();
+    await expect(prPill).toHaveAttribute('href', 'https://github.com/acme/widgets/pull/37');
+    await expect(prPill).toHaveAttribute('target', '_blank');
+
+    // Reassociation is secondary, but its popover follows the same Escape /
+    // focus-return contract as Details.
+    const prEdit = page.getByTestId('pr-association-edit');
+    await prEdit.click();
+    await expect(page.getByTestId('pr-mapping-popover')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('pr-mapping-popover')).toHaveCount(0);
+    await expect(prEdit).toBeFocused();
 
     await issuePill.click();
     const issueForm = page.getByTestId('issue-mapping-form');
@@ -192,8 +225,9 @@ test.describe('session detail view', () => {
         repo: 'acme/widgets',
         number: 73,
       });
+    await expect(issuePill).toHaveAttribute('href', 'https://github.com/acme/widgets/issues/73');
 
-    await issuePill.click();
+    await page.getByTestId('issue-association-edit').click();
     await page.getByTestId('issue-mapping-form').getByRole('button', { name: 'Clear' }).click();
     await expect(issuePill).toHaveText('Issue —');
   });

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -118,6 +118,56 @@ async function createFailedRun(baseUrl: string) {
 }
 
 test.describe("durable session workbench", () => {
+  test("fleet polling stays compact and row details load on demand", async ({
+    page,
+    weaver,
+  }) => {
+    const goal = "Full operator context fetched only after disclosure";
+    const session = await weaver.seedSession({
+      goal,
+      name: "compact-fleet-row",
+    });
+    const summaryResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return (
+        response.request().method() === "GET" &&
+        url.pathname === "/api/sessions/summary" &&
+        !url.searchParams.has("archived") &&
+        url.searchParams.get("automation") === "true"
+      );
+    });
+    const detailRequests: string[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (
+        request.method() === "GET" &&
+        url.pathname === `/api/sessions/${session.id}`
+      ) {
+        detailRequests.push(url.pathname);
+      }
+    });
+
+    await page.goto(weaver.baseUrl);
+    const summary = (await (await summaryResponse).json()) as Array<
+      Record<string, unknown> & { id: string; branch: Record<string, unknown> }
+    >;
+    const rowSummary = summary.find(
+      (candidate) => candidate.id === session.id,
+    )!;
+    expect(rowSummary.branch.goal).toBeUndefined();
+    expect(rowSummary.resolved_launch).toBeUndefined();
+
+    const row = page.locator(`[data-session-id="${session.id}"]`);
+    await expect(row).toBeVisible();
+    expect(detailRequests).toEqual([]);
+
+    await row.getByTestId("session-details-toggle").click();
+    await expect
+      .poll(() => detailRequests)
+      .toEqual([`/api/sessions/${session.id}`]);
+    await expect(row.getByTestId("session-preview")).toContainText(goal);
+  });
+
   test("@workbench pointer, keyboard, undo, preference, and SSE share one layout", async ({
     page,
     weaver,
@@ -275,6 +325,15 @@ test.describe("durable session workbench", () => {
       .getByTestId("confirm-dialog")
       .getByTestId("confirm-dialog-confirm")
       .click();
+
+    // Archived summaries are not part of the recurring snapshot, but widened
+    // server search can still render a cold result before History is opened.
+    await search.fill("Normal searchable");
+    await expect(normalRow).toHaveCount(0);
+    await page.getByTestId("search-history").check();
+    await expect(normalRow).toBeVisible();
+    await search.fill("");
+
     await page.getByTestId("history-view").click();
     const archivedNormal = page.locator(`[data-session-id="${normal.id}"]`);
     const archivedAutomation = page.locator(


### PR DESCRIPTION
## Summary
- keep GitHub issue and PR destinations in the session header with secondary reassociation
- disable browser history completion where Loom owns suggestions
- poll compact active summaries, load History lazily, and fetch full session detail on demand

## Validation
- pre-commit gate and focused REST/Playwright contracts pass
- exhaustive Playwright: 107 passed; one ACP timing retry passed immediately
- agent lint review: no blocking findings