### PR TITLE
feat(loom): add terminal mailbox workbench

### DIFF
--- a/crates/loom/frontend/src/App.vue
+++ b/crates/loom/frontend/src/App.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import AppRail from './components/AppRail.vue';
 import ConfirmDialog from './components/ConfirmDialog.vue';
+import ShortcutHelp from './components/ShortcutHelp.vue';
 import StatusBar from './components/StatusBar.vue';
 import { me } from './auth';
+import {
+  useCommandRegistry,
+  useCommandDispatcher,
+  useCommandScope,
+  type Command,
+} from './lib/commands';
 import { acceptConfirmation, cancelConfirmation, confirmation } from './lib/confirmation';
 import { useFleet } from './lib/sessionsStore';
 
@@ -36,6 +43,55 @@ watch(authed, (ok) => (ok ? startFleetPoll() : stopFleetPoll()), { immediate: tr
 // next poll and a deep link shows the base title only until that row arrives (no
 // wrong-name flash, just a late refine).
 const route = useRoute();
+const router = useRouter();
+const commands = useCommandRegistry();
+const globalCommands = computed<Command[]>(() => [
+  {
+    id: 'global.help',
+    label: 'Show keyboard shortcuts',
+    keys: ['?'],
+    hint: true,
+    run: commands.toggleHelp,
+  },
+  {
+    id: 'global.sessions',
+    label: 'Go to Sessions',
+    keys: ['g s'],
+    run: () => void router.push('/'),
+  },
+  {
+    id: 'global.issues',
+    label: 'Go to Issues',
+    keys: ['g i'],
+    run: () => void router.push('/issues'),
+  },
+  {
+    id: 'global.watches',
+    label: 'Go to Watches',
+    keys: ['g w'],
+    run: () => void router.push('/watches'),
+  },
+  {
+    id: 'global.shell',
+    label: 'Go to Shell',
+    keys: ['g h'],
+    run: () => void router.push('/shell'),
+  },
+  {
+    id: 'global.settings',
+    label: 'Go to Settings',
+    keys: ['g ,'],
+    run: () => void router.push('/settings'),
+  },
+  {
+    id: 'global.new-session',
+    label: 'New session',
+    keys: ['n'],
+    run: () => void router.push('/sessions/new'),
+  },
+]);
+useCommandScope('global', 'Global', globalCommands, -100);
+useCommandDispatcher();
 const BASE_TITLE = 'Weaver';
 function withSection(section?: string | null): string {
   return section ? `${BASE_TITLE} - ${section}` : BASE_TITLE;
@@ -87,7 +143,7 @@ function cacheKey(route: { path: string; params: Record<string, string | string[
 
 <template>
   <router-view v-if="!authed" />
-  <div v-else class="flex h-screen overflow-hidden bg-canvas font-sans text-fg">
+  <div v-else data-ui="terminal" class="flex h-screen overflow-hidden bg-canvas font-sans text-fg">
     <AppRail />
     <div class="flex min-w-0 flex-1 flex-col">
       <main class="flex min-h-0 flex-1 flex-col overflow-auto">
@@ -111,4 +167,5 @@ function cacheKey(route: { path: string; params: Record<string, string | string[
     @confirm="acceptConfirmation"
     @cancel="cancelConfirmation"
   />
+  <ShortcutHelp />
 </template>

--- a/crates/loom/frontend/src/components/KeyHint.vue
+++ b/crates/loom/frontend/src/components/KeyHint.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineProps<{ keys: string }>();
+</script>
+
+<template>
+  <kbd
+    class="inline-flex min-w-4 items-center justify-center border border-line bg-input px-1 font-mono text-[10px] font-medium leading-4 text-muted"
+  >
+    {{ keys }}
+  </kbd>
+</template>

--- a/crates/loom/frontend/src/components/SessionMailboxPreview.vue
+++ b/crates/loom/frontend/src/components/SessionMailboxPreview.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Session, SessionSummary } from '../types';
+import { effectiveAttention, messageOf, quietTags, signalChips } from '../lib/sessionState';
+import { timeAgo } from '../lib/time';
+import AgentUsage from './AgentUsage.vue';
+import GithubStatus from './GithubStatus.vue';
+import KeyHint from './KeyHint.vue';
+
+const props = defineProps<{
+  session?: SessionSummary;
+  detail?: Session;
+  loading?: boolean;
+  error?: string;
+  position: number;
+  total: number;
+  selected?: boolean;
+  expanded?: boolean;
+}>();
+defineEmits<{
+  open: [event: MouseEvent];
+  toggleSelect: [];
+  toggleDetails: [];
+}>();
+
+const title = computed(
+  () => props.session?.branch.title || props.session?.branch.name || 'No session selected',
+);
+const attention = computed(() => (props.session ? effectiveAttention(props.session) : null));
+const statusMessage = computed(() => (props.session ? messageOf(props.session) : ''));
+const repoName = computed(() => {
+  const path = props.session?.branch.repo_root ?? '';
+  return path.split('/').filter(Boolean).at(-1) ?? path;
+});
+</script>
+
+<template>
+  <aside
+    data-testid="session-mailbox-preview"
+    class="session-mailbox-preview min-h-0 border border-line bg-surface"
+    aria-label="Current session preview"
+  >
+    <header class="terminal-pane-heading">
+      <span>SESSION://INSPECT</span>
+      <span v-if="total"
+        >{{ String(position).padStart(2, '0') }}/{{ String(total).padStart(2, '0') }}</span
+      >
+      <span v-else>--/--</span>
+    </header>
+
+    <template v-if="session">
+      <div class="min-h-0 flex-1 overflow-y-auto">
+        <section class="border-b border-line px-4 py-4">
+          <p class="mb-2 text-2xs uppercase tracking-[0.18em] text-faint">
+            <span class="text-accent">loom@local</span>:{{ repoName }}$ inspect
+            {{ session.id.slice(0, 8) }}
+          </p>
+          <h2 class="break-words font-mono text-lg font-semibold leading-6 text-fg">
+            {{ title }}
+          </h2>
+          <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs uppercase">
+            <span
+              class="inline-flex items-center gap-1.5"
+              :class="
+                attention?.level === 'blocked'
+                  ? 'text-block'
+                  : attention?.level === 'attention'
+                    ? 'text-attn'
+                    : 'text-ok'
+              "
+            >
+              <span class="text-[8px]" aria-hidden="true">◆</span>
+              {{ attention?.level ?? 'ok' }}
+            </span>
+            <span class="text-muted">{{ session.status }}</span>
+            <span v-if="session.last_activity_at" class="text-faint">
+              {{ timeAgo(session.last_activity_at) }}
+            </span>
+          </div>
+        </section>
+
+        <section v-if="statusMessage || attention?.note" class="terminal-preview-section">
+          <h3>LAST SIGNAL</h3>
+          <p class="terminal-output-line">
+            {{ attention?.note || statusMessage }}
+          </p>
+        </section>
+
+        <section class="terminal-preview-section">
+          <h3>TASK BUFFER</h3>
+          <p
+            v-if="detail?.branch.goal"
+            class="whitespace-pre-wrap font-sans text-sm leading-5 text-fg"
+          >
+            {{ detail.branch.goal }}
+          </p>
+          <p v-else-if="loading" class="terminal-loading">fetching session context<span>_</span></p>
+          <p v-else-if="error" class="text-xs text-block">{{ error }}</p>
+          <p v-else class="text-xs text-faint">No task context available.</p>
+        </section>
+
+        <section class="terminal-preview-section">
+          <h3>PROCESS</h3>
+          <dl class="terminal-kv">
+            <dt>repo</dt>
+            <dd :title="session.branch.repo_root">{{ repoName }}</dd>
+            <dt>branch</dt>
+            <dd :title="session.branch.branch">{{ session.branch.branch }}</dd>
+            <dt>space</dt>
+            <dd>{{ session.placement?.space_name ?? 'unplaced' }}</dd>
+            <dt>group</dt>
+            <dd>{{ session.placement?.group_name ?? 'unplaced' }}</dd>
+            <dt>profile</dt>
+            <dd>{{ session.profile || 'default' }}</dd>
+            <dt>origin</dt>
+            <dd>{{ session.origin }}</dd>
+          </dl>
+        </section>
+
+        <section
+          v-if="signalChips(session).length || quietTags(session).length"
+          class="terminal-preview-section"
+        >
+          <h3>FLAGS</h3>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              v-for="chip in signalChips(session)"
+              :key="chip.key"
+              class="terminal-flag"
+              :class="chip.level === 'blocked' ? 'text-block' : 'text-attn'"
+            >
+              {{ chip.key }}={{ chip.level }}
+            </span>
+            <span v-for="tag in quietTags(session)" :key="tag.key" class="terminal-flag">
+              {{ tag.key }}={{ tag.value }}
+            </span>
+          </div>
+        </section>
+
+        <section v-if="session.usage" class="terminal-preview-section">
+          <h3>CONTEXT</h3>
+          <AgentUsage :usage="session.usage" />
+        </section>
+
+        <section v-if="session.branch.github" class="terminal-preview-section">
+          <h3>UPSTREAM</h3>
+          <GithubStatus :gh="session.branch.github" />
+        </section>
+      </div>
+
+      <footer class="border-t border-line bg-rail/70 p-2">
+        <div class="grid grid-cols-3 gap-1.5">
+          <router-link
+            :to="`/s/${session.id}`"
+            class="terminal-action terminal-action--primary"
+            @click="$emit('open', $event)"
+          >
+            <KeyHint keys="Enter" />
+            open
+          </router-link>
+          <button type="button" class="terminal-action" @click="$emit('toggleSelect')">
+            <KeyHint keys="x" />
+            {{ selected ? 'unselect' : 'select' }}
+          </button>
+          <button type="button" class="terminal-action" @click="$emit('toggleDetails')">
+            <KeyHint keys="o" />
+            {{ expanded ? 'collapse' : 'details' }}
+          </button>
+        </div>
+      </footer>
+    </template>
+
+    <div v-else class="flex flex-1 items-center justify-center p-6 text-center text-xs text-faint">
+      <p>
+        <span class="text-accent">&gt;</span> no session in current buffer<span class="cursor-blink"
+          >_</span
+        >
+      </p>
+    </div>
+  </aside>
+</template>

--- a/crates/loom/frontend/src/components/SessionWorkbenchRow.vue
+++ b/crates/loom/frontend/src/components/SessionWorkbenchRow.vue
@@ -40,6 +40,7 @@ const props = defineProps({
   dragging: { type: Boolean, default: false },
   dropBefore: { type: Boolean, default: false },
   clearingTag: { type: String, default: '' },
+  cursor: { type: Boolean, default: false },
 });
 
 const emit = defineEmits<{
@@ -57,6 +58,7 @@ const emit = defineEmits<{
   error: [message: string];
   clearTag: [key: string];
   recordOpen: [event: MouseEvent];
+  activate: [];
 }>();
 const disclosureId = useId();
 const detailsButtonId = `${disclosureId}-details-button`;
@@ -118,14 +120,18 @@ function onKeydown(event: KeyboardEvent) {
   <li
     data-testid="session-card"
     :data-session-id="session.id"
-    class="group relative flex flex-wrap items-start gap-2 border-b border-line px-3 py-2.5 last:border-0 hover:bg-subtle/70 focus-within:bg-subtle/70"
+    class="session-mailbox-row group relative flex flex-wrap items-start gap-1.5 border-b border-line px-2 py-1.5 last:border-0 hover:bg-subtle/70 focus-within:bg-subtle/70"
     :class="[
       dragging ? 'opacity-40' : '',
       dropBefore ? 'shadow-[inset_0_2px_0_var(--accent)]' : '',
+      cursor ? 'session-mailbox-row--cursor' : '',
     ]"
+    :data-cursor="cursor ? 'true' : undefined"
     @dragover.stop.prevent="emit('dragOver')"
     @drop.stop.prevent="emit('drop')"
     @keydown="onKeydown"
+    @focusin="emit('activate')"
+    @mousedown="emit('activate')"
   >
     <span
       v-if="session.status !== 'archived'"
@@ -160,7 +166,9 @@ function onKeydown(event: KeyboardEvent) {
       <div class="flex min-w-0 items-center gap-2">
         <router-link
           :to="`/s/${session.id}`"
-          class="stretched-link min-w-0 truncate text-sm font-medium leading-5 text-fg hover:text-accent"
+          data-session-primary
+          :tabindex="cursor ? 0 : -1"
+          class="session-mailbox-primary stretched-link min-w-0 truncate font-mono text-xs font-medium leading-4 text-fg hover:text-accent"
           @click="emit('recordOpen', $event)"
         >
           {{ title() }}

--- a/crates/loom/frontend/src/components/ShortcutHelp.vue
+++ b/crates/loom/frontend/src/components/ShortcutHelp.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue';
+import { useCommandRegistry } from '../lib/commands';
+import KeyHint from './KeyHint.vue';
+
+const { activeScopes, helpOpen } = useCommandRegistry();
+const closeButton = ref<HTMLButtonElement>();
+let returnFocus: HTMLElement | null = null;
+
+watch(helpOpen, async (open) => {
+  if (open) {
+    returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    await nextTick();
+    closeButton.value?.focus();
+  } else {
+    returnFocus?.focus();
+    returnFocus = null;
+  }
+});
+
+function keepFocusInHelp(event: KeyboardEvent) {
+  if (event.key !== 'Tab') return;
+  event.preventDefault();
+  closeButton.value?.focus();
+}
+</script>
+
+<template>
+  <div
+    v-if="helpOpen"
+    data-testid="shortcut-help"
+    class="fixed inset-0 z-[70] flex items-center justify-center bg-black/45 p-4"
+    @mousedown.self="helpOpen = false"
+  >
+    <section
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="shortcut-help-title"
+      class="max-h-[80vh] w-full max-w-xl overflow-auto border border-line bg-surface shadow-xl"
+      @keydown="keepFocusInHelp"
+    >
+      <header class="flex items-center border-b border-line bg-rail px-3 py-2">
+        <div>
+          <p class="font-mono text-2xs uppercase tracking-wider text-faint">command reference</p>
+          <h2 id="shortcut-help-title" class="font-mono text-sm font-semibold text-fg">
+            Loom keyboard shortcuts
+          </h2>
+        </div>
+        <button
+          ref="closeButton"
+          type="button"
+          class="btn-secondary ml-auto px-2 py-1 text-xs"
+          @click="helpOpen = false"
+        >
+          <KeyHint keys="Esc" />
+          Close
+        </button>
+      </header>
+
+      <div class="divide-y divide-line">
+        <section v-for="scope in activeScopes" :key="scope.id" class="px-3 py-3">
+          <h3 class="mb-1.5 font-mono text-2xs font-semibold uppercase tracking-wider text-muted">
+            {{ scope.label }}
+          </h3>
+          <dl class="grid grid-cols-[minmax(7rem,auto)_1fr] gap-x-4 gap-y-1.5 text-xs">
+            <template v-for="command in scope.commands" :key="command.id">
+              <dt :data-command-id="command.id" class="flex flex-wrap gap-1">
+                <KeyHint v-for="keys in command.keys" :key="keys" :keys="keys" />
+              </dt>
+              <dd class="text-fg">{{ command.label }}</dd>
+            </template>
+          </dl>
+        </section>
+      </div>
+    </section>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/StatusBar.vue
+++ b/crates/loom/frontend/src/components/StatusBar.vue
@@ -3,6 +3,8 @@ import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { unmatchedAutomationRuns, unmatchedRunProjection } from '../lib/automationSessions';
 import { effectiveAttention } from '../lib/sessionState';
 import { useFleet } from '../lib/sessionsStore';
+import { useCommandRegistry } from '../lib/commands';
+import KeyHint from './KeyHint.vue';
 
 // The workbench status bar — live fleet vitals in one 24px mono strip (see
 // docs/loom-ui.md). Read-only API state from the one shared fleet snapshot the
@@ -11,6 +13,7 @@ import { useFleet } from '../lib/sessionsStore';
 // filtered list; "all calm" reads a reassuring green). Right: connection dot +
 // a ticking clock — the "is this thing live?" glance.
 const { sessions, runs, online } = useFleet();
+const { chord: commandChord, hints: commandHints } = useCommandRegistry();
 const clock = ref('');
 
 // Automation sessions are ordinary fleet sessions now. Only failed launch
@@ -79,9 +82,29 @@ onUnmounted(() => clearInterval(clockTimer));
     </span>
 
     <span
-      class="ml-auto flex items-center gap-1.5"
-      :title="online ? 'Connected' : 'Server unreachable'"
+      v-if="commandChord"
+      data-testid="command-chord"
+      class="ml-auto flex items-center gap-1.5 whitespace-nowrap text-accent"
     >
+      <KeyHint :keys="commandChord" />
+      …
+    </span>
+    <span
+      v-else
+      data-testid="command-hints"
+      class="ml-auto hidden min-w-0 items-center gap-2 overflow-hidden lg:flex"
+    >
+      <span
+        v-for="command in commandHints"
+        :key="command.id"
+        class="flex shrink-0 items-center gap-1 text-faint"
+      >
+        <KeyHint :keys="command.keys[0]" />
+        {{ command.label.toLowerCase() }}
+      </span>
+    </span>
+
+    <span class="flex items-center gap-1.5" :title="online ? 'Connected' : 'Server unreachable'">
       <span
         class="h-1.5 w-1.5 rounded-full"
         :class="online ? 'bg-accent' : 'bg-block-line'"

--- a/crates/loom/frontend/src/lib/commands.ts
+++ b/crates/loom/frontend/src/lib/commands.ts
@@ -88,17 +88,19 @@ export function createCommandRegistry(): CommandRegistry {
       .filter((scope) => scope.commands.length > 0);
   });
 
-  const hints = computed(() => {
-    const visible: Command[] = [];
+  const activeCommands = computed(() => {
+    const seen = new Set<string>();
+    const commands: Command[] = [];
     for (const scope of activeScopes.value) {
       for (const command of scope.commands) {
-        if (command.hint && !visible.some((candidate) => candidate.id === command.id)) {
-          visible.push(command);
-        }
+        if (seen.has(command.id)) continue;
+        seen.add(command.id);
+        commands.push(command);
       }
     }
-    return visible.slice(0, 5);
+    return commands;
   });
+  const hints = computed(() => activeCommands.value.filter((command) => command.hint).slice(0, 5));
 
   function activate(scope: CommandScope) {
     if (scopes.get(scope.id) === scope) return;
@@ -119,19 +121,6 @@ export function createCommandRegistry(): CommandRegistry {
     clearChord();
     chord.value = next;
     chordTimer = window.setTimeout(clearChord, 1200);
-  }
-
-  function commandsInPriorityOrder(): Command[] {
-    const seen = new Set<string>();
-    const result: Command[] = [];
-    for (const scope of activeScopes.value) {
-      for (const command of scope.commands) {
-        if (seen.has(command.id)) continue;
-        seen.add(command.id);
-        result.push(command);
-      }
-    }
-    return result;
   }
 
   function dispatch(event: KeyboardEvent): boolean {
@@ -155,7 +144,7 @@ export function createCommandRegistry(): CommandRegistry {
       return true;
     }
 
-    const commands = commandsInPriorityOrder();
+    const commands = activeCommands.value;
     const sequence = chord.value ? `${chord.value} ${key}` : key;
     const exact = commands.find((command) => command.keys.includes(sequence));
     if (exact) {

--- a/crates/loom/frontend/src/lib/commands.ts
+++ b/crates/loom/frontend/src/lib/commands.ts
@@ -1,0 +1,227 @@
+import {
+  computed,
+  inject,
+  onActivated,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  ref,
+  toValue,
+  type ComputedRef,
+  type InjectionKey,
+  type MaybeRefOrGetter,
+  type Ref,
+} from 'vue';
+
+export interface Command {
+  id: string;
+  label: string;
+  keys: string[];
+  run: () => void | Promise<void>;
+  enabled?: () => boolean;
+  hint?: boolean;
+}
+
+interface CommandScope {
+  id: string;
+  label: string;
+  priority: number;
+  commands: MaybeRefOrGetter<Command[]>;
+}
+
+interface ActiveCommandScope extends Omit<CommandScope, 'commands'> {
+  commands: Command[];
+}
+
+export interface CommandRegistry {
+  activeScopes: ComputedRef<ActiveCommandScope[]>;
+  hints: ComputedRef<Command[]>;
+  chord: Ref<string>;
+  helpOpen: Ref<boolean>;
+  activate: (scope: CommandScope) => void;
+  deactivate: (id: string) => void;
+  dispatch: (event: KeyboardEvent) => boolean;
+  clearChord: () => void;
+  toggleHelp: () => void;
+}
+
+export const commandRegistryKey: InjectionKey<CommandRegistry> = Symbol('loom-commands');
+
+function eventKey(event: KeyboardEvent): string {
+  if (event.key === ' ') return 'Space';
+  // Some automation/browser keyboard layouts report the physical slash key
+  // with Shift separately instead of resolving it to the printable `?`.
+  if (event.key === '/' && event.shiftKey) return '?';
+  return event.key;
+}
+
+function ownsKeyboard(event: KeyboardEvent): boolean {
+  return event.composedPath().some((node) => {
+    if (!(node instanceof HTMLElement)) return false;
+    return (
+      node.matches(
+        'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="dialog"], [role="menu"], [role="listbox"], [data-command-capture]',
+      ) || node.classList.contains('xterm')
+    );
+  });
+}
+
+export function createCommandRegistry(): CommandRegistry {
+  const scopes = new Map<string, CommandScope>();
+  const revision = ref(0);
+  const chord = ref('');
+  const helpOpen = ref(false);
+  let chordTimer: number | undefined;
+
+  function available(command: Command): boolean {
+    return command.enabled?.() !== false;
+  }
+
+  const activeScopes = computed<ActiveCommandScope[]>(() => {
+    revision.value;
+    return [...scopes.values()]
+      .sort((left, right) => right.priority - left.priority)
+      .map((scope) => ({
+        ...scope,
+        commands: toValue(scope.commands).filter(available),
+      }))
+      .filter((scope) => scope.commands.length > 0);
+  });
+
+  const hints = computed(() => {
+    const visible: Command[] = [];
+    for (const scope of activeScopes.value) {
+      for (const command of scope.commands) {
+        if (command.hint && !visible.some((candidate) => candidate.id === command.id)) {
+          visible.push(command);
+        }
+      }
+    }
+    return visible.slice(0, 5);
+  });
+
+  function activate(scope: CommandScope) {
+    if (scopes.get(scope.id) === scope) return;
+    scopes.set(scope.id, scope);
+    revision.value += 1;
+  }
+
+  function deactivate(id: string) {
+    if (scopes.delete(id)) revision.value += 1;
+  }
+
+  function clearChord() {
+    window.clearTimeout(chordTimer);
+    chord.value = '';
+  }
+
+  function setChord(next: string) {
+    clearChord();
+    chord.value = next;
+    chordTimer = window.setTimeout(clearChord, 1200);
+  }
+
+  function commandsInPriorityOrder(): Command[] {
+    const seen = new Set<string>();
+    const result: Command[] = [];
+    for (const scope of activeScopes.value) {
+      for (const command of scope.commands) {
+        if (seen.has(command.id)) continue;
+        seen.add(command.id);
+        result.push(command);
+      }
+    }
+    return result;
+  }
+
+  function dispatch(event: KeyboardEvent): boolean {
+    if (event.defaultPrevented) return false;
+
+    if (helpOpen.value) {
+      if (event.key !== 'Escape') return false;
+      event.preventDefault();
+      helpOpen.value = false;
+      clearChord();
+      return true;
+    }
+
+    if (ownsKeyboard(event)) return false;
+    if (event.ctrlKey || event.metaKey || event.altKey) return false;
+
+    const key = eventKey(event);
+    if (key === 'Escape' && chord.value) {
+      event.preventDefault();
+      clearChord();
+      return true;
+    }
+
+    const commands = commandsInPriorityOrder();
+    const sequence = chord.value ? `${chord.value} ${key}` : key;
+    const exact = commands.find((command) => command.keys.includes(sequence));
+    if (exact) {
+      event.preventDefault();
+      clearChord();
+      void exact.run();
+      return true;
+    }
+
+    const prefix = commands.some((command) =>
+      command.keys.some((binding) => binding.startsWith(`${sequence} `)),
+    );
+    if (prefix) {
+      event.preventDefault();
+      setChord(sequence);
+      return true;
+    }
+
+    clearChord();
+    return false;
+  }
+
+  function toggleHelp() {
+    helpOpen.value = !helpOpen.value;
+    clearChord();
+  }
+
+  return {
+    activeScopes,
+    hints,
+    chord,
+    helpOpen,
+    activate,
+    deactivate,
+    dispatch,
+    clearChord,
+    toggleHelp,
+  };
+}
+
+export function useCommandRegistry(): CommandRegistry {
+  const registry = inject(commandRegistryKey);
+  if (!registry) throw new Error('command registry is not provided');
+  return registry;
+}
+
+/** Register commands for a mounted view. Keep-alive views are active only while visible. */
+export function useCommandScope(
+  id: string,
+  label: string,
+  commands: MaybeRefOrGetter<Command[]>,
+  priority = 0,
+) {
+  const registry = useCommandRegistry();
+  const scope = { id, label, commands, priority };
+  onMounted(() => registry.activate(scope));
+  onActivated(() => registry.activate(scope));
+  onDeactivated(() => registry.deactivate(id));
+  onBeforeUnmount(() => registry.deactivate(id));
+}
+
+export function useCommandDispatcher() {
+  const registry = useCommandRegistry();
+  onMounted(() => window.addEventListener('keydown', registry.dispatch));
+  onBeforeUnmount(() => {
+    window.removeEventListener('keydown', registry.dispatch);
+    registry.clearChord();
+  });
+}

--- a/crates/loom/frontend/src/main.ts
+++ b/crates/loom/frontend/src/main.ts
@@ -28,6 +28,7 @@ import Shell from './views/Shell.vue';
 import Login from './views/Login.vue';
 import { me, loadMe } from './auth';
 import { setUnauthorizedHandler } from './api';
+import { commandRegistryKey, createCommandRegistry } from './lib/commands';
 import './styles.css';
 
 const router = createRouter({
@@ -80,5 +81,5 @@ setUnauthorizedHandler(() => {
 // Resolve identity once up front so the first paint picks the right chrome
 // (full shell vs. bare login), then mount.
 loadMe().finally(() => {
-  createApp(App).use(router).mount('#app');
+  createApp(App).use(router).provide(commandRegistryKey, createCommandRegistry()).mount('#app');
 });

--- a/crates/loom/frontend/src/styles.css
+++ b/crates/loom/frontend/src/styles.css
@@ -133,6 +133,42 @@
   --agent-line: #9880a8; /* plum dot / hairline */
 }
 
+/* Terminal-first application chrome. This is a presentation layer over the
+   same routes and components, not a parallel UI. Human prose keeps its own
+   serif/sans voice; operator chrome and mailbox rows use the mono instrument
+   face. */
+[data-ui='terminal'] {
+  --ui-row-height: 1.75rem;
+  --ui-radius: 0;
+  --ui-cursor-bg: var(--subtle);
+  --ui-cursor-fg: var(--fg);
+  letter-spacing: -0.005em;
+}
+
+.session-mailbox {
+  font-family: var(--font-mono);
+}
+
+.session-mailbox-group {
+  border-radius: var(--ui-radius);
+  box-shadow: none;
+}
+
+.session-mailbox-row {
+  min-height: var(--ui-row-height);
+  border-left: 2px solid transparent;
+}
+
+.session-mailbox-row--cursor {
+  border-left-color: var(--accent);
+  background: var(--ui-cursor-bg);
+  color: var(--ui-cursor-fg);
+}
+
+.session-mailbox-row--cursor .session-mailbox-primary {
+  color: var(--accent);
+}
+
 /* Dark palette — "the reading room, by lamplight". Warm charcoal, not a neutral
    void: the canvas carries a faint brown-black warmth (aged paper under a desk
    lamp) and the text is a warm paper-white, so a long night reads as a lit study

--- a/crates/loom/frontend/src/styles.css
+++ b/crates/loom/frontend/src/styles.css
@@ -149,6 +149,24 @@
   font-family: var(--font-mono);
 }
 
+.session-mailbox :is(input, select, button),
+.session-mailbox-preview :is(button, a) {
+  border-radius: 0;
+}
+
+.session-workbench-grid {
+  display: grid;
+  min-width: 0;
+  align-items: start;
+  gap: 0.75rem;
+}
+
+@media (min-width: 64rem) {
+  .session-workbench-grid {
+    grid-template-columns: minmax(0, 1.35fr) minmax(21rem, 0.75fr);
+  }
+}
+
 .session-mailbox-group {
   border-radius: var(--ui-radius);
   box-shadow: none;
@@ -167,6 +185,168 @@
 
 .session-mailbox-row--cursor .session-mailbox-primary {
   color: var(--accent);
+}
+
+.session-mailbox-preview {
+  position: sticky;
+  top: 0;
+  display: none;
+  height: calc(100vh - 8.25rem);
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+@media (min-width: 64rem) {
+  .session-mailbox-preview {
+    display: flex;
+  }
+}
+
+.terminal-pane-heading {
+  display: flex;
+  min-height: 1.75rem;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--line);
+  background: var(--accent);
+  color: var(--accent-fg);
+  padding: 0.25rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.terminal-preview-section {
+  border-bottom: 1px solid var(--line);
+  padding: 0.75rem 1rem;
+}
+
+.terminal-preview-section > h3 {
+  margin: 0 0 0.5rem;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+}
+
+.terminal-preview-section > h3::before {
+  content: '[ ';
+  color: var(--faint);
+}
+
+.terminal-preview-section > h3::after {
+  content: ' ]';
+  color: var(--faint);
+}
+
+.terminal-output-line {
+  border-left: 2px solid var(--accent);
+  margin: 0;
+  background: var(--code);
+  padding: 0.5rem 0.625rem;
+  color: var(--code-fg);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.terminal-output-line::before {
+  content: '> ';
+  color: var(--accent);
+}
+
+.terminal-loading {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+
+.terminal-kv {
+  display: grid;
+  grid-template-columns: 4.5rem minmax(0, 1fr);
+  gap: 0.25rem 0.75rem;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  line-height: 1rem;
+}
+
+.terminal-kv dt {
+  color: var(--muted);
+}
+
+.terminal-kv dt::after {
+  content: ':';
+}
+
+.terminal-kv dd {
+  min-width: 0;
+  overflow: hidden;
+  margin: 0;
+  color: var(--code-fg);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.terminal-flag {
+  border: 1px solid var(--line);
+  background: var(--input);
+  padding: 0.125rem 0.375rem;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+}
+
+.terminal-action {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border: 1px solid var(--line);
+  background: var(--input);
+  padding: 0.375rem;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  cursor: pointer;
+}
+
+.terminal-action:hover {
+  border-color: var(--accent);
+  color: var(--fg);
+}
+
+.terminal-action--primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+.terminal-action--primary:hover {
+  background: var(--accent-hover);
+  color: var(--accent-fg);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes terminal-cursor-blink {
+    0%,
+    45% {
+      opacity: 1;
+    }
+    55%,
+    100% {
+      opacity: 0;
+    }
+  }
+
+  .cursor-blink,
+  .terminal-loading > span {
+    animation: terminal-cursor-blink 1s step-end infinite;
+  }
 }
 
 /* Dark palette — "the reading room, by lamplight". Warm charcoal, not a neutral
@@ -215,6 +395,53 @@
   --agent: #a98cc0; /* dusk plum — model / AI identity accent */
   --agent-soft: #2f234533; /* plum @ ~20% */
   --agent-line: #8b6fa8; /* plum dot / hairline */
+}
+
+/* The terminal workbench's dark palette: a restrained phosphor console rather
+   than a novelty green filter. Near-black planes carry hierarchy through one-
+   step luminance changes; green is reserved for the cursor, commands and live
+   focus, while amber/red keep their operational meanings. */
+.dark [data-ui='terminal'] {
+  color-scheme: dark;
+  --canvas: #060a08;
+  --rail: #030605;
+  --surface: #0a100d;
+  --input: #0e1712;
+  --line: #1b3026;
+  --fg: #d2e7da;
+  --muted: #8ca99a;
+  --faint: #526d60;
+  --subtle: #0d1c15;
+  --subtle-hover: #14291f;
+  --tree-line: #315442;
+  --accent: #48d597;
+  --accent-hover: #67e8ad;
+  --accent-fg: #031009;
+  --code: #050906;
+  --code-fg: #a9c8b7;
+
+  --attn: #e8b04d;
+  --attn-fg: #171004;
+  --attn-soft: #4c320f55;
+  --attn-line: #d89a35;
+  --block: #ff7182;
+  --block-fg: #190306;
+  --block-soft: #52131d55;
+  --block-line: #e45265;
+
+  --ok: #65d69b;
+  --ok-soft: #123b2855;
+  --ok-line: #48b980;
+  --info: #69cbd0;
+  --info-soft: #10363a55;
+  --info-line: #4aaeb4;
+  --agent: #b59be7;
+  --agent-soft: #2c205055;
+  --agent-line: #9175cf;
+
+  background-color: var(--canvas);
+  background-image: linear-gradient(to bottom, rgb(72 213 151 / 2%) 1px, transparent 1px);
+  background-size: 100% 1.75rem;
 }
 
 html,

--- a/crates/loom/frontend/src/theme.ts
+++ b/crates/loom/frontend/src/theme.ts
@@ -7,7 +7,9 @@ const STORAGE_KEY = 'loom-theme';
 function preferred(): Theme {
   const stored = localStorage.getItem(STORAGE_KEY);
   if (stored === 'light' || stored === 'dark') return stored;
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  // Loom is an operator console: fresh installs lead with the terminal palette.
+  // The explicit light choice remains sticky once selected.
+  return 'dark';
 }
 
 function apply(t: Theme) {

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onActivated, ref, watch } from 'vue';
+import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import type {
   Session,
@@ -11,6 +11,7 @@ import type {
 } from '../types';
 import AutomationRunRow from '../components/AutomationRunRow.vue';
 import ConfirmDialog from '../components/ConfirmDialog.vue';
+import SessionMailboxPreview from '../components/SessionMailboxPreview.vue';
 import SessionWorkbenchRow from '../components/SessionWorkbenchRow.vue';
 import {
   archiveSession,
@@ -291,6 +292,12 @@ const cursorSessionIds = computed(() =>
   ),
 );
 const cursorSessionId = ref('');
+const cursorSession = computed(() =>
+  displayedGroups.value
+    .flatMap((display) => display.sessions)
+    .find((session) => session.id === cursorSessionId.value),
+);
+const cursorPosition = computed(() => cursorSessionIds.value.indexOf(cursorSessionId.value) + 1);
 watch(
   cursorSessionIds,
   (ids) => {
@@ -334,6 +341,7 @@ function rowExpanded(id: string) {
 }
 
 async function loadRowDetail(id: string) {
+  if (rowDetails.value[id] || rowDetailLoading.value.has(id)) return;
   rowDetailLoading.value = new Set(rowDetailLoading.value).add(id);
   const errors = { ...rowDetailErrors.value };
   delete errors[id];
@@ -348,6 +356,31 @@ async function loadRowDetail(id: string) {
     rowDetailLoading.value = loading;
   }
 }
+
+const mailboxPreviewVisible = ref(false);
+let previewMedia: MediaQueryList | undefined;
+let previewTimer: number | undefined;
+function syncMailboxPreview() {
+  mailboxPreviewVisible.value = previewMedia?.matches ?? false;
+}
+onMounted(() => {
+  previewMedia = window.matchMedia('(min-width: 64rem)');
+  syncMailboxPreview();
+  previewMedia.addEventListener('change', syncMailboxPreview);
+});
+watch(
+  [cursorSessionId, mailboxPreviewVisible],
+  ([id, visible]) => {
+    window.clearTimeout(previewTimer);
+    if (!visible || !id || rowDetails.value[id] || rowDetailLoading.value.has(id)) return;
+    previewTimer = window.setTimeout(() => void loadRowDetail(id), 120);
+  },
+  { immediate: true },
+);
+onBeforeUnmount(() => {
+  window.clearTimeout(previewTimer);
+  previewMedia?.removeEventListener('change', syncMailboxPreview);
+});
 
 function toggleRow(id: string) {
   const next = new Set(expandedRows.value);
@@ -1256,202 +1289,222 @@ function scrollSpaces(direction: number) {
       {{ archiveResult }}
     </div>
 
-    <div
-      v-if="selected.size"
-      data-testid="selection-toolbar"
-      class="sticky top-2 z-20 mb-3 flex flex-wrap items-center gap-2 rounded border border-accent bg-surface px-3 py-2 shadow"
-    >
-      <strong class="text-xs">
-        {{ selected.size }} selected
-        <span v-if="hiddenSelectedCount" class="font-normal text-muted">
-          · {{ hiddenSelectedCount }} hidden by this view
-        </span>
-      </strong>
-      <select
-        v-model="bulkDestination"
-        aria-label="Move selected to group"
-        class="rounded bg-input px-2 py-1 text-xs"
-      >
-        <option v-for="entry in allGroups" :key="entry.group.id" :value="entry.group.id">
-          {{ entry.label }}
-        </option>
-      </select>
-      <button
-        class="btn-primary px-2 py-1 text-xs"
-        type="button"
-        :disabled="layoutBusy"
-        @click="performMove(selectedInLayoutOrder(), bulkDestination)"
-      >
-        Move
-      </button>
-      <button
-        class="btn-secondary px-2 py-1 text-xs"
-        type="button"
-        @click="pendingBulkArchive = true"
-      >
-        Archive
-      </button>
-      <button class="btn-secondary px-2 py-1 text-xs" type="button" @click="clearSelection">
-        Clear
-      </button>
-    </div>
-
-    <section v-if="showInterventions" class="mb-4" aria-labelledby="interventions-heading">
-      <div class="mb-1.5 flex items-center gap-2">
-        <h2
-          id="interventions-heading"
-          class="text-2xs font-semibold uppercase tracking-wider text-muted"
+    <div class="session-workbench-grid">
+      <div class="min-w-0">
+        <div
+          v-if="selected.size"
+          data-testid="selection-toolbar"
+          class="sticky top-2 z-20 mb-3 flex flex-wrap items-center gap-2 border border-accent bg-surface px-3 py-2"
         >
-          Interventions
-        </h2>
-        <span class="rounded-full bg-block-soft px-1.5 font-mono text-2xs text-block">{{
-          operationalRuns.length
-        }}</span>
-      </div>
-      <ul
-        v-if="operationalRuns.length"
-        data-testid="interventions"
-        class="rounded border border-line bg-surface"
-      >
-        <AutomationRunRow
-          v-for="run in operationalRuns"
-          :key="run.id"
-          :run="run"
-          :projection="unmatchedRunProjection(run)"
-          @changed="refresh"
-          @error="error = $event"
-        />
-      </ul>
-      <p v-else class="rounded border border-dashed border-line px-3 py-3 text-sm text-muted">
-        No automation runs need intervention.
-      </p>
-    </section>
+          <strong class="text-xs">
+            {{ selected.size }} selected
+            <span v-if="hiddenSelectedCount" class="font-normal text-muted">
+              · {{ hiddenSelectedCount }} hidden by this view
+            </span>
+          </strong>
+          <select
+            v-model="bulkDestination"
+            aria-label="Move selected to group"
+            class="rounded bg-input px-2 py-1 text-xs"
+          >
+            <option v-for="entry in allGroups" :key="entry.group.id" :value="entry.group.id">
+              {{ entry.label }}
+            </option>
+          </select>
+          <button
+            class="btn-primary px-2 py-1 text-xs"
+            type="button"
+            :disabled="layoutBusy"
+            @click="performMove(selectedInLayoutOrder(), bulkDestination)"
+          >
+            Move
+          </button>
+          <button
+            class="btn-secondary px-2 py-1 text-xs"
+            type="button"
+            @click="pendingBulkArchive = true"
+          >
+            Archive
+          </button>
+          <button class="btn-secondary px-2 py-1 text-xs" type="button" @click="clearSelection">
+            Clear
+          </button>
+        </div>
 
-    <section
-      v-for="display in displayedGroups"
-      :key="display.key"
-      :data-group-id="display.group?.id"
-      :data-testid="display.group ? 'session-group' : undefined"
-      class="session-mailbox-group mb-2 border border-line bg-surface"
-      :class="
-        display.group && dropGroupId === display.group.id && !dropBeforeId
-          ? 'ring-1 ring-accent'
-          : ''
-      "
-      @dragover.prevent="display.group && dragOver(display.group.id)"
-      @drop.prevent="display.group && drop(display.group.id)"
-    >
-      <header
-        v-if="display.group"
-        class="flex min-h-7 items-center gap-2 border-b border-line bg-input/40 px-2 py-1 font-mono"
-      >
-        <button
-          type="button"
-          :aria-expanded="!display.group.collapsed"
-          :aria-controls="`group-${display.group.id}`"
-          :aria-label="`${display.group.collapsed ? 'Expand' : 'Collapse'} ${display.group.name}`"
-          class="flex min-w-0 flex-1 items-center gap-2 text-left"
-          @click="toggleGroup(display.group)"
-        >
-          <span class="text-faint" :class="display.group.collapsed ? '' : 'rotate-90'">▸</span>
-          <span class="truncate text-sm font-medium text-fg">{{ display.group.name }}</span>
-          <span class="font-mono text-2xs text-faint">{{ display.sessions.length }}</span>
-        </button>
-      </header>
-      <ul
-        v-show="!display.group?.collapsed"
-        :id="display.group ? `group-${display.group.id}` : undefined"
-        data-testid="session-list"
-      >
-        <SessionWorkbenchRow
-          v-for="session in display.sessions"
-          :key="session.id"
-          :session="session"
-          :detail="rowDetails[session.id]"
-          :detail-loading="rowDetailLoading.has(session.id)"
-          :detail-error="rowDetailErrors[session.id]"
-          :qualified="display.qualified"
-          :selected="isSelected(session.id)"
-          :expanded="rowExpanded(session.id)"
-          :move-open="moveOpenId === session.id"
-          :destination="rowDestination[session.id]"
-          :before="rowBefore[session.id]"
-          :all-groups="allGroups"
-          :all-sessions="sessions"
-          :parent-session="parentSessionOf(session)"
-          :dragging="draggingId === session.id"
-          :drop-before="
-            dropGroupId === (display.group?.id ?? session.placement?.group_id) &&
-            dropBeforeId === session.id
+        <section v-if="showInterventions" class="mb-4" aria-labelledby="interventions-heading">
+          <div class="mb-1.5 flex items-center gap-2">
+            <h2
+              id="interventions-heading"
+              class="text-2xs font-semibold uppercase tracking-wider text-muted"
+            >
+              Interventions
+            </h2>
+            <span class="rounded-full bg-block-soft px-1.5 font-mono text-2xs text-block">{{
+              operationalRuns.length
+            }}</span>
+          </div>
+          <ul
+            v-if="operationalRuns.length"
+            data-testid="interventions"
+            class="rounded border border-line bg-surface"
+          >
+            <AutomationRunRow
+              v-for="run in operationalRuns"
+              :key="run.id"
+              :run="run"
+              :projection="unmatchedRunProjection(run)"
+              @changed="refresh"
+              @error="error = $event"
+            />
+          </ul>
+          <p v-else class="rounded border border-dashed border-line px-3 py-3 text-sm text-muted">
+            No automation runs need intervention.
+          </p>
+        </section>
+
+        <section
+          v-for="display in displayedGroups"
+          :key="display.key"
+          :data-group-id="display.group?.id"
+          :data-testid="display.group ? 'session-group' : undefined"
+          class="session-mailbox-group mb-2 border border-line bg-surface"
+          :class="
+            display.group && dropGroupId === display.group.id && !dropBeforeId
+              ? 'ring-1 ring-accent'
+              : ''
           "
-          :clearing-tag="clearingTag"
-          :cursor="cursorSessionId === session.id"
-          @activate="cursorSessionId = session.id"
-          @toggle-select="setSelected(session.id, $event)"
-          @toggle-details="toggleRow(session.id)"
-          @open-move="openMove(session)"
-          @update-destination="rowDestination[session.id] = $event"
-          @update-before="rowBefore[session.id] = $event"
-          @move="performMove([session.id], $event.groupId, $event.beforeId || null)"
-          @drag-start="dragStart(session.id, $event)"
-          @drag-end="clearDrag"
-          @drag-over="dragOver(display.group?.id ?? session.placement?.group_id ?? '', session.id)"
-          @drop="drop(display.group?.id ?? session.placement?.group_id ?? '', session.id)"
-          @changed="refresh"
-          @error="error = $event"
-          @clear-tag="clearTag(session.id, $event)"
-          @record-open="recordSessionLinkOpen($event, session.id)"
-        />
-        <li
-          v-if="display.group && !display.sessions.length"
-          data-testid="empty-group"
-          class="px-3 py-5 text-center text-sm text-faint"
+          @dragover.prevent="display.group && dragOver(display.group.id)"
+          @drop.prevent="display.group && drop(display.group.id)"
         >
-          {{
-            display.group.session_ids.length
-              ? 'No sessions match the current view or filters.'
-              : 'Empty group — drop sessions here or use Move.'
-          }}
-        </li>
-      </ul>
-    </section>
+          <header
+            v-if="display.group"
+            class="flex min-h-7 items-center gap-2 border-b border-line bg-input/40 px-2 py-1 font-mono"
+          >
+            <button
+              type="button"
+              :aria-expanded="!display.group.collapsed"
+              :aria-controls="`group-${display.group.id}`"
+              :aria-label="`${display.group.collapsed ? 'Expand' : 'Collapse'} ${display.group.name}`"
+              class="flex min-w-0 flex-1 items-center gap-2 text-left"
+              @click="toggleGroup(display.group)"
+            >
+              <span class="text-faint" :class="display.group.collapsed ? '' : 'rotate-90'">▸</span>
+              <span class="truncate text-sm font-medium text-fg">{{ display.group.name }}</span>
+              <span class="font-mono text-2xs text-faint">{{ display.sessions.length }}</span>
+            </button>
+          </header>
+          <ul
+            v-show="!display.group?.collapsed"
+            :id="display.group ? `group-${display.group.id}` : undefined"
+            data-testid="session-list"
+          >
+            <SessionWorkbenchRow
+              v-for="session in display.sessions"
+              :key="session.id"
+              :session="session"
+              :detail="rowDetails[session.id]"
+              :detail-loading="rowDetailLoading.has(session.id)"
+              :detail-error="rowDetailErrors[session.id]"
+              :qualified="display.qualified"
+              :selected="isSelected(session.id)"
+              :expanded="rowExpanded(session.id)"
+              :move-open="moveOpenId === session.id"
+              :destination="rowDestination[session.id]"
+              :before="rowBefore[session.id]"
+              :all-groups="allGroups"
+              :all-sessions="sessions"
+              :parent-session="parentSessionOf(session)"
+              :dragging="draggingId === session.id"
+              :drop-before="
+                dropGroupId === (display.group?.id ?? session.placement?.group_id) &&
+                dropBeforeId === session.id
+              "
+              :clearing-tag="clearingTag"
+              :cursor="cursorSessionId === session.id"
+              @activate="cursorSessionId = session.id"
+              @toggle-select="setSelected(session.id, $event)"
+              @toggle-details="toggleRow(session.id)"
+              @open-move="openMove(session)"
+              @update-destination="rowDestination[session.id] = $event"
+              @update-before="rowBefore[session.id] = $event"
+              @move="performMove([session.id], $event.groupId, $event.beforeId || null)"
+              @drag-start="dragStart(session.id, $event)"
+              @drag-end="clearDrag"
+              @drag-over="
+                dragOver(display.group?.id ?? session.placement?.group_id ?? '', session.id)
+              "
+              @drop="drop(display.group?.id ?? session.placement?.group_id ?? '', session.id)"
+              @changed="refresh"
+              @error="error = $event"
+              @clear-tag="clearTag(session.id, $event)"
+              @record-open="recordSessionLinkOpen($event, session.id)"
+            />
+            <li
+              v-if="display.group && !display.sessions.length"
+              data-testid="empty-group"
+              class="px-3 py-5 text-center text-sm text-faint"
+            >
+              {{
+                display.group.session_ids.length
+                  ? 'No sessions match the current view or filters.'
+                  : 'Empty group — drop sessions here or use Move.'
+              }}
+            </li>
+          </ul>
+        </section>
 
-    <section v-if="view === 'history' && historicalRuns.length" class="mt-4">
-      <h2 class="mb-1.5 text-2xs font-semibold uppercase tracking-wider text-muted">
-        Automation run history
-      </h2>
-      <ul data-testid="automation-run-history" class="rounded border border-line bg-surface">
-        <AutomationRunRow
-          v-for="run in historicalRuns"
-          :key="run.id"
-          :run="run"
-          projection="history"
-          @changed="refresh"
-          @error="error = $event"
-        />
-      </ul>
-    </section>
+        <section v-if="view === 'history' && historicalRuns.length" class="mt-4">
+          <h2 class="mb-1.5 text-2xs font-semibold uppercase tracking-wider text-muted">
+            Automation run history
+          </h2>
+          <ul data-testid="automation-run-history" class="rounded border border-line bg-surface">
+            <AutomationRunRow
+              v-for="run in historicalRuns"
+              :key="run.id"
+              :run="run"
+              projection="history"
+              @changed="refresh"
+              @error="error = $event"
+            />
+          </ul>
+        </section>
 
-    <div
-      v-if="
-        (view !== 'space' || searchResults !== null) &&
-        !smartSessions.length &&
-        !(view === 'history' && historicalRuns.length) &&
-        !(showInterventions && operationalRuns.length)
-      "
-      class="rounded border border-dashed border-line p-6 text-center"
-    >
-      <p class="text-sm text-muted">
-        {{
-          view === 'history'
-            ? historySessions.length
-              ? 'No archived sessions match this search or the current filters.'
-              : 'No archived sessions yet.'
-            : searchText
-              ? 'No sessions match this search.'
-              : 'No actionable sessions here.'
-        }}
-      </p>
+        <div
+          v-if="
+            (view !== 'space' || searchResults !== null) &&
+            !smartSessions.length &&
+            !(view === 'history' && historicalRuns.length) &&
+            !(showInterventions && operationalRuns.length)
+          "
+          class="rounded border border-dashed border-line p-6 text-center"
+        >
+          <p class="text-sm text-muted">
+            {{
+              view === 'history'
+                ? historySessions.length
+                  ? 'No archived sessions match this search or the current filters.'
+                  : 'No archived sessions yet.'
+                : searchText
+                  ? 'No sessions match this search.'
+                  : 'No actionable sessions here.'
+            }}
+          </p>
+        </div>
+      </div>
+
+      <SessionMailboxPreview
+        :session="cursorSession"
+        :detail="cursorSession ? rowDetails[cursorSession.id] : undefined"
+        :loading="cursorSession ? rowDetailLoading.has(cursorSession.id) : false"
+        :error="cursorSession ? rowDetailErrors[cursorSession.id] : ''"
+        :position="cursorPosition"
+        :total="cursorSessionIds.length"
+        :selected="cursorSession ? isSelected(cursorSession.id) : false"
+        :expanded="cursorSession ? rowExpanded(cursorSession.id) : false"
+        @open="cursorSession && recordSessionLinkOpen($event, cursorSession.id)"
+        @toggle-select="toggleCursorSelection"
+        @toggle-details="toggleCursorDetails"
+      />
     </div>
 
     <div

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -33,6 +33,7 @@ import { effectiveAttention } from '../lib/sessionState';
 import { useLayoutCommands } from '../lib/layoutCommands';
 import { useFleet } from '../lib/sessionsStore';
 import { beginSessionOpen, recordSessionListReturn } from '../lib/workbenchMetrics';
+import { useCommandScope, type Command } from '../lib/commands';
 
 defineOptions({ name: 'SessionList' });
 
@@ -129,6 +130,7 @@ function updateFilters() {
 }
 
 const searchText = ref('');
+const searchInput = ref<HTMLInputElement>();
 const includeHistory = ref(false);
 const searchResults = ref<SessionSummary[] | null>(null);
 const searching = ref(false);
@@ -283,6 +285,19 @@ const displayedGroups = computed(() => {
     ? [{ key: 'smart', group: undefined, sessions: smartSessions.value, qualified: true }]
     : [];
 });
+const cursorSessionIds = computed(() =>
+  displayedGroups.value.flatMap((display) =>
+    display.group?.collapsed ? [] : display.sessions.map((session) => session.id),
+  ),
+);
+const cursorSessionId = ref('');
+watch(
+  cursorSessionIds,
+  (ids) => {
+    if (!ids.includes(cursorSessionId.value)) cursorSessionId.value = ids[0] ?? '';
+  },
+  { immediate: true },
+);
 const unmatchedRuns = computed(() =>
   unmatchedAutomationRuns(runs.value, sessions.value).sort((left, right) =>
     right.updated_at.localeCompare(left.updated_at),
@@ -756,6 +771,124 @@ function openForm() {
   router.push('/sessions/new');
 }
 
+function focusCursor() {
+  if (!cursorSessionId.value) cursorSessionId.value = cursorSessionIds.value[0] ?? '';
+  const id = cursorSessionId.value;
+  if (!id) return;
+  void nextTick(() => {
+    document
+      .querySelector<HTMLElement>(`[data-session-id="${CSS.escape(id)}"] [data-session-primary]`)
+      ?.focus({ preventScroll: true });
+    document
+      .querySelector<HTMLElement>(`[data-session-id="${CSS.escape(id)}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  });
+}
+
+function moveCursor(direction: -1 | 1) {
+  const ids = cursorSessionIds.value;
+  if (!ids.length) return;
+  const current = ids.indexOf(cursorSessionId.value);
+  const fallback = direction > 0 ? 0 : ids.length - 1;
+  const next = current < 0 ? fallback : Math.min(Math.max(current + direction, 0), ids.length - 1);
+  cursorSessionId.value = ids[next];
+  focusCursor();
+}
+
+function moveCursorTo(edge: 'first' | 'last') {
+  const ids = cursorSessionIds.value;
+  cursorSessionId.value = edge === 'first' ? (ids[0] ?? '') : (ids.at(-1) ?? '');
+  focusCursor();
+}
+
+function activateCursor() {
+  if (!cursorSessionId.value) return;
+  document
+    .querySelector<HTMLAnchorElement>(
+      `[data-session-id="${CSS.escape(cursorSessionId.value)}"] [data-session-primary]`,
+    )
+    ?.click();
+}
+
+function toggleCursorSelection() {
+  const id = cursorSessionId.value;
+  const session = sessionsById.value.get(id);
+  if (!id || !session || session.status === 'archived') return;
+  setSelected(id, !isSelected(id));
+}
+
+function toggleCursorDetails() {
+  if (cursorSessionId.value) toggleRow(cursorSessionId.value);
+}
+
+const sessionCommands = computed<Command[]>(() => [
+  {
+    id: 'sessions.cursor-down',
+    label: 'Move row cursor down',
+    keys: ['j'],
+    hint: true,
+    run: () => moveCursor(1),
+  },
+  {
+    id: 'sessions.cursor-up',
+    label: 'Move row cursor up',
+    keys: ['k'],
+    run: () => moveCursor(-1),
+  },
+  {
+    id: 'sessions.first',
+    label: 'Go to first row',
+    keys: ['g g'],
+    run: () => moveCursorTo('first'),
+  },
+  {
+    id: 'sessions.last',
+    label: 'Go to last row',
+    keys: ['G'],
+    run: () => moveCursorTo('last'),
+  },
+  {
+    id: 'sessions.open',
+    label: 'Open current session',
+    keys: ['Enter'],
+    hint: true,
+    enabled: () => !!cursorSessionId.value,
+    run: activateCursor,
+  },
+  {
+    id: 'sessions.search',
+    label: 'Search sessions',
+    keys: ['/'],
+    hint: true,
+    run: () => searchInput.value?.focus(),
+  },
+  {
+    id: 'sessions.details',
+    label: 'Toggle row details',
+    keys: ['o'],
+    hint: true,
+    enabled: () => !!cursorSessionId.value,
+    run: toggleCursorDetails,
+  },
+  {
+    id: 'sessions.select',
+    label: 'Toggle row selection',
+    keys: ['Space', 'x'],
+    enabled: () => {
+      const session = sessionsById.value.get(cursorSessionId.value);
+      return !!session && session.status !== 'archived';
+    },
+    run: toggleCursorSelection,
+  },
+  {
+    id: 'sessions.refresh',
+    label: 'Refresh sessions',
+    keys: ['r'],
+    run: refresh,
+  },
+]);
+useCommandScope('sessions', 'Sessions', sessionCommands, 100);
+
 const clearingTag = ref('');
 async function clearTag(sessionId: string, key: string) {
   clearingTag.value = `${sessionId}:${key}`;
@@ -782,18 +915,19 @@ function scrollSpaces(direction: number) {
 </script>
 
 <template>
-  <div class="px-5 py-3">
+  <div class="session-mailbox px-3 py-2">
     <h1 class="sr-only">Sessions</h1>
 
     <div class="mb-3 flex flex-wrap items-center gap-2">
       <label class="relative min-w-52 flex-1 sm:max-w-md">
         <span class="sr-only">Search sessions</span>
         <input
+          ref="searchInput"
           v-model="searchText"
           type="search"
           data-testid="fleet-search"
           placeholder="Search sessions, prompts, repos, issues…"
-          class="w-full rounded border border-line bg-input px-3 py-1.5 text-sm outline-none focus:ring-1 focus:ring-accent"
+          class="w-full border border-line bg-input px-2 py-1 text-xs outline-none focus:ring-1 focus:ring-accent"
         />
         <span v-if="searching" class="absolute right-2 top-2 text-2xs text-faint">searching…</span>
       </label>
@@ -846,7 +980,7 @@ function scrollSpaces(direction: number) {
       </button>
     </div>
 
-    <div class="mb-3 flex min-w-0 items-stretch gap-1">
+    <div class="mb-2 flex min-w-0 items-stretch gap-1">
       <button
         class="btn-secondary px-2 text-xs"
         aria-label="Scroll spaces left"
@@ -857,14 +991,14 @@ function scrollSpaces(direction: number) {
       <nav
         data-testid="space-tabs-scroll"
         aria-label="Session workbench views"
-        class="flex min-w-0 flex-1 gap-1 overflow-x-auto rounded border border-line bg-surface p-1"
+        class="flex min-w-0 flex-1 gap-0.5 overflow-x-auto border border-line bg-surface p-0.5"
       >
         <router-link
           :to="{ path: '/', query: viewQuery('attention') }"
           data-testid="attention-view"
           :aria-current="view === 'attention' ? 'page' : undefined"
           :class="view === 'attention' ? 'bg-attn-soft text-attn' : 'text-muted hover:bg-subtle'"
-          class="flex shrink-0 items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium"
+          class="flex shrink-0 items-center gap-1.5 px-2 py-1 text-xs font-medium"
         >
           Attention
           <span class="font-mono text-2xs">{{
@@ -882,7 +1016,7 @@ function scrollSpaces(direction: number) {
               ? 'bg-accent text-accent-fg'
               : 'text-muted hover:bg-subtle'
           "
-          class="flex shrink-0 items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium"
+          class="flex shrink-0 items-center gap-1.5 px-2 py-1 text-xs font-medium"
         >
           {{ space.name }}
           <span class="font-mono text-2xs">
@@ -894,7 +1028,7 @@ function scrollSpaces(direction: number) {
           data-testid="all-view"
           :aria-current="view === 'all' ? 'page' : undefined"
           :class="view === 'all' ? 'bg-accent text-accent-fg' : 'text-muted hover:bg-subtle'"
-          class="flex shrink-0 items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium"
+          class="flex shrink-0 items-center gap-1.5 px-2 py-1 text-xs font-medium"
         >
           All <span class="font-mono text-2xs">{{ liveSessions.length }}</span>
         </router-link>
@@ -903,7 +1037,7 @@ function scrollSpaces(direction: number) {
           data-testid="history-view"
           :aria-current="view === 'history' ? 'page' : undefined"
           :class="view === 'history' ? 'bg-accent text-accent-fg' : 'text-muted hover:bg-subtle'"
-          class="flex shrink-0 items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium"
+          class="flex shrink-0 items-center gap-1.5 px-2 py-1 text-xs font-medium"
         >
           History
           <span class="font-mono text-2xs">{{
@@ -1198,7 +1332,7 @@ function scrollSpaces(direction: number) {
       :key="display.key"
       :data-group-id="display.group?.id"
       :data-testid="display.group ? 'session-group' : undefined"
-      class="mb-3 rounded border border-line bg-surface"
+      class="session-mailbox-group mb-2 border border-line bg-surface"
       :class="
         display.group && dropGroupId === display.group.id && !dropBeforeId
           ? 'ring-1 ring-accent'
@@ -1209,7 +1343,7 @@ function scrollSpaces(direction: number) {
     >
       <header
         v-if="display.group"
-        class="flex min-h-9 items-center gap-2 border-b border-line bg-input/40 px-3 py-1.5"
+        class="flex min-h-7 items-center gap-2 border-b border-line bg-input/40 px-2 py-1 font-mono"
       >
         <button
           type="button"
@@ -1251,6 +1385,8 @@ function scrollSpaces(direction: number) {
             dropBeforeId === session.id
           "
           :clearing-tag="clearingTag"
+          :cursor="cursorSessionId === session.id"
+          @activate="cursorSessionId = session.id"
           @toggle-select="setSelected(session.id, $event)"
           @toggle-details="toggleRow(session.id)"
           @open-move="openMove(session)"

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -26,9 +26,10 @@ group, and returning to the workbench restores the current view.
 
 The shell polls a compact summary of active sessions. It fetches archived
 summaries only when History opens, and fetches full goal, launch, policy, and
-runtime context only when a session page or row disclosure needs it. Search
-still matches goal text on the server, so this transport hierarchy does not
-weaken discovery.
+runtime context only for the current desktop mailbox cursor, a row disclosure,
+or a session page. Cursor changes are debounced and each fetched detail is
+reused by row disclosure. Search still matches goal text on the server, so this
+transport hierarchy does not weaken discovery.
 
 ## Launch
 
@@ -128,13 +129,21 @@ separate from checkbox selection.
 
 ## Visual system
 
-The default presentation is a dense terminal workbench, not a separate themed
-component tree. Operator chrome, command hints, mailbox rows, paths, identifiers,
-timestamps, and structured data use monospace; human conversation and documents
-retain readable prose faces. Ruled rows, cursor gutters, borders, and spacing
-establish hierarchy before cards or shadows do.
+The default presentation is a dense dark terminal workbench, not a separate
+themed component tree. On desktop, Sessions is a mailbox split: the compact
+fleet remains on the left while a sticky inspector follows the keyboard cursor
+on the right. Narrow layouts omit that inspector and keep the same rows,
+disclosure, and routes.
 
-The palette stays neutral and low-contrast, reserving saturated color for
-status, selection, destructive actions, and focus. Light/dark palette values
-are independent of terminal density. Loading, empty, error, and disabled states
-keep the resolved layout stable.
+Operator chrome, command hints, mailbox rows, paths, identifiers, timestamps,
+and structured data use monospace; human conversation and documents retain
+readable prose faces. Near-black planes, ruled rows, cursor gutters, borders,
+and spacing establish hierarchy before cards or shadows do. Phosphor green is
+reserved for commands, live focus, and healthy state; amber and red retain
+attention and blocked meaning.
+
+Terminal density and split-pane structure are attached to the existing
+components through shared tokens and a small inspector component. Light mode
+overrides the same semantic tokens, so it remains an explicit preference rather
+than a second implementation. Loading, empty, error, and disabled states keep
+the resolved layout stable.

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -111,10 +111,30 @@ well as color. Controls have visible focus and accessible names. Narrow layouts
 retain the same routes and actions; panels may stack, but lifecycle, review, and
 confirmation semantics do not change.
 
+## Keyboard command model
+
+Loom's operator chrome is keyboard-first. Global navigation uses discoverable
+`g …` chords, `?` opens the commands available in the current view, and the
+status bar shows a short context-sensitive key legend. Sessions behaves like a
+mailbox: `j`/`k` move a stable row cursor, `Enter` opens it, `/` focuses search,
+`x` or `Space` changes bulk selection, and `o` toggles disclosure.
+
+The application owns one prioritized command registry rather than view-local
+window listeners. Kept-alive routes register commands only while active, and
+transient surfaces get first refusal. Character commands never capture typing
+from form controls, contenteditable regions, dialogs, menus, or xterm. The row
+cursor uses stable session identity and roving focus; it is deliberately
+separate from checkbox selection.
+
 ## Visual system
 
-The palette is neutral and low-contrast, reserving saturated color for status,
-selection, destructive actions, and focus. Typography favors compact labels and
-readable working text; monospace is for terminal output, paths, identifiers, and
-structured data. Borders and spacing establish hierarchy before shadows do, and
-loading, empty, error, and disabled states keep the resolved layout stable.
+The default presentation is a dense terminal workbench, not a separate themed
+component tree. Operator chrome, command hints, mailbox rows, paths, identifiers,
+timestamps, and structured data use monospace; human conversation and documents
+retain readable prose faces. Ruled rows, cursor gutters, borders, and spacing
+establish hierarchy before cards or shadows do.
+
+The palette stays neutral and low-contrast, reserving saturated color for
+status, selection, destructive actions, and focus. Light/dark palette values
+are independent of terminal density. Loading, empty, error, and disabled states
+keep the resolved layout stable.

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -118,6 +118,92 @@ async function createFailedRun(baseUrl: string) {
 }
 
 test.describe("durable session workbench", () => {
+  test("terminal mailbox commands navigate rows without stealing text input", async ({
+    page,
+    weaver,
+  }) => {
+    await weaver.seedSession({
+      goal: "First keyboard-operated task",
+      name: "keyboard-mailbox-one",
+    });
+    await weaver.seedSession({
+      goal: "Second keyboard-operated task",
+      name: "keyboard-mailbox-two",
+    });
+    await weaver.seedSession({
+      goal: "Third keyboard-operated task",
+      name: "keyboard-mailbox-three",
+    });
+
+    await page.goto(weaver.baseUrl);
+    const rows = page.locator('[data-testid="session-card"]');
+    await expect(rows).toHaveCount(3);
+    await expect(page.locator('[data-ui="terminal"]')).toBeVisible();
+    await expect(page.locator('[data-cursor="true"]')).toHaveCount(1);
+
+    // Leave any browser-restored form focus before exercising application
+    // commands; character shortcuts deliberately never steal input.
+    await rows.nth(0).locator("[data-session-primary]").focus();
+    await page.keyboard.press("Shift+/");
+    const help = page.getByTestId("shortcut-help");
+    await expect(help).toBeVisible();
+    await expect(
+      help.locator('[data-command-id="sessions.cursor-down"]'),
+    ).toBeVisible();
+    await expect(
+      help.locator('[data-command-id="global.sessions"]'),
+    ).toBeVisible();
+    await page.keyboard.press("Tab");
+    await expect(help.getByRole("button", { name: "Close" })).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(help).toHaveCount(0);
+
+    const firstId = await rows.nth(0).getAttribute("data-session-id");
+    const secondId = await rows.nth(1).getAttribute("data-session-id");
+    await page.keyboard.press("j");
+    await expect(page.locator('[data-cursor="true"]')).toHaveAttribute(
+      "data-session-id",
+      secondId!,
+    );
+    await expect(
+      page.locator(`[data-session-id="${secondId}"] [data-session-primary]`),
+    ).toBeFocused();
+
+    await page.keyboard.press("x");
+    await expect(
+      page.locator(`[data-session-id="${secondId}"]`).getByRole("checkbox"),
+    ).toBeChecked();
+    await page.keyboard.press("o");
+    await expect(
+      page
+        .locator(`[data-session-id="${secondId}"]`)
+        .getByTestId("session-preview"),
+    ).toBeVisible();
+
+    await page.keyboard.press("g");
+    await expect(page.getByTestId("command-chord")).toContainText("g");
+    await page.keyboard.press("g");
+    await expect(page.locator('[data-cursor="true"]')).toHaveAttribute(
+      "data-session-id",
+      firstId!,
+    );
+
+    await page.keyboard.press("/");
+    const search = page.getByTestId("fleet-search");
+    await expect(search).toBeFocused();
+    await page.keyboard.type("j");
+    await expect(search).toHaveValue("j");
+
+    await search.fill("");
+    await page.getByTestId("status-bar").click();
+    await page.keyboard.press("g");
+    await page.keyboard.press("i");
+    await expect(page).toHaveURL(`${weaver.baseUrl}/issues`);
+    await page.keyboard.press("g");
+    await page.keyboard.press("s");
+    await expect(page).toHaveURL(weaver.baseUrl + "/");
+  });
+
   test("fleet polling stays compact and row details load on demand", async ({
     page,
     weaver,

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -135,11 +135,16 @@ test.describe("durable session workbench", () => {
       name: "keyboard-mailbox-three",
     });
 
+    await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto(weaver.baseUrl);
     const rows = page.locator('[data-testid="session-card"]');
     await expect(rows).toHaveCount(3);
-    await expect(page.locator('[data-ui="terminal"]')).toBeVisible();
+    await expect(page.locator("html")).toHaveClass(/dark/);
     await expect(page.locator('[data-cursor="true"]')).toHaveCount(1);
+    const preview = page.getByTestId("session-mailbox-preview");
+    await expect(preview).toBeVisible();
+    await expect(preview).toContainText("keyboard-mailbox-one");
+    await expect(preview).toContainText("First keyboard-operated task");
 
     // Leave any browser-restored form focus before exercising application
     // commands; character shortcuts deliberately never steal input.
@@ -168,6 +173,8 @@ test.describe("durable session workbench", () => {
     await expect(
       page.locator(`[data-session-id="${secondId}"] [data-session-primary]`),
     ).toBeFocused();
+    await expect(preview).toContainText("keyboard-mailbox-two");
+    await expect(preview).toContainText("Second keyboard-operated task");
 
     await page.keyboard.press("x");
     await expect(
@@ -204,7 +211,7 @@ test.describe("durable session workbench", () => {
     await expect(page).toHaveURL(weaver.baseUrl + "/");
   });
 
-  test("fleet polling stays compact and row details load on demand", async ({
+  test("fleet polling stays compact and the cursor preview loads one detail", async ({
     page,
     weaver,
   }) => {
@@ -245,12 +252,15 @@ test.describe("durable session workbench", () => {
 
     const row = page.locator(`[data-session-id="${session.id}"]`);
     await expect(row).toBeVisible();
-    expect(detailRequests).toEqual([]);
-
-    await row.getByTestId("session-details-toggle").click();
     await expect
       .poll(() => detailRequests)
       .toEqual([`/api/sessions/${session.id}`]);
+    await expect(page.getByTestId("session-mailbox-preview")).toContainText(
+      goal,
+    );
+
+    await row.getByTestId("session-details-toggle").click();
+    expect(detailRequests).toEqual([`/api/sessions/${session.id}`]);
     await expect(row.getByTestId("session-preview")).toContainText(goal);
   });
 


### PR DESCRIPTION
Make Loom feel like a keyboard-operated terminal mailbox without forking the UI into separate implementations.

Adds a scoped command registry with safe input boundaries, global navigation chords, generated shortcut help, and contextual status-bar hints. Sessions has a stable row cursor with j/k navigation, Enter to open, search, disclosure, selection, first/last, and refresh commands while preserving real links and pointer controls.

The workbench now uses a desktop split pane: the dense fleet stays on the left and a sticky inspector follows the current cursor on the right. Cursor detail loading is debounced, bounded to the visible desktop inspector, and shared with inline disclosure. Narrow layouts keep the existing row/disclosure workflow.

Fresh installs lead with a near-black phosphor terminal palette. The haxor treatment is implemented through semantic CSS tokens and one small inspector component over the same routes, actions, and REST data; an explicit light preference remains sticky. This keeps one information architecture and one component tree rather than maintaining classic and terminal UIs.

Preview: https://loom.rjp.io/s/vl6leyx9/artifacts/terminal-mailbox-preview

Validation:
- ./scripts/pre-commit.sh
- npm run build (crates/loom/frontend)
- npx playwright test tests/session-layout.spec.ts (4 passed)
- substantive agent lint review: no blocking findings; adopted the useful static-marker test cleanup