### PR TITLE
Add Slack placement and idle retention

### DIFF
--- a/crates/loom-store/migrations/0019_slack_space.sql
+++ b/crates/loom-store/migrations/0019_slack_space.sql
@@ -1,0 +1,70 @@
+-- Slack-origin sessions are conversations, so keep them in their own
+-- operator-visible space instead of mixing them into the generic User inbox.
+-- Adopt a manually-created Slack/Inbox when one already exists.
+INSERT OR IGNORE INTO session_spaces
+    (id, name, rank, system_key, created_at, updated_at)
+SELECT
+    'space-slack',
+    'Slack',
+    COALESCE(MAX(rank) + 1, 0),
+    'slack',
+    strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+    strftime('%Y-%m-%dT%H:%M:%fZ','now')
+FROM session_spaces;
+
+UPDATE session_spaces
+SET system_key = 'slack',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+WHERE name = 'Slack' COLLATE NOCASE
+  AND system_key IS NULL;
+
+INSERT OR IGNORE INTO session_groups
+    (id, space_id, name, rank, system_key, created_at, updated_at)
+SELECT
+    'group-slack-inbox',
+    id,
+    'Inbox',
+    0,
+    'inbox',
+    strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+    strftime('%Y-%m-%dT%H:%M:%fZ','now')
+FROM session_spaces
+WHERE system_key = 'slack';
+
+UPDATE session_groups
+SET system_key = 'inbox',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+WHERE space_id = (
+        SELECT id FROM session_spaces WHERE system_key = 'slack'
+    )
+  AND name = 'Inbox' COLLATE NOCASE
+  AND system_key IS NULL;
+
+-- Preserve an operator's explicit origin default if they configured one before
+-- this system space existed.
+INSERT OR IGNORE INTO session_placement_defaults
+    (selector_kind, selector_value, group_id)
+SELECT
+    'origin',
+    'slack',
+    session_groups.id
+FROM session_groups
+JOIN session_spaces ON session_spaces.id = session_groups.space_id
+WHERE session_spaces.system_key = 'slack'
+  AND session_groups.system_key = 'inbox';
+
+-- Move only legacy Slack sessions still sitting in the old fallback inbox.
+-- Manual placements remain untouched.
+UPDATE session_placements
+SET group_id = (
+        SELECT session_groups.id
+        FROM session_groups
+        JOIN session_spaces ON session_spaces.id = session_groups.space_id
+        WHERE session_spaces.system_key = 'slack'
+          AND session_groups.system_key = 'inbox'
+    ),
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+WHERE group_id = 'group-user-inbox'
+  AND session_id IN (
+      SELECT id FROM sessions WHERE origin = 'slack'
+  );

--- a/crates/loom-store/src/db.rs
+++ b/crates/loom-store/src/db.rs
@@ -100,6 +100,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "github-head-freshness",
         include_str!("../migrations/0018_github_head_freshness.sql"),
     ),
+    (
+        19,
+        "slack-space",
+        include_str!("../migrations/0019_slack_space.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -361,7 +366,7 @@ mod tests {
                 .fetch_one(&db)
                 .await
                 .unwrap();
-        assert_eq!(spaces, 3);
+        assert_eq!(spaces, 4);
         assert_eq!(revision, 1);
 
         let columns = table_columns(&db, "sessions").await.unwrap();
@@ -529,7 +534,122 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn v11_database_upgrades_to_layout_v12_deterministically_and_idempotently() {
+    async fn v17_database_adopts_manual_slack_space_without_overwriting_placements() {
+        let db = core_connect_in_memory().await.unwrap();
+        LOOM_STREAM.ensure_indicator(&db).await.unwrap();
+        for (version, name, migration) in LOOM_MIGRATIONS.iter().take(17) {
+            for statement in split_statements(migration) {
+                sqlx::query(&statement).execute(&db).await.unwrap();
+            }
+            LOOM_STREAM.stamp(&db, *version, name).await.unwrap();
+        }
+
+        sqlx::query(
+            "INSERT INTO session_spaces
+             (id, name, rank, system_key, created_at, updated_at)
+             VALUES ('custom-slack', 'Slack', 3, NULL, '', '')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO session_groups
+             (id, space_id, name, rank, system_key, created_at, updated_at)
+             VALUES ('custom-slack-inbox', 'custom-slack', 'Inbox', 0, NULL, '', '')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO session_placement_defaults
+             (selector_kind, selector_value, group_id)
+             VALUES ('origin', 'slack', 'custom-slack-inbox')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        for id in ["fallback-slack", "manually-placed-slack"] {
+            insert_branch(&db, id).await;
+        }
+        sqlx::query(
+            "INSERT INTO sessions
+             (id, branch_id, work_dir, term_session, status, origin, class, created_at)
+             VALUES
+             ('fallback-slack', 'fallback-slack', '/fallback', 't-fallback',
+              'running', 'slack', 'interactive', ''),
+             ('manually-placed-slack', 'manually-placed-slack', '/manual', 't-manual',
+              'running', 'slack', 'interactive', '')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO session_placements (session_id, group_id, rank, updated_at)
+             VALUES
+             ('fallback-slack', 'group-user-inbox', 0, ''),
+             ('manually-placed-slack', 'group-github-inbox', 0, '')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        LOOM_STREAM.apply_pending(&db).await.unwrap();
+        LOOM_STREAM.apply_pending(&db).await.unwrap();
+
+        let adopted_space: (String, String) =
+            sqlx::query_as("SELECT id, system_key FROM session_spaces WHERE name = 'Slack'")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(
+            adopted_space,
+            ("custom-slack".to_string(), "slack".to_string())
+        );
+        let adopted_group: (String, String) = sqlx::query_as(
+            "SELECT id, system_key FROM session_groups
+             WHERE space_id = 'custom-slack' AND name = 'Inbox'",
+        )
+        .fetch_one(&db)
+        .await
+        .unwrap();
+        assert_eq!(
+            adopted_group,
+            ("custom-slack-inbox".to_string(), "inbox".to_string())
+        );
+        let placement_default: String = sqlx::query_scalar(
+            "SELECT group_id FROM session_placement_defaults
+             WHERE selector_kind = 'origin' AND selector_value = 'slack'",
+        )
+        .fetch_one(&db)
+        .await
+        .unwrap();
+        assert_eq!(placement_default, "custom-slack-inbox");
+        let placements: Vec<(String, String)> = sqlx::query_as(
+            "SELECT session_id, group_id FROM session_placements
+             WHERE session_id IN ('fallback-slack', 'manually-placed-slack')
+             ORDER BY session_id",
+        )
+        .fetch_all(&db)
+        .await
+        .unwrap();
+        assert_eq!(
+            placements,
+            [
+                (
+                    "fallback-slack".to_string(),
+                    "custom-slack-inbox".to_string(),
+                ),
+                (
+                    "manually-placed-slack".to_string(),
+                    "group-github-inbox".to_string(),
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn v11_database_upgrades_layout_deterministically_and_idempotently() {
         let db = core_connect_in_memory().await.unwrap();
         LOOM_STREAM.ensure_indicator(&db).await.unwrap();
         for (version, name, migration) in LOOM_MIGRATIONS.iter().take(11) {
@@ -554,6 +674,7 @@ mod tests {
             "user",
             "github",
             "ops",
+            "slack",
             "parent",
             "child",
             "parked-child",
@@ -576,6 +697,8 @@ mod tests {
               'parked', NULL, '2026-01-01T00:00:01.000Z'),
              ('ops', 'ops', '/ops', 't-ops', 'running', 'actions', 'automation',
               'parked', NULL, '2026-01-01T00:00:02.000Z'),
+             ('slack', 'slack', '/slack', 't-slack', 'running', 'slack', 'interactive',
+              NULL, NULL, '2026-01-01T00:00:02.500Z'),
              ('parent', 'parent', '/parent', 't-parent', 'running', 'github', 'interactive',
               NULL, NULL, '2026-01-01T00:00:03.000Z'),
              ('child', 'child', '/child', 't-child', 'running', 'agent', 'interactive',
@@ -628,6 +751,7 @@ mod tests {
             ("user", "group-user-later"),
             ("github", "group-github-later"),
             ("ops", "group-ops-later"),
+            ("slack", "group-slack-inbox"),
             ("parent", "group-github-inbox"),
             ("child", "group-github-inbox"),
             ("parked-child", "group-github-later"),
@@ -644,7 +768,7 @@ mod tests {
             .fetch_one(&db)
             .await
             .unwrap();
-        assert_eq!(placed, 10);
+        assert_eq!(placed, 11);
         let inbox_order: Vec<String> = sqlx::query_scalar(
             "SELECT session_id FROM session_placements
              WHERE group_id = 'group-user-inbox' ORDER BY rank",
@@ -665,7 +789,7 @@ mod tests {
             .fetch_one(&db)
             .await
             .unwrap();
-        assert_eq!(defaults, 8);
+        assert_eq!(defaults, 9);
         let revision: i64 =
             sqlx::query_scalar("SELECT revision FROM session_layout_state WHERE id = 1")
                 .fetch_one(&db)

--- a/crates/loom-store/src/db.rs
+++ b/crates/loom-store/src/db.rs
@@ -324,6 +324,16 @@ mod tests {
         .unwrap();
     }
 
+    async fn migrate_through(db: &Db, count: usize) {
+        LOOM_STREAM.ensure_indicator(db).await.unwrap();
+        for (version, name, migration) in LOOM_MIGRATIONS.iter().take(count) {
+            for statement in split_statements(migration) {
+                sqlx::query(&statement).execute(db).await.unwrap();
+            }
+            LOOM_STREAM.stamp(db, *version, name).await.unwrap();
+        }
+    }
+
     #[tokio::test]
     async fn fresh_schema_records_baseline_and_has_final_shape() {
         let db = connect_in_memory().await.unwrap();
@@ -434,13 +444,7 @@ mod tests {
     #[tokio::test]
     async fn v12_database_adds_the_review_inbox_while_upgrading_to_latest() {
         let db = core_connect_in_memory().await.unwrap();
-        LOOM_STREAM.ensure_indicator(&db).await.unwrap();
-        for (version, name, migration) in LOOM_MIGRATIONS.iter().take(12) {
-            for statement in split_statements(migration) {
-                sqlx::query(&statement).execute(&db).await.unwrap();
-            }
-            LOOM_STREAM.stamp(&db, *version, name).await.unwrap();
-        }
+        migrate_through(&db, 12).await;
         assert!(table_columns(&db, "review_conversation_inbox")
             .await
             .unwrap()
@@ -467,13 +471,7 @@ mod tests {
     #[tokio::test]
     async fn v14_database_backfills_same_id_session_channels() {
         let db = core_connect_in_memory().await.unwrap();
-        LOOM_STREAM.ensure_indicator(&db).await.unwrap();
-        for (version, name, migration) in LOOM_MIGRATIONS.iter().take(14) {
-            for statement in split_statements(migration) {
-                sqlx::query(&statement).execute(&db).await.unwrap();
-            }
-            LOOM_STREAM.stamp(&db, *version, name).await.unwrap();
-        }
+        migrate_through(&db, 14).await;
         insert_branch(&db, "channel-branch").await;
         sqlx::query(
             "UPDATE branches
@@ -536,13 +534,7 @@ mod tests {
     #[tokio::test]
     async fn v17_database_adopts_manual_slack_space_without_overwriting_placements() {
         let db = core_connect_in_memory().await.unwrap();
-        LOOM_STREAM.ensure_indicator(&db).await.unwrap();
-        for (version, name, migration) in LOOM_MIGRATIONS.iter().take(17) {
-            for statement in split_statements(migration) {
-                sqlx::query(&statement).execute(&db).await.unwrap();
-            }
-            LOOM_STREAM.stamp(&db, *version, name).await.unwrap();
-        }
+        migrate_through(&db, 17).await;
 
         sqlx::query(
             "INSERT INTO session_spaces
@@ -651,13 +643,7 @@ mod tests {
     #[tokio::test]
     async fn v11_database_upgrades_layout_deterministically_and_idempotently() {
         let db = core_connect_in_memory().await.unwrap();
-        LOOM_STREAM.ensure_indicator(&db).await.unwrap();
-        for (version, name, migration) in LOOM_MIGRATIONS.iter().take(11) {
-            for statement in split_statements(migration) {
-                sqlx::query(&statement).execute(&db).await.unwrap();
-            }
-            LOOM_STREAM.stamp(&db, *version, name).await.unwrap();
-        }
+        migrate_through(&db, 11).await;
         let recorded: Vec<(i64, String)> =
             sqlx::query_as("SELECT version, name FROM loom_schema_migrations ORDER BY version")
                 .fetch_all(&db)

--- a/crates/loom-store/src/session.rs
+++ b/crates/loom-store/src/session.rs
@@ -1626,6 +1626,17 @@ mod tests {
     async fn placement_defaults_route_ops_and_delegated_sessions_inherit() {
         let db = crate::db::connect_in_memory().await.unwrap();
 
+        let slack_branch = branch_id(&db, "weaver/slack-thread").await;
+        let mut slack = new_session("slack-thread", &slack_branch, None);
+        slack.origin = "slack".to_string();
+        insert(&db, &slack).await.unwrap();
+        let slack_placement = crate::session_layout::placement(&db, "slack-thread")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(slack_placement.space_name, "Slack");
+        assert_eq!(slack_placement.group_name, "Inbox");
+
         let watch_branch = branch_id(&db, "weaver/watch-result").await;
         let mut watch = new_session("watch-result", &watch_branch, None);
         watch.origin = "watch".to_string();

--- a/crates/loom-watch/src/monitor.rs
+++ b/crates/loom-watch/src/monitor.rs
@@ -185,30 +185,34 @@ pub async fn run(state: AppState) {
         screen_hash.retain(|k, _| alive.contains(k));
         stale_seen.retain(|k| alive.contains(k));
 
-        // 3. Retention: reap finished / long-idle automation sessions, on a
-        //    slower cadence than the tick.
+        // 3. Retention: reap finished / long-idle automation sessions and
+        //    inactive Slack conversations, on a slower cadence than the tick.
         reap_tick += 1;
         if reap_tick >= REAP_EVERY_TICKS {
             reap_tick = 0;
-            reap_automation(&state, &sessions, now).await;
+            let slack_idle_archive_secs = core_config::get(&state.db, "slack.idle_archive_secs")
+                .await
+                .and_then(|value| value.trim().parse::<i64>().ok())
+                .unwrap_or(core_config::DEFAULT_SLACK_IDLE_ARCHIVE_SECS);
+            reap_sessions(&state, &sessions, slack_idle_archive_secs, now).await;
         }
     }
 }
 
-/// Why the reaper archives an automation session — [`reap_decision`]'s verdict.
+/// Why the retention reaper archives a session — [`reap_decision`]'s verdict.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReapReason {
-    /// The tracking issue the session was launched for has been closed.
+    /// The tracking issue an automation session was launched for has closed.
     IssueClosed,
-    /// The session sat idle past `automation.idle_archive_secs`.
+    /// The session sat idle past its origin's configured TTL.
     IdleTtl,
 }
 
-/// Whether the reaper may consider `session` at all: automation-class, not a
-/// warm (watch-managed) session — those are exempt infrastructure — and in a
-/// non-terminal status.
+/// Whether the reaper may consider `session` at all: automation-class or
+/// Slack-origin, not a warm (watch-managed) session — those are exempt
+/// infrastructure — and in a non-terminal status.
 fn reap_candidate(session: &Session) -> bool {
-    session.class == "automation"
+    (session.class == "automation" || session.origin == "slack")
         && session.managed_by.is_none()
         && matches!(session.status.as_str(), "created" | "running" | "orphaned")
 }
@@ -233,7 +237,7 @@ fn reap_decision(
     if idle < REAP_GRACE_SECS {
         return None;
     }
-    if issue_closed {
+    if issue_closed && session.class == "automation" {
         return Some(ReapReason::IssueClosed);
     }
     if idle_archive_secs > 0 && idle >= idle_archive_secs {
@@ -242,27 +246,39 @@ fn reap_decision(
     None
 }
 
-/// One reaper pass: archive every automation session [`reap_decision`] convicts,
-/// via the shared archive path (worktree teardown + transcript capture + the
-/// `status` event that lands on SSE). Errors are logged, never fatal to a tick.
-async fn reap_automation(state: &AppState, sessions: &[Session], now: DateTime<Utc>) {
+/// One reaper pass: archive every session [`reap_decision`] convicts via the
+/// shared archive path (worktree teardown + transcript capture + the `status`
+/// event that lands on SSE). Errors are logged, never fatal to a tick.
+async fn reap_sessions(
+    state: &AppState,
+    sessions: &[Session],
+    slack_idle_archive_secs: i64,
+    now: DateTime<Utc>,
+) {
     for session in sessions {
-        // Only a candidate's tracking issue is worth a lookup.
         if !reap_candidate(session) {
             continue;
         }
-        let issue_closed = match session.tracking_issue_id {
-            Some(issue_id) => match weaver_core::issue::get(&state.db, issue_id).await {
-                Ok(issue) => issue.is_some_and(|i| i.status == "closed"),
-                Err(e) => {
-                    tracing::warn!(id = %session.id, issue = issue_id, error = %e,
-                        "reaper: tracking issue lookup failed");
-                    false
-                }
-            },
-            None => false,
+        let issue_closed = if session.class == "automation" {
+            match session.tracking_issue_id {
+                Some(issue_id) => match weaver_core::issue::get(&state.db, issue_id).await {
+                    Ok(issue) => issue.is_some_and(|i| i.status == "closed"),
+                    Err(e) => {
+                        tracing::warn!(id = %session.id, issue = issue_id, error = %e,
+                            "reaper: tracking issue lookup failed");
+                        false
+                    }
+                },
+                None => false,
+            }
+        } else {
+            false
         };
-        let ttl = session.policy_idle_archive_secs.unwrap_or(0);
+        let ttl = if session.origin == "slack" {
+            slack_idle_archive_secs
+        } else {
+            session.policy_idle_archive_secs.unwrap_or(0)
+        };
         let Some(reason) = reap_decision(session, issue_closed, ttl, now) else {
             continue;
         };
@@ -279,7 +295,7 @@ async fn reap_automation(state: &AppState, sessions: &[Session], now: DateTime<U
             }
         };
         tracing::info!(id = %session.id, branch = %branch.branch, ?reason,
-            "reaping automation session");
+            "reaping session");
         match crate::lifecycle::auto_archive(state, session, &branch).await {
             Ok(Some(_)) => {}
             Ok(None) => tracing::info!(
@@ -554,6 +570,18 @@ mod tests {
         );
         assert_eq!(reap_decision(&idle, false, 0, now), None);
 
+        // Slack conversations remain interactive sessions, but their
+        // origin-specific TTL makes them retention candidates. A closed issue
+        // is not a Slack retention signal.
+        let mut slack = idle.clone();
+        slack.class = "interactive".to_string();
+        slack.origin = "slack".to_string();
+        assert_eq!(
+            reap_decision(&slack, false, ttl, now),
+            Some(ReapReason::IdleTtl)
+        );
+        assert_eq!(reap_decision(&slack, true, 0, now), None);
+
         // Past the grace window but under the TTL: kept on the TTL axis, but a
         // closed tracking issue still reaps it.
         let mid = iso(now - Duration::seconds(REAP_GRACE_SECS + 60));
@@ -575,8 +603,8 @@ mod tests {
         inflight.acp_inflight = Some("{}".to_string());
         assert_eq!(reap_decision(&inflight, true, ttl, now), None);
 
-        // Not a candidate: interactive class, warm (watch-managed), or already
-        // in a terminal status.
+        // Not a candidate: an ordinary interactive session, warm
+        // (watch-managed), or already in a terminal status.
         let mut interactive = idle.clone();
         interactive.class = "interactive".to_string();
         assert_eq!(reap_decision(&interactive, true, ttl, now), None);

--- a/crates/loom-watch/src/monitor.rs
+++ b/crates/loom-watch/src/monitor.rs
@@ -217,6 +217,13 @@ fn reap_candidate(session: &Session) -> bool {
         && matches!(session.status.as_str(), "created" | "running" | "orphaned")
 }
 
+fn retention_issue_id(session: &Session) -> Option<i64> {
+    if session.class != "automation" {
+        return None;
+    }
+    session.tracking_issue_id
+}
+
 /// The pure reaper verdict for one session. `issue_closed` is the pre-fetched
 /// status of the session's tracking issue (false when it has none), and
 /// `idle_archive_secs <= 0` disables the TTL trigger. Both triggers share a
@@ -237,7 +244,7 @@ fn reap_decision(
     if idle < REAP_GRACE_SECS {
         return None;
     }
-    if issue_closed && session.class == "automation" {
+    if issue_closed {
         return Some(ReapReason::IssueClosed);
     }
     if idle_archive_secs > 0 && idle >= idle_archive_secs {
@@ -259,20 +266,16 @@ async fn reap_sessions(
         if !reap_candidate(session) {
             continue;
         }
-        let issue_closed = if session.class == "automation" {
-            match session.tracking_issue_id {
-                Some(issue_id) => match weaver_core::issue::get(&state.db, issue_id).await {
-                    Ok(issue) => issue.is_some_and(|i| i.status == "closed"),
-                    Err(e) => {
-                        tracing::warn!(id = %session.id, issue = issue_id, error = %e,
-                            "reaper: tracking issue lookup failed");
-                        false
-                    }
-                },
-                None => false,
-            }
-        } else {
-            false
+        let issue_closed = match retention_issue_id(session) {
+            Some(issue_id) => match weaver_core::issue::get(&state.db, issue_id).await {
+                Ok(issue) => issue.is_some_and(|i| i.status == "closed"),
+                Err(e) => {
+                    tracing::warn!(id = %session.id, issue = issue_id, error = %e,
+                        "reaper: tracking issue lookup failed");
+                    false
+                }
+            },
+            None => false,
         };
         let ttl = if session.origin == "slack" {
             slack_idle_archive_secs
@@ -549,7 +552,7 @@ mod tests {
 
     #[test]
     fn reap_decision_triggers_and_guards() {
-        use super::{reap_decision, ReapReason, REAP_GRACE_SECS};
+        use super::{reap_decision, retention_issue_id, ReapReason, REAP_GRACE_SECS};
         let now = Utc::now();
         let iso = |t: chrono::DateTime<Utc>| t.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
         let long_ago = iso(now - Duration::hours(9));
@@ -580,7 +583,9 @@ mod tests {
             reap_decision(&slack, false, ttl, now),
             Some(ReapReason::IdleTtl)
         );
-        assert_eq!(reap_decision(&slack, true, 0, now), None);
+        slack.tracking_issue_id = Some(42);
+        assert_eq!(retention_issue_id(&slack), None);
+        assert_eq!(reap_decision(&slack, false, 0, now), None);
 
         // Past the grace window but under the TTL: kept on the TTL axis, but a
         // closed tracking issue still reaps it.

--- a/crates/loom/tests/integration/session_layout.rs
+++ b/crates/loom/tests/integration/session_layout.rs
@@ -26,8 +26,17 @@ async fn layout_http_session_view_conflict_and_cli_share_one_contract() {
     assert_eq!(created["placement"]["group_id"], "group-user-inbox");
 
     let seeded = ts.client.get("/api/session-layout").await.unwrap();
-    assert_eq!(seeded["spaces"].as_array().unwrap().len(), 3);
+    assert_eq!(seeded["spaces"].as_array().unwrap().len(), 4);
     assert_eq!(seeded["spaces"][0]["name"], "User");
+    let slack = seeded["spaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|space| space["id"] == "space-slack")
+        .unwrap();
+    assert_eq!(slack["name"], "Slack");
+    assert_eq!(slack["groups"][0]["id"], "group-slack-inbox");
+    assert_eq!(slack["groups"][0]["name"], "Inbox");
     let seeded_revision = seeded["revision"].as_i64().unwrap();
 
     let with_group = ts

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -202,6 +202,19 @@ pub const REGISTRY: &[SettingSpec] = &[
         options: &[],
     },
     SettingSpec {
+        key: "slack.idle_archive_secs",
+        label: "Slack idle archive (seconds)",
+        description: "Archive a Slack-origin session after this many seconds \
+            without session activity. The agent, worktree, and terminal are \
+            removed while the branch, conversation, and history remain \
+            recoverable. A live ACP turn is never interrupted. Set 0 to \
+            disable; an individual session can opt out with auto-archive.",
+        kind: SettingKind::Int,
+        default: "86400",
+        group: "Slack",
+        options: &[],
+    },
+    SettingSpec {
         key: "auth.trust_loopback",
         label: "Trust loopback requests",
         description: "When enabled, requests from 127.0.0.1/::1 are trusted as \
@@ -506,6 +519,10 @@ pub const DEFAULT_AUTOMATION_TURN_CAP: i64 = 100;
 /// session (8 hours). 0 disables the TTL trigger; a closed tracking issue
 /// still archives the session.
 pub const DEFAULT_AUTOMATION_IDLE_ARCHIVE_SECS: i64 = 28800;
+
+/// Idle TTL after which the retention reaper archives a Slack-origin session
+/// (24 hours). 0 disables the TTL trigger.
+pub const DEFAULT_SLACK_IDLE_ARCHIVE_SECS: i64 = 86400;
 
 /// Look up the [`SettingSpec`] for a key, if it is a registered setting.
 pub fn spec(key: &str) -> Option<&'static SettingSpec> {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,6 +219,8 @@ Attention, All, and History are projections over it. Successful automation is
 placed as an ordinary session in Ops; an unmatched provisioning or failed run
 is projected as an Intervention in Attention/Ops without inventing a browser-
 local session. Hidden warm infrastructure has no placement.
+GitHub and Slack triggers have their own origin-default Inbox spaces; delegated
+sessions inherit their parent's placement.
 
 ### Database ownership and the PostgreSQL seam
 
@@ -721,6 +723,12 @@ from under it. Every automatic retention path skips a branch carrying the exact
 quiet tag `auto-archive: disabled`; the session Details popover toggles it, while a
 manual Archive deliberately ignores it. The `automation.*` settings live in
 `weaver-core::config::registry()` under the **Automation** group.
+
+Slack-origin sessions remain interactive but share the retention reaper's
+lifecycle safeguards. `slack.idle_archive_secs` defaults to `86400` seconds;
+the reaper uses the same durable `last_activity_at`, no-live-ACP-turn guard,
+grace period, and per-session `auto-archive: disabled` opt-out before archiving
+a Slack conversation.
 
 ## GitHub integration
 

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -29,6 +29,8 @@ Successful automation is an ordinary session placed in the Ops space. A failed
 or incomplete run without a session appears as a typed **Intervention** in
 Attention and Ops, where the operator can inspect or clean it up. There is no
 separate Automations destination.
+GitHub and Slack triggers land in their respective Inbox spaces. Delegated
+sessions inherit their parent's placement.
 
 Search, moves, ordering, collapse preferences, and placement defaults all use
 the layout REST API. Selecting a row opens the session without changing its

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -154,8 +154,23 @@ Do not create standalone Slack-token secrets that the deployment never reads.
 
 `slack.enabled` (default on) closes the socket without discarding the tokens
 — use it to pause the integration without losing configuration. It, along
-with `slack.allowed_users` and `slack.default_repo`, lives in **Settings →
-Slack**.
+with `slack.allowed_users`, `slack.default_repo`, and
+`slack.idle_archive_secs`, lives in **Settings → Slack**.
+
+## Placement and retention
+
+Slack-origin sessions are placed in **Slack → Inbox**. Sessions created before
+this space existed move there only when they are still in the fallback
+**User → Inbox**; an operator's manual placement is preserved.
+
+The retention monitor archives a Slack-origin session after
+`slack.idle_archive_secs` without session activity (default `86400`, one day).
+Activity includes agent output and user prompts through Loom, so an active
+conversation keeps extending the deadline. A live ACP turn is never
+interrupted. Archiving removes the agent, terminal, and worktree while keeping
+the branch, conversation, artifacts, and history recoverable. Set the value to
+`0` to disable Slack retention globally, or disable auto-archive on one session
+from its actions menu.
 
 ## The reply route
 


### PR DESCRIPTION
Place Slack-origin sessions in a dedicated `Slack / Inbox` and route future Slack launches there. The migration adopts an existing manually created Slack inbox, moves legacy sessions only while they remain in `User / Inbox`, and preserves explicit defaults and manual placements.

Archive Slack-origin sessions after `slack.idle_archive_secs` without activity, defaulting to 86,400 seconds. Slack sessions remain interactive; retention skips warm sessions and live ACP turns, does not inherit automation's closed-issue trigger, and honors per-session `auto-archive: disabled`.

A localhost rollout migrated session `fhzugr2h` into `Slack / Inbox`, registered the `86400` default, and reconnected Socket Mode. The existing public session URL remained reachable.

This follows the end-to-end Slack trigger work in #256.
