### PR TITLE
feat(loom): streamline mailbox triage workflows

### DIFF
--- a/crates/loom/frontend/src/App.vue
+++ b/crates/loom/frontend/src/App.vue
@@ -137,6 +137,9 @@ function cacheKey(route: { path: string; params: Record<string, string | string[
   // artifacts and back is a tab flip on the warm page, never a remount.
   const id = route.params.id;
   if (typeof id === 'string' && route.path.startsWith(`/s/${id}`)) return `s:${id}`;
+  // A watch id selects the right pane of one master/detail workbench. Keep the
+  // list instance stable while its route-backed cursor moves.
+  if (route.path === '/watches' || route.path.startsWith('/watches/')) return '/watches';
   return route.path;
 }
 </script>

--- a/crates/loom/frontend/src/components/SessionMailboxPreview.vue
+++ b/crates/loom/frontend/src/components/SessionMailboxPreview.vue
@@ -28,6 +28,14 @@ const title = computed(
 );
 const attention = computed(() => (props.session ? effectiveAttention(props.session) : null));
 const statusMessage = computed(() => (props.session ? messageOf(props.session) : ''));
+const taskSummary = computed(() => {
+  const first = props.detail?.branch.goal
+    ?.split('\n')
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (!first) return '';
+  return first.length > 140 ? `${first.slice(0, 137)}…` : first;
+});
 const repoName = computed(() => {
   const path = props.session?.branch.repo_root ?? '';
   return path.split('/').filter(Boolean).at(-1) ?? path;
@@ -41,7 +49,7 @@ const repoName = computed(() => {
     aria-label="Current session preview"
   >
     <header class="terminal-pane-heading">
-      <span>SESSION://INSPECT</span>
+      <span>SESSION://NOW</span>
       <span v-if="total"
         >{{ String(position).padStart(2, '0') }}/{{ String(total).padStart(2, '0') }}</span
       >
@@ -86,37 +94,6 @@ const repoName = computed(() => {
           </p>
         </section>
 
-        <section class="terminal-preview-section">
-          <h3>TASK BUFFER</h3>
-          <p
-            v-if="detail?.branch.goal"
-            class="whitespace-pre-wrap font-sans text-sm leading-5 text-fg"
-          >
-            {{ detail.branch.goal }}
-          </p>
-          <p v-else-if="loading" class="terminal-loading">fetching session context<span>_</span></p>
-          <p v-else-if="error" class="text-xs text-block">{{ error }}</p>
-          <p v-else class="text-xs text-faint">No task context available.</p>
-        </section>
-
-        <section class="terminal-preview-section">
-          <h3>PROCESS</h3>
-          <dl class="terminal-kv">
-            <dt>repo</dt>
-            <dd :title="session.branch.repo_root">{{ repoName }}</dd>
-            <dt>branch</dt>
-            <dd :title="session.branch.branch">{{ session.branch.branch }}</dd>
-            <dt>space</dt>
-            <dd>{{ session.placement?.space_name ?? 'unplaced' }}</dd>
-            <dt>group</dt>
-            <dd>{{ session.placement?.group_name ?? 'unplaced' }}</dd>
-            <dt>profile</dt>
-            <dd>{{ session.profile || 'default' }}</dd>
-            <dt>origin</dt>
-            <dd>{{ session.origin }}</dd>
-          </dl>
-        </section>
-
         <section
           v-if="signalChips(session).length || quietTags(session).length"
           class="terminal-preview-section"
@@ -145,6 +122,49 @@ const repoName = computed(() => {
         <section v-if="session.branch.github" class="terminal-preview-section">
           <h3>UPSTREAM</h3>
           <GithubStatus :gh="session.branch.github" />
+        </section>
+
+        <section class="terminal-preview-section">
+          <h3>TASK</h3>
+          <details data-testid="session-mailbox-task">
+            <summary
+              class="cursor-pointer list-none rounded border border-line bg-rail/50 px-2.5 py-2 text-xs text-muted hover:border-accent hover:text-fg"
+            >
+              <span v-if="taskSummary" class="block font-sans leading-4 text-fg">{{
+                taskSummary
+              }}</span>
+              <span class="mt-1 block font-mono text-2xs text-faint">open full task buffer</span>
+            </summary>
+            <p
+              v-if="detail?.branch.goal"
+              class="mt-2 whitespace-pre-wrap font-sans text-sm leading-5 text-fg"
+            >
+              {{ detail.branch.goal }}
+            </p>
+            <p v-else-if="loading" class="terminal-loading">
+              fetching session context<span>_</span>
+            </p>
+            <p v-else-if="error" class="mt-2 text-xs text-block">{{ error }}</p>
+            <p v-else class="mt-2 text-xs text-faint">No task context available.</p>
+          </details>
+        </section>
+
+        <section class="terminal-preview-section">
+          <h3>PROCESS</h3>
+          <dl class="terminal-kv">
+            <dt>repo</dt>
+            <dd :title="session.branch.repo_root">{{ repoName }}</dd>
+            <dt>branch</dt>
+            <dd :title="session.branch.branch">{{ session.branch.branch }}</dd>
+            <dt>space</dt>
+            <dd>{{ session.placement?.space_name ?? 'unplaced' }}</dd>
+            <dt>group</dt>
+            <dd>{{ session.placement?.group_name ?? 'unplaced' }}</dd>
+            <dt>profile</dt>
+            <dd>{{ session.profile || 'default' }}</dd>
+            <dt>origin</dt>
+            <dd>{{ session.origin }}</dd>
+          </dl>
         </section>
       </div>
 

--- a/crates/loom/frontend/src/components/SessionTerminals.vue
+++ b/crates/loom/frontend/src/components/SessionTerminals.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue';
 import AgentTerminal from './AgentTerminal.vue';
+import KeyHint from './KeyHint.vue';
 import { get, del } from '../api';
 
 // The session's terminal area: an inner tab strip over the always-mounted agent
@@ -34,8 +35,11 @@ const noShells = computed(() => props.shellsOnly && shells.value.length === 0);
 async function loadShells() {
   try {
     const idxs = (await get(`/sessions/${props.id}/shells`)) as number[];
-    shells.value = [...idxs].sort((a, b) => a - b);
-    nextIdx = shells.value.length ? Math.max(...shells.value) + 1 : 0;
+    // A keyboard command can add the first shell while this mount probe is in
+    // flight. Merge rediscovered supervisors with those local tabs so a late
+    // empty response never erases the shell the user just opened.
+    shells.value = [...new Set([...shells.value, ...idxs])].sort((a, b) => a - b);
+    nextIdx = shells.value.length ? Math.max(nextIdx, Math.max(...shells.value) + 1) : nextIdx;
     // Land the shells-only view on the first rediscovered shell.
     if (props.shellsOnly && active.value === -1 && shells.value.length) {
       active.value = shells.value[0];
@@ -50,6 +54,8 @@ function addShell() {
   shells.value.push(idx);
   active.value = idx;
 }
+
+defineExpose({ addShell });
 
 async function closeShell(idx: number) {
   shells.value = shells.value.filter((n) => n !== idx);
@@ -140,6 +146,7 @@ onMounted(loadShells);
           data-testid="acp-open-shell"
           @click="addShell"
         >
+          <KeyHint keys="n" />
           Open a shell in the worktree
         </button>
       </div>

--- a/crates/loom/frontend/src/components/StatusBar.vue
+++ b/crates/loom/frontend/src/components/StatusBar.vue
@@ -17,7 +17,9 @@ import KeyHint from './KeyHint.vue';
 // docs/loom-ui.md). Read-only API state from the one shared fleet snapshot the
 // whole app polls (lib/sessionsStore) — no second poll of its own. Left:
 // session + attention counts (the attention segment goes amber and links to the
-// filtered list; "all calm" reads a reassuring green). Right: connection dot +
+// filtered list; the calm copy says there is no NEW attention, without implying
+// that every durable health signal (for example a PR conflict) has disappeared).
+// Right: connection dot +
 // a ticking clock — the "is this thing live?" glance.
 const { sessions, runs, online, focusedSessionId, sessionById } = useFleet();
 const { chord: commandChord, hints: commandHints } = useCommandRegistry();
@@ -124,7 +126,7 @@ onUnmounted(() => clearInterval(clockTimer));
       </router-link>
       <span v-else class="flex items-center gap-1.5 text-ok" data-testid="status-bar-attention">
         <span class="h-1.5 w-1.5 rounded-full bg-ok-line" aria-hidden="true"></span>
-        all calm
+        no new attention
       </span>
     </span>
 

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -11,7 +11,7 @@ import {
   nextTick,
 } from 'vue';
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router';
-import { get, getSession, ideInfo } from '../api';
+import { clearSessionTag, get, getSession, ideInfo } from '../api';
 import type { Session, WeaverEvent } from '../types';
 import SessionTerminals from '../components/SessionTerminals.vue';
 import IdeFrame from '../components/IdeFrame.vue';
@@ -24,6 +24,7 @@ import ChangesPanel from '../components/ChangesPanel.vue';
 import { cancelSessionBacktrack, completeSessionOpen } from '../lib/workbenchMetrics';
 import { openSessionEvents, type SessionEventsHandle } from '../lib/sessionEvents';
 import { useCommandScope, type Command } from '../lib/commands';
+import { signalChips } from '../lib/sessionState';
 
 // Named + keyed-by-id in App.vue's <keep-alive> so the page (and its live
 // terminal) stays warm: every `/s/:id…` path (the work tabs and the Artifacts
@@ -81,6 +82,7 @@ const reviewDocked = computed(() => artifactsDocked.value || changesActive.value
 const railOpen = computed(() => artifactsActive.value && poppedOut.value);
 const dockedArtifactsRef = ref<InstanceType<typeof ArtifactsPanel> | null>(null);
 const railArtifactsRef = ref<InstanceType<typeof ArtifactsPanel> | null>(null);
+const acpShellsRef = ref<InstanceType<typeof SessionTerminals> | null>(null);
 let layoutNavigationAuthorized = false;
 
 function activeArtifactsPanel(): InstanceType<typeof ArtifactsPanel> | null {
@@ -206,6 +208,41 @@ const sessionCommands = computed<Command[]>(() => [
     hint: true,
     run: () => moveWorkTab(1),
   },
+  ...(reviewActive.value
+    ? [
+        {
+          id: 'session.review.artifacts',
+          label: 'Open Artifacts',
+          keys: ['a'],
+          run: async () => {
+            await guardedArtifactLayout(async () => {
+              await router.push(`/s/${props.id}/artifacts`);
+            });
+          },
+        },
+        {
+          id: 'session.review.changes',
+          label: 'Open Changes',
+          keys: ['c'],
+          run: async () => {
+            await guardedArtifactLayout(async () => {
+              await router.push(`/s/${props.id}/changes`);
+            });
+          },
+        },
+      ]
+    : []),
+  ...(isAcp.value && workTab.value === 'shells'
+    ? [
+        {
+          id: 'session.shell.new',
+          label: 'Open a worktree shell',
+          keys: ['n'],
+          hint: true,
+          run: () => acpShellsRef.value?.addShell(),
+        },
+      ]
+    : []),
 ]);
 useCommandScope(`session:${props.id}`, 'Session', sessionCommands, 10);
 
@@ -283,15 +320,38 @@ const ideOpen = ref(false);
 
 let source: SessionEventsHandle | null = null;
 
-async function loadSession() {
-  ws.value = await getSession(props.id);
+async function loadSession(acknowledge = false): Promise<string> {
+  let session = await getSession(props.id);
+  if (!acknowledge) {
+    ws.value = session;
+    return '';
+  }
+
+  // Attention is a wake-up signal, not a permanent task state. Entering (or
+  // returning to) a session acknowledges every loud tag visible in the
+  // snapshot the user opened. Lifecycle failures remain visible because they
+  // are derived state rather than dismissible tags; a later tag write raises
+  // attention again through the normal event stream.
+  const keys = [...new Set(signalChips(session).map((chip) => chip.key))];
+  if (!keys.length) {
+    ws.value = session;
+    return '';
+  }
+  const results = await Promise.allSettled(keys.map((key) => clearSessionTag(props.id, key)));
+  // Re-read even after a partial failure: successful acknowledgements should
+  // disappear, while any failed tag remains available for the existing manual
+  // clear gesture.
+  session = await getSession(props.id);
+  ws.value = session;
+  const failed = results.filter((result) => result.status === 'rejected').length;
+  return failed ? `Couldn't acknowledge ${failed} attention signal${failed === 1 ? '' : 's'}.` : '';
 }
 
-async function loadAll() {
+async function loadAll(acknowledge = false) {
   try {
-    await loadSession();
+    const acknowledgementError = await loadSession(acknowledge);
     events.value = (await get(`/sessions/${props.id}/log`)) as WeaverEvent[];
-    error.value = '';
+    error.value = acknowledgementError;
   } catch (e) {
     error.value = (e as Error).message;
   }
@@ -325,7 +385,7 @@ function openStream() {
 
 onMounted(() => {
   requestAnimationFrame(() => completeSessionOpen(props.id));
-  loadAll();
+  loadAll(true);
   openStream();
   // Gate the editor affordance on the server setting (cheap; the panel itself
   // re-checks availability when opened).
@@ -344,7 +404,7 @@ onMounted(() => {
 onActivated(() => {
   if (source) return; // initial mount already loaded + opened the stream
   requestAnimationFrame(() => completeSessionOpen(props.id));
-  loadAll();
+  loadAll(true);
   openStream();
 });
 
@@ -437,7 +497,7 @@ onUnmounted(() => {
              area with the Agent inner tab dropped. Lazily mounted on first open,
              then kept (v-show) so re-selecting is instant. -->
         <div v-if="isAcp && mounted.shells" v-show="workTab === 'shells'" class="h-full">
-          <SessionTerminals :id="props.id" shells-only />
+          <SessionTerminals ref="acpShellsRef" :id="props.id" shells-only />
         </div>
 
         <!-- Conversation — the agent's chat with the model. Lazily mounted, then

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -320,13 +320,12 @@ const ideOpen = ref(false);
 
 let source: SessionEventsHandle | null = null;
 
-async function loadSession(acknowledge = false): Promise<string> {
-  let session = await getSession(props.id);
-  if (!acknowledge) {
-    ws.value = session;
-    return '';
-  }
+async function loadSession() {
+  ws.value = await getSession(props.id);
+}
 
+async function acknowledgeSessionAttention(): Promise<string> {
+  let session = await getSession(props.id);
   // Attention is a wake-up signal, not a permanent task state. Entering (or
   // returning to) a session acknowledges every loud tag visible in the
   // snapshot the user opened. Lifecycle failures remain visible because they
@@ -347,14 +346,25 @@ async function loadSession(acknowledge = false): Promise<string> {
   return failed ? `Couldn't acknowledge ${failed} attention signal${failed === 1 ? '' : 's'}.` : '';
 }
 
-async function loadAll(acknowledge = false) {
+async function loadAllWith(sessionLoad: () => Promise<string>) {
   try {
-    const acknowledgementError = await loadSession(acknowledge);
+    const acknowledgementError = await sessionLoad();
     events.value = (await get(`/sessions/${props.id}/log`)) as WeaverEvent[];
     error.value = acknowledgementError;
   } catch (e) {
     error.value = (e as Error).message;
   }
+}
+
+async function loadAll() {
+  return loadAllWith(async () => {
+    await loadSession();
+    return '';
+  });
+}
+
+async function acknowledgeAndLoadAll() {
+  return loadAllWith(acknowledgeSessionAttention);
 }
 
 function closeStream() {
@@ -385,7 +395,7 @@ function openStream() {
 
 onMounted(() => {
   requestAnimationFrame(() => completeSessionOpen(props.id));
-  loadAll(true);
+  acknowledgeAndLoadAll();
   openStream();
   // Gate the editor affordance on the server setting (cheap; the panel itself
   // re-checks availability when opened).
@@ -404,7 +414,7 @@ onMounted(() => {
 onActivated(() => {
   if (source) return; // initial mount already loaded + opened the stream
   requestAnimationFrame(() => completeSessionOpen(props.id));
-  loadAll(true);
+  acknowledgeAndLoadAll();
   openStream();
 });
 

--- a/crates/loom/frontend/src/views/Watches.vue
+++ b/crates/loom/frontend/src/views/Watches.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
-import { ref, reactive, computed, watch as watchEffect, onMounted, onActivated } from 'vue';
+import {
+  ref,
+  reactive,
+  computed,
+  nextTick,
+  watch as watchEffect,
+  onMounted,
+  onActivated,
+} from 'vue';
 import { useRouter } from 'vue-router';
 import {
   createWatch,
@@ -35,6 +43,7 @@ import {
   capabilitiesFrom,
   GRANTABLE_CAPABILITIES,
 } from '../lib/watch';
+import { useCommandScope, type Command } from '../lib/commands';
 
 // Named so App.vue's <keep-alive :include> keeps this view warm across nav.
 defineOptions({ name: 'Watches' });
@@ -63,10 +72,44 @@ const selected = computed(() => watches.value.find((w) => w.id === selectedId.va
 // The right pane's mode: a selected watch, or the create form.
 const creatingNew = ref(false);
 
-function select(w: Watch) {
+async function select(w: Watch) {
   creatingNew.value = false;
-  if (w.id !== selectedId.value) router.push(`/watches/${w.id}`);
+  const changed = w.id !== selectedId.value;
   selectedId.value = w.id;
+  if (changed) await router.push(`/watches/${w.id}`);
+}
+
+async function focusSelected() {
+  if (!selectedId.value) return;
+  await nextTick();
+  // Route-backed selection updates the kept-alive view in a second render
+  // turn. Focus after that paint so the browser does not restore it to the row
+  // that initiated the navigation.
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+  const row = document.querySelector<HTMLElement>(
+    `[data-watch-id="${CSS.escape(selectedId.value)}"]`,
+  );
+  row?.focus({ preventScroll: true });
+  row?.scrollIntoView({ block: 'nearest' });
+}
+
+async function moveSelection(direction: -1 | 1) {
+  if (!watches.value.length) return;
+  const current = watches.value.findIndex((watch) => watch.id === selectedId.value);
+  const fallback = direction > 0 ? 0 : watches.value.length - 1;
+  const next =
+    current < 0 ? fallback : Math.min(Math.max(current + direction, 0), watches.value.length - 1);
+  await select(watches.value[next]);
+  await focusSelected();
+}
+
+async function moveSelectionTo(edge: 'first' | 'last') {
+  const watch = edge === 'first' ? watches.value[0] : watches.value.at(-1);
+  if (!watch) return;
+  await select(watch);
+  await focusSelected();
 }
 
 // A builtin watch is the daemon-seeded row for a stock program (its name is
@@ -127,6 +170,11 @@ async function loadProfiles() {
 // ── Right pane: tabs ────────────────────────────────────────────────────────
 type Tab = 'activity' | 'script' | 'config';
 const tab = ref<Tab>('activity');
+const tabs: { key: Tab; label: string }[] = [
+  { key: 'activity', label: 'Activity' },
+  { key: 'script', label: 'Script' },
+  { key: 'config', label: 'Config' },
+];
 
 // ── Activity: the round history + execution log ────────────────────────────
 const runs = ref<WatchRun[]>([]);
@@ -135,6 +183,26 @@ const runsError = ref('');
 const expanded = reactive<Record<number, boolean>>({});
 // The last Run now / Dry-run result, shown inline above the history.
 const lastRun = ref<{ outcome: string; summary: string; dry: boolean } | null>(null);
+const showRoutineRuns = ref(false);
+
+function isSignalRun(run: WatchRun): boolean {
+  return (
+    Boolean(run.actions?.length) ||
+    Boolean(run.stderr) ||
+    (run.exit_code != null && run.exit_code !== 0) ||
+    !['ok', 'noop'].includes(run.outcome)
+  );
+}
+
+// The newest round always stays visible so "did it just run?" has an answer.
+// Older successful/no-op rounds without actions are routine history; keep them
+// one click away instead of letting them bury the last intervention or failure.
+const visibleRuns = computed(() =>
+  showRoutineRuns.value
+    ? runs.value
+    : runs.value.filter((run, index) => index === 0 || isSignalRun(run)),
+);
+const hiddenRoutineRuns = computed(() => runs.value.length - visibleRuns.value.length);
 
 async function loadRuns() {
   if (!selectedId.value) return;
@@ -275,6 +343,7 @@ async function saveConfig() {
 // so this is for custom programs — or a second instance of a stock program
 // with its own name, prompt, and scope.
 const creating = ref(false);
+const watchNameInput = ref<HTMLInputElement | null>(null);
 type TriggerKind = 'auto' | 'cron' | 'every' | 'on';
 const form = reactive({
   name: '',
@@ -312,10 +381,57 @@ function resetForm() {
   form.capabilities = { mark: true, escalate: true, nudge: false, interrupt: false, launch: false };
 }
 
-function openCreate() {
+async function openCreate() {
   resetForm();
   creatingNew.value = true;
+  await nextTick();
+  watchNameInput.value?.focus();
 }
+
+const watchCommands = computed<Command[]>(() => [
+  {
+    id: 'watches.cursor-down',
+    label: 'Move watch cursor down',
+    keys: ['j'],
+    hint: true,
+    run: () => moveSelection(1),
+  },
+  {
+    id: 'watches.cursor-up',
+    label: 'Move watch cursor up',
+    keys: ['k'],
+    run: () => moveSelection(-1),
+  },
+  {
+    id: 'watches.first',
+    label: 'Go to first watch',
+    keys: ['g g'],
+    run: () => moveSelectionTo('first'),
+  },
+  {
+    id: 'watches.last',
+    label: 'Go to last watch',
+    keys: ['G'],
+    run: () => moveSelectionTo('last'),
+  },
+  ...tabs.map((candidate, index) => ({
+    id: `watches.tab.${candidate.key}`,
+    label: `Open ${candidate.label}`,
+    keys: [String(index + 1)],
+    enabled: () => Boolean(selected.value && !creatingNew.value),
+    run: () => {
+      tab.value = candidate.key;
+    },
+  })),
+  {
+    id: 'watches.new',
+    label: 'New watch',
+    keys: ['n'],
+    enabled: () => !creatingNew.value,
+    run: openCreate,
+  },
+]);
+useCommandScope('watches', 'Watches', watchCommands, 100);
 
 // Prefill from a builtin's suggested defaults when the program changes. The
 // script declares its own subscriptions, so default to honouring them (auto).
@@ -408,6 +524,7 @@ watchEffect(
 
 watchEffect(selectedId, () => {
   lastRun.value = null;
+  showRoutineRuns.value = false;
   runsError.value = '';
   runs.value = [];
   editing.value = false;
@@ -531,6 +648,7 @@ onActivated(() => {
           <div>
             <label class="mb-1 block text-xs text-muted">Name — unique, used as its handle</label>
             <input
+              ref="watchNameInput"
               v-model="form.name"
               data-testid="watch-name"
               placeholder="status-strict"
@@ -842,9 +960,28 @@ onActivated(() => {
               </p>
             </div>
 
-            <ul v-else data-testid="watch-runs" class="space-y-2">
+            <div
+              v-if="runs.length > 1"
+              class="mb-3 flex items-center gap-2 font-mono text-2xs text-faint"
+              data-testid="watch-run-digest"
+            >
+              <span v-if="hiddenRoutineRuns">
+                {{ hiddenRoutineRuns }} routine round{{ hiddenRoutineRuns === 1 ? '' : 's' }} hidden
+              </span>
+              <span v-else>showing full round history</span>
+              <button
+                type="button"
+                class="text-accent hover:underline"
+                data-testid="watch-runs-toggle"
+                @click="showRoutineRuns = !showRoutineRuns"
+              >
+                {{ showRoutineRuns ? 'Show signals' : 'Show all' }}
+              </button>
+            </div>
+
+            <ul v-if="runs.length" data-testid="watch-runs" class="space-y-2">
               <li
-                v-for="r in runs"
+                v-for="r in visibleRuns"
                 :key="r.id"
                 data-testid="watch-run-row"
                 class="rounded border border-line bg-surface"

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -114,6 +114,19 @@ async function openAcp(
 }
 
 test.describe('acp conversation', () => {
+  test('opens the first worktree shell from the keyboard', async ({ page, weaver }) => {
+    await openAcp(page, weaver, {
+      goal: 'say:Ready for shell work.',
+      name: 'acp-shell-keyboard',
+    });
+
+    await page.keyboard.press('2');
+    await expect(page.getByTestId('acp-open-shell')).toBeVisible();
+    await page.keyboard.press('n');
+    await expect(page.getByRole('button', { name: 'Shell 1' })).toBeVisible();
+    await expect(page.locator('.xterm')).toBeVisible();
+  });
+
   // A chat opens at its newest exchange: the transcript scrolls to its foot on
   // load and stays there while the async markdown paint grows the content.
   test('opens scrolled to the foot of a long transcript', async ({ page, weaver }) => {

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -39,6 +39,10 @@ test.describe('session detail view', () => {
     await page.keyboard.press('3');
     await expect(page.locator('[data-tab="review"]')).toHaveAttribute('aria-selected', 'true');
     await expect(page).toHaveURL(new RegExp(`/s/${s.id}/artifacts(?:/|$)`));
+    await page.keyboard.press('c');
+    await expect(page).toHaveURL(`${weaver.baseUrl}/s/${s.id}/changes`);
+    await page.keyboard.press('a');
+    await expect(page).toHaveURL(new RegExp(`/s/${s.id}/artifacts(?:/|$)`));
     await page.keyboard.press('[');
     await expect(page.locator('[data-tab="conversation"]')).toHaveAttribute(
       'aria-selected',
@@ -299,29 +303,48 @@ test.describe('session detail view', () => {
     await expect(issuePill).toHaveText('Issue —');
   });
 
-  test('clearing the attention chip marks the agent’s attention calm', async ({ page, weaver }) => {
+  test('viewing a session acknowledges current attention and later signals can return', async ({
+    page,
+    weaver,
+  }) => {
     const s = await weaver.seedSession({
       goal: 'Acknowledge me',
       name: 'ack-task',
     });
-    // The agent raises its attention; the human's only write here is to clear it.
+    // Agent and watch signals are both current when the user enters.
     await weaver.setStatus(s, 'attention', 'waiting on review');
+    await weaver.mark(s, 'blocked', {
+      note: 'external assessment',
+      by: 'status-watch',
+    });
 
     await page.goto(`${weaver.baseUrl}/s/${s.id}`);
 
-    // Attention shows as a deletable signal chip — there is no separate "Mark OK"
-    // control; the chip's × is the calm gesture.
+    // Opening is the acknowledgement gesture: current loud tags disappear
+    // server-side, while the durable status message remains as recent context.
+    await expect
+      .poll(async () =>
+        (await weaver.getSession(s.id)).branch.tags.filter((tag) =>
+          ['attention', 'blocked'].includes(tag.value),
+        ),
+      )
+      .toEqual([]);
+    await expect(page.getByText('waiting on review', { exact: true })).toBeVisible();
+    await expect(page.getByTestId('status-bar-attention')).toContainText('no new attention');
+
+    // A signal raised after the page was opened is not continuously erased.
+    await weaver.setStatus(s, 'attention', 'new decision needed');
     const chip = page.locator('[data-testid="signal-chip"][data-signal-key="attention"]');
     await expect(chip).toHaveAttribute('data-level', 'attention');
 
-    await chip.getByTestId('signal-chip-clear').click();
-
-    // The chip goes away…
-    await expect(chip).toHaveCount(0);
-    // …and it's cleared server-side: the × DELETEs the `attention` tag, so the
-    // calm state is its absence (there is no stored `ok`).
-    const updated = await weaver.getSession(s.id);
-    expect(updated.branch.tags.find((t) => t.key === 'attention')).toBeUndefined();
+    // Leaving and returning is a new acknowledgement.
+    await page.goto(weaver.baseUrl);
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
+    await expect
+      .poll(async () =>
+        (await weaver.getSession(s.id)).branch.tags.some((tag) => tag.key === 'attention'),
+      )
+      .toBe(false);
   });
 
   test('scratch attachments share one bounded browse and drop target', async ({ page, weaver }) => {

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -190,6 +190,13 @@ test.describe("durable session workbench", () => {
     await expect(preview).toBeVisible();
     await expect(preview).toContainText("keyboard-mailbox-one");
     await expect(preview).toContainText("First keyboard-operated task");
+    await expect(
+      preview.getByTestId("session-mailbox-task"),
+    ).not.toHaveAttribute("open");
+    await preview.getByTestId("session-mailbox-task").click();
+    await expect(preview.getByTestId("session-mailbox-task")).toHaveAttribute(
+      "open",
+    );
     const githubStatus = page.getByTestId("status-bar-github");
     await expect(githubStatus).toContainText("PR #238");
     await expect(githubStatus).toContainText("Issue #670");

--- a/e2e/tests/watches.spec.ts
+++ b/e2e/tests/watches.spec.ts
@@ -40,6 +40,40 @@ test.describe('watch panel', () => {
     await expect(detail).toContainText('attention ≠ ok');
   });
 
+  test('uses the mailbox command grammar for selection, tabs, and creation', async ({
+    page,
+    weaver,
+  }) => {
+    await weaver.seedWatch({ name: 'alpha' });
+    await weaver.seedWatch({ name: 'bravo' });
+    await weaver.seedWatch({ name: 'charlie' });
+    await page.goto(`${weaver.baseUrl}/watches`);
+
+    const rows = page.getByTestId('watch-row');
+    await expect(rows).toHaveCount(3);
+    await rows.first().focus();
+    await page.keyboard.press('Shift+/');
+    const help = page.getByTestId('shortcut-help');
+    await expect(help.locator('[data-command-id="watches.cursor-down"]')).toBeVisible();
+    await expect(help.locator('[data-command-id="watches.tab.script"]')).toBeVisible();
+    await page.keyboard.press('Escape');
+
+    const secondId = await rows.nth(1).getAttribute('data-watch-id');
+    await page.keyboard.press('j');
+    await expect(rows.nth(1)).toHaveAttribute('data-selected', 'true');
+    await expect(rows.nth(1)).toBeFocused();
+    await expect(page).toHaveURL(new RegExp(`/watches/${secondId}$`));
+
+    await page.keyboard.press('2');
+    await expect(page.getByTestId('watch-tab-script')).toHaveAttribute('aria-selected', 'true');
+    await page.keyboard.press('3');
+    await expect(page.getByTestId('watch-tab-config')).toHaveAttribute('aria-selected', 'true');
+
+    await page.keyboard.press('n');
+    await expect(page.getByTestId('watch-form')).toBeVisible();
+    await expect(page.getByTestId('watch-name')).toBeFocused();
+  });
+
   test('shows the builtin script source under the Script tab', async ({ page, weaver }) => {
     await weaver.seedWatch({ name: 'sourced' });
     await page.goto(`${weaver.baseUrl}/watches`);
@@ -118,6 +152,24 @@ test.describe('watch panel', () => {
     const stdout = page.getByTestId('watch-run-stdout').first();
     await expect(stdout).toBeVisible();
     await expect(stdout).toContainText(/noop|surveyed 0/i);
+  });
+
+  test('keeps routine history behind a signal-first digest', async ({ page, weaver }) => {
+    const watch = await weaver.seedWatch({ name: 'digest-me' });
+    for (let index = 0; index < 3; index += 1) {
+      const response = await page.request.post(`${weaver.baseUrl}/api/watches/${watch.id}/run`, {
+        data: { dry_run: true },
+      });
+      expect(response.ok()).toBe(true);
+    }
+
+    await page.goto(`${weaver.baseUrl}/watches/${watch.id}`);
+    await expect(page.getByTestId('watch-run-row')).toHaveCount(1);
+    await expect(page.getByTestId('watch-run-digest')).toContainText('2 routine rounds hidden');
+
+    await page.getByTestId('watch-runs-toggle').click();
+    await expect(page.getByTestId('watch-run-row')).toHaveCount(3);
+    await expect(page.getByTestId('watch-run-digest')).toContainText('showing full round history');
   });
 
   test('edits the prompt and capabilities under the Config tab', async ({ page, weaver }) => {


### PR DESCRIPTION
Make attention behave like an inbox signal: opening or returning to a session acknowledges its current loud marks, while new marks can raise attention again. The calm footer now distinguishes unread attention from persistent PR health.

Turn the fleet inspector into a Now-first pane with bounded task context. Extend the mailbox command grammar across Watches, Review, and ACP Shells; preserve route-backed keyboard focus; and collapse routine Watch history behind a signal-first digest.