### PR TITLE
fix(loom): continue live Slack sessions

### DIFF
--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -900,6 +900,43 @@ impl AcpRegistry {
         });
     }
 
+    /// Register a prompt probe in place of a real session task.
+    ///
+    /// Upper-crate delivery tests use this to prove that an integration hands a
+    /// follow-up to the ACP conversation rather than merely acknowledging its
+    /// transport event. Production code never registers probes.
+    pub fn register_prompt_probe(
+        &self,
+        session_id: &str,
+        prompts: mpsc::UnboundedSender<(String, Option<String>)>,
+    ) {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(8);
+        let (events_tx, _) = broadcast::channel(8);
+        self.register(
+            session_id,
+            AcpHandle {
+                cmd_tx,
+                events_tx,
+                metadata: Arc::new(Mutex::new(AcpMetadata::default())),
+            },
+        );
+        tokio::spawn(async move {
+            while let Some(command) = cmd_rx.recv().await {
+                if let Command::Prompt {
+                    text, by, reply, ..
+                } = command
+                {
+                    let _ = prompts.send((text, by));
+                    let _ = reply.send(Ok(PromptAck {
+                        queued: false,
+                        steered: false,
+                        turn: Some(0),
+                    }));
+                }
+            }
+        });
+    }
+
     /// Remove the session's slot only if it still holds `generation` — a task
     /// that has been superseded leaves the newer registration untouched.
     fn remove_own(&self, session_id: &str, generation: u64) {

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -1079,7 +1079,7 @@ async fn launch(
             let prompt = followup_prompt(trigger, instruction);
             match forward_followup(state, &session, &prompt).await {
                 Ok(()) => {
-                    events::record(
+                    if let Err(error) = events::record(
                         &state.db,
                         &state.bus,
                         &b.id,
@@ -1090,7 +1090,14 @@ async fn launch(
                         }),
                     )
                     .await
-                    .ok();
+                    {
+                        tracing::warn!(
+                            session = %session.id,
+                            branch = %b.id,
+                            %error,
+                            "slack: recording forwarded follow-up failed"
+                        );
+                    }
                     // Acknowledge only after the conversation accepted the
                     // follow-up. The eyes reaction therefore means "delivered
                     // to the session", not merely "received by loom".

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -5,8 +5,9 @@
 //! inbound, HMAC-verified webhook, loom is an **outbound websocket client**. A
 //! background task ([`run`]) opens a [Socket Mode] connection with the app-level
 //! token, receives `slash_commands` / `app_mention` envelopes, and — for an
-//! authorized trigger — pulls the conversation, launches a session, and replies
-//! in-thread with a live "On it" card. As the session reports `weaver status`,
+//! authorized trigger — continues the session already wired to that thread or
+//! pulls the conversation and launches one, replying in-thread with a live "On
+//! it" card only for a launch. As the session reports `weaver status`,
 //! [`sync_status_message`] edits that Slack message in place, exactly as
 //! [`crate::github::sync_status_comment`] edits the GitHub comment.
 //!
@@ -988,9 +989,9 @@ async fn handle_trigger(state: AppState, web: SlackWeb, bot: AuthTest, trigger: 
 
     match launch(&state, &web, &bot, &trigger, &repo, &instruction).await {
         Ok(Outcome::Launched) => update_health(|h| h.sessions_launched += 1),
-        // An ack on a thread that already has a session is not a launch, and
+        // A follow-up delivered to an existing session is not a launch, and
         // counting it as one would overstate what the trigger path did.
-        Ok(Outcome::AlreadyRunning) => {}
+        Ok(Outcome::Forwarded) => {}
         Err(e) => {
             tracing::warn!(error = %e, repo = %repo, "slack: launch failed");
             record_skip(&format!("launch failed: {e}"));
@@ -1022,9 +1023,9 @@ async fn notify(web: &SlackWeb, trigger: &Trigger, text: &str) -> Result<()> {
 #[derive(Debug, PartialEq, Eq)]
 enum Outcome {
     Launched,
-    /// The thread already had a live session, so the trigger was acknowledged
-    /// rather than acted on.
-    AlreadyRunning,
+    /// The thread already had a live session and the follow-up was delivered
+    /// into its conversation.
+    Forwarded,
 }
 
 /// The launch body: seed context, reuse-or-create the session, wire it, and post
@@ -1074,19 +1075,68 @@ async fn launch(
         // An archived session no longer counts as active, so a thread whose
         // session was archived falls straight through to a fresh launch on the
         // kept branch.
-        if let Ok(Some(_)) = crate::session::active_for_branch(&state.db, &b.id).await {
-            // A live session already owns this thread — don't launch a
-            // second. Ack (👀 on the mention; a note for a slash) and stop.
-            if let Anchor::Mention { event_ts, .. } = &trigger.anchor {
-                web.add_reaction(&trigger.channel_id, event_ts, "eyes")
+        if let Ok(Some(session)) = crate::session::active_for_branch(&state.db, &b.id).await {
+            let prompt = followup_prompt(trigger, instruction);
+            match forward_followup(state, &session, &prompt).await {
+                Ok(()) => {
+                    events::record(
+                        &state.db,
+                        &state.bus,
+                        &b.id,
+                        "nudge",
+                        json!({
+                            "by": format!("slack ({})", trigger.user_id),
+                            "text": instruction,
+                        }),
+                    )
                     .await
                     .ok();
-            } else {
-                notify(web, trigger, "Already working on this thread.")
-                    .await
-                    .ok();
+                    // Acknowledge only after the conversation accepted the
+                    // follow-up. The eyes reaction therefore means "delivered
+                    // to the session", not merely "received by loom".
+                    if let Anchor::Mention { event_ts, .. } = &trigger.anchor {
+                        web.add_reaction(&trigger.channel_id, event_ts, "eyes")
+                            .await
+                            .ok();
+                    } else {
+                        notify(web, trigger, "Passed this to the existing session.")
+                            .await
+                            .ok();
+                    }
+                    tracing::info!(
+                        session = %session.id,
+                        channel = %trigger.channel_id,
+                        "slack: forwarded follow-up to active session"
+                    );
+                    return Ok(Outcome::Forwarded);
+                }
+                Err(error) => {
+                    // The DB can briefly outlive the ACP task or terminal. Do
+                    // not acknowledge and drop the message: retire that stale
+                    // owner, then launch below with this request in its goal.
+                    tracing::warn!(
+                        session = %session.id,
+                        branch = %b.id,
+                        %error,
+                        "slack: active session unreachable; archiving it and launching a fresh session"
+                    );
+                    match crate::lifecycle::auto_archive(state, &session, b).await {
+                        Ok(Some(_)) => {}
+                        Ok(None) => {
+                            return Err(anyhow!(
+                                "session {} is unreachable and automatic archive is disabled",
+                                session.id
+                            ));
+                        }
+                        Err(archive_error) => {
+                            return Err(anyhow!(
+                                "archiving unreachable session {} failed: {archive_error}",
+                                session.id
+                            ));
+                        }
+                    }
+                }
             }
-            return Ok(Outcome::AlreadyRunning);
         }
     }
 
@@ -1161,6 +1211,68 @@ async fn launch(
     drop(_guard);
     sync_status_message(state.clone(), created.branch.id.clone()).await;
     Ok(Outcome::Launched)
+}
+
+/// Prompt text for a follow-up sent into an already-running Slack session.
+///
+/// The opening goal already carries the reply endpoint and thread wiring. This
+/// compact wrapper preserves attribution and makes the new request explicit in
+/// the conversation without replaying up to 40 history messages on every turn.
+fn followup_prompt(trigger: &Trigger, instruction: &str) -> String {
+    let instruction = if instruction.trim().is_empty() {
+        "(no explicit instruction — inspect the latest Slack thread context)"
+    } else {
+        instruction.trim()
+    };
+    format!(
+        "New Slack follow-up from <@{user}> in channel {channel}:\n\n{instruction}\n\n\
+         Continue this session and reply on its wired Slack thread when a response is warranted.",
+        user = trigger.user_id,
+        channel = trigger.channel_id,
+    )
+}
+
+/// Send an ACP prompt through the registered task so it is journaled and either
+/// started or durably queued according to the conversation's current state.
+async fn forward_acp_followup(
+    registry: &crate::acp::AcpRegistry,
+    session_id: &str,
+    prompt: &str,
+) -> Result<()> {
+    let handle = registry
+        .get(session_id)
+        .ok_or_else(|| anyhow!("session has no live ACP task"))?;
+    handle
+        .prompt(
+            prompt.to_string(),
+            Some("slack".to_string()),
+            false,
+            Vec::new(),
+        )
+        .await
+        .context("sending follow-up to ACP conversation")?;
+    Ok(())
+}
+
+/// Deliver a Slack follow-up through the session's actual conversation
+/// protocol. ACP relays speak JSON-RPC on stdin, so terminal paste would corrupt
+/// that stream; terminal agents keep using their interactive composer.
+async fn forward_followup(
+    state: &AppState,
+    session: &crate::session::Session,
+    prompt: &str,
+) -> Result<()> {
+    if session.protocol == "acp" {
+        forward_acp_followup(&state.acp, &session.id, prompt).await
+    } else {
+        crate::backend::paste(&session.term_session, prompt)
+            .await
+            .context("pasting follow-up into terminal session")?;
+        crate::backend::send_enter(&session.term_session)
+            .await
+            .context("submitting terminal follow-up")?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -1698,6 +1810,24 @@ mod tests {
         };
 
         assert_eq!(history_target(&t), HistoryTarget::Thread("4.4"));
+    }
+
+    #[tokio::test]
+    async fn active_acp_session_receives_slack_followup() {
+        let registry = crate::acp::AcpRegistry::new();
+        let (prompt_tx, mut prompts) = tokio::sync::mpsc::unbounded_channel();
+        registry.register_prompt_probe("s-live", prompt_tx);
+        let t = trigger("U2", "T1", false);
+        let prompt = followup_prompt(&t, "replace the existing PR");
+
+        forward_acp_followup(&registry, "s-live", &prompt)
+            .await
+            .unwrap();
+
+        let (delivered, by) = prompts.recv().await.unwrap();
+        assert_eq!(delivered, prompt);
+        assert_eq!(by.as_deref(), Some("slack"));
+        assert!(delivered.contains("replace the existing PR"));
     }
 
     #[test]

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -48,14 +48,17 @@ frame it receives, in order:
 5. **Resolves the repo** from an `owner/name:` prefix on the command text, or
    the `slack.default_repo` setting (see [Which repo](#which-repo)). Neither
    set gets a reply asking for one.
-6. **Reuses or launches.** A thread that already has a live session attached
-   is acknowledged — a 👀 reaction on the mention, or an "Already working on
-   this thread." reply for a slash command — rather than launched again.
-   Otherwise loom clones/resolves the repo, pulls conversation history to
-   seed the session goal (the thread's replies for a mention, the channel's
-   recent messages for a slash command, capped at 40 messages), and creates
-   the session on a stable `slack-<hash>` branch derived from the thread
-   identity, so a later trigger on the same thread finds the same branch.
+6. **Continues or launches.** A thread that already has a live session attached
+   receives the new request in that session's conversation, then is
+   acknowledged — a 👀 reaction on the mention, or a short confirmation for a
+   slash command — rather than launched again. If the recorded session is
+   unreachable, loom archives it and relaunches on the kept branch so the
+   request is not dropped. Otherwise loom clones/resolves the repo, pulls
+   conversation history to seed the session goal (the thread's replies for a
+   mention, the channel's recent messages for a slash command, capped at 40
+   messages), and creates the session on a stable `slack-<hash>` branch derived
+   from the thread identity, so a later trigger on the same thread finds the
+   same branch.
 7. **Wires and replies.** The branch is tagged with the thread's identity (the
    `slack` tag — see [The status card](#the-status-card)), and loom posts (or,
    for a slash command, edits its placeholder into) the "On it" card.


### PR DESCRIPTION
Forward subsequent Slack mentions into the session already wired to their thread instead of stopping after the eyes acknowledgment. ACP follow-ups use the durable conversation prompt path, while terminal agents receive a submitted terminal prompt.

Acknowledge only after the session accepts the message. If an active database row has no reachable conversation, archive it and relaunch on the kept branch so the follow-up is preserved; new and restored sessions continue to receive the On it card, while live continuations do not.

Add regression coverage for ACP delivery and update the Slack trigger contract.