### PR TITLE
feat(loom): surface GitHub signals and session shortcuts

### DIFF
--- a/crates/loom/frontend/src/components/GithubStatus.vue
+++ b/crates/loom/frontend/src/components/GithubStatus.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { GithubStatus } from '../types';
+import {
+  githubChecksChip,
+  githubConflictChip,
+  githubReviewChip,
+  githubStateChip,
+  type GithubChip,
+} from '../lib/githubStatus';
 
 // A branch's GitHub pull-request snapshot, fetched server-side via `gh`. Tints
 // are text-color only (never a loud fill) and use GitHub's own familiar hue
@@ -10,48 +17,12 @@ import type { GithubStatus } from '../types';
 // so they swap with the light/dark theme.
 const props = defineProps<{ gh: GithubStatus; compact?: boolean }>();
 
-interface Chip {
-  label: string;
-  cls: string;
-}
-
 // `draft` reads as its own state while the PR is open; merged/closed win out.
-const stateChip = computed<Chip>(() => {
-  const draft = props.gh.is_draft && props.gh.pr_state === 'OPEN';
-  const key = draft ? 'DRAFT' : props.gh.pr_state;
-  const tint: Record<string, string> = {
-    OPEN: 'text-ok',
-    MERGED: 'text-agent',
-    CLOSED: 'text-block',
-    DRAFT: 'text-faint',
-  };
-  return { label: key.toLowerCase(), cls: tint[key] ?? 'text-muted' };
-});
-
-const reviewChip = computed<Chip | null>(() => {
-  const r = props.gh.review_decision;
-  if (!r) return null;
-  const map: Record<string, Chip> = {
-    APPROVED: { label: 'approved', cls: 'text-ok' },
-    CHANGES_REQUESTED: { label: 'changes requested', cls: 'text-block' },
-    REVIEW_REQUIRED: { label: 'review required', cls: 'text-muted' },
-  };
-  return map[r] ?? { label: r.toLowerCase().replace(/_/g, ' '), cls: 'text-muted' };
-});
-
-const checksChip = computed<Chip | null>(() => {
-  const c = props.gh.checks;
-  if (!c) return null;
-  const map: Record<string, Chip> = {
-    passing: { label: 'checks passing', cls: 'text-ok' },
-    failing: { label: 'checks failing', cls: 'text-block' },
-    pending: { label: 'checks pending', cls: 'text-info' },
-  };
-  return map[c] ?? { label: `checks ${c}`, cls: 'text-muted' };
-});
-
+const stateChip = computed(() => githubStateChip(props.gh));
+const reviewChip = computed(() => githubReviewChip(props.gh));
+const checksChip = computed(() => githubChecksChip(props.gh));
 // Only surface mergeability when it's a problem — a clean PR needn't say so.
-const conflicting = computed(() => props.gh.mergeable === 'CONFLICTING');
+const conflicting = computed(() => githubConflictChip(props.gh));
 </script>
 
 <template>
@@ -84,22 +55,23 @@ const conflicting = computed(() => props.gh.mergeable === 'CONFLICTING');
       class="block text-sm text-accent hover:underline"
     >
       <span class="font-mono">#{{ gh.pr_number }}</span>
-      <span class="text-fg">{{ gh.pr_title }}</span>
+      <span class="ml-1 text-fg">{{ gh.pr_title }}</span>
     </a>
     <div class="flex flex-wrap items-center gap-2">
       <span
         v-for="chip in [stateChip, reviewChip, checksChip].filter(Boolean)"
-        :key="(chip as Chip).label"
-        :class="(chip as Chip).cls"
+        :key="(chip as GithubChip).label"
+        :class="(chip as GithubChip).cls"
         class="rounded bg-subtle px-1.5 py-0.5 text-[0.7rem] font-medium font-mono uppercase tracking-wide"
       >
-        {{ (chip as Chip).label }}
+        {{ (chip as GithubChip).label }}
       </span>
       <span
         v-if="conflicting"
-        class="rounded bg-subtle px-1.5 py-0.5 text-[0.7rem] font-medium font-mono uppercase tracking-wide text-block"
+        :class="conflicting.cls"
+        class="rounded bg-subtle px-1.5 py-0.5 text-[0.7rem] font-medium font-mono uppercase tracking-wide"
       >
-        conflicts
+        {{ conflicting.label }}
       </span>
     </div>
   </div>

--- a/crates/loom/frontend/src/components/StatusBar.vue
+++ b/crates/loom/frontend/src/components/StatusBar.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { useRoute } from 'vue-router';
 import { unmatchedAutomationRuns, unmatchedRunProjection } from '../lib/automationSessions';
+import {
+  githubChecksChip,
+  githubConflictChip,
+  githubReviewChip,
+  githubStateChip,
+} from '../lib/githubStatus';
 import { effectiveAttention } from '../lib/sessionState';
 import { useFleet } from '../lib/sessionsStore';
 import { useCommandRegistry } from '../lib/commands';
@@ -12,8 +19,9 @@ import KeyHint from './KeyHint.vue';
 // session + attention counts (the attention segment goes amber and links to the
 // filtered list; "all calm" reads a reassuring green). Right: connection dot +
 // a ticking clock — the "is this thing live?" glance.
-const { sessions, runs, online } = useFleet();
+const { sessions, runs, online, focusedSessionId, sessionById } = useFleet();
 const { chord: commandChord, hints: commandHints } = useCommandRegistry();
+const route = useRoute();
 const clock = ref('');
 
 // Automation sessions are ordinary fleet sessions now. Only failed launch
@@ -27,6 +35,45 @@ const needsMe = computed(
       (run) => unmatchedRunProjection(run) === 'intervention',
     ).length,
 );
+const contextSession = computed(() => {
+  const routeId = route.params.id;
+  const id =
+    typeof routeId === 'string' && route.path.startsWith(`/s/${routeId}`)
+      ? routeId
+      : route.path === '/'
+        ? focusedSessionId.value
+        : '';
+  return id ? sessionById(id) : undefined;
+});
+const github = computed(() => contextSession.value?.branch.github ?? null);
+const githubIssue = computed(() => contextSession.value?.github_issue ?? null);
+const githubSignals = computed(() => {
+  const status = github.value;
+  if (!status) return [];
+  const state = githubStateChip(status);
+  const review = githubReviewChip(status);
+  const checks = githubChecksChip(status);
+  const signals = [
+    state.key === 'OPEN' ? null : state,
+    review?.key === 'APPROVED' ? null : review,
+    checks?.key === 'passing' ? null : checks,
+    githubConflictChip(status),
+  ].filter((signal) => signal !== null);
+  const compactLabels: Record<string, string> = {
+    CHANGES_REQUESTED: 'changes',
+    REVIEW_REQUIRED: 'review',
+    failing: 'CI fail',
+    CONFLICTING: 'conflict',
+  };
+  return signals.map((signal) => ({
+    ...signal,
+    label: compactLabels[signal.key] ?? signal.label,
+  }));
+});
+const githubIssueUrl = computed(() => {
+  const issue = githubIssue.value;
+  return issue ? `https://github.com/${issue.repo}/issues/${issue.number}` : '';
+});
 
 let clockTimer: number | undefined;
 
@@ -46,12 +93,12 @@ onUnmounted(() => clearInterval(clockTimer));
 <template>
   <footer
     data-testid="status-bar"
-    class="flex h-6 shrink-0 items-center gap-2 overflow-hidden border-t border-line bg-rail px-3 font-mono text-2xs text-muted sm:gap-4"
+    class="flex h-6 shrink-0 items-center gap-2 overflow-hidden whitespace-nowrap border-t border-line bg-rail px-3 font-mono text-2xs text-muted sm:gap-4"
   >
     <!-- Counts dim while the server is unreachable — they're the last good
          snapshot, not live truth, and the offline dot on the right says why. -->
     <span
-      class="flex min-w-0 items-center gap-2 sm:gap-4"
+      class="flex shrink-0 items-center gap-2 sm:gap-4"
       :class="online ? '' : 'opacity-50'"
       :title="online ? '' : 'Last known counts — server unreachable'"
     >
@@ -82,6 +129,44 @@ onUnmounted(() => clearInterval(clockTimer));
     </span>
 
     <span
+      v-if="github || githubIssue"
+      data-testid="status-bar-github"
+      class="hidden min-w-0 shrink items-center gap-2 overflow-hidden whitespace-nowrap border-l border-line pl-3 md:flex"
+    >
+      <a
+        v-if="github"
+        :href="github.pr_url"
+        target="_blank"
+        rel="noopener"
+        class="shrink-0 text-accent hover:underline"
+        data-testid="status-bar-pr"
+        :title="`Open PR #${github.pr_number}: ${github.pr_title}`"
+      >
+        PR #{{ github.pr_number }}
+      </a>
+      <a
+        v-if="githubIssue"
+        :href="githubIssueUrl"
+        target="_blank"
+        rel="noopener"
+        class="shrink-0 text-accent hover:underline"
+        data-testid="status-bar-issue"
+        :title="`Open ${githubIssue.repo} issue #${githubIssue.number}`"
+      >
+        Issue #{{ githubIssue.number }}
+      </a>
+      <span
+        v-for="signal in githubSignals"
+        :key="signal.label"
+        :class="signal.cls"
+        class="shrink-0"
+        data-testid="status-bar-pr-signal"
+      >
+        {{ signal.label }}
+      </span>
+    </span>
+
+    <span
       v-if="commandChord"
       data-testid="command-chord"
       class="ml-auto flex items-center gap-1.5 whitespace-nowrap text-accent"
@@ -104,7 +189,10 @@ onUnmounted(() => clearInterval(clockTimer));
       </span>
     </span>
 
-    <span class="flex items-center gap-1.5" :title="online ? 'Connected' : 'Server unreachable'">
+    <span
+      class="flex shrink-0 items-center gap-1.5"
+      :title="online ? 'Connected' : 'Server unreachable'"
+    >
       <span
         class="h-1.5 w-1.5 rounded-full"
         :class="online ? 'bg-accent' : 'bg-block-line'"
@@ -112,6 +200,6 @@ onUnmounted(() => clearInterval(clockTimer));
       ></span>
       {{ online ? 'online' : 'offline' }}
     </span>
-    <span class="hidden text-faint sm:inline">{{ clock }}</span>
+    <span class="hidden shrink-0 text-faint sm:inline">{{ clock }}</span>
   </footer>
 </template>

--- a/crates/loom/frontend/src/lib/githubStatus.ts
+++ b/crates/loom/frontend/src/lib/githubStatus.ts
@@ -1,0 +1,61 @@
+import type { GithubStatus } from '../types';
+
+export interface GithubChip {
+  key: string;
+  label: string;
+  cls: string;
+}
+
+export function githubStateChip(gh: GithubStatus): GithubChip {
+  const draft = gh.is_draft && gh.pr_state === 'OPEN';
+  const key = draft ? 'DRAFT' : gh.pr_state;
+  const tint: Record<string, string> = {
+    OPEN: 'text-ok',
+    MERGED: 'text-agent',
+    CLOSED: 'text-block',
+    DRAFT: 'text-faint',
+  };
+  return { key, label: key.toLowerCase(), cls: tint[key] ?? 'text-muted' };
+}
+
+export function githubReviewChip(gh: GithubStatus): GithubChip | null {
+  const review = gh.review_decision;
+  if (!review) return null;
+  const chips: Record<string, GithubChip> = {
+    APPROVED: { key: 'APPROVED', label: 'approved', cls: 'text-ok' },
+    CHANGES_REQUESTED: {
+      key: 'CHANGES_REQUESTED',
+      label: 'changes requested',
+      cls: 'text-block',
+    },
+    REVIEW_REQUIRED: {
+      key: 'REVIEW_REQUIRED',
+      label: 'review required',
+      cls: 'text-attn-line',
+    },
+  };
+  return (
+    chips[review] ?? {
+      key: review,
+      label: review.toLowerCase().replace(/_/g, ' '),
+      cls: 'text-muted',
+    }
+  );
+}
+
+export function githubChecksChip(gh: GithubStatus): GithubChip | null {
+  const checks = gh.checks;
+  if (!checks) return null;
+  const chips: Record<string, GithubChip> = {
+    passing: { key: 'passing', label: 'CI passing', cls: 'text-ok' },
+    failing: { key: 'failing', label: 'CI failing', cls: 'text-block' },
+    pending: { key: 'pending', label: 'CI pending', cls: 'text-info' },
+  };
+  return chips[checks] ?? { key: checks, label: `CI ${checks}`, cls: 'text-muted' };
+}
+
+export function githubConflictChip(gh: GithubStatus): GithubChip | null {
+  return gh.mergeable === 'CONFLICTING'
+    ? { key: 'CONFLICTING', label: 'conflicts', cls: 'text-block' }
+    : null;
+}

--- a/crates/loom/frontend/src/lib/sessionsStore.ts
+++ b/crates/loom/frontend/src/lib/sessionsStore.ts
@@ -21,6 +21,10 @@ const resourceErrors = ref<Partial<Record<'sessions' | 'history' | 'runs' | 'lay
 // Last fetch reached the server? Drives the status bar's online dot; the cached
 // counts dim rather than vanish while the server is briefly unreachable.
 const online = ref(true);
+// The mailbox cursor is view state, but the persistent status line also needs
+// to describe the row under that cursor. Session detail routes use their own
+// route id; this value is consulted only while the Sessions route is active.
+const focusedSessionId = ref('');
 
 let inflight: Promise<void> | null = null;
 let refreshRequested = false;
@@ -107,6 +111,10 @@ function sessionById(id: string): SessionSummary | undefined {
   return sessions.value.find((s) => s.id === id);
 }
 
+function focusSession(id: string): void {
+  focusedSessionId.value = id;
+}
+
 // One fleet poll for the whole app, started from the shell (App.vue) once the
 // caller is authenticated and stopped on sign-out. Guarded so a double-call
 // (HMR, a re-mount) can't leave two intervals running.
@@ -137,6 +145,8 @@ export function useFleet() {
     layout,
     resourceErrors,
     online,
+    focusedSessionId,
+    focusSession,
     refresh,
     loadHistory,
     sessionById,

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -23,6 +23,7 @@ import ArtifactsPanel from '../components/ArtifactsPanel.vue';
 import ChangesPanel from '../components/ChangesPanel.vue';
 import { cancelSessionBacktrack, completeSessionOpen } from '../lib/workbenchMetrics';
 import { openSessionEvents, type SessionEventsHandle } from '../lib/sessionEvents';
+import { useCommandScope, type Command } from '../lib/commands';
 
 // Named + keyed-by-id in App.vue's <keep-alive> so the page (and its live
 // terminal) stays warm: every `/s/:id…` path (the work tabs and the Artifacts
@@ -158,6 +159,55 @@ async function selectTab(t: WorkTab) {
     });
   }
 }
+
+const workTabs = computed<{ key: WorkTab; label: string }[]>(() =>
+  isAcp.value
+    ? [
+        { key: 'conversation', label: 'Conversation' },
+        { key: 'shells', label: 'Shells' },
+        { key: 'review', label: 'Review' },
+      ]
+    : [
+        { key: 'terminal', label: 'Agent' },
+        { key: 'conversation', label: 'Conversation' },
+        { key: 'review', label: 'Review' },
+      ],
+);
+async function moveWorkTab(direction: -1 | 1) {
+  const tabs = workTabs.value;
+  const current = tabs.findIndex((tab) => tab.key === workTab.value);
+  const next = (Math.max(current, 0) + direction + tabs.length) % tabs.length;
+  await selectTab(tabs[next].key);
+}
+const sessionCommands = computed<Command[]>(() => [
+  {
+    id: 'session.back',
+    label: 'Back to sessions',
+    keys: ['b', 'Escape'],
+    hint: true,
+    run: () => void router.push('/'),
+  },
+  ...workTabs.value.map((tab, index) => ({
+    id: `session.tab.${tab.key}`,
+    label: `Open ${tab.label}`,
+    keys: [String(index + 1)],
+    run: () => selectTab(tab.key),
+  })),
+  {
+    id: 'session.tab.previous',
+    label: 'Previous work surface',
+    keys: ['['],
+    run: () => moveWorkTab(-1),
+  },
+  {
+    id: 'session.tab.next',
+    label: 'Next work surface',
+    keys: [']'],
+    hint: true,
+    run: () => moveWorkTab(1),
+  },
+]);
+useCommandScope(`session:${props.id}`, 'Session', sessionCommands, 10);
 
 // Pop the artifact out beside the terminal / dock it back into the tab.
 async function togglePop() {

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -40,7 +40,7 @@ defineOptions({ name: 'SessionList' });
 
 const route = useRoute();
 const router = useRouter();
-const { sessions, runs, layout, resourceErrors, refresh, loadHistory } = useFleet();
+const { sessions, runs, layout, resourceErrors, refresh, loadHistory, focusSession } = useFleet();
 
 type WorkbenchView = 'space' | 'attention' | 'all' | 'history';
 
@@ -305,6 +305,7 @@ watch(
   },
   { immediate: true },
 );
+watch(cursorSessionId, focusSession, { immediate: true });
 const unmatchedRuns = computed(() =>
   unmatchedAutomationRuns(runs.value, sessions.value).sort((left, right) =>
     right.updated_at.localeCompare(left.updated_at),
@@ -899,7 +900,6 @@ const sessionCommands = computed<Command[]>(() => [
     id: 'sessions.details',
     label: 'Toggle row details',
     keys: ['o'],
-    hint: true,
     enabled: () => !!cursorSessionId.value,
     run: toggleCursorDetails,
   },

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -120,6 +120,14 @@ status bar shows a short context-sensitive key legend. Sessions behaves like a
 mailbox: `j`/`k` move a stable row cursor, `Enter` opens it, `/` focuses search,
 `x` or `Space` changes bulk selection, and `o` toggles disclosure.
 
+Inside a session, `b` or `Escape` returns to the preserved Sessions mailbox.
+Editable controls, dialogs, menus, and the live terminal own their keystrokes,
+so typing `b` or sending terminal Escape never triggers navigation. The bottom
+line advertises `b back to sessions` and `?` remains the complete contextual
+help. Number keys `1`/`2`/`3` jump directly to the visible work surfaces
+(`Agent`/`Conversation`/`Review` for terminal sessions and
+`Conversation`/`Shells`/`Review` for ACP); `[` and `]` move between them.
+
 The application owns one prioritized command registry rather than view-local
 window listeners. Kept-alive routes register commands only while active, and
 transient surfaces get first refusal. Character commands never capture typing
@@ -141,6 +149,11 @@ readable prose faces. Near-black planes, ruled rows, cursor gutters, borders,
 and spacing establish hierarchy before cards or shadows do. Phosphor green is
 reserved for commands, live focus, and healthy state; amber and red retain
 attention and blocked meaning.
+
+The bottom status line also follows the active session—the mailbox cursor on
+Sessions or the route on session detail—and exposes its linked GitHub PR and
+issue. PR review, CI, and conflict signals reuse the same semantic colors as the
+full GitHub panel and the same fleet snapshot, without another request.
 
 Terminal density and split-pane structure are attached to the existing
 components through shared tokens and a small inspector component. Light mode

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -1,6 +1,73 @@
 import { test, expect } from '../fixtures/weaver';
 
 test.describe('session detail view', () => {
+  test('session exit commands are discoverable without stealing text input', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await weaver.seedSession({
+      goal: 'Leave the session from the keyboard',
+      name: 'keyboard-exit',
+    });
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
+
+    const hints = page.getByTestId('command-hints');
+    await expect(hints).toContainText('back to sessions');
+    await page.keyboard.press('Shift+/');
+    const help = page.getByTestId('shortcut-help');
+    await expect(help.locator('[data-command-id="session.back"]')).toBeVisible();
+    await expect(help.locator('[data-command-id="session.tab.terminal"] + dd')).toContainText(
+      'Open Agent',
+    );
+    await expect(help.locator('[data-command-id="session.tab.conversation"] + dd')).toContainText(
+      'Open Conversation',
+    );
+    await expect(help.locator('[data-command-id="session.tab.review"] + dd')).toContainText(
+      'Open Review',
+    );
+    await page.keyboard.press('Escape');
+    await expect(help).toHaveCount(0);
+    await expect(page).toHaveURL(`${weaver.baseUrl}/s/${s.id}`);
+
+    const renameButton = page.getByRole('button', { name: 'Rename' });
+    await renameButton.focus();
+    await page.keyboard.press('2');
+    await expect(page.locator('[data-tab="conversation"]')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await page.keyboard.press('3');
+    await expect(page.locator('[data-tab="review"]')).toHaveAttribute('aria-selected', 'true');
+    await expect(page).toHaveURL(new RegExp(`/s/${s.id}/artifacts(?:/|$)`));
+    await page.keyboard.press('[');
+    await expect(page.locator('[data-tab="conversation"]')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await page.keyboard.press(']');
+    await expect(page.locator('[data-tab="review"]')).toHaveAttribute('aria-selected', 'true');
+    await page.keyboard.press('1');
+    await expect(page.locator('[data-tab="terminal"]')).toHaveAttribute('aria-selected', 'true');
+    await expect(page).toHaveURL(`${weaver.baseUrl}/s/${s.id}`);
+
+    await renameButton.click();
+    const titleInput = page.locator('header input').first();
+    await titleInput.press('End');
+    await titleInput.press('b');
+    await expect(titleInput).toHaveValue('keyboard-exitb');
+    await expect(page).toHaveURL(`${weaver.baseUrl}/s/${s.id}`);
+    await titleInput.press('Escape');
+    await expect(page).toHaveURL(`${weaver.baseUrl}/s/${s.id}`);
+
+    await page.keyboard.press('b');
+    await expect(page).toHaveURL(weaver.baseUrl + '/');
+
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
+    await page.getByTestId('status-bar').click();
+    await page.keyboard.press('Escape');
+    await expect(page).toHaveURL(weaver.baseUrl + '/');
+  });
+
   test('renders goal, status and identity metadata', async ({ page, weaver }) => {
     const goal = Array.from(
       { length: 40 },

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -122,17 +122,62 @@ test.describe("durable session workbench", () => {
     page,
     weaver,
   }) => {
-    await weaver.seedSession({
+    const firstSession = await weaver.seedSession({
       goal: "First keyboard-operated task",
       name: "keyboard-mailbox-one",
     });
-    await weaver.seedSession({
+    const secondSession = await weaver.seedSession({
       goal: "Second keyboard-operated task",
       name: "keyboard-mailbox-two",
     });
     await weaver.seedSession({
       goal: "Third keyboard-operated task",
       name: "keyboard-mailbox-three",
+    });
+    await page.route("**/api/sessions/summary**", async (route) => {
+      const response = await route.fetch();
+      const summaries = (await response.json()) as Array<{
+        id: string;
+        github_repo: string | null;
+        github_issue: { repo: string; number: number } | null;
+        branch: Record<string, unknown>;
+      }>;
+      await route.fulfill({
+        response,
+        json: summaries.map((summary) => {
+          const number =
+            summary.id === firstSession.id
+              ? 238
+              : summary.id === secondSession.id
+                ? 239
+                : null;
+          if (!number) return summary;
+          const needsAction = number === 239;
+          return {
+            ...summary,
+            github_repo: "marin-community/loom",
+            github_issue: {
+              repo: "marin-community/loom",
+              number: number === 238 ? 670 : 671,
+            },
+            branch: {
+              ...summary.branch,
+              github: {
+                pr_number: number,
+                pr_url: `https://github.com/marin-community/loom/pull/${number}`,
+                pr_state: "OPEN",
+                pr_title: `Mailbox PR ${number}`,
+                is_draft: false,
+                review_decision: needsAction ? "CHANGES_REQUESTED" : "APPROVED",
+                checks: needsAction ? "failing" : "passing",
+                mergeable: needsAction ? "CONFLICTING" : "MERGEABLE",
+                merged_at: null,
+                fetched_at: new Date().toISOString(),
+              },
+            },
+          };
+        }),
+      });
     });
 
     await page.setViewportSize({ width: 1440, height: 900 });
@@ -145,6 +190,12 @@ test.describe("durable session workbench", () => {
     await expect(preview).toBeVisible();
     await expect(preview).toContainText("keyboard-mailbox-one");
     await expect(preview).toContainText("First keyboard-operated task");
+    const githubStatus = page.getByTestId("status-bar-github");
+    await expect(githubStatus).toContainText("PR #238");
+    await expect(githubStatus).toContainText("Issue #670");
+    await expect(githubStatus.getByTestId("status-bar-pr-signal")).toHaveCount(
+      0,
+    );
 
     // Leave any browser-restored form focus before exercising application
     // commands; character shortcuts deliberately never steal input.
@@ -175,6 +226,11 @@ test.describe("durable session workbench", () => {
     ).toBeFocused();
     await expect(preview).toContainText("keyboard-mailbox-two");
     await expect(preview).toContainText("Second keyboard-operated task");
+    await expect(githubStatus).toContainText("PR #239");
+    await expect(githubStatus).toContainText("Issue #671");
+    await expect(githubStatus).toContainText("changes");
+    await expect(githubStatus).toContainText("CI fail");
+    await expect(githubStatus).toContainText("conflict");
 
     await page.keyboard.press("x");
     await expect(


### PR DESCRIPTION
Extend the terminal mailbox with cursor-aware operational signals and a complete session navigation key language.

The bottom status line now follows the active session: the mailbox cursor on Sessions or the route on session detail. It always exposes direct PR and issue links, expands only actionable or pending PR state (review, CI, conflicts, draft/closed/merged), and reuses the existing compact fleet snapshot—no backend route or extra poll.

Inside a session:
- b or Escape returns to the preserved Sessions mailbox
- 1/2/3 select the visible Agent/Conversation/Review or Conversation/Shells/Review surfaces
- [ and ] move between work surfaces
- ? shows the contextual command reference

The existing command ownership boundary remains authoritative: inputs, composers, dialogs, menus, and xterm retain their keys, so typing b or sending terminal Escape cannot navigate accidentally.

The shared GitHub formatter now provides stable machine keys as well as display copy, keeping compact status filtering independent of wording.

Preview: https://loom.rjp.io/s/vl6leyx9/artifacts/terminal-mailbox-preview

Validation:
- ./scripts/pre-commit.sh
- npx playwright test tests/session-layout.spec.ts tests/detail.spec.ts (14 passed)
- focused status-line and session-command journeys
- substantive agent lint review: no blocking findings; fixed its new-code stringly-typed finding