### PR TITLE
fix(loom): stop long ACP sessions degrading the whole database

### DIFF
--- a/crates/loom/migrations/0015_chat_block_ref_id.sql
+++ b/crates/loom/migrations/0015_chat_block_ref_id.sql
@@ -1,0 +1,23 @@
+-- Promote the upstream id a chat block is addressed by out of its opaque JSON
+-- payload and into an indexed column: `tool_call_id` for a `tool_call`,
+-- `request_id` for a `permission_request`, empty for every other kind.
+--
+-- These ids answer the replay-idempotency questions ("is this tool call already
+-- journaled", "was this permission already resolved"). Reading them out of the
+-- payload meant loading and parsing every block of that kind for the session on
+-- each question — quadratic in the length of a long-running session's journal.
+
+ALTER TABLE chat_blocks ADD COLUMN ref_id TEXT NOT NULL DEFAULT '';
+
+UPDATE chat_blocks
+   SET ref_id = COALESCE(
+           json_extract(payload, '$.tool_call_id'),
+           json_extract(payload, '$.request_id'),
+           ''
+       )
+ WHERE kind IN ('tool_call', 'permission_request');
+
+-- `kind` ahead of `ref_id` keeps the two id namespaces apart and leaves a
+-- `(session_id, kind)` prefix for the kind-scoped scans (open permissions).
+CREATE INDEX IF NOT EXISTS idx_chat_blocks_ref
+    ON chat_blocks(session_id, kind, ref_id);

--- a/crates/loom/src/acp/mod.rs
+++ b/crates/loom/src/acp/mod.rs
@@ -50,7 +50,7 @@ mod wire;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use rand::RngCore;
@@ -74,6 +74,11 @@ use wire::{
 /// into thousands of SQLite writes. A short periodic flush keeps the possible
 /// duplicate replay bounded while allowing catch-up to run at spool speed.
 const ACK_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
+
+/// How often a live ACP session restamps `last_activity_at`. Frames arrive far
+/// faster than idleness is measured, so the stamp is throttled to keep a chatty
+/// adapter from turning every delta into a write.
+const ACTIVITY_TOUCH_INTERVAL: Duration = Duration::from_secs(30);
 
 // ---------------------------------------------------------------------------
 // Public surface
@@ -1391,6 +1396,8 @@ struct Task {
     /// Latched when a journal write fails: the ack watermark freezes (so the
     /// un-journaled frames replay after a restart) and the failure is logged.
     journal_failed: bool,
+    /// When this task last stamped `last_activity_at`. See [`Task::touch_activity`].
+    last_activity_touch: Option<Instant>,
 }
 
 impl Task {
@@ -1455,6 +1462,7 @@ impl Task {
             highest_seq: 0,
             acked: 0,
             journal_failed: false,
+            last_activity_touch: None,
         })
     }
 
@@ -1543,6 +1551,7 @@ impl Task {
             highest_seq: session.acp_ack_seq.max(0) as u64,
             acked: session.acp_ack_seq.max(0) as u64,
             journal_failed: false,
+            last_activity_touch: None,
         })
     }
 
@@ -1930,6 +1939,7 @@ impl Task {
                 ev = self.stream.recv() => match ev {
                     Some(RelayEvent::Frame { seq, payload }) => {
                         self.highest_seq = seq;
+                        self.touch_activity().await;
                         match serde_json::from_slice::<Incoming>(&payload) {
                             Ok(inc) => self.dispatch_frame(seq, inc).await,
                             Err(e) => tracing::warn!(session = %self.session_id, error = %e, "unparseable acp frame"),
@@ -1998,6 +2008,35 @@ impl Task {
     }
 
     /// Route one inbound frame (notification / agent request / response).
+    /// Record that the adapter is producing output.
+    ///
+    /// `last_activity_at` is what the staleness monitor and the metadata
+    /// assistant read. Turn boundaries alone are far too coarse a signal for an
+    /// ACP session: a single turn runs for hours, so a session streaming tool
+    /// calls the whole time would otherwise be indistinguishable from one that
+    /// stopped at the prompt. A turn that genuinely wedges still goes stale —
+    /// this stamps output, not liveness.
+    ///
+    /// A `session/load` replay is deliberately excluded: re-streamed history is
+    /// not new activity, and stamping it would date a recovered session to its
+    /// restart.
+    async fn touch_activity(&mut self) {
+        if self.suppress_journal {
+            return;
+        }
+        let now = Instant::now();
+        if self
+            .last_activity_touch
+            .is_some_and(|last| now.duration_since(last) < ACTIVITY_TOUCH_INTERVAL)
+        {
+            return;
+        }
+        self.last_activity_touch = Some(now);
+        if let Err(e) = session::touch(&self.db, &self.session_id).await {
+            tracing::warn!(session = %self.session_id, error = %e, "could not stamp session activity");
+        }
+    }
+
     async fn dispatch_frame(&mut self, seq: u64, inc: Incoming) {
         match inc.kind() {
             IncomingKind::Notification => {

--- a/crates/loom/src/chat.rs
+++ b/crates/loom/src/chat.rs
@@ -325,6 +325,20 @@ pub struct ChatBlockView {
     pub created_at: String,
 }
 
+/// The upstream id a block of `kind` is addressed by, mirrored into the indexed
+/// `ref_id` column at insert time. Replay idempotency asks about a block by this
+/// id rather than by `(turn, seq)`: a tool call's position is not stable across a
+/// restart but its adapter-assigned id is, and a permission is answered by
+/// request id. Every other kind has no such id and stores `''`.
+fn ref_id<'a>(kind: &str, payload: &'a Value) -> &'a str {
+    let key = match kind {
+        self::kind::TOOL_CALL => "tool_call_id",
+        self::kind::PERMISSION_REQUEST => "request_id",
+        _ => return "",
+    };
+    payload.get(key).and_then(Value::as_str).unwrap_or_default()
+}
+
 /// Insert a block idempotently. Returns `true` when the row was newly written,
 /// `false` when `(session_id, turn, seq)` already existed (a replay). `payload`
 /// is serialized to a JSON string for storage.
@@ -337,8 +351,8 @@ pub async fn insert(
     payload: &Value,
 ) -> Result<bool> {
     let res = sqlx::query(
-        "INSERT INTO chat_blocks (session_id, turn, seq, kind, payload, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)
+        "INSERT INTO chat_blocks (session_id, turn, seq, kind, payload, ref_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT DO NOTHING",
     )
     .bind(session_id)
@@ -346,6 +360,7 @@ pub async fn insert(
     .bind(seq)
     .bind(kind)
     .bind(payload.to_string())
+    .bind(ref_id(kind, payload))
     .bind(now_iso())
     .execute(db)
     .await?;
@@ -353,6 +368,11 @@ pub async fn insert(
 }
 
 /// Every block for a session, in `(turn, seq)` order.
+///
+/// This reads a whole journal into memory, which for a long-running session is
+/// tens of megabytes. It is for the one-shot whole-conversation consumers —
+/// archive capture and handoff. Anything serving a request wants
+/// [`list_page`], whose cost is set by the page rather than by the session's age.
 pub async fn list(db: &Db, session_id: &str) -> Result<Vec<ChatBlockView>> {
     let rows = sqlx::query_as::<_, ChatBlockRow>(
         "SELECT turn, seq, kind, payload, created_at FROM chat_blocks
@@ -435,6 +455,22 @@ impl From<ChatBlockRow> for ChatBlockView {
     }
 }
 
+/// Whether `(turn, seq)` names a journaled block. Lets a paged reader tell a
+/// cursor this session never issued from one that has simply run off the end.
+pub async fn block_exists(db: &Db, session_id: &str, turn: i64, seq: i64) -> Result<bool> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+             SELECT 1 FROM chat_blocks WHERE session_id = ? AND turn = ? AND seq = ?
+         )",
+    )
+    .bind(session_id)
+    .bind(turn)
+    .bind(seq)
+    .fetch_one(db)
+    .await?;
+    Ok(exists)
+}
+
 /// The highest `(turn, seq)` present for a session, or `None` when the journal is
 /// empty. Used on task (re)start to resume the block cursor without double-writing.
 pub async fn max_turn_seq(db: &Db, session_id: &str) -> Result<Option<(i64, i64)>> {
@@ -491,28 +527,39 @@ pub async fn permission_outcome(
     session_id: &str,
     request_id: &str,
 ) -> Result<PermissionOutcome> {
-    let rows = sqlx::query("SELECT payload FROM chat_blocks WHERE session_id = ? AND kind = ?")
-        .bind(session_id)
-        .bind(kind::PERMISSION_REQUEST)
-        .fetch_all(db)
-        .await?;
-    for r in rows {
-        let payload: Value =
-            serde_json::from_str(&r.get::<String, _>("payload")).unwrap_or(Value::Null);
-        if payload.get("request_id").and_then(Value::as_str) == Some(request_id) {
-            return Ok(match payload.get("outcome") {
-                Some(Value::Null) | None => PermissionOutcome::Open,
-                Some(o) if o.get("cancelled").and_then(Value::as_bool) == Some(true) => {
-                    PermissionOutcome::Cancelled
-                }
-                Some(o) => match o.get("option_id").and_then(Value::as_str) {
-                    Some(id) => PermissionOutcome::Resolved(id.to_string()),
-                    None => PermissionOutcome::Open,
-                },
-            });
+    let Some(block) = permission_block(db, session_id, request_id).await? else {
+        return Ok(PermissionOutcome::Unknown);
+    };
+    Ok(match block.payload.get("outcome") {
+        Some(Value::Null) | None => PermissionOutcome::Open,
+        Some(o) if o.get("cancelled").and_then(Value::as_bool) == Some(true) => {
+            PermissionOutcome::Cancelled
         }
-    }
-    Ok(PermissionOutcome::Unknown)
+        Some(o) => match o.get("option_id").and_then(Value::as_str) {
+            Some(id) => PermissionOutcome::Resolved(id.to_string()),
+            None => PermissionOutcome::Open,
+        },
+    })
+}
+
+/// The journaled `permission_request` block carrying `request_id`, found through
+/// the indexed `ref_id` rather than by reading every permission block's payload.
+async fn permission_block(
+    db: &Db,
+    session_id: &str,
+    request_id: &str,
+) -> Result<Option<ChatBlockView>> {
+    let row = sqlx::query_as::<_, ChatBlockRow>(
+        "SELECT turn, seq, kind, payload, created_at FROM chat_blocks
+         WHERE session_id = ? AND kind = ? AND ref_id = ?
+         ORDER BY turn ASC, seq ASC LIMIT 1",
+    )
+    .bind(session_id)
+    .bind(kind::PERMISSION_REQUEST)
+    .bind(request_id)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.map(ChatBlockView::from))
 }
 
 /// Resolve an open `permission_request` in place: set its `outcome` to the chosen
@@ -559,43 +606,30 @@ async fn set_permission_outcome(
     request_id: &str,
     outcome: Value,
 ) -> Result<Option<ChatBlockView>> {
-    let rows = sqlx::query_as::<_, ChatBlockRow>(
-        "SELECT turn, seq, kind, payload, created_at FROM chat_blocks
-         WHERE session_id = ? AND kind = ?",
-    )
-    .bind(session_id)
-    .bind(kind::PERMISSION_REQUEST)
-    .fetch_all(db)
-    .await?;
-    for row in rows {
-        let mut view = ChatBlockView::from(row);
-        if view.payload.get("request_id").and_then(Value::as_str) != Some(request_id) {
-            continue;
-        }
-        // Only an open block is resolvable; a resolved one is left untouched.
-        if !view
-            .payload
-            .get("outcome")
-            .map(Value::is_null)
-            .unwrap_or(true)
-        {
-            return Ok(None);
-        }
-        if let Value::Object(map) = &mut view.payload {
-            map.insert("outcome".to_string(), outcome);
-        }
-        sqlx::query(
-            "UPDATE chat_blocks SET payload = ? WHERE session_id = ? AND turn = ? AND seq = ?",
-        )
+    let Some(mut view) = permission_block(db, session_id, request_id).await? else {
+        return Ok(None);
+    };
+    // Only an open block is resolvable; a resolved one is left untouched.
+    if !view
+        .payload
+        .get("outcome")
+        .map(Value::is_null)
+        .unwrap_or(true)
+    {
+        return Ok(None);
+    }
+    if let Value::Object(map) = &mut view.payload {
+        map.insert("outcome".to_string(), outcome);
+    }
+    // `ref_id` is the request id and does not move with the outcome.
+    sqlx::query("UPDATE chat_blocks SET payload = ? WHERE session_id = ? AND turn = ? AND seq = ?")
         .bind(view.payload.to_string())
         .bind(session_id)
         .bind(view.turn)
         .bind(view.seq)
         .execute(db)
         .await?;
-        return Ok(Some(view));
-    }
-    Ok(None)
+    Ok(Some(view))
 }
 
 /// Whether a `tool_call` block for `tool_call_id` is already journaled — the
@@ -603,22 +637,18 @@ async fn set_permission_outcome(
 /// re-journaling the block at a fresh seq (tool calls have no `(turn, seq)`
 /// stability across a restart, but their upstream id is stable).
 pub async fn tool_call_exists(db: &Db, session_id: &str, tool_call_id: &str) -> Result<bool> {
-    let rows = sqlx::query("SELECT payload FROM chat_blocks WHERE session_id = ? AND kind = ?")
-        .bind(session_id)
-        .bind(kind::TOOL_CALL)
-        .fetch_all(db)
-        .await?;
-    Ok(rows.into_iter().any(|r| {
-        serde_json::from_str::<Value>(&r.get::<String, _>("payload"))
-            .ok()
-            .and_then(|p| {
-                p.get("tool_call_id")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            })
-            .as_deref()
-            == Some(tool_call_id)
-    }))
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+             SELECT 1 FROM chat_blocks
+              WHERE session_id = ? AND kind = ? AND ref_id = ?
+         )",
+    )
+    .bind(session_id)
+    .bind(kind::TOOL_CALL)
+    .bind(tool_call_id)
+    .fetch_one(db)
+    .await?;
+    Ok(exists)
 }
 
 /// Whether a `turn_end` block is already journaled for `turn` — the idempotency

--- a/crates/loom/src/db.rs
+++ b/crates/loom/src/db.rs
@@ -80,6 +80,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "metadata-assistance",
         include_str!("../migrations/0014_metadata_assistance.sql"),
     ),
+    (
+        15,
+        "chat-block-ref-id",
+        include_str!("../migrations/0015_chat_block_ref_id.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);

--- a/crates/loom/src/history.rs
+++ b/crates/loom/src/history.rs
@@ -91,26 +91,84 @@ pub async fn page(
         )));
     }
 
-    let (source, records) = load(db, session, branch).await?;
+    if session.protocol == "acp" {
+        return acp_page(db, session, &options, limit, &kinds, query.as_deref()).await;
+    }
+
+    let (source, records) = load_terminal(db, session, branch).await?;
     let end = match options.before.as_deref() {
         Some(before) => records
             .iter()
             .position(|record| record.cursor == before)
-            .ok_or_else(|| {
-                PageError::bad_request("before is not a cursor from this session history")
-            })?,
+            .ok_or_else(unknown_cursor)?,
         None => records.len(),
     };
-    let mut matching = records[..end]
+    let matching = records[..end]
         .iter()
-        .filter(|record| kinds.is_empty() || kinds.contains(record.kind.as_str()))
-        .filter(|record| {
-            query
-                .as_deref()
-                .is_none_or(|needle| searchable_text(record).to_lowercase().contains(needle))
-        })
+        .filter(|record| matches(record, &kinds, query.as_deref()))
         .cloned()
         .collect::<Vec<_>>();
+    Ok(tail_page(source, matching, limit))
+}
+
+/// The newest-tail page of an ACP session's journal.
+///
+/// The journal is read backwards a chunk at a time and stops as soon as the page
+/// is provably full, so an ordinary page costs one bounded query no matter how
+/// long the session has been running. Only a search that matches little has to
+/// walk the whole journal, and even then it holds one chunk at a time.
+async fn acp_page(
+    db: &Db,
+    session: &Session,
+    options: &PageOptions,
+    limit: usize,
+    kinds: &HashSet<&str>,
+    query: Option<&str>,
+) -> Result<HistoryPageView, PageError> {
+    let mut before = match options.before.as_deref() {
+        Some(cursor) => {
+            let (turn, seq) = parse_acp_cursor(cursor)?;
+            if !crate::chat::block_exists(db, &session.id, turn, seq).await? {
+                return Err(unknown_cursor());
+            }
+            Some((turn, seq))
+        }
+        None => None,
+    };
+    let chunk = limit.saturating_add(1).max(SCAN_CHUNK);
+    let mut matching: Vec<HistoryRecordView> = Vec::new();
+    loop {
+        let (blocks, has_older) = crate::chat::list_page(db, &session.id, before, chunk).await?;
+        let Some(oldest) = blocks.first() else { break };
+        before = Some((oldest.turn, oldest.seq));
+        let mut older: Vec<HistoryRecordView> = blocks
+            .iter()
+            .map(acp_record)
+            .filter(|record| matches(record, kinds, query))
+            .collect();
+        older.append(&mut matching);
+        matching = older;
+        // One record beyond the page is all it takes to know more remain.
+        if matching.len() > limit || !has_older {
+            break;
+        }
+    }
+    Ok(tail_page("acp".to_string(), matching, limit))
+}
+
+/// Blocks read per backwards step of [`acp_page`]. Large enough that an unfiltered
+/// page is a single query, small enough that a whole-journal search stays bounded
+/// in memory.
+const SCAN_CHUNK: usize = 512;
+
+/// Cut the newest `limit` records out of a chronological run of matching records,
+/// plus the cursor the caller pages further back with. `matching` holding more
+/// than `limit` is what proves older records remain.
+fn tail_page(
+    source: String,
+    mut matching: Vec<HistoryRecordView>,
+    limit: usize,
+) -> HistoryPageView {
     let has_more = matching.len() > limit;
     if has_more {
         matching.drain(..matching.len() - limit);
@@ -122,11 +180,32 @@ pub async fn page(
             .cursor
             .clone()
     });
-    Ok(HistoryPageView {
+    HistoryPageView {
         source,
         records: matching,
         older_cursor,
-    })
+    }
+}
+
+fn matches(record: &HistoryRecordView, kinds: &HashSet<&str>, query: Option<&str>) -> bool {
+    (kinds.is_empty() || kinds.contains(record.kind.as_str()))
+        && query.is_none_or(|needle| searchable_text(record).to_lowercase().contains(needle))
+}
+
+/// The `(turn, seq)` an `acp:<turn>:<seq>` cursor addresses. A cursor this
+/// session never issued is a bad request, not an empty page.
+fn parse_acp_cursor(cursor: &str) -> Result<(i64, i64), PageError> {
+    let (turn, seq) = cursor
+        .strip_prefix("acp:")
+        .and_then(|rest| rest.split_once(':'))
+        .ok_or_else(unknown_cursor)?;
+    let turn = turn.parse().map_err(|_| unknown_cursor())?;
+    let seq = seq.parse().map_err(|_| unknown_cursor())?;
+    Ok((turn, seq))
+}
+
+fn unknown_cursor() -> PageError {
+    PageError::bad_request("before is not a cursor from this session history")
 }
 
 fn validate_kinds(kinds: &[String]) -> Result<HashSet<&str>, PageError> {
@@ -147,18 +226,14 @@ fn validate_kinds(kinds: &[String]) -> Result<HashSet<&str>, PageError> {
     Ok(out)
 }
 
-async fn load(
+/// A terminal provider's transcript, normalized. Unlike the ACP journal this has
+/// no queryable form — it is a file the Iris normalizer reads whole — so paging
+/// happens after the load rather than inside it.
+async fn load_terminal(
     db: &Db,
     session: &Session,
     branch: &Branch,
 ) -> Result<(String, Vec<HistoryRecordView>), anyhow::Error> {
-    if session.protocol == "acp" {
-        let blocks = crate::chat::list(db, &session.id).await?;
-        return Ok((
-            "acp".to_string(),
-            blocks.iter().map(acp_record).collect::<Vec<_>>(),
-        ));
-    }
     Ok(
         match crate::chatlog::conversation(db, session, branch).await {
             Some(log) => {
@@ -349,6 +424,131 @@ mod tests {
     use super::*;
     use serde_json::json;
     use weaver_core::transcript::iris::{Message, Role};
+
+    /// An ACP session with `blocks` agent messages, the `n`th reading `m<n>`.
+    async fn seed_acp_session(db: &Db, blocks: usize) -> (Session, Branch) {
+        let branch = weaver_core::branch::upsert(db, "/repo", "weaver/history", "main")
+            .await
+            .unwrap();
+        crate::session::insert(
+            db,
+            &crate::session::NewSession {
+                id: "histsess".to_string(),
+                branch_id: branch.id.clone(),
+                work_dir: "/w".to_string(),
+                term_session: "weaver-histsess".to_string(),
+                agent_kind: "claude".to_string(),
+                model: String::new(),
+                effort: String::new(),
+                status: "running".to_string(),
+                github_repo: None,
+                parent_branch_id: None,
+                managed_by: None,
+                created_by: None,
+                protocol: "acp".to_string(),
+                origin: "user".to_string(),
+                class: "interactive".to_string(),
+                tracking_issue_id: None,
+            },
+        )
+        .await
+        .unwrap();
+        for seq in 0..blocks {
+            crate::chat::insert(
+                db,
+                "histsess",
+                0,
+                seq as i64,
+                kind::AGENT_MESSAGE,
+                &json!({ "text": format!("m{seq}") }),
+            )
+            .await
+            .unwrap();
+        }
+        let session = crate::session::get(db, "histsess").await.unwrap().unwrap();
+        (session, branch)
+    }
+
+    /// The journal is read backwards in bounded steps, so a page has to be
+    /// assembled correctly whether it falls inside the first step or beyond it.
+    #[tokio::test]
+    async fn acp_paging_walks_back_past_one_scan_step() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let total = SCAN_CHUNK + 40;
+        let (session, branch) = seed_acp_session(&db, total).await;
+
+        let newest = page(
+            &db,
+            &session,
+            &branch,
+            PageOptions {
+                limit: Some(2),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let content = |page: &HistoryPageView, at: usize| page.records[at].content.clone().unwrap();
+        assert_eq!(newest.records.len(), 2);
+        assert_eq!(content(&newest, 0), format!("m{}", total - 2));
+        assert_eq!(content(&newest, 1), format!("m{}", total - 1));
+        assert_eq!(
+            newest.older_cursor.as_deref(),
+            Some(format!("acp:0:{}", total - 2).as_str()),
+            "the oldest record of the page is where the next one resumes"
+        );
+
+        // The only hit sits older than the first backwards step: the scan has to
+        // keep going rather than report an empty page.
+        let found = page(
+            &db,
+            &session,
+            &branch,
+            PageOptions {
+                query: Some("m0".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(found.records.len(), 1);
+        assert_eq!(content(&found, 0), "m0");
+        assert!(found.older_cursor.is_none(), "nothing older matches");
+
+        let older = page(
+            &db,
+            &session,
+            &branch,
+            PageOptions {
+                before: newest.older_cursor.clone(),
+                limit: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(content(&older, 0), format!("m{}", total - 3));
+    }
+
+    #[tokio::test]
+    async fn acp_rejects_a_cursor_this_session_never_issued() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let (session, branch) = seed_acp_session(&db, 3).await;
+        for cursor in ["iris:0:0", "acp:nope", "acp:0:99"] {
+            let error = page(
+                &db,
+                &session,
+                &branch,
+                PageOptions {
+                    before: Some(cursor.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("an unknown cursor is a bad request");
+            assert!(matches!(error, PageError::BadRequest(_)), "{cursor}");
+        }
+    }
 
     #[test]
     fn iris_tool_input_is_optional_but_preserved_when_present() {

--- a/crates/loom/src/monitor.rs
+++ b/crates/loom/src/monitor.rs
@@ -165,8 +165,9 @@ pub async fn run(state: AppState) {
                 continue;
             }
 
-            // An ACP (relay) session has no vt100 screen to hash — its activity is
-            // the turn boundary, bumped by `record_acp_lifecycle`. Skip the capture.
+            // An ACP (relay) session has no vt100 screen to hash — the acp task
+            // stamps its own activity from the adapter's frame stream. Skip the
+            // capture.
             if session.protocol == "acp" {
                 continue;
             }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2712,8 +2712,10 @@ pub(super) async fn preview_session(
     // blocks rendered as plain text (CLI convenience). `lines` is the block count,
     // defaulting to a reasonable tail when unset.
     if session.protocol == "acp" {
-        let blocks = crate::chat::list(&st.db, &session.id).await?;
         let n = if q.lines == 0 { 40 } else { q.lines };
+        // Only the tail is rendered, so only the tail is read — a session that has
+        // been running for days has a journal far larger than any preview.
+        let (blocks, _) = crate::chat::list_page(&st.db, &session.id, None, n).await?;
         let screen = crate::chat::preview_text(&blocks, n);
         return Ok(Json(json!({ "screen": screen })));
     }

--- a/crates/weaver-core/src/db.rs
+++ b/crates/weaver-core/src/db.rs
@@ -9,7 +9,11 @@ use tokio::sync::{Mutex, MutexGuard};
 pub type Db = SqlitePool;
 
 const MIGRATION_POOL_CONNECTIONS: u32 = 1;
-const SHARED_POOL_CONNECTIONS: u32 = 5;
+/// WAL readers do not block each other, so pool size sets how many requests can
+/// be in the database at once. Sized for the dashboard's fan-out — several list
+/// views, each session's detail panes, and the CLI — so that one slow read cannot
+/// queue every unrelated request behind it.
+const SHARED_POOL_CONNECTIONS: u32 = 32;
 /// Ordinary WAL writer contention should queue rather than leak SQLITE_BUSY
 /// into user-facing reads or durable ACP journal writes. This is intentionally
 /// longer than a normal transaction; exhausting it indicates a genuinely


### PR DESCRIPTION
A session's chat journal was being read in full to answer questions about a
single block, and its activity was only stamped at turn boundaries. Both scale
with how long a session has run, so one four-day session (25.5k blocks / 52 MB)
made every unrelated request slow and made itself look idle while it worked.

Measured against a snapshot of a real 631 MB database, where `chat_blocks` is
558 MB of it:

| | before | after |
|---|---|---|
| `tool_call_exists` (per completed tool call) | 53 MB read + ~7,700 JSON parses | covering-index probe |
| `GET /sessions/{id}/preview` | 0.8–1.9 s for 1.3 KB of output | 3 ms |
| `GET /sessions/{id}/history` | 1.6 s | one bounded query |
| `GET /api/sessions` under 5 concurrent journal reads | 1.57 s (37 ms idle) | pool no longer saturates |

### Changes

- **`ref_id` column (migration 0015).** The upstream id a block is addressed by
  — `tool_call_id` for a `tool_call`, `request_id` for a `permission_request` —
  moves out of the opaque JSON payload into an indexed column. The
  replay-idempotency lookups read every block of that kind for the session to
  find one id; `tool_call_exists` ran on the acp task's own frame loop, so a
  long session paid for its whole history on every completed tool call.
  Backfill measured at ~10 s on the 631 MB database.
- **Activity stamped from the frame stream** (throttled to 30 s) instead of only
  at turn boundaries. A turn runs for hours, so the staleness monitor was
  marking actively-streaming sessions stale 30 minutes into every turn
  (`session marked stale id=… idle_secs=1800` while the journal kept moving).
  A genuinely wedged turn still goes stale — this stamps output, not liveness,
  and a `session/load` replay is excluded so recovery does not backdate.
- **Bounded reads.** `/history` pages inside SQL for ACP sessions, walking the
  journal backwards in bounded steps and stopping as soon as the page is
  provably full; `/preview` reads only the tail it renders. The full-journal
  `chat::list` stays for the one-shot consumers that genuinely need it (archive
  capture, handoff) and now says so.
- **Shared pool 5 → 32.** WAL readers do not block each other, so five
  connections meant a handful of slow reads queued every unrelated request.

### Behaviour note

`tagStale` fades a tag once `last_activity_at` passes its `set_at`. ACP sessions
never tripped this mid-turn before because activity was frozen; they now behave
as terminal sessions already do. An agent's own `attention` tag set mid-turn
renders faded while it keeps working — still surfaced, still clearable, and
consistent with the definition in ARCHITECTURE.md, but it is a visible change.

### Testing

398 lib tests and 155/156 integration tests pass. The one failure,
`watches::status_judgement_uses_the_oneshot_agent`, reproduces identically on
unmodified `main` (verified from a baseline worktree) — it exercises the
one-shot ACP prompt path that also fails at runtime with "supervisor for
weaver-acp-prompt-… did not come up within 5s", and is not touched here.