### PR TITLE
feat(loom): multiplex live streams onto one SSE connection

### DIFF
--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -46,6 +46,7 @@ import type {
   AcpUsage,
 } from '../types';
 import { canSend } from '../lib/sessionState';
+import { openTopic, type TopicHandle } from '../lib/eventStream';
 import { useFollowFoot } from '../lib/followFoot';
 import { formatTokens } from '../lib/usage';
 import MarkdownView from './MarkdownView.vue';
@@ -297,21 +298,19 @@ function onQueue(ev: SseQueue) {
 }
 
 // ── SSE lifecycle (kept-alive discipline) ────────────────────────────────────
-let source: EventSource | null = null;
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let source: TopicHandle | null = null;
 let snapshotFallbackTimer: ReturnType<typeof setTimeout> | null = null;
-function rebindStream() {
-  closeStream();
-  openStream();
-}
 function rebindAfterHandoff(event: Event) {
   const handedOffId = (event as CustomEvent<{ id?: string }>).detail?.id;
   if (handedOffId !== id.value) return;
-  rebindStream();
+  // A handoff replaces the task behind this session and closes the old
+  // broadcast. The topic name is unchanged, so only a reconnect makes the
+  // server re-resolve it onto the new task.
+  source?.refresh();
 }
 function openStream() {
-  const stream = new EventSource(`/api/sessions/${id.value}/chat/stream`);
-  source = stream;
+  const topic = openTopic(`chat:${id.value}`);
+  source = topic;
   // The stream normally opens immediately and then owns the first snapshot,
   // closing the snapshot→SSE gap. If a proxy/browser delays EventSource setup,
   // do not leave the conversation on "Loading…" forever: fetch after a short
@@ -322,46 +321,24 @@ function openStream() {
       if (state.value === 'loading') load();
     }, 1500);
   }
-  stream.addEventListener('block', (e) =>
-    onBlock(JSON.parse((e as MessageEvent).data) as ChatBlock),
-  );
-  stream.addEventListener('delta', (e) =>
-    onDelta(JSON.parse((e as MessageEvent).data) as SseDelta),
-  );
-  stream.addEventListener('tool', (e) => onTool(JSON.parse((e as MessageEvent).data) as SseTool));
-  stream.addEventListener('turn', (e) => onTurn(JSON.parse((e as MessageEvent).data) as SseTurn));
-  stream.addEventListener('queue', (e) =>
-    onQueue(JSON.parse((e as MessageEvent).data) as SseQueue),
-  );
-  stream.addEventListener('metadata', (e) => {
-    applyMetadata(JSON.parse((e as MessageEvent).data) as AcpMetadata);
-  });
+  topic.on('block', (d) => onBlock(d as ChatBlock));
+  topic.on('delta', (d) => onDelta(d as SseDelta));
+  topic.on('tool', (d) => onTool(d as SseTool));
+  topic.on('turn', (d) => onTurn(d as SseTurn));
+  topic.on('queue', (d) => onQueue(d as SseQueue));
+  topic.on('metadata', (d) => applyMetadata(d as AcpMetadata));
   // Fetch only after the server installed the subscription, closing the
   // snapshot-to-stream gap without the former duplicate journal request. A
   // reconnect reconciles the newest page while retaining explicitly loaded
-  // older pages.
-  stream.addEventListener('open', () => {
+  // older pages. `onOpen` also fires when the shared stream reconnects for an
+  // unrelated topic, which is exactly when a gap could have opened here.
+  topic.onOpen(() => {
     if (snapshotFallbackTimer) clearTimeout(snapshotFallbackTimer);
     snapshotFallbackTimer = null;
     load({ preserve: state.value === 'ready' });
   });
-  // A provider handoff cleanly closes the old task's broadcast. Browsers do not
-  // consistently reconnect an EventSource after a clean EOF, so explicitly
-  // replace it and refetch the durable snapshot before tailing the new task.
-  stream.onerror = () => {
-    if (source !== stream) return;
-    stream.close();
-    source = null;
-    if (reconnectTimer) return;
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      if (!source) openStream();
-    }, 100);
-  };
 }
 function closeStream() {
-  if (reconnectTimer) clearTimeout(reconnectTimer);
-  reconnectTimer = null;
   if (snapshotFallbackTimer) clearTimeout(snapshotFallbackTimer);
   snapshotFallbackTimer = null;
   source?.close();
@@ -393,7 +370,7 @@ watch(
     // A handoff replaces the task and its broadcast channel without replacing
     // loom's stable session id. Rebind deterministically when the header reloads
     // the new provider; clean SSE EOF is not reported consistently by browsers.
-    rebindStream();
+    source?.refresh();
   },
 );
 

--- a/crates/loom/frontend/src/components/ArtifactsPanel.vue
+++ b/crates/loom/frontend/src/components/ArtifactsPanel.vue
@@ -347,8 +347,8 @@ function closeStream() {
 function openStream() {
   closeStream();
   source = openSessionEvents(props.id);
-  source.on('artifact_written', (e) => {
-    const d = JSON.parse(e.data).data as { name?: string; rev?: number };
+  source.on('artifact_written', (ev) => {
+    const d = ev.data as { name?: string; rev?: number };
     loadList().catch(() => {});
     // If the artifact that just changed is the one we're viewing (and we're not
     // mid-edit), refresh the viewer to its new latest — but only while visible;
@@ -364,8 +364,8 @@ function openStream() {
       else pendingRefresh.value = true;
     }
   });
-  source.on('artifact_deleted', (e) => {
-    const d = JSON.parse(e.data).data as { name?: string };
+  source.on('artifact_deleted', (ev) => {
+    const d = ev.data as { name?: string };
     loadList().catch(() => {});
     // The open artifact was removed elsewhere (CLI, or another tab) — clear the
     // viewer back to the empty state. Our own delete already advanced the view.
@@ -375,17 +375,17 @@ function openStream() {
     }
   });
   // Inline comments: forward to ArtifactDocument rather than subscribing twice.
-  source.on('comment_added', (e) => {
-    const d = JSON.parse(e.data).data as { artifact?: string; thread?: number };
+  source.on('comment_added', (ev) => {
+    const d = ev.data as { artifact?: string; thread?: number };
     commentsRef.value?.onCommentEvent('comment_added', d);
   });
-  source.on('comment_resolved', (e) => {
-    const d = JSON.parse(e.data).data as { artifact?: string; thread?: number };
+  source.on('comment_resolved', (ev) => {
+    const d = ev.data as { artifact?: string; thread?: number };
     commentsRef.value?.onCommentEvent('comment_resolved', d);
   });
   for (const kind of ['review_submitted', 'review_delivery', 'review_comment_resolved']) {
-    source.on(kind, (e) => {
-      const d = JSON.parse(e.data).data as {
+    source.on(kind, (ev) => {
+      const d = ev.data as {
         subject_key?: string;
         session_id?: string;
       };

--- a/crates/loom/frontend/src/components/LogsPanel.vue
+++ b/crates/loom/frontend/src/components/LogsPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue';
 import * as api from '../api';
+import { openTopic, type TopicHandle } from '../lib/eventStream';
 import type { Diagnostics, LogLine, ServerStatus, TaskRecord } from '../types';
 
 // Live server logs, straight from the process's tracing output — the same lines
@@ -65,7 +66,7 @@ const shortTime = (ts: string): string => {
 
 // --- Live stream -----------------------------------------------------------
 const live = ref(true);
-let source: EventSource | null = null;
+let source: TopicHandle | null = null;
 
 function push(line: LogLine) {
   lines.value.push(line);
@@ -77,15 +78,10 @@ function push(line: LogLine) {
 
 function openStream() {
   closeStream();
-  source = new EventSource('/api/logs/stream');
-  source.addEventListener('log', (e) => {
-    try {
-      push(JSON.parse((e as MessageEvent).data) as LogLine);
-    } catch {
-      /* ignore a malformed frame */
-    }
-  });
-  // EventSource auto-reconnects on transient errors; nothing to do here.
+  source = openTopic('logs');
+  // The shared stream owns reconnection; a dropped tail resumes from the ring
+  // buffer's newest lines, so no snapshot is refetched here.
+  source.on('log', (data) => push(data as LogLine));
 }
 
 function closeStream() {

--- a/crates/loom/frontend/src/lib/eventStream.ts
+++ b/crates/loom/frontend/src/lib/eventStream.ts
@@ -1,0 +1,244 @@
+// One `/api/events` EventSource for the whole tab.
+//
+// Browsers cap HTTP/1.1 at 6 connections per origin and that cap is a hard wall:
+// with 6 held open an ordinary `fetch()` never resolves — no error, no timeout,
+// nothing in the server log, because the request never leaves the browser. The
+// UI wants four live streams (fleet layout, a session's events, its ACP chat,
+// the operator log tail), so one tab used to spend 3 slots and two tabs spent
+// every one of them. They are multiplexed onto a single connection here.
+//
+// Subscribers name a topic (`layout`, `logs`, `session:<id>`, `chat:<id>`) and
+// get a handle whose lifetime they own, so components stay free to open and
+// close independently (keep-alive activate/deactivate) without tracking each
+// other.
+//
+// Reconnects are deliberately one-directional: adding a topic reopens the
+// connection, dropping one does not. SSE has no client→server channel, so a
+// topic set only changes by reconnecting, and reconnecting on every unsubscribe
+// would churn the shared stream on each navigation. A dropped topic simply stops
+// having listeners and is pruned at the next reconnect, which keeps returning to
+// a recently-viewed session free.
+
+type Listener = (data: unknown) => void;
+
+interface Sub {
+  topic: string;
+  /** event name -> this subscriber's callbacks */
+  listeners: Map<string, Set<Listener>>;
+  /** fired on every (re)connect that covers this topic */
+  opens: Set<() => void>;
+  closed: boolean;
+}
+
+export interface TopicHandle {
+  /** Subscribe to one event name within the topic. */
+  on(event: string, fn: Listener): void;
+  /**
+   * Run `fn` whenever the underlying stream (re)connects, including immediately
+   * if it is already connected. A reconnect can drop frames, so this is where a
+   * subscriber re-snapshots.
+   */
+  onOpen(fn: () => void): void;
+  /**
+   * Force the shared connection to reopen, re-resolving every topic on it
+   * server-side. Needed when a topic's *source* was replaced rather than its
+   * content changing — an ACP provider handoff swaps the task behind
+   * `chat:<id>`, and only a reconnect re-binds it.
+   */
+  refresh(): void;
+  /** Drop this handle's subscriptions. */
+  close(): void;
+}
+
+/** topic -> live subscribers */
+const subs = new Map<string, Set<Sub>>();
+
+let source: EventSource | null = null;
+/** Topics the *current* connection was opened with. */
+let connected = new Set<string>();
+let reconnectQueued = false;
+let forceReconnect = false;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+let retryDelay = 0;
+
+const BASE_RETRY_MS = 250;
+const MAX_RETRY_MS = 5000;
+
+function liveTopics(): string[] {
+  return [...subs.keys()];
+}
+
+/** A frame the server multiplexes onto the stream. */
+interface Frame {
+  topic: string;
+  event: string;
+  data: unknown;
+}
+
+function dispatch(frame: Frame): void {
+  for (const sub of [...(subs.get(frame.topic) ?? [])]) {
+    if (sub.closed) continue;
+    for (const fn of [...(sub.listeners.get(frame.event) ?? [])]) {
+      try {
+        fn(frame.data);
+      } catch {
+        /* a subscriber's handler must not break the fan-out */
+      }
+    }
+  }
+}
+
+function fireOpen(topics: Iterable<string>): void {
+  for (const topic of topics) {
+    for (const sub of [...(subs.get(topic) ?? [])]) {
+      if (sub.closed) continue;
+      for (const fn of [...sub.opens]) {
+        try {
+          fn();
+        } catch {
+          /* one subscriber's re-snapshot must not block the others */
+        }
+      }
+    }
+  }
+}
+
+function closeSource(): void {
+  source?.close();
+  source = null;
+  connected = new Set();
+}
+
+function connect(): void {
+  closeSource();
+  if (retryTimer) {
+    clearTimeout(retryTimer);
+    retryTimer = null;
+  }
+  const topics = liveTopics();
+  if (topics.length === 0) return;
+
+  const stream = new EventSource(`/api/events?topics=${encodeURIComponent(topics.join(','))}`);
+  source = stream;
+  connected = new Set(topics);
+
+  stream.onmessage = (e: MessageEvent) => {
+    let frame: Frame;
+    try {
+      frame = JSON.parse(e.data) as Frame;
+    } catch {
+      return; // ignore a malformed frame
+    }
+    dispatch(frame);
+  };
+
+  stream.onopen = () => {
+    // A superseded connection must not re-snapshot subscribers against the
+    // topic set its replacement now owns.
+    if (source !== stream) return;
+    retryDelay = 0;
+    fireOpen(connected);
+  };
+
+  // EventSource retries transient failures itself, but browsers do not
+  // consistently reconnect after a clean EOF (a server restart, a provider
+  // handoff closing the task broadcast). Drive the retry explicitly, backing off
+  // so a server that stays down is not hammered.
+  stream.onerror = () => {
+    if (source !== stream) return;
+    if (stream.readyState !== EventSource.CLOSED) return;
+    closeSource();
+    if (retryTimer || liveTopics().length === 0) return;
+    retryDelay = retryDelay ? Math.min(retryDelay * 2, MAX_RETRY_MS) : BASE_RETRY_MS;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      connect();
+    }, retryDelay);
+  };
+}
+
+/**
+ * Reconnect only if some live topic is missing from the current connection.
+ * Coalesced onto a microtask: one navigation re-subscribes several components
+ * (detail, conversation, artifacts, terminal) and they must cost one reconnect,
+ * not four.
+ */
+function ensureConnected(force = false): void {
+  if (force) forceReconnect = true;
+  if (reconnectQueued) return;
+  reconnectQueued = true;
+  queueMicrotask(() => {
+    reconnectQueued = false;
+    const forced = forceReconnect;
+    forceReconnect = false;
+    const topics = liveTopics();
+    if (topics.length === 0) {
+      closeSource();
+      return;
+    }
+    if (!forced && source && topics.every((t) => connected.has(t))) return;
+    connect();
+  });
+}
+
+export function openTopic(topic: string): TopicHandle {
+  const sub: Sub = { topic, listeners: new Map(), opens: new Set(), closed: false };
+  let set = subs.get(topic);
+  if (!set) {
+    set = new Set();
+    subs.set(topic, set);
+  }
+  set.add(sub);
+  ensureConnected();
+
+  return {
+    on(event: string, fn: Listener) {
+      if (sub.closed) return;
+      let handlers = sub.listeners.get(event);
+      if (!handlers) {
+        handlers = new Set();
+        sub.listeners.set(event, handlers);
+      }
+      handlers.add(fn);
+    },
+    onOpen(fn: () => void) {
+      if (sub.closed) return;
+      sub.opens.add(fn);
+      // Already streaming this topic: no reconnect is coming, so give this
+      // subscriber its "connected" edge anyway or it would never snapshot.
+      if (source && source.readyState === EventSource.OPEN && connected.has(topic)) {
+        queueMicrotask(() => {
+          if (!sub.closed) fn();
+        });
+      }
+    },
+    refresh() {
+      if (sub.closed) return;
+      ensureConnected(true);
+    },
+    close() {
+      if (sub.closed) return;
+      sub.closed = true;
+      sub.listeners.clear();
+      sub.opens.clear();
+      const peers = subs.get(topic);
+      peers?.delete(sub);
+      if (peers && peers.size === 0) subs.delete(topic);
+      // Deliberately no reconnect: the topic keeps flowing on the existing
+      // connection with no listeners until something else forces a reconnect,
+      // and is dropped then.
+      if (subs.size === 0) closeSource();
+    },
+  };
+}
+
+/** Test seam: drop all state and close the connection. */
+export function resetEventStream(): void {
+  subs.clear();
+  closeSource();
+  if (retryTimer) {
+    clearTimeout(retryTimer);
+    retryTimer = null;
+  }
+  retryDelay = 0;
+}

--- a/crates/loom/frontend/src/lib/sessionEvents.ts
+++ b/crates/loom/frontend/src/lib/sessionEvents.ts
@@ -1,90 +1,34 @@
-// One shared `/api/sessions/{id}/events` EventSource per session id.
+// A session's event feed, as one topic on the tab's multiplexed stream.
 //
-// Browsers cap HTTP/1.1 at 6 connections per origin, and that cap is a hard
-// wall: with 6 held open, an ordinary `fetch()` never resolves — no error, no
-// timeout, nothing in the server log, because the request never leaves the
-// browser. SessionDetail, ArtifactsPanel, and TerminalConversation all want the
-// *same* per-session stream, so opening one each spent half the page's entire
-// connection budget on duplicates of a single stream.
+// SessionDetail, ArtifactsPanel, and TerminalConversation all want the *same*
+// per-session feed, so they share a subscription here — and `eventStream` in
+// turn folds every topic in the tab onto a single connection, so the whole UI
+// costs one of the browser's 6 per-origin sockets instead of three. See
+// `lib/eventStream.ts` for why that cap matters.
 //
-// Subscribers share one connection here and the stream closes when the last one
-// leaves. Each subscriber gets its own handle, so components stay free to open
-// and close independently (keep-alive activate/deactivate) without tracking each
-// other.
+// Each subscriber gets its own handle, so components stay free to open and close
+// independently (keep-alive activate/deactivate) without tracking each other.
 
-type Listener = (ev: MessageEvent) => void;
+import { openTopic, type TopicHandle } from './eventStream';
+import type { WeaverEvent } from '../types';
 
-interface Shared {
-  es: EventSource;
-  /** kind -> live subscriber callbacks */
-  listeners: Map<string, Set<Listener>>;
-  /** kinds already wired onto the EventSource (wire each at most once) */
-  wired: Set<string>;
-  refs: number;
-}
-
-const streams = new Map<string, Shared>();
+type Listener = (event: WeaverEvent) => void;
 
 export interface SessionEventsHandle {
   /** Subscribe this handle to one event kind. */
   on(kind: string, fn: Listener): void;
-  /** Drop this handle's subscriptions; closes the stream when it was the last. */
+  /** Drop this handle's subscriptions. */
   close(): void;
 }
 
 export function openSessionEvents(id: string): SessionEventsHandle {
-  let shared = streams.get(id);
-  if (!shared) {
-    shared = {
-      es: new EventSource(`/api/sessions/${id}/events`),
-      listeners: new Map(),
-      wired: new Set(),
-      refs: 0,
-    };
-    streams.set(id, shared);
-  }
-  const stream = shared;
-  stream.refs += 1;
-
-  const mine: Array<[string, Listener]> = [];
-  let closed = false;
-
+  const topic: TopicHandle = openTopic(`session:${id}`);
   return {
     on(kind: string, fn: Listener) {
-      if (closed) return;
-      let set = stream.listeners.get(kind);
-      if (!set) {
-        set = new Set();
-        stream.listeners.set(kind, set);
-      }
-      set.add(fn);
-      mine.push([kind, fn]);
-      if (stream.wired.has(kind)) return;
-      stream.wired.add(kind);
-      // Resolve subscribers at delivery time, not wiring time, so a handle that
-      // subscribes later still receives this kind. One subscriber throwing must
-      // not stop delivery to the rest.
-      stream.es.addEventListener(kind, (e) => {
-        for (const cb of [...(stream.listeners.get(kind) ?? [])]) {
-          try {
-            cb(e as MessageEvent);
-          } catch {
-            /* a subscriber's handler must not break the fan-out */
-          }
-        }
-      });
+      topic.on(kind, (data) => fn(data as WeaverEvent));
     },
     close() {
-      if (closed) return;
-      closed = true;
-      for (const [kind, fn] of mine) stream.listeners.get(kind)?.delete(fn);
-      mine.length = 0;
-      stream.refs -= 1;
-      if (stream.refs > 0) return;
-      stream.es.close();
-      // Only drop the registry entry if it is still ours: a component that
-      // re-opened the same id mid-teardown has already installed a fresh one.
-      if (streams.get(id) === stream) streams.delete(id);
+      topic.close();
     },
   };
 }

--- a/crates/loom/frontend/src/lib/sessionsStore.ts
+++ b/crates/loom/frontend/src/lib/sessionsStore.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue';
 import { getSessionLayout, listRuns, listSessionSummaries } from '../api';
+import { openTopic, type TopicHandle } from './eventStream';
 import type { AutomationRun, SessionLayout, SessionSummary } from '../types';
 
 // One shared snapshot of the fleet. The session list, the status bar, and the
@@ -119,15 +120,15 @@ function focusSession(id: string): void {
 // caller is authenticated and stopped on sign-out. Guarded so a double-call
 // (HMR, a re-mount) can't leave two intervals running.
 let timer: number | undefined;
-let layoutEvents: EventSource | undefined;
+let layoutEvents: TopicHandle | undefined;
 const POLL_MS = 3000;
 
 function startFleetPoll(): void {
   if (timer !== undefined) return;
   refreshActive();
   timer = window.setInterval(refreshActive, POLL_MS);
-  layoutEvents = new EventSource('/api/session-layout/events');
-  layoutEvents.addEventListener('session_layout', () => void refreshActive());
+  layoutEvents = openTopic('layout');
+  layoutEvents.on('session_layout', () => void refreshActive());
 }
 
 function stopFleetPoll(): void {

--- a/crates/loom/frontend/src/views/SessionDetail.vue
+++ b/crates/loom/frontend/src/views/SessionDetail.vue
@@ -397,8 +397,7 @@ function openStream() {
   // triage, any free-form key); a tag write re-fetches the session so the
   // resolved badge and the pill row refresh.
   for (const kind of ['status', 'tag', 'github', 'handoff', 'metadata']) {
-    source.on(kind, (e) => {
-      const ev = JSON.parse(e.data) as WeaverEvent;
+    source.on(kind, (ev) => {
       events.value.push(ev);
       loadSession().catch(() => {});
     });

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -137,7 +137,11 @@ async fn automation_owns_session(st: &AppState, subject: &str, session_id: &str)
     .unwrap_or(false)
 }
 
-async fn grant_allows(
+/// Whether `principal`'s grant permits `method raw_path`. The router runs this
+/// over every request; the multiplexed `/api/events` stream re-runs it per topic
+/// against the route that topic stands in for, so folding streams onto one
+/// connection cannot widen what a scoped credential can read.
+pub(super) async fn grant_allows(
     st: &AppState,
     principal: &Principal,
     method: &axum::http::Method,
@@ -148,6 +152,12 @@ async fn grant_allows(
     }
     let path = raw_path.strip_prefix("/api").unwrap_or(raw_path);
     let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
+    // The multiplexed stream carries no authority of its own: it is a container
+    // whose every topic is re-checked here against the single-stream route it
+    // stands in for. Reaching the route grants nothing; the topic list does.
+    if *method == axum::http::Method::GET && path == "/events" {
+        return true;
+    }
     match &principal.grant {
         Grant::Admin => true,
         Grant::Automation { subject, .. } => {

--- a/crates/loom/src/web/eventmux.rs
+++ b/crates/loom/src/web/eventmux.rs
@@ -1,0 +1,235 @@
+//! One multiplexed SSE stream per browser origin.
+//!
+//! Browsers cap HTTP/1.1 at 6 connections per origin, and an EventSource holds
+//! one for its whole life. The UI wants four different live streams — the fleet
+//! layout, a session's event feed, its ACP chat deltas, and the operator log
+//! tail — so a single tab spent 3 of the 6 slots and two tabs spent all of them.
+//! Past the cap an ordinary `fetch()` never resolves: no error, no timeout, and
+//! nothing in the server log, because the request never leaves the browser.
+//!
+//! `GET /api/events?topics=…` folds all of them onto one connection. Every frame
+//! is the default `message` event carrying `{topic, event, data}`, so the client
+//! routes on `topic` and recovers the original per-stream event name from
+//! `event`. The per-stream routes stay as they are — they remain the documented
+//! single-stream API, and this is the browser's connection-thrifty path.
+//!
+//! Authorization is deliberately *not* a new policy surface: each topic maps
+//! back to the concrete route it replaces and is run through the same
+//! [`grant_allows`] check the router applies, so a session-scoped credential
+//! reaches exactly the topics whose routes it could already have called.
+
+use std::convert::Infallible;
+use std::pin::Pin;
+
+use axum::{
+    extract::{Query, State},
+    http::{Method, StatusCode},
+    response::sse::{self, KeepAlive, Sse},
+    Extension,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::{Stream, StreamExt, StreamMap};
+
+use crate::auth::Principal;
+use crate::logs;
+
+use super::auth::grant_allows;
+use super::{require_branch, require_session, ApiResult, AppError, AppState};
+
+/// A boxed per-topic stream. Every topic is erased to this so one [`StreamMap`]
+/// can fold them together regardless of which broadcast they came from.
+type TopicStream = Pin<Box<dyn Stream<Item = Result<sse::Event, Infallible>> + Send>>;
+
+/// Cap on topics per connection. The point of this route is to spend one socket
+/// instead of six; a client asking for hundreds of topics is a bug, and each one
+/// costs a broadcast receiver.
+const MAX_TOPICS: usize = 64;
+
+/// `StreamMap` key for the never-yielding entry that keeps the response open.
+/// Not a parseable topic name, so it cannot collide with a caller's topic.
+const KEEPALIVE_KEY: &str = "__keepalive";
+
+#[derive(Debug, Deserialize)]
+pub(super) struct EventsQuery {
+    /// Comma-separated topic list: `layout`, `logs`, `session:<key>`,
+    /// `chat:<key>`.
+    #[serde(default)]
+    topics: String,
+}
+
+/// One frame on the multiplexed stream. `event` is the event name the
+/// single-stream route would have used, so the client's per-topic handlers are
+/// unchanged from the un-multiplexed shape.
+#[derive(Debug, Serialize)]
+struct Frame<'a> {
+    topic: &'a str,
+    event: &'a str,
+    data: Value,
+}
+
+fn frame(topic: &str, event: &str, data: Value) -> Result<sse::Event, Infallible> {
+    Ok(sse::Event::default()
+        .json_data(Frame { topic, event, data })
+        .unwrap_or_default())
+}
+
+/// The parsed form of one requested topic.
+enum Topic {
+    Layout,
+    Logs,
+    Session(String),
+    Chat(String),
+}
+
+impl Topic {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw.split_once(':') {
+            Some(("session", key)) if !key.is_empty() => Some(Self::Session(key.to_string())),
+            Some(("chat", key)) if !key.is_empty() => Some(Self::Chat(key.to_string())),
+            Some(_) => None,
+            None => match raw {
+                "layout" => Some(Self::Layout),
+                "logs" => Some(Self::Logs),
+                _ => None,
+            },
+        }
+    }
+
+    /// The route this topic stands in for. Authorization runs against this path,
+    /// so the multiplexed stream can never widen a credential's reach.
+    fn route(&self) -> String {
+        match self {
+            Self::Layout => "/api/session-layout/events".to_string(),
+            Self::Logs => "/api/logs/stream".to_string(),
+            Self::Session(key) => format!("/api/sessions/{key}/events"),
+            Self::Chat(key) => format!("/api/sessions/{key}/chat/stream"),
+        }
+    }
+}
+
+/// `GET /api/events?topics=layout,logs,session:abc,chat:abc` — every live stream
+/// the caller asked for, folded onto one connection.
+///
+/// A topic the credential may not read fails the whole request: the client picks
+/// its own topics, so that is a bug worth surfacing loudly rather than a stream
+/// that silently omits a view's updates. A topic that merely fails to *resolve*
+/// (an archived session the UI has not dropped yet) is non-fatal — it reports an
+/// `error` frame on its own topic and the other topics keep flowing.
+pub(super) async fn events_mux(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Query(q): Query<EventsQuery>,
+) -> ApiResult<Sse<impl Stream<Item = Result<sse::Event, Infallible>>>> {
+    let raw: Vec<&str> = q
+        .topics
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect();
+    if raw.len() > MAX_TOPICS {
+        return Err(AppError::new(
+            StatusCode::BAD_REQUEST,
+            format!("too many topics ({}, max {MAX_TOPICS})", raw.len()),
+        ));
+    }
+
+    // Keyed by topic, so a topic repeated in the query opens one receiver rather
+    // than doubling every frame.
+    let mut streams: StreamMap<String, TopicStream> = StreamMap::new();
+
+    for name in raw {
+        if streams.contains_key(name) {
+            continue;
+        }
+        let topic = Topic::parse(name).ok_or_else(|| {
+            AppError::new(StatusCode::BAD_REQUEST, format!("unknown topic '{name}'"))
+        })?;
+        if !grant_allows(&st, &principal, &Method::GET, &topic.route()).await {
+            return Err(AppError::new(
+                StatusCode::FORBIDDEN,
+                format!("credential grant forbids topic '{name}'"),
+            ));
+        }
+        streams.insert(name.to_string(), topic_stream(&st, name, topic).await);
+    }
+
+    // Never let the merged stream terminate: an SSE response that ends puts the
+    // browser into a reconnect loop, and `StreamMap` finishes once every entry
+    // is exhausted. With no topics (or once every topic's broadcast closes) this
+    // keeps the connection parked on keep-alive instead. `Topic::parse` rejects
+    // this name, so it cannot collide with a real topic.
+    streams.insert(KEEPALIVE_KEY.to_string(), Box::pin(tokio_stream::pending()));
+
+    Ok(Sse::new(streams.map(|(_, event)| event)).keep_alive(KeepAlive::default()))
+}
+
+/// Build one topic's stream, already framed with its topic name.
+async fn topic_stream(st: &AppState, name: &str, topic: Topic) -> TopicStream {
+    let owned = name.to_string();
+    match topic {
+        Topic::Layout => {
+            let stream = BroadcastStream::new(st.bus.subscribe()).filter_map(move |result| {
+                let event = result.ok()?;
+                if event.kind != "session_layout" {
+                    return None;
+                }
+                Some(frame(&owned, "session_layout", event.data))
+            });
+            Box::pin(stream)
+        }
+        Topic::Logs => {
+            let stream =
+                BroadcastStream::new(logs::buffer().subscribe()).filter_map(move |result| {
+                    // A lagged subscriber yields Err; skip the gap (the client can
+                    // re-snapshot).
+                    let line = result.ok()?;
+                    Some(frame(&owned, "log", json!(line)))
+                });
+            Box::pin(stream)
+        }
+        Topic::Session(key) => {
+            let branch = match require_branch(&st.db, &key).await {
+                Ok(branch) => branch,
+                Err(e) => return unresolved(&owned, &e),
+            };
+            let id = branch.id;
+            let stream = BroadcastStream::new(st.bus.subscribe()).filter_map(move |result| {
+                let event = result.ok()?;
+                if event.branch_id != id {
+                    return None;
+                }
+                let kind = event.kind.clone();
+                Some(frame(&owned, &kind, json!(event)))
+            });
+            Box::pin(stream)
+        }
+        Topic::Chat(key) => {
+            let session = match require_session(&st.db, &key).await {
+                Ok((session, _)) => session,
+                Err(e) => return unresolved(&owned, &e),
+            };
+            match st.acp.get(&session.id) {
+                Some(handle) => {
+                    let stream = BroadcastStream::new(handle.subscribe()).filter_map(move |r| {
+                        let ev = r.ok()?;
+                        Some(frame(&owned, &ev.event, ev.data))
+                    });
+                    Box::pin(stream)
+                }
+                // No live task yet: hold the topic open with no events, exactly
+                // as the single-stream route does. A handoff installs a new task
+                // and the client rebinds.
+                None => Box::pin(tokio_stream::pending()),
+            }
+        }
+    }
+}
+
+/// A topic that could not be resolved reports one `error` frame and then goes
+/// quiet, leaving every other topic on the connection untouched.
+fn unresolved(topic: &str, err: &AppError) -> TopicStream {
+    let first = frame(topic, "error", json!({ "message": err.message() }));
+    Box::pin(tokio_stream::once(first).chain(tokio_stream::pending()))
+}

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -77,6 +77,7 @@ mod deployment;
 mod diagnostics;
 mod discussion;
 mod env;
+mod eventmux;
 mod issues;
 mod launches;
 mod logview;
@@ -103,6 +104,7 @@ use deployment::*;
 use diagnostics::*;
 use discussion::*;
 use env::*;
+use eventmux::*;
 use issues::*;
 use launches::*;
 use logview::*;
@@ -716,6 +718,10 @@ pub fn router(state: AppState) -> Router {
     // Everything else requires an authenticated principal — a bearer token, a
     // session cookie, or a trusted-loopback request — gated by `require_auth`.
     let protected = Router::new()
+        // Every live stream the browser wants, folded onto one connection so a
+        // tab spends 1 of its 6 per-origin sockets instead of 3. The per-stream
+        // routes below remain the single-stream API.
+        .route("/events", get(events_mux))
         // Shared Spaces → Groups → Sessions workbench organization.
         .route("/session-layout", get(get_session_layout))
         .route("/session-layout/events", get(session_layout_events))

--- a/crates/loom/tests/integration/eventmux.rs
+++ b/crates/loom/tests/integration/eventmux.rs
@@ -1,0 +1,231 @@
+//! The multiplexed `/api/events` stream: many topics on one connection.
+//!
+//! The browser caps HTTP/1.1 at 6 connections per origin, so the UI folds every
+//! live stream onto this one route. These cases pin the three properties that
+//! make that safe: frames stay attributable to their topic, one bad topic does
+//! not take the connection down with it, and multiplexing cannot widen what a
+//! scoped credential may read.
+
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use reqwest::StatusCode;
+use serde_json::json;
+use serial_test::serial;
+
+use crate::acp::start_new;
+use crate::fixtures::TestServer;
+
+fn events_url(ts: &TestServer, topics: &str) -> String {
+    format!(
+        "http://{}/api/events?topics={}",
+        ts.addr,
+        urlencoding_encode(topics)
+    )
+}
+
+/// Percent-encode the few characters our topic lists actually use, so the tests
+/// don't pull in a dependency for `,` and `:`.
+fn urlencoding_encode(raw: &str) -> String {
+    raw.chars()
+        .map(|c| match c {
+            ':' => "%3A".to_string(),
+            ',' => "%2C".to_string(),
+            other => other.to_string(),
+        })
+        .collect()
+}
+
+/// Read the SSE body until `done` matches or the deadline passes.
+async fn read_until(
+    resp: reqwest::Response,
+    timeout: Duration,
+    done: impl Fn(&str) -> bool,
+) -> String {
+    let mut stream = resp.bytes_stream();
+    let mut body = String::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline - tokio::time::Instant::now();
+        match tokio::time::timeout(remaining, stream.next()).await {
+            Ok(Some(Ok(chunk))) => {
+                body.push_str(&String::from_utf8_lossy(&chunk));
+                if done(&body) {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    body
+}
+
+/// One connection carrying a session's chat topic delivers the same events the
+/// dedicated `/chat/stream` route would, each tagged with its topic so the
+/// client can route it.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multiplexed_stream_tags_frames_with_their_topic() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-mux", None, None).await;
+
+    // Opening the stream subscribes the broadcasts before we prompt.
+    let resp = reqwest::Client::new()
+        .get(events_url(&ts, "chat:acp-mux,session:acp-mux"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    ts.client
+        .post(
+            "/api/sessions/acp-mux/prompt",
+            json!({ "text": "say:multiplexed" }),
+        )
+        .await
+        .unwrap();
+
+    let body = read_until(resp, Duration::from_secs(10), |b| {
+        b.contains("\"state\":\"ended\"")
+    })
+    .await;
+
+    // Every frame is the default `message` event; the topic lives in the payload
+    // so two sessions' `delta`s can share one connection.
+    assert!(
+        body.contains("\"topic\":\"chat:acp-mux\""),
+        "frames carry their topic: {body}"
+    );
+    assert!(
+        body.contains("\"event\":\"turn\""),
+        "stream carried turn events: {body}"
+    );
+    assert!(
+        body.contains("\"event\":\"block\""),
+        "stream carried block events: {body}"
+    );
+    assert!(
+        body.contains("\"event\":\"delta\""),
+        "stream carried delta events: {body}"
+    );
+}
+
+/// A topic name the server doesn't know is a client bug, not something to
+/// silently ignore into a stream that looks alive but delivers nothing.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_topic_is_rejected() {
+    let ts = TestServer::start().await;
+    let resp = reqwest::Client::new()
+        .get(events_url(&ts, "layout,not-a-topic"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// A topic that cannot be resolved — an archived session the UI has not dropped
+/// yet — must not take down the other topics sharing the connection. It reports
+/// an error on its own topic and everything else keeps flowing.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unresolvable_topic_is_isolated_from_the_rest() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-live", None, None).await;
+
+    let resp = reqwest::Client::new()
+        .get(events_url(&ts, "session:no-such-session,chat:acp-live"))
+        .send()
+        .await
+        .unwrap();
+    // The connection itself is fine — the dead topic is reported in-band.
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    ts.client
+        .post(
+            "/api/sessions/acp-live/prompt",
+            json!({ "text": "say:still-flowing" }),
+        )
+        .await
+        .unwrap();
+
+    let body = read_until(resp, Duration::from_secs(10), |b| {
+        b.contains("\"state\":\"ended\"")
+    })
+    .await;
+
+    assert!(
+        body.contains("\"topic\":\"session:no-such-session\"")
+            && body.contains("\"event\":\"error\""),
+        "dead topic reported an error frame: {body}"
+    );
+    assert!(
+        body.contains("\"topic\":\"chat:acp-live\"") && body.contains("\"event\":\"delta\""),
+        "the live topic kept streaming: {body}"
+    );
+}
+
+/// Folding streams onto one route must not become a way around per-session
+/// scoping: each topic is authorized against the route it stands in for.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_token_cannot_subscribe_to_another_session() {
+    let ts = TestServer::start().await;
+    let mine = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({ "cwd": ts.cwd(), "goal": "scoped", "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let session_id = mine["id"].as_str().unwrap();
+    let branch_id = mine["branch"]["id"].as_str().unwrap();
+    let token =
+        loom::auth::create_session_token(&ts.state.db, Some("rjpower"), session_id, branch_id)
+            .await
+            .unwrap();
+
+    let theirs = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({ "cwd": ts.cwd(), "goal": "unrelated", "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let other_id = theirs["id"].as_str().unwrap();
+
+    let http = reqwest::Client::new();
+
+    // Its own session's topic is exactly what `/sessions/{id}/events` allows.
+    let own = http
+        .get(events_url(&ts, &format!("session:{session_id}")))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(own.status(), StatusCode::OK);
+
+    // A sibling's is not — and asking for it alongside a permitted topic must
+    // not smuggle it through.
+    let other = http
+        .get(events_url(
+            &ts,
+            &format!("session:{session_id},session:{other_id}"),
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(other.status(), StatusCode::FORBIDDEN);
+
+    // Operator-only topics stay operator-only.
+    let logs = http
+        .get(events_url(&ts, "logs"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(logs.status(), StatusCode::FORBIDDEN);
+}

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -17,6 +17,7 @@ mod conversation;
 mod custom_agents;
 mod diagnostics;
 mod env;
+mod eventmux;
 mod ide;
 mod logs;
 mod mcp_conformance;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -290,6 +290,7 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/ready` | public structured readiness: database access plus core and loom migration versions; optional future remote runner degradation will be reported without failing the whole API |
 | `GET /metrics` | public OpenMetrics scrape derived from durable session/profile/run/migration state; labels are bounded operational dimensions and never contain session/branch/path/user/token/error values (deployments normally restrict this at the public edge) |
 | `GET /api/diagnostics` | admin-only redacted counts, profile capacity, automation failures/staleness, orphan/error inventory, migration state, and non-secret federation metadata; backs Settings → Diagnostics |
+| `GET /api/events?topics=…` | every live stream the caller names, multiplexed onto one SSE connection — the browser holds 6 per origin, so the SPA subscribes here rather than opening one EventSource per view. Topics are `layout`, `logs`, `session:{id}`, `chat:{id}`; each frame is the default `message` event carrying `{topic, event, data}`, where `event` is the name the single-stream route below uses. Every topic is authorized against the route it stands in for, so this widens no credential; an unresolvable topic reports one `error` frame on its own topic and leaves the rest streaming |
 | `POST /api/session-launches/resolve` | resolve a canonical profile selection plus one-launch overrides into concrete selectors, provenance, policy, capacity, validation, and profile/resolver revisions without provisioning |
 | `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false` — `automation` — default `false` — and admin-only `managed` — default `false`; canonical create requires both revisions from resolve and returns 409 plus a fresh preview on drift/admission change; flattened selectors remain compatible; valid Scratch input is decoded before provisioning; visible creates atomically assign configured origin/profile placement and a same-id default channel while managed warm infrastructure has no placement or layout revision effect; create stamps `resolved_launch`; `tracking_issue` is present only for an explicit claimed/imported work item) |
 | `GET POST /api/channels`; `GET DELETE /api/channels/{id}` | list/create communication contexts, inspect one, or archive a custom channel; session channels follow their session lifecycle |
@@ -502,10 +503,13 @@ Details → Advanced, not as the primary file or work surface.
   runtime supervisors, git, gh, and agent adapters) go through
   `tokio::process::Command`. The `weaver` CLI remains synchronous-feeling while
   delegating its reads and writes to `weaver-api` over HTTP.
-- **Events:** state changes flow through `EventBus`; the SSE handler in
-  `web.rs` fans them out. `weaver hook` posts to the branch events route; Loom
+- **Events:** state changes flow through `EventBus`; the SSE handlers in
+  `web.rs` fan them out. `weaver hook` posts to the branch events route; Loom
   writes the row, and the monitor tick promotes it into session status and a
-  fresh `EventBus` notification.
+  fresh `EventBus` notification. Browsers cap HTTP/1.1 at 6 connections per
+  origin and an EventSource holds one for its whole life, so the SPA subscribes
+  to `GET /api/events` and receives every topic over that single connection;
+  the per-stream routes remain the single-stream API for other clients.
 - **No tracking-branch state in the server:** loom can be killed and restarted
   at any time. Terminal *and* relay supervisors and worktrees survive (the
   supervisor is a detached process, independent of `loom server run`); "orphaned"

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -4,6 +4,16 @@ Loom is a calm operations workbench for supervising coding sessions. The UI is
 a thin client of the REST API: organization, drafts, issue mutations, and
 lifecycle state are server-backed so the CLI observes the same system.
 
+Live updates arrive over one connection. Browsers cap HTTP/1.1 at six
+connections per origin and an EventSource holds one for its whole life, so a
+view that opens its own stream spends a slot the rest of the page needs — past
+the cap a `fetch()` simply never resolves, with no error and nothing in the
+server log. Components subscribe to a named topic through `lib/eventStream.ts`
+(`layout`, `logs`, `session:{id}`, `chat:{id}`) and it multiplexes them onto a
+single `GET /api/events`. Subscribe and unsubscribe with the component's
+keep-alive lifecycle; use `onOpen` to re-snapshot, since a reconnect can leave
+a gap.
+
 ## App shell and workbench
 
 The rail has five stable destinations: **Sessions**, **Issues**, **Watch**,

--- a/e2e/tests/event-stream.spec.ts
+++ b/e2e/tests/event-stream.spec.ts
@@ -1,0 +1,147 @@
+import type { Page, Request } from '@playwright/test';
+import { test, expect } from '../fixtures/weaver';
+import type { Session, WeaverFixture } from '../fixtures/weaver';
+import { join } from 'path';
+
+// The page's live streams all ride one connection.
+//
+// Browsers cap HTTP/1.1 at 6 connections per origin and an EventSource holds one
+// for its whole life. The UI used to open three (fleet layout, the session's
+// event feed, its ACP chat deltas), so two tabs exhausted the pool and every
+// `fetch()` after that hung with no error and nothing in the server log. These
+// specs assert the property that prevents it — not the plumbing, the count.
+
+const FAKE_AGENT = join(
+  __dirname,
+  '..',
+  '..',
+  'crates',
+  'loom',
+  'tests',
+  'fixtures',
+  'fake-acp-agent.mjs',
+);
+const HEADERS = { 'content-type': 'application/json' };
+const SKIP_MSG = 'server does not launch acp sessions over REST here';
+
+/** Any request that holds a connection open for its lifetime. */
+function isStream(url: string): boolean {
+  return (
+    url.includes('/api/events') ||
+    url.includes('/api/logs/stream') ||
+    url.includes('/chat/stream') ||
+    url.includes('/api/session-layout/events') ||
+    /\/api\/sessions\/[^/]+\/events/.test(url)
+  );
+}
+
+/**
+ * Track streaming requests that are still open. An SSE request never
+ * "finishes", so anything left in this set is holding one of the six slots.
+ */
+function trackStreams(page: Page): Set<Request> {
+  const inflight = new Set<Request>();
+  page.on('request', (r) => {
+    if (isStream(r.url())) inflight.add(r);
+  });
+  page.on('requestfinished', (r) => inflight.delete(r));
+  page.on('requestfailed', (r) => inflight.delete(r));
+  return inflight;
+}
+
+async function launchAcpSession(
+  weaver: WeaverFixture,
+  opts: { goal: string; name: string },
+): Promise<Session | null> {
+  const res = await fetch(`${weaver.baseUrl}/api/agents/custom`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify({
+      name: 'acp-fake',
+      label: 'ACP fake',
+      setup: '',
+      launch: `FAKE_ACP_STEERING=1 node ${FAKE_AGENT}`,
+      resume: '',
+      reports_status: false,
+      protocol: 'acp',
+    }),
+  });
+  if (!res.ok && res.status !== 409)
+    throw new Error(`defining the fake agent failed: ${await res.text()}`);
+
+  const created = await fetch(`${weaver.baseUrl}/api/sessions`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify({
+      goal: opts.goal,
+      cwd: weaver.repoPath,
+      agent: 'acp-fake',
+      name: opts.name,
+      protocol: 'acp',
+      mode: 'default',
+    }),
+  });
+  if (!created.ok) return null;
+  const s = (await created.json()) as Session & { protocol?: string };
+  return s.protocol === 'acp' ? s : null;
+}
+
+test.describe('multiplexed event stream', () => {
+  test('a session page holds exactly one streaming connection', async ({ page, weaver }) => {
+    const inflight = trackStreams(page);
+    const s = await launchAcpSession(weaver, {
+      goal: 'say:Streaming over one socket.',
+      name: 'mux-one-conn',
+    });
+    test.skip(s === null, SKIP_MSG);
+
+    await page.goto(`${weaver.baseUrl}/s/${s!.id}`);
+    // The conversation rendering means layout, session events, and chat deltas
+    // are all live — the three streams this used to cost.
+    await expect(page.getByTestId('acp-conversation')).toBeVisible();
+    await expect(page.getByText('Streaming over one socket.')).toBeVisible();
+
+    const open = [...inflight];
+    expect(
+      open.map((r) => r.url()),
+      'the whole page streams over a single connection',
+    ).toHaveLength(1);
+
+    // ...and it is the multiplexed route, carrying both per-session topics.
+    const url = open[0].url();
+    expect(url).toContain('/api/events?topics=');
+    const topics = decodeURIComponent(new URL(url).searchParams.get('topics') ?? '').split(',');
+    expect(topics).toContain('layout');
+    expect(topics).toContain(`session:${s!.id}`);
+    expect(topics).toContain(`chat:${s!.id}`);
+  });
+
+  test('navigating between sessions does not accumulate connections', async ({ page, weaver }) => {
+    const inflight = trackStreams(page);
+    const first = await launchAcpSession(weaver, {
+      goal: 'say:First session.',
+      name: 'mux-nav-first',
+    });
+    test.skip(first === null, SKIP_MSG);
+    const second = await launchAcpSession(weaver, {
+      goal: 'say:Second session.',
+      name: 'mux-nav-second',
+    });
+    test.skip(second === null, SKIP_MSG);
+
+    await page.goto(`${weaver.baseUrl}/s/${first!.id}`);
+    await expect(page.getByText('First session.')).toBeVisible();
+
+    // Round-trip into the other session and back. Each hop re-subscribes several
+    // components; the shared stream must reconnect, not stack up.
+    await page.goto(`${weaver.baseUrl}/s/${second!.id}`);
+    await expect(page.getByText('Second session.')).toBeVisible();
+    await page.goto(`${weaver.baseUrl}/s/${first!.id}`);
+    await expect(page.getByText('First session.')).toBeVisible();
+
+    expect(
+      [...inflight].map((r) => r.url()),
+      'navigation replaces the connection instead of adding one',
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## The bug

The loom server periodically goes "unresponsive to sessions": the session list renders fine, but opening a session detail hangs, then recovers on its own minutes later. It looks like a server stall, but the server is healthy throughout — every detail endpoint answers in under 10ms, and there is nothing in the log, because **the request never leaves the browser**.

Browsers cap HTTP/1.1 at 6 connections per origin and an `EventSource` holds one for its entire life. The UI opened three per tab:

| stream | opened by |
|---|---|
| `/api/session-layout/events` | `lib/sessionsStore.ts` (global fleet store) |
| `/api/sessions/{id}/events` | `lib/sessionEvents.ts` (shared by SessionDetail, ArtifactsPanel, TerminalConversation) |
| `/api/sessions/{id}/chat/stream` | `components/AcpConversation.vue` |

plus `/api/logs/stream` when the Logs panel is open. One tab spent half the budget; two tabs exhausted it. Past the cap an ordinary `fetch()` never resolves — no error, no timeout, no server-side trace. The "recovery" is just a stream dropping and freeing a slot.

HTTP/2 is not an escape hatch here: browsers only negotiate h2 over TLS, so plain-http localhost stays capped at 6 regardless of what the server supports.

## The fix

`GET /api/events?topics=layout,logs,session:<id>,chat:<id>` folds every live stream onto one connection (`crates/loom/src/web/eventmux.rs`). Each frame is the default `message` event carrying `{topic, event, data}`, where `event` is the name the single-stream route already used — so per-topic handlers keep their shape. The per-stream routes are unchanged and remain the single-stream API for other clients.

Three decisions worth review:

**Authorization is not a new policy surface.** Each topic maps back to the concrete route it stands in for (`chat:x` → `/api/sessions/x/chat/stream`) and is run through the same `grant_allows` the router applies to every request. A session-scoped credential reaches exactly the topics whose routes it could already have called. The `/api/events` container itself is allowed unconditionally because it carries no authority of its own — the topic list does.

**A forbidden topic fails the request; an unresolvable one does not.** A topic the credential may not read 403s the whole connection (the client picks its own topics, so that is a bug worth surfacing loudly). A topic that merely fails to *resolve* — an archived session the UI has not dropped yet — reports one `error` frame on its own topic and leaves every other topic streaming. Without that split, archiving a session while it is subscribed would take down every other view's updates.

**Client reconnects are one-directional.** Adding a topic reopens the connection; dropping one does not. SSE has no client→server channel, so the topic set can only change by reconnecting, and reconnecting on every unsubscribe would churn the shared stream on each navigation. Dead topics are pruned at the next reconnect, which makes returning to a recently-viewed session free. Reconnects coalesce onto a microtask, since one navigation re-subscribes four components.

Two things fell out of the consolidation: the retry/backoff logic `AcpConversation` had duplicated now lives in one place, and `onOpen` fires on every reconnect (including one triggered by an unrelated topic) — exactly when a gap could have opened, so re-snapshotting there is correct. An ACP provider handoff replaces the task behind an unchanged topic name, so it forces a reconnect via `refresh()`.

## Verification

- 4 integration tests in `crates/loom/tests/integration/eventmux.rs`: topic tagging, unknown topic → 400, an unresolvable topic isolated from the rest, and a session-scoped token blocked from a sibling's topic and from `logs`.
- Full loom suite: 162 passed. `cargo clippy` and `cargo fmt` clean.
- 2 e2e specs in `e2e/tests/event-stream.spec.ts` asserting the property rather than the plumbing: a live ACP session page holds **exactly one** streaming connection carrying `layout` + `session:<id>` + `chat:<id>`, and navigating between sessions does not accumulate connections. Full e2e suite: 121 passed.

`grep "new EventSource"` over the frontend now returns exactly one hit.

Note: CI runs no Playwright job, so the e2e results above are local-only and will not be re-verified by this PR's checks.
