### PR TITLE
fix(loom): make ACP restart recovery durable

### DIFF
--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -70,6 +70,11 @@ use wire::{
     SessionUpdate, ToolCall, ToolCallContent, ToolCallLocation,
 };
 
+/// Persisting the relay cursor for every streaming delta turns a restart replay
+/// into thousands of SQLite writes. A short periodic flush keeps the possible
+/// duplicate replay bounded while allowing catch-up to run at spool speed.
+const ACK_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
+
 // ---------------------------------------------------------------------------
 // Public surface
 // ---------------------------------------------------------------------------
@@ -1915,6 +1920,11 @@ impl Task {
 
     async fn run(mut self, mut cmd_rx: mpsc::Receiver<Command>) {
         let mut handoff_reply = None;
+        let mut ack_tick = tokio::time::interval(ACK_FLUSH_INTERVAL);
+        ack_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Consume interval's immediate first tick; the handshake already
+        // flushed everything safe before the main loop starts.
+        ack_tick.tick().await;
         loop {
             tokio::select! {
                 ev = self.stream.recv() => match ev {
@@ -1924,8 +1934,8 @@ impl Task {
                             Ok(inc) => self.dispatch_frame(seq, inc).await,
                             Err(e) => tracing::warn!(session = %self.session_id, error = %e, "unparseable acp frame"),
                         }
-                        if let Err(e) = self.maybe_ack().await {
-                            tracing::warn!(session = %self.session_id, error = %e, "acp ack failed");
+                        if self.journal_replay_needed() {
+                            break;
                         }
                     }
                     Some(RelayEvent::Exit { status }) => {
@@ -1953,8 +1963,18 @@ impl Task {
                             }
                         }
                     }
-                    Some(c) => self.on_command(c).await,
+                    Some(c) => {
+                        self.on_command(c).await;
+                        if self.journal_replay_needed() {
+                            break;
+                        }
+                    }
                     None => break,
+                },
+                _ = ack_tick.tick() => {
+                    if let Err(e) = self.maybe_ack().await {
+                        tracing::warn!(session = %self.session_id, error = %e, "acp ack failed");
+                    }
                 },
             }
         }
@@ -1963,6 +1983,18 @@ impl Task {
             let _ = reply.send(Ok(snapshot));
         }
         tracing::info!(session = %self.session_id, "acp task stopped");
+    }
+
+    fn journal_replay_needed(&self) -> bool {
+        if !self.journal_failed {
+            return false;
+        }
+        tracing::warn!(
+            session = %self.session_id,
+            acked = self.acked,
+            "acp task yielding after journal failure so the durable relay backlog can replay"
+        );
+        true
     }
 
     /// Route one inbound frame (notification / agent request / response).

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -15,6 +15,8 @@ use crate::{backend, config, db, github, monitor, runner, session_manager, watch
 use weaver_core::branch as branch_mod;
 use weaver_core::watch as watch_store;
 
+const ACP_REPAIR_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1500);
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServerState {
     pub pid: u32,
@@ -142,7 +144,7 @@ pub async fn run(addr: &str) -> Result<()> {
     // adopting an orphan): without it the relay keeps spooling frames loom no
     // longer journals. A dead relay is left for the monitor to mark `orphaned`,
     // exactly as for a terminal session.
-    reattach_acp_sessions(&state).await;
+    repair_acp_sessions(&state).await;
 
     // Two independent startup adopt policies. The fleet-wide one recreates every
     // recoverable *ordinary* session's terminal, gated on `server.auto_adopt`. The
@@ -175,16 +177,19 @@ pub async fn run(addr: &str) -> Result<()> {
     result
 }
 
-/// On startup, re-attach to every `protocol='acp'` session whose relay supervisor
-/// is still alive — resuming the journal/SSE/ack task loom lost on restart. A dead
-/// relay is left untouched here; the monitor marks it `orphaned` on its next tick,
-/// and adopt (manual or auto) respawns it. Runs unconditionally, before the
-/// `server.auto_adopt` pass, so a live agent is never mistaken for an orphan.
-async fn reattach_acp_sessions(state: &AppState) {
+/// Restore the Loom-side driver for every live ACP relay that currently lacks
+/// one. Startup calls this once, and the active server repeats it in the
+/// background so a transport disconnect cannot leave a durable session row in
+/// a permanently undriveable state.
+///
+/// The relay remains the runtime authority: a missing relay is left for the
+/// monitor to mark orphaned, while a surviving relay is re-subscribed from the
+/// persisted ACK cursor.
+pub async fn repair_acp_sessions(state: &AppState) {
     let sessions = match session_mod::list(&state.db).await {
         Ok(s) => s,
         Err(e) => {
-            tracing::warn!("acp reattach: listing sessions failed: {e}");
+            tracing::warn!("acp repair: listing sessions failed: {e}");
             return;
         }
     };
@@ -199,19 +204,41 @@ async fn reattach_acp_sessions(state: &AppState) {
             continue; // dead relay — the monitor will mark it orphaned.
         }
         match crate::acp::attach(state, &session.id).await {
-            Ok(()) => tracing::info!("acp reattach: re-attached session {}", session.id),
+            Ok(()) => tracing::info!("acp repair: re-attached session {}", session.id),
             Err(e) => tracing::warn!(
-                "acp reattach: could not re-attach session {}: {e}",
+                "acp repair: could not re-attach session {}: {e}",
                 session.id
             ),
         }
     }
 }
 
+/// Keep repairing live relays only while this process owns `loom.json`.
+///
+/// `loom server restart` deliberately overlaps the draining old process with
+/// its replacement. Without the ownership fence, both generations could notice
+/// the other's evicted ACP subscription and repeatedly steal Tapestry's
+/// single-subscriber relay from one another.
+async fn repair_acp_sessions_loop(state: AppState) {
+    let my_pid = std::process::id();
+    let mut interval = tokio::time::interval(ACP_REPAIR_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Startup already performed the first repair pass.
+    interval.tick().await;
+    loop {
+        interval.tick().await;
+        if read_state().map(|owner| owner.pid) != Some(my_pid) {
+            tracing::info!("acp repair loop stopped because a newer server owns loom.json");
+            return;
+        }
+        repair_acp_sessions(&state).await;
+    }
+}
+
 /// On startup, adopt every recoverable *ordinary* session whose terminal is gone.
 /// Engine-managed (warm) sessions are skipped here — they have their own adopt
 /// policy in [`reconcile_managed_sessions`], gated on `watch.adopt_warm`. A live
-/// ACP session was already re-attached by [`reattach_acp_sessions`]; a dead-relay
+/// ACP session was already re-attached by [`repair_acp_sessions`]; a dead-relay
 /// ACP session falls through to `web::adopt`, which respawns it via `session/load`.
 async fn reconcile_sessions(state: &AppState) {
     let sessions = match session_mod::list(&state.db).await {
@@ -338,6 +365,7 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
         Err(e) => tracing::warn!("could not prepare the machine-local token: {e}"),
     }
     tokio::spawn(monitor::run(state.clone()));
+    tokio::spawn(repair_acp_sessions_loop(state.clone()));
     tokio::spawn(session_manager::run(state.db.clone()));
     tokio::spawn(crate::review_delivery::run(state.clone()));
     // The GitHub poller is always spawned; it self-gates on the `github.poll`
@@ -355,7 +383,7 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
     // here cheaply.
     tokio::spawn(crate::slack::run(state.clone()));
     tracing::debug!(
-        "background tasks spawned (monitor, session reconciler, review delivery, github poll, watch, ide reaper, slack)"
+        "background tasks spawned (monitor, ACP repair, session reconciler, review delivery, github poll, watch, ide reaper, slack)"
     );
     // `into_make_service_with_connect_info` surfaces the peer `SocketAddr` to the
     // auth middleware, which uses it to recognise (and optionally trust) loopback.

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1724,6 +1724,85 @@ async fn crash_recovery_replays_without_duplicates() {
     );
 }
 
+/// A relay can survive while its Loom-side task exits (for example after a
+/// journal write loses a prolonged SQLite lock race). The repair pass must
+/// re-register the driver, replay the unacked frames, and leave the session
+/// driveable instead of preserving a `running` zombie.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repair_restores_a_live_relay_after_journal_failure() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-repair", None, None).await;
+
+    // Fail one durable block write while leaving the session row and relay
+    // intact. The ACP task should yield immediately so the frame stays in
+    // Tapestry's spool for a clean replay.
+    sqlx::query(
+        "CREATE TRIGGER fail_acp_usage
+         BEFORE INSERT ON chat_blocks
+         WHEN NEW.session_id = 'acp-repair' AND NEW.kind = 'usage'
+         BEGIN
+           SELECT RAISE(FAIL, 'forced journal failure');
+         END",
+    )
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+    ts.client
+        .post(
+            "/api/sessions/acp-repair/prompt",
+            json!({ "text": "usage:1:10|say:survived" }),
+        )
+        .await
+        .unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while ts.state.acp.is_live("acp-repair") {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "journal failure did not retire the damaged ACP task"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(
+        backend::has_session("weaver-acp-repair").await,
+        "the relay and provider survive the Loom-side failure"
+    );
+
+    sqlx::query("DROP TRIGGER fail_acp_usage")
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+    loom::server::repair_acp_sessions(&ts.state).await;
+    assert!(
+        ts.state.acp.is_live("acp-repair"),
+        "repair registers a replacement ACP task"
+    );
+
+    let chat = poll_chat(&ts, "acp-repair", Duration::from_secs(10), |blocks| {
+        blocks
+            .iter()
+            .any(|block| block["kind"] == "agent_message" && block["payload"]["text"] == "survived")
+            && blocks.iter().any(|block| block["kind"] == "turn_end")
+    })
+    .await;
+    assert_eq!(chat["live_turn"], Value::Null);
+
+    ts.client
+        .post(
+            "/api/sessions/acp-repair/prompt",
+            json!({ "text": "say:still-driveable" }),
+        )
+        .await
+        .expect("the repaired ACP task accepts another prompt");
+    poll_chat(&ts, "acp-repair", Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "still-driveable"
+        })
+    })
+    .await;
+}
+
 /// 5b. Adapter user echoes never re-journal: a `user_message_chunk` streamed
 ///    mid-turn (claude re-streams retained user turns after `/compact`) must not
 ///    duplicate the history — the prompt loom journaled at dispatch is the only

--- a/crates/tapestry/src/supervisor.rs
+++ b/crates/tapestry/src/supervisor.rs
@@ -608,6 +608,14 @@ mod relay {
         Exit { code: i32 },
     }
 
+    /// A subscriber catching up to a stable spool snapshot. It is promoted to
+    /// `subscriber` only after successive replay passes reach the live tail.
+    struct Replay {
+        id: u64,
+        out_tx: mpsc::Sender<Out>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
     /// Control messages to the relay core (the single owner of the spool +
     /// subscriber). Spooled frames travel on their own bounded channel (so the
     /// reader thread can park under back-pressure), not through here.
@@ -623,6 +631,14 @@ mod relay {
             cursor: u64,
             out_tx: mpsc::Sender<Out>,
             resp: oneshot::Sender<u64>,
+        },
+        /// One bounded replay pass reached the spool snapshot it started from.
+        /// The core either starts another pass for frames appended meanwhile or
+        /// promotes the subscriber to the live stream.
+        ReplayComplete {
+            id: u64,
+            through: u64,
+            delivered: bool,
         },
         /// A subscriber's connection ended; clear it if still current.
         Unsubscribe(u64),
@@ -789,6 +805,7 @@ mod relay {
         let mut spool = Spool::create(crate::paths::spool_dir(&cfg.name), segment_max)
             .context("creating frame spool")?;
         let mut subscriber: Option<(u64, mpsc::Sender<Out>)> = None;
+        let mut replaying: Option<Replay> = None;
         let mut next_sub_id: u64 = 0;
         let mut exited: Option<i32> = None;
         let mut frame_open = true;
@@ -812,39 +829,53 @@ mod relay {
                         }
                         Cmd::Subscribe { cursor, out_tx, resp } => {
                             // A new subscriber evicts the previous one.
-                            subscriber = None;
-                            let mut wedged = false;
-                            // Replay spooled frames strictly after the cursor,
-                            // segment by segment (bounding memory to one segment).
-                            'replay: for path in spool.replay_segments(cursor) {
-                                for (seq, body) in read_records(&path) {
-                                    if seq > cursor
-                                        && !deliver(&out_tx, Out::Frame { seq, body }).await
-                                    {
-                                        wedged = true;
-                                        break 'replay;
-                                    }
-                                }
-                            }
-                            // If the child is already fully done, the late
-                            // subscriber still learns the terminal state.
-                            if !wedged && finished {
-                                if let Some(code) = exited {
-                                    if !deliver(&out_tx, Out::Exit { code }).await {
-                                        wedged = true;
-                                    }
-                                }
+                            drop(subscriber.take());
+                            if let Some(replay) = replaying.take() {
+                                replay.task.abort();
                             }
                             let id = next_sub_id;
                             next_sub_id += 1;
-                            if !wedged {
-                                subscriber = Some((id, out_tx));
-                            }
+                            (replaying, subscriber) = place_subscriber(
+                                id,
+                                cursor,
+                                &spool,
+                                out_tx,
+                                cmd_tx.clone(),
+                                finished,
+                                exited,
+                            ).await;
+                            // Registration completes immediately. Replay owns
+                            // its own task, so ACK/WRITE/PING remain responsive
+                            // even when the durable backlog is much larger than
+                            // the subscriber's bounded buffers.
                             let _ = resp.send(id);
+                        }
+                        Cmd::ReplayComplete { id, through, delivered } => {
+                            if !matches!(&replaying, Some(replay) if replay.id == id) {
+                                continue;
+                            }
+                            let Replay { out_tx, .. } = replaying.take().expect("matched above");
+                            if !delivered {
+                                continue;
+                            }
+                            (replaying, subscriber) = place_subscriber(
+                                id,
+                                through,
+                                &spool,
+                                out_tx,
+                                cmd_tx.clone(),
+                                finished,
+                                exited,
+                            ).await;
                         }
                         Cmd::Unsubscribe(id) => {
                             if matches!(&subscriber, Some((cur, _)) if *cur == id) {
                                 subscriber = None;
+                            }
+                            if matches!(&replaying, Some(replay) if replay.id == id) {
+                                if let Some(replay) = replaying.take() {
+                                    replay.task.abort();
+                                }
                             }
                         }
                         Cmd::Capture { resp } => {
@@ -904,6 +935,9 @@ mod relay {
         // session's artifacts (socket, spool, stderr log) — reached only on an
         // explicit kill, which destroys the session.
         drop(subscriber);
+        if let Some(replay) = replaying {
+            replay.task.abort();
+        }
         drop(write_tx);
         let _ = writer_thread.join();
         let _ = std::fs::remove_file(&socket);
@@ -921,6 +955,72 @@ mod relay {
             tokio::time::timeout(EVICT_AFTER, tx.send(msg)).await,
             Ok(Ok(()))
         )
+    }
+
+    /// Put a new or caught-up subscriber in exactly one state: draining the
+    /// durable tail, following live frames, or finished after receiving EXIT.
+    async fn place_subscriber(
+        id: u64,
+        cursor: u64,
+        spool: &Spool,
+        out_tx: mpsc::Sender<Out>,
+        cmd_tx: mpsc::UnboundedSender<Cmd>,
+        finished: bool,
+        exited: Option<i32>,
+    ) -> (Option<Replay>, Option<(u64, mpsc::Sender<Out>)>) {
+        let through = spool.spooled();
+        if cursor < through {
+            let task = spawn_replay(
+                id,
+                cursor,
+                through,
+                spool.replay_segments(cursor),
+                out_tx.clone(),
+                cmd_tx,
+            );
+            return (Some(Replay { id, out_tx, task }), None);
+        }
+        if finished {
+            if let Some(code) = exited {
+                let _ = deliver(&out_tx, Out::Exit { code }).await;
+            }
+            return (None, None);
+        }
+        (None, Some((id, out_tx)))
+    }
+
+    /// Replay a stable spool snapshot without blocking the relay core. A slow
+    /// but connected consumer applies ordinary channel/socket back-pressure;
+    /// disconnecting closes the channel, and a replacement subscriber aborts
+    /// this task. Once the snapshot is drained the core catches up any frames
+    /// appended in parallel before promoting the subscriber to live delivery.
+    fn spawn_replay(
+        id: u64,
+        cursor: u64,
+        through: u64,
+        paths: Vec<PathBuf>,
+        out_tx: mpsc::Sender<Out>,
+        cmd_tx: mpsc::UnboundedSender<Cmd>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut delivered = true;
+            'replay: for path in paths {
+                for (seq, body) in read_records(&path) {
+                    if seq > cursor
+                        && seq <= through
+                        && out_tx.send(Out::Frame { seq, body }).await.is_err()
+                    {
+                        delivered = false;
+                        break 'replay;
+                    }
+                }
+            }
+            let _ = cmd_tx.send(Cmd::ReplayComplete {
+                id,
+                through,
+                delivered,
+            });
+        })
     }
 
     /// Once the child has exited *and* its stdout has drained (`!frame_open`),

--- a/crates/tapestry/src/supervisor.rs
+++ b/crates/tapestry/src/supervisor.rs
@@ -616,6 +616,13 @@ mod relay {
         task: tokio::task::JoinHandle<()>,
     }
 
+    /// The one valid destination after placing a subscriber at a spool cursor.
+    enum Placement {
+        Replaying(Replay),
+        Live(u64, mpsc::Sender<Out>),
+        Finished,
+    }
+
     /// Control messages to the relay core (the single owner of the spool +
     /// subscriber). Spooled frames travel on their own bounded channel (so the
     /// reader thread can park under back-pressure), not through here.
@@ -835,15 +842,16 @@ mod relay {
                             }
                             let id = next_sub_id;
                             next_sub_id += 1;
-                            (replaying, subscriber) = place_subscriber(
+                            let placement = place_subscriber(
                                 id,
                                 cursor,
                                 &spool,
                                 out_tx,
                                 cmd_tx.clone(),
-                                finished,
-                                exited,
-                            ).await;
+                                if finished { exited } else { None },
+                            )
+                            .await;
+                            apply_placement(&mut replaying, &mut subscriber, placement);
                             // Registration completes immediately. Replay owns
                             // its own task, so ACK/WRITE/PING remain responsive
                             // even when the durable backlog is much larger than
@@ -858,15 +866,16 @@ mod relay {
                             if !delivered {
                                 continue;
                             }
-                            (replaying, subscriber) = place_subscriber(
+                            let placement = place_subscriber(
                                 id,
                                 through,
                                 &spool,
                                 out_tx,
                                 cmd_tx.clone(),
-                                finished,
-                                exited,
-                            ).await;
+                                if finished { exited } else { None },
+                            )
+                            .await;
+                            apply_placement(&mut replaying, &mut subscriber, placement);
                         }
                         Cmd::Unsubscribe(id) => {
                             if matches!(&subscriber, Some((cur, _)) if *cur == id) {
@@ -965,9 +974,8 @@ mod relay {
         spool: &Spool,
         out_tx: mpsc::Sender<Out>,
         cmd_tx: mpsc::UnboundedSender<Cmd>,
-        finished: bool,
-        exited: Option<i32>,
-    ) -> (Option<Replay>, Option<(u64, mpsc::Sender<Out>)>) {
+        terminal_status: Option<i32>,
+    ) -> Placement {
         let through = spool.spooled();
         if cursor < through {
             let task = spawn_replay(
@@ -978,15 +986,34 @@ mod relay {
                 out_tx.clone(),
                 cmd_tx,
             );
-            return (Some(Replay { id, out_tx, task }), None);
+            return Placement::Replaying(Replay { id, out_tx, task });
         }
-        if finished {
-            if let Some(code) = exited {
-                let _ = deliver(&out_tx, Out::Exit { code }).await;
+        if let Some(code) = terminal_status {
+            let _ = deliver(&out_tx, Out::Exit { code }).await;
+            return Placement::Finished;
+        }
+        Placement::Live(id, out_tx)
+    }
+
+    fn apply_placement(
+        replaying: &mut Option<Replay>,
+        subscriber: &mut Option<(u64, mpsc::Sender<Out>)>,
+        placement: Placement,
+    ) {
+        match placement {
+            Placement::Replaying(replay) => {
+                *replaying = Some(replay);
+                *subscriber = None;
             }
-            return (None, None);
+            Placement::Live(id, out_tx) => {
+                *replaying = None;
+                *subscriber = Some((id, out_tx));
+            }
+            Placement::Finished => {
+                *replaying = None;
+                *subscriber = None;
+            }
         }
-        (None, Some((id, out_tx)))
     }
 
     /// Replay a stable spool snapshot without blocking the relay core. A slow

--- a/crates/tapestry/tests/relay.rs
+++ b/crates/tapestry/tests/relay.rs
@@ -82,13 +82,15 @@ impl Relay {
 
     /// Block until the spool has assigned at least `n` sequence numbers.
     async fn wait_spooled(&self, n: u64) {
-        for _ in 0..400 {
-            if self.ping().await.spooled >= n {
+        let mut last = 0;
+        for _ in 0..800 {
+            last = self.ping().await.spooled;
+            if last >= n {
                 return;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            tokio::time::sleep(Duration::from_millis(25)).await;
         }
-        panic!("spool never reached seq {n}");
+        panic!("spool never reached seq {n} (stopped at {last})");
     }
 
     async fn kill(&self) {
@@ -211,6 +213,39 @@ async fn replay_survives_client_death_and_respects_the_cursor() {
     r.wait_spooled(3).await;
     let mut sub = r.subscribe(2).await;
     assert_eq!(next_frame(&mut sub).await, (3, b"got:c".to_vec()));
+
+    r.kill().await;
+}
+
+/// A large durable replay may fill every bounded client/socket buffer while its
+/// consumer catches up. Control traffic must remain responsive during that
+/// back-pressure so Loom can ACK, prompt, inspect, or replace the subscriber
+/// instead of having the supervisor misclassify recovery as a wedged client.
+#[tokio::test]
+#[serial]
+async fn large_slow_replay_does_not_block_relay_control() {
+    let script = r#"python3 -c 'import sys, time
+for _ in range(1000):
+ print("x" * 1024)
+sys.stdout.flush()
+time.sleep(30)'"#;
+    let r = Relay::start("slow-replay", script, None).await;
+    r.wait_spooled(1000).await;
+
+    let mut sub = r.subscribe(0).await;
+    assert_eq!(next_frame(&mut sub).await.0, 1);
+
+    let pong = tokio::time::timeout(Duration::from_secs(2), async {
+        Client::connect(&r.name)
+            .await
+            .unwrap()
+            .ping()
+            .await
+            .unwrap()
+    })
+    .await
+    .expect("relay control blocked behind durable replay");
+    assert_eq!(pong.spooled, 1000);
 
     r.kill().await;
 }

--- a/crates/weaver-core/src/db.rs
+++ b/crates/weaver-core/src/db.rs
@@ -10,6 +10,11 @@ pub type Db = SqlitePool;
 
 const MIGRATION_POOL_CONNECTIONS: u32 = 1;
 const SHARED_POOL_CONNECTIONS: u32 = 5;
+/// Ordinary WAL writer contention should queue rather than leak SQLITE_BUSY
+/// into user-facing reads or durable ACP journal writes. This is intentionally
+/// longer than a normal transaction; exhausting it indicates a genuinely
+/// abnormal external/schema lock, which callers may then recover from.
+const SQLITE_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// An on-disk database whose core schema is migrated, but whose shared pool has
 /// not opened yet.
@@ -39,6 +44,11 @@ impl DatabaseBootstrap {
         } = self;
         migrator.close().await;
         let pool = SqlitePoolOptions::new()
+            // Open and configure every connection before the server starts
+            // serving. `journal_mode = WAL` is a connection setup pragma that
+            // can itself need a schema lock; opening a cold extra connection
+            // under live write load must not introduce surprise lock failures.
+            .min_connections(SHARED_POOL_CONNECTIONS)
             .max_connections(SHARED_POOL_CONNECTIONS)
             .connect_with(options)
             .await
@@ -192,7 +202,7 @@ pub async fn begin_bootstrap(path: &Path) -> Result<DatabaseBootstrap> {
         // A writer that loses the lock race waits its turn instead of failing
         // with SQLITE_BUSY "database is locked". Only effective for writes that
         // take the lock up front — see [`begin_immediate`].
-        .busy_timeout(std::time::Duration::from_secs(5));
+        .busy_timeout(SQLITE_BUSY_TIMEOUT);
 
     // Keep the migration connection alive after the core stream completes so
     // higher-level schema owners can migrate through it too. Only `finish`
@@ -219,7 +229,7 @@ pub async fn connect_in_memory() -> Result<Db> {
     let options = SqliteConnectOptions::new()
         .in_memory(true)
         .journal_mode(SqliteJournalMode::Wal)
-        .busy_timeout(std::time::Duration::from_secs(5));
+        .busy_timeout(SQLITE_BUSY_TIMEOUT);
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         .connect_with(options)
@@ -337,6 +347,16 @@ mod tests {
 
         let db = bootstrap.finish().await.unwrap();
         assert_eq!(db.options().get_max_connections(), SHARED_POOL_CONNECTIONS);
+        assert_eq!(
+            db.size(),
+            SHARED_POOL_CONNECTIONS,
+            "the shared pool is fully configured before it is returned"
+        );
+        let busy_timeout_ms = sqlx::query_scalar::<_, i64>("PRAGMA busy_timeout")
+            .fetch_one(&db)
+            .await
+            .unwrap();
+        assert_eq!(busy_timeout_ms, SQLITE_BUSY_TIMEOUT.as_millis() as i64);
     }
 
     #[tokio::test]
@@ -363,8 +383,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db = connect(&dir.path().join("weaver.db")).await.unwrap();
 
-        // Pre-open the whole pool so polling each waiter once gets as far as
-        // the writer lock rather than pausing to establish a connection.
+        // Check out the whole eagerly-opened pool so polling each waiter once
+        // gets as far as the writer lock.
         let mut connections = Vec::new();
         for _ in 0..5 {
             connections.push(db.acquire().await.unwrap());

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -487,9 +487,17 @@ Details → Advanced, not as the primary file or work surface.
   at any time. Terminal *and* relay supervisors and worktrees survive (the
   supervisor is a detached process, independent of `loom server run`); "orphaned"
   is a first-class status, recovered via `loom session adopt` (or the Adopt button
-  in the UI). On startup loom re-attaches every live-relay ACP session so its
-  journal keeps flowing; adopt re-attaches when the relay outlived a crashed task,
-  or respawns the adapter and reopens the conversation via `session/load` (falling
+  in the UI). On startup and periodically afterward, the active loom generation
+  re-attaches every live-relay ACP session missing its in-process driver so its
+  journal keeps flowing; a `loom.json` ownership fence prevents an older draining
+  server from competing for Tapestry's single relay subscription. ACP cursors
+  flush periodically rather than once per streaming frame, and a failed durable
+  journal write yields the task so the repair pass replays from the last ACK
+  instead of accumulating an unbounded backlog. Tapestry drains durable replay
+  in a separate back-pressured task, keeping ACK, write, ping, and replacement
+  subscriber control responsive even when the replay exceeds every bounded
+  stream buffer. Adopt re-attaches when the relay outlived a crashed task, or
+  respawns the adapter and reopens the conversation via `session/load` (falling
   back to a fresh session re-oriented from the goal) when the relay is gone too.
 - **No unowned session runtimes:** the database is the ownership authority for
   detached supervisors. Startup and periodic reconciliation remove


### PR DESCRIPTION
Detached Tapestry relays could outlive a disconnected Loom ACP driver while the durable session row remained `running`. After a prolonged SQLite journal failure froze the ACK cursor, restart replay could fill the relay subscriber buffers, evict Loom, and leave the session permanently undriveable.

Periodically repair missing ACP drivers from their persisted cursor, fenced to the active Loom generation. Yield immediately after a durable journal failure and batch ACK persistence so relay replay remains the source of truth without creating thousands of SQLite writes.

Move durable Tapestry replay out of the relay control loop so slow catch-up cannot block ACK, write, ping, or subscriber replacement. Eagerly configure the complete SQLite WAL pool and extend the busy timeout so ordinary writer contention queues instead of surfacing as journal failures.