### PR TITLE
Make the Slack trigger path diagnosable

### DIFF
--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -17,10 +17,12 @@
 //!
 //! [Socket Mode]: https://docs.slack.dev/apis/events-api/using-socket-mode/
 
+use std::sync::RwLock;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
 use serde_json::{json, Value};
 use weaver_core::{config, events, tags};
 
@@ -48,6 +50,66 @@ const STATUS_CARD_CAP: usize = 15;
 /// Cap on how many conversation messages seed a session, so a busy channel can't
 /// produce an unbounded launch prompt.
 const HISTORY_CAP: usize = 40;
+
+// ---------------------------------------------------------------------------
+// Live supervisor health.
+// ---------------------------------------------------------------------------
+
+/// What the Socket Mode supervisor is doing right now.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SocketState {
+    /// A token is missing, or `slack.enabled` is off. Nothing is listening.
+    #[default]
+    Idle,
+    /// Opening the websocket.
+    Connecting,
+    /// Live — envelopes are arriving on this connection.
+    Connected,
+    /// The last attempt failed; the supervisor is backing off before retrying.
+    Failed,
+}
+
+/// What the supervisor has seen, for the Connections pane and the logs. An
+/// `auth.test` probe only proves a credential works; this proves the socket is
+/// actually up and shows what it has done with what arrived.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SocketHealth {
+    pub state: SocketState,
+    /// The app this connection belongs to, from the `hello` frame's
+    /// `connection_info`. The one way to tell — from inside — that the app token
+    /// and the bot token belong to the same Slack app.
+    pub app_id: Option<String>,
+    pub connected_at: Option<String>,
+    pub last_error: Option<String>,
+    pub last_event_at: Option<String>,
+    pub events_received: u64,
+    pub sessions_launched: u64,
+    /// Why the most recent trigger was not acted on. A dropped mention is the
+    /// integration's quietest failure, so it is kept where an operator looks.
+    pub last_skip: Option<String>,
+    pub last_skip_at: Option<String>,
+}
+
+static HEALTH: RwLock<Option<SocketHealth>> = RwLock::new(None);
+
+/// The supervisor's current health snapshot.
+pub fn health() -> SocketHealth {
+    HEALTH
+        .read()
+        .expect("health lock")
+        .clone()
+        .unwrap_or_default()
+}
+
+fn update_health(f: impl FnOnce(&mut SocketHealth)) {
+    let mut guard = HEALTH.write().expect("health lock");
+    f(guard.get_or_insert_with(SocketHealth::default));
+}
+
+fn now() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
 
 /// `env`, else the `key` setting; empty when neither is set. Mirrors
 /// [`crate::github_trigger`]'s private resolver — kept per-module by design.
@@ -90,17 +152,107 @@ fn api_base() -> String {
         .unwrap_or_else(|| "https://slack.com/api".to_string())
 }
 
-/// The allowlist of Slack user IDs permitted to trigger, from
-/// `slack.allowed_users` (space/comma separated). Empty ⇒ deny-by-default.
-async fn allowed_users(db: &Db) -> Vec<String> {
-    config::get(db, "slack.allowed_users")
+/// Who may launch a session from Slack.
+///
+/// Two gates hold regardless of this setting and are not configurable: the
+/// event must come from the workspace the app is installed in (which excludes
+/// Slack Connect channels shared with an external org), and loom never triggers
+/// on its own posts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Access {
+    /// The default. Any person in the installed workspace, in a conversation the
+    /// bot has been invited to. Slack's own two grants — workspace membership
+    /// and the channel invite — are the boundary, so there is no second list of
+    /// opaque user ids to maintain. Posts from *other apps* are excluded: an
+    /// alerting bot that happens to say `@loom` must not launch a privileged
+    /// session.
+    Workspace,
+    /// Only these Slack user ids, from `slack.allowed_users`. A tighter boundary
+    /// for a large or mixed workspace. A listed id is trusted even when it posts
+    /// through another app's user token, which is how an approved automation
+    /// identity opts in.
+    Listed(Vec<String>),
+}
+
+/// Read the configured access boundary. `slack.allowed_users` empty ⇒
+/// [`Access::Workspace`].
+pub async fn access(db: &Db) -> Access {
+    let listed: Vec<String> = config::get(db, "slack.allowed_users")
         .await
         .unwrap_or_default()
         .split([' ', ',', '\n', '\t'])
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
-        .collect()
+        .collect();
+    if listed.is_empty() {
+        Access::Workspace
+    } else {
+        Access::Listed(listed)
+    }
+}
+
+/// Why a trigger was not acted on. Every variant is logged, counted, and shown
+/// in the Connections pane — a silently dropped mention is indistinguishable
+/// from a broken socket, which is the failure this whole path exists to avoid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Denial {
+    /// From another Slack workspace, including a Slack Connect channel shared
+    /// with an external org.
+    OtherWorkspace,
+    /// loom's own post. Never trigger on ourselves.
+    Own,
+    /// Posted through another app rather than typed by a person, under
+    /// [`Access::Workspace`].
+    Automation,
+    /// Not on `slack.allowed_users`, under [`Access::Listed`].
+    NotListed,
+}
+
+impl Denial {
+    /// The one-line reason recorded in [`SocketHealth::last_skip`] and the log.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Denial::OtherWorkspace => "event came from another Slack workspace",
+            Denial::Own => "loom's own message",
+            Denial::Automation => {
+                "posted by an app, not a person (add its user id to slack.allowed_users to allow it)"
+            }
+            Denial::NotListed => "user is not on slack.allowed_users",
+        }
+    }
+
+    /// What to say in-thread, or `None` to drop silently. Only a person who
+    /// could have meant to trigger gets a reply. Replying to our own posts would
+    /// loop, replying to an app would answer a machine, and replying into a
+    /// foreign workspace would talk to an org loom does not serve.
+    pub fn reply(&self) -> Option<&'static str> {
+        match self {
+            Denial::NotListed => Some(
+                "You're not on this bot's allowed-users list — ask an admin to add your Slack user id.",
+            ),
+            Denial::Own | Denial::Automation | Denial::OtherWorkspace => None,
+        }
+    }
+}
+
+/// Decide whether a parsed trigger may launch a session. Pure, so the whole
+/// policy is unit-testable without a database or a socket.
+pub fn authorize(access: &Access, bot: &AuthTest, trigger: &Trigger) -> Result<(), Denial> {
+    if trigger.user_id == bot.user_id {
+        return Err(Denial::Own);
+    }
+    // The socket is one workspace, but events still carry an explicit team_id and
+    // Slack Connect delivers events from external teams.
+    if trigger.team_id != bot.team_id {
+        return Err(Denial::OtherWorkspace);
+    }
+    match access {
+        Access::Workspace if trigger.via_app => Err(Denial::Automation),
+        Access::Workspace => Ok(()),
+        Access::Listed(users) if users.iter().any(|u| u == &trigger.user_id) => Ok(()),
+        Access::Listed(_) => Err(Denial::NotListed),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -205,13 +357,15 @@ impl SlackWeb {
         slack_response(method, resp).await
     }
 
-    /// Resolve our own identity — the bot user id (to skip our own events) and
-    /// the workspace `team_id` (the authorization boundary).
+    /// Resolve our own identity — the bot user id (to skip our own events), the
+    /// workspace `team_id` (the authorization boundary), and whether the token
+    /// is really a bot token.
     pub async fn auth_test(&self) -> Result<AuthTest> {
         let v = self.call_bot("auth.test", json!({})).await?;
         Ok(AuthTest {
             user_id: v["user_id"].as_str().unwrap_or_default().to_string(),
             team_id: v["team_id"].as_str().unwrap_or_default().to_string(),
+            bot_id: v["bot_id"].as_str().map(str::to_string),
         })
     }
 
@@ -306,6 +460,19 @@ impl SlackWeb {
 pub struct AuthTest {
     pub user_id: String,
     pub team_id: String,
+    /// Set only for a real bot token. `auth.test` answers for a human's user
+    /// token (`xoxp-…`) too — with that person's user id and no `bot_id` — so a
+    /// deployment handed the wrong token connects, reports healthy, and then
+    /// discards every mention its operator types as loom's own. This field is
+    /// what tells the two apart.
+    pub bot_id: Option<String>,
+}
+
+impl AuthTest {
+    /// Whether the configured token is a bot token rather than a user token.
+    pub fn is_bot(&self) -> bool {
+        self.bot_id.is_some()
+    }
 }
 
 /// Extract `{user, text}` messages from a `conversations.*` response.
@@ -357,13 +524,20 @@ pub struct Trigger {
     pub anchor: Anchor,
     /// The id we dedupe on (`event_id` for events; the slash `trigger_id`).
     pub dedupe_id: String,
+    /// The source message carried a `bot_id`: posted through an app rather than
+    /// typed by a person. Slack keeps the human's user id on such a message, so
+    /// this is the only signal that separates the two.
+    pub via_app: bool,
 }
 
 /// A decoded Socket Mode envelope.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Envelope {
-    /// The connection is live.
-    Hello,
+    /// The connection is live. `app_id` comes from `connection_info` and is the
+    /// only in-band evidence of *which* Slack app the app-level token opened —
+    /// the check that catches an app token and a bot token from two different
+    /// apps, a pairing that otherwise connects and then receives nothing.
+    Hello { app_id: Option<String> },
     /// Slack is about to close this socket. `reason` is `warning` (a ~10s
     /// pre-close notice), `refresh_requested`, or `link_disabled`.
     Disconnect { reason: String },
@@ -381,7 +555,9 @@ pub enum Envelope {
 /// Decode a raw Socket Mode frame.
 pub fn parse_envelope(v: &Value) -> Envelope {
     match v["type"].as_str().unwrap_or_default() {
-        "hello" => Envelope::Hello,
+        "hello" => Envelope::Hello {
+            app_id: v["connection_info"]["app_id"].as_str().map(str::to_string),
+        },
         "disconnect" => Envelope::Disconnect {
             reason: v["reason"].as_str().unwrap_or_default().to_string(),
         },
@@ -424,27 +600,23 @@ pub fn trigger_from_slash(payload: &Value) -> Option<Trigger> {
         text,
         anchor: Anchor::Slash,
         dedupe_id,
+        // A slash command is always typed by a person.
+        via_app: false,
     })
 }
 
 /// Build a [`Trigger`] from an `events_api` payload, for `app_mention` only.
-/// Returns `None` for other event types and for the bot's own mentions (a
-/// self-trigger guard). `bot_user_id` is our own user id from `auth.test`.
+/// Returns `None` for any other event type.
 ///
-/// Slack may attach a `bot_id` to messages posted through another app's user
-/// token while preserving the human user's id. Those messages still pass the
-/// configured allowed-user check in [`handle_trigger`]; rejecting every
-/// `bot_id` here would silently discard an explicitly authorized identity.
-pub fn trigger_from_event(payload: &Value, bot_user_id: &str) -> Option<Trigger> {
+/// Parsing is structural only — who may act on the result is
+/// [`authorize`]'s decision, so every rejection is one that can be logged and
+/// shown rather than a silent `None` here.
+pub fn trigger_from_event(payload: &Value) -> Option<Trigger> {
     let event = &payload["event"];
     if event["type"].as_str() != Some("app_mention") {
         return None;
     }
     let user_id = event["user"].as_str()?.to_string();
-    // Skip our own posts — never trigger on ourselves.
-    if user_id == bot_user_id {
-        return None;
-    }
     let team_id = payload["team_id"].as_str().unwrap_or_default().to_string();
     let channel_id = event["channel"].as_str()?.to_string();
     let event_ts = event["ts"].as_str()?.to_string();
@@ -462,6 +634,7 @@ pub fn trigger_from_event(payload: &Value, bot_user_id: &str) -> Option<Trigger>
         text,
         anchor: Anchor::Mention { root_ts, event_ts },
         dedupe_id,
+        via_app: event.get("bot_id").is_some(),
     })
 }
 
@@ -779,23 +952,17 @@ async fn handle_trigger(state: AppState, web: SlackWeb, bot: AuthTest, trigger: 
         Err(e) => tracing::warn!(error = %e, "slack: dedupe insert failed; proceeding"),
     }
 
-    // Authorize. The socket is one workspace, but events still carry an explicit
-    // team_id, and Slack Connect delivers events from external teams — so gate on
-    // our own team, then on the allowlist.
-    if trigger.team_id != bot.team_id {
-        tracing::warn!(team = %trigger.team_id, "slack: rejecting event from another workspace");
-        return;
-    }
-    let allowed = allowed_users(&state.db).await;
-    if !allowed.iter().any(|u| u == &trigger.user_id) {
-        tracing::info!(user = %trigger.user_id, "slack: user not on slack.allowed_users; ignoring");
-        // A gentle nudge so the person knows to ask, rather than a silent drop.
-        let _ = notify(
-            &web,
-            &trigger,
-            "You're not on this bot's allowed-users list — ask an admin to add your Slack user id.",
-        )
-        .await;
+    if let Err(denial) = authorize(&access(&state.db).await, &bot, &trigger) {
+        tracing::info!(
+            user = %trigger.user_id,
+            channel = %trigger.channel_id,
+            reason = denial.reason(),
+            "slack: trigger not authorized"
+        );
+        record_skip(denial.reason());
+        if let Some(text) = denial.reply() {
+            let _ = notify(&web, &trigger, text).await;
+        }
         return;
     }
 
@@ -811,6 +978,7 @@ async fn handle_trigger(state: AppState, web: SlackWeb, bot: AuthTest, trigger: 
                 .trim()
                 .to_string();
             if d.is_empty() {
+                record_skip("no repository: slack.default_repo is unset and the request has no owner/name: prefix");
                 let _ = notify(&web, &trigger, "No repository to work on. Prefix your request with `owner/name:` or set a Slack default repository in loom's settings.").await;
                 return;
             }
@@ -818,10 +986,22 @@ async fn handle_trigger(state: AppState, web: SlackWeb, bot: AuthTest, trigger: 
         }
     };
 
-    if let Err(e) = launch(&state, &web, &bot, &trigger, &repo, &instruction).await {
-        tracing::warn!(error = %e, repo = %repo, "slack: launch failed");
-        let _ = notify(&web, &trigger, &format!("Couldn't start a session: {e}")).await;
+    match launch(&state, &web, &bot, &trigger, &repo, &instruction).await {
+        Ok(()) => update_health(|h| h.sessions_launched += 1),
+        Err(e) => {
+            tracing::warn!(error = %e, repo = %repo, "slack: launch failed");
+            record_skip(&format!("launch failed: {e}"));
+            let _ = notify(&web, &trigger, &format!("Couldn't start a session: {e}")).await;
+        }
     }
+}
+
+/// Record why a trigger did not become a session, for the Connections pane.
+fn record_skip(reason: &str) {
+    update_health(|h| {
+        h.last_skip = Some(reason.to_string());
+        h.last_skip_at = Some(now());
+    });
 }
 
 /// Post a short message back to the trigger's thread (an error/ack). For a
@@ -1059,9 +1239,15 @@ pub async fn run(state: AppState) {
         if !is_enabled(&state.db).await {
             // Not configured / switched off — poll occasionally for a later
             // config change rather than spin.
+            update_health(|h| {
+                h.state = SocketState::Idle;
+                h.app_id = None;
+                h.connected_at = None;
+            });
             tokio::time::sleep(Duration::from_secs(30)).await;
             continue;
         }
+        update_health(|h| h.state = SocketState::Connecting);
         match connect_and_run(&state).await {
             Ok(reason) => {
                 // A clean disconnect (`warning`/`refresh_requested`) — reconnect
@@ -1069,11 +1255,20 @@ pub async fn run(state: AppState) {
                 // drops the instant it opens can't spin `apps.connections.open`
                 // (itself rate-limited).
                 tracing::debug!(reason = %reason, "slack: reconnecting");
+                update_health(|h| {
+                    h.state = SocketState::Connecting;
+                    h.connected_at = None;
+                });
                 backoff = 1;
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
             Err(e) => {
                 tracing::warn!(error = %e, backoff, "slack: connection error; backing off");
+                update_health(|h| {
+                    h.state = SocketState::Failed;
+                    h.connected_at = None;
+                    h.last_error = Some(e.to_string());
+                });
                 // Jittered, capped backoff so a flapping endpoint isn't hammered
                 // in lockstep.
                 let jitter = rand::random::<u64>() % 500;
@@ -1083,6 +1278,11 @@ pub async fn run(state: AppState) {
         }
     }
 }
+
+/// How often a live socket re-reads `slack.enabled`. The switch documents
+/// itself as closing a live connection, so it cannot wait for Slack's own
+/// refresh (tens of minutes away) to take effect.
+const KILL_SWITCH_POLL: Duration = Duration::from_secs(10);
 
 /// One connection lifecycle: open the socket, then read/ACK/dispatch until Slack
 /// asks us to disconnect or the stream ends. Returns the disconnect reason on a
@@ -1103,10 +1303,46 @@ async fn connect_and_run(state: &AppState) -> Result<String> {
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
         .await
         .context("opening the socket")?;
-    tracing::info!(bot = %bot.user_id, team = %bot.team_id, "slack: socket connected");
+    tracing::info!(
+        bot = %bot.user_id,
+        team = %bot.team_id,
+        token = if bot.is_bot() { "bot" } else { "user" },
+        "slack: socket connected"
+    );
+    // A user token authenticates and connects exactly like a bot token, then
+    // silently discards every mention typed by the person it belongs to. Say so
+    // once per connection rather than leaving a healthy-looking dead socket.
+    if !bot.is_bot() {
+        tracing::warn!(
+            user = %bot.user_id,
+            "slack: LOOM_SLACK_BOT_TOKEN is a user token (xoxp-…), not a bot token (xoxb-…) — \
+             loom will post as that person and ignore their mentions as its own"
+        );
+    }
+    update_health(|h| {
+        h.state = SocketState::Connected;
+        h.connected_at = Some(now());
+        h.last_error = None;
+    });
 
-    while let Some(msg) = ws.next().await {
-        let msg = msg.context("reading from the socket")?;
+    let mut kill_switch = tokio::time::interval(KILL_SWITCH_POLL);
+    kill_switch.tick().await; // the first tick completes immediately
+
+    loop {
+        let msg = tokio::select! {
+            frame = ws.next() => match frame {
+                Some(msg) => msg.context("reading from the socket")?,
+                None => break,
+            },
+            _ = kill_switch.tick() => {
+                if is_enabled(&state.db).await {
+                    continue;
+                }
+                tracing::info!("slack: disabled by settings; closing the socket");
+                ws.close(None).await.ok();
+                return Ok("disabled".to_string());
+            }
+        };
         let text = match msg {
             Message::Text(t) => t.as_str().to_string(),
             Message::Ping(p) => {
@@ -1120,7 +1356,10 @@ async fn connect_and_run(state: &AppState) -> Result<String> {
             continue;
         };
         match parse_envelope(&frame) {
-            Envelope::Hello => tracing::debug!("slack: hello"),
+            Envelope::Hello { app_id } => {
+                tracing::info!(app = app_id.as_deref().unwrap_or("?"), "slack: hello");
+                update_health(|h| h.app_id = app_id);
+            }
             Envelope::Disconnect { reason } => return Ok(reason),
             Envelope::Other {
                 envelope_id: Some(id),
@@ -1141,18 +1380,46 @@ async fn connect_and_run(state: &AppState) -> Result<String> {
                 ))
                 .await
                 .ok();
+                // Every arriving envelope is logged. Whether loom is receiving
+                // at all is the first question a stalled integration raises, and
+                // it used to be unanswerable from the outside.
+                let event_type = payload["event"]["type"].as_str().unwrap_or("-");
+                tracing::info!(
+                    kind = %kind,
+                    event = %event_type,
+                    channel = payload["event"]["channel"]
+                        .as_str()
+                        .or_else(|| payload["channel_id"].as_str())
+                        .unwrap_or("-"),
+                    user = payload["event"]["user"]
+                        .as_str()
+                        .or_else(|| payload["user_id"].as_str())
+                        .unwrap_or("-"),
+                    "slack: envelope received"
+                );
+                update_health(|h| {
+                    h.events_received += 1;
+                    h.last_event_at = Some(now());
+                });
                 let trigger = match kind.as_str() {
                     "slash_commands" => trigger_from_slash(&payload),
-                    "events_api" => trigger_from_event(&payload, &bot.user_id),
+                    "events_api" => trigger_from_event(&payload),
                     _ => None, // `interactive` is unused in V1
                 };
-                if let Some(trigger) = trigger {
-                    tokio::spawn(handle_trigger(
-                        state.clone(),
-                        web.clone(),
-                        bot.clone(),
-                        trigger,
-                    ));
+                match trigger {
+                    Some(trigger) => {
+                        tokio::spawn(handle_trigger(
+                            state.clone(),
+                            web.clone(),
+                            bot.clone(),
+                            trigger,
+                        ));
+                    }
+                    // Slack delivers every subscribed event type, so this is the
+                    // ordinary case for anything that isn't an app_mention.
+                    None => {
+                        tracing::debug!(kind = %kind, event = %event_type, "slack: not a trigger")
+                    }
                 }
             }
         }
@@ -1165,9 +1432,44 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn auth(user_id: &str, team_id: &str) -> AuthTest {
+        AuthTest {
+            user_id: user_id.into(),
+            team_id: team_id.into(),
+            bot_id: Some("B1".into()),
+        }
+    }
+
+    fn trigger(user_id: &str, team_id: &str, via_app: bool) -> Trigger {
+        Trigger {
+            team_id: team_id.into(),
+            channel_id: "C1".into(),
+            user_id: user_id.into(),
+            text: "do it".into(),
+            anchor: Anchor::Mention {
+                root_ts: "1.1".into(),
+                event_ts: "1.1".into(),
+            },
+            dedupe_id: "slack:Ev1".into(),
+            via_app,
+        }
+    }
+
     #[test]
     fn parse_envelope_classifies_frames() {
-        assert_eq!(parse_envelope(&json!({"type": "hello"})), Envelope::Hello);
+        assert_eq!(
+            parse_envelope(&json!({"type": "hello"})),
+            Envelope::Hello { app_id: None }
+        );
+        // The hello frame names the app the app-level token opened.
+        assert_eq!(
+            parse_envelope(&json!({
+                "type": "hello", "connection_info": {"app_id": "A123"}
+            })),
+            Envelope::Hello {
+                app_id: Some("A123".into())
+            }
+        );
         assert_eq!(
             parse_envelope(&json!({"type": "disconnect", "reason": "warning"})),
             Envelope::Disconnect {
@@ -1200,13 +1502,13 @@ mod tests {
     }
 
     #[test]
-    fn mention_anchors_on_thread_and_skips_self() {
+    fn mention_anchors_on_its_thread() {
         let payload = json!({
             "team_id": "T1", "event_id": "Ev1",
             "event": {"type": "app_mention", "user": "U2", "channel": "C1",
                       "ts": "1.1", "thread_ts": "0.9", "text": "<@BOT> do it"}
         });
-        let t = trigger_from_event(&payload, "BOT").unwrap();
+        let t = trigger_from_event(&payload).unwrap();
         assert_eq!(
             t.anchor,
             Anchor::Mention {
@@ -1216,29 +1518,114 @@ mod tests {
         );
         assert_eq!(t.text, "do it");
         assert_eq!(t.dedupe_id, "slack:Ev1");
-        // The bot's own mention never triggers.
-        let mut own = payload.clone();
-        own["event"]["user"] = json!("BOT");
-        assert!(trigger_from_event(&own, "BOT").is_none());
+        assert!(!t.via_app);
 
-        // An allowed human posting through another app's user token retains
-        // their user id but also carries a bot_id. Authorization happens after
-        // parsing, so this must remain eligible for the allowed-user check.
+        // A message posted through another app keeps the human's user id, so
+        // `bot_id` is the only thing separating the two.
         let mut app_post = payload;
         app_post["event"]["bot_id"] = json!("OTHER_APP");
-        assert!(trigger_from_event(&app_post, "BOT").is_some());
+        assert!(trigger_from_event(&app_post).unwrap().via_app);
+    }
+
+    #[test]
+    fn only_app_mentions_parse_as_triggers() {
+        let payload = json!({
+            "team_id": "T1", "event_id": "Ev9",
+            "event": {"type": "message", "user": "U2", "channel": "C1", "ts": "1.1", "text": "hi"}
+        });
+        assert!(trigger_from_event(&payload).is_none());
+    }
+
+    /// The default boundary: the workspace plus the channel invite. No list to
+    /// maintain, and a deployment that ships tokens works for the people who can
+    /// already see the bot.
+    #[test]
+    fn workspace_access_admits_any_person_in_the_workspace() {
+        let bot = auth("BOT", "T1");
+        let t = trigger("U2", "T1", false);
+        assert_eq!(authorize(&Access::Workspace, &bot, &t), Ok(()));
+    }
+
+    #[test]
+    fn workspace_access_rejects_other_apps() {
+        let bot = auth("BOT", "T1");
+        // An alerting bot whose message happens to contain `@loom` must not
+        // launch a privileged session.
+        assert_eq!(
+            authorize(&Access::Workspace, &bot, &trigger("U2", "T1", true)),
+            Err(Denial::Automation)
+        );
+        // …unless its identity is named explicitly, which is how an approved
+        // automation opts in.
+        assert_eq!(
+            authorize(
+                &Access::Listed(vec!["U2".into()]),
+                &bot,
+                &trigger("U2", "T1", true)
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn hard_gates_hold_under_every_access_mode() {
+        let bot = auth("BOT", "T1");
+        for access in [
+            Access::Workspace,
+            Access::Listed(vec!["BOT".into(), "U2".into()]),
+        ] {
+            // loom's own post never triggers loom, even when listed.
+            assert_eq!(
+                authorize(&access, &bot, &trigger("BOT", "T1", false)),
+                Err(Denial::Own)
+            );
+            // Another workspace (a Slack Connect channel) is always rejected.
+            assert_eq!(
+                authorize(&access, &bot, &trigger("U2", "T_OTHER", false)),
+                Err(Denial::OtherWorkspace)
+            );
+        }
+    }
+
+    #[test]
+    fn listed_access_admits_only_listed_users() {
+        let bot = auth("BOT", "T1");
+        let access = Access::Listed(vec!["U2".into()]);
+        assert_eq!(
+            authorize(&access, &bot, &trigger("U2", "T1", false)),
+            Ok(())
+        );
+        assert_eq!(
+            authorize(&access, &bot, &trigger("U3", "T1", false)),
+            Err(Denial::NotListed)
+        );
+        // A rejected person is told why; the quiet denials stay quiet.
+        assert!(Denial::NotListed.reply().is_some());
+        assert!(Denial::Own.reply().is_none());
+        assert!(Denial::Automation.reply().is_none());
+        assert!(Denial::OtherWorkspace.reply().is_none());
+    }
+
+    /// A user token authenticates and connects like a bot token; `bot_id` is the
+    /// only field that distinguishes them.
+    #[test]
+    fn auth_test_separates_bot_tokens_from_user_tokens() {
+        assert!(auth("U1", "T1").is_bot());
+        assert!(!AuthTest {
+            user_id: "U1".into(),
+            team_id: "T1".into(),
+            bot_id: None,
+        }
+        .is_bot());
     }
 
     #[test]
     fn top_level_mention_anchors_on_its_own_ts() {
-        let t = trigger_from_event(
-            &json!({
-                "team_id": "T1", "event_id": "Ev2",
-                "event": {"type": "app_mention", "user": "U2", "channel": "C1",
-                          "ts": "5.5", "text": "<@BOT> hi"}
-            }),
-            "BOT",
-        )
+        let t = trigger_from_event(&json!({
+            "team_id": "T1", "event_id": "Ev2",
+            "event": {"type": "app_mention", "user": "U2", "channel": "C1",
+                      "ts": "5.5", "text": "<@BOT> hi"}
+        }))
         .unwrap();
         assert_eq!(
             t.anchor,
@@ -1252,19 +1639,13 @@ mod tests {
 
     #[test]
     fn threaded_mention_reads_its_thread() {
-        let trigger = Trigger {
-            team_id: "T1".into(),
-            channel_id: "C1".into(),
-            user_id: "U1".into(),
-            text: "look above".into(),
-            anchor: Anchor::Mention {
-                root_ts: "4.4".into(),
-                event_ts: "5.5".into(),
-            },
-            dedupe_id: "slack:Ev3".into(),
+        let mut t = trigger("U1", "T1", false);
+        t.anchor = Anchor::Mention {
+            root_ts: "4.4".into(),
+            event_ts: "5.5".into(),
         };
 
-        assert_eq!(history_target(&trigger), HistoryTarget::Thread("4.4"));
+        assert_eq!(history_target(&t), HistoryTarget::Thread("4.4"));
     }
 
     #[test]

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -987,7 +987,10 @@ async fn handle_trigger(state: AppState, web: SlackWeb, bot: AuthTest, trigger: 
     };
 
     match launch(&state, &web, &bot, &trigger, &repo, &instruction).await {
-        Ok(()) => update_health(|h| h.sessions_launched += 1),
+        Ok(Outcome::Launched) => update_health(|h| h.sessions_launched += 1),
+        // An ack on a thread that already has a session is not a launch, and
+        // counting it as one would overstate what the trigger path did.
+        Ok(Outcome::AlreadyRunning) => {}
         Err(e) => {
             tracing::warn!(error = %e, repo = %repo, "slack: launch failed");
             record_skip(&format!("launch failed: {e}"));
@@ -1015,6 +1018,15 @@ async fn notify(web: &SlackWeb, trigger: &Trigger, text: &str) -> Result<()> {
     Ok(())
 }
 
+/// What an authorized trigger did.
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    Launched,
+    /// The thread already had a live session, so the trigger was acknowledged
+    /// rather than acted on.
+    AlreadyRunning,
+}
+
 /// The launch body: seed context, reuse-or-create the session, wire it, and post
 /// the card. Serialized on [`CREATE_LOCK`].
 async fn launch(
@@ -1024,7 +1036,7 @@ async fn launch(
     trigger: &Trigger,
     repo: &str,
     instruction: &str,
-) -> Result<()> {
+) -> Result<Outcome> {
     let _guard = CREATE_LOCK.lock().await;
 
     // Establish the thread root. A slash command is thread-blind, so we post the
@@ -1074,7 +1086,7 @@ async fn launch(
                     .await
                     .ok();
             }
-            return Ok(());
+            return Ok(Outcome::AlreadyRunning);
         }
     }
 
@@ -1147,7 +1159,7 @@ async fn launch(
     tracing::info!(session = %created.session.id, repo = %repo, channel = %trigger.channel_id, "slack: launched session");
     drop(_guard);
     sync_status_message(state.clone(), created.branch.id.clone()).await;
-    Ok(())
+    Ok(Outcome::Launched)
 }
 
 #[derive(Debug, PartialEq)]

--- a/crates/loom/frontend/src/components/SlackPanel.vue
+++ b/crates/loom/frontend/src/components/SlackPanel.vue
@@ -1,16 +1,25 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, onUnmounted } from 'vue';
 import * as api from '../api';
 import type { SlackStatus } from '../types';
+import { slackPath, firstBreak, pathVerdict, type LinkState } from '../lib/slackPath';
+import { compactAge, exactTime } from '../lib/time';
 
-// Read-only Slack connection state for the Connections settings pane — the
-// bot-token `auth.test` result, alongside GitHub's identity block above. The
-// tokens themselves are never exposed here (set via `LOOM_SLACK_APP_TOKEN` /
-// `LOOM_SLACK_BOT_TOKEN` in the server environment, outside the settings
-// registry); this card only reports whether they work. `slack.enabled` is the
-// kill switch, editable as a regular setting below.
+// The Slack trigger path, link by link. A message becomes a session only if
+// every link holds, and the ways this integration fails are mostly *late*
+// links: a live socket carrying a person's token instead of the app's, or no
+// repository to work on. A single connected/disconnected light reports health
+// through all of them, so the path is the pane.
+//
+// Tokens live outside the settings registry (`LOOM_SLACK_APP_TOKEN` /
+// `LOOM_SLACK_BOT_TOKEN` in the server environment) and are never rendered
+// here — only whether they are set, and who Slack says they belong to.
+const REFRESH_MS = 15_000;
+
 const status = ref<SlackStatus | null>(null);
 const error = ref('');
+const loading = ref(true);
+let timer: ReturnType<typeof setInterval> | undefined;
 
 async function load() {
   try {
@@ -18,50 +27,118 @@ async function load() {
     error.value = '';
   } catch (e) {
     error.value = (e as Error).message;
+  } finally {
+    loading.value = false;
   }
 }
 
-// Dot + label: sage once `auth.test` succeeds, ochre once configured but
-// failing (the same "wants a look" tone the fleet reserves for attention),
-// faint when the tokens aren't set at all.
-const indicator = computed(() => {
-  if (!status.value) return { dot: 'bg-faint/50', text: 'text-faint', label: 'Checking…' };
-  if (status.value.connected) return { dot: 'bg-ok-line', text: 'text-ok', label: 'Connected' };
-  if (status.value.configured) {
-    return { dot: 'bg-attn-line', text: 'text-attn', label: 'Not connected' };
-  }
-  return { dot: 'bg-faint/50', text: 'text-faint', label: 'Not configured' };
+const links = computed(() => (status.value ? slackPath(status.value) : []));
+const broken = computed(() => firstBreak(links.value));
+const verdict = computed(() =>
+  status.value ? pathVerdict(links.value) : { text: 'Checking…', tone: 'wait' as LinkState },
+);
+const socket = computed(() => status.value?.socket);
+
+// Text as well as color, per the visual system: every state also has a word.
+const TONE: Record<LinkState, { dot: string; text: string; word: string }> = {
+  ok: { dot: 'bg-ok-line', text: 'text-ok', word: 'ready' },
+  attn: { dot: 'bg-attn-line', text: 'text-attn', word: 'needs a look' },
+  off: { dot: 'bg-faint/40', text: 'text-faint', word: 'off' },
+  wait: { dot: 'bg-faint/40 animate-pulse', text: 'text-muted', word: 'checking' },
+};
+
+// The counters only mean something once the socket has been up, and a quiet run
+// is normal — so they are a footer, not a headline.
+const traffic = computed(() => {
+  const s = socket.value;
+  if (!s || s.state !== 'connected') return '';
+  const last = s.last_event_at ? `last ${compactAge(s.last_event_at)} ago` : 'none yet';
+  return `${s.events_received} received · ${s.sessions_launched} launched · ${last}`;
 });
+
+onMounted(() => {
+  load();
+  // Socket state changes without anyone touching this page — a Slack refresh, a
+  // dropped connection, the first mention of the day. Poll while the pane is
+  // open so what it shows stays true.
+  timer = setInterval(load, REFRESH_MS);
+});
+onUnmounted(() => clearInterval(timer));
 </script>
 
 <template>
   <div>
     <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">Slack</h2>
-    <div class="rounded-md border border-line bg-surface px-3 py-2.5">
-      <p v-if="error" class="text-sm text-block">{{ error }}</p>
+    <div class="overflow-hidden rounded-md border border-line bg-surface" data-testid="slack-panel">
+      <p v-if="error" class="px-3 py-2.5 text-sm text-block">{{ error }}</p>
 
       <template v-else>
-        <div class="flex items-center gap-1.5">
-          <span class="h-1.5 w-1.5 rounded-full" :class="indicator.dot" aria-hidden="true"></span>
-          <span class="text-sm font-medium" :class="indicator.text">{{ indicator.label }}</span>
-          <span v-if="status?.configured && !status.enabled" class="text-2xs text-faint">
-            · disabled
-          </span>
+        <!-- Verdict: the diagnosis before the detail. -->
+        <div class="flex items-baseline gap-2 border-b border-line px-3 py-2.5">
+          <span
+            class="h-1.5 w-1.5 shrink-0 rounded-full"
+            :class="TONE[verdict.tone].dot"
+            aria-hidden="true"
+          ></span>
+          <p
+            class="text-sm font-medium"
+            :class="TONE[verdict.tone].text"
+            data-testid="slack-verdict"
+          >
+            {{ verdict.text }}
+          </p>
+          <p v-if="broken?.fix" class="min-w-0 flex-1 text-xs text-muted">{{ broken.fix }}</p>
         </div>
 
-        <p v-if="status?.connected" class="mt-1 text-xs text-muted">
-          Bot <code class="font-mono">{{ status.bot_user }}</code> in workspace
-          <code class="font-mono">{{ status.team }}</code
-          >.
-        </p>
-        <p v-else-if="status?.configured && status.error" class="mt-1 text-xs text-block">
-          {{ status.error }}
-        </p>
-        <p v-else-if="status && !status.configured" class="mt-1 text-xs text-muted">
-          Set <code class="font-mono">LOOM_SLACK_APP_TOKEN</code> and
-          <code class="font-mono">LOOM_SLACK_BOT_TOKEN</code> in the server environment to enable
-          the <code class="font-mono">@loom</code> Slack trigger.
-        </p>
+        <!-- The path: one row per check the server makes, in the order it makes
+             them, joined by a hairline down the marker gutter so the sequence
+             reads as a sequence rather than six independent lights. -->
+        <ol v-if="links.length" class="px-3 py-2">
+          <li
+            v-for="(l, i) in links"
+            :key="l.key"
+            class="relative flex items-baseline gap-2.5 py-1 pl-4"
+            :data-testid="`slack-link-${l.key}`"
+          >
+            <span
+              v-if="i < links.length - 1"
+              class="absolute bottom-[-0.25rem] left-[3px] top-[0.85rem] w-px bg-line"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="absolute left-0 top-[0.5rem] h-[7px] w-[7px] rounded-full ring-2 ring-surface"
+              :class="TONE[l.state].dot"
+              aria-hidden="true"
+            ></span>
+            <span class="w-28 shrink-0 text-xs" :class="l === broken ? 'text-fg' : 'text-muted'">
+              {{ l.label }}
+            </span>
+            <span class="min-w-0 flex-1 font-mono text-2xs" :class="TONE[l.state].text">
+              {{ l.detail }}
+            </span>
+            <span class="sr-only">{{ TONE[l.state].word }}</span>
+          </li>
+        </ol>
+        <p v-else-if="loading" class="px-3 py-2.5 text-sm text-muted">Checking…</p>
+
+        <!-- What the socket has actually done. A skipped trigger is this
+             integration's quietest failure, so it stays on the page instead of
+             only in the log. -->
+        <div v-if="traffic || socket?.last_skip" class="border-t border-line px-3 py-2">
+          <p v-if="traffic" class="font-mono text-2xs text-faint">{{ traffic }}</p>
+          <p
+            v-if="socket?.last_skip"
+            class="mt-0.5 text-2xs text-attn"
+            data-testid="slack-last-skip"
+          >
+            Last skipped trigger: {{ socket.last_skip
+            }}<template v-if="socket.last_skip_at">
+              (<time :datetime="socket.last_skip_at" :title="exactTime(socket.last_skip_at)"
+                >{{ compactAge(socket.last_skip_at) }} ago</time
+              >)</template
+            >
+          </p>
+        </div>
       </template>
     </div>
   </div>

--- a/crates/loom/frontend/src/lib/slackPath.test.mjs
+++ b/crates/loom/frontend/src/lib/slackPath.test.mjs
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { slackPath, firstBreak, pathVerdict } from './slackPath.ts';
+
+const status = (overrides = {}) => ({
+  enabled: true,
+  app_token_set: true,
+  bot_token_set: true,
+  configured: true,
+  identity: { user_id: 'U_BOT', team_id: 'T1', token_kind: 'bot', error: null },
+  access: { mode: 'workspace', users: [] },
+  default_repo: 'acme/web',
+  socket: {
+    state: 'connected',
+    app_id: 'A1',
+    connected_at: '2026-08-05T01:00:00Z',
+    last_error: null,
+    last_event_at: null,
+    events_received: 0,
+    sessions_launched: 0,
+    last_skip: null,
+    last_skip_at: null,
+  },
+  ...overrides,
+});
+
+const link = (s, key) => slackPath(s).find((l) => l.key === key);
+
+test('a whole path reports ready, with no link singled out', () => {
+  const links = slackPath(status());
+  assert.equal(firstBreak(links), null);
+  assert.equal(pathVerdict(links).text, 'Ready for @loom and /loom');
+  assert.ok(links.every((l) => l.state === 'ok'));
+});
+
+test('a user token is a fault, not a healthy identity', () => {
+  // The production failure this pane exists for: auth.test succeeds, the socket
+  // is live, and every mention the token's owner types is dropped as loom's own.
+  const s = status({
+    identity: { user_id: 'U_HUMAN', team_id: 'T1', token_kind: 'user', error: null },
+  });
+  const identity = link(s, 'identity');
+  assert.equal(identity.state, 'attn');
+  assert.match(identity.fix, /xoxb/);
+  assert.equal(pathVerdict(slackPath(s)).text, 'Mentions stop at identity');
+});
+
+test('a live socket does not mask a later broken link', () => {
+  const s = status({ default_repo: '' });
+  assert.equal(link(s, 'socket').state, 'ok');
+  assert.equal(firstBreak(slackPath(s)).key, 'repo');
+  assert.equal(pathVerdict(slackPath(s)).text, 'Mentions stop at repository');
+});
+
+test('the earliest break wins, so the operator fixes causes before symptoms', () => {
+  const s = status({
+    enabled: false,
+    socket: { ...status().socket, state: 'idle' },
+    default_repo: '',
+  });
+  assert.equal(firstBreak(slackPath(s)).key, 'enabled');
+  assert.equal(pathVerdict(slackPath(s)).text, 'Slack is switched off');
+});
+
+test('missing tokens name the variables that are missing', () => {
+  const s = status({ app_token_set: false, bot_token_set: false, configured: false });
+  assert.match(link(s, 'tokens').detail, /LOOM_SLACK_APP_TOKEN and LOOM_SLACK_BOT_TOKEN/);
+  assert.equal(pathVerdict(slackPath(s)).text, 'Slack is not set up');
+});
+
+test('both access modes are healthy, and each says who it admits', () => {
+  assert.match(link(status(), 'access').detail, /anyone in the workspace/);
+  const listed = status({ access: { mode: 'listed', users: ['U1', 'U2'] } });
+  assert.equal(link(listed, 'access').detail, '2 listed people');
+  assert.equal(firstBreak(slackPath(listed)), null);
+});
+
+test('connecting reads as pending, never as a fault', () => {
+  const s = status({ socket: { ...status().socket, state: 'connecting', app_id: null } });
+  assert.equal(link(s, 'socket').state, 'wait');
+  assert.equal(pathVerdict(slackPath(s)).text, 'Connecting to Slack…');
+});
+
+test('a failed socket surfaces the error Slack gave', () => {
+  const s = status({
+    socket: { ...status().socket, state: 'failed', last_error: 'invalid_auth' },
+  });
+  assert.equal(link(s, 'socket').detail, 'invalid_auth · app A1');
+  assert.equal(link(s, 'socket').state, 'attn');
+});

--- a/crates/loom/frontend/src/lib/slackPath.ts
+++ b/crates/loom/frontend/src/lib/slackPath.ts
@@ -1,0 +1,159 @@
+import type { SlackStatus } from '../types';
+
+/** How a link in the trigger path is doing.
+ *
+ *  `ok` carries the phosphor green the visual system reserves for healthy
+ *  state, `attn` the amber it reserves for "wants a look", and `off` the faint
+ *  grey of a link that is deliberately not in use. `wait` is the pre-answer
+ *  state, held separately so a slow request never reads as a fault. */
+export type LinkState = 'ok' | 'attn' | 'off' | 'wait';
+
+/** One step a Slack message takes on its way to becoming a session. */
+export interface PathLink {
+  key: string;
+  /** What this link does, in the operator's words. */
+  label: string;
+  state: LinkState;
+  /** The machine fact behind the state — an id, a count, a mode. Rendered mono. */
+  detail: string;
+  /** What to do about it, present only when this link is what's broken. */
+  fix?: string;
+}
+
+const OK_MARK = 'ok';
+
+/** The Slack trigger path, in the order the server actually checks it.
+ *
+ *  A message becomes a session only if every link holds, which is why this is
+ *  a sequence and not a status flag: an integration can hold a live socket and
+ *  still discard every mention. Rendering the whole path means the broken link
+ *  names itself instead of hiding behind "connected". */
+export function slackPath(s: SlackStatus): PathLink[] {
+  const socket = s.socket;
+  const identity = s.identity;
+
+  const tokens: PathLink = {
+    key: 'tokens',
+    label: 'Tokens',
+    state: s.configured ? OK_MARK : 'off',
+    detail: s.configured
+      ? 'app-level and bot tokens set'
+      : [
+          s.app_token_set ? null : 'LOOM_SLACK_APP_TOKEN',
+          s.bot_token_set ? null : 'LOOM_SLACK_BOT_TOKEN',
+        ]
+          .filter(Boolean)
+          .join(' and ') + ' not set',
+    fix: s.configured ? undefined : 'Set both in the server environment, then restart loom.',
+  };
+
+  const enabled: PathLink = {
+    key: 'enabled',
+    label: 'Switch',
+    state: s.enabled ? OK_MARK : 'off',
+    detail: s.enabled ? 'on' : 'off',
+    fix: s.enabled ? undefined : 'Turn Slack integration on below.',
+  };
+
+  const socketLabels: Record<string, { state: LinkState; detail: string }> = {
+    connected: { state: OK_MARK, detail: 'listening' },
+    connecting: { state: 'wait', detail: 'opening the socket' },
+    failed: { state: 'attn', detail: socket.last_error ?? 'connection failed' },
+    idle: { state: 'off', detail: 'not connected' },
+  };
+  const socketRow = socketLabels[socket.state] ?? socketLabels.idle;
+  const connection: PathLink = {
+    key: 'socket',
+    label: 'Connection',
+    state: socketRow.state,
+    detail: socket.app_id ? `${socketRow.detail} · app ${socket.app_id}` : socketRow.detail,
+    fix:
+      socket.state === 'failed'
+        ? 'Check the app-level token, then watch the server log for the retry.'
+        : undefined,
+  };
+
+  const identityRow = ((): PathLink => {
+    if (!identity) {
+      return { key: 'identity', label: 'Identity', state: 'off', detail: 'no bot token' };
+    }
+    if (identity.error) {
+      return {
+        key: 'identity',
+        label: 'Identity',
+        state: 'attn',
+        detail: identity.error,
+        fix: 'Slack rejected the bot token. Reinstall the app and set the new token.',
+      };
+    }
+    // A person's token authenticates and connects exactly like the app's, so
+    // this is the one link that looks healthy while the integration is dead.
+    if (identity.token_kind === 'user') {
+      return {
+        key: 'identity',
+        label: 'Identity',
+        state: 'attn',
+        detail: `${identity.user_id} · a person, not the app`,
+        fix:
+          'LOOM_SLACK_BOT_TOKEN holds a user token (xoxp-…). loom posts as that ' +
+          'person and drops their mentions as its own. Use the app’s bot token (xoxb-…).',
+      };
+    }
+    return {
+      key: 'identity',
+      label: 'Identity',
+      state: OK_MARK,
+      detail: `${identity.user_id} in ${identity.team_id}`,
+    };
+  })();
+
+  const access: PathLink =
+    s.access.mode === 'workspace'
+      ? {
+          key: 'access',
+          label: 'Who can trigger',
+          state: OK_MARK,
+          detail: 'anyone in the workspace, where the bot is invited',
+        }
+      : {
+          key: 'access',
+          label: 'Who can trigger',
+          state: OK_MARK,
+          detail: `${s.access.users.length} listed ${s.access.users.length === 1 ? 'person' : 'people'}`,
+        };
+
+  const repo: PathLink = {
+    key: 'repo',
+    label: 'Repository',
+    state: s.default_repo ? OK_MARK : 'attn',
+    detail: s.default_repo || 'none',
+    fix: s.default_repo
+      ? undefined
+      : 'Set a default repository below, or prefix each request with owner/name:.',
+  };
+
+  return [tokens, enabled, connection, identityRow, access, repo];
+}
+
+/** The first link standing between a Slack message and a session, or `null`
+ *  when the whole path holds. Drives the pane's headline, so the operator reads
+ *  the diagnosis before the detail. */
+export function firstBreak(links: PathLink[]): PathLink | null {
+  return links.find((l) => l.state === 'attn' || l.state === 'off') ?? null;
+}
+
+/** The pane's one-line verdict. */
+export function pathVerdict(links: PathLink[]): { text: string; tone: LinkState } {
+  if (links.some((l) => l.state === 'wait')) {
+    return { text: 'Connecting to Slack…', tone: 'wait' };
+  }
+  const broken = firstBreak(links);
+  if (!broken) return { text: 'Ready for @loom and /loom', tone: OK_MARK };
+  if (broken.state === 'off' && broken.key === 'tokens') {
+    return { text: 'Slack is not set up', tone: 'off' };
+  }
+  if (broken.state === 'off' && broken.key === 'enabled') {
+    return { text: 'Slack is switched off', tone: 'off' };
+  }
+  return { text: `Mentions stop at ${broken.label.toLowerCase()}`, tone: broken.state };
+}

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -1474,19 +1474,55 @@ export interface GithubConfig {
   app_slug: string;
 }
 
-/** Read-only Slack connection state for the Connections settings pane
- *  (`GET /api/slack/status`). `configured` means both the app-level and bot
- *  tokens are set (via env, outside the settings registry); `connected` means
- *  an `auth.test` with the bot token just succeeded — a live credential-health
- *  check, not merely "tokens present". `bot_user`/`team` are populated only
- *  when connected; `error` only when configured but not connected. */
-export interface SlackStatus {
-  configured: boolean;
-  enabled: boolean;
-  connected: boolean;
-  bot_user: string | null;
-  team: string | null;
+/** What the Socket Mode supervisor is doing right now. Only `connected` can
+ *  carry a mention to loom. */
+export type SlackSocketState = 'idle' | 'connecting' | 'connected' | 'failed';
+
+/** The live supervisor, as opposed to a fresh credential probe. `app_id` comes
+ *  from the `hello` frame and names the Slack app the app-level token opened.
+ *  `last_skip` is why the most recent trigger did not become a session — the
+ *  integration's quietest failure. */
+export interface SlackSocket {
+  state: SlackSocketState;
+  app_id: string | null;
+  connected_at: string | null;
+  last_error: string | null;
+  last_event_at: string | null;
+  events_received: number;
+  sessions_launched: number;
+  last_skip: string | null;
+  last_skip_at: string | null;
+}
+
+/** Who loom is in Slack. `token_kind` is `'user'` when `LOOM_SLACK_BOT_TOKEN`
+ *  holds a person's token (`xoxp-…`) instead of the app's (`xoxb-…`): that
+ *  connects and authenticates normally, then posts as that person and discards
+ *  their mentions as loom's own. */
+export interface SlackIdentity {
+  user_id?: string;
+  team_id?: string;
+  token_kind?: 'bot' | 'user';
   error: string | null;
+}
+
+/** Who may launch a session: everyone in the installed workspace, or a list. */
+export interface SlackAccess {
+  mode: 'workspace' | 'listed';
+  users: string[];
+}
+
+/** Every link in the Slack trigger path (`GET /api/slack/status`), reported
+ *  link by link because a live socket is not the same as a working
+ *  integration. */
+export interface SlackStatus {
+  enabled: boolean;
+  app_token_set: boolean;
+  bot_token_set: boolean;
+  configured: boolean;
+  identity: SlackIdentity | null;
+  access: SlackAccess;
+  default_repo: string;
+  socket: SlackSocket;
 }
 
 // --- Conversation log (iris format) ----------------------------------------

--- a/crates/loom/src/web/branches.rs
+++ b/crates/loom/src/web/branches.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use serde_json::json;
 use weaver_api::{BranchStatusReq, BranchView, CreateEventReq, TagReq};
 use weaver_core::branch::{TitleProvenance, TitleUpdate};
-use weaver_core::{branch as branch_mod, tags};
+use weaver_core::{branch as branch_mod, config, tags};
 
 use crate::{events, session as session_mod};
 
@@ -269,31 +269,54 @@ pub(super) async fn slack_reply(
     Ok(Json(json!({ "posted": true, "ts": ts })))
 }
 
-/// `GET /api/slack/status` — read-only connection state for the Connections
-/// settings pane. `connected` reflects whether an `auth.test` with the bot token
-/// succeeds (a credential-health proxy for the live socket).
+/// `GET /api/slack/status` — the state of every link in the Slack trigger path,
+/// for the Connections settings pane.
+///
+/// One `connected` boolean is not enough to run this integration: a deployment
+/// can hold a live socket and still discard every mention — because the bot
+/// token is a person's rather than the app's, because the app-level token opened
+/// a different app than the bot belongs to, because no repository is set, or
+/// because the access list excludes everyone. Each link is reported separately
+/// so the pane can name the one that is broken instead of reporting health.
 pub(super) async fn slack_status(State(st): State<AppState>) -> ApiResult<Json<serde_json::Value>> {
-    let configured = !crate::slack::app_token(&st.db).await.is_empty()
-        && !crate::slack::bot_token(&st.db).await.is_empty();
+    let app_token_set = !crate::slack::app_token(&st.db).await.is_empty();
+    let bot_token_set = !crate::slack::bot_token(&st.db).await.is_empty();
     let enabled = crate::slack::is_enabled(&st.db).await;
-    let (connected, bot_user, team, error) = if configured {
-        match crate::slack::SlackWeb::from_db(&st.db).await {
-            Some(web) => match web.auth_test().await {
-                Ok(id) => (true, Some(id.user_id), Some(id.team_id), None),
-                Err(e) => (false, None, None, Some(e.to_string())),
-            },
-            None => (false, None, None, None),
-        }
-    } else {
-        (false, None, None, None)
+
+    // `auth.test` proves the bot credential still works and says who loom is —
+    // including whether the token belongs to the app or to a person.
+    let identity = match crate::slack::SlackWeb::from_db(&st.db).await {
+        Some(web) => match web.auth_test().await {
+            Ok(id) => json!({
+                "user_id": id.user_id,
+                "team_id": id.team_id,
+                "token_kind": if id.is_bot() { "bot" } else { "user" },
+                "error": serde_json::Value::Null,
+            }),
+            Err(e) => json!({ "error": e.to_string() }),
+        },
+        None => serde_json::Value::Null,
     };
+
+    let access = match crate::slack::access(&st.db).await {
+        crate::slack::Access::Workspace => json!({ "mode": "workspace", "users": [] }),
+        crate::slack::Access::Listed(users) => json!({ "mode": "listed", "users": users }),
+    };
+
     Ok(Json(json!({
-        "configured": configured,
         "enabled": enabled,
-        "connected": connected,
-        "bot_user": bot_user,
-        "team": team,
-        "error": error,
+        "app_token_set": app_token_set,
+        "bot_token_set": bot_token_set,
+        "configured": app_token_set && bot_token_set,
+        "identity": identity,
+        "access": access,
+        "default_repo": config::get(&st.db, "slack.default_repo")
+            .await
+            .unwrap_or_default()
+            .trim(),
+        // What the supervisor is actually doing, as opposed to what a fresh
+        // credential probe suggests it could do.
+        "socket": crate::slack::health(),
     })))
 }
 

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -176,13 +176,16 @@ pub const REGISTRY: &[SettingSpec] = &[
     },
     SettingSpec {
         key: "slack.allowed_users",
-        label: "Slack allowed users",
-        description: "Space- or comma-separated Slack user IDs (e.g. `U0123ABCD`) \
-            permitted to trigger `/marinbot`. A session is privileged — it holds \
-            repo and agent credentials — so the trigger is deny-by-default: with \
-            this empty, no one can launch even inside the installed workspace. \
-            Events from another workspace or an externally-shared (Slack Connect) \
-            channel are always rejected, regardless of this list.",
+        label: "Restrict to Slack users",
+        description: "Leave empty (the default) to let anyone in the installed \
+            workspace launch a session from a conversation the bot has been \
+            invited to — Slack's own workspace membership and channel invite are \
+            the boundary. Fill in space- or comma-separated Slack user IDs (e.g. \
+            `U0123ABCD`) to narrow it to those people. Three rules hold either \
+            way: another workspace, including an externally-shared Slack Connect \
+            channel, is always rejected; loom never triggers on its own posts; \
+            and a message posted by another app counts only when its ID is \
+            listed here.",
         kind: SettingKind::String,
         default: "",
         group: "Slack",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -361,10 +361,15 @@ Full behaviour, authorization rules, and hardening notes:
 
 Set `slack_app_token` and `slack_bot_token` in `loom.toml` (`loom config
 render-env` writes them into `.env` as `LOOM_SLACK_APP_TOKEN` /
-`LOOM_SLACK_BOT_TOKEN`), then add the Slack user ids allowed to trigger it to
-`slack.allowed_users` — empty means no one can, even from inside the
-workspace. Full behaviour, the Slack app's required scopes, and invite
-requirements: [docs/slack-trigger.md](../docs/slack-trigger.md).
+`LOOM_SLACK_BOT_TOKEN`), then set `slack.default_repo` to the repository a
+prefix-less request targets. `slack_bot_token` must be the app's **bot** token
+(`xoxb-…`): the user token from the same install connects and passes
+`auth.test` just as well, then makes loom post as that person and discard their
+mentions as its own. Anyone in the workspace can trigger from a channel the bot
+has been invited to; `slack.allowed_users` narrows that to named user ids.
+**Settings → Connections** reports every link in the path. Full behaviour, the
+Slack app's required scopes, and invite requirements:
+[docs/slack-trigger.md](../docs/slack-trigger.md).
 
 ## Where state lives
 

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -14,10 +14,9 @@ HMAC-verified webhook, loom is an **outbound [Socket Mode]** websocket client
 — there is no public URL to expose or secret to verify a signature against.
 The connection self-gates on configuration: it only opens once both Slack
 tokens are set and the `slack.enabled` kill switch is on (see [Configure the
-tokens](#configure-the-tokens)). In place of GitHub's signature check, two
-authorization gates protect the trigger — the event's workspace must be the
-one the app is installed in, and the Slack user must be on an explicit
-allowlist (see [Who can trigger](#who-can-trigger)).
+tokens](#configure-the-tokens)). In place of GitHub's signature check, the
+trigger is protected by the workspace the app is installed in and the channels
+its bot has been invited to (see [Who can trigger](#who-can-trigger)).
 
 [Socket Mode]: https://docs.slack.dev/apis/events-api/using-socket-mode/
 
@@ -33,18 +32,19 @@ frame it receives, in order:
    reason GitHub's webhook handler returns `200` before finishing a clone.
 2. **Parses the trigger.** A `slash_commands` payload becomes a thread-blind
    trigger (see [Anchor](#the-status-card)); an `events_api` payload is kept
-   only for `app_mention` — other event types, and any event from the bot's
-   own user id, are dropped without dispatch (a self-trigger guard, since
-   loom subscribes to `app_mention` only, not `message.*` — see [Slack app
-   configuration](#slack-app-configuration)).
+   only for `app_mention`. Parsing is structural — *who may act on the result*
+   is step 4's decision, so every rejection is one loom can log, count, and
+   show rather than a silent drop.
 3. **Dedupes.** Socket Mode delivery is *at-least-once* — a missed ACK or a
    reconnect boundary redelivers a frame — so loom keeps the same delivery
    ledger the GitHub webhook uses, keyed on Slack's `event_id` (a mention) or
    `trigger_id` (a slash command). A replay is a no-op.
-4. **Authorizes.** The event's `team_id` must match the workspace loom's bot
-   token belongs to, and the Slack user id must be on the [allowed-users
-   list](#who-can-trigger). Either failing drops the trigger — the second
-   with a reply nudging the user to ask an admin, rather than a silent drop.
+4. **Authorizes.** The event must come from loom's own workspace, must not be
+   loom's own post, and must be typed by a person rather than posted through
+   another app (see [Who can trigger](#who-can-trigger)). Every refusal is
+   logged with its reason and shown as the last skipped trigger in **Settings →
+   Connections**; a person excluded by an explicit allow-list also gets a reply
+   telling them to ask an admin.
 5. **Resolves the repo** from an `owner/name:` prefix on the command text, or
    the `slack.default_repo` setting (see [Which repo](#which-repo)). Neither
    set gets a reply asking for one.
@@ -89,26 +89,34 @@ busy thread's status trail never spams the channel.
 
 ## Who can trigger
 
-Two gates, both deny-by-default:
+By default the boundary is the one Slack already enforces: **anyone in the
+installed workspace, in a conversation the bot has been invited to.** Both
+halves are real grants — someone has an account in this workspace, and someone
+ran `/invite @marinbot` in that channel — and Socket Mode only delivers
+`app_mention` from channels the bot is in, so there is no second list of opaque
+user IDs to keep in sync with the team.
 
-- **Workspace.** The socket is authenticated as one workspace's bot, but
-  events still carry an explicit `team_id` — Slack Connect delivers events
-  from external, shared-channel teams over the same connection, so every
-  trigger's `team_id` is checked against the bot's own before anything else
-  runs. An event from another workspace is rejected outright.
-- **`slack.allowed_users`** — a space- or comma-separated list of Slack user
-  IDs (`U0123ABCD`, not display names) permitted to trigger. A session is
-  privileged — it holds repo and agent credentials — so this defaults to
-  empty, meaning **no one** can launch until it's set, even from inside the
-  installed workspace:
+Three rules hold regardless, and none of them is configurable:
 
-  ```sh
-  loom config set slack.allowed_users "U0123ABCD U0456EFGH"
-  ```
+- **One workspace.** The socket is authenticated as one workspace's bot, but
+  events still carry an explicit `team_id` — Slack Connect delivers events from
+  external, shared-channel teams over the same connection, so every trigger's
+  `team_id` is checked against the bot's own before anything else runs. An event
+  from another workspace is rejected outright.
+- **Never itself.** loom does not trigger on its own posts.
+- **People, not apps.** A message posted through another app carries a `bot_id`
+  while keeping the human's user ID. Those do not trigger, so an alerting bot
+  whose text happens to contain `@marinbot` cannot launch a privileged session.
 
-  Also settable in **Settings → Slack**. Membership in a channel or workspace
-  admin status is not by itself a grant — the same principle as GitHub's
-  approved-users list being separate from repo write access.
+To narrow it further, list the Slack user IDs (`U0123ABCD`, not display names)
+allowed to trigger:
+
+```sh
+loom config set slack.allowed_users "U0123ABCD U0456EFGH"
+```
+
+Also settable in **Settings → Slack**. A listed ID is trusted even when it posts
+through another app, which is how an approved automation identity opts in.
 
 ## Which repo
 
@@ -141,6 +149,13 @@ Two secrets enable the integration — set **both**, or it stays idle
   OAuth token (`xoxb-…`) every Web API call (`chat.postMessage`,
   `conversations.history`, …) authenticates as.
 
+  It must be the **bot** token, not the user token (`xoxp-…`) issued by the same
+  install. A user token authenticates, connects, and passes `auth.test` exactly
+  like the bot token — but it resolves to a *person*, so loom posts as them and
+  discards every mention they type as its own. **Settings → Connections** names
+  this outright; `auth.test` returns a `bot_id` only for the bot token, and that
+  is what the pane checks.
+
 Both are held outside the settings registry — like the GitHub webhook secret
 and App private key — so `GET /api/settings` never returns them. Set them
 through the environment, or in `loom.toml` (see
@@ -152,10 +167,25 @@ versioned `LOOM_DOTENV` payload managed by the
 [Marin `infra/loom` runbook](https://github.com/marin-community/marin/tree/main/infra/loom).
 Do not create standalone Slack-token secrets that the deployment never reads.
 
-`slack.enabled` (default on) closes the socket without discarding the tokens
-— use it to pause the integration without losing configuration. It, along
-with `slack.allowed_users`, `slack.default_repo`, and
+`slack.enabled` (default on) closes the live socket within ten seconds without
+discarding the tokens — use it to pause the integration without losing
+configuration. It, along with `slack.allowed_users`, `slack.default_repo`, and
 `slack.idle_archive_secs`, lives in **Settings → Slack**.
+
+## Diagnosing it
+
+**Settings → Connections** shows the whole trigger path in the order the server
+checks it — tokens, switch, connection, identity, who can trigger, repository —
+so a broken link names itself. A live socket is not the same as a working
+integration: the connection can be up while the bot token belongs to a person,
+or while no repository is configured, and the pane distinguishes those.
+
+`GET /api/slack/status` returns the same structure for scripting. Alongside it,
+the server log carries one line per arriving envelope (`slack: envelope
+received`, with the event type, channel, and user), the app id from the `hello`
+frame, and a reason for every trigger that did not become a session. The most
+recent of those reasons is also kept on the pane, since a mention that is
+silently dropped otherwise looks exactly like a mention that never arrived.
 
 ## Placement and retention
 


### PR DESCRIPTION
The Connections pane sat on "Checking…" forever: `SlackPanel` imported `onMounted` and never registered it, so `load()` never ran. Behind that, the status it would have shown could not have explained the failure anyway. `/api/slack/status` reported `connected` from a fresh `auth.test`, which succeeds for a user token (`xoxp-…`) just as it does for the app's bot token — with the token owner's user id. A deployment holding the wrong token connects, reports healthy, and then discards every mention its operator types, because the self-trigger guard compares the sender against that same id. Nothing was logged when a trigger was dropped, so a discarded mention and a dead socket looked identical. That is the state `loom.oa.dev` was in.

Report the trigger path link by link instead: tokens, switch, socket, identity, who may trigger, repository. The pane renders the sequence the server actually checks and names the first link that does not hold, so a live socket no longer reports health on behalf of the five checks after it. `auth.test` now keeps `bot_id`, which is present only for a bot token and is what separates the two. The supervisor records what it is doing — socket state, the app id from the `hello` frame, event and launch counts, and the reason the most recent trigger did not become a session — and logs one line per arriving envelope.

Trigger access defaults to the workspace. Slack already enforces two grants, workspace membership and the channel invite, and Socket Mode only delivers `app_mention` from channels the bot is in, so the previous deny-by-default list of opaque user ids was a third boundary that had to be maintained by hand; production had it empty, which admitted no one. `slack.allowed_users` still narrows to named ids when set.

Because trusting the workspace also trusts anything posting into it, a message carrying a `bot_id` — posted through an app rather than typed by a person — no longer triggers unless its id is listed. Alerting bots share these channels, and one whose text contains `@loom` must not launch a session holding repo and agent credentials. Verified against real `#marin-alerts` history: human-typed messages carry no `bot_id`, API-posted ones do.

`slack.enabled` off now closes a live socket within ten seconds, which is what the setting already claimed to do; it previously waited for Slack's own refresh.

**Behavior change for existing deployments.** A deployment relying on an empty `slack.allowed_users` to admit no one now admits its whole workspace. Set the list explicitly to keep a narrow boundary.

## Testing

`./scripts/pre-commit.sh` clean. Nine unit tests cover the path derivation and eight the authorization decision, including the user-token case and each hard gate under both access modes.

Verified against the real Slack app on an isolated `WEAVER_HOME`: socket up with the bot token, app id `A0AJ4HA07K9` from `hello`, an app-posted mention refused with its reason recorded on the status endpoint, an authorized mention carried through to repo resolution, and the kill switch closing the socket.
