### PR TITLE
feat(config): make Slack behavior deployment-configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "serial_test",
  "sha2",
  "smartdoc",
@@ -2260,6 +2261,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,6 +3036,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/README.md
+++ b/README.md
@@ -450,7 +450,9 @@ and keep provider credentials server-side. See
 The complete setting registry is self-documenting in Settings and
 `weaver config ls`. Environment variables and runtime defaults are catalogued in
 [Architecture](docs/ARCHITECTURE.md#environment); standalone deployment values
-live in [deploy/README.md](deploy/README.md).
+live in [deploy/README.md](deploy/README.md). Registered settings share one
+[configuration precedence policy](docs/configuration.md): runtime override →
+deployment default → built-in default.
 
 ## Developing weaver
 

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -719,20 +719,85 @@ fn status_bullet(event: &events::Event) -> Option<String> {
     Some(line)
 }
 
-/// Render the Slack status card: the "On it" header linking the session, any
-/// published-document links, then the `weaver status` trail (oldest-first, capped).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusPresentation {
+    pub header_template: String,
+    pub show_artifacts: bool,
+    pub show_updates: bool,
+}
+
+impl Default for StatusPresentation {
+    fn default() -> Self {
+        Self {
+            header_template: config::DEFAULT_SLACK_STATUS_HEADER_TEMPLATE.to_string(),
+            show_artifacts: config::DEFAULT_SLACK_STATUS_ARTIFACTS,
+            show_updates: config::DEFAULT_SLACK_STATUS_UPDATES,
+        }
+    }
+}
+
+async fn status_presentation(db: &Db) -> StatusPresentation {
+    let header_template = config::get_or(
+        db,
+        "slack.status_header_template",
+        config::DEFAULT_SLACK_STATUS_HEADER_TEMPLATE,
+    )
+    .await;
+    StatusPresentation {
+        header_template: if header_template.trim().is_empty() {
+            config::DEFAULT_SLACK_STATUS_HEADER_TEMPLATE.to_string()
+        } else {
+            header_template
+        },
+        show_artifacts: config::get_bool(
+            db,
+            "slack.status_artifacts",
+            config::DEFAULT_SLACK_STATUS_ARTIFACTS,
+        )
+        .await,
+        show_updates: config::get_bool(
+            db,
+            "slack.status_updates",
+            config::DEFAULT_SLACK_STATUS_UPDATES,
+        )
+        .await,
+    }
+}
+
+fn retain_current_session_events(
+    events: &mut Vec<events::Event>,
+    wired_at: &str,
+    session_created_at: &str,
+) {
+    let publish_after = std::cmp::max(wired_at, session_created_at);
+    events.retain(|event| event.created_at.as_str() >= publish_after);
+}
+
+/// Render the configured Slack status card: its header, optional artifact
+/// links, then the optional `weaver status` trail (oldest-first, capped).
 /// Pure, so the mrkdwn format is unit-testable. Slack link syntax is
 /// `<url|label>`, not Markdown's `[label](url)`.
-pub fn render_status(session_url: &str, artifacts: &[String], events: &[events::Event]) -> String {
-    let bullets: Vec<String> = events
-        .iter()
-        .filter(|e| {
-            e.kind == "tag" && e.data["key"] == tags::ATTENTION_KEY && e.data["by"] == "agent"
-        })
-        .filter_map(status_bullet)
-        .collect();
-    let mut body = format!("On it — <{session_url}>");
-    if !artifacts.is_empty() {
+pub fn render_status(
+    session_url: &str,
+    artifacts: &[String],
+    events: &[events::Event],
+    presentation: &StatusPresentation,
+) -> String {
+    let bullets: Vec<String> = if presentation.show_updates {
+        events
+            .iter()
+            .filter(|e| {
+                e.kind == "tag" && e.data["key"] == tags::ATTENTION_KEY && e.data["by"] == "agent"
+            })
+            .filter_map(status_bullet)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let mut body = presentation
+        .header_template
+        .replace("{session_url}", session_url);
+    if presentation.show_artifacts && !artifacts.is_empty() {
         let links: Vec<String> = artifacts
             .iter()
             .map(|name| {
@@ -824,32 +889,43 @@ async fn sync_status_message_once(state: &AppState, branch_id: &str) -> bool {
     };
 
     let _guard = SYNC_LOCK.lock().await;
-    let mut events = match events::history(&state.db, branch_id, 500).await {
-        Ok(ev) => ev,
-        Err(e) => {
-            tracing::warn!(branch = %branch_id, error = %e, "slack status card: reading event history failed");
-            return true;
+    let presentation = status_presentation(&state.db).await;
+    let mut events = if presentation.show_updates {
+        match events::history(&state.db, branch_id, 500).await {
+            Ok(ev) => ev,
+            Err(e) => {
+                tracing::warn!(branch = %branch_id, error = %e, "slack status card: reading event history failed");
+                return true;
+            }
         }
+    } else {
+        Vec::new()
     };
-    // Statuses from before the wiring stay private — hand-wiring an old session
-    // must not retroactively publish its history.
-    events.retain(|e| e.created_at >= wired.set_at);
-    let artifacts: Vec<String> = match crate::branch::get(&state.db, branch_id).await {
-        Ok(Some(branch)) => {
-            weaver_core::artifact::list_for_session(&state.db, &branch.repo_root, branch_id)
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .map(|a| a.name)
-                .filter(|n| n != "goal")
-                .collect()
+    // Statuses from before the wiring stay private, and a fresh session on a
+    // reused conversation starts a fresh trail. Branch event history outlives
+    // individual sessions, so the session boundary is essential on relaunch.
+    retain_current_session_events(&mut events, &wired.set_at, &session.created_at);
+    let artifacts: Vec<String> = if presentation.show_artifacts {
+        match crate::branch::get(&state.db, branch_id).await {
+            Ok(Some(branch)) => {
+                weaver_core::artifact::list_for_session(&state.db, &branch.repo_root, branch_id)
+                    .await
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|a| a.name)
+                    .filter(|n| n != "goal")
+                    .collect()
+            }
+            _ => Vec::new(),
         }
-        _ => Vec::new(),
+    } else {
+        Vec::new()
     };
     let body = render_status(
         &crate::links::session_url(&base, &session.id),
         &artifacts,
         &events,
+        &presentation,
     );
 
     // Trust the tracked message ts only while its note still names the current
@@ -1147,7 +1223,10 @@ async fn launch(
         }
     }
 
-    let goal = slack_goal(repo, trigger, instruction, &history);
+    let prompt_instructions = config::get(&state.db, "slack.prompt_instructions")
+        .await
+        .unwrap_or_default();
+    let goal = slack_goal(repo, trigger, instruction, &history, &prompt_instructions);
     let branch_exists = crate::git::branch_exists(&repo_root, &branch_ref).await;
     let mut req = weaver_api::dto::CreateReq {
         repo: Some(repo.to_string()),
@@ -1331,13 +1410,19 @@ async fn pull_history(web: &SlackWeb, trigger: &Trigger) -> String {
 
 /// The seed goal handed to the session — the Slack analog of GitHub's
 /// `trigger_goal`.
-fn slack_goal(repo: &str, trigger: &Trigger, instruction: &str, history: &str) -> String {
+fn slack_goal(
+    repo: &str,
+    trigger: &Trigger,
+    instruction: &str,
+    history: &str,
+    prompt_instructions: &str,
+) -> String {
     let instruction = if instruction.trim().is_empty() {
         "(no explicit instruction — infer the task from the conversation)"
     } else {
         instruction.trim()
     };
-    format!(
+    let mut goal = format!(
         "You've been summoned from Slack (channel {channel}) to work on `{repo}`.\n\n\
          ## Request (from <@{user}>)\n{instruction}\n\n\
          ## Conversation context\n{history}\n\n\
@@ -1350,7 +1435,12 @@ fn slack_goal(repo: &str, trigger: &Trigger, instruction: &str, history: &str) -
          - Your `weaver status` messages and the built-in `status_update` MCP tool are mirrored onto the Slack thread. For a short answer, avoid narrating every lookup; use status updates only when they add useful progress context.",
         channel = trigger.channel_id,
         user = trigger.user_id,
-    )
+    );
+    if !prompt_instructions.trim().is_empty() {
+        goal.push_str("\n\n## Organization instructions\n");
+        goal.push_str(prompt_instructions.trim());
+    }
+    goal
 }
 
 /// Resolve the Slack-specific effort override without making an otherwise valid
@@ -1893,7 +1983,12 @@ mod tests {
             data: json!({"key": "attention", "value": "attention", "note": "ready <now>", "by": "agent"}),
             created_at: "2026-07-20T21:04:00Z".into(),
         };
-        let card = render_status("http://loom/s/abc", &[], std::slice::from_ref(&ev));
+        let card = render_status(
+            "http://loom/s/abc",
+            &[],
+            std::slice::from_ref(&ev),
+            &StatusPresentation::default(),
+        );
         assert!(card.starts_with("On it — <http://loom/s/abc>"));
         assert!(card.contains("*attention*"), "single-star bold: {card}");
         assert!(card.contains("ready &lt;now&gt;"), "escaped: {card}");
@@ -1901,11 +1996,24 @@ mod tests {
     }
 
     #[test]
-    fn render_status_links_artifacts_without_a_docs_label() {
+    fn render_status_hides_artifacts_by_default_and_can_enable_them() {
+        let artifacts = ["design".to_string(), "plan".to_string()];
+        let default_card = render_status(
+            "http://loom/s/abc",
+            &artifacts,
+            &[],
+            &StatusPresentation::default(),
+        );
+        assert_eq!(default_card, "On it — <http://loom/s/abc>");
+
         let card = render_status(
             "http://loom/s/abc",
-            &["design".to_string(), "plan".to_string()],
+            &artifacts,
             &[],
+            &StatusPresentation {
+                show_artifacts: true,
+                ..StatusPresentation::default()
+            },
         );
         assert_eq!(
             card.lines().nth(1),
@@ -1914,5 +2022,61 @@ mod tests {
             )
         );
         assert!(!card.contains("Docs:"));
+    }
+
+    #[test]
+    fn render_status_can_customize_the_header_and_hide_updates() {
+        let ev = events::Event {
+            id: 1,
+            branch_id: "b".into(),
+            kind: "tag".into(),
+            data: json!({"key": "attention", "value": "", "note": "old update", "by": "agent"}),
+            created_at: "2026-07-20T21:04:00Z".into(),
+        };
+        let card = render_status(
+            "http://loom/s/abc",
+            &[],
+            &[ev],
+            &StatusPresentation {
+                header_template: "Working: {session_url}".into(),
+                show_updates: false,
+                ..StatusPresentation::default()
+            },
+        );
+        assert_eq!(card, "Working: http://loom/s/abc");
+    }
+
+    #[test]
+    fn status_trail_starts_at_the_current_session_on_a_reused_thread() {
+        let event = |id, created_at: &str| events::Event {
+            id,
+            branch_id: "b".into(),
+            kind: "tag".into(),
+            data: json!({"key": "attention", "value": "", "note": format!("update {id}"), "by": "agent"}),
+            created_at: created_at.into(),
+        };
+        let mut events = vec![
+            event(1, "2026-08-06T07:47:00.000Z"),
+            event(2, "2026-08-06T10:45:00.000Z"),
+        ];
+        retain_current_session_events(
+            &mut events,
+            "2026-08-06T07:00:00.000Z",
+            "2026-08-06T10:44:00.000Z",
+        );
+        assert_eq!(events.iter().map(|event| event.id).collect::<Vec<_>>(), [2]);
+    }
+
+    #[test]
+    fn slack_goal_appends_organization_instructions_last() {
+        let goal = slack_goal(
+            "acme/widgets",
+            &trigger("U1", "T1", false),
+            "summarize",
+            "thread context",
+            "Use our incident template.",
+        );
+        assert!(goal.contains("## How to respond"));
+        assert!(goal.ends_with("## Organization instructions\nUse our incident template."));
     }
 }

--- a/crates/loom/Cargo.toml
+++ b/crates/loom/Cargo.toml
@@ -48,6 +48,9 @@ rpassword = "7"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Deployment manifests are operator-authored YAML; JSON remains accepted
+# because it is a YAML subset.
+serde_yaml_ng = "0.10"
 # SHA-256 for hashing API tokens / session ids at rest (high-entropy secrets, so
 # a fast digest is right — the slow KDF above is only for low-entropy passwords).
 sha2 = "0.10"

--- a/crates/loom/frontend/src/components/AppearancePanel.vue
+++ b/crates/loom/frontend/src/components/AppearancePanel.vue
@@ -67,7 +67,7 @@ let disposed = false;
 const sizeNumber = computed(() => clampFontSize(Number(draft[SIZE_KEY])));
 
 const dirty = computed(() => KEYS.some((k) => draft[k] !== stored.value[k]?.value));
-const allDefault = computed(() => KEYS.every((k) => stored.value[k]?.is_default));
+const allInherited = computed(() => KEYS.every((k) => stored.value[k]?.source !== 'runtime'));
 
 function adopt(settings: SettingView[]) {
   const byKey: Record<string, SettingView> = {};
@@ -115,7 +115,7 @@ async function save() {
 }
 
 async function resetDefaults() {
-  await commit(patchBody(true), 'Reset terminal appearance to defaults.');
+  await commit(patchBody(true), 'Cleared terminal appearance overrides.');
 }
 
 function nudgeSize(delta: number) {
@@ -323,11 +323,11 @@ onUnmounted(() => {
         </button>
         <button
           class="btn-secondary px-3 py-1.5 text-xs disabled:opacity-50"
-          :disabled="busy || allDefault || !loaded"
-          title="Reset theme, font, and size to their defaults"
+          :disabled="busy || allInherited || !loaded"
+          title="Clear runtime overrides and inherit deployment or built-in values"
           @click="resetDefaults"
         >
-          Reset to defaults
+          Clear overrides
         </button>
         <span v-if="dirty" class="text-2xs text-faint"
           >Unsaved changes — applies to terminals opened after saving.</span

--- a/crates/loom/frontend/src/components/SettingFieldRow.vue
+++ b/crates/loom/frontend/src/components/SettingFieldRow.vue
@@ -3,7 +3,7 @@ import type { SettingView } from '../types';
 
 defineProps<{
   setting: SettingView;
-  defaultLabel: string;
+  inheritedLabel: string;
   sourceLabel: string;
   isDefault: boolean;
   canReset: boolean;
@@ -48,14 +48,14 @@ const emit = defineEmits<{
         <button
           class="btn-secondary px-2.5 py-1 text-xs disabled:opacity-50"
           :disabled="busy || !canReset"
-          :title="`Clear runtime override; inherit: ${defaultLabel}`"
+          :title="`Clear runtime override; inherit: ${inheritedLabel}`"
           @click="emit('reset')"
         >
           Reset
         </button>
       </div>
       <p class="text-2xs text-faint">
-        Inherited value <code class="font-mono">{{ defaultLabel }}</code>
+        Inherited value <code class="font-mono">{{ inheritedLabel }}</code>
       </p>
     </div>
   </div>

--- a/crates/loom/frontend/src/components/SettingFieldRow.vue
+++ b/crates/loom/frontend/src/components/SettingFieldRow.vue
@@ -4,7 +4,9 @@ import type { SettingView } from '../types';
 defineProps<{
   setting: SettingView;
   defaultLabel: string;
+  sourceLabel: string;
   isDefault: boolean;
+  canReset: boolean;
   dirty: boolean;
   busy: boolean;
 }>();
@@ -26,7 +28,7 @@ const emit = defineEmits<{
           class="rounded px-1.5 py-0.5 text-2xs"
           :class="isDefault ? 'bg-input text-faint' : 'bg-info-soft text-info'"
         >
-          {{ isDefault ? 'default' : 'custom' }}
+          {{ sourceLabel }}
         </span>
       </div>
       <p class="mt-0.5 line-clamp-2 text-xs text-muted">{{ setting.description }}</p>
@@ -45,15 +47,15 @@ const emit = defineEmits<{
         </button>
         <button
           class="btn-secondary px-2.5 py-1 text-xs disabled:opacity-50"
-          :disabled="busy || isDefault"
-          :title="`Reset to default: ${defaultLabel}`"
+          :disabled="busy || !canReset"
+          :title="`Clear runtime override; inherit: ${defaultLabel}`"
           @click="emit('reset')"
         >
           Reset
         </button>
       </div>
       <p class="text-2xs text-faint">
-        Default <code class="font-mono">{{ defaultLabel }}</code>
+        Inherited value <code class="font-mono">{{ defaultLabel }}</code>
       </p>
     </div>
   </div>

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -1171,7 +1171,8 @@ export interface ProgramView {
   };
 }
 
-export type SettingKind = 'string' | 'int' | 'bool' | 'enum';
+export type SettingKind = 'string' | 'text' | 'int' | 'bool' | 'enum';
+export type SettingSource = 'default' | 'deployment' | 'runtime';
 
 /** One configurable setting: its registry metadata plus its current value. */
 export interface SettingView {
@@ -1184,6 +1185,10 @@ export interface SettingView {
   /** Allowed values for an `enum` setting, in display order; empty otherwise. */
   options: string[];
   value: string;
+  /** Layer supplying the effective value: runtime > deployment > built-in. */
+  source: SettingSource;
+  /** Value declared by deployment IaC, when present. */
+  deployment_value: string | null;
   is_default: boolean;
 }
 

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -138,11 +138,23 @@ function setting(key: string): SettingView | undefined {
 }
 
 function isDefaultValue(s: SettingView): boolean {
-  return s.is_default && !dirty(s);
+  return s.source === 'default' && !dirty(s);
 }
 
 function dirty(s: SettingView): boolean {
   return drafts.value[s.key] !== s.value;
+}
+
+function sourceLabel(s: SettingView): string {
+  return dirty(s) ? 'unsaved' : s.source;
+}
+
+function inheritedValue(s: SettingView): string {
+  return s.deployment_value ?? s.default;
+}
+
+function canReset(s: SettingView): boolean {
+  return dirty(s) || s.source === 'runtime';
 }
 
 function dirtyKeys(keys: string[]): string[] {
@@ -324,8 +336,10 @@ onMounted(load);
               v-for="s in currentSettings"
               :key="s.key"
               :setting="s"
-              :default-label="defaultText(s.default)"
+              :default-label="defaultText(inheritedValue(s))"
+              :source-label="sourceLabel(s)"
               :is-default="isDefaultValue(s)"
+              :can-reset="canReset(s)"
               :dirty="dirty(s)"
               :busy="busy === s.label"
               @save="saveSetting(s)"
@@ -376,11 +390,20 @@ onMounted(load);
                     {{ opt.label }}
                   </button>
                 </div>
+                <textarea
+                  v-if="s.kind === 'text'"
+                  :id="s.key"
+                  v-model="drafts[s.key]"
+                  rows="5"
+                  :placeholder="defaultText(inheritedValue(s))"
+                  class="w-full resize-y rounded bg-input px-2 py-1 font-mono text-sm outline-none ring-accent focus:ring-1"
+                />
                 <input
+                  v-else
                   :id="s.key"
                   v-model="drafts[s.key]"
                   :type="s.kind === 'int' ? 'number' : 'text'"
-                  :placeholder="defaultText(s.default)"
+                  :placeholder="defaultText(inheritedValue(s))"
                   class="w-full rounded bg-input px-2 py-1 text-sm outline-none ring-accent focus:ring-1"
                   :class="{ 'font-mono': s.kind === 'string' }"
                 />

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -336,7 +336,7 @@ onMounted(load);
               v-for="s in currentSettings"
               :key="s.key"
               :setting="s"
-              :default-label="defaultText(inheritedValue(s))"
+              :inherited-label="defaultText(inheritedValue(s))"
               :source-label="sourceLabel(s)"
               :is-default="isDefaultValue(s)"
               :can-reset="canReset(s)"

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -969,9 +969,9 @@ enum FederationCmd {
 
 #[derive(Subcommand)]
 enum DeploymentCmd {
-    /// Reconcile profiles, secret references, and workload federation mappings.
+    /// Reconcile settings, profiles, secret references, and workload federation mappings.
     Apply {
-        /// JSON manifest path, or `-` for stdin.
+        /// YAML (or JSON) manifest path, or `-` for stdin.
         #[arg(long, default_value = "-")]
         file: String,
     },
@@ -2255,17 +2255,21 @@ async fn run_deployment(cmd: DeploymentCmd) -> Result<()> {
                 std::fs::read_to_string(&file)
                     .with_context(|| format!("reading deployment manifest {file}"))?
             };
-            let request: weaver_api::DeploymentReq =
-                serde_json::from_str(&contents).context("decoding deployment manifest")?;
+            let request = parse_deployment_manifest(&contents)?;
             let result = client::default()?.reconcile_deployment(&request).await?;
             println!(
-                "reconciled {} profiles and {} federation mappings",
+                "reconciled {} settings, {} profiles, and {} federation mappings",
+                result.settings.len(),
                 result.profiles.len(),
                 result.federations.len()
             );
         }
     }
     Ok(())
+}
+
+fn parse_deployment_manifest(contents: &str) -> Result<weaver_api::DeploymentReq> {
+    serde_yaml_ng::from_str(contents).context("decoding deployment manifest as YAML or JSON")
 }
 
 async fn run_profile(cmd: ProfileCmd) -> Result<()> {
@@ -5663,6 +5667,51 @@ mod tests {
         );
 
         std::env::remove_var("WEAVER_HOME");
+    }
+
+    #[test]
+    fn deployment_manifest_accepts_yaml_and_json_scalars() {
+        let yaml = parse_deployment_manifest(
+            r#"
+settings:
+  slack.status_updates: false
+  slack.idle_archive_secs: 7200
+  slack.prompt_instructions: |
+    Answer in the thread.
+    Keep it concise.
+prune: true
+"#,
+        )
+        .unwrap();
+        assert_eq!(yaml.settings["slack.status_updates"].stored(), "false");
+        assert_eq!(yaml.settings["slack.idle_archive_secs"].stored(), "7200");
+        assert_eq!(
+            yaml.settings["slack.prompt_instructions"].stored(),
+            "Answer in the thread.\nKeep it concise.\n"
+        );
+        assert!(yaml.prune);
+
+        let json = parse_deployment_manifest(
+            r#"{"settings":{"slack.status_header_template":"Working — <{session_url}>"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            json.settings["slack.status_header_template"].stored(),
+            "Working — <{session_url}>"
+        );
+    }
+
+    #[test]
+    fn deployment_manifest_rejects_non_scalar_settings() {
+        let error = parse_deployment_manifest(
+            r#"
+settings:
+  slack.status_updates:
+    nested: false
+"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("deployment manifest"));
     }
 
     #[test]

--- a/crates/loom/src/web/deployment.rs
+++ b/crates/loom/src/web/deployment.rs
@@ -4,6 +4,7 @@ use axum::{extract::State, http::StatusCode, Extension, Json};
 use weaver_api::{DeploymentReq, DeploymentView};
 
 use crate::auth::Principal;
+use crate::config;
 
 use super::{profiles, ApiResult, AppError, AppState};
 
@@ -17,6 +18,18 @@ pub(super) async fn reconcile_deployment(
 ) -> ApiResult<Json<DeploymentView>> {
     if !principal.is_admin() {
         return Err(AppError::new(StatusCode::FORBIDDEN, "admin grant required"));
+    }
+
+    let mut setting_values = Vec::with_capacity(req.settings.len());
+    for (key, declared) in &req.settings {
+        if config::spec(key).is_none() {
+            return Err(AppError::bad_request(format!("unknown setting '{key}'")));
+        }
+        let value = declared.stored();
+        if let Err(why) = config::validate(key, &value) {
+            return Err(AppError::bad_request(format!("{key}: {why}")));
+        }
+        setting_values.push((key.clone(), value));
     }
 
     let mut profile_names = BTreeSet::new();
@@ -63,6 +76,8 @@ pub(super) async fn reconcile_deployment(
     // Keep the common lock order (profiles, then registry generation). Profile
     // validation and persistence must observe one custom-agent/MCP generation.
     let _resolver_permit = st.launch_gate.acquire_resolver().await;
+
+    config::reconcile_deployment(&st.db, &setting_values, req.prune).await?;
 
     for declared in &req.profiles {
         let input = super::profiles::input(
@@ -139,7 +154,15 @@ pub(super) async fn reconcile_deployment(
         .into_iter()
         .filter(|mapping| federation_names.contains(&mapping.name))
         .collect();
+    let setting_names: BTreeSet<&str> = req.settings.keys().map(String::as_str).collect();
+    let settings = config::describe(&st.db)
+        .await?
+        .into_iter()
+        .filter(|setting| setting_names.contains(setting.spec.key))
+        .map(Into::into)
+        .collect();
     Ok(Json(DeploymentView {
+        settings,
         profiles: profile_views,
         federations: mappings,
     }))

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -736,7 +736,28 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn deployment_reconcile_rest_journey() {
     let ts = TestServer::start_api_only().await;
+    let invalid = ts
+        .client
+        .post(
+            "/api/deployment/reconcile",
+            json!({
+                "settings": { "slack.status_updates": "sometimes" },
+                "profiles": [],
+                "federations": []
+            }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        invalid.to_string().contains("slack.status_updates"),
+        "validation error should name the setting: {invalid}"
+    );
+
     let manifest = json!({
+        "settings": {
+            "slack.status_updates": false,
+            "slack.prompt_instructions": "Use the Marin response style."
+        },
         "profiles": [{
             "profile": {
                 "name": "ops",
@@ -774,6 +795,21 @@ async fn deployment_reconcile_rest_journey() {
         .post("/api/deployment/reconcile", manifest.clone())
         .await
         .unwrap();
+    let deployed_settings = first["settings"].as_array().unwrap();
+    let prompt_setting = deployed_settings
+        .iter()
+        .find(|setting| setting["key"] == "slack.prompt_instructions")
+        .unwrap();
+    assert_eq!(prompt_setting["source"], "deployment");
+    assert_eq!(
+        prompt_setting["deployment_value"],
+        "Use the Marin response style."
+    );
+    let status_setting = deployed_settings
+        .iter()
+        .find(|setting| setting["key"] == "slack.status_updates")
+        .unwrap();
+    assert_eq!(status_setting["value"], "false");
     assert_eq!(first["profiles"][0]["revision"], 2);
     assert_eq!(
         first["profiles"][0]["mcp_access"],
@@ -784,9 +820,41 @@ async fn deployment_reconcile_rest_journey() {
         first["profiles"][0]["env"][0]["secret_ref"],
         "projects/example/secrets/ops-kubeconfig/versions/latest"
     );
-    assert!(!first.to_string().contains("value"));
+    assert!(first["profiles"][0]["env"][0].get("value").is_none());
     let mapping_id = first["federations"][0]["id"].clone();
     assert_eq!(first["federations"][0]["service_tag"], "marin-ops");
+
+    let runtime = ts
+        .client
+        .patch("/api/settings", json!({ "slack.status_updates": true }))
+        .await
+        .unwrap();
+    let runtime_setting = runtime["settings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|setting| setting["key"] == "slack.status_updates")
+        .unwrap();
+    assert_eq!(runtime_setting["value"], "true");
+    assert_eq!(runtime_setting["source"], "runtime");
+    assert_eq!(runtime_setting["deployment_value"], "false");
+
+    let inherited = ts
+        .client
+        .patch(
+            "/api/settings",
+            json!({ "slack.status_updates": serde_json::Value::Null }),
+        )
+        .await
+        .unwrap();
+    let inherited_setting = inherited["settings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|setting| setting["key"] == "slack.status_updates")
+        .unwrap();
+    assert_eq!(inherited_setting["value"], "false");
+    assert_eq!(inherited_setting["source"], "deployment");
 
     let second = ts
         .client
@@ -799,10 +867,19 @@ async fn deployment_reconcile_rest_journey() {
     ts.client
         .post(
             "/api/deployment/reconcile",
-            json!({ "profiles": [], "federations": [], "prune": true }),
+            json!({ "settings": {}, "profiles": [], "federations": [], "prune": true }),
         )
         .await
         .unwrap();
+    let pruned = ts.client.get("/api/settings").await.unwrap();
+    let pruned_setting = pruned["settings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|setting| setting["key"] == "slack.status_updates")
+        .unwrap();
+    assert_eq!(pruned_setting["value"], "true");
+    assert_eq!(pruned_setting["source"], "default");
     let profile = reqwest::Client::new()
         .get(format!("http://{}/api/profiles/ops", ts.addr))
         .send()

--- a/crates/loom/tests/integration/typed_client.rs
+++ b/crates/loom/tests/integration/typed_client.rs
@@ -9,7 +9,7 @@
 use serial_test::serial;
 
 use serde_json::{Map, Value};
-use weaver_api::{CreateReq, SettingKind};
+use weaver_api::{CreateReq, SettingKind, SettingSource};
 
 use crate::fixtures::TestServer;
 
@@ -134,6 +134,8 @@ async fn typed_settings_get_and_patch_share_the_rich_envelope() {
     assert!(!initial_setting.label.is_empty());
     assert!(!initial_setting.description.is_empty());
     assert_eq!(initial_setting.default, "false");
+    assert_eq!(initial_setting.source, SettingSource::Default);
+    assert_eq!(initial_setting.deployment_value, None);
     assert!(!initial_setting.group.is_empty());
     assert!(initial_setting.options.is_empty());
 
@@ -152,5 +154,6 @@ async fn typed_settings_get_and_patch_share_the_rich_envelope() {
     assert_eq!(updated_setting.group, initial_setting.group);
     assert_eq!(updated_setting.options, initial_setting.options);
     assert_eq!(updated_setting.value, "true");
+    assert_eq!(updated_setting.source, SettingSource::Runtime);
     assert!(!updated_setting.is_default);
 }

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -10,6 +10,8 @@
 //! call these once they've gathered the parts — so the wire struct has exactly
 //! one definition while the DB access stays where the daemon owns it.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -1101,9 +1103,33 @@ pub struct DeploymentProfileEnvReq {
     pub secret_ref: Option<String>,
 }
 
-/// Declarative runtime resources rendered by Pulumi and reconciled by name.
+/// A scalar setting value in a JSON or YAML deployment manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DeploymentSettingValue {
+    String(String),
+    Int(i64),
+    Bool(bool),
+}
+
+impl DeploymentSettingValue {
+    pub fn stored(&self) -> String {
+        match self {
+            Self::String(value) => value.clone(),
+            Self::Int(value) => value.to_string(),
+            Self::Bool(value) => value.to_string(),
+        }
+    }
+}
+
+/// Declarative runtime resources rendered by infrastructure tooling and
+/// reconciled by name.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DeploymentReq {
+    /// Organization defaults for registered runtime settings. Live DB values
+    /// remain a higher-precedence override.
+    #[serde(default)]
+    pub settings: BTreeMap<String, DeploymentSettingValue>,
     #[serde(default)]
     pub profiles: Vec<DeploymentProfileReq>,
     #[serde(default)]
@@ -1115,6 +1141,7 @@ pub struct DeploymentReq {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeploymentView {
+    pub settings: Vec<SettingView>,
     pub profiles: Vec<ProfileView>,
     pub federations: Vec<FederationView>,
 }
@@ -2630,6 +2657,7 @@ pub struct CreateEventReq {
 
 wire_enum!(SettingKind {
     String => "string",
+    Text => "text",
     Int => "int",
     Bool => "bool",
     Enum => "enum",
@@ -2639,9 +2667,26 @@ impl From<weaver_core::config::SettingKind> for SettingKind {
     fn from(kind: weaver_core::config::SettingKind) -> Self {
         match kind {
             weaver_core::config::SettingKind::String => Self::String,
+            weaver_core::config::SettingKind::Text => Self::Text,
             weaver_core::config::SettingKind::Int => Self::Int,
             weaver_core::config::SettingKind::Bool => Self::Bool,
             weaver_core::config::SettingKind::Enum => Self::Enum,
+        }
+    }
+}
+
+wire_enum!(SettingSource {
+    Default => "default",
+    Deployment => "deployment",
+    Runtime => "runtime",
+});
+
+impl From<weaver_core::config::SettingSource> for SettingSource {
+    fn from(source: weaver_core::config::SettingSource) -> Self {
+        match source {
+            weaver_core::config::SettingSource::Default => Self::Default,
+            weaver_core::config::SettingSource::Deployment => Self::Deployment,
+            weaver_core::config::SettingSource::Runtime => Self::Runtime,
         }
     }
 }
@@ -2658,6 +2703,8 @@ pub struct SettingView {
     pub group: String,
     pub options: Vec<String>,
     pub value: String,
+    pub source: SettingSource,
+    pub deployment_value: Option<String>,
     pub is_default: bool,
 }
 
@@ -2677,6 +2724,8 @@ impl From<weaver_core::config::SettingView> for SettingView {
                 .map(|option| (*option).to_string())
                 .collect(),
             value: setting.value,
+            source: setting.source.into(),
+            deployment_value: setting.deployment_value,
             is_default: setting.is_default,
         }
     }

--- a/crates/weaver-core/migrations/0018_deployment_settings.sql
+++ b/crates/weaver-core/migrations/0018_deployment_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE deployment_settings (
+    key        TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -1,11 +1,13 @@
-//! Key/value settings stored in the `settings` table.
+//! Layered key/value settings.
 //!
-//! The table itself is a plain key/value store, but every setting weaver knows
-//! about is also declared in [`REGISTRY`] — a single source of truth that gives
-//! each key a label, help text, type, default, and group. The registry drives
-//! validation ([`validate`]) and the settings pane in the web UI
-//! ([`describe`]); the raw [`get`]/[`set`] helpers still accept arbitrary keys
-//! so nothing breaks if a setting is read before it is registered.
+//! Runtime overrides live in `settings`, infrastructure-provided defaults live
+//! in `deployment_settings`, and reads resolve in that order before the
+//! built-in default. Every setting weaver knows about is declared in
+//! [`REGISTRY`] — a single source of truth that gives each key a label, help
+//! text, type, default, and group. The registry drives validation
+//! ([`validate`]) and the settings pane in the web UI ([`describe`]); the raw
+//! [`get`]/[`apply`] helpers still accept arbitrary runtime keys so nothing
+//! breaks if a setting is read before it is registered.
 
 use anyhow::Result;
 use serde::Serialize;
@@ -37,6 +39,17 @@ pub const DEFAULT_GITHUB_TRIGGER_PHRASE: &str = "@loom";
 pub const DEFAULT_SLACK_EFFORT: &str = "high";
 /// Sentinel that leaves a Slack-origin session's profile effort unchanged.
 pub const SLACK_AGENT_DEFAULT_EFFORT: &str = "agent-default";
+/// Whether Slack status cards include this session's progress trail.
+pub const DEFAULT_SLACK_STATUS_UPDATES: bool = true;
+/// Whether Slack status cards link session artifacts.
+pub const DEFAULT_SLACK_STATUS_ARTIFACTS: bool = false;
+/// Slack mrkdwn template for a status card's first line.
+pub const DEFAULT_SLACK_STATUS_HEADER_TEMPLATE: &str = "On it — <{session_url}>";
+/// Bound organization prompt additions so a mistaken setting cannot dominate
+/// every Slack launch payload.
+pub const MAX_SLACK_PROMPT_INSTRUCTIONS_BYTES: usize = 16 * 1024;
+/// Slack messages are bounded; reserve most of that budget for status content.
+pub const MAX_SLACK_STATUS_HEADER_TEMPLATE_BYTES: usize = 1024;
 /// The palette the browser terminal (xterm.js) renders with. `dark` keeps the
 /// classic black background; `light` swaps in a light, readable palette.
 pub const DEFAULT_TERMINAL_THEME: &str = "dark";
@@ -80,8 +93,10 @@ pub const DEFAULT_SESSION_MEMORY_MAX_GB: i64 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SettingKind {
-    /// Free-form text (commands, names, …).
+    /// One-line free-form text (commands, names, …).
     String,
+    /// Multi-line free-form text (prompts, templates, …).
+    Text,
     /// A signed integer.
     Int,
     /// A boolean — stored as `true`/`false`.
@@ -230,6 +245,53 @@ pub const REGISTRY: &[SettingSpec] = &[
             "xhigh",
             "max",
         ],
+    },
+    SettingSpec {
+        key: "slack.status_updates",
+        label: "Show Slack progress updates",
+        description: "Include this session's `weaver status` reports in the \
+            editable Slack status card. Reports from an earlier session on the \
+            same conversation are never repeated.",
+        kind: SettingKind::Bool,
+        default: "true",
+        group: "Slack",
+        options: &[],
+    },
+    SettingSpec {
+        key: "slack.status_artifacts",
+        label: "Link Slack artifacts",
+        description: "Include links to the session's published artifacts in \
+            the Slack status card. Off by default: the thread should receive a \
+            self-contained answer, and internal design documents are rarely \
+            useful conversation links.",
+        kind: SettingKind::Bool,
+        default: "false",
+        group: "Slack",
+        options: &[],
+    },
+    SettingSpec {
+        key: "slack.status_header_template",
+        label: "Slack status header",
+        description: "Header template for the editable Slack status card. \
+            `{session_url}` expands to the public session URL; Slack mrkdwn is \
+            accepted. Keep the placeholder when readers should be able to open \
+            the session.",
+        kind: SettingKind::String,
+        default: DEFAULT_SLACK_STATUS_HEADER_TEMPLATE,
+        group: "Slack",
+        options: &[],
+    },
+    SettingSpec {
+        key: "slack.prompt_instructions",
+        label: "Additional Slack instructions",
+        description: "Organization-specific instructions appended to every \
+            Slack launch prompt. Use this to tune response style and workflow \
+            without copying Loom's maintained response contract. Never put \
+            secrets here.",
+        kind: SettingKind::Text,
+        default: "",
+        group: "Slack",
+        options: &[],
     },
     SettingSpec {
         key: "slack.idle_archive_secs",
@@ -567,8 +629,24 @@ pub fn validate(key: &str, value: &str) -> std::result::Result<(), String> {
     let Some(spec) = spec(key) else {
         return Ok(());
     };
+    match key {
+        "slack.prompt_instructions" if value.len() > MAX_SLACK_PROMPT_INSTRUCTIONS_BYTES => {
+            return Err(format!(
+                "must be at most {MAX_SLACK_PROMPT_INSTRUCTIONS_BYTES} bytes"
+            ));
+        }
+        "slack.status_header_template" if value.trim().is_empty() => {
+            return Err("must not be empty".to_string());
+        }
+        "slack.status_header_template" if value.len() > MAX_SLACK_STATUS_HEADER_TEMPLATE_BYTES => {
+            return Err(format!(
+                "must be at most {MAX_SLACK_STATUS_HEADER_TEMPLATE_BYTES} bytes"
+            ));
+        }
+        _ => {}
+    }
     match spec.kind {
-        SettingKind::String => Ok(()),
+        SettingKind::String | SettingKind::Text => Ok(()),
         SettingKind::Int => value
             .trim()
             .parse::<i64>()
@@ -591,36 +669,62 @@ pub fn validate(key: &str, value: &str) -> std::result::Result<(), String> {
     }
 }
 
+/// Which configuration layer supplies a setting's effective value.
+///
+/// Runtime overrides are ordinary rows in `settings`; deployment defaults are
+/// reconciled separately by infrastructure tooling; `default` is the immutable
+/// value compiled into [`REGISTRY`]. Keeping the two mutable layers separate
+/// lets an operator experiment live and later reset cleanly to the deployment's
+/// declared policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SettingSource {
+    Default,
+    Deployment,
+    Runtime,
+}
+
 /// A registered setting paired with its current effective value — what the
-/// settings pane renders. `value` is the stored value, or the default when the
-/// key is absent; `is_default` says which.
+/// settings pane renders.
 #[derive(Debug, Clone, Serialize)]
 pub struct SettingView {
     #[serde(flatten)]
     pub spec: &'static SettingSpec,
-    /// Effective value: the stored value, or `spec.default` when unset.
+    /// Effective value, resolved runtime → deployment → built-in default.
     pub value: String,
-    /// True when no value is stored and `value` is the default.
+    /// The layer supplying [`Self::value`].
+    pub source: SettingSource,
+    /// The deployment-provided fallback, if one is declared. The Settings UI
+    /// uses this to explain what clearing a runtime override will reveal.
+    pub deployment_value: Option<String>,
+    /// Backward-compatible shorthand for `source == default`.
     pub is_default: bool,
 }
 
 /// The full registry with each setting's current effective value, ordered as
 /// declared in [`REGISTRY`].
 pub async fn describe(db: &Db) -> Result<Vec<SettingView>> {
-    let stored: std::collections::HashMap<String, String> = list(db).await?.into_iter().collect();
+    let runtime: std::collections::HashMap<String, String> = list(db).await?.into_iter().collect();
+    let deployment: std::collections::HashMap<String, String> =
+        list_deployment(db).await?.into_iter().collect();
     Ok(REGISTRY
         .iter()
-        .map(|spec| match stored.get(spec.key) {
-            Some(value) => SettingView {
+        .map(|spec| {
+            let deployment_value = deployment.get(spec.key).cloned();
+            let (value, source) = if let Some(value) = runtime.get(spec.key) {
+                (value.clone(), SettingSource::Runtime)
+            } else if let Some(value) = &deployment_value {
+                (value.clone(), SettingSource::Deployment)
+            } else {
+                (spec.default.to_string(), SettingSource::Default)
+            };
+            SettingView {
                 spec,
-                value: value.clone(),
-                is_default: false,
-            },
-            None => SettingView {
-                spec,
-                value: spec.default.to_string(),
-                is_default: true,
-            },
+                value,
+                source,
+                deployment_value,
+                is_default: source == SettingSource::Default,
+            }
         })
         .collect())
 }
@@ -630,15 +734,32 @@ pub async fn describe(db: &Db) -> Result<Vec<SettingView>> {
 // ---------------------------------------------------------------------------
 
 pub async fn get(db: &Db, key: &str) -> Option<String> {
-    let value = sqlx::query("SELECT value FROM settings WHERE key = ?")
+    let runtime = sqlx::query("SELECT value FROM settings WHERE key = ?")
         .bind(key)
         .fetch_optional(db)
         .await
         .ok()
         .flatten()
         .map(|r| r.get::<String, _>("value"));
-    tracing::debug!(key, found = value.is_some(), "config get");
-    value
+    if runtime.is_some() {
+        tracing::debug!(key, source = "runtime", "config get");
+        return runtime;
+    }
+    let deployment = sqlx::query("SELECT value FROM deployment_settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(db)
+        .await
+        .ok()
+        .flatten()
+        .map(|r| r.get::<String, _>("value"));
+    tracing::debug!(
+        key,
+        source = deployment
+            .as_ref()
+            .map_or("built-in default", |_| "deployment"),
+        "config get"
+    );
+    deployment
 }
 
 pub async fn get_or(db: &Db, key: &str, default: &str) -> String {
@@ -659,8 +780,8 @@ pub async fn get_bool(db: &Db, key: &str, default: bool) -> bool {
     }
 }
 
-/// One requested change: `Some(value)` writes a key, `None` clears it (so the
-/// key falls back to its registered default).
+/// One requested runtime change: `Some(value)` writes a key, `None` clears it
+/// (so the key falls back to its deployment value, then its registered default).
 pub type Change = (String, Option<String>);
 
 /// Apply a batch of [`Change`]s atomically — either all writes land or none do.
@@ -707,6 +828,57 @@ pub async fn list(db: &Db) -> Result<Vec<(String, String)>> {
         .collect())
 }
 
+/// Deployment-provided setting defaults, kept separate from live runtime
+/// overrides so a Settings-pane reset has deterministic precedence semantics.
+pub async fn list_deployment(db: &Db) -> Result<Vec<(String, String)>> {
+    let rows = sqlx::query("SELECT key, value FROM deployment_settings ORDER BY key")
+        .fetch_all(db)
+        .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.get::<String, _>("key"), r.get::<String, _>("value")))
+        .collect())
+}
+
+/// Reconcile the deployment-default layer atomically.
+///
+/// Values must already have passed [`validate`]. With `prune`, omitted
+/// deployment keys are removed; runtime rows are never touched.
+pub async fn reconcile_deployment(db: &Db, values: &[(String, String)], prune: bool) -> Result<()> {
+    let mut tx = crate::db::begin_immediate(db).await?;
+    let now = now_iso();
+    for (key, value) in values {
+        sqlx::query(
+            "INSERT INTO deployment_settings (key, value, updated_at) VALUES (?, ?, ?)
+             ON CONFLICT(key) DO UPDATE
+               SET value = excluded.value, updated_at = excluded.updated_at",
+        )
+        .bind(key)
+        .bind(value)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if prune {
+        let declared: std::collections::HashSet<&str> =
+            values.iter().map(|(key, _)| key.as_str()).collect();
+        let existing: Vec<String> =
+            sqlx::query_scalar("SELECT key FROM deployment_settings ORDER BY key")
+                .fetch_all(&mut *tx)
+                .await?;
+        for key in existing {
+            if !declared.contains(key.as_str()) {
+                sqlx::query("DELETE FROM deployment_settings WHERE key = ?")
+                    .bind(key)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -738,6 +910,21 @@ mod tests {
         assert!(validate("server.auto_adopt", "maybe").is_err());
         // Unregistered keys are free-form.
         assert!(validate("some.future.key", "anything").is_ok());
+    }
+
+    #[test]
+    fn validate_bounds_slack_prompt_and_header_text() {
+        assert!(validate("slack.status_header_template", " ").is_err());
+        assert!(validate(
+            "slack.status_header_template",
+            &"x".repeat(MAX_SLACK_STATUS_HEADER_TEMPLATE_BYTES + 1)
+        )
+        .is_err());
+        assert!(validate(
+            "slack.prompt_instructions",
+            &"x".repeat(MAX_SLACK_PROMPT_INSTRUCTIONS_BYTES + 1)
+        )
+        .is_err());
     }
 
     #[test]
@@ -784,6 +971,8 @@ mod tests {
         assert_eq!(json["kind"], "enum");
         assert_eq!(json["options"], serde_json::json!(["dark", "light"]));
         assert_eq!(json["value"], "dark");
+        assert_eq!(json["source"], "default");
+        assert_eq!(json["deployment_value"], serde_json::Value::Null);
         assert_eq!(json["is_default"], true);
 
         assert!(views
@@ -813,6 +1002,7 @@ mod tests {
             .find(|v| v.spec.key == "server.auto_adopt")
             .unwrap();
         assert!(auto_adopt.is_default);
+        assert_eq!(auto_adopt.source, SettingSource::Default);
         assert_eq!(auto_adopt.value, "false");
 
         apply(&db, &[("server.auto_adopt".into(), Some("true".into()))])
@@ -824,7 +1014,57 @@ mod tests {
             .find(|v| v.spec.key == "server.auto_adopt")
             .unwrap();
         assert!(!auto_adopt.is_default);
+        assert_eq!(auto_adopt.source, SettingSource::Runtime);
         assert_eq!(auto_adopt.value, "true");
+    }
+
+    #[tokio::test]
+    async fn runtime_overrides_deployment_and_reset_reveals_it() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let key = "slack.status_updates";
+
+        reconcile_deployment(&db, &[(key.into(), "false".into())], false)
+            .await
+            .unwrap();
+        assert_eq!(get(&db, key).await.as_deref(), Some("false"));
+        let deployed = describe(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|view| view.spec.key == key)
+            .unwrap();
+        assert_eq!(deployed.source, SettingSource::Deployment);
+        assert_eq!(deployed.deployment_value.as_deref(), Some("false"));
+        assert!(!deployed.is_default);
+
+        apply(&db, &[(key.into(), Some("true".into()))])
+            .await
+            .unwrap();
+        let runtime = describe(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|view| view.spec.key == key)
+            .unwrap();
+        assert_eq!(runtime.value, "true");
+        assert_eq!(runtime.source, SettingSource::Runtime);
+        assert_eq!(runtime.deployment_value.as_deref(), Some("false"));
+
+        apply(&db, &[(key.into(), None)]).await.unwrap();
+        assert_eq!(get(&db, key).await.as_deref(), Some("false"));
+
+        reconcile_deployment(&db, &[], true).await.unwrap();
+        assert_eq!(get(&db, key).await, None);
+        let reset = describe(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|view| view.spec.key == key)
+            .unwrap();
+        assert_eq!(reset.value, "true");
+        assert_eq!(reset.source, SettingSource::Default);
+        assert_eq!(reset.deployment_value, None);
+        assert!(reset.is_default);
     }
 
     #[tokio::test]

--- a/crates/weaver-core/src/migrations.rs
+++ b/crates/weaver-core/src/migrations.rs
@@ -108,6 +108,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "title_provenance",
         include_str!("../migrations/0017_title_provenance.sql"),
     ),
+    (
+        18,
+        "deployment_settings",
+        include_str!("../migrations/0018_deployment_settings.sql"),
+    ),
 ];
 
 /// Latest core schema version compiled into this binary.
@@ -482,6 +487,10 @@ mod tests {
             table_columns(&pool, "notes").await.unwrap().is_empty(),
             "the notes table must be dropped"
         );
+        assert!(!table_columns(&pool, "deployment_settings")
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     /// Review migration 16 shipped the final review shape; later unrelated

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -2111,8 +2111,7 @@ async fn cmd_config(cmd: ConfigCmd) -> Result<()> {
         ConfigCmd::Ls => {
             let settings = client.list_settings().await?;
             for s in &settings.settings {
-                let suffix = if s.is_default { "  (default)" } else { "" };
-                println!("{} = {}{suffix}", s.key, s.value);
+                println!("{} = {}  ({})", s.key, s.value, s.source);
             }
         }
         ConfigCmd::Get { key } => {

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,6 +13,11 @@ The rest of this README documents the **standalone** stack. It exposes loom to
 the internet, so its front-door and auth settings are wired for untrusted
 exposure out of the box.
 
+Non-secret runtime policy can also be declared in an operator-owned YAML
+manifest and reconciled on each rollout, while live database edits remain a
+higher-precedence override. See the
+[configuration policy](../docs/configuration.md).
+
 ## What the standalone stack runs
 
 [`standalone/docker-compose.yml`](standalone/docker-compose.yml) brings up three

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -260,12 +260,14 @@ local SQLite.
 - **`server.json`** in `$WEAVER_HOME`: pid + bound addr, written when `loom`
   comes up. The `loom` CLI uses it to find the daemon when `WEAVER_API` is
   unset.
-- **Settings** live in the `settings` table; each key is declared in
-  `weaver-core::config::registry()`. Both binaries read it. This is the
-  **global** (machine/user) store; **per-repo** conventions instead live in a
-  committed `.weaver/config.toml` read by `weaver-core::repo_config` — distinct
-  from the settings table, and resolved repo-file → builtin-default like a repo's
-  own `WEAVER.md`.
+- **Settings** use runtime rows in `settings`, deployment defaults in
+  `deployment_settings`, and immutable defaults declared in
+  `weaver-core::config::REGISTRY`; reads resolve in that order. Both binaries
+  use the same helpers. This is the **global** (machine/user) store; see
+  [configuration policy](configuration.md). **Per-repo** conventions instead
+  live in a committed `.weaver/config.toml` read by
+  `weaver-core::repo_config` — distinct from global settings, and resolved
+  repo-file → builtin-default like a repo's own `WEAVER.md`.
 - **Worktrees** live under `<repo>/.worktrees/<slug>` on `weaver/<slug>`
   (unless `--branch` reused an existing branch).
 - **Which repo a session forks from** is either a local checkout (`CreateReq.cwd`
@@ -311,7 +313,7 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/mcps` | merged trusted-builtin and operator-authored MCP registry |
 | `GET POST /api/mcps/custom`; `GET PUT DELETE /api/mcps/custom/{path}` | admin-only custom MCP CRUD; every write creates an immutable revision and validates real MCP discovery plus optional tests through `uv` |
 | `PUT DELETE /api/profiles/{profile}/env/{name}` | write-only profile environment management; a write supplies exactly one literal `value` or a full GCP Secret Manager `secret_ref`, and reads expose only source/reference metadata |
-| `POST /api/deployment/reconcile` | admin-only idempotent reconciliation of deployment-managed profiles, environment references, and federation mappings; pruning never touches operator-managed rows |
+| `POST /api/deployment/reconcile` | admin-only idempotent reconciliation of deployment setting defaults, profiles, environment references, and federation mappings; runtime setting overrides and other operator-managed rows are never pruned |
 | `POST /api/auth/federate` | exchange an exact mapped, signature-verified GitHub or Google OIDC identity for a ten-minute Ed25519-signed, profile-scoped Loom automation token |
 | `GET POST /api/runs`; `GET /api/runs/{id}` | durable, subject-scoped automation runs with idempotency reservation; an optional channel routes distinct deliveries through one live ACP session, and verified GitHub callers may provide a validated deterministic key or use the workflow run/attempt |
 | `POST /api/sessions/{id}/restricted-github/{tool}` | session-token-scoped fixed GitHub operations for a restricted session; checks stamped tool policy, fixes the target repository and thread from the session, and resolves a GitHub App token or explicit App-less profile token server-side |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,93 @@
+# Configuration policy
+
+Loom resolves every registered setting through one explicit precedence chain:
+
+| Precedence | Source | Owned by | How to change it |
+|---|---|---|---|
+| 1 | Runtime override | operator | Settings, `PATCH /api/settings`, or `loom config set` |
+| 2 | Deployment default | infrastructure repository | `loom deployment apply` / `POST /api/deployment/reconcile` |
+| 3 | Built-in default | Loom release | `weaver-core::config::REGISTRY` |
+
+The runtime and deployment layers are separate database tables. A live edit
+therefore does not destroy the deployment's declared value: clearing the
+runtime override reveals the deployment default, and removing the deployment
+default reveals the built-in. `GET /api/settings` reports the effective
+`value`, its `source`, and any `deployment_value`; the Settings UI shows the
+same provenance.
+
+This policy applies only to registered, non-secret global settings. Secrets
+stay in the environment, profile secret references, or the credential-specific
+store and are never returned by the settings API. Per-repository setup,
+environment, and agent defaults belong in committed `.weaver/config.toml`; a
+repo-specific session primer belongs in `WEAVER.md`.
+
+## Deployment manifests
+
+`loom deployment apply` accepts YAML or JSON. Its `settings` map accepts string,
+integer, and boolean scalars and validates every key against the same registry
+used by the runtime API and Settings UI:
+
+```yaml
+settings:
+  slack.status_updates: true
+  slack.status_artifacts: false
+  slack.status_header_template: "On it — <{session_url}>"
+  slack.prompt_instructions: |
+    Prefer a concise answer in the thread.
+    Link a pull request only when the request asks for a change.
+
+profiles: []
+federations: []
+prune: true
+```
+
+Apply it through the authenticated local CLI:
+
+```sh
+loom deployment apply --file loom-deployment.yaml
+```
+
+With `prune: true`, deployment-managed settings, profiles, and federation
+mappings omitted from the manifest are removed from the deployment layer.
+Runtime setting overrides are never pruned. A full desired-state manifest
+should use `prune: true`; a partial update should use `false`.
+
+Infrastructure tooling may instead send the same document as JSON to the
+admin-only `POST /api/deployment/reconcile` route. Reconciliation is
+idempotent, so the normal deployment loop can apply it on every rollout.
+
+## Runtime overrides
+
+Runtime edits take effect without rebuilding a deployment:
+
+```sh
+loom config set slack.status_updates false
+```
+
+The Settings page and `PATCH /api/settings` use the same validation and storage
+path. Send `null` to clear an override and inherit again:
+
+```json
+{"slack.status_updates": null}
+```
+
+`weaver config ls` prints the effective value and source for diagnostics.
+
+## Adding configurable behavior
+
+New global behavior follows one route:
+
+1. Declare a dotted key, type, help text, and safe built-in default in
+   `weaver-core::config::REGISTRY`.
+2. Read it through `config::get`, `get_or`, or `get_bool`; those helpers apply
+   the complete precedence chain.
+3. Add focused behavior and validation tests. The registry automatically
+   exposes the key to deployment manifests, the REST settings API, and the
+   Settings UI.
+
+Prefer typed switches and enums for policy. For prose customization, prefer an
+additive instruction field over replacing Loom's maintained prompt wholesale;
+this lets releases improve the base contract without forcing every deployment
+to copy it. Templates should expose a small documented placeholder set and
+retain a safe built-in fallback. Configuration is operator-controlled input,
+not a secret store.

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -72,15 +72,24 @@ records the card message's `ts`. From then on, every `weaver status <level>
 "<message>"` the agent writes re-renders that message via `chat.update`:
 
 > On it — <{base}/s/{id}>
-> <{base}/s/{id}/artifacts/design|design>
 >
 > • 🟢 `Jul 18 21:04` reading the thread; mapping the code
 > • 🟠 `Jul 18 22:15` *attention* — ready for review
 
 Up to 15 bullets show in full (oldest first); older ones collapse into a
 single `… N earlier update(s)` line rather than growing the message
-unbounded. If the tracked message was deleted, loom posts a fresh one and
-re-records its `ts` — the same recreate-on-drop behavior as the GitHub card.
+unbounded. A relaunched session on the same conversation starts a new trail;
+the branch's older status history is not repeated. If the tracked message was
+deleted, loom posts a fresh one and re-records its `ts` — the same
+recreate-on-drop behavior as the GitHub card.
+
+Artifact links are off by default: the thread should receive a self-contained
+answer, and an internal design document is rarely useful conversation context.
+`slack.status_artifacts` can opt a deployment back in. The progress trail,
+header template, and additional launch instructions are likewise registered
+settings (`slack.status_updates`, `slack.status_header_template`, and
+`slack.prompt_instructions`), configurable through both the runtime Settings
+API and a deployment manifest. See [Configuration policy](configuration.md).
 
 Where a trigger anchors differs by shape: a **slash command's payload carries
 no thread reference at all**, so it can only start a new thread — loom posts
@@ -181,10 +190,11 @@ Do not create standalone Slack-token secrets that the deployment never reads.
 `slack.enabled` (default on) closes the live socket within ten seconds without
 discarding the tokens — use it to pause the integration without losing
 configuration. It, along with `slack.allowed_users`, `slack.default_repo`, and
-`slack.idle_archive_secs`, lives in **Settings → Slack**. `slack.effort`
-defaults Slack-origin sessions to `high` reasoning effort for a faster
-conversational response; `agent-default` preserves the selected profile's
-effort, and locked or incompatible profiles fall back automatically.
+`slack.idle_archive_secs`, lives in **Settings → Slack**. Presentation and
+prompt settings live there as well. `slack.effort` defaults Slack-origin
+sessions to `high` reasoning effort for a faster conversational response;
+`agent-default` preserves the selected profile's effort, and locked or
+incompatible profiles fall back automatically.
 
 ## Diagnosing it
 

--- a/e2e/tests/appearance.spec.ts
+++ b/e2e/tests/appearance.spec.ts
@@ -39,9 +39,9 @@ test.describe('settings · terminal appearance', () => {
     await expect(page.getByTestId('font-jetbrains')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-size-input')).toHaveValue('16');
 
-    // Reset returns all three to their registry defaults.
-    await panel.getByRole('button', { name: 'Reset to defaults' }).click();
-    await expect(panel.getByText('Reset terminal appearance to defaults.')).toBeVisible();
+    // Clearing overrides returns all three to their inherited values.
+    await panel.getByRole('button', { name: 'Clear overrides' }).click();
+    await expect(panel.getByText('Cleared terminal appearance overrides.')).toBeVisible();
     await expect(page.getByTestId('theme-dark')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-plex')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-size-input')).toHaveValue('13');


### PR DESCRIPTION
Fix Slack thread status cards so a relaunched session starts a fresh progress trail, and stop linking session artifacts by default. Deployments can opt artifact links back in, hide updates, customize the header, and append organization response instructions through registered settings.

Add one configuration precedence policy for registered non-secret settings: runtime database override, then deployment default, then built-in default. Deployment defaults are reconciled independently through the admin REST route and YAML-or-JSON `loom deployment apply`, so live edits survive rollout and clearing an override reveals the declared infrastructure value.

Expose setting provenance through the API, CLI, and Settings UI, and document when configuration belongs in this global registry versus secrets, per-repository config, or maintained base prompts.