### PR TITLE
feat(loom): preview rich tool results and polish repository picker

### DIFF
--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -33,7 +33,6 @@ import type {
   AgentMessagePayload,
   ThoughtPayload,
   ToolCallPayload,
-  ToolContent,
   PlanEntry,
   PlanPayload,
   PermissionPayload,
@@ -51,6 +50,7 @@ import { useFollowFoot } from '../lib/followFoot';
 import { formatTokens } from '../lib/usage';
 import MarkdownView from './MarkdownView.vue';
 import AgentUsage from './AgentUsage.vue';
+import ToolContentPreview from './ToolContentPreview.vue';
 
 // The Conversation surface for an *ACP* session (`protocol='acp'`): typeset
 // dialogue, not chat bubbles. Serif prose for the humans and the agent; the
@@ -1159,29 +1159,20 @@ function activitySummary(row: Extract<Row, { type: 'activity' }>): string {
   }
   return parts.join(' · ');
 }
-// Whether a call carries anything worth expanding (a diff or non-empty text).
+// Whether a call carries anything worth expanding.
 function hasDetail(t: ToolCallPayload): boolean {
-  return (t.content ?? []).some((c) => c.type === 'diff' || (c.type === 'text' && !!c.text));
+  return (t.content ?? []).some(
+    (content) =>
+      content.type === 'diff' ||
+      content.type === 'image' ||
+      (content.type === 'text' && !!content.text),
+  );
 }
 // Execute titles are the command line itself. Keep long commands compact in the
 // activity list, but always let the operator disclose the complete command even
 // when the call produced no output to use as a detail panel.
 function canExpandTool(t: ToolCallPayload): boolean {
   return t.tool_kind === 'execute' || hasDetail(t);
-}
-interface DiffLine {
-  sign: '-' | '+';
-  text: string;
-}
-// A diff content block rendered as ±diff lines.
-function diffLines(c: Extract<ToolContent, { type: 'diff' }>): DiffLine[] {
-  const lines: DiffLine[] = [];
-  const push = (sign: '-' | '+', body: string) => {
-    for (const l of body.replace(/\n$/, '').split('\n')) lines.push({ sign, text: l });
-  };
-  if (c.old) push('-', c.old);
-  push('+', c.new);
-  return lines;
 }
 function planGlyph(status: string): string {
   return status === 'completed' ? '✓' : status === 'in_progress' ? '▸' : '○';
@@ -1214,6 +1205,22 @@ function activityItemOpen(item: ActivityItem): boolean {
 }
 function toggleActivityItem(item: ActivityItem) {
   toggleFold(`tool-${item.tool.tool_call_id}`, item.failed);
+}
+function isSoloToolActivity(row: Extract<Row, { type: 'activity' }>): boolean {
+  return row.entries.length === 1 && row.items.length === 1;
+}
+function activityRowOpen(row: Extract<Row, { type: 'activity' }>): boolean {
+  if (isSoloToolActivity(row) && canExpandTool(row.items[0].tool)) {
+    return activityItemOpen(row.items[0]);
+  }
+  return foldOpen(row.key, row.failures > 0);
+}
+function toggleActivityRow(row: Extract<Row, { type: 'activity' }>) {
+  if (isSoloToolActivity(row) && canExpandTool(row.items[0].tool)) {
+    toggleActivityItem(row.items[0]);
+  } else {
+    toggleFold(row.key, row.failures > 0);
+  }
 }
 
 // ── Working timer (elapsed + time since observable progress) ─────────────────
@@ -1405,17 +1412,30 @@ function goTo(anchor: string) {
                   type="button"
                   class="acp-fold-head"
                   data-testid="acp-activity-head"
-                  @click="toggleFold(row.key, row.failures > 0)"
+                  :disabled="isSoloToolActivity(row) && !canExpandTool(row.items[0].tool)"
+                  :aria-expanded="
+                    isSoloToolActivity(row) && canExpandTool(row.items[0].tool)
+                      ? activityRowOpen(row)
+                      : undefined
+                  "
+                  @click="toggleActivityRow(row)"
                 >
-                  <span class="chev" :class="{ open: foldOpen(row.key, row.failures > 0) }">▸</span>
                   <span
-                    v-if="row.entries.length === 1 && row.items.length === 1"
-                    class="acp-activity-solo"
+                    v-if="!isSoloToolActivity(row) || canExpandTool(row.items[0].tool)"
+                    class="chev"
+                    :class="{ open: activityRowOpen(row) }"
+                    >▸</span
                   >
+                  <span v-if="isSoloToolActivity(row)" class="acp-activity-solo">
                     <span class="acp-tool-glyph">{{ toolGlyph(row.items[0].tool.tool_kind) }}</span>
-                    <span class="truncate">{{
-                      row.items[0].tool.title || row.items[0].tool.tool_kind
-                    }}</span>
+                    <span
+                      :class="{
+                        truncate: !activityRowOpen(row),
+                        'acp-activity-title-open': activityRowOpen(row),
+                      }"
+                      data-testid="acp-activity-title"
+                      >{{ row.items[0].tool.title || row.items[0].tool.tool_kind }}</span
+                    >
                   </span>
                   <span v-else>{{ activitySummary(row) }}</span>
                   <span
@@ -1425,7 +1445,26 @@ function goTo(anchor: string) {
                     >{{ row.failures }} failed</span
                   >
                 </button>
-                <ul v-if="foldOpen(row.key, row.failures > 0)" class="acp-activity-list">
+                <div
+                  v-if="
+                    isSoloToolActivity(row) &&
+                    hasDetail(row.items[0].tool) &&
+                    activityItemOpen(row.items[0])
+                  "
+                  class="acp-detail acp-detail-solo"
+                  data-testid="acp-detail"
+                >
+                  <ToolContentPreview
+                    v-for="(content, index) in row.items[0].tool.content"
+                    :key="index"
+                    :content="content"
+                    :title="row.items[0].tool.title || row.items[0].tool.tool_kind"
+                  />
+                </div>
+                <ul
+                  v-else-if="!isSoloToolActivity(row) && foldOpen(row.key, row.failures > 0)"
+                  class="acp-activity-list"
+                >
                   <li
                     v-for="entry in row.entries"
                     :key="
@@ -1477,24 +1516,12 @@ function goTo(anchor: string) {
                         class="acp-detail"
                         data-testid="acp-detail"
                       >
-                        <template v-for="(c, ci) in entry.item.tool.content" :key="ci">
-                          <!-- A diff renders as real ±diff lines. -->
-                          <pre
-                            v-if="c.type === 'diff'"
-                            class="acp-diff"
-                            data-testid="acp-diff"
-                          ><code
-                          v-for="(l, li) in diffLines(c)"
-                          :key="li"
-                          class="acp-diff-line"
-                          :class="l.sign === '-' ? 'acp-diff-del' : 'acp-diff-add'"
-                        >{{ l.sign }} {{ l.text }}
-  </code></pre>
-                          <!-- Text / command output on the recessed panel tone. -->
-                          <pre v-else-if="c.type === 'text' && c.text" class="acp-payload">{{
-                            c.text
-                          }}</pre>
-                        </template>
+                        <ToolContentPreview
+                          v-for="(content, index) in entry.item.tool.content"
+                          :key="index"
+                          :content="content"
+                          :title="entry.item.tool.title || entry.item.tool.tool_kind"
+                        />
                       </div>
                     </template>
                   </li>
@@ -2019,6 +2046,9 @@ function goTo(anchor: string) {
 .acp-fold-head:hover {
   color: var(--muted);
 }
+.acp-fold-head:disabled {
+  cursor: default;
+}
 .chev {
   display: inline-block;
   flex: none;
@@ -2105,6 +2135,11 @@ function goTo(anchor: string) {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+.acp-activity-title-open {
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
 .acp-activity-status {
   margin-left: auto;
   flex: none;
@@ -2122,45 +2157,12 @@ function goTo(anchor: string) {
   border-radius: 0.25rem;
   overflow: hidden;
 }
-.acp-payload {
-  margin: 0;
-  padding: 0.55rem 0.65rem;
-  background: var(--code);
-  color: var(--code-fg);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  line-height: 1.2rem;
-  white-space: pre-wrap;
-  overflow: auto;
-  max-height: 16rem;
+.acp-detail-solo {
+  max-width: 46rem;
+  margin-left: 1.15rem;
 }
 .acp-detail > * + * {
   border-top: 1px solid var(--line);
-}
-
-/* Diff — ±lines on the recessed tone. */
-.acp-diff {
-  margin: 0;
-  padding: 0.4rem 0;
-  background: var(--code);
-  overflow: auto;
-  max-height: 16rem;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  line-height: 1.2rem;
-}
-.acp-diff-line {
-  display: block;
-  padding: 0 0.65rem;
-  white-space: pre;
-}
-.acp-diff-del {
-  background: var(--block-soft);
-  color: var(--block);
-}
-.acp-diff-add {
-  background: var(--ok-soft);
-  color: var(--ok);
 }
 
 /* Permission card — ochre rule + attention wash; the interface asking (sans). */

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -1209,14 +1209,17 @@ function toggleActivityItem(item: ActivityItem) {
 function isSoloToolActivity(row: Extract<Row, { type: 'activity' }>): boolean {
   return row.entries.length === 1 && row.items.length === 1;
 }
+function isSoloExpandableActivity(row: Extract<Row, { type: 'activity' }>): boolean {
+  return isSoloToolActivity(row) && canExpandTool(row.items[0].tool);
+}
 function activityRowOpen(row: Extract<Row, { type: 'activity' }>): boolean {
-  if (isSoloToolActivity(row) && canExpandTool(row.items[0].tool)) {
+  if (isSoloExpandableActivity(row)) {
     return activityItemOpen(row.items[0]);
   }
   return foldOpen(row.key, row.failures > 0);
 }
 function toggleActivityRow(row: Extract<Row, { type: 'activity' }>) {
-  if (isSoloToolActivity(row) && canExpandTool(row.items[0].tool)) {
+  if (isSoloExpandableActivity(row)) {
     toggleActivityItem(row.items[0]);
   } else {
     toggleFold(row.key, row.failures > 0);
@@ -1413,15 +1416,11 @@ function goTo(anchor: string) {
                   class="acp-fold-head"
                   data-testid="acp-activity-head"
                   :disabled="isSoloToolActivity(row) && !canExpandTool(row.items[0].tool)"
-                  :aria-expanded="
-                    isSoloToolActivity(row) && canExpandTool(row.items[0].tool)
-                      ? activityRowOpen(row)
-                      : undefined
-                  "
+                  :aria-expanded="isSoloExpandableActivity(row) ? activityRowOpen(row) : undefined"
                   @click="toggleActivityRow(row)"
                 >
                   <span
-                    v-if="!isSoloToolActivity(row) || canExpandTool(row.items[0].tool)"
+                    v-if="!isSoloToolActivity(row) || isSoloExpandableActivity(row)"
                     class="chev"
                     :class="{ open: activityRowOpen(row) }"
                     >▸</span
@@ -2130,11 +2129,7 @@ function goTo(anchor: string) {
   background: color-mix(in srgb, var(--subtle) 55%, transparent);
   color: var(--fg);
 }
-.acp-activity-title.open {
-  min-width: 0;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
+.acp-activity-title.open,
 .acp-activity-title-open {
   min-width: 0;
   white-space: pre-wrap;

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -128,11 +128,29 @@ const branchMatches = computed(() => {
 function pickRepo(path: string) {
   repo.value = path;
   repoFocused.value = false;
+  repoActiveOption.value = -1;
+}
+
+function nextOption(current: number, count: number, delta: -1 | 1): number {
+  if (current < 0) return delta > 0 ? 0 : count - 1;
+  return (current + delta + count) % count;
+}
+
+function revealOption(prefix: string, index: number) {
+  void nextTick(() => {
+    document.getElementById(`${prefix}-${index}`)?.scrollIntoView({ block: 'nearest' });
+  });
+}
+
+function onRepoInput() {
+  repoFocused.value = true;
+  repoActiveOption.value = -1;
 }
 
 function onRepoKeydown(event: KeyboardEvent) {
   const count = repoMatches.value.length + (cloneCandidate.value ? 1 : 0);
   if (event.key === 'Escape') {
+    event.stopPropagation();
     repoFocused.value = false;
     repoActiveOption.value = -1;
     return;
@@ -140,13 +158,16 @@ function onRepoKeydown(event: KeyboardEvent) {
   if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
     if (!count) return;
     event.preventDefault();
+    event.stopPropagation();
     repoFocused.value = true;
     const delta = event.key === 'ArrowDown' ? 1 : -1;
-    repoActiveOption.value = (repoActiveOption.value + delta + count) % count;
+    repoActiveOption.value = nextOption(repoActiveOption.value, count, delta);
+    revealOption('launch-repository-option', repoActiveOption.value);
     return;
   }
   if (event.key !== 'Enter' || repoActiveOption.value < 0) return;
   event.preventDefault();
+  event.stopPropagation();
   if (cloneCandidate.value && repoActiveOption.value === 0) void addAndCloneRepo();
   else {
     const index = repoActiveOption.value - (cloneCandidate.value ? 1 : 0);
@@ -214,11 +235,18 @@ watch(repo, () => {
 function pickBranch(b: RepoBranch) {
   existingBranch.value = b.name;
   branchFocused.value = false;
+  branchActiveOption.value = -1;
+}
+
+function onBranchInput() {
+  branchFocused.value = true;
+  branchActiveOption.value = -1;
 }
 
 function onBranchKeydown(event: KeyboardEvent) {
   const count = branchMatches.value.length;
   if (event.key === 'Escape') {
+    event.stopPropagation();
     branchFocused.value = false;
     branchActiveOption.value = -1;
     return;
@@ -226,13 +254,16 @@ function onBranchKeydown(event: KeyboardEvent) {
   if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
     if (!count) return;
     event.preventDefault();
+    event.stopPropagation();
     branchFocused.value = true;
     const delta = event.key === 'ArrowDown' ? 1 : -1;
-    branchActiveOption.value = (branchActiveOption.value + delta + count) % count;
+    branchActiveOption.value = nextOption(branchActiveOption.value, count, delta);
+    revealOption('launch-branch-option', branchActiveOption.value);
     return;
   }
   if (event.key === 'Enter' && branchActiveOption.value >= 0) {
     event.preventDefault();
+    event.stopPropagation();
     const match = branchMatches.value[branchActiveOption.value];
     if (match) pickBranch(match);
   }
@@ -670,7 +701,7 @@ onActivated(() => void refreshLaunchData());
               id="launch-repository"
               v-model="repo"
               @focus="repoFocused = true"
-              @input="repoFocused = true"
+              @input="onRepoInput"
               @blur="repoFocused = false"
               @keydown="onRepoKeydown"
               role="combobox"
@@ -701,6 +732,7 @@ onActivated(() => void refreshLaunchData());
                   data-testid="clone-repo"
                   :disabled="cloningRepo"
                   class="flex w-full items-center gap-2 px-2 py-1.5 text-left text-accent hover:bg-subtle disabled:opacity-60"
+                  :class="{ 'bg-subtle': repoActiveOption === 0 }"
                   @mousedown.prevent="addAndCloneRepo"
                 >
                   <span class="shrink-0 text-sm">+ Clone new repo</span>
@@ -721,6 +753,9 @@ onActivated(() => void refreshLaunchData());
                   data-testid="recent-repo"
                   @mousedown.prevent="pickRepo(r.repo_root)"
                   class="flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left hover:bg-subtle"
+                  :class="{
+                    'bg-subtle text-fg': repoActiveOption === index + (cloneCandidate ? 1 : 0),
+                  }"
                 >
                   <span class="min-w-0">
                     <span class="block truncate text-sm">{{ repoName(r.repo_root) }}</span>
@@ -844,7 +879,7 @@ onActivated(() => void refreshLaunchData());
                 id="launch-existing-branch"
                 v-model="existingBranch"
                 @focus="branchFocused = true"
-                @input="branchFocused = true"
+                @input="onBranchInput"
                 @blur="branchFocused = false"
                 @keydown="onBranchKeydown"
                 role="combobox"
@@ -876,6 +911,7 @@ onActivated(() => void refreshLaunchData());
                     data-testid="branch-option"
                     @mousedown.prevent="pickBranch(b)"
                     class="flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left hover:bg-subtle"
+                    :class="{ 'bg-subtle text-fg': branchActiveOption === index }"
                   >
                     <span class="min-w-0">
                       <span class="block truncate text-sm font-mono">

--- a/crates/loom/frontend/src/components/ToolContentPreview.vue
+++ b/crates/loom/frontend/src/components/ToolContentPreview.vue
@@ -1,0 +1,379 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, ref, useId, watch } from 'vue';
+import type { ToolContent } from '../types';
+
+const props = defineProps<{
+  content: ToolContent;
+  title: string;
+}>();
+
+interface DiffLine {
+  sign: '-' | '+';
+  text: string;
+}
+
+function diffLines(content: Extract<ToolContent, { type: 'diff' }>): DiffLine[] {
+  const lines: DiffLine[] = [];
+  const push = (sign: '-' | '+', body: string) => {
+    for (const line of body.replace(/\n$/, '').split('\n')) lines.push({ sign, text: line });
+  };
+  if (content.old) push('-', content.old);
+  push('+', content.new);
+  return lines;
+}
+
+const imageSrc = computed(() => {
+  if (props.content.type !== 'image') return '';
+  if (!/^image\/[a-z0-9.+-]+$/i.test(props.content.mime_type)) return '';
+  return `data:${props.content.mime_type};base64,${props.content.data}`;
+});
+const detailLabel = computed(() => {
+  if (props.content.type === 'diff') return props.content.path;
+  if (props.content.type === 'image') return props.content.uri ?? props.content.mime_type;
+  return 'Command output';
+});
+
+const expanded = ref(false);
+const closeButton = ref<HTMLButtonElement | null>(null);
+const titleId = `${useId()}-title`;
+let returnFocus: HTMLElement | null = null;
+let previousBodyOverflow = '';
+
+function openViewer() {
+  returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  expanded.value = true;
+}
+
+function closeViewer() {
+  expanded.value = false;
+}
+
+function onDocumentKeydown(event: KeyboardEvent) {
+  if (!expanded.value) return;
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeViewer();
+  } else if (event.key === 'Tab') {
+    event.preventDefault();
+    closeButton.value?.focus();
+  }
+}
+
+watch(expanded, async (open) => {
+  if (open) {
+    previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', onDocumentKeydown);
+    await nextTick();
+    closeButton.value?.focus();
+  } else {
+    document.body.style.overflow = previousBodyOverflow;
+    document.removeEventListener('keydown', onDocumentKeydown);
+    await nextTick();
+    returnFocus?.focus();
+    returnFocus = null;
+  }
+});
+
+onBeforeUnmount(() => {
+  if (expanded.value) document.body.style.overflow = previousBodyOverflow;
+  document.removeEventListener('keydown', onDocumentKeydown);
+});
+</script>
+
+<template>
+  <div class="tool-preview">
+    <button
+      v-if="content.type === 'image' && imageSrc"
+      type="button"
+      class="tool-image-preview"
+      data-testid="tool-image-preview"
+      :aria-label="`Open full-size preview of ${title}`"
+      @click="openViewer"
+    >
+      <img :src="imageSrc" :alt="title" />
+      <span class="tool-preview-action">View full size <span aria-hidden="true">↗</span></span>
+    </button>
+
+    <div v-else-if="content.type === 'diff'" class="tool-code-preview">
+      <pre class="acp-diff" data-testid="acp-diff"><code
+        v-for="(line, index) in diffLines(content)"
+        :key="index"
+        class="acp-diff-line"
+        :class="line.sign === '-' ? 'acp-diff-del' : 'acp-diff-add'"
+      >{{ line.sign }} {{ line.text }}
+</code></pre>
+      <button
+        type="button"
+        class="tool-preview-action"
+        data-testid="tool-content-expand"
+        @click="openViewer"
+      >
+        Expand diff <span aria-hidden="true">↗</span>
+      </button>
+    </div>
+
+    <div v-else-if="content.type === 'text' && content.text" class="tool-code-preview">
+      <pre class="acp-payload" data-testid="tool-text-preview">{{ content.text }}</pre>
+      <button
+        type="button"
+        class="tool-preview-action"
+        data-testid="tool-content-expand"
+        @click="openViewer"
+      >
+        Expand output <span aria-hidden="true">↗</span>
+      </button>
+    </div>
+
+    <p v-else-if="content.type === 'image'" class="tool-preview-unsupported">
+      Image preview unavailable ({{ content.mime_type || 'unknown type' }})
+    </p>
+  </div>
+
+  <Teleport to="body">
+    <div
+      v-if="expanded"
+      class="tool-viewer-backdrop"
+      data-testid="tool-detail-backdrop"
+      @mousedown.self="closeViewer"
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+        class="tool-viewer"
+        data-testid="tool-detail-dialog"
+      >
+        <header class="tool-viewer-header">
+          <div class="tool-viewer-heading">
+            <h2 :id="titleId">{{ title }}</h2>
+            <p :title="detailLabel">{{ detailLabel }}</p>
+          </div>
+          <button
+            ref="closeButton"
+            type="button"
+            class="btn-secondary tool-viewer-close"
+            data-testid="tool-detail-close"
+            @click="closeViewer"
+          >
+            Close
+          </button>
+        </header>
+        <div class="tool-viewer-body">
+          <img
+            v-if="content.type === 'image' && imageSrc"
+            :src="imageSrc"
+            :alt="title"
+            class="tool-viewer-image"
+            data-testid="tool-detail-image"
+          />
+          <pre v-else-if="content.type === 'diff'" class="tool-viewer-code acp-diff"><code
+            v-for="(line, index) in diffLines(content)"
+            :key="index"
+            class="acp-diff-line"
+            :class="line.sign === '-' ? 'acp-diff-del' : 'acp-diff-add'"
+          >{{ line.sign }} {{ line.text }}
+</code></pre>
+          <pre v-else-if="content.type === 'text'" class="tool-viewer-code acp-payload">{{
+            content.text
+          }}</pre>
+        </div>
+      </section>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.tool-preview {
+  min-width: 0;
+}
+.tool-image-preview,
+.tool-code-preview {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.3rem;
+  background: var(--code);
+}
+.tool-image-preview {
+  display: flex;
+  min-height: 7rem;
+  max-height: 18rem;
+  cursor: zoom-in;
+  align-items: center;
+  justify-content: center;
+}
+.tool-image-preview:hover,
+.tool-image-preview:focus-visible {
+  border-color: var(--muted);
+}
+.tool-image-preview img {
+  display: block;
+  width: 100%;
+  max-height: 18rem;
+  max-width: 100%;
+  object-fit: contain;
+}
+.tool-preview-action {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  border-top: 1px solid var(--line);
+  padding: 0.3rem 0.55rem;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 0.6875rem;
+  line-height: 1rem;
+}
+.tool-image-preview .tool-preview-action {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: auto;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+  border-top-left-radius: 0.25rem;
+}
+button.tool-preview-action:hover,
+button.tool-preview-action:focus-visible,
+.tool-image-preview:hover .tool-preview-action {
+  color: var(--fg);
+}
+.tool-preview-unsupported {
+  margin: 0;
+  padding: 0.55rem 0.65rem;
+  background: var(--code);
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+.acp-payload {
+  margin: 0;
+  max-height: 16rem;
+  overflow: auto;
+  padding: 0.55rem 0.65rem;
+  background: var(--code);
+  color: var(--code-fg);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.2rem;
+  white-space: pre-wrap;
+}
+.acp-diff {
+  margin: 0;
+  max-height: 16rem;
+  overflow: auto;
+  padding: 0.4rem 0;
+  background: var(--code);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.2rem;
+}
+.acp-diff-line {
+  display: block;
+  padding: 0 0.65rem;
+  white-space: pre;
+}
+.acp-diff-del {
+  background: var(--block-soft);
+  color: var(--block);
+}
+.acp-diff-add {
+  background: var(--ok-soft);
+  color: var(--ok);
+}
+.tool-viewer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: color-mix(in srgb, var(--canvas) 82%, transparent);
+}
+.tool-viewer {
+  display: flex;
+  max-height: calc(100vh - 2rem);
+  width: min(88rem, 100%);
+  min-height: min(42rem, calc(100vh - 2rem));
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  background: var(--surface);
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 35%);
+}
+.tool-viewer-header {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 1rem;
+  border-bottom: 1px solid var(--line);
+  padding: 0.65rem 0.75rem;
+  background: var(--rail);
+}
+.tool-viewer-heading {
+  min-width: 0;
+}
+.tool-viewer-heading h2,
+.tool-viewer-heading p {
+  overflow: hidden;
+  margin: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tool-viewer-heading h2 {
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+.tool-viewer-heading p {
+  margin-top: 0.1rem;
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+}
+.tool-viewer-close {
+  margin-left: auto;
+  flex: none;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.75rem;
+}
+.tool-viewer-body {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  background: var(--code);
+}
+.tool-viewer-image {
+  display: block;
+  min-width: 100%;
+  max-width: none;
+  height: auto;
+  margin: auto;
+}
+.tool-viewer-code {
+  min-width: 100%;
+  max-height: none;
+  min-height: 100%;
+  border-radius: 0;
+}
+
+@media (max-width: 640px) {
+  .tool-viewer-backdrop {
+    padding: 0;
+  }
+  .tool-viewer {
+    max-height: 100vh;
+    min-height: 100vh;
+    border: 0;
+    border-radius: 0;
+  }
+}
+</style>

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -405,7 +405,13 @@ export interface ToolDiffContent {
   old: string | null;
   new: string;
 }
-export type ToolContent = ToolTextContent | ToolDiffContent;
+export interface ToolImageContent {
+  type: 'image';
+  data: string;
+  mime_type: string;
+  uri: string | null;
+}
+export type ToolContent = ToolTextContent | ToolDiffContent | ToolImageContent;
 export interface ToolLocation {
   path: string;
   line: number | null;

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -1223,10 +1223,23 @@ impl LiveTool {
         let mut out = Vec::new();
         for c in &self.content {
             match c {
-                ToolCallContent::Content { content } => out.push(json!({
-                    "type": "text",
-                    "text": content.text().unwrap_or("").to_string(),
-                })),
+                ToolCallContent::Content { content } => match content {
+                    wire::ContentBlock::Text { text } => out.push(json!({
+                        "type": "text",
+                        "text": text,
+                    })),
+                    wire::ContentBlock::Image {
+                        data,
+                        mime_type,
+                        uri,
+                    } => out.push(json!({
+                        "type": "image",
+                        "data": data,
+                        "mime_type": mime_type,
+                        "uri": uri,
+                    })),
+                    wire::ContentBlock::Other => {}
+                },
                 ToolCallContent::Diff {
                     path,
                     old_text,
@@ -3659,8 +3672,9 @@ fn queued_prompt_text(text: &str, resources: &[Value]) -> String {
 mod tests {
     use super::{
         auto_choice, deny_choice, preferred_config_value, preferred_mode, queued_prompt_text,
-        PermissionOption,
+        LiveTool, PermissionOption,
     };
+    use crate::acp::wire::{ContentBlock, ToolCallContent};
     use serde_json::json;
 
     #[test]
@@ -3673,6 +3687,28 @@ mod tests {
         assert_eq!(
             queued_prompt_text("review", &resources),
             "review\n\nReferenced files:\n- src/main.rs\n- https://example.test/context\n"
+        );
+    }
+
+    #[test]
+    fn live_tool_preserves_image_content_for_the_journal() {
+        let mut tool = LiveTool::new("call-image", 1);
+        tool.content = vec![ToolCallContent::Content {
+            content: ContentBlock::Image {
+                data: "aW1hZ2U=".to_string(),
+                mime_type: "image/png".to_string(),
+                uri: Some("file:///tmp/screenshot.png".to_string()),
+            },
+        }];
+
+        assert_eq!(
+            tool.content_json(),
+            vec![json!({
+                "type": "image",
+                "data": "aW1hZ2U=",
+                "mime_type": "image/png",
+                "uri": "file:///tmp/screenshot.png",
+            })]
         );
     }
 

--- a/crates/loom/src/acp/wire.rs
+++ b/crates/loom/src/acp/wire.rs
@@ -209,13 +209,24 @@ pub struct ThreadStatus {
     pub kind: String,
 }
 
-/// A content block. Only text is consumed; other types degrade to
-/// [`ContentBlock::Other`] (mapped to empty text by [`ContentBlock::text`]).
+/// A displayable ACP content block.
+///
+/// Agent prose consumes only [`ContentBlock::Text`], while tool calls also
+/// preserve images for the durable chat journal and Conversation preview.
+/// Other protocol content (audio/resources and future variants) degrades to
+/// [`ContentBlock::Other`] until loom has a truthful renderer for it.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentBlock {
     Text {
         text: String,
+    },
+    Image {
+        data: String,
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+        #[serde(default)]
+        uri: Option<String>,
     },
     #[serde(other)]
     Other,
@@ -226,7 +237,7 @@ impl ContentBlock {
     pub fn text(&self) -> Option<&str> {
         match self {
             ContentBlock::Text { text } => Some(text),
-            ContentBlock::Other => None,
+            ContentBlock::Image { .. } | ContentBlock::Other => None,
         }
     }
 }
@@ -563,11 +574,51 @@ mod tests {
     fn deserializes_thought_chunk_and_unknown_content_degrades() {
         let u: SessionUpdate = serde_json::from_value(json!({
             "sessionUpdate": "agent_thought_chunk",
-            "content": { "type": "image", "data": "…", "mimeType": "image/png" },
+            "content": { "type": "audio", "data": "…", "mimeType": "audio/wav" },
         }))
         .unwrap();
         match u {
             SessionUpdate::AgentThoughtChunk { content, .. } => assert_eq!(content.text(), None),
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deserializes_tool_call_with_image_content() {
+        let u: SessionUpdate = serde_json::from_value(json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call_image",
+            "title": "Read screenshot.png",
+            "kind": "read",
+            "status": "completed",
+            "content": [{
+                "type": "content",
+                "content": {
+                    "type": "image",
+                    "data": "aW1hZ2U=",
+                    "mimeType": "image/png",
+                    "uri": "file:///tmp/screenshot.png"
+                }
+            }]
+        }))
+        .unwrap();
+
+        match u {
+            SessionUpdate::ToolCall(tc) => match &tc.content.unwrap()[0] {
+                ToolCallContent::Content {
+                    content:
+                        ContentBlock::Image {
+                            data,
+                            mime_type,
+                            uri,
+                        },
+                } => {
+                    assert_eq!(data, "aW1hZ2U=");
+                    assert_eq!(mime_type, "image/png");
+                    assert_eq!(uri.as_deref(), Some("file:///tmp/screenshot.png"));
+                }
+                other => panic!("wrong image content: {other:?}"),
+            },
             other => panic!("wrong variant: {other:?}"),
         }
     }

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -14,6 +14,7 @@
 //                        turn (what claude does after /compact); must NOT re-journal
 //   tool:edit[:title]    a tool_call (in_progress) then tool_call_update (completed);
 //                        an `edit` kind carries a diff, others a text content block
+//   image[:title]        a read tool whose result is an ACP image content block
 //   toolfail[:title]     a tool_call that ends with status `failed`
 //   plan                 a plan update with two entries
 //   usage:USED:SIZE      a usage_update
@@ -214,6 +215,34 @@ async function runToken(tok) {
     });
     await sleep(10);
     notify({ sessionUpdate: "tool_call_update", toolCallId, status: "failed" });
+  } else if (tok === "image" || tok.startsWith("image:")) {
+    const title = tok.includes(":") ? tok.slice(tok.indexOf(":") + 1) : "Read screenshot.png";
+    const toolCallId = "call-image-" + Math.floor(Math.random() * 100000);
+    notify({
+      sessionUpdate: "tool_call",
+      toolCallId,
+      title,
+      kind: "read",
+      status: "in_progress",
+      content: [
+        {
+          type: "content",
+          content: {
+            type: "image",
+            mimeType: "image/png",
+            data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            uri: "file:///tmp/screenshot.png",
+          },
+        },
+      ],
+      locations: [{ path: "/tmp/screenshot.png", line: 1 }],
+    });
+    await sleep(10);
+    notify({
+      sessionUpdate: "tool_call_update",
+      toolCallId,
+      status: "completed",
+    });
   } else if (tok.startsWith("tool:")) {
     const rest = tok.slice(5);
     const [kind, title] = rest.split(":");

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -33,8 +33,9 @@ weaver replays it for you automatically.
 - `weaver artifact write <name> [<file>]` — write a versioned document (a
   design, report, diagram, plan) for the user to read; prints a dashboard URL
   to hand them. Reads stdin with `-`; `--repo` shares it repo-wide; an image
-  file is embedded so it renders inline. `weaver artifact ls` / `show <name>
-  [--rev N]` / `rm <name>` round it out.
+  path can be passed directly — the CLI snapshots and embeds its bytes, so do
+  not hand-roll base64 and the dashboard never depends on that local path.
+  `weaver artifact ls` / `show <name> [--rev N]` / `rm <name>` round it out.
 - `weaver tag set|rm|ls` — free-form quiet tags on the branch; `weaver log` —
   the event trail; `weaver readme` — this guide, back on demand.
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -32,8 +32,13 @@ read-time join: the document references issues, while the issue ledger owns task
 state. A plan is simply an artifact convention; there is no plan parser or sync
 engine.
 
-Image input to `weaver artifact write` is wrapped as a bounded data-URI Markdown
-document so it renders through the same surface without adding a blob API.
+Pass a local image path directly to `weaver artifact write` (for example,
+`weaver artifact write screenshot /tmp/result.png`). The CLI reads and snapshots
+the image immediately, wrapping it as a bounded data-URI Markdown document, so
+the stored artifact does not depend on that filesystem path and remains
+available when the dashboard or execution is remote. Local paths embedded
+inside arbitrary Markdown are deliberately not a storage contract; write the
+image itself rather than hand-building base64.
 
 ### The goal artifact
 

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 //   say:TEXT             two agent_message_chunks that consolidate to TEXT
 //   think:TEXT           an agent_thought_chunk
 //   tool:KIND[:TITLE]    a tool_call (in_progress → completed); `edit` carries a diff
+//   image[:TITLE]        a read tool that carries an ACP image content block
 //   plan                 a plan update
 //   usage:USED:SIZE      a usage_update
 //   wait:MS              sleep (keeps the turn live — for queue/interrupt tests)
@@ -157,16 +158,51 @@ test.describe('acp conversation', () => {
         exact: true,
       }),
     ).toBeVisible();
-    // The edit folds into an activity line, closed by default — no output visible.
+    // A lone edit is one disclosure: opening it reveals the inline diff preview.
     const head = page.getByTestId('acp-activity-head').filter({ hasText: 'Edit web.rs' });
     await expect(head).toBeVisible();
     await expect(page.getByTestId('acp-diff')).toBeHidden();
-    // Opening the group lists the call; opening the call reveals its diff as ±lines.
     await head.click();
-    const item = page.getByTestId('acp-activity-item').filter({ hasText: 'Edit web.rs' });
-    await expect(item).toBeVisible();
-    await item.getByRole('button').click();
     await expect(page.getByTestId('acp-diff')).toContainText('new line');
+
+    // The bounded preview can expand into a full-screen code viewer and closes
+    // with Escape, returning focus to the expansion control.
+    const expand = page.getByTestId('tool-content-expand');
+    await expand.click();
+    const viewer = page.getByTestId('tool-detail-dialog');
+    await expect(viewer).toContainText('Edit web.rs');
+    await expect(viewer).toContainText('new line');
+    await page.keyboard.press('Escape');
+    await expect(viewer).toBeHidden();
+    await expect(expand).toBeFocused();
+  });
+
+  test('previews ACP image tool results and opens the full-size image', async ({
+    page,
+    weaver,
+  }) => {
+    await openAcp(page, weaver, {
+      goal: 'image:Read /tmp/screenshot.png|say:image inspected',
+    });
+    await expect(page.getByText('image inspected', { exact: true })).toBeVisible();
+
+    const head = page
+      .getByTestId('acp-activity-head')
+      .filter({ hasText: 'Read /tmp/screenshot.png' });
+    await head.click();
+    const preview = page.getByTestId('tool-image-preview');
+    await expect(preview.locator('img')).toHaveAttribute('src', /^data:image\/png;base64,/);
+    await preview.click();
+
+    const viewer = page.getByTestId('tool-detail-dialog');
+    await expect(viewer).toContainText('Read /tmp/screenshot.png');
+    await expect(page.getByTestId('tool-detail-image')).toHaveAttribute(
+      'src',
+      /^data:image\/png;base64,/,
+    );
+    await page.getByTestId('tool-detail-close').click();
+    await expect(viewer).toBeHidden();
+    await expect(preview).toBeFocused();
   });
 
   test('adapter user echoes do not duplicate the visible history', async ({ page, weaver }) => {
@@ -313,18 +349,17 @@ test.describe('acp conversation', () => {
     await openAcp(page, weaver, { goal: `tool:execute:${command}|say:done` });
     await expect(page.getByText('done', { exact: true })).toBeVisible();
 
-    await page.getByTestId('acp-activity-head').click();
-    const item = page.getByTestId('acp-activity-item');
+    const item = page.getByTestId('acp-activity-head');
     const title = item.getByTestId('acp-activity-title');
     await expect(title).toHaveClass(/truncate/);
-    await expect(item.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+    await expect(item).toHaveAttribute('aria-expanded', 'false');
     await expect.poll(() => title.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true);
     const collapsedHeight = await title.evaluate((el) => el.clientHeight);
 
-    await item.getByRole('button').click();
+    await item.click();
     await expect(title).not.toHaveClass(/truncate/);
     await expect(title).toHaveText(command);
-    await expect(item.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+    await expect(item).toHaveAttribute('aria-expanded', 'true');
     await expect
       .poll(() => title.evaluate((el) => el.clientHeight))
       .toBeGreaterThan(collapsedHeight);

--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -3,6 +3,28 @@ import { test, expect } from '../fixtures/weaver';
 test.describe('creating a session via the UI form', () => {
   const repoPlaceholder = 'owner/name or /home/you/code/project';
 
+  test('keeps arrow navigation inside the repository picker', async ({ page, weaver }) => {
+    await weaver.seedSession({
+      goal: 'make this repository recent',
+      name: 'recent-repository',
+    });
+    await page.goto(`${weaver.baseUrl}/sessions/new`);
+
+    const repo = page.getByPlaceholder(repoPlaceholder);
+    await repo.focus();
+    const option = page.getByTestId('recent-repo').filter({ hasText: weaver.repoPath });
+    await expect(option).toBeVisible();
+
+    await repo.press('ArrowDown');
+    await expect(option).toHaveAttribute('aria-selected', 'true');
+    await expect(option).toHaveClass(/bg-subtle/);
+    await expect(page).toHaveURL(`${weaver.baseUrl}/sessions/new`);
+
+    await repo.press('Enter');
+    await expect(repo).toHaveValue(weaver.repoPath);
+    await expect(page.getByTestId('recent-repos')).toBeHidden();
+  });
+
   test('launches from the workbench with canonical profile and title', async ({ page, weaver }) => {
     await fetch(`${weaver.baseUrl}/api/profiles`, {
       method: 'POST',


### PR DESCRIPTION
Preserve ACP image tool content in the durable chat journal and render bounded inline previews for image, diff, and text results. Lone operations now disclose in one click, and every preview can open in a keyboard-accessible full-screen viewer.

Keep repository and branch picker arrow keys inside their comboboxes, show and scroll the active option, and correct initial Up/Down selection.

Clarify that `weaver artifact write <name> <image-path>` snapshots local image bytes, so agents do not need to encode base64 and remote dashboards do not depend on the source path.

Session: https://loom.rjp.io/s/t3hxl9mv