### PR TITLE
feat(loom): show pull request freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,12 +232,14 @@ loom config set server.auto_adopt true
 ## GitHub
 
 With the `gh` CLI installed and authenticated, loom tracks each active session's
-pull request. A background loop polls `gh pr view` for the branch every 30s and
-surfaces the result on the dashboard: a link straight to the PR, its state
-(open / draft / merged / closed), the review decision (approved / changes
-requested / review required), and a rolled-up CI verdict (checks passing /
-failing / pending). Session **Details** keeps the associations and a **Refresh**
-button available without occupying the workbench header.
+pull request. A background loop polls `gh pr view` for the branch every five
+minutes, with an immediate refresh available from Session **Details**, and
+surfaces the result on the dashboard: a link straight to the PR, its head-update
+age, its state (open / draft / merged / closed), the review decision (approved /
+changes requested / review required), and a rolled-up CI verdict. Compact rows
+render CI as `OK` / `TESTING` / `FAILED` / `PENDING`; Session **Details** keeps
+the associations and an immediate **Refresh** button available without occupying
+the workbench header.
 
 Every session detail has a **Conversation** tab that renders the agent's chat
 with the model — user turns, replies, thinking, and tool calls — live and

--- a/crates/loom-forge/src/github.rs
+++ b/crates/loom-forge/src/github.rs
@@ -1141,11 +1141,6 @@ mod tests {
     }
 
     #[test]
-    fn background_poll_is_five_minutes() {
-        assert_eq!(POLL_TICK, Duration::from_secs(5 * 60));
-    }
-
-    #[test]
     fn slug_from_managed_clone_root() {
         // A managed clone lives at `<repos_dir>/owner/name`.
         let root = crate::repo::repos_dir().join("acme").join("widgets");

--- a/crates/loom-forge/src/github.rs
+++ b/crates/loom-forge/src/github.rs
@@ -860,7 +860,9 @@ pub async fn apply_snapshot(
         current.head_updated_at = previous.head_updated_at.clone().or(current.head_updated_at);
     }
     upsert_status(&state.db, &branch.id, &current).await?;
-    let changed = prev.as_ref().map(GithubStatus::signature) != Some(current.signature());
+    let changed = prev
+        .as_ref()
+        .is_none_or(|previous| current.meaningfully_differs_from(previous));
     if changed {
         events::record(
             &state.db,

--- a/crates/loom-forge/src/github.rs
+++ b/crates/loom-forge/src/github.rs
@@ -118,7 +118,7 @@ pub async fn create_pr(work_dir: &Path, base: &str, title: &str, body: &str) -> 
 // has no GitHub remote.
 // ---------------------------------------------------------------------------
 
-const POLL_TICK: Duration = Duration::from_secs(30);
+const POLL_TICK: Duration = Duration::from_secs(5 * 60);
 
 /// Branch tag marking that loom has back-linked this branch's PR to its session
 /// (posted the `…/s/{id}` comment). Set by the poll loop's back-link poster or,
@@ -437,8 +437,7 @@ pub async fn record_status_comment(
 
 /// The fields requested from `gh pr view --json`. Kept in one place so the parse
 /// struct and the query can't drift.
-const PR_FIELDS: &str =
-    "number,url,state,title,isDraft,reviewDecision,mergeable,mergedAt,statusCheckRollup";
+const PR_FIELDS: &str = "number,url,state,title,isDraft,reviewDecision,mergeable,mergedAt,statusCheckRollup,headRefOid,updatedAt";
 
 /// The shape of one `gh pr view --json` record. Internal — callers see
 /// [`GithubStatus`].
@@ -456,6 +455,10 @@ struct PrJson {
     mergeable: Option<String>,
     #[serde(rename = "mergedAt", default)]
     merged_at: Option<String>,
+    #[serde(rename = "headRefOid", default)]
+    head_ref_oid: Option<String>,
+    #[serde(rename = "updatedAt", default)]
+    updated_at: Option<String>,
     #[serde(rename = "statusCheckRollup", default)]
     status_check_rollup: Option<Vec<CheckJson>>,
 }
@@ -486,6 +489,11 @@ impl PrJson {
             checks: rollup_checks(self.status_check_rollup.as_deref().unwrap_or(&[])),
             mergeable: nonempty(self.mergeable),
             merged_at: nonempty(self.merged_at),
+            head_sha: nonempty(self.head_ref_oid),
+            // GitHub's PR `updatedAt` is only the initial estimate. Once a
+            // snapshot exists, `apply_snapshot` holds this timestamp steady
+            // until `headRefOid` changes, excluding comments/labels/reviews.
+            head_updated_at: nonempty(self.updated_at),
             fetched_at: now_iso(),
         }
     }
@@ -662,7 +670,7 @@ pub async fn fetch_open_pr(
 pub async fn get_status(db: &Db, branch_id: &str) -> Result<Option<GithubStatus>> {
     let row = sqlx::query_as::<_, GithubStatus>(
         "SELECT pr_number, pr_url, pr_state, pr_title, is_draft, review_decision,
-                checks, mergeable, merged_at, fetched_at
+                checks, mergeable, merged_at, head_sha, head_updated_at, fetched_at
          FROM branch_github WHERE branch_id = ?",
     )
     .bind(branch_id)
@@ -743,14 +751,17 @@ pub async fn upsert_status(db: &Db, branch_id: &str, s: &GithubStatus) -> Result
     sqlx::query(
         "INSERT INTO branch_github
            (branch_id, pr_number, pr_url, pr_state, pr_title, is_draft,
-            review_decision, checks, mergeable, merged_at, fetched_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            review_decision, checks, mergeable, merged_at, head_sha,
+            head_updated_at, fetched_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(branch_id) DO UPDATE SET
            pr_number = excluded.pr_number, pr_url = excluded.pr_url,
            pr_state = excluded.pr_state, pr_title = excluded.pr_title,
            is_draft = excluded.is_draft, review_decision = excluded.review_decision,
            checks = excluded.checks, mergeable = excluded.mergeable,
-           merged_at = excluded.merged_at, fetched_at = excluded.fetched_at",
+           merged_at = excluded.merged_at, head_sha = excluded.head_sha,
+           head_updated_at = excluded.head_updated_at,
+           fetched_at = excluded.fetched_at",
     )
     .bind(branch_id)
     .bind(s.pr_number)
@@ -762,6 +773,8 @@ pub async fn upsert_status(db: &Db, branch_id: &str, s: &GithubStatus) -> Result
     .bind(&s.checks)
     .bind(&s.mergeable)
     .bind(&s.merged_at)
+    .bind(&s.head_sha)
+    .bind(&s.head_updated_at)
     .bind(&s.fetched_at)
     .execute(db)
     .await?;
@@ -838,15 +851,23 @@ pub async fn apply_snapshot(
     archive_on_merge: bool,
 ) -> Result<()> {
     let prev = get_status(&state.db, &branch.id).await?;
-    upsert_status(&state.db, &branch.id, snap).await?;
-    let changed = prev.as_ref().map(GithubStatus::signature) != Some(snap.signature());
+    let mut current = snap.clone();
+    if let Some(previous) = prev.as_ref().filter(|previous| {
+        previous.pr_number == current.pr_number
+            && previous.head_sha.is_some()
+            && previous.head_sha == current.head_sha
+    }) {
+        current.head_updated_at = previous.head_updated_at.clone().or(current.head_updated_at);
+    }
+    upsert_status(&state.db, &branch.id, &current).await?;
+    let changed = prev.as_ref().map(GithubStatus::signature) != Some(current.signature());
     if changed {
         events::record(
             &state.db,
             &state.bus,
             &branch.id,
             "github",
-            snap.event_data(),
+            current.event_data(),
         )
         .await
         .ok();
@@ -862,27 +883,27 @@ pub async fn apply_snapshot(
     let prev_state = prev.as_ref().map(|p| p.pr_state.as_str());
     for (fire, kind, data) in [
         (
-            pr_just_opened(prev_state, snap),
+            pr_just_opened(prev_state, &current),
             "pr_opened",
             json!({ "pr": snap.pr_number }),
         ),
         (
-            pr_just_merged(prev_state, snap),
+            pr_just_merged(prev_state, &current),
             "pr_merged",
             json!({ "pr": snap.pr_number }),
         ),
         (
-            checks_went_red(prev_checks, snap),
+            checks_went_red(prev_checks, &current),
             "pr_red",
             json!({ "pr": snap.pr_number, "checks": "failing" }),
         ),
         (
-            checks_went_green(prev_checks, snap),
+            checks_went_green(prev_checks, &current),
             "pr_green",
             json!({ "pr": snap.pr_number, "checks": "passing" }),
         ),
         (
-            review_decision_changed(prev.as_ref(), snap),
+            review_decision_changed(prev.as_ref(), &current),
             "pr_review",
             json!({ "pr": snap.pr_number, "decision": snap.review_decision }),
         ),
@@ -898,17 +919,17 @@ pub async fn apply_snapshot(
     // first sees the PR open, so someone reading the GitHub thread can jump to the
     // live session. Gated on the open *transition* (not every poll while OPEN): a
     // repo where loom can't comment then fails once, rather than re-posting — and
-    // logging a failure — on every 30s poll. Skipped once the branch is tagged
+    // logging a failure — on every poll. Skipped once the branch is tagged
     // linked (here or by the `@loom` reply).
-    if pr_just_opened(prev_state, snap) {
-        maybe_post_backlink(state, session, branch, snap).await;
+    if pr_just_opened(prev_state, &current) {
+        maybe_post_backlink(state, session, branch, &current).await;
     }
 
     let recovered = tags::get(&state.db, &branch.id, tags::RECOVERED_KEY)
         .await?
         .is_some_and(|tag| tag.value == tags::RECOVERED_VALUE);
     if archive_on_merge
-        && snap.pr_state == "MERGED"
+        && current.pr_state == "MERGED"
         && !session_mod::is_terminal(&session.status)
         && !recovered
     {
@@ -920,10 +941,10 @@ pub async fn apply_snapshot(
         // archive records a `status` event, so no extra log line is needed.
         match crate::lifecycle::auto_archive(state, session, branch).await {
             Ok(Some(_)) => {
-                close_claimed_issues(state, branch, snap.pr_number, &claimed).await;
+                close_claimed_issues(state, branch, current.pr_number, &claimed).await;
                 tracing::info!(
                     branch = %branch.branch,
-                    pr = snap.pr_number,
+                    pr = current.pr_number,
                     "archived session after PR merge"
                 );
             }
@@ -1120,6 +1141,11 @@ mod tests {
     }
 
     #[test]
+    fn background_poll_is_five_minutes() {
+        assert_eq!(POLL_TICK, Duration::from_secs(5 * 60));
+    }
+
+    #[test]
     fn slug_from_managed_clone_root() {
         // A managed clone lives at `<repos_dir>/owner/name`.
         let root = crate::repo::repos_dir().join("acme").join("widgets");
@@ -1248,7 +1274,8 @@ mod tests {
         let json = r#"{
             "number": 7, "url": "https://x/pr/7", "state": "OPEN", "title": "T",
             "isDraft": false, "reviewDecision": "", "mergeable": "MERGEABLE",
-            "mergedAt": null, "statusCheckRollup": []
+            "mergedAt": null, "headRefOid": "abc123", "updatedAt": "2026-08-03T21:42:17Z",
+            "statusCheckRollup": []
         }"#;
         let status = serde_json::from_str::<PrJson>(json).unwrap().into_status();
         assert_eq!(status.pr_number, 7);
@@ -1259,6 +1286,11 @@ mod tests {
         // Empty rollup means "no checks", not "passing".
         assert_eq!(status.checks, None);
         assert_eq!(status.mergeable.as_deref(), Some("MERGEABLE"));
+        assert_eq!(status.head_sha.as_deref(), Some("abc123"));
+        assert_eq!(
+            status.head_updated_at.as_deref(),
+            Some("2026-08-03T21:42:17Z")
+        );
     }
 
     // ---- apply_snapshot: storage + archive-on-merge --------------------------
@@ -1290,6 +1322,8 @@ mod tests {
             checks: Some("passing".to_string()),
             mergeable: Some("MERGEABLE".to_string()),
             merged_at: (state == "MERGED").then(now_iso),
+            head_sha: Some("head-one".to_string()),
+            head_updated_at: Some("2026-08-03T21:42:17Z".to_string()),
             fetched_at: now_iso(),
         }
     }
@@ -1388,6 +1422,11 @@ mod tests {
         assert_eq!(stored.pr_number, 5);
         assert_eq!(stored.pr_state, "OPEN");
         assert_eq!(stored.checks.as_deref(), Some("passing"));
+        assert_eq!(stored.head_sha.as_deref(), Some("head-one"));
+        assert_eq!(
+            stored.head_updated_at.as_deref(),
+            Some("2026-08-03T21:42:17Z")
+        );
         // …and an open PR leaves the live session (and its worktree) alone.
         let session = session_mod::get(&f.state.db, &f.session.id)
             .await
@@ -1395,6 +1434,45 @@ mod tests {
             .unwrap();
         assert_eq!(session.status, "running");
         assert!(f.work_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn head_freshness_changes_only_with_the_head_sha() {
+        let f = fixture().await;
+        let first = snapshot("OPEN");
+        apply_snapshot(&f.state, &f.session, &f.branch, &first, false)
+            .await
+            .unwrap();
+
+        let mut metadata_only = first.clone();
+        metadata_only.head_updated_at = Some("2026-08-04T10:00:00Z".to_string());
+        apply_snapshot(&f.state, &f.session, &f.branch, &metadata_only, false)
+            .await
+            .unwrap();
+        let stored = get_status(&f.state.db, &f.branch.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.head_updated_at.as_deref(),
+            Some("2026-08-03T21:42:17Z"),
+            "unrelated PR metadata must not make the head look fresh"
+        );
+
+        let mut pushed = metadata_only;
+        pushed.head_sha = Some("head-two".to_string());
+        apply_snapshot(&f.state, &f.session, &f.branch, &pushed, false)
+            .await
+            .unwrap();
+        let stored = get_status(&f.state.db, &f.branch.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.head_sha.as_deref(), Some("head-two"));
+        assert_eq!(
+            stored.head_updated_at.as_deref(),
+            Some("2026-08-04T10:00:00Z")
+        );
     }
 
     #[tokio::test]

--- a/crates/loom-store/migrations/0018_github_head_freshness.sql
+++ b/crates/loom-store/migrations/0018_github_head_freshness.sql
@@ -1,0 +1,2 @@
+ALTER TABLE branch_github ADD COLUMN head_sha TEXT;
+ALTER TABLE branch_github ADD COLUMN head_updated_at TEXT;

--- a/crates/loom-store/src/db.rs
+++ b/crates/loom-store/src/db.rs
@@ -95,6 +95,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "session-transitions",
         include_str!("../migrations/0017_session_transitions.sql"),
     ),
+    (
+        18,
+        "github-head-freshness",
+        include_str!("../migrations/0018_github_head_freshness.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -400,6 +405,13 @@ mod tests {
             assert!(
                 inbox_columns.iter().any(|column| column == expected),
                 "missing review inbox column {expected}"
+            );
+        }
+        let github_columns = table_columns(&db, "branch_github").await.unwrap();
+        for expected in ["head_sha", "head_updated_at"] {
+            assert!(
+                github_columns.iter().any(|column| column == expected),
+                "missing GitHub freshness column {expected}"
             );
         }
 

--- a/crates/loom/frontend/package.json
+++ b/crates/loom/frontend/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "rspack build --mode production",
     "dev": "rspack serve --mode development",
-    "test:unit": "node --no-warnings --experimental-strip-types --test src/lib/reviewDraftController.test.mjs",
+    "test:unit": "node --no-warnings --experimental-strip-types --test src/lib/*.test.mjs",
     "typecheck": "vue-tsc --noEmit",
     "format": "prettier --write src",
     "format:check": "prettier --check src"

--- a/crates/loom/frontend/src/components/GithubStatus.vue
+++ b/crates/loom/frontend/src/components/GithubStatus.vue
@@ -3,11 +3,13 @@ import { computed } from 'vue';
 import type { GithubStatus } from '../types';
 import {
   githubChecksChip,
+  githubCompactChip,
   githubConflictChip,
   githubReviewChip,
   githubStateChip,
   type GithubChip,
 } from '../lib/githubStatus';
+import { compactAge, exactTime } from '../lib/time';
 
 // A branch's GitHub pull-request snapshot, fetched server-side via `gh`. Tints
 // are text-color only (never a loud fill) and use GitHub's own familiar hue
@@ -23,6 +25,26 @@ const reviewChip = computed(() => githubReviewChip(props.gh));
 const checksChip = computed(() => githubChecksChip(props.gh));
 // Only surface mergeability when it's a problem — a clean PR needn't say so.
 const conflicting = computed(() => githubConflictChip(props.gh));
+const compactChip = computed(() => githubCompactChip(props.gh));
+const headAge = computed(() => compactAge(props.gh.head_updated_at));
+const headAgeClass = computed(() => {
+  if (!props.gh.head_updated_at) return 'text-faint';
+  const ageMs = Date.now() - Date.parse(props.gh.head_updated_at);
+  if (!Number.isFinite(ageMs) || ageMs >= 24 * 60 * 60 * 1000) return 'text-faint';
+  return ageMs < 60 * 60 * 1000 ? 'text-ok' : 'text-muted';
+});
+const compactDescription = computed(() => {
+  const descriptions: Record<string, string> = {
+    OK: 'CI passed',
+    TESTING: 'CI is running',
+    FAILED: 'CI failed',
+    PENDING: 'CI has not reported checks',
+    DRAFT: 'draft pull request',
+    MERGED: 'merged pull request',
+    CLOSED: 'closed pull request',
+  };
+  return descriptions[compactChip.value.key] ?? compactChip.value.label;
+});
 </script>
 
 <template>
@@ -40,10 +62,24 @@ const conflicting = computed(() => githubConflictChip(props.gh));
       @click.stop
       >PR #{{ gh.pr_number }}</a
     >
-    <span :class="stateChip.cls" class="font-mono uppercase tracking-wide">{{
-      stateChip.label
-    }}</span>
-    <span v-if="checksChip" :class="checksChip.cls" class="font-mono" title="CI checks">●</span>
+    <span
+      :class="compactChip.cls"
+      class="font-mono uppercase tracking-wide"
+      :title="compactDescription"
+    >
+      {{ compactChip.label }}
+    </span>
+    <time
+      v-if="gh.head_updated_at"
+      :datetime="gh.head_updated_at"
+      :title="`PR head updated ${exactTime(gh.head_updated_at)}`"
+      :aria-label="`PR head updated ${exactTime(gh.head_updated_at)}`"
+      :class="headAgeClass"
+      class="font-mono"
+      data-testid="github-head-age"
+    >
+      {{ headAge }}
+    </time>
   </span>
 
   <!-- Full: a labelled block for the session overview. -->
@@ -66,6 +102,14 @@ const conflicting = computed(() => githubConflictChip(props.gh));
       >
         {{ (chip as GithubChip).label }}
       </span>
+      <time
+        v-if="gh.head_updated_at"
+        :datetime="gh.head_updated_at"
+        :title="exactTime(gh.head_updated_at)"
+        class="rounded bg-subtle px-1.5 py-0.5 font-mono text-[0.7rem] text-muted"
+      >
+        updated {{ headAge }}
+      </time>
       <span
         v-if="conflicting"
         :class="conflicting.cls"

--- a/crates/loom/frontend/src/lib/githubStatus.test.mjs
+++ b/crates/loom/frontend/src/lib/githubStatus.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { githubCompactChip } from './githubStatus.ts';
+import { compactAge } from './time.ts';
+
+const status = (overrides = {}) => ({
+  pr_state: 'OPEN',
+  is_draft: false,
+  checks: null,
+  ...overrides,
+});
+
+test('compact PR status uses explicit CI words', () => {
+  assert.equal(githubCompactChip(status({ checks: 'passing' })).label, 'OK');
+  assert.equal(githubCompactChip(status({ checks: 'pending' })).label, 'TESTING');
+  assert.equal(githubCompactChip(status({ checks: 'failing' })).label, 'FAILED');
+  assert.equal(githubCompactChip(status()).label, 'PENDING');
+});
+
+test('terminal and draft PR states override CI', () => {
+  assert.equal(githubCompactChip(status({ is_draft: true, checks: 'passing' })).label, 'DRAFT');
+  assert.equal(
+    githubCompactChip(status({ pr_state: 'MERGED', checks: 'passing' })).label,
+    'MERGED',
+  );
+  assert.equal(
+    githubCompactChip(status({ pr_state: 'CLOSED', checks: 'passing' })).label,
+    'CLOSED',
+  );
+});
+
+test('compact age drops prose without losing its unit', () => {
+  const now = Date.parse('2026-08-04T12:00:00Z');
+  assert.equal(compactAge('2026-08-04T11:59:50Z', now), 'now');
+  assert.equal(compactAge('2026-08-04T11:50:00Z', now), '10m');
+  assert.equal(compactAge('2026-08-04T11:00:00Z', now), '1h');
+});

--- a/crates/loom/frontend/src/lib/githubStatus.ts
+++ b/crates/loom/frontend/src/lib/githubStatus.ts
@@ -54,6 +54,24 @@ export function githubChecksChip(gh: GithubStatus): GithubChip | null {
   return chips[checks] ?? { key: checks, label: `CI ${checks}`, cls: 'text-muted' };
 }
 
+/** One unambiguous word for the fleet row. Terminal PR states override CI;
+ * otherwise the label describes CI only: OK passed, TESTING is running,
+ * FAILED needs work, and PENDING means GitHub has not reported checks yet. */
+export function githubCompactChip(gh: GithubStatus): GithubChip {
+  const state = githubStateChip(gh);
+  if (state.key !== 'OPEN') {
+    return { ...state, label: state.key };
+  }
+  const checks: Record<string, GithubChip> = {
+    passing: { key: 'OK', label: 'OK', cls: 'text-ok' },
+    pending: { key: 'TESTING', label: 'TESTING', cls: 'text-info' },
+    failing: { key: 'FAILED', label: 'FAILED', cls: 'text-block' },
+  };
+  return gh.checks
+    ? (checks[gh.checks] ?? { key: 'PENDING', label: 'PENDING', cls: 'text-faint' })
+    : { key: 'PENDING', label: 'PENDING', cls: 'text-faint' };
+}
+
 export function githubConflictChip(gh: GithubStatus): GithubChip | null {
   return gh.mergeable === 'CONFLICTING'
     ? { key: 'CONFLICTING', label: 'conflicts', cls: 'text-block' }

--- a/crates/loom/frontend/src/lib/githubStatus.ts
+++ b/crates/loom/frontend/src/lib/githubStatus.ts
@@ -67,9 +67,8 @@ export function githubCompactChip(gh: GithubStatus): GithubChip {
     pending: { key: 'TESTING', label: 'TESTING', cls: 'text-info' },
     failing: { key: 'FAILED', label: 'FAILED', cls: 'text-block' },
   };
-  return gh.checks
-    ? (checks[gh.checks] ?? { key: 'PENDING', label: 'PENDING', cls: 'text-faint' })
-    : { key: 'PENDING', label: 'PENDING', cls: 'text-faint' };
+  const reported = gh.checks ? checks[gh.checks] : undefined;
+  return reported ?? { key: 'PENDING', label: 'PENDING', cls: 'text-faint' };
 }
 
 export function githubConflictChip(gh: GithubStatus): GithubChip | null {

--- a/crates/loom/frontend/src/lib/time.ts
+++ b/crates/loom/frontend/src/lib/time.ts
@@ -19,6 +19,13 @@ export function timeAgo(iso: string | null | undefined, now: number = Date.now()
   return `${Math.round(days / 30)}mo ago`;
 }
 
+// Tighter age for compact operational metadata, e.g. "now", "10m", "1h".
+// Keep this separate from timeAgo: prose/activity surfaces still benefit from
+// reading "10m ago", while a PR pill should spend as little width as possible.
+export function compactAge(iso: string | null | undefined, now: number = Date.now()): string {
+  return timeAgo(iso, now).replace('just now', 'now').replace(' ago', '');
+}
+
 /** Locale-formatted exact time for a relative timestamp's tooltip/a11y label.
  *  Invalid input is preserved rather than silently disappearing. */
 export function exactTime(iso: string): string {

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -116,6 +116,10 @@ export interface GithubStatus {
   /** 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null. */
   mergeable: string | null;
   merged_at: string | null;
+  /** Current GitHub PR head and the update time associated with that head. The
+   * time stays fixed across metadata-only PR updates. */
+  head_sha: string | null;
+  head_updated_at: string | null;
   fetched_at: string;
 }
 

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -985,6 +985,8 @@ fn pr_snapshot(state: &str, number: i64) -> weaver_core::github::GithubStatus {
         checks: Some("passing".to_string()),
         mergeable: None,
         merged_at: (state == "MERGED").then(db::now_iso),
+        head_sha: Some(format!("head-{number}")),
+        head_updated_at: Some(db::now_iso()),
         fetched_at: db::now_iso(),
     }
 }

--- a/crates/weaver-core/src/github.rs
+++ b/crates/weaver-core/src/github.rs
@@ -39,24 +39,13 @@ impl GithubStatus {
     /// identity and the human-meaningful state. `mergeable` and timestamps are
     /// deliberately excluded: they flap (e.g. `UNKNOWN` ⇄ `MERGEABLE`) without
     /// telling the user anything.
-    pub fn signature(
-        &self,
-    ) -> (
-        i64,
-        String,
-        Option<String>,
-        Option<String>,
-        bool,
-        Option<String>,
-    ) {
-        (
-            self.pr_number,
-            self.pr_state.clone(),
-            self.review_decision.clone(),
-            self.checks.clone(),
-            self.is_draft,
-            self.head_sha.clone(),
-        )
+    pub fn meaningfully_differs_from(&self, other: &Self) -> bool {
+        self.pr_number != other.pr_number
+            || self.pr_state != other.pr_state
+            || self.review_decision != other.review_decision
+            || self.checks != other.checks
+            || self.is_draft != other.is_draft
+            || self.head_sha != other.head_sha
     }
 
     /// Payload for the `github` event the poller records when the snapshot

--- a/crates/weaver-core/src/github.rs
+++ b/crates/weaver-core/src/github.rs
@@ -14,7 +14,10 @@ use sqlx::FromRow;
 /// `BranchView::github`. `pr_state` is `OPEN` / `CLOSED` / `MERGED`; `checks` is
 /// the rolled-up `passing` / `failing` / `pending` (or `null` when the PR has no
 /// checks); `review_decision` is GitHub's `APPROVED` / `CHANGES_REQUESTED` /
-/// `REVIEW_REQUIRED` (or `null` when review isn't required).
+/// `REVIEW_REQUIRED` (or `null` when review isn't required). `head_updated_at`
+/// is the time associated with the current `head_sha`; the poller preserves it
+/// while the head is unchanged so unrelated PR metadata does not make code look
+/// newly pushed.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct GithubStatus {
     pub pr_number: i64,
@@ -26,6 +29,8 @@ pub struct GithubStatus {
     pub checks: Option<String>,
     pub mergeable: Option<String>,
     pub merged_at: Option<String>,
+    pub head_sha: Option<String>,
+    pub head_updated_at: Option<String>,
     pub fetched_at: String,
 }
 
@@ -34,13 +39,23 @@ impl GithubStatus {
     /// identity and the human-meaningful state. `mergeable` and timestamps are
     /// deliberately excluded: they flap (e.g. `UNKNOWN` ⇄ `MERGEABLE`) without
     /// telling the user anything.
-    pub fn signature(&self) -> (i64, String, Option<String>, Option<String>, bool) {
+    pub fn signature(
+        &self,
+    ) -> (
+        i64,
+        String,
+        Option<String>,
+        Option<String>,
+        bool,
+        Option<String>,
+    ) {
         (
             self.pr_number,
             self.pr_state.clone(),
             self.review_decision.clone(),
             self.checks.clone(),
             self.is_draft,
+            self.head_sha.clone(),
         )
     }
 
@@ -54,6 +69,8 @@ impl GithubStatus {
             "review": self.review_decision,
             "checks": self.checks,
             "draft": self.is_draft,
+            "head_sha": self.head_sha,
+            "head_updated_at": self.head_updated_at,
         })
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -426,9 +426,9 @@ canonical space/group placement.
 
 `BranchView::github` is the branch's latest GitHub pull-request snapshot
 (`pr_number`, `pr_url`, `pr_state`, `pr_title`, `is_draft`, `review_decision`,
-`checks`, `mergeable`, `merged_at`, `fetched_at`), or `null` when GitHub polling
-is off, there is no PR, or `gh` is unavailable. See [GitHub
-integration](#github-integration).
+`checks`, `mergeable`, `merged_at`, `head_sha`, `head_updated_at`, `fetched_at`),
+or `null` when GitHub polling is off, there is no PR, or `gh` is unavailable.
+See [GitHub integration](#github-integration).
 
 Status is two orthogonal axes. The session's `status` is the **lifecycle**
 (orchestrator-owned, mechanical): `created` / `running` / `orphaned` / `done` /
@@ -727,14 +727,16 @@ manual Archive deliberately ignores it. The `automation.*` settings live in
 When the `gh` CLI is installed and authenticated, loom keeps a per-branch
 pull-request snapshot alongside the session. A second background loop
 (`github::poll`, sibling of the monitor, spawned in `server::serve`) ticks every
-30s and, for each active session, runs `gh pr list --head <branch> …` from the
-repo root. `<branch>` is the worktree's live HEAD (falling back to loom's stored
+five minutes and, for each active session, runs
+`gh pr list --head <branch> …` from the repo root. `<branch>` is the worktree's live
+HEAD (falling back to loom's stored
 branch identity when the worktree cannot be read), so an agent that switches or
 renames its branch before opening a PR is still discovered. The result — PR
 number, URL, state (`OPEN`/`CLOSED`/`MERGED`), draft
 flag, `reviewDecision`, a rolled-up `checks` verdict (`passing`/`failing`/
-`pending`), and mergeability — is written to the loom-owned `branch_github`
-table (one row per branch, keyed `branch_id`) and served as `BranchView.github`.
+`pending`), head SHA/update age, and mergeability — is written to the loom-owned
+`branch_github` table (one row per branch, keyed `branch_id`) and served as
+`BranchView.github`.
 The dashboard renders it on the session list and session header; `POST
 /api/sessions/{id}/github` forces an immediate re-poll.
 

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -172,6 +172,11 @@ test.describe("durable session workbench", () => {
                 checks: needsAction ? "failing" : "passing",
                 mergeable: needsAction ? "CONFLICTING" : "MERGEABLE",
                 merged_at: null,
+                head_sha: `head-${number}`,
+                head_updated_at: new Date(
+                  Date.now() -
+                    (needsAction ? 2 * 60 * 60 * 1000 : 10 * 60 * 1000),
+                ).toISOString(),
                 fetched_at: new Date().toISOString(),
               },
             },
@@ -190,6 +195,8 @@ test.describe("durable session workbench", () => {
       "href",
       "https://github.com/marin-community/loom/pull/238",
     );
+    await expect(rows.nth(0).getByTestId("github-compact")).toContainText("OK");
+    await expect(rows.nth(0).getByTestId("github-head-age")).toHaveText("10m");
     await expect(rows.nth(2).getByTestId("github-compact")).toHaveCount(0);
     await expect(page.locator("html")).toHaveClass(/dark/);
     await expect(page.locator('[data-cursor="true"]')).toHaveCount(1);


### PR DESCRIPTION
Track each pull request's head SHA and stable update time so the session fleet can show when reviewable code last changed. Compact PR indicators now use explicit CI states (OK, TESTING, FAILED, PENDING) plus a short age, with draft, merged, and closed taking precedence and accessible exact timestamps.

Reduce background GitHub polling from 30 seconds to five minutes to avoid needless API pressure; Session Details retains immediate refresh. Add the snapshot migration and cover head-change preservation, status vocabulary, schema upgrades, and the fleet journey.

Weaver session: https://loom.oa.dev/s/6kpbdjkz