### PR TITLE
fix(loom): preserve cross-repo session ancestry

### DIFF
--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -227,6 +227,13 @@ impl Actor {
         }
     }
 
+    fn bound_parent_session(&self) -> Option<&str> {
+        match &self.0 {
+            ActorKind::Session { session_id, .. } => Some(session_id),
+            _ => None,
+        }
+    }
+
     fn creator_identity(&self) -> (&'static str, String) {
         match &self.0 {
             ActorKind::Admin { username, .. } => ("user", username.clone()),
@@ -895,11 +902,12 @@ pub async fn create(st: AppState, req: CreateReq, actor: Actor) -> Result<Provis
         .ok_or_else(|| ProvisionError::internal("branch vanished"))?;
     tracing::debug!(branch = %branch.id, title = %title, "stamped branch title/goal/description");
 
-    // Resolve the launching parent once: it names an explicitly claimed work
-    // item's `source_branch` and the session's tree parent (`parent_branch_id`).
-    // Only attribute to a parent in *this* repo, and never to the branch itself
-    // — `resolve_key` searches globally, so a stray `$WEAVER_BRANCH` from a
-    // checkout elsewhere must not misattribute the link to an unrelated branch.
+    // Resolve the repository-scoped launching branch once: it names an
+    // explicitly claimed work item's `source_branch` and supplies the legacy
+    // `parent_branch_id` fallback. Only attribute that branch link inside this
+    // repo, and never to the branch itself — `resolve_key` searches globally,
+    // so a stray `$WEAVER_BRANCH` from a checkout elsewhere must not
+    // misattribute work-item provenance to an unrelated repository.
     let parent = match req
         .parent_branch
         .as_deref()
@@ -912,11 +920,19 @@ pub async fn create(st: AppState, req: CreateReq, actor: Actor) -> Result<Provis
         None => None,
     };
     let parent_branch_name = parent.as_ref().map(|b| b.branch.clone());
-    let parent_session_id = match &parent {
-        Some(parent) => session_mod::active_for_branch(&st.db, &parent.id)
-            .await?
-            .map(|session| session.id),
-        None => None,
+    // Session ancestry is global, unlike branch/work-item provenance. A scoped
+    // session credential identifies the exact launcher even when the child is
+    // created in another repository. Admin compatibility launches have no
+    // bound session, so retain the same-repo active-branch lookup for them.
+    let parent_session_id = if let Some(parent_session_id) = actor.bound_parent_session() {
+        Some(parent_session_id.to_string())
+    } else {
+        match &parent {
+            Some(parent) => session_mod::active_for_branch(&st.db, &parent.id)
+                .await?
+                .map(|session| session.id),
+            None => None,
+        }
     };
     let stamped_allowed_tools = serde_json::to_string(&resolved.runtime_permissions)
         .map_err(|error| ProvisionError::invalid(error.to_string()))?;

--- a/crates/loom/tests/integration/auth.rs
+++ b/crates/loom/tests/integration/auth.rs
@@ -476,7 +476,21 @@ async fn session_token_can_delegate_through_the_cli_resolve_then_create_path() {
         .await
         .unwrap();
 
-    let cwd = ts.cwd();
+    // The session tree spans repositories. Branch ancestry and work-item
+    // provenance remain repository-scoped, but the authenticated launcher is
+    // still the exact parent of a child created elsewhere.
+    let other_repo = tempfile::tempdir().unwrap();
+    crate::fixtures::sh(other_repo.path(), "git", &["init", "-b", "main"]);
+    crate::fixtures::sh(
+        other_repo.path(),
+        "git",
+        &["config", "user.email", "t@t.test"],
+    );
+    crate::fixtures::sh(other_repo.path(), "git", &["config", "user.name", "Test"]);
+    std::fs::write(other_repo.path().join("README.md"), "other\n").unwrap();
+    crate::fixtures::sh(other_repo.path(), "git", &["add", "."]);
+    crate::fixtures::sh(other_repo.path(), "git", &["commit", "-m", "init"]);
+    let cwd = other_repo.path().to_string_lossy().into_owned();
     let output = Command::new(env!("CARGO_BIN_EXE_loom"))
         .args([
             "session",
@@ -502,6 +516,10 @@ async fn session_token_can_delegate_through_the_cli_resolve_then_create_path() {
     let child = children
         .iter()
         .find(|session| session.parent_session_id.as_deref() == Some(parent_id))
-        .expect("CLI launch created a child of the scoped session");
+        .expect("cross-repo CLI launch created a child of the scoped session");
     assert_eq!(child.creator_kind, "session");
+    assert_eq!(
+        child.parent_branch_id, None,
+        "legacy branch ancestry remains repository-scoped"
+    );
 }


### PR DESCRIPTION
Preserve the authenticated launcher’s exact session ID when delegated work targets another repository. Repository-scoped branch ancestry remains guarded to the child repository, while global session ancestry now drives dashboard nesting and placement inheritance across repositories.

Adds a scoped CLI/API regression journey that launches into a second repository and verifies the exact parent session is retained without leaking the legacy branch parent.

Agent lint review skipped: localized low-risk provenance fix covered by cross-repo and same-repo integration journeys.