### PR TITLE
feat(loom): sort sessions into trees

### DIFF
--- a/crates/loom/frontend/src/components/SessionConversation.vue
+++ b/crates/loom/frontend/src/components/SessionConversation.vue
@@ -64,8 +64,8 @@ async function loadCue(onReturn = false) {
     cue.value = current;
     if (ensuredDue && current.status === 'generated') cueOpen.value = true;
     if (current.status === 'generating') await followGeneration(sessionId, epoch);
-  } catch (error) {
-    if (isCurrent(sessionId, epoch)) cueError.value = (error as Error).message;
+  } catch {
+    if (isCurrent(sessionId, epoch)) cueError.value = "Couldn't prepare a catch-up. Try again.";
   } finally {
     if (isCurrent(sessionId, epoch)) cueOperation.value = '';
   }
@@ -83,8 +83,8 @@ async function generateCue() {
     cue.value = generated;
     if (generated.status === 'generated') cueOpen.value = true;
     if (generated.status === 'generating') await followGeneration(sessionId, epoch);
-  } catch (error) {
-    if (isCurrent(sessionId, epoch)) cueError.value = (error as Error).message;
+  } catch {
+    if (isCurrent(sessionId, epoch)) cueError.value = "Couldn't prepare a catch-up. Try again.";
   } finally {
     if (isCurrent(sessionId, epoch)) cueOperation.value = '';
   }
@@ -111,7 +111,7 @@ watch(
       v-if="cue?.status === 'generated' && cue.text"
       data-testid="resumption-cue"
       class="mx-3 mt-2 flex shrink-0 items-start gap-2 rounded border border-line bg-subtle px-3 py-2 text-sm"
-      aria-label="Generated resumption cue"
+      aria-label="Session catch-up"
     >
       <details
         class="min-w-0 flex-1"
@@ -119,7 +119,7 @@ watch(
         @toggle="cueOpen = ($event.target as HTMLDetailsElement).open"
       >
         <summary class="cursor-pointer text-xs font-medium text-fg">
-          Resume context
+          Where you left off
           <span v-if="cue.generated_at" class="ml-1 font-mono text-2xs font-normal text-faint">
             {{ new Date(cue.generated_at).toLocaleString() }}
           </span>
@@ -141,7 +141,7 @@ watch(
         :disabled="!!cueOperation"
         @click="generateCue"
       >
-        {{ cueOperation === 'generating' ? 'Generating…' : 'Refresh' }}
+        {{ cueOperation === 'generating' ? 'Preparing…' : 'Update' }}
       </button>
     </section>
     <div
@@ -159,15 +159,15 @@ watch(
       >
         {{
           cueOperation === 'checking'
-            ? 'Checking resumption cue…'
+            ? 'Checking where you left off…'
             : cueOperation === 'generating'
-              ? 'Generating resumption cue…'
+              ? 'Preparing your catch-up…'
               : cue?.status === 'generating'
-                ? 'Check resumption cue'
-                : 'Generate resumption cue'
+                ? 'Check catch-up'
+                : 'Catch me up'
         }}
       </button>
-      <span v-else>Metadata assistance is unavailable for this session.</span>
+      <span v-else>Catch-up is unavailable for this session.</span>
       <span v-if="cueError" class="text-block" role="alert">{{ cueError }}</span>
     </div>
     <AcpConversation

--- a/crates/loom/frontend/src/components/SessionWorkbenchRow.vue
+++ b/crates/loom/frontend/src/components/SessionWorkbenchRow.vue
@@ -25,6 +25,8 @@ interface GroupOption {
 
 const props = defineProps({
   session: { type: Object as PropType<SessionSummary>, required: true },
+  treeDepth: { type: Number, default: 0 },
+  reorderable: { type: Boolean, default: true },
   detail: { type: Object as PropType<Session | undefined>, default: undefined },
   detailLoading: { type: Boolean, default: false },
   detailError: { type: String, default: '' },
@@ -74,6 +76,11 @@ function title() {
   if (!props.qualified || !props.session.placement) return task;
   return `${props.session.placement.group_name} / ${task}`;
 }
+const titleParts = computed(() =>
+  title()
+    .split(/\s+\/\s+/)
+    .filter((part) => part.length > 0),
+);
 
 const positionOptions = computed(() => {
   const group = props.allGroups.find((entry) => entry.group.id === props.destination)?.group;
@@ -120,6 +127,7 @@ function onKeydown(event: KeyboardEvent) {
   <li
     data-testid="session-card"
     :data-session-id="session.id"
+    :data-tree-depth="treeDepth"
     class="session-mailbox-row group relative flex flex-wrap items-start gap-1.5 border-b border-line px-2 py-1.5 last:border-0 hover:bg-subtle/70 focus-within:bg-subtle/70"
     :class="[
       dragging ? 'opacity-40' : '',
@@ -127,6 +135,7 @@ function onKeydown(event: KeyboardEvent) {
       cursor ? 'session-mailbox-row--cursor' : '',
     ]"
     :data-cursor="cursor ? 'true' : undefined"
+    :style="{ paddingLeft: `${0.5 + Math.min(treeDepth, 5)}rem` }"
     @dragover.stop.prevent="emit('dragOver')"
     @drop.stop.prevent="emit('drop')"
     @keydown="onKeydown"
@@ -134,7 +143,7 @@ function onKeydown(event: KeyboardEvent) {
     @mousedown="emit('activate')"
   >
     <span
-      v-if="session.status !== 'archived'"
+      v-if="session.status !== 'archived' && reorderable"
       draggable="true"
       data-testid="session-drag"
       aria-hidden="true"
@@ -145,6 +154,9 @@ function onKeydown(event: KeyboardEvent) {
       ⠿
     </span>
     <span v-else class="w-3" aria-hidden="true"></span>
+    <span v-if="treeDepth" class="mt-0.5 shrink-0 font-mono text-xs text-faint" aria-hidden="true">
+      └
+    </span>
 
     <input
       v-if="session.status !== 'archived'"
@@ -171,7 +183,10 @@ function onKeydown(event: KeyboardEvent) {
           class="session-mailbox-primary stretched-link min-w-0 truncate font-mono text-xs font-medium leading-4 text-fg hover:text-accent"
           @click="emit('recordOpen', $event)"
         >
-          {{ title() }}
+          <template v-for="(part, index) in titleParts" :key="`${part}-${index}`">
+            <span v-if="index" class="text-faint"> / </span>
+            <span :class="index < titleParts.length - 1 ? 'text-muted' : ''">{{ part }}</span>
+          </template>
         </router-link>
         <span
           v-if="effectiveAttention(session).level !== 'ok'"

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -31,7 +31,6 @@ import { signalChips } from '../lib/sessionState';
 // deep-links) resolves to this one instance, so moving terminal ⇄ artifacts is a
 // tab flip on a warm page — no remount, no reconnect, no jump.
 defineOptions({ name: 'SessionDetail' });
-const CHANNEL_ACK_ERROR = "Couldn't acknowledge the channel's new messages.";
 
 const props = defineProps<{ id: string; name?: string }>();
 const route = useRoute();
@@ -327,14 +326,15 @@ async function loadSession() {
 
 async function acknowledgeSessionAttention(): Promise<string> {
   let session = await getSession(props.id);
-  let channelMarkerFailed = false;
   try {
     // The session id is also its default channel id. Opening the workbench is
     // the user's acknowledgement gesture for both legacy tags and channel
     // urgency; future messages raise unread attention again.
     await markChannelRead(props.id);
   } catch {
-    channelMarkerFailed = true;
+    // A read receipt is best-effort bookkeeping, not a failed session load.
+    // Leave the channel unread so another view can retry without presenting an
+    // internal acknowledgement failure the user cannot act on.
   }
   // Attention is a wake-up signal, not a permanent task state. Entering (or
   // returning to) a session acknowledges every loud tag visible in the
@@ -344,7 +344,7 @@ async function acknowledgeSessionAttention(): Promise<string> {
   const keys = [...new Set(signalChips(session).map((chip) => chip.key))];
   if (!keys.length) {
     ws.value = session;
-    return channelMarkerFailed ? CHANNEL_ACK_ERROR : '';
+    return '';
   }
   const results = await Promise.allSettled(keys.map((key) => clearSessionTag(props.id, key)));
   // Re-read even after a partial failure: successful acknowledgements should
@@ -357,7 +357,6 @@ async function acknowledgeSessionAttention(): Promise<string> {
   if (failed) {
     notices.push(`Couldn't acknowledge ${failed} attention signal${failed === 1 ? '' : 's'}.`);
   }
-  if (channelMarkerFailed) notices.push(CHANNEL_ACK_ERROR);
   return notices.join(' ');
 }
 

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -43,6 +43,11 @@ const router = useRouter();
 const { sessions, runs, layout, resourceErrors, refresh, loadHistory, focusSession } = useFleet();
 
 type WorkbenchView = 'space' | 'attention' | 'all' | 'history';
+type SessionSort = 'manual' | 'name' | 'activity' | 'created';
+interface SessionTreeRow {
+  session: SessionSummary;
+  depth: number;
+}
 
 const liveSessions = computed(() =>
   sessions.value.filter((session) => session.status !== 'archived'),
@@ -111,13 +116,21 @@ function attentionFromQuery(value: unknown): SessionSearchAttention | '' {
     ? (value as SessionSearchAttention)
     : '';
 }
+const SESSION_SORTS = new Set<SessionSort>(['manual', 'name', 'activity', 'created']);
+function sortFromQuery(value: unknown): SessionSort {
+  return typeof value === 'string' && SESSION_SORTS.has(value as SessionSort)
+    ? (value as SessionSort)
+    : 'manual';
+}
 const statusFilter = ref<SessionSearchStatus | ''>(statusFromQuery(route.query.status));
 const attentionFilter = ref<SessionSearchAttention | ''>(attentionFromQuery(route.query.attention));
+const sessionSort = ref<SessionSort>(sortFromQuery(route.query.sort));
 watch(
-  () => [route.query.status, route.query.attention],
-  ([status, attention]) => {
+  () => [route.query.status, route.query.attention, route.query.sort],
+  ([status, attention, sort]) => {
     statusFilter.value = statusFromQuery(status);
     attentionFilter.value = attentionFromQuery(attention);
+    sessionSort.value = sortFromQuery(sort);
   },
 );
 function updateFilters() {
@@ -126,6 +139,14 @@ function updateFilters() {
       ...route.query,
       status: statusFilter.value || undefined,
       attention: attentionFilter.value || undefined,
+    },
+  });
+}
+function updateSort() {
+  router.replace({
+    query: {
+      ...route.query,
+      sort: sessionSort.value === 'manual' ? undefined : sessionSort.value,
     },
   });
 }
@@ -249,6 +270,119 @@ function parentSessionOf(session: SessionSummary) {
   const legacyCandidates = sessionsByBranch.value.get(session.parent_id) ?? [];
   return legacyCandidates.length === 1 ? legacyCandidates[0] : undefined;
 }
+function sessionName(session: SessionSummary) {
+  return session.branch.title || session.branch.name;
+}
+function directSessionComparison(left: SessionSummary, right: SessionSummary) {
+  if (sessionSort.value === 'name') {
+    return sessionName(left).localeCompare(sessionName(right), undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    });
+  }
+  if (sessionSort.value === 'activity') {
+    return right.last_activity_at.localeCompare(left.last_activity_at);
+  }
+  if (sessionSort.value === 'created') {
+    return right.created_at.localeCompare(left.created_at);
+  }
+  return 0;
+}
+function nameParentOf(session: SessionSummary, input: SessionSummary[]) {
+  const path = sessionName(session).split(/\s+\/\s+/);
+  if (path.length < 2) return undefined;
+  const candidates = input
+    .filter((candidate) => candidate.id !== session.id)
+    .map((candidate) => ({
+      session: candidate,
+      path: sessionName(candidate).split(/\s+\/\s+/),
+    }))
+    .filter(
+      (candidate) =>
+        candidate.path.length < path.length &&
+        candidate.path.every(
+          (segment, index) =>
+            segment.localeCompare(path[index], undefined, { sensitivity: 'base' }) === 0,
+        ),
+    );
+  const longest = Math.max(0, ...candidates.map((candidate) => candidate.path.length));
+  const closest = candidates.filter((candidate) => candidate.path.length === longest);
+  return closest.length === 1 ? closest[0].session : undefined;
+}
+function sessionTree(input: SessionSummary[]): SessionTreeRow[] {
+  const inputIndex = new Map(input.map((session, index) => [session.id, index]));
+  const inputById = new Map(input.map((session) => [session.id, session]));
+  const inputByBranch = input.reduce((byBranch, session) => {
+    const candidates = byBranch.get(session.branch.id) ?? [];
+    candidates.push(session);
+    byBranch.set(session.branch.id, candidates);
+    return byBranch;
+  }, new Map<string, SessionSummary[]>());
+  const inputIds = new Set(inputIndex.keys());
+  const children = new Map<string, SessionSummary[]>();
+  const roots: SessionSummary[] = [];
+
+  for (const session of input) {
+    const legacyParents = session.parent_id ? (inputByBranch.get(session.parent_id) ?? []) : [];
+    const persistedParent = session.parent_session_id
+      ? inputById.get(session.parent_session_id)
+      : legacyParents.length === 1
+        ? legacyParents[0]
+        : parentSessionOf(session);
+    const parent =
+      persistedParent ??
+      (!session.parent_session_id && !session.parent_id ? nameParentOf(session, input) : undefined);
+    if (!parent || parent.id === session.id || !inputIds.has(parent.id)) {
+      roots.push(session);
+      continue;
+    }
+    const siblings = children.get(parent.id) ?? [];
+    siblings.push(session);
+    children.set(parent.id, siblings);
+  }
+
+  const threadTimestamp = new Map<string, string>();
+  function timestampFor(session: SessionSummary, visiting = new Set<string>()): string {
+    const cached = threadTimestamp.get(session.id);
+    if (cached !== undefined) return cached;
+    if (visiting.has(session.id)) return '';
+    visiting.add(session.id);
+    const own = sessionSort.value === 'created' ? session.created_at : session.last_activity_at;
+    const latest = (children.get(session.id) ?? []).reduce((value, child) => {
+      const childTimestamp = timestampFor(child, visiting);
+      return childTimestamp > value ? childTimestamp : value;
+    }, own);
+    visiting.delete(session.id);
+    threadTimestamp.set(session.id, latest);
+    return latest;
+  }
+  function compare(left: SessionSummary, right: SessionSummary) {
+    if (sessionSort.value === 'activity' || sessionSort.value === 'created') {
+      const difference = timestampFor(right).localeCompare(timestampFor(left));
+      if (difference) return difference;
+    }
+    return (
+      directSessionComparison(left, right) ||
+      (inputIndex.get(left.id) ?? 0) - (inputIndex.get(right.id) ?? 0)
+    );
+  }
+
+  const rows: SessionTreeRow[] = [];
+  const emitted = new Set<string>();
+  function append(session: SessionSummary, depth: number) {
+    if (emitted.has(session.id)) return;
+    emitted.add(session.id);
+    rows.push({ session, depth });
+    for (const child of [...(children.get(session.id) ?? [])].sort(compare)) {
+      append(child, depth + 1);
+    }
+  }
+  for (const root of [...roots].sort(compare)) append(root, 0);
+  // Corrupt legacy ancestry can contain a cycle. Keep every row operable by
+  // projecting any unvisited nodes as roots rather than dropping the cycle.
+  for (const session of [...input].sort(compare)) append(session, 0);
+  return rows;
+}
 const groupedSessions = computed(() =>
   (activeSpace.value?.groups ?? []).map((group) => ({
     group,
@@ -278,23 +412,30 @@ const displayedGroups = computed(() => {
     return groupedSessions.value.map(({ group, sessions }) => ({
       key: group.id,
       group,
-      sessions,
+      rows: sessionTree(sessions),
       qualified: false,
     }));
   }
   return smartSessions.value.length
-    ? [{ key: 'smart', group: undefined, sessions: smartSessions.value, qualified: true }]
+    ? [
+        {
+          key: 'smart',
+          group: undefined,
+          rows: sessionTree(smartSessions.value),
+          qualified: true,
+        },
+      ]
     : [];
 });
 const cursorSessionIds = computed(() =>
   displayedGroups.value.flatMap((display) =>
-    display.group?.collapsed ? [] : display.sessions.map((session) => session.id),
+    display.group?.collapsed ? [] : display.rows.map(({ session }) => session.id),
   ),
 );
 const cursorSessionId = ref('');
 const cursorSession = computed(() =>
   displayedGroups.value
-    .flatMap((display) => display.sessions)
+    .flatMap((display) => display.rows.map(({ session }) => session))
     .find((session) => session.id === cursorSessionId.value),
 );
 const cursorPosition = computed(() => cursorSessionIds.value.indexOf(cursorSessionId.value) + 1);
@@ -996,6 +1137,18 @@ function scrollSpaces(direction: number) {
         <option value="attention">Attention</option>
         <option value="ok">Calm</option>
       </select>
+      <select
+        v-model="sessionSort"
+        aria-label="Sort sessions"
+        data-testid="session-sort"
+        class="rounded border border-line bg-input px-2 py-1.5 text-xs"
+        @change="updateSort"
+      >
+        <option value="manual">Manual order</option>
+        <option value="activity">Last active</option>
+        <option value="name">Name</option>
+        <option value="created">Date created</option>
+      </select>
       <button
         class="btn-secondary px-2.5 py-1 text-xs"
         type="button"
@@ -1390,7 +1543,7 @@ function scrollSpaces(direction: number) {
             >
               <span class="text-faint" :class="display.group.collapsed ? '' : 'rotate-90'">▸</span>
               <span class="truncate text-sm font-medium text-fg">{{ display.group.name }}</span>
-              <span class="font-mono text-2xs text-faint">{{ display.sessions.length }}</span>
+              <span class="font-mono text-2xs text-faint">{{ display.rows.length }}</span>
             </button>
           </header>
           <ul
@@ -1399,48 +1552,52 @@ function scrollSpaces(direction: number) {
             data-testid="session-list"
           >
             <SessionWorkbenchRow
-              v-for="session in display.sessions"
-              :key="session.id"
-              :session="session"
-              :detail="rowDetails[session.id]"
-              :detail-loading="rowDetailLoading.has(session.id)"
-              :detail-error="rowDetailErrors[session.id]"
+              v-for="row in display.rows"
+              :key="row.session.id"
+              :session="row.session"
+              :tree-depth="row.depth"
+              :reorderable="sessionSort === 'manual'"
+              :detail="rowDetails[row.session.id]"
+              :detail-loading="rowDetailLoading.has(row.session.id)"
+              :detail-error="rowDetailErrors[row.session.id]"
               :qualified="display.qualified"
-              :selected="isSelected(session.id)"
-              :expanded="rowExpanded(session.id)"
-              :move-open="moveOpenId === session.id"
-              :destination="rowDestination[session.id]"
-              :before="rowBefore[session.id]"
+              :selected="isSelected(row.session.id)"
+              :expanded="rowExpanded(row.session.id)"
+              :move-open="moveOpenId === row.session.id"
+              :destination="rowDestination[row.session.id]"
+              :before="rowBefore[row.session.id]"
               :all-groups="allGroups"
               :all-sessions="sessions"
-              :parent-session="parentSessionOf(session)"
-              :dragging="draggingId === session.id"
+              :parent-session="parentSessionOf(row.session)"
+              :dragging="draggingId === row.session.id"
               :drop-before="
-                dropGroupId === (display.group?.id ?? session.placement?.group_id) &&
-                dropBeforeId === session.id
+                dropGroupId === (display.group?.id ?? row.session.placement?.group_id) &&
+                dropBeforeId === row.session.id
               "
               :clearing-tag="clearingTag"
-              :cursor="cursorSessionId === session.id"
-              @activate="cursorSessionId = session.id"
-              @toggle-select="setSelected(session.id, $event)"
-              @toggle-details="toggleRow(session.id)"
-              @open-move="openMove(session)"
-              @update-destination="rowDestination[session.id] = $event"
-              @update-before="rowBefore[session.id] = $event"
-              @move="performMove([session.id], $event.groupId, $event.beforeId || null)"
-              @drag-start="dragStart(session.id, $event)"
+              :cursor="cursorSessionId === row.session.id"
+              @activate="cursorSessionId = row.session.id"
+              @toggle-select="setSelected(row.session.id, $event)"
+              @toggle-details="toggleRow(row.session.id)"
+              @open-move="openMove(row.session)"
+              @update-destination="rowDestination[row.session.id] = $event"
+              @update-before="rowBefore[row.session.id] = $event"
+              @move="performMove([row.session.id], $event.groupId, $event.beforeId || null)"
+              @drag-start="dragStart(row.session.id, $event)"
               @drag-end="clearDrag"
               @drag-over="
-                dragOver(display.group?.id ?? session.placement?.group_id ?? '', session.id)
+                dragOver(display.group?.id ?? row.session.placement?.group_id ?? '', row.session.id)
               "
-              @drop="drop(display.group?.id ?? session.placement?.group_id ?? '', session.id)"
+              @drop="
+                drop(display.group?.id ?? row.session.placement?.group_id ?? '', row.session.id)
+              "
               @changed="refresh"
               @error="error = $event"
-              @clear-tag="clearTag(session.id, $event)"
-              @record-open="recordSessionLinkOpen($event, session.id)"
+              @clear-tag="clearTag(row.session.id, $event)"
+              @record-open="recordSessionLinkOpen($event, row.session.id)"
             />
             <li
-              v-if="display.group && !display.sessions.length"
+              v-if="display.group && !display.rows.length"
               data-testid="empty-group"
               class="px-3 py-5 text-center text-sm text-faint"
             >

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -88,6 +88,8 @@ export interface SeedOpts {
   base?: string;
   /** Branch id of the launching session — sets this session's tree parent. */
   parent?: string;
+  /** Existing backlog issue this session should claim as its explicit work item. */
+  claimIssue?: number;
 }
 
 /** A watch as returned by `/api/watches` (the fields the e2e tests
@@ -531,6 +533,7 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
             name: opts.name,
             base: opts.base,
             parent_branch: opts.parent,
+            claim_issue: opts.claimIssue,
           }),
         })) as Session;
       },

--- a/e2e/tests/app-icon-ux.spec.ts
+++ b/e2e/tests/app-icon-ux.spec.ts
@@ -42,7 +42,7 @@ test.describe('consistent page titles', () => {
     await expect(page).toHaveTitle('Weaver - Settings');
 
     await page.goto(`${weaver.baseUrl}/issues`);
-    await expect(page).toHaveTitle('Weaver - Issues');
+    await expect(page).toHaveTitle('Weaver - Backlog');
 
     await page.goto(`${weaver.baseUrl}/watches`);
     await expect(page).toHaveTitle('Weaver - Watches');

--- a/e2e/tests/conversation.spec.ts
+++ b/e2e/tests/conversation.spec.ts
@@ -69,6 +69,37 @@ function footDistance(conv: ReturnType<Page['getByTestId']>) {
 }
 
 test.describe('conversation view', () => {
+  test('offers a plain-language catch-up without exposing resumption internals', async ({
+    page,
+    weaver,
+  }) => {
+    const session = await weaver.seedSession({ goal: 'demo', name: 'catch-up' });
+    await weaver.seedConversation(session, demoLog());
+    await page.route(`**/api/sessions/${session.id}/resumption-cue`, async (route) => {
+      const generated = route.request().method() === 'POST';
+      await route.fulfill({
+        json: {
+          status: generated ? 'generated' : 'not_due',
+          source_cursor: generated ? 'cursor-1' : null,
+          text: generated ? 'The sorting work is ready for review.' : null,
+          generated_at: generated ? '2026-07-30T12:00:00Z' : null,
+          evidence: [],
+        },
+      });
+    });
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}`);
+    await page.locator('[data-tab="conversation"]').click();
+    const catchUp = page.getByTestId('generate-resumption-cue');
+    await expect(catchUp).toHaveText('Catch me up');
+    await expect(page.getByText(/resumption cue/i)).toHaveCount(0);
+    await catchUp.click();
+    await expect(page.getByLabel('Session catch-up')).toContainText('Where you left off');
+    await expect(page.getByLabel('Session catch-up')).toContainText(
+      'The sorting work is ready for review.',
+    );
+  });
+
   // A chat opens at its newest exchange — the transcript scrolls to its foot on
   // load (waiting out the async markdown paint), not to turn one.
   test('opens scrolled to the foot — the newest exchange shows first', async ({ page, weaver }) => {

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -1,6 +1,20 @@
 import { test, expect } from '../fixtures/weaver';
 
 test.describe('session detail view', () => {
+  test('does not surface a failed background channel acknowledgement', async ({
+    page,
+    weaver,
+  }) => {
+    const session = await weaver.seedSession({ goal: 'Keep working', name: 'ack-failure' });
+    await page.route(`**/api/channels/${session.id}/read-marker`, async (route) => {
+      await route.fulfill({ status: 500, json: { error: 'read marker failed' } });
+    });
+
+    await page.goto(`${weaver.baseUrl}/s/${session.id}`);
+    await expect(page.getByRole('heading', { name: 'ack-failure' })).toBeVisible();
+    await expect(page.getByText(/couldn't acknowledge the channel/i)).toHaveCount(0);
+  });
+
   test('session exit commands are discoverable without stealing text input', async ({
     page,
     weaver,

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -226,7 +226,12 @@ test.describe('session detail view', () => {
   });
 
   test('edits pull request and issue associations from visible pills', async ({ page, weaver }) => {
-    const s = await weaver.seedSession({ goal: 'Map my PR', name: 'pr-map' });
+    const issue = await weaver.seedBacklogIssue(weaver.repoPath, 'Map my issue');
+    const s = await weaver.seedSession({
+      goal: 'Map my PR',
+      name: 'pr-map',
+      claimIssue: issue.id,
+    });
     let requestBody: unknown;
     await page.route(`**/api/sessions/${s.id}/github`, async (route) => {
       if (route.request().method() !== 'PUT') return route.fallback();

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -327,6 +327,121 @@ test.describe("durable session workbench", () => {
     await expect(row.getByTestId("session-preview")).toContainText(goal);
   });
 
+  test("session sorting keeps delegated work in a named tree", async ({
+    page,
+    weaver,
+  }) => {
+    const parent = await weaver.seedSession({
+      goal: "Parent work",
+      title: "Project / Parent",
+      name: "tree-parent",
+    });
+    const child = await weaver.seedSession({
+      goal: "Delegated work",
+      title: "Project / Child",
+      name: "tree-child",
+      parent: parent.branch.id,
+    });
+    const alpha = await weaver.seedSession({
+      goal: "Alphabetical peer",
+      name: "Alpha",
+    });
+    const zulu = await weaver.seedSession({
+      goal: "Old peer",
+      name: "Zulu",
+    });
+    const namedRoot = await weaver.seedSession({
+      goal: "Implicit tree root",
+      name: "Area",
+    });
+    const namedChild = await weaver.seedSession({
+      goal: "Implicit tree child",
+      title: "Area / Task",
+      name: "area-task",
+    });
+    const namedGrandchild = await weaver.seedSession({
+      goal: "Implicit tree grandchild",
+      title: "Area / Task / Step",
+      name: "area-task-step",
+    });
+    const activity = new Map([
+      [parent.id, "2026-01-01T00:00:00Z"],
+      [child.id, "2026-04-01T00:00:00Z"],
+      [alpha.id, "2026-03-01T00:00:00Z"],
+      [zulu.id, "2026-02-01T00:00:00Z"],
+      [namedRoot.id, "2025-01-01T00:00:00Z"],
+      [namedChild.id, "2025-02-01T00:00:00Z"],
+      [namedGrandchild.id, "2025-03-01T00:00:00Z"],
+    ]);
+    await page.route("**/api/sessions/summary**", async (route) => {
+      const response = await route.fetch();
+      const summaries = (await response.json()) as Array<{
+        id: string;
+        last_activity_at: string;
+      }>;
+      await route.fulfill({
+        response,
+        json: summaries.map((summary) => ({
+          ...summary,
+          last_activity_at:
+            activity.get(summary.id) ?? summary.last_activity_at,
+        })),
+      });
+    });
+
+    await page.goto(weaver.baseUrl);
+    const rows = page.getByTestId("session-card");
+    const ids = async () =>
+      rows.evaluateAll((items) =>
+        items.map((item) => item.getAttribute("data-session-id")),
+      );
+    await expect(rows).toHaveCount(7);
+    await expect(
+      page.locator(`[data-session-id="${child.id}"]`),
+    ).toHaveAttribute("data-tree-depth", "1");
+    await expect(
+      page
+        .locator(`[data-session-id="${child.id}"] [data-session-primary]`)
+        .locator(".text-muted"),
+    ).toContainText("Project");
+    await expect(
+      page.locator(`[data-session-id="${namedChild.id}"]`),
+    ).toHaveAttribute("data-tree-depth", "1");
+    await expect(
+      page.locator(`[data-session-id="${namedGrandchild.id}"]`),
+    ).toHaveAttribute("data-tree-depth", "2");
+
+    await page.getByTestId("session-sort").selectOption("name");
+    await expect(page).toHaveURL(/[?&]sort=name(?:&|$)/);
+    await expect
+      .poll(ids)
+      .toEqual([
+        alpha.id,
+        namedRoot.id,
+        namedChild.id,
+        namedGrandchild.id,
+        parent.id,
+        child.id,
+        zulu.id,
+      ]);
+    await expect(page.getByTestId("session-drag")).toHaveCount(0);
+
+    await page.reload();
+    await expect(page.getByTestId("session-sort")).toHaveValue("name");
+    await page.getByTestId("session-sort").selectOption("activity");
+    await expect
+      .poll(ids)
+      .toEqual([
+        parent.id,
+        child.id,
+        alpha.id,
+        zulu.id,
+        namedRoot.id,
+        namedChild.id,
+        namedGrandchild.id,
+      ]);
+  });
+
   test("@workbench pointer, keyboard, undo, preference, and SSE share one layout", async ({
     page,
     weaver,


### PR DESCRIPTION
Adds URL-backed session sorting by manual order, recent activity, name, or creation date while preserving workbench groups. Durable delegation links form session threads, and unambiguous slash-delimited names such as A / B / C provide a compatibility tree for older sessions. Activity and creation sorting rank whole threads by their newest descendant, and computed sorts hide drag handles so they cannot be mistaken for persisted manual order.

Makes session return feedback actionable: failed background channel read receipts no longer appear as page errors, and resumption-cue controls now read “Catch me up” and “Where you left off.” Also updates two stale end-to-end expectations found while exercising the complete dashboard.

Agent lint review passed for the substantive implementation; a second review was skipped at user request for the small session-return follow-up.