### PR TITLE
feat(loom): support artifact-backed images

### DIFF
--- a/crates/loom/frontend/src/components/ArtifactsPanel.vue
+++ b/crates/loom/frontend/src/components/ArtifactsPanel.vue
@@ -14,6 +14,7 @@ import { getArtifacts, getArtifact, putArtifact, deleteArtifact } from '../api';
 import type { ArtifactMeta, ArtifactView } from '../types';
 import { confirmAction } from '../lib/confirmation';
 import { openSessionEvents, type SessionEventsHandle } from '../lib/sessionEvents';
+import { artifactImageUrl as rawArtifactImageUrl } from '../markdown';
 import ArtifactDocument from './ArtifactDocument.vue';
 import HtmlArtifactView from './HtmlArtifactView.vue';
 
@@ -91,9 +92,12 @@ const kind = computed(() => view.value?.meta.kind ?? 'markdown');
 const isMarkdown = computed(() => kind.value === 'markdown');
 const isHtml = computed(() => kind.value === 'html');
 const isImage = computed(() => kind.value === 'image');
+function isRenderableKind(value: string): boolean {
+  return value === 'markdown' || value === 'html' || value === 'image';
+}
 // Markdown, HTML, and images have a rendered Preview ⇄ Source toggle; every
 // other kind is shown as read-only source only.
-const isRenderable = computed(() => isMarkdown.value || isHtml.value || isImage.value);
+const isRenderable = computed(() => isRenderableKind(kind.value));
 // The pseudo-path drives the markdown image base. The artifact name carries no
 // extension, so stamp one on from the kind.
 const pseudoPath = computed(() => {
@@ -104,9 +108,8 @@ const pseudoPath = computed(() => {
 });
 const artifactImageUrl = computed(() => {
   if (!view.value || !isImage.value) return '';
-  const base = `/api/sessions/${encodeURIComponent(props.id)}/artifacts/${encodeURIComponent(selected.value)}/raw`;
   const rev = viewRev.value ?? view.value.meta.rev;
-  return `${base}?rev=${rev}`;
+  return rawArtifactImageUrl(props.id, selected.value, rev);
 });
 
 type ViewMode = 'preview' | 'source';
@@ -200,12 +203,7 @@ async function openArtifact(name: string, rev?: number, opts?: { keepMode?: bool
     };
     draftContent.value = nextView.content;
     if (!opts?.keepMode) {
-      viewMode.value =
-        nextView.meta.kind === 'markdown' ||
-        nextView.meta.kind === 'html' ||
-        nextView.meta.kind === 'image'
-          ? 'preview'
-          : 'source';
+      viewMode.value = isRenderableKind(nextView.meta.kind) ? 'preview' : 'source';
     }
   } catch (e) {
     if (epoch !== openEpoch) return;

--- a/crates/loom/frontend/src/components/ArtifactsPanel.vue
+++ b/crates/loom/frontend/src/components/ArtifactsPanel.vue
@@ -22,8 +22,8 @@ import HtmlArtifactView from './HtmlArtifactView.vue';
 // the right with a version picker and a preview/source edit toggle — saving an
 // edit appends a new revision (`author: user`). Markdown
 // renders through `ArtifactDocument` (GFM + mermaid + smartdoc chips + the inline
-// comment layer); an
-// `html` artifact renders as a live document in a sandboxed iframe.
+// comment layer); an `html` artifact renders as a live document in a sandboxed
+// iframe, and an `image` artifact renders through its raw stored-bytes endpoint.
 //
 // The host (SessionDetail) places this either as a full-width work-area tab or,
 // when popped out, in a resizable rail beside the live terminal — `compact`
@@ -90,9 +90,10 @@ let openingName = '';
 const kind = computed(() => view.value?.meta.kind ?? 'markdown');
 const isMarkdown = computed(() => kind.value === 'markdown');
 const isHtml = computed(() => kind.value === 'html');
-// Markdown and HTML both have a rendered Preview ⇄ Source toggle; every other
-// kind is shown as read-only source only.
-const isRenderable = computed(() => isMarkdown.value || isHtml.value);
+const isImage = computed(() => kind.value === 'image');
+// Markdown, HTML, and images have a rendered Preview ⇄ Source toggle; every
+// other kind is shown as read-only source only.
+const isRenderable = computed(() => isMarkdown.value || isHtml.value || isImage.value);
 // The pseudo-path drives the markdown image base. The artifact name carries no
 // extension, so stamp one on from the kind.
 const pseudoPath = computed(() => {
@@ -100,6 +101,12 @@ const pseudoPath = computed(() => {
   if (isMarkdown.value) return `${name}.md`;
   if (isHtml.value) return `${name}.html`;
   return name;
+});
+const artifactImageUrl = computed(() => {
+  if (!view.value || !isImage.value) return '';
+  const base = `/api/sessions/${encodeURIComponent(props.id)}/artifacts/${encodeURIComponent(selected.value)}/raw`;
+  const rev = viewRev.value ?? view.value.meta.rev;
+  return `${base}?rev=${rev}`;
 });
 
 type ViewMode = 'preview' | 'source';
@@ -194,7 +201,11 @@ async function openArtifact(name: string, rev?: number, opts?: { keepMode?: bool
     draftContent.value = nextView.content;
     if (!opts?.keepMode) {
       viewMode.value =
-        nextView.meta.kind === 'markdown' || nextView.meta.kind === 'html' ? 'preview' : 'source';
+        nextView.meta.kind === 'markdown' ||
+        nextView.meta.kind === 'html' ||
+        nextView.meta.kind === 'image'
+          ? 'preview'
+          : 'source';
     }
   } catch (e) {
     if (epoch !== openEpoch) return;
@@ -633,6 +644,18 @@ onUnmounted(() => {
             :content="view.content"
             class="h-full w-full"
           />
+
+          <div
+            v-if="view && isImage && viewMode === 'preview' && !editing"
+            class="flex h-full w-full items-center justify-center overflow-auto bg-surface p-4"
+          >
+            <img
+              :src="artifactImageUrl"
+              :alt="view.meta.title || view.meta.name"
+              class="max-h-full max-w-full object-contain"
+              data-testid="artifact-image"
+            />
+          </div>
 
           <div
             v-if="!view && !loading"

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -136,9 +136,16 @@ function nextOption(current: number, count: number, delta: -1 | 1): number {
   return (current + delta + count) % count;
 }
 
+const REPOSITORY_OPTION_PREFIX = 'launch-repository-option';
+const BRANCH_OPTION_PREFIX = 'launch-branch-option';
+
+function optionId(prefix: string, index: number): string {
+  return `${prefix}-${index}`;
+}
+
 function revealOption(prefix: string, index: number) {
   void nextTick(() => {
-    document.getElementById(`${prefix}-${index}`)?.scrollIntoView({ block: 'nearest' });
+    document.getElementById(optionId(prefix, index))?.scrollIntoView({ block: 'nearest' });
   });
 }
 
@@ -162,7 +169,7 @@ function onRepoKeydown(event: KeyboardEvent) {
     repoFocused.value = true;
     const delta = event.key === 'ArrowDown' ? 1 : -1;
     repoActiveOption.value = nextOption(repoActiveOption.value, count, delta);
-    revealOption('launch-repository-option', repoActiveOption.value);
+    revealOption(REPOSITORY_OPTION_PREFIX, repoActiveOption.value);
     return;
   }
   if (event.key !== 'Enter' || repoActiveOption.value < 0) return;
@@ -258,7 +265,7 @@ function onBranchKeydown(event: KeyboardEvent) {
     branchFocused.value = true;
     const delta = event.key === 'ArrowDown' ? 1 : -1;
     branchActiveOption.value = nextOption(branchActiveOption.value, count, delta);
-    revealOption('launch-branch-option', branchActiveOption.value);
+    revealOption(BRANCH_OPTION_PREFIX, branchActiveOption.value);
     return;
   }
   if (event.key === 'Enter' && branchActiveOption.value >= 0) {
@@ -709,7 +716,9 @@ onActivated(() => void refreshLaunchData());
               :aria-expanded="repoFocused && Boolean(repoMatches.length || cloneCandidate)"
               aria-controls="launch-repository-options"
               :aria-activedescendant="
-                repoActiveOption >= 0 ? `launch-repository-option-${repoActiveOption}` : undefined
+                repoActiveOption >= 0
+                  ? optionId(REPOSITORY_OPTION_PREFIX, repoActiveOption)
+                  : undefined
               "
               placeholder="owner/name or /home/you/code/project"
               autocomplete="off"
@@ -725,7 +734,7 @@ onActivated(() => void refreshLaunchData());
             >
               <li v-if="cloneCandidate">
                 <button
-                  id="launch-repository-option-0"
+                  :id="optionId(REPOSITORY_OPTION_PREFIX, 0)"
                   type="button"
                   role="option"
                   :aria-selected="repoActiveOption === 0"
@@ -746,7 +755,7 @@ onActivated(() => void refreshLaunchData());
               </li>
               <li v-for="(r, index) in repoMatches" :key="r.repo_root">
                 <button
-                  :id="`launch-repository-option-${index + (cloneCandidate ? 1 : 0)}`"
+                  :id="optionId(REPOSITORY_OPTION_PREFIX, index + (cloneCandidate ? 1 : 0))"
                   type="button"
                   role="option"
                   :aria-selected="repoActiveOption === index + (cloneCandidate ? 1 : 0)"
@@ -887,7 +896,9 @@ onActivated(() => void refreshLaunchData());
                 :aria-expanded="branchFocused && Boolean(branchMatches.length)"
                 aria-controls="launch-branch-options"
                 :aria-activedescendant="
-                  branchActiveOption >= 0 ? `launch-branch-option-${branchActiveOption}` : undefined
+                  branchActiveOption >= 0
+                    ? optionId(BRANCH_OPTION_PREFIX, branchActiveOption)
+                    : undefined
                 "
                 placeholder="feature/foo"
                 autocomplete="off"
@@ -904,7 +915,7 @@ onActivated(() => void refreshLaunchData());
               >
                 <li v-for="(b, index) in branchMatches" :key="b.name">
                   <button
-                    :id="`launch-branch-option-${index}`"
+                    :id="optionId(BRANCH_OPTION_PREFIX, index)"
                     type="button"
                     role="option"
                     :aria-selected="branchActiveOption === index"

--- a/crates/loom/frontend/src/markdown.ts
+++ b/crates/loom/frontend/src/markdown.ts
@@ -12,8 +12,9 @@ import type MarkdownIt from 'markdown-it';
 import type Token from 'markdown-it/lib/token.mjs';
 import type { IssueRefStatus } from './types';
 
-/** Where to resolve a relative `![](…)` image to: the session's raw-bytes
- *  endpoint, with the path resolved against the markdown file's directory. */
+/** Where to resolve image sources: relative paths use the session's raw
+ *  worktree endpoint; `artifact:<name>` uses the stored artifact's raw image
+ *  endpoint. */
 export interface RenderContext {
   /** Session id, for building `/api/sessions/{id}/raw?path=…` URLs. */
   sessionId: string;
@@ -55,10 +56,16 @@ export function resolvePath(dir: string, rel: string): string {
   return stack.join('/');
 }
 
-/** Map a markdown `src`/`href` to a viewable URL. Relative paths point at the
- *  raw-bytes endpoint so images in the worktree render inline; external links
- *  pass through unchanged. */
+/** Map a markdown image source to a viewable URL. `artifact:<name>` resolves
+ *  against loom's artifact store; other relative paths point at the worktree's
+ *  raw-bytes endpoint, while external links pass through unchanged. */
 export function resolveUrl(ctx: RenderContext, url: string): string {
+  if (url.startsWith('artifact:')) {
+    const name = url.slice('artifact:'.length);
+    if (name !== '.' && name !== '..' && /^[A-Za-z0-9._-]+$/.test(name)) {
+      return `/api/sessions/${encodeURIComponent(ctx.sessionId)}/artifacts/${encodeURIComponent(name)}/raw`;
+    }
+  }
   if (!url || isExternal(url)) return url;
   const dir = ctx.filePath.includes('/')
     ? ctx.filePath.slice(0, ctx.filePath.lastIndexOf('/'))
@@ -124,8 +131,8 @@ async function getMarkdownIt(): Promise<MarkdownIt> {
       }),
     });
 
-    // Relative image sources point at the worktree's raw-bytes endpoint so
-    // images committed alongside the doc render inline.
+    // Artifact-backed image sources point at loom's raw artifact endpoint;
+    // other relative sources point at the worktree's raw-bytes endpoint.
     const defaultImage =
       md.renderer.rules.image ??
       ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options));

--- a/crates/loom/frontend/src/markdown.ts
+++ b/crates/loom/frontend/src/markdown.ts
@@ -56,6 +56,12 @@ export function resolvePath(dir: string, rel: string): string {
   return stack.join('/');
 }
 
+/** Raw endpoint for an image artifact, optionally pinned to one revision. */
+export function artifactImageUrl(sessionId: string, name: string, rev?: number): string {
+  const base = `/api/sessions/${encodeURIComponent(sessionId)}/artifacts/${encodeURIComponent(name)}/raw`;
+  return rev == null ? base : `${base}?rev=${rev}`;
+}
+
 /** Map a markdown image source to a viewable URL. `artifact:<name>` resolves
  *  against loom's artifact store; other relative paths point at the worktree's
  *  raw-bytes endpoint, while external links pass through unchanged. */
@@ -63,7 +69,7 @@ export function resolveUrl(ctx: RenderContext, url: string): string {
   if (url.startsWith('artifact:')) {
     const name = url.slice('artifact:'.length);
     if (name !== '.' && name !== '..' && /^[A-Za-z0-9._-]+$/.test(name)) {
-      return `/api/sessions/${encodeURIComponent(ctx.sessionId)}/artifacts/${encodeURIComponent(name)}/raw`;
+      return artifactImageUrl(ctx.sessionId, name);
     }
   }
   if (!url || isExternal(url)) return url;

--- a/crates/loom/src/web/artifacts.rs
+++ b/crates/loom/src/web/artifacts.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 
 use axum::{
     extract::{Path, Query, State},
-    http::header,
+    http::{header, HeaderValue},
+    response::{IntoResponse, Response},
     Json,
 };
+use base64::Engine as _;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use weaver_api::{
@@ -30,6 +32,54 @@ use super::{ApiResult, AppError, AppState};
 #[derive(Debug, Deserialize)]
 pub(super) struct RevQuery {
     rev: Option<i64>,
+}
+
+const MAX_ARTIFACT_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+
+/// Pull a standalone image data URI out of artifact content. New writes store
+/// the URI directly under the explicit `image` kind; the markdown case
+/// preserves artifacts written before that kind existed. Content detection
+/// also keeps historical revisions readable if an artifact's envelope kind
+/// changes later (kind is current metadata, not versioned metadata).
+fn artifact_image_uri(content: &str) -> Option<&str> {
+    let content = content.trim();
+    if content.starts_with("data:image/") {
+        return Some(content);
+    }
+    if !content.starts_with("![") || !content.ends_with(')') {
+        return None;
+    }
+    let start = content.rfind("](data:image/")? + 2;
+    Some(&content[start..content.len() - 1])
+}
+
+/// Decode the bounded image data-URI formats accepted by `weaver artifact
+/// write`. The MIME whitelist prevents a caller from using an artifact as an
+/// arbitrary same-origin response.
+fn decode_artifact_image(content: &str) -> Option<(&'static str, Vec<u8>)> {
+    let uri = artifact_image_uri(content)?;
+    let (metadata, payload) = uri.strip_prefix("data:")?.split_once(',')?;
+    let mime = metadata.strip_suffix(";base64")?;
+    let mime = match mime {
+        "image/png" => "image/png",
+        "image/jpeg" => "image/jpeg",
+        "image/gif" => "image/gif",
+        "image/webp" => "image/webp",
+        "image/svg+xml" => "image/svg+xml",
+        "image/avif" => "image/avif",
+        "image/bmp" => "image/bmp",
+        "image/x-icon" => "image/x-icon",
+        _ => return None,
+    };
+    // Refuse an oversized encoded payload before allocating its decoded form.
+    let max_encoded = MAX_ARTIFACT_IMAGE_BYTES.div_ceil(3) * 4;
+    if payload.len() > max_encoded {
+        return None;
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(payload)
+        .ok()?;
+    (bytes.len() <= MAX_ARTIFACT_IMAGE_BYTES).then_some((mime, bytes))
 }
 
 /// The wire metadata for an artifact envelope.
@@ -148,6 +198,42 @@ pub(super) async fn get_artifact(
     Ok(Json(
         artifact_view(&st.db, &branch.repo_root, &a, q.rev).await?,
     ))
+}
+
+/// Raw bytes for a standalone image artifact. Markdown documents can use
+/// `![alt](artifact:<name>)`; the renderer maps that source to this route, so
+/// the browser depends only on loom's artifact store (never an agent-local
+/// path). `?rev=N` pins an older image revision; omitted means latest.
+pub(super) async fn raw_artifact_image(
+    State(st): State<AppState>,
+    Path((key, name)): Path<(String, String)>,
+    Query(q): Query<RevQuery>,
+) -> ApiResult<Response> {
+    let (_, branch) = require_session(&st.db, &key).await?;
+    let a = artifact::get(&st.db, &branch.repo_root, &branch.id, &name)
+        .await?
+        .ok_or_else(|| AppError::not_found("artifact"))?;
+    let version = match q.rev {
+        Some(rev) => artifact::version(&st.db, a.id, rev).await?,
+        None => artifact::latest_version(&st.db, a.id).await?,
+    }
+    .ok_or_else(|| AppError::not_found("artifact revision"))?;
+    let (mime, bytes) = decode_artifact_image(&version.content)
+        .ok_or_else(|| AppError::bad_request("artifact is not a valid image"))?;
+
+    let mut response = bytes.into_response();
+    response
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(mime));
+    response.headers_mut().insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_static("inline"),
+    );
+    response.headers_mut().insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    Ok(response)
 }
 
 /// Write a new revision of an artifact (a user edit, `author: user`), returning
@@ -436,6 +522,30 @@ mod tests {
             acp: crate::acp::AcpRegistry::new(),
             launch_gate: crate::launch_gate::RepoLaunchGate::default(),
         }
+    }
+
+    #[test]
+    fn decodes_typed_and_legacy_image_artifacts() {
+        let png = "data:image/png;base64,aGVsbG8=";
+        let (mime, bytes) = decode_artifact_image(png).expect("typed image");
+        assert_eq!(mime, "image/png");
+        assert_eq!(bytes, b"hello");
+
+        let legacy = format!("![Screenshot]({png})\n");
+        let (mime, bytes) = decode_artifact_image(&legacy).expect("legacy image wrapper");
+        assert_eq!(mime, "image/png");
+        assert_eq!(bytes, b"hello");
+    }
+
+    #[test]
+    fn rejects_non_image_and_non_standalone_artifacts() {
+        assert!(decode_artifact_image("# Notes\n\nNot an image.").is_none());
+        assert!(
+            decode_artifact_image("Before\n\n![Screenshot](data:image/png;base64,aGVsbG8=)")
+                .is_none()
+        );
+        assert!(decode_artifact_image("data:text/html;base64,aGVsbG8=").is_none());
+        assert!(decode_artifact_image("data:image/png;base64,not!base64").is_none());
     }
 
     #[tokio::test]

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -823,6 +823,10 @@ pub fn router(state: AppState) -> Router {
                 .delete(delete_artifact),
         )
         .route(
+            "/sessions/{id}/artifacts/{name}/raw",
+            get(raw_artifact_image),
+        )
+        .route(
             "/sessions/{id}/artifacts/{name}/threads",
             get(list_threads).post(create_thread),
         )

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -35,6 +35,7 @@ weaver replays it for you automatically.
   to hand them. Reads stdin with `-`; `--repo` shares it repo-wide; an image
   path can be passed directly — the CLI snapshots and embeds its bytes, so do
   not hand-roll base64 and the dashboard never depends on that local path.
+  Markdown can reuse it as `![Result](artifact:<image-name>)`.
   `weaver artifact ls` / `show <name> [--rev N]` / `rm <name>` round it out.
 - `weaver tag set|rm|ls` — free-form quiet tags on the branch; `weaver log` —
   the event trail; `weaver readme` — this guide, back on demand.

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -222,10 +222,10 @@ enum ArtifactCmd {
     /// `<file>`, or stdin when `<file>` is `-` or omitted.
     ///
     /// An image file (`.png`, `.jpg`, `.gif`, `.webp`, `.svg`, …; raster formats
-    /// are also recognised from stdin by their magic bytes) is embedded as a
-    /// base64 data-URI in a markdown wrapper, so it renders inline in loom — no
-    /// need to hand-roll the data URI. A `.html`/`.htm` file is stored as the
-    /// `html` kind, which loom renders in a sandboxed iframe.
+    /// are also recognised from stdin by their magic bytes) is stored as an
+    /// `image` artifact backed by a base64 data URI, so it renders inline in
+    /// loom — no need to hand-roll the data URI. A `.html`/`.htm` file is stored
+    /// as the `html` kind, which loom renders in a sandboxed iframe.
     Write {
         /// The artifact name (its identity within the scope), e.g. `plan`.
         name: String,
@@ -236,8 +236,8 @@ enum ArtifactCmd {
         title: String,
         /// The content kind: `markdown` (the default; GFM + mermaid) or `html`
         /// (rendered in a sandboxed iframe). A `.html`/`.htm` file picks `html`
-        /// on its own. Ignored for image files, which are always wrapped as
-        /// markdown; any other value is stored verbatim and shown as source.
+        /// on its own. Ignored for image files, which use the `image` kind; any
+        /// other value is stored verbatim and shown as source.
         #[arg(long, default_value = "markdown")]
         kind: String,
         /// Publish repo-shared (visible to every branch) instead of scoping it
@@ -498,10 +498,9 @@ fn image_mime_from_magic(bytes: &[u8]) -> Option<&'static str> {
 }
 
 /// If `bytes` is a recognised image (by `filename` extension, else raster magic
-/// bytes), wrap it as a markdown document embedding it as a base64 data URI, so
-/// it renders inline in loom with no binary storage. `None` means "not an image
-/// — treat as text". `alt` is the image's alt text (the artifact title or name).
-fn embed_image_markdown(alt: &str, filename: Option<&str>, bytes: &[u8]) -> Result<Option<String>> {
+/// bytes), encode it as a data URI for an `image` artifact. `None` means "not an
+/// image — treat as text".
+fn encode_image_data_uri(filename: Option<&str>, bytes: &[u8]) -> Result<Option<String>> {
     use base64::Engine;
     let mime = filename
         .and_then(image_mime_from_ext)
@@ -515,8 +514,7 @@ fn embed_image_markdown(alt: &str, filename: Option<&str>, bytes: &[u8]) -> Resu
         );
     }
     let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
-    let alt = if alt.is_empty() { "image" } else { alt };
-    Ok(Some(format!("![{alt}](data:{mime};base64,{b64})\n")))
+    Ok(Some(format!("data:{mime};base64,{b64}")))
 }
 
 /// How many outstanding tasks `weaver summary` lists before collapsing the rest.
@@ -1372,19 +1370,14 @@ async fn cmd_artifact(cmd: ArtifactCmd) -> Result<()> {
             repo,
         } => {
             let raw = read_bytes_or_stdin(file.as_deref())?;
-            let alt = if title.trim().is_empty() {
-                name.trim()
-            } else {
-                title.trim()
-            };
-            // An image is auto-wrapped as a base64 data-URI markdown doc (kind
-            // forced to markdown so loom renders it inline); everything else is
-            // stored as text under the requested kind. A `.html`/`.htm` file
-            // promotes the default `markdown` to `html` (loom sandboxes it in an
-            // iframe); an explicit `--kind` always wins.
+            // An image becomes an `image` artifact backed by a base64 data URI;
+            // everything else is stored as text under the requested kind. A
+            // `.html`/`.htm` file promotes the default `markdown` to `html`
+            // (loom sandboxes it in an iframe); an explicit `--kind` always
+            // wins.
             let (kind, content): (String, String) =
-                match embed_image_markdown(alt, file.as_deref(), &raw)? {
-                    Some(md) => ("markdown".to_string(), md),
+                match encode_image_data_uri(file.as_deref(), &raw)? {
+                    Some(uri) => ("image".to_string(), uri),
                     None => {
                         let text = String::from_utf8(raw).map_err(|_| {
                             anyhow!(
@@ -1860,33 +1853,32 @@ mod tests {
     }
 
     #[test]
-    fn embed_wraps_an_image_and_passes_text_through() {
-        // A PNG by extension → a markdown image with a base64 data URI + alt text.
+    fn image_encoding_produces_a_data_uri_and_passes_text_through() {
+        // A PNG by extension → a base64 data URI.
         let png = b"\x89PNG\r\n\x1a\nzzzz";
-        let md = embed_image_markdown("My shot", Some("shot.png"), png)
+        let uri = encode_image_data_uri(Some("shot.png"), png)
             .unwrap()
             .expect("png embeds");
-        assert!(md.starts_with("![My shot](data:image/png;base64,"));
-        assert!(md.trim_end().ends_with(')'));
+        assert!(uri.starts_with("data:image/png;base64,"));
 
-        // Extension-less stdin still embeds via magic bytes; empty alt → "image".
-        let md = embed_image_markdown("", None, png)
+        // Extension-less stdin still embeds via magic bytes.
+        let uri = encode_image_data_uri(None, png)
             .unwrap()
             .expect("magic embeds");
-        assert!(md.starts_with("![image](data:image/png;base64,"));
+        assert!(uri.starts_with("data:image/png;base64,"));
 
         // SVG (text) embeds by extension so it renders as an image, not source.
         let svg = b"<svg xmlns='http://www.w3.org/2000/svg'></svg>";
-        let md = embed_image_markdown("d", Some("d.svg"), svg)
+        let uri = encode_image_data_uri(Some("d.svg"), svg)
             .unwrap()
             .expect("svg embeds");
-        assert!(md.starts_with("![d](data:image/svg+xml;base64,"));
+        assert!(uri.starts_with("data:image/svg+xml;base64,"));
 
         // Non-image content is left for the text path.
-        assert!(embed_image_markdown("notes", Some("notes.md"), b"# Hi")
+        assert!(encode_image_data_uri(Some("notes.md"), b"# Hi")
             .unwrap()
             .is_none());
-        assert!(embed_image_markdown("notes", None, b"plain text")
+        assert!(encode_image_data_uri(None, b"plain text")
             .unwrap()
             .is_none());
     }
@@ -1895,6 +1887,6 @@ mod tests {
     fn embed_rejects_an_oversized_image() {
         let mut big = b"\x89PNG\r\n\x1a\n".to_vec();
         big.resize(MAX_IMAGE_BYTES + 1, 0);
-        assert!(embed_image_markdown("x", Some("x.png"), &big).is_err());
+        assert!(encode_image_data_uri(Some("x.png"), &big).is_err());
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -306,6 +306,7 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/sessions/{id}/shells`; `DELETE /api/sessions/{id}/shell/{idx}`; `GET /api/sessions/{id}/shell/{idx}/terminal` | list, close, or open per-session debug shells through WebSocket |
 | `GET /api/sessions/{id}/artifacts` | list the branch's [artifacts](artifacts.md) plus repo-shared ones |
 | `GET PUT /api/sessions/{id}/artifacts/{name}` | read content + projected refs (`rev=N` for a revision) / write a user edit as a new revision |
+| `GET /api/sessions/{id}/artifacts/{name}/raw` | serve a stored image artifact's bytes for Markdown embedding (`rev=N` optionally pins a revision) |
 | `GET /api/sessions/{id}/changes` | bounded typed worktree change set relative to the session base: file status/totals plus hunk lines with stable old/new line coordinates; backs the SPA and `loom session changes` |
 | `GET POST /api/sessions/{id}/reviews` | list submitted reviews plus the caller's private draft / create or recover a draft for an exact artifact revision or Changes version |
 | `GET PATCH /api/reviews/{id}` | inspect a review by stable ID (including history after artifact deletion) / persist a draft's overall summary or guarded target version |

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -22,23 +22,26 @@ instead of overwriting a revision. Removing an artifact removes all of its
 revisions; individual revisions are not pruned.
 
 Markdown is the primary format. The renderer supports GFM and Mermaid and
-projects two live reference forms:
+projects these live reference forms:
 
 - `#41` resolves an issue and renders its current ledger status.
 - `artifact:design` links another artifact.
+- `![Run output](artifact:screenshot)` embeds an image artifact in Markdown.
 
 References inside code spans or blocks remain literal. Smartdoc projection is a
 read-time join: the document references issues, while the issue ledger owns task
-state. A plan is simply an artifact convention; there is no plan parser or sync
-engine.
+state. An embedded image resolves the latest artifact visible to that session,
+using the same branch-scoped-before-repo-shared lookup as an artifact read. A
+plan is simply an artifact convention; there is no plan parser or sync engine.
 
 Pass a local image path directly to `weaver artifact write` (for example,
 `weaver artifact write screenshot /tmp/result.png`). The CLI reads and snapshots
-the image immediately, wrapping it as a bounded data-URI Markdown document, so
-the stored artifact does not depend on that filesystem path and remains
-available when the dashboard or execution is remote. Local paths embedded
-inside arbitrary Markdown are deliberately not a storage contract; write the
-image itself rather than hand-building base64.
+the image immediately into a bounded `image` artifact, so the stored artifact
+does not depend on that filesystem path and remains available when the dashboard
+or execution is remote. Another Markdown artifact can embed it with
+`![Result](artifact:screenshot)`. Local paths embedded inside arbitrary Markdown
+are deliberately not a storage contract; write the image itself rather than
+hand-building base64.
 
 ### The goal artifact
 

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -154,7 +154,7 @@ export interface WeaverFixture {
    *  appends an immutable revision after. Content is piped on stdin; `--repo`
    *  publishes it repo-shared instead of scoping it to the branch. A `Buffer`
    *  exercises the binary path — an image is sniffed from its magic bytes and
-   *  embedded as a base64 data-URI markdown doc. */
+   *  stored as an `image` artifact backed by a base64 data URI. */
   writeArtifact(
     session: Session,
     name: string,

--- a/e2e/tests/artifacts.spec.ts
+++ b/e2e/tests/artifacts.spec.ts
@@ -319,7 +319,7 @@ test.describe('artifacts surface', () => {
     await expect(page.locator('[data-term-tab="agent"]')).toBeVisible();
   });
 
-  test('an image file is embedded as a base64 data-URI and renders inline', async ({
+  test('an image artifact renders directly and embeds into another artifact', async ({
     page,
     weaver,
   }) => {
@@ -327,19 +327,49 @@ test.describe('artifacts surface', () => {
       goal: 'shots',
       name: 'artifacts-image',
     });
-    // A 1×1 transparent PNG, piped as raw bytes (no extension): the CLI sniffs
-    // it from its magic bytes and wraps it as a base64 data-URI markdown doc.
+    // A 1×1 transparent PNG, piped as raw bytes (no source extension): the CLI
+    // sniffs it from its magic bytes and stores a self-contained image artifact.
     const png = Buffer.from(
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
       'base64',
     );
-    await weaver.writeArtifact(session, 'shot', png, { title: 'Screenshot' });
+    await weaver.writeArtifact(session, 'A.png', png, { title: 'Screenshot' });
+    await weaver.writeArtifact(
+      session,
+      'B.md',
+      '# Results\n\n![Linked screenshot](artifact:A.png)\n',
+      { title: 'Results' },
+    );
 
-    await page.goto(`${weaver.baseUrl}/s/${session.id}/artifacts/shot`);
+    await page.goto(`${weaver.baseUrl}/s/${session.id}/artifacts/A.png`);
 
-    // Preview renders the embedded image inline (alt = the title), src a data URI.
-    const img = page.locator('.markdown-body img');
-    await expect(img).toHaveAttribute('src', /^data:image\/png;base64,/);
-    await expect(img).toHaveAttribute('alt', 'Screenshot');
+    // Standalone image artifacts use the authenticated raw-bytes route.
+    const standalone = page.getByTestId('artifact-image');
+    await expect(standalone).toHaveAttribute(
+      'src',
+      new RegExp(`/api/sessions/${session.id}/artifacts/A\\.png/raw\\?rev=1$`),
+    );
+    await expect(standalone).toHaveAttribute('alt', 'Screenshot');
+    await expect
+      .poll(() => standalone.evaluate((img: HTMLImageElement) => img.naturalWidth))
+      .toBe(1);
+
+    const raw = await page.request.get(
+      `${weaver.baseUrl}/api/sessions/${session.id}/artifacts/A.png/raw`,
+    );
+    expect(raw.ok()).toBe(true);
+    expect(raw.headers()['content-type']).toBe('image/png');
+    expect(await raw.body()).toEqual(png);
+
+    // Markdown can reuse the stored image by artifact name. The reference is
+    // resolved at read time, so no base64 or agent-local path is copied into B.
+    await page.goto(`${weaver.baseUrl}/s/${session.id}/artifacts/B.md`);
+    const linked = page.locator('.markdown-body img');
+    await expect(linked).toHaveAttribute(
+      'src',
+      new RegExp(`/api/sessions/${session.id}/artifacts/A\\.png/raw$`),
+    );
+    await expect(linked).toHaveAttribute('alt', 'Linked screenshot');
+    await expect.poll(() => linked.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBe(1);
   });
 });


### PR DESCRIPTION
Store CLI image uploads as explicit, bounded image artifacts and serve them through an authenticated raw-bytes endpoint. Markdown artifacts can reuse those stored images with `![Result](artifact:A.png)`, so remote dashboards never depend on agent-local paths or duplicate base64 across documents.

Render standalone image artifacts directly and retain compatibility with existing Markdown-wrapped image artifacts. Centralize the raw-artifact URL, renderable-kind predicate, and repository/branch option IDs identified during lint review.

Session: https://loom.rjp.io/s/t3hxl9mv