### PR TITLE
fix(loom): preserve handoff runtime transitions

### DIFF
--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -185,7 +185,11 @@ pub async fn prompt_once(
         bail!("one-shot ACP prompts require a fresh session");
     }
 
-    let relay_name = format!("weaver-acp-prompt-{:016x}", rand::random::<u64>());
+    let relay_name = format!(
+        "{}{:016x}",
+        crate::backend::TRANSIENT_SESSION_PREFIX,
+        rand::random::<u64>()
+    );
     // The relay is detached like a normal work session, but deliberately has
     // no database row. Keep the periodic supervisor reconciler from mistaking
     // this in-flight prompt for crash debris; dropping the lease after cleanup

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -171,6 +171,7 @@ pub enum AcpPromptEffort<'a> {
 /// session that will subsequently take over.
 pub async fn prompt_once(
     db: &Db,
+    transient_sessions: &crate::backend::TransientSessionRegistry,
     launch: AcpLaunch,
     prompt: &str,
     model: AcpPromptModel<'_>,
@@ -185,6 +186,11 @@ pub async fn prompt_once(
     }
 
     let relay_name = format!("weaver-acp-prompt-{:016x}", rand::random::<u64>());
+    // The relay is detached like a normal work session, but deliberately has
+    // no database row. Keep the periodic supervisor reconciler from mistaking
+    // this in-flight prompt for crash debris; dropping the lease after cleanup
+    // makes a relay left by a process crash reclaimable on restart.
+    let _relay_lease = transient_sessions.lease(&relay_name);
     let env: Vec<(&str, &str)> = launch
         .env
         .iter()
@@ -750,13 +756,15 @@ impl std::ops::Deref for AcpCtx {
     }
 }
 
-/// The registry of live ACP session tasks, held on [`crate::AppState`]. Clone-cheap
-/// (an `Arc`ed map); handlers look a session up to drive it or tail its stream.
-/// Each registration carries a generation so a task that exits after it has been
-/// superseded (stopped then re-attached) removes only its own slot.
+/// The registry of live ACP work and transient prompt tasks, held on
+/// [`crate::AppState`]. Clone-cheap (through `Arc`); handlers look a session up
+/// to drive it or tail its stream. Each work-session registration carries a
+/// generation so a task that exits after it has been superseded (stopped then
+/// re-attached) removes only its own slot.
 #[derive(Clone, Default)]
 pub struct AcpRegistry {
     inner: Arc<Mutex<RegistryInner>>,
+    transient_sessions: crate::backend::TransientSessionRegistry,
 }
 
 #[derive(Default)]
@@ -807,6 +815,10 @@ pub(crate) struct ClaimLivenessProbe {
 impl AcpRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn transient_sessions(&self) -> &crate::backend::TransientSessionRegistry {
+        &self.transient_sessions
     }
 
     /// The live handle for `session_id`, or `None` when no task is running.

--- a/crates/loom-agent/src/agent.rs
+++ b/crates/loom-agent/src/agent.rs
@@ -1515,11 +1515,12 @@ struct OneShotLaunchPolicy<'a> {
 /// provider-specific execution remains behind that runtime's ACP adapter.
 pub struct AgentManager<'a> {
     db: &'a Db,
+    acp: &'a crate::acp::AcpRegistry,
 }
 
 impl<'a> AgentManager<'a> {
-    pub fn new(db: &'a Db) -> Self {
-        Self { db }
+    pub fn new(db: &'a Db, acp: &'a crate::acp::AcpRegistry) -> Self {
+        Self { db, acp }
     }
 
     /// Ask the incoming runtime's advertised Haiku/Luna-class model for a
@@ -1555,6 +1556,7 @@ impl<'a> AgentManager<'a> {
         let launch = transient_prompt_launch(incoming);
         match crate::acp::prompt_once(
             self.db,
+            self.acp.transient_sessions(),
             launch,
             prompt,
             crate::acp::AcpPromptModel::FirstContaining(&["haiku", "luna"]),
@@ -1803,6 +1805,7 @@ impl<'a> AgentManager<'a> {
         };
         match crate::acp::prompt_once(
             self.db,
+            self.acp.transient_sessions(),
             launch,
             prompt,
             preferred_model,

--- a/crates/loom-core/src/session_manager.rs
+++ b/crates/loom-core/src/session_manager.rs
@@ -32,11 +32,18 @@ pub struct ReconcileReport {
 #[derive(Debug, PartialEq, Eq)]
 enum OwnedResource<'a> {
     Agent(&'a str),
+    TransientRelay,
     DebugShell(&'a str),
 }
 
 /// Parse only supervisor names reserved by Loom.
 fn owned_resource(name: &str) -> Option<OwnedResource<'_>> {
+    if name
+        .strip_prefix("weaver-acp-prompt-")
+        .is_some_and(|nonce| !nonce.is_empty())
+    {
+        return Some(OwnedResource::TransientRelay);
+    }
     if let Some(id) = name.strip_prefix("weaver-").filter(|id| !id.is_empty()) {
         return Some(OwnedResource::Agent(id));
     }
@@ -68,9 +75,13 @@ pub async fn teardown_reserved_runtime(session_id: &str) -> Vec<String> {
 ///
 /// Every non-archived session owns its agent and debug supervisors, including
 /// inspectable `done`/`error` sessions. An active automation run temporarily
-/// owns the agent's deterministic name before a session row appears. Archived,
-/// missing, and cancellation-invalidated sessions own no runtime.
-pub async fn reconcile_supervisors(db: &Db) -> Result<ReconcileReport> {
+/// owns the agent's deterministic name before a session row appears. A live
+/// one-shot ACP prompt owns its nondurable relay through the ACP registry.
+/// Archived, missing, and cancellation-invalidated sessions own no runtime.
+pub async fn reconcile_supervisors(
+    db: &Db,
+    acp: &crate::acp::AcpRegistry,
+) -> Result<ReconcileReport> {
     // Close the only crash window in cancellation-wins provisioning: a session
     // row may have landed just before the request was cancelled, while the
     // provisioning task died before it could perform its final ownership check.
@@ -110,6 +121,7 @@ pub async fn reconcile_supervisors(db: &Db) -> Result<ReconcileReport> {
                     && (sessions.get(id).is_some_and(|status| status != "archived")
                         || run_owners.contains(id))
             }
+            OwnedResource::TransientRelay => acp.transient_sessions().contains(&name),
             OwnedResource::DebugShell(id) => {
                 !invalidated.contains(id)
                     && sessions.get(id).is_some_and(|status| status != "archived")
@@ -121,7 +133,9 @@ pub async fn reconcile_supervisors(db: &Db) -> Result<ReconcileReport> {
 
         match backend::kill_session(&name).await {
             Ok(()) => match resource {
-                OwnedResource::Agent(_) => report.removed_agents += 1,
+                OwnedResource::Agent(_) | OwnedResource::TransientRelay => {
+                    report.removed_agents += 1
+                }
                 OwnedResource::DebugShell(_) => report.removed_debug_shells += 1,
             },
             Err(error) => report.warnings.push(format!("{name}: {error}")),
@@ -146,12 +160,12 @@ pub async fn reconcile_supervisors(db: &Db) -> Result<ReconcileReport> {
 /// Periodically converge detached supervisors after startup. A one-shot pass
 /// runs before adoption in `server::run`; this loop handles a process crash or
 /// a late provisioning/cancellation race after the server is already serving.
-pub async fn run(db: Db) {
+pub async fn run(db: Db, acp: crate::acp::AcpRegistry) {
     let start = tokio::time::Instant::now() + RECONCILE_INTERVAL;
     let mut interval = tokio::time::interval_at(start, RECONCILE_INTERVAL);
     loop {
         interval.tick().await;
-        if let Err(error) = reconcile_supervisors(&db).await {
+        if let Err(error) = reconcile_supervisors(&db, &acp).await {
             tracing::warn!(%error, "session resource reconciliation failed");
         }
     }
@@ -166,6 +180,10 @@ mod tests {
         assert_eq!(
             owned_resource("weaver-abc-123"),
             Some(OwnedResource::Agent("abc-123"))
+        );
+        assert_eq!(
+            owned_resource("weaver-acp-prompt-deadbeef"),
+            Some(OwnedResource::TransientRelay)
         );
         assert_eq!(
             owned_resource("loom-shell-abc-123-7"),

--- a/crates/loom-core/src/session_manager.rs
+++ b/crates/loom-core/src/session_manager.rs
@@ -39,7 +39,7 @@ enum OwnedResource<'a> {
 /// Parse only supervisor names reserved by Loom.
 fn owned_resource(name: &str) -> Option<OwnedResource<'_>> {
     if name
-        .strip_prefix("weaver-acp-prompt-")
+        .strip_prefix(backend::TRANSIENT_SESSION_PREFIX)
         .is_some_and(|nonce| !nonce.is_empty())
     {
         return Some(OwnedResource::TransientRelay);

--- a/crates/loom-ctx/src/backend.rs
+++ b/crates/loom-ctx/src/backend.rs
@@ -12,10 +12,51 @@
 //! restart leaves running terminals untouched — the recovery property that keeps
 //! agents alive across restarts.
 
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
 use anyhow::{bail, Result};
 
 use crate::runner;
 use weaver_core::db::Db;
+
+/// Names of nondurable supervisors currently owned by this Loom process.
+#[derive(Clone, Default)]
+pub struct TransientSessionRegistry {
+    names: Arc<Mutex<HashSet<String>>>,
+}
+
+/// Process-local ownership for a short-lived detached supervisor.
+///
+/// One-shot ACP prompts need Tapestry's relay transport but do not have a
+/// durable session row. The resource reconciler uses this lease to distinguish
+/// a live prompt from a relay left behind by a crashed Loom process.
+pub struct TransientSessionLease {
+    registry: TransientSessionRegistry,
+    name: String,
+}
+
+impl Drop for TransientSessionLease {
+    fn drop(&mut self) {
+        self.registry.names.lock().unwrap().remove(&self.name);
+    }
+}
+
+impl TransientSessionRegistry {
+    /// Claim a transient supervisor name until the returned guard is dropped.
+    pub fn lease(&self, name: &str) -> TransientSessionLease {
+        self.names.lock().unwrap().insert(name.to_string());
+        TransientSessionLease {
+            registry: self.clone(),
+            name: name.to_string(),
+        }
+    }
+
+    /// Whether this Loom process currently owns the transient supervisor.
+    pub fn contains(&self, name: &str) -> bool {
+        self.names.lock().unwrap().contains(name)
+    }
+}
 
 /// Whether a session with this name has a live supervisor.
 pub async fn has_session(name: &str) -> bool {

--- a/crates/loom-ctx/src/backend.rs
+++ b/crates/loom-ctx/src/backend.rs
@@ -20,6 +20,9 @@ use anyhow::{bail, Result};
 use crate::runner;
 use weaver_core::db::Db;
 
+/// Supervisor namespace reserved for one-shot ACP prompts.
+pub const TRANSIENT_SESSION_PREFIX: &str = "weaver-acp-prompt-";
+
 /// Names of nondurable supervisors currently owned by this Loom process.
 #[derive(Clone, Default)]
 pub struct TransientSessionRegistry {

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -636,7 +636,7 @@ pub async fn handoff_session(
             return Err(HandoffError::internal(error.to_string()));
         }
     };
-    let digest = agent::AgentManager::new(&st.db)
+    let digest = agent::AgentManager::new(&st.db, &st.acp)
         .summarize_handoff(
             &target,
             &context.summary_request,

--- a/crates/loom-launch/src/metadata_assist.rs
+++ b/crates/loom-launch/src/metadata_assist.rs
@@ -443,6 +443,7 @@ async fn title_preflight(
 pub async fn spawn_title_generation(
     db: Db,
     bus: EventBus,
+    acp: crate::acp::AcpRegistry,
     session: Session,
     branch: Branch,
     explicit: bool,
@@ -482,7 +483,7 @@ pub async fn spawn_title_generation(
 
     tokio::spawn(async move {
         let _claim = claim;
-        let status = match generate_title(&db, &session, &branch, &fence).await {
+        let status = match generate_title(&db, &acp, &session, &branch, &fence).await {
             Ok(status) => status,
             Err(error) => {
                 tracing::warn!(session = %session.id, %error, "metadata title generation failed");
@@ -511,6 +512,7 @@ pub async fn spawn_title_generation(
 
 async fn generate_title(
     db: &Db,
+    acp: &crate::acp::AcpRegistry,
     session: &Session,
     branch: &Branch,
     fence: &TitleFence,
@@ -531,7 +533,7 @@ async fn generate_title(
         Ok(snapshot) => snapshot,
         Err(status) => return Ok(status),
     };
-    let output = AgentManager::new(db)
+    let output = AgentManager::new(db, acp)
         .run_metadata(&run.session.agent_kind, &prompt, PROMPT_TIMEOUT)
         .await
         .and_then(|text| branch::sanitize_generated_title(&text))
@@ -911,6 +913,7 @@ pub async fn current_cue(db: &Db, session: &Session, branch: &Branch) -> Result<
 
 pub async fn ensure_cue(
     db: &Db,
+    acp: &crate::acp::AcpRegistry,
     session: &Session,
     branch: &Branch,
     force: bool,
@@ -941,11 +944,12 @@ pub async fn ensure_cue(
     // UI hanging on whichever session was opened. `current_cue` reports
     // `generating` for as long as the claim is held, which is what clients poll.
     let db = db.clone();
+    let acp = acp.clone();
     let session = session.clone();
     let branch = branch.clone();
     tokio::spawn(async move {
         let _claim = claim;
-        if let Err(error) = generate_cue(&db, &session, &branch, force).await {
+        if let Err(error) = generate_cue(&db, &acp, &session, &branch, force).await {
             tracing::warn!(session = %session.id, %error, "resumption cue generation failed");
         }
     });
@@ -959,6 +963,7 @@ pub async fn ensure_cue(
 /// `generating` rather than starting a duplicate model call.
 async fn generate_cue(
     db: &Db,
+    acp: &crate::acp::AcpRegistry,
     session: &Session,
     branch: &Branch,
     force: bool,
@@ -983,7 +988,7 @@ async fn generate_cue(
             Ok(snapshot) => snapshot,
             Err(view) => return Ok(view),
         };
-    let output = AgentManager::new(db)
+    let output = AgentManager::new(db, acp)
         .run_metadata(
             &run_snapshot.session.agent_kind,
             &prepared.prompt,

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -1315,6 +1315,7 @@ pub async fn create(st: AppState, req: CreateReq, actor: Actor) -> Result<Provis
     crate::metadata_assist::spawn_title_generation(
         st.db.clone(),
         st.bus.clone(),
+        st.acp.clone(),
         session.clone(),
         branch.clone(),
         false,

--- a/crates/loom-store/src/session.rs
+++ b/crates/loom-store/src/session.rs
@@ -952,13 +952,15 @@ pub async fn increment_turn_count(db: &Db, id: &str) -> Result<i64> {
 /// The monitor discovers liveness from a fleet snapshot, which can be stale by
 /// the time teardown finishes. Keep the terminal-state guard in the UPDATE so
 /// an archive racing that snapshot cannot be overwritten back to `orphaned`.
+/// A handoff owns an intentional supervisor-free interval while replacing the
+/// provider, so the monitor must not invalidate its mutation generation either.
 /// Returns whether this call performed the transition.
 pub async fn mark_orphaned(db: &Db, id: &str) -> Result<bool> {
     let result = sqlx::query(
         "UPDATE sessions
          SET status = 'orphaned', mutation_revision = mutation_revision + 1
          WHERE id = ?
-           AND status NOT IN ('orphaned', 'done', 'error', 'archived')",
+           AND status NOT IN ('orphaned', 'done', 'error', 'archived', 'handoff')",
     )
     .bind(id)
     .execute(db)
@@ -1862,6 +1864,21 @@ mod tests {
         assert!(
             !mark_orphaned(&db, "orphan").await.unwrap(),
             "an already-orphaned row does not emit another edge"
+        );
+    }
+
+    #[tokio::test]
+    async fn orphan_transition_does_not_interrupt_a_handoff() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let branch = branch_id(&db, "weaver/handoff-orphan-race").await;
+        let mut session = new_session("handoff-orphan-race", &branch, None);
+        session.status = "handoff".to_string();
+        insert(&db, &session).await.unwrap();
+
+        assert!(!mark_orphaned(&db, &session.id).await.unwrap());
+        assert_eq!(
+            get(&db, &session.id).await.unwrap().unwrap().status,
+            "handoff"
         );
     }
 

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -120,7 +120,7 @@ pub async fn run(addr: &str) -> Result<()> {
     // adopting anything, remove only Loom-namespaced runtimes that have no
     // durable session/active-reservation owner. This is the inverse of the
     // monitor's missing-supervisor -> orphaned transition.
-    match session_manager::reconcile_supervisors(&state.db).await {
+    match session_manager::reconcile_supervisors(&state.db, &state.acp).await {
         Ok(report) if !report.warnings.is_empty() => tracing::warn!(
             warnings = report.warnings.len(),
             "session resource reconciliation completed with warnings"
@@ -484,7 +484,7 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
     }
     tokio::spawn(monitor::run(state.clone()));
     tokio::spawn(repair_acp_sessions_loop(state.clone()));
-    tokio::spawn(session_manager::run(state.db.clone()));
+    tokio::spawn(session_manager::run(state.db.clone(), state.acp.clone()));
     tokio::spawn(crate::review_delivery::run(state.clone()));
     // The GitHub poller is always spawned; it self-gates on the `github.poll`
     // setting and on `gh` being available, so it idles cheaply when GitHub

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -869,6 +869,7 @@ pub(super) async fn regenerate_session_title(
     crate::metadata_assist::spawn_title_generation(
         st.db.clone(),
         st.bus.clone(),
+        st.acp.clone(),
         session.clone(),
         branch,
         true,
@@ -906,7 +907,7 @@ pub(super) async fn ensure_resumption_cue(
 ) -> ApiResult<Json<ResumptionCueView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
     Ok(Json(
-        crate::metadata_assist::ensure_cue(&st.db, &session, &branch, req.force).await?,
+        crate::metadata_assist::ensure_cue(&st.db, &st.acp, &session, &branch, req.force).await?,
     ))
 }
 

--- a/crates/loom/src/web/watches.rs
+++ b/crates/loom/src/web/watches.rs
@@ -320,7 +320,7 @@ pub(super) async fn agent_oneshot(
                 runtime
             }
         });
-    let output = agent::AgentManager::new(&st.db)
+    let output = agent::AgentManager::new(&st.db, &st.acp)
         .run_oneshot(
             runtime,
             &req.prompt,

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -177,6 +177,7 @@ async fn transient_prompt_uses_acp_and_cleans_its_relay() {
 
     let output = acp::prompt_once(
         &ts.state.db,
+        ts.state.acp.transient_sessions(),
         transient_launch(&ts, vec![]),
         "say:summary",
         AcpPromptModel::Exact("fake-fast"),
@@ -199,6 +200,7 @@ async fn transient_prompt_failures_fall_back_without_leaking_relays() {
 
     let missing_model = acp::prompt_once(
         &ts.state.db,
+        ts.state.acp.transient_sessions(),
         transient_launch(&ts, vec![]),
         "say:unused",
         AcpPromptModel::FirstContaining(&["haiku", "luna"]),
@@ -211,6 +213,7 @@ async fn transient_prompt_failures_fall_back_without_leaking_relays() {
 
     let missing_effort = acp::prompt_once(
         &ts.state.db,
+        ts.state.acp.transient_sessions(),
         transient_launch(&ts, vec![]),
         "say:unused",
         AcpPromptModel::Exact("fake-fast"),
@@ -223,6 +226,7 @@ async fn transient_prompt_failures_fall_back_without_leaking_relays() {
 
     let empty = acp::prompt_once(
         &ts.state.db,
+        ts.state.acp.transient_sessions(),
         transient_launch(&ts, vec![]),
         "think:not returned",
         AcpPromptModel::Exact("fake-fast"),
@@ -235,6 +239,7 @@ async fn transient_prompt_failures_fall_back_without_leaking_relays() {
 
     let oversized = acp::prompt_once(
         &ts.state.db,
+        ts.state.acp.transient_sessions(),
         transient_launch(&ts, vec![]),
         &format!("say:{}", "x".repeat(33 * 1024)),
         AcpPromptModel::Exact("fake-fast"),
@@ -247,6 +252,7 @@ async fn transient_prompt_failures_fall_back_without_leaking_relays() {
 
     let cancelled = acp::prompt_once(
         &ts.state.db,
+        ts.state.acp.transient_sessions(),
         transient_launch(&ts, vec![]),
         "permission:file.txt",
         AcpPromptModel::Exact("fake-fast"),
@@ -259,6 +265,7 @@ async fn transient_prompt_failures_fall_back_without_leaking_relays() {
 
     let timeout = acp::prompt_once(
         &ts.state.db,
+        ts.state.acp.transient_sessions(),
         transient_launch(
             &ts,
             vec![(

--- a/crates/loom/tests/integration/session_management.rs
+++ b/crates/loom/tests/integration/session_management.rs
@@ -131,19 +131,27 @@ async fn supervisor_reconciliation_removes_only_unowned_loom_resources() {
         .await
         .unwrap();
     let stray = "weaver-no-database-owner";
+    let transient = "weaver-acp-prompt-active";
+    let stale_transient = "weaver-acp-prompt-stale";
     let unrelated = "other-tapestry-user";
-    for name in [&owned, stray, unrelated] {
+    let transient_lease = ts.state.acp.transient_sessions().lease(transient);
+    for name in [&owned, stray, transient, stale_transient, unrelated] {
         backend::new_session(name, ts.repo_path(), "sleep 60", &[], false, 0)
             .await
             .unwrap();
     }
 
-    let report = loom::session_manager::reconcile_supervisors(&ts.state.db)
+    let report = loom::session_manager::reconcile_supervisors(&ts.state.db, &ts.state.acp)
         .await
         .unwrap();
-    assert_eq!(report.removed_agents, 1);
+    assert_eq!(report.removed_agents, 2);
     wait_dead(stray).await;
+    wait_dead(stale_transient).await;
     assert!(backend::has_session(&owned).await);
+    assert!(
+        backend::has_session(transient).await,
+        "an in-flight one-shot ACP relay retains process-local ownership"
+    );
     assert!(
         backend::has_session(finished_term).await,
         "rollout must preserve supervisors owned by inspectable terminal sessions"
@@ -153,10 +161,15 @@ async fn supervisor_reconciliation_removes_only_unowned_loom_resources() {
     runs::cancel_for_session(&ts.state.db, &active.session_id)
         .await
         .unwrap();
-    loom::session_manager::reconcile_supervisors(&ts.state.db)
+    loom::session_manager::reconcile_supervisors(&ts.state.db, &ts.state.acp)
         .await
         .unwrap();
     wait_dead(&owned).await;
+    drop(transient_lease);
+    loom::session_manager::reconcile_supervisors(&ts.state.db, &ts.state.acp)
+        .await
+        .unwrap();
+    wait_dead(transient).await;
     ts.client
         .delete(&format!("/api/sessions/{finished_id}"))
         .await
@@ -200,7 +213,7 @@ async fn reconciliation_terminalizes_a_session_that_landed_after_cancellation() 
         .await
         .unwrap();
 
-    let report = loom::session_manager::reconcile_supervisors(&ts.state.db)
+    let report = loom::session_manager::reconcile_supervisors(&ts.state.db, &ts.state.acp)
         .await
         .unwrap();
     assert_eq!(report.invalidated_sessions, 1);


### PR DESCRIPTION
Prevent provider handoffs from being interrupted by Loom's own background reconciliation.

Track one-shot ACP prompt relays as transient work in the ACP registry so the supervisor reconciler preserves an active incoming-provider summary while still reclaiming abandoned relays. Treat the handoff lifecycle state as an intentional supervisor-free transition so the monitor cannot rewrite it to orphaned and invalidate the replacement commit.

Add regression coverage for transient relay ownership and handoff orphan fencing.