### PR TITLE
feat(loom): ship the system deps agents keep hitting, and let them add more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,14 @@ RUN set -eux; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
       > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
+    # The index is deliberately kept in the image — no closing `rm -rf
+    # /var/lib/apt/lists/*`. It costs ~20 MB here, and it is the difference
+    # between an agent's `sudo apt-get install -y <pkg>` (the sudoers grant
+    # further down) working on the first try and failing with "Unable to locate
+    # package" until the agent works out that it has to refresh an index it cannot
+    # see. A stale index only bites once a bookworm point release moves a version,
+    # and `sudo apt-get update` fixes that.
+    #
     # Base runtime + the repo tools loom's agents shell out to. gh/gcloud/docker
     # come from the signed repos configured above; the rest are stock bookworm.
     # The last groups are the everyday dev CLIs an agent reaches for in a checkout —
@@ -93,19 +101,68 @@ RUN set -eux; \
     # diffutils (applying diffs when a native edit won't fit), procps (ps/pkill
     # to manage servers an agent spawns), rsync, file, gettext-base (envsubst in
     # CI/templating), and shellcheck (agents lint the shell they write).
+    #
+    # git-lfs is needed to clone the Hugging Face repos and other LFS-backed
+    # checkouts agents work in; without it the pointer files check out instead of
+    # the payload. cmake + ninja-build + python3-dev + the -dev libraries are what
+    # a source build of a Python C extension asks for when no wheel matches.
+    # iproute2 (ss), lsof, netcat-openbsd, dnsutils and strace answer "is the
+    # server I just started actually listening, and on what" — the loop an agent
+    # runs constantly and cannot run with ps alone. tmux keeps a dev server alive
+    # across commands. graphviz renders dot; poppler-utils (pdftotext) reads the
+    # PDFs agents are pointed at. (ImageMagick already ships in the rust base.)
     apt-get install -y --no-install-recommends \
-      nodejs git ca-certificates gh google-cloud-cli tini \
+      nodejs git git-lfs ca-certificates gh google-cloud-cli tini \
       docker-ce-cli docker-buildx-plugin docker-compose-plugin sudo \
-      jq ripgrep fd-find build-essential pkg-config \
-      python3 python3-pip python3-venv \
+      jq ripgrep fd-find build-essential pkg-config cmake ninja-build \
+      python3 python3-pip python3-venv python3-dev \
+      libssl-dev libffi-dev zlib1g-dev \
       unzip zip less wget vim tree \
       bubblewrap socat \
       sqlite3 openssh-client patch diffutils procps rsync file \
-      gettext-base shellcheck sccache; \
-    rm -rf /var/lib/apt/lists/*; \
+      gettext-base shellcheck sccache \
+      iproute2 lsof netcat-openbsd dnsutils strace tmux \
+      graphviz poppler-utils; \
+    # Chromium's shared-library and font dependencies, so a Playwright browser
+    # downloaded at runtime (`playwright install chromium`, cached under the
+    # persisted $HOME) actually launches — screenshotting a UI is routine agent
+    # work and it should not need a root install per session. These are exactly
+    # Playwright's own debian12 `chromium` + `tools` lists, i.e. what `playwright
+    # install-deps` would apt-get; keep them in sync with upstream's nativeDeps
+    # table rather than pruning to whatever the current Chromium build happens to
+    # dlopen. The fonts are the same list's, and are what keeps a screenshot from
+    # rendering CJK/emoji text as tofu. Firefox and WebKit are not covered: they
+    # need a much larger (GTK/GStreamer) set, and agents here drive Chromium.
+    apt-get install -y --no-install-recommends \
+      libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libcairo2 \
+      libcups2 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0 libnspr4 libnss3 \
+      libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 \
+      libxfixes3 libxkbcommon0 libxrandr2 \
+      xvfb libfontconfig1 libfreetype6 xfonts-scalable \
+      fonts-liberation fonts-freefont-ttf fonts-noto-color-emoji fonts-unifont \
+      fonts-ipafont-gothic fonts-wqy-zenhei fonts-tlwg-loma-otf; \
     # Debian ships fd as `fdfind` to avoid a name clash; expose the conventional
     # `fd` name agents (and fd-aware tools) expect.
-    ln -s "$(command -v fdfind)" /usr/local/bin/fd
+    ln -s "$(command -v fdfind)" /usr/local/bin/fd; \
+    # Runtime system packages for the agent user: a session that turns out to need
+    # a package installs it itself (`sudo apt-get install -y <pkg>`; the retained
+    # index above means no `update` step) instead of improvising around the missing
+    # one. dpkg maintainer scripts run arbitrary code, so this grant is effectively
+    # container root — but it is only ever handed to containers that already mount
+    # the root-equivalent host Docker socket (docker-compose.yml, crate::runner),
+    # so it adds no reach; see deploy/README.md "Security posture". It names the
+    # three package tools rather than a blanket ALL, and restricted profiles
+    # (docs/restricted-sessions.md) get no shell at all. Same single-line sudoers
+    # idiom as loom-cgroup-init further down; `app` is created later in the build,
+    # which sudo resolves at runtime.
+    #
+    # Such an install lands in the container's own writable layer: it lasts as long
+    # as that session container and is invisible to other sessions. It is the
+    # escape hatch for a one-off — anything agents reach for repeatedly belongs in
+    # the package lists above.
+    echo 'app ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/dpkg' \
+      > /etc/sudoers.d/loom-packages; \
+    chmod 440 /etc/sudoers.d/loom-packages
 
 # The agent runtimes loom's sessions launch — Claude Code (`claude`) and the
 # OpenAI Codex CLI (`codex`) — are deliberately NOT baked into the image. The
@@ -207,7 +264,8 @@ EOF
 # service runs with SYS_ADMIN + apparmor=unconfined (docker-compose.yml); where
 # that grant is absent this script fails and the entrypoint just warns — loom
 # runs fine, sessions are simply unlimited. The app user may run exactly this
-# script as root (sudoers line below), nothing else.
+# script as root (sudoers line below) — that and the package tools above are its
+# only privileged commands.
 RUN <<'EOF'
 cat > /usr/local/bin/loom-cgroup-init <<'SH'
 #!/bin/sh

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -129,6 +129,29 @@ moved on since it was set.
   terminal TUI. State the question as text, set `weaver status attention
   "<the question>"`, and continue on your best safe assumption when possible.
 
+## Your environment
+
+Shared deploys run your session inside loom's own container image, which is
+built for this work. Before you engineer around a missing tool, check whether
+it is already there or one command away:
+
+- **System packages are yours to install**: `sudo apt-get install -y <pkg>`.
+  The apt index ships in the image, so no `update` step first. Don't
+  hand-extract `.deb` files or patch `LD_LIBRARY_PATH` — if `sudo -n apt-get`
+  is refused you are not in that image, and the fix is to say so, not to
+  improvise a private prefix.
+- **Screenshots work.** Chromium's shared libraries and fonts are installed;
+  `playwright install chromium` fetches the browser itself into a cache shared
+  by every session. Firefox and WebKit are not covered — their (much larger)
+  dependency set is what `playwright install-deps --dry-run <browser>` lists,
+  and you install it with `sudo apt-get install -y …`.
+- **Language toolchains**: `uv` for Python (`uv run --with <pkg>`, `uv tool
+  install`), `npm i -g` for node CLIs. Both write to your persisted `$HOME`.
+- An `apt-get` install lasts for **your session only** — it is not shared with
+  other sessions and not durable. If a package is one every session here would
+  want, say so in your PR or file an issue against loom's `Dockerfile` instead
+  of assuming the next session inherits it.
+
 ## Working a GitHub issue
 
 A session often comes from a GitHub thread — an `@loom` mention on an issue or

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -140,11 +140,14 @@ it is already there or one command away:
   hand-extract `.deb` files or patch `LD_LIBRARY_PATH` — if `sudo -n apt-get`
   is refused you are not in that image, and the fix is to say so, not to
   improvise a private prefix.
-- **Screenshots work.** Chromium's shared libraries and fonts are installed;
-  `playwright install chromium` fetches the browser itself into a cache shared
-  by every session. Firefox and WebKit are not covered — their (much larger)
-  dependency set is what `playwright install-deps --dry-run <browser>` lists,
-  and you install it with `sudo apt-get install -y …`.
+- **Screenshots work.** Chromium's shared libraries and fonts are installed, but
+  not a browser. Fetch it with the same package you script with — `uv run --with
+  playwright playwright install chromium`, or `npx playwright install chromium` —
+  because each playwright version pins its own browser build, and the node CLI's
+  build is not the one your Python package will accept. The download lands in a
+  cache every session shares, so it costs a minute once per version. Firefox and
+  WebKit are not covered: `playwright install-deps --dry-run <browser>` lists
+  their (much larger) dependency set for `sudo apt-get install -y …`.
 - **Language toolchains**: `uv` for Python (`uv run --with <pkg>`, `uv tool
   install`), `npm i -g` for node CLIs. Both write to your persisted `$HOME`.
 - An `apt-get` install lasts for **your session only** — it is not shared with

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -186,6 +186,18 @@ Codex and Claude use for command sandboxing. Remove the first two and loom
 still runs with sessions unlimited; remove the seccomp exception and their
 command sandboxes cannot start.
 
+The `app` user may also run `apt-get`, `apt` and `dpkg` under `sudo`, so an agent
+can install a system package it turns out to need (see
+[Agent runtime](#agent-runtime--client-packages)) instead of improvising around
+the missing one. `dpkg` maintainer scripts run arbitrary code, so this is
+effectively container root — but it is granted only to containers that already
+mount the root-equivalent Docker socket above, so it adds no reach. It is scoped
+to those three commands rather than a blanket `ALL`, and restricted profiles
+([docs/restricted-sessions.md](../docs/restricted-sessions.md)) get no shell at
+all. Drop `/etc/sudoers.d/loom-packages` from the
+[`Dockerfile`](../Dockerfile) to remove it; agents then need a rebuild for every
+missing package.
+
 Background on these knobs is in the repo
 [README "Authentication"](../README.md#authentication) and
 [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md). To change one after the fact:
@@ -416,9 +428,32 @@ The agent tooling the image ships splits by how it updates:
   docker compose exec loom uv tool install <tool>  # python CLIs → ~/.local/bin
   ```
 
-  Only OS/system packages (`apt-get`) still need an image rebuild — the system
-  dirs are read-only to the non-root user. Add those to the
-  [`Dockerfile`](../Dockerfile) and rerun `docker compose up -d --build`.
+  System packages work too, without a rebuild: the app user may run `apt-get`,
+  `apt` and `dpkg` under `sudo` (nothing else — see
+  [Security posture](#security-posture)), and the image keeps its apt index so an
+  install works on the first try with no `update` step:
+
+  ```sh
+  docker compose exec loom sudo apt-get install -y ffmpeg
+  ```
+
+  That install lands in the *container's* writable layer, so it lasts as long as
+  that container and is invisible to other sessions — it is the escape hatch for
+  a one-off, not a fleet dependency. Anything agents reach for repeatedly belongs
+  in the [`Dockerfile`](../Dockerfile), applied with
+  `docker compose up -d --build`.
+
+- **Browsers and screenshots.** The image ships Chromium's shared libraries and
+  fonts (Playwright's own `debian12` dependency list, i.e. what `playwright
+  install-deps` would install) but not a browser. An agent downloads the browser
+  it wants — `playwright install chromium`, or the npm/Python package's own
+  installer — into `~/.cache/ms-playwright` on the `loom_home` volume, so the
+  download happens once per deploy and every later session finds it cached.
+  Firefox and WebKit need a much larger dependency set that is *not* installed
+  (63 more packages for Firefox). `playwright install-deps --dry-run <browser>`
+  lists them and `sudo apt-get install -y …` installs them; note that `sudo
+  playwright install-deps` itself is refused, since the grant covers only the
+  package tools. Put them in the Dockerfile if you want them fleet-wide.
 
 - **`docker build` in sessions.** The image ships the Docker CLI (client only,
   plus the buildx/compose plugins), and the `loom` container bind-mounts the

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -446,9 +446,13 @@ The agent tooling the image ships splits by how it updates:
 - **Browsers and screenshots.** The image ships Chromium's shared libraries and
   fonts (Playwright's own `debian12` dependency list, i.e. what `playwright
   install-deps` would install) but not a browser. An agent downloads the browser
-  it wants — `playwright install chromium`, or the npm/Python package's own
-  installer — into `~/.cache/ms-playwright` on the `loom_home` volume, so the
+  it wants into `~/.cache/ms-playwright` on the `loom_home` volume, so the
   download happens once per deploy and every later session finds it cached.
+  Deliberately not baked in: each playwright release pins its own browser build
+  (`chromium-1187` for 1.55, `chromium-1228` for current), so an image-resident
+  copy would serve one version and go stale, and a system-owned
+  `PLAYWRIGHT_BROWSERS_PATH` would leave a mismatched session unable to install
+  the build it needs. The shared cache under `$HOME` has neither problem.
   Firefox and WebKit need a much larger dependency set that is *not* installed
   (63 more packages for Firefox). `playwright install-deps --dry-run <browser>`
   lists them and `sudo apt-get install -y …` installs them; note that `sudo


### PR DESCRIPTION
Agents in loom sessions were spending turns rebuilding a package manager by hand.
Playwright's Chromium would not launch (no libnspr4/libnss3), there was no root
to install them, so the next move was fetching .debs from deb.debian.org and
extracting them under LD_LIBRARY_PATH.

The image now carries Playwright's own debian12 Chromium dependency and font
lists — what `playwright install-deps` would apt-get — so a browser downloaded
at runtime actually runs, and screenshots render CJK, Thai and emoji instead of
tofu. It also adds the everyday tools a checkout needs and did not have:
git-lfs, cmake/ninja/python3-dev plus the common -dev libraries for source
builds, ss/lsof/nc/dig/strace for "is the server I started listening", tmux,
graphviz and pdftotext.

For anything not baked in, the app user may now run apt-get, apt and dpkg under
sudo, and the apt index stays in the image (~20 MB) so an install works on the
first try instead of failing with "Unable to locate package" until the agent
works out it must refresh an index it cannot see. dpkg maintainer scripts run
arbitrary code, so that grant is effectively container root — but it is only
handed to containers that already mount the root-equivalent host Docker socket,
so it adds no reach, and restricted profiles have no shell at all. It names the
three package tools rather than a blanket ALL.

Such an install lands in the session container's writable layer, so it lasts as
long as that session and is invisible to other sessions. Both the deploy README
and the session primer say so and point repeat needs at the Dockerfile, so
nobody treats the escape hatch as a fleet dependency. The primer gains a short
environment section for the same reason the .deb extraction happened: an agent
that does not know the container has these affordances invents a worse
substitute.

Verified by building the runtime stage and, as the unprivileged app user,
installing a package over sudo, confirming bare `sudo id` is still refused, and
driving `playwright install chromium` through to a rendered screenshot.

Agent lint review skipped: the review scope is Rust, TypeScript and Vue, and
this branch changes only the Dockerfile and two Markdown files.