### PR TITLE
Route automation alert threads to their triage session

### DIFF
--- a/crates/loom-agent/src/lib.rs
+++ b/crates/loom-agent/src/lib.rs
@@ -10,7 +10,7 @@ pub use loom_store::Ctx;
 pub use loom_store::{
     agent_env, agent_kind, backend, changes, channels, chat, chatlog, client_context, ctx, db,
     envfile, history, launch_gate, links, logs, loom_config, paths, profile_data, repo_env,
-    review_inbox, runner, runs, scratch, session, session_layout, status,
+    review_inbox, runner, runs, scratch, session, session_layout, slack_routes, status,
 };
 
 pub(crate) use weaver_core::db::Db;

--- a/crates/loom-agent/src/mcp/messaging.rs
+++ b/crates/loom-agent/src/mcp/messaging.rs
@@ -101,12 +101,21 @@ fn tools() -> Value {
         },
         {
             "name": "slack_reply",
-            "description": "Post a message to the Slack thread fixed to this session.",
+            "description": "Post a message to a Slack thread this session owns. Omit 'thread' for the thread fixed to this session. Pass 'thread' to answer in a thread an automation delivery announced to this session — an alert's own thread, whose channel and thread_ts arrive with the alert.",
             "inputSchema": {
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "text": { "type": "string", "minLength": 1, "maxLength": 4000 }
+                    "text": { "type": "string", "minLength": 1, "maxLength": 4000 },
+                    "thread": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "channel": { "type": "string" },
+                            "thread_ts": { "type": "string" }
+                        },
+                        "required": ["channel", "thread_ts"]
+                    }
                 },
                 "required": ["text"]
             }
@@ -156,6 +165,12 @@ async fn call_tool(name: &str, arguments: Value) -> Result<Value> {
             if text.is_empty() || text.len() > 4000 {
                 bail!("slack_reply text must contain 1 to 4000 bytes");
             }
+            let mut body = json!({ "text": text });
+            // The server authorizes the thread against this session's routes, so
+            // pass it through as given rather than validating a Slack id here.
+            if let Some(thread) = arguments.get("thread") {
+                body["thread"] = thread.clone();
+            }
             client
                 .post(
                     &format!(
@@ -165,7 +180,7 @@ async fn call_tool(name: &str, arguments: Value) -> Result<Value> {
                             percent_encoding::NON_ALPHANUMERIC
                         )
                     ),
-                    json!({ "text": text }),
+                    body,
                 )
                 .await?;
             "message posted to the session Slack thread".to_string()

--- a/crates/loom-core/src/lib.rs
+++ b/crates/loom-core/src/lib.rs
@@ -9,5 +9,5 @@ pub use loom_policy::{
     acp, agent, agent_env, agent_kind, auth, automation, backend, changes, channels, chat, chatlog,
     client_context, ctx, custom_agents, custom_mcp, db, envfile, history, launch_gate, links, logs,
     loom_config, mcp, paths, profile, profile_data, repo_env, review_inbox, runner, runs, scratch,
-    session, session_layout, status,
+    session, session_layout, slack_routes, status,
 };

--- a/crates/loom-deliver/src/lib.rs
+++ b/crates/loom-deliver/src/lib.rs
@@ -10,7 +10,7 @@ pub use loom_launch::{
     github_manifest, github_trigger, handoff, history, ide, launch, launch_gate, lifecycle, links,
     logs, loom_config, mcp, metadata_assist, paths, profile, profile_data, provision, repo,
     repo_env, review_inbox, runner, runs, runtime, scratch, session, session_layout,
-    session_manager, setup, shell, status, terminal, user_token, Ctx, EditorState,
+    session_manager, setup, shell, slack_routes, status, terminal, user_token, Ctx, EditorState,
 };
 
 pub(crate) use weaver_core::db::Db;

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -51,6 +51,10 @@ const STATUS_CARD_CAP: usize = 15;
 /// Cap on how many conversation messages seed a session, so a busy channel can't
 /// produce an unbounded launch prompt.
 const HISTORY_CAP: usize = 40;
+/// Bounds on a caller-supplied Slack channel id and message `ts`. Slack's own
+/// ids are far shorter; these only keep a malformed value out of a Web API call.
+const MAX_CHANNEL_ID: usize = 32;
+const MAX_THREAD_TS: usize = 32;
 
 // ---------------------------------------------------------------------------
 // Live supervisor health.
@@ -86,6 +90,10 @@ pub struct SocketHealth {
     pub last_event_at: Option<String>,
     pub events_received: u64,
     pub sessions_launched: u64,
+    /// Mentions delivered into the session an automation run had routed that
+    /// thread to, rather than launching. Distinguishes a working alert-thread
+    /// conversation from one that silently launches a duplicate session per reply.
+    pub followups_routed: u64,
     /// Why the most recent trigger was not acted on. A dropped mention is the
     /// integration's quietest failure, so it is kept where an operator looks.
     pub last_skip: Option<String>,
@@ -991,6 +999,39 @@ pub fn parse_wiring(value: &str) -> Option<(String, String, String)> {
     Some((team.to_string(), channel.to_string(), root.to_string()))
 }
 
+/// Validate a caller-supplied [`weaver_api::SlackThreadRef`] into a trimmed
+/// `(channel, thread_ts)`. Slack ids are opaque, so this is a shape check, not a
+/// existence check: enough that a malformed or injected value cannot reach a Web
+/// API call or be stored as a route. Existence is Slack's answer to give, at
+/// `chat.postMessage` time.
+pub fn parse_thread_ref(
+    target: &weaver_api::SlackThreadRef,
+) -> Result<(String, String), &'static str> {
+    const CHANNEL_SHAPE: &str = "slack channel must be a Slack channel id such as C0123ABCD";
+    const TS_SHAPE: &str = "slack thread_ts must look like 1700000000.123456";
+
+    let channel = target.channel.trim();
+    if channel.len() > MAX_CHANNEL_ID
+        || !matches!(channel.as_bytes().first(), Some(b'C' | b'G' | b'D'))
+        || !channel
+            .bytes()
+            .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit())
+    {
+        return Err(CHANNEL_SHAPE);
+    }
+    let thread_ts = target.thread_ts.trim();
+    let (seconds, fraction) = thread_ts.split_once('.').ok_or(TS_SHAPE)?;
+    if thread_ts.len() > MAX_THREAD_TS
+        || seconds.is_empty()
+        || fraction.is_empty()
+        || !seconds.bytes().all(|b| b.is_ascii_digit())
+        || !fraction.bytes().all(|b| b.is_ascii_digit())
+    {
+        return Err(TS_SHAPE);
+    }
+    Ok((channel.to_string(), thread_ts.to_string()))
+}
+
 /// Spawn every status-card mirror a branch is wired for. The one seam the status
 /// write path (and artifact publish/delete) calls — GitHub self-gates on the
 /// `github` tag, Slack on the `slack` tag, so an unwired branch is a no-op for
@@ -1043,9 +1084,26 @@ async fn handle_trigger(state: AppState, web: SlackWeb, bot: AuthTest, trigger: 
         return;
     }
 
+    let (prefix_repo, instruction) = parse_repo_prefix(&trigger.text);
+
+    // A thread an automation delivery already pointed at a session belongs to
+    // that session — an operator answering under an alert means "you, the session
+    // handling this alert", not "start something new". This runs before the repo
+    // is resolved because a routed thread needs none: the session already exists.
+    if let Some(outcome) = forward_to_routed_session(&state, &web, &trigger, &instruction).await {
+        match outcome {
+            Ok(()) => update_health(|h| h.followups_routed += 1),
+            Err(e) => {
+                tracing::warn!(error = %e, "slack: routed follow-up failed");
+                record_skip(&format!("routed follow-up failed: {e}"));
+                let _ = notify(&web, &trigger, &format!("Couldn't reach that session: {e}")).await;
+            }
+        }
+        return;
+    }
+
     // Resolve the repo: an `owner/name:` prefix wins, else the configured
     // default. Without either there's nothing to work on.
-    let (prefix_repo, instruction) = parse_repo_prefix(&trigger.text);
     let repo = match prefix_repo {
         Some(r) => r,
         None => {
@@ -1074,6 +1132,91 @@ async fn handle_trigger(state: AppState, web: SlackWeb, bot: AuthTest, trigger: 
             let _ = notify(&web, &trigger, &format!("Couldn't start a session: {e}")).await;
         }
     }
+}
+
+/// Deliver a mention into the session an automation run routed this thread to.
+///
+/// `None` means "not ours, carry on": the thread has no route, the trigger is a
+/// thread-blind slash command, or the routed session is no longer live (an
+/// archived operator session leaves its alert threads behind, and a human
+/// reviving one is better served by the ordinary launch path than by an error).
+/// `Some(Err(_))` is a route that exists and could not be delivered to.
+async fn forward_to_routed_session(
+    state: &AppState,
+    web: &SlackWeb,
+    trigger: &Trigger,
+    instruction: &str,
+) -> Option<Result<()>> {
+    let Anchor::Mention { event_ts, .. } = &trigger.anchor else {
+        return None;
+    };
+    let (route, session) = routed_session(&state.db, trigger).await?;
+
+    let prompt = followup_prompt(trigger, instruction);
+    if let Err(error) = forward_followup(state, &session, &prompt).await {
+        return Some(Err(error));
+    }
+    if let Err(error) = events::record(
+        &state.db,
+        &state.bus,
+        &route.branch_id,
+        "nudge",
+        json!({
+            "by": format!("slack ({})", trigger.user_id),
+            "text": instruction,
+        }),
+    )
+    .await
+    {
+        tracing::warn!(
+            session = %session.id,
+            branch = %route.branch_id,
+            %error,
+            "slack: recording routed follow-up failed"
+        );
+    }
+    // Acknowledge only once the conversation accepted it, so 👀 means "delivered
+    // to the session" rather than "received by loom".
+    web.add_reaction(&trigger.channel_id, event_ts, "eyes")
+        .await
+        .ok();
+    tracing::info!(
+        session = %session.id,
+        branch = %route.branch_id,
+        channel = %trigger.channel_id,
+        thread = %route.thread_ts,
+        source = %route.source,
+        "slack: forwarded follow-up to the session routed to this thread"
+    );
+    Some(Ok(()))
+}
+
+/// Resolve a mention's thread to the live session an automation delivery routed
+/// it to. The whole routing decision, over `Db` alone: a lookup failure is
+/// treated as "no route" so a database hiccup falls back to the ordinary launch
+/// path rather than dropping the operator's message.
+async fn routed_session(
+    db: &Db,
+    trigger: &Trigger,
+) -> Option<(crate::slack_routes::SlackRoute, crate::session::Session)> {
+    let Anchor::Mention { root_ts, .. } = &trigger.anchor else {
+        return None;
+    };
+    let route = match crate::slack_routes::for_thread(db, &trigger.channel_id, root_ts).await {
+        Ok(route) => route?,
+        Err(error) => {
+            tracing::warn!(%error, "slack: reading the thread's route failed");
+            return None;
+        }
+    };
+    let session = match crate::session::active_for_branch(db, &route.branch_id).await {
+        Ok(session) => session?,
+        Err(error) => {
+            tracing::warn!(branch = %route.branch_id, %error, "slack: routed session lookup failed");
+            return None;
+        }
+    };
+    Some((route, session))
 }
 
 /// Record why a trigger did not become a session, for the Connections pane.
@@ -1927,6 +2070,104 @@ mod tests {
         assert!(delivered.contains("replace the existing PR"));
     }
 
+    /// A live operator session plus one alert thread routed to it.
+    async fn db_with_routed_alert(status: &str) -> (Db, String) {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let branch = weaver_core::branch::upsert(&db, "/repo", "weaver/ops", "main")
+            .await
+            .unwrap();
+        crate::session::insert(
+            &db,
+            &crate::session::NewSession {
+                id: "s-ops".to_string(),
+                branch_id: branch.id.clone(),
+                work_dir: "/work/s-ops".to_string(),
+                term_session: "weaver-s-ops".to_string(),
+                agent_kind: "shell".to_string(),
+                model: String::new(),
+                effort: String::new(),
+                status: status.to_string(),
+                github_repo: None,
+                parent_branch_id: None,
+                managed_by: None,
+                created_by: None,
+                protocol: "acp".to_string(),
+                origin: "grafana".to_string(),
+                class: "automation".to_string(),
+                tracking_issue_id: None,
+            },
+        )
+        .await
+        .unwrap();
+        crate::slack_routes::record(&db, "C1", "1700.1", &branch.id, "grafana")
+            .await
+            .unwrap();
+        (db, branch.id)
+    }
+
+    fn mention_in(channel: &str, root_ts: &str) -> Trigger {
+        Trigger {
+            team_id: "T1".into(),
+            channel_id: channel.into(),
+            user_id: "U2".into(),
+            text: "try restarting the controller".into(),
+            anchor: Anchor::Mention {
+                root_ts: root_ts.into(),
+                event_ts: "1700.9".into(),
+            },
+            dedupe_id: "slack:Ev1".into(),
+            via_app: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_mention_under_a_routed_alert_finds_that_session() {
+        let (db, branch) = db_with_routed_alert("running").await;
+
+        let (route, session) = routed_session(&db, &mention_in("C1", "1700.1"))
+            .await
+            .expect("the alert's thread routes to the operator session");
+        assert_eq!(route.branch_id, branch);
+        assert_eq!(session.id, "s-ops");
+    }
+
+    /// The fall-through cases all mean "let the ordinary launch path handle it",
+    /// which is what keeps an unrelated mention from being swallowed.
+    #[tokio::test]
+    async fn an_unrouted_thread_falls_through_to_a_launch() {
+        let (db, _branch) = db_with_routed_alert("running").await;
+
+        // Another thread in the same channel, and the same ts in another channel.
+        assert!(routed_session(&db, &mention_in("C1", "1700.2"))
+            .await
+            .is_none());
+        assert!(routed_session(&db, &mention_in("C2", "1700.1"))
+            .await
+            .is_none());
+    }
+
+    /// A slash command carries no thread at all, so it can never continue an
+    /// alert conversation — only start its own.
+    #[tokio::test]
+    async fn a_slash_command_never_routes() {
+        let (db, _branch) = db_with_routed_alert("running").await;
+        let mut slash = mention_in("C1", "1700.1");
+        slash.anchor = Anchor::Slash;
+
+        assert!(routed_session(&db, &slash).await.is_none());
+    }
+
+    /// Operator sessions are archived on idle, leaving their alert threads behind.
+    /// A later reply should start a fresh session rather than fail.
+    #[tokio::test]
+    async fn an_archived_session_leaves_its_threads_to_the_launch_path() {
+        let (db, _branch) = db_with_routed_alert("archived").await;
+
+        assert!(routed_session(&db, &mention_in("C1", "1700.1"))
+            .await
+            .is_none());
+    }
+
     #[test]
     fn repo_prefix_splits_only_a_leading_slug() {
         assert_eq!(
@@ -1972,6 +2213,46 @@ mod tests {
         // Two branches for the same thread hash to the same short name.
         assert_eq!(short_hash("T1/C1/1720.5"), short_hash("T1/C1/1720.5"));
         assert_ne!(short_hash("T1/C1/1720.5"), short_hash("T1/C1/1720.6"));
+    }
+
+    fn thread_ref(channel: &str, thread_ts: &str) -> weaver_api::SlackThreadRef {
+        weaver_api::SlackThreadRef {
+            channel: channel.into(),
+            thread_ts: thread_ts.into(),
+        }
+    }
+
+    #[test]
+    fn a_thread_ref_accepts_slack_ids_and_trims() {
+        assert_eq!(
+            parse_thread_ref(&thread_ref(" C0123ABCD ", " 1700000000.123456 ")),
+            Ok(("C0123ABCD".to_string(), "1700000000.123456".to_string()))
+        );
+        // Private channels and DMs are addressable too.
+        assert!(parse_thread_ref(&thread_ref("G0123ABCD", "1700000000.1")).is_ok());
+        assert!(parse_thread_ref(&thread_ref("D0123ABCD", "1700000000.1")).is_ok());
+    }
+
+    /// A channel *name* is the likely caller mistake, and it would post to
+    /// whatever Slack resolves `#alerts` to rather than failing.
+    #[test]
+    fn a_thread_ref_rejects_anything_that_is_not_an_id_and_a_ts() {
+        for bad in [
+            thread_ref("#marin-eng", "1700000000.1"),
+            thread_ref("c0123abcd", "1700000000.1"),
+            thread_ref("X0123ABCD", "1700000000.1"),
+            thread_ref("", "1700000000.1"),
+            thread_ref("C0123ABCD", "1700000000"),
+            thread_ref("C0123ABCD", "1700000000."),
+            thread_ref("C0123ABCD", ".123456"),
+            thread_ref("C0123ABCD", "17e9.123456"),
+            thread_ref("C0123ABCD", &"9".repeat(40)),
+        ] {
+            assert!(
+                parse_thread_ref(&bad).is_err(),
+                "{bad:?} should not parse as a Slack thread"
+            );
+        }
     }
 
     #[test]

--- a/crates/loom-editor/src/lib.rs
+++ b/crates/loom-editor/src/lib.rs
@@ -8,7 +8,7 @@ pub use loom_core::{
     acp, agent, agent_env, agent_kind, auth, automation, backend, changes, channels, chat, chatlog,
     client_context, ctx, custom_agents, custom_mcp, db, envfile, history, launch, launch_gate,
     links, logs, loom_config, mcp, paths, profile, profile_data, repo_env, review_inbox, runner,
-    runs, scratch, session, session_layout, session_manager, shell, status,
+    runs, scratch, session, session_layout, session_manager, shell, slack_routes, status,
 };
 
 /// The state slice editor and terminal handlers actually consume.

--- a/crates/loom-forge/src/lib.rs
+++ b/crates/loom-forge/src/lib.rs
@@ -14,7 +14,8 @@ pub use loom_editor::{
     acp, agent, agent_env, agent_kind, auth, automation, backend, changes, channels, chat, chatlog,
     client_context, ctx, custom_agents, custom_mcp, db, envfile, history, ide, launch, launch_gate,
     links, logs, loom_config, mcp, paths, profile, profile_data, repo_env, review_inbox, runner,
-    runs, scratch, session, session_layout, session_manager, shell, status, terminal, EditorState,
+    runs, scratch, session, session_layout, session_manager, shell, slack_routes, status, terminal,
+    EditorState,
 };
 
 /// Shared process state consumed by runtime services and the REST adapter.

--- a/crates/loom-launch/src/lib.rs
+++ b/crates/loom-launch/src/lib.rs
@@ -11,8 +11,8 @@ pub use loom_forge::{
     client_context, ctx, custom_agents, custom_mcp, db, envfile, github, github_app,
     github_manifest, github_trigger, history, ide, launch, launch_gate, lifecycle, links, logs,
     loom_config, mcp, paths, profile, profile_data, repo, repo_env, review_inbox, runner, runs,
-    runtime, scratch, session, session_layout, session_manager, shell, status, terminal,
-    user_token, Ctx, EditorState,
+    runtime, scratch, session, session_layout, session_manager, shell, slack_routes, status,
+    terminal, user_token, Ctx, EditorState,
 };
 
 pub(crate) use weaver_core::db::Db;

--- a/crates/loom-policy/src/lib.rs
+++ b/crates/loom-policy/src/lib.rs
@@ -10,7 +10,8 @@ pub use loom_agent::Ctx;
 pub use loom_agent::{
     acp, agent, agent_env, agent_kind, backend, changes, channels, chat, chatlog, client_context,
     ctx, custom_agents, envfile, history, launch_gate, links, logs, loom_config, mcp, paths,
-    profile_data, repo_env, review_inbox, runner, runs, scratch, session, session_layout, status,
+    profile_data, repo_env, review_inbox, runner, runs, scratch, session, session_layout,
+    slack_routes, status,
 };
 
 pub(crate) use weaver_core::config;

--- a/crates/loom-store/migrations/0020_slack_alert_routes.sql
+++ b/crates/loom-store/migrations/0020_slack_alert_routes.sql
@@ -1,0 +1,21 @@
+-- Slack threads an automation delivery pointed at a session.
+--
+-- Distinct from the single-valued `slack` branch tag, which fixes one thread as
+-- a session's status-card home. One long-lived operator session triages many
+-- alerts, each announced in its own thread, so the thread-to-session relation is
+-- many-to-one and cannot live on that tag. Keyed on the thread rather than the
+-- branch: the lookup that matters is inbound — a mention arrives carrying a
+-- channel and a thread, and has to find the session that owns it.
+CREATE TABLE slack_routes (
+    channel_id TEXT NOT NULL,
+    thread_ts  TEXT NOT NULL,
+    branch_id  TEXT NOT NULL REFERENCES branches(id) ON DELETE CASCADE,
+    -- The run source that opened the route (`grafana`, `ops`, `actions`), for
+    -- attribution in logs and the settings pane.
+    source     TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (channel_id, thread_ts)
+);
+
+CREATE INDEX idx_slack_routes_branch ON slack_routes(branch_id, updated_at);

--- a/crates/loom-store/src/db.rs
+++ b/crates/loom-store/src/db.rs
@@ -105,6 +105,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "slack-space",
         include_str!("../migrations/0019_slack_space.sql"),
     ),
+    (
+        20,
+        "slack-alert-routes",
+        include_str!("../migrations/0020_slack_alert_routes.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);

--- a/crates/loom-store/src/lib.rs
+++ b/crates/loom-store/src/lib.rs
@@ -13,6 +13,7 @@ pub mod review_inbox;
 pub mod runs;
 pub mod session;
 pub mod session_layout;
+pub mod slack_routes;
 pub mod status;
 
 pub use loom_ctx::Ctx;

--- a/crates/loom-store/src/slack_routes.rs
+++ b/crates/loom-store/src/slack_routes.rs
@@ -88,18 +88,6 @@ pub async fn allows(db: &Db, branch_id: &str, channel_id: &str, thread_ts: &str)
     Ok(allowed)
 }
 
-/// Every thread routed to a branch, most recently delivered first.
-pub async fn for_branch(db: &Db, branch_id: &str) -> Result<Vec<SlackRoute>> {
-    let routes = sqlx::query_as::<_, SlackRoute>(
-        "SELECT channel_id, thread_ts, branch_id, source, created_at, updated_at
-         FROM slack_routes WHERE branch_id = ? ORDER BY updated_at DESC",
-    )
-    .bind(branch_id)
-    .fetch_all(db)
-    .await?;
-    Ok(routes)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,6 +113,8 @@ mod tests {
         assert!(for_thread(&db, "C1", "9999.9").await.unwrap().is_none());
     }
 
+    /// The relation this table exists for: one operator session triaging several
+    /// alerts, each announced in its own thread.
     #[tokio::test]
     async fn one_session_owns_many_threads() {
         let (db, branch) = db_with_branch().await;
@@ -135,8 +125,17 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(for_branch(&db, &branch).await.unwrap().len(), 2);
-        assert!(allows(&db, &branch, "C1", "1800.2").await.unwrap());
+        for thread_ts in ["1700.1", "1800.2"] {
+            assert_eq!(
+                for_thread(&db, "C1", thread_ts)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .branch_id,
+                branch
+            );
+            assert!(allows(&db, &branch, "C1", thread_ts).await.unwrap());
+        }
     }
 
     /// The route is the authorization: a branch may not address a thread that
@@ -153,16 +152,41 @@ mod tests {
         assert!(!allows(&db, "other-branch", "C1", "1700.1").await.unwrap());
     }
 
+    /// Grafana redelivers the same alert; the newest delivery owns the thread, so
+    /// a relaunched operator session inherits the conversation rather than losing it.
     #[tokio::test]
-    async fn redelivery_is_idempotent() {
+    async fn redelivery_is_idempotent_and_the_newest_session_takes_the_thread() {
         let (db, branch) = db_with_branch().await;
-        record(&db, "C1", "1700.1", &branch, "grafana")
-            .await
-            .unwrap();
-        record(&db, "C1", "1700.1", &branch, "grafana")
+        let relaunched = weaver_core::branch::upsert(&db, "/tmp/repo", "weaver/ops-2", "main")
             .await
             .unwrap();
 
-        assert_eq!(for_branch(&db, &branch).await.unwrap().len(), 1);
+        record(&db, "C1", "1700.1", &branch, "grafana")
+            .await
+            .unwrap();
+        record(&db, "C1", "1700.1", &branch, "grafana")
+            .await
+            .unwrap();
+        assert_eq!(
+            for_thread(&db, "C1", "1700.1")
+                .await
+                .unwrap()
+                .unwrap()
+                .branch_id,
+            branch
+        );
+
+        record(&db, "C1", "1700.1", &relaunched.id, "grafana")
+            .await
+            .unwrap();
+        assert_eq!(
+            for_thread(&db, "C1", "1700.1")
+                .await
+                .unwrap()
+                .unwrap()
+                .branch_id,
+            relaunched.id
+        );
+        assert!(!allows(&db, &branch, "C1", "1700.1").await.unwrap());
     }
 }

--- a/crates/loom-store/src/slack_routes.rs
+++ b/crates/loom-store/src/slack_routes.rs
@@ -1,0 +1,168 @@
+//! Slack threads an automation delivery pointed at a session.
+//!
+//! The `slack` branch tag fixes *one* thread as a session's status-card home,
+//! which is the right model for a session that was born from a conversation. An
+//! operator session is the other shape: it is long-lived, it is fed alerts by
+//! [`crate::runs`]'s channel dispatch, and each alert is announced in its own
+//! Slack thread. Many threads, one session — so the relation lives here instead,
+//! keyed on the thread, because the lookup that matters is inbound: a mention
+//! arrives carrying a channel and a thread and has to find the session that owns
+//! it.
+//!
+//! A route is a delivery record, not a grant the caller chooses: it is written
+//! only where loom itself accepted a run for that thread, and it is what
+//! authorizes a session's later replies into a thread it was not wired to.
+
+use anyhow::Result;
+use sqlx::FromRow;
+
+use crate::db::{now_iso, Db};
+
+/// One thread-to-session route.
+#[derive(Debug, Clone, PartialEq, Eq, FromRow)]
+pub struct SlackRoute {
+    pub channel_id: String,
+    pub thread_ts: String,
+    pub branch_id: String,
+    pub source: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Point a Slack thread at a branch. Re-delivering the same alert re-stamps
+/// `updated_at`; a thread that somehow reaches a second session moves, because
+/// the newest delivery is the one a human replying now means.
+pub async fn record(
+    db: &Db,
+    channel_id: &str,
+    thread_ts: &str,
+    branch_id: &str,
+    source: &str,
+) -> Result<()> {
+    let now = now_iso();
+    sqlx::query(
+        "INSERT INTO slack_routes
+             (channel_id, thread_ts, branch_id, source, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(channel_id, thread_ts) DO UPDATE SET
+             branch_id = excluded.branch_id,
+             source = excluded.source,
+             updated_at = excluded.updated_at",
+    )
+    .bind(channel_id)
+    .bind(thread_ts)
+    .bind(branch_id)
+    .bind(source)
+    .bind(&now)
+    .bind(&now)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// The route for one thread, or `None` when no delivery claimed it.
+pub async fn for_thread(db: &Db, channel_id: &str, thread_ts: &str) -> Result<Option<SlackRoute>> {
+    let route = sqlx::query_as::<_, SlackRoute>(
+        "SELECT channel_id, thread_ts, branch_id, source, created_at, updated_at
+         FROM slack_routes WHERE channel_id = ? AND thread_ts = ?",
+    )
+    .bind(channel_id)
+    .bind(thread_ts)
+    .fetch_optional(db)
+    .await?;
+    Ok(route)
+}
+
+/// Whether `branch_id` may address this thread — the authorization behind a
+/// session replying into a thread it holds no `slack` tag for.
+pub async fn allows(db: &Db, branch_id: &str, channel_id: &str, thread_ts: &str) -> Result<bool> {
+    let allowed = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM slack_routes
+         WHERE branch_id = ? AND channel_id = ? AND thread_ts = ?)",
+    )
+    .bind(branch_id)
+    .bind(channel_id)
+    .bind(thread_ts)
+    .fetch_one(db)
+    .await?;
+    Ok(allowed)
+}
+
+/// Every thread routed to a branch, most recently delivered first.
+pub async fn for_branch(db: &Db, branch_id: &str) -> Result<Vec<SlackRoute>> {
+    let routes = sqlx::query_as::<_, SlackRoute>(
+        "SELECT channel_id, thread_ts, branch_id, source, created_at, updated_at
+         FROM slack_routes WHERE branch_id = ? ORDER BY updated_at DESC",
+    )
+    .bind(branch_id)
+    .fetch_all(db)
+    .await?;
+    Ok(routes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn db_with_branch() -> (Db, String) {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let branch = weaver_core::branch::upsert(&db, "/tmp/repo", "weaver/ops", "main")
+            .await
+            .unwrap();
+        (db, branch.id)
+    }
+
+    #[tokio::test]
+    async fn a_recorded_thread_resolves_to_its_branch() {
+        let (db, branch) = db_with_branch().await;
+        record(&db, "C1", "1700.1", &branch, "grafana")
+            .await
+            .unwrap();
+
+        let route = for_thread(&db, "C1", "1700.1").await.unwrap().unwrap();
+        assert_eq!(route.branch_id, branch);
+        assert_eq!(route.source, "grafana");
+        assert!(for_thread(&db, "C1", "9999.9").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn one_session_owns_many_threads() {
+        let (db, branch) = db_with_branch().await;
+        record(&db, "C1", "1700.1", &branch, "grafana")
+            .await
+            .unwrap();
+        record(&db, "C1", "1800.2", &branch, "grafana")
+            .await
+            .unwrap();
+
+        assert_eq!(for_branch(&db, &branch).await.unwrap().len(), 2);
+        assert!(allows(&db, &branch, "C1", "1800.2").await.unwrap());
+    }
+
+    /// The route is the authorization: a branch may not address a thread that
+    /// was never delivered to it, even in a channel it does hold a route in.
+    #[tokio::test]
+    async fn a_branch_may_not_address_an_unrouted_thread() {
+        let (db, branch) = db_with_branch().await;
+        record(&db, "C1", "1700.1", &branch, "grafana")
+            .await
+            .unwrap();
+
+        assert!(!allows(&db, &branch, "C1", "1700.2").await.unwrap());
+        assert!(!allows(&db, &branch, "C2", "1700.1").await.unwrap());
+        assert!(!allows(&db, "other-branch", "C1", "1700.1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn redelivery_is_idempotent() {
+        let (db, branch) = db_with_branch().await;
+        record(&db, "C1", "1700.1", &branch, "grafana")
+            .await
+            .unwrap();
+        record(&db, "C1", "1700.1", &branch, "grafana")
+            .await
+            .unwrap();
+
+        assert_eq!(for_branch(&db, &branch).await.unwrap().len(), 1);
+    }
+}

--- a/crates/loom-watch/src/lib.rs
+++ b/crates/loom-watch/src/lib.rs
@@ -12,7 +12,7 @@ pub use loom_launch::{
     github_manifest, github_trigger, handoff, history, ide, launch, launch_gate, lifecycle, links,
     logs, loom_config, mcp, metadata_assist, paths, profile, profile_data, provision, repo,
     repo_env, review_inbox, runner, runs, runtime, scratch, session, session_layout,
-    session_manager, setup, shell, status, terminal, user_token, Ctx, EditorState,
+    session_manager, setup, shell, slack_routes, status, terminal, user_token, Ctx, EditorState,
 };
 
 pub(crate) use weaver_core::db::Db;

--- a/crates/loom/frontend/src/components/SlackPanel.vue
+++ b/crates/loom/frontend/src/components/SlackPanel.vue
@@ -53,7 +53,10 @@ const traffic = computed(() => {
   const s = socket.value;
   if (!s || s.state !== 'connected') return '';
   const last = s.last_event_at ? `last ${compactAge(s.last_event_at)} ago` : 'none yet';
-  return `${s.events_received} received · ${s.sessions_launched} launched · ${last}`;
+  // Routed follow-ups only appear once an automation delivery has claimed a
+  // thread, so they stay out of the line entirely until then.
+  const routed = s.followups_routed ? ` · ${s.followups_routed} routed` : '';
+  return `${s.events_received} received · ${s.sessions_launched} launched${routed} · ${last}`;
 });
 
 onMounted(() => {

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -1495,6 +1495,9 @@ export interface SlackSocket {
   last_event_at: string | null;
   events_received: number;
   sessions_launched: number;
+  /** Mentions delivered into the session an automation run had routed that
+   *  thread to, rather than launching a second one on the same thread. */
+  followups_routed: number;
   last_skip: string | null;
   last_skip_at: string | null;
 }

--- a/crates/loom/src/lib.rs
+++ b/crates/loom/src/lib.rs
@@ -32,7 +32,7 @@ pub use loom_launch::{handoff, metadata_assist, provision, setup};
 pub use loom_policy::{auth, automation, custom_mcp, db, profile};
 pub use loom_store::{
     agent_env, channels, chat, chatlog, history, profile_data, repo_env, review_inbox, runs,
-    session, session_layout, status,
+    session, session_layout, slack_routes, status,
 };
 pub use loom_watch::{builtins, monitor, tasks, watch};
 

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use weaver_api::{
     AutomationTokenReq, AutomationTokenView, FederateReq, FederationReq, FederationView, RunReq,
-    RunView,
+    RunView, SlackThreadRef,
 };
 
 use crate::auth::{Grant, Principal};
@@ -153,6 +153,34 @@ async fn remove_late_session(st: &AppState, session_id: &str) {
     }
 }
 
+/// Point the delivery's Slack thread at the branch the run landed on, so that
+/// session can reply there and a mention in that thread reaches it. Best-effort:
+/// the run itself already succeeded, and a lost route degrades to a thread the
+/// operator has to answer from the dashboard instead.
+async fn route_slack_thread(
+    st: &AppState,
+    target: Option<&SlackThreadRef>,
+    branch_id: &str,
+    source: &str,
+) {
+    let Some(target) = target else {
+        return;
+    };
+    let Ok((channel, thread_ts)) = crate::slack::parse_thread_ref(target) else {
+        return;
+    };
+    if let Err(error) =
+        crate::slack_routes::record(&st.db, &channel, &thread_ts, branch_id, source).await
+    {
+        tracing::warn!(
+            branch = branch_id,
+            channel = %channel,
+            %error,
+            "could not route the delivery's Slack thread to its session"
+        );
+    }
+}
+
 async fn launch_run(
     st: &AppState,
     req: RunReq,
@@ -162,15 +190,18 @@ async fn launch_run(
     failure: LaunchFailure,
 ) -> ApiResult<Json<RunView>> {
     let actor = crate::provision::Actor::automation(
-        req.source,
+        req.source.clone(),
         subject,
         profiles,
         run.id.clone(),
         run.session_id.clone(),
     );
+    let slack = req.slack.clone();
+    let source = req.source.clone();
     match crate::provision::create(st.clone(), req.session, actor).await {
         Ok(created) => {
             if crate::runs::launched(&st.db, &run.id, &created.session.id).await? {
+                route_slack_thread(st, slack.as_ref(), &created.branch.id, &source).await;
                 run_view(st, &run.id).await
             } else {
                 remove_late_session(st, &created.session.id).await;
@@ -270,6 +301,11 @@ async fn prompt_channel_run(
             "automation delivery was archived or removed while running",
         ));
     }
+    // Each alert on a channel arrives in its own thread while the session stays
+    // the same, so routes accumulate on this one branch. The session's `slack`
+    // wiring tag is deliberately left alone: one status card cannot follow a
+    // session that is triaging several incidents at once.
+    route_slack_thread(st, req.slack.as_ref(), &session.branch_id, &run.source).await;
     run_view(st, &run.id).await
 }
 
@@ -312,6 +348,11 @@ pub(super) async fn create_run(
     }
     req.session.profile = Some(profile.clone());
     req.session.class = None;
+    // Reject a malformed thread up front rather than accepting the run and
+    // silently dropping the route: the caller can then fix and redeliver.
+    if let Some(target) = req.slack.as_ref() {
+        crate::slack::parse_thread_ref(target).map_err(AppError::bad_request)?;
+    }
     req.channel = match req.channel.take() {
         Some(channel) => {
             let channel = channel.trim().to_string();

--- a/crates/loom/src/web/branches.rs
+++ b/crates/loom/src/web/branches.rs
@@ -235,13 +235,22 @@ pub(super) async fn set_branch_status(
 }
 
 /// `POST /api/branches/{id}/slack/reply` — post a message from the session back
-/// to its wired Slack thread. The token stays on the server: the agent (holding
-/// `LOOM_TOKEN`) calls this route rather than being handed the workspace-wide
-/// bot token, and loom derives the destination from the branch's `slack` wiring
-/// tag. The Slack analog of the GitHub-triggered session replying with `gh`.
+/// to a Slack thread it owns. The token stays on the server: the agent (holding
+/// `LOOM_TOKEN`) calls this route rather than being handed the workspace-wide bot
+/// token. The Slack analog of the GitHub-triggered session replying with `gh`.
+///
+/// Two destinations, both resolved server-side. Without `thread`, the branch's
+/// `slack` wiring tag — the conversation the session was born from. With
+/// `thread`, one of the threads an automation delivery routed to this branch
+/// ([`crate::slack_routes`]), which is how one operator session answers in each
+/// alert's own thread. A thread never delivered to this branch is refused, so the
+/// field selects among the session's own threads rather than granting the
+/// workspace.
 #[derive(Deserialize)]
 pub(super) struct SlackReplyReq {
     pub text: String,
+    #[serde(default)]
+    pub thread: Option<weaver_api::SlackThreadRef>,
 }
 
 pub(super) async fn slack_reply(
@@ -254,11 +263,29 @@ pub(super) async fn slack_reply(
     if text.is_empty() {
         return Err(AppError::bad_request("text is required"));
     }
-    let wired = tags::get(&st.db, &branch.id, crate::slack::WIRED_TAG)
-        .await?
-        .ok_or_else(|| AppError::bad_request("this branch is not wired to a Slack thread"))?;
-    let (_team, channel, root) = crate::slack::parse_wiring(&wired.value)
-        .ok_or_else(|| AppError::bad_request("malformed slack wiring tag"))?;
+    let (channel, root) = match req.thread.as_ref() {
+        Some(target) => {
+            let (channel, thread_ts) =
+                crate::slack::parse_thread_ref(target).map_err(AppError::bad_request)?;
+            if !crate::slack_routes::allows(&st.db, &branch.id, &channel, &thread_ts).await? {
+                return Err(AppError::new(
+                    StatusCode::FORBIDDEN,
+                    "this session holds no Slack route for that thread",
+                ));
+            }
+            (channel, thread_ts)
+        }
+        None => {
+            let wired = tags::get(&st.db, &branch.id, crate::slack::WIRED_TAG)
+                .await?
+                .ok_or_else(|| {
+                    AppError::bad_request("this branch is not wired to a Slack thread")
+                })?;
+            let (_team, channel, root) = crate::slack::parse_wiring(&wired.value)
+                .ok_or_else(|| AppError::bad_request("malformed slack wiring tag"))?;
+            (channel, root)
+        }
+    };
     let web = crate::slack::SlackWeb::from_db(&st.db)
         .await
         .ok_or_else(|| AppError::bad_request("Slack is not configured on this server"))?;

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -2327,21 +2327,23 @@ async fn recover_restarts_a_poisoned_live_acp_runtime() {
         )
         .await
         .expect("the replacement accepts a prompt");
+    // Wait for the turn to close, not for its message: turn_end is journaled
+    // after agent_message, so counting on the message's snapshot races it.
     let chat = poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
-        blocks.iter().any(|block| {
-            block["kind"] == "agent_message" && block["payload"]["text"] == "healthy again"
-        })
+        count_kind(blocks, "turn_end") >= 4
     })
     .await;
+    let blocks = chat["blocks"].as_array().unwrap();
     assert_eq!(
-        chat["blocks"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .filter(|block| block["kind"] == "turn_end")
-            .count(),
+        count_kind(blocks, "turn_end"),
         4,
         "recovery continues the existing journal"
+    );
+    assert!(
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "healthy again"
+        }),
+        "the replacement task answered the prompt"
     );
 }
 

--- a/crates/loom/tests/integration/branches.rs
+++ b/crates/loom/tests/integration/branches.rs
@@ -2,6 +2,7 @@
 //! board, claim release on teardown, and attaching a session to a pre-existing
 //! git branch (with or without an existing worktree).
 
+use reqwest::StatusCode;
 use serde_json::json;
 use serial_test::serial;
 
@@ -450,6 +451,69 @@ async fn attach_to_existing_branch() {
         .delete(&format!(
             "/api/sessions/{}",
             attached_y["id"].as_str().unwrap()
+        ))
+        .await
+        .unwrap();
+}
+
+/// The Slack reply route's destination is server-resolved. A thread the session
+/// was never delivered is refused, so `thread` selects among the session's own
+/// alert threads rather than granting the agent the workspace. Both refusals
+/// land before any Slack call, so they hold on a server with no Slack
+/// configured — which is also what a leaked `LOOM_TOKEN` would face.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn slack_reply_refuses_a_thread_the_session_was_not_delivered() {
+    let ts = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let session = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "slack reply scope", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let branch_id = session["branch"]["id"].as_str().unwrap().to_string();
+    let reply_url = format!("http://{}/api/branches/{branch_id}/slack/reply", ts.addr);
+
+    // An unrouted thread is forbidden even though it is well-formed.
+    let unrouted = http
+        .post(&reply_url)
+        .json(&json!({
+            "text": "status update",
+            "thread": { "channel": "C0123ABCD", "thread_ts": "1700000000.123456" },
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unrouted.status(), StatusCode::FORBIDDEN);
+
+    // A channel name is not an id: rejected on shape, before any Slack call.
+    let malformed = http
+        .post(&reply_url)
+        .json(&json!({
+            "text": "status update",
+            "thread": { "channel": "#marin-eng", "thread_ts": "1700000000.123456" },
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+
+    // Without `thread`, an unwired branch still reports that it has no thread.
+    let unwired = http
+        .post(&reply_url)
+        .json(&json!({ "text": "status update" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unwired.status(), StatusCode::BAD_REQUEST);
+
+    ts.client
+        .delete(&format!(
+            "/api/sessions/{}",
+            session["id"].as_str().unwrap()
         ))
         .await
         .unwrap();

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -1146,6 +1146,17 @@ pub struct DeploymentView {
     pub federations: Vec<FederationView>,
 }
 
+/// One Slack thread, as an automation caller names it. `channel` is a Slack
+/// channel id (`C…`/`G…`/`D…`, never a `#name`) and `thread_ts` the message `ts`
+/// of the thread's root. The workspace is loom's own — a caller cannot address
+/// another team — and the bot token stays server-side, so this is a destination
+/// request, not a capability the caller holds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SlackThreadRef {
+    pub channel: String,
+    pub thread_ts: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunReq {
     pub profile: String,
@@ -1164,6 +1175,12 @@ pub struct RunReq {
     /// live ACP session.
     #[serde(default)]
     pub channel: Option<String>,
+    /// The Slack thread this delivery was announced in. Loom routes the thread to
+    /// the session the run lands on, which lets that session reply there and
+    /// lets a `@bot` mention in the thread reach it — without re-pointing the
+    /// session's single `slack` status-card wiring.
+    #[serde(default)]
+    pub slack: Option<SlackThreadRef>,
     pub session: CreateReq,
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,6 +184,9 @@ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npm test
     `channel_deliveries` (durable communication context, append-only stream,
     per-subject read/mode state, and separate runtime acceptance receipts),
     `recent_repos`,
+    `slack_routes` (Slack threads an automation delivery pointed at a branch,
+    keyed on the thread: many alert threads may route to one operator session,
+    which is why this is not the single-valued `slack` branch tag),
     `branch_github` (per-branch PR snapshot), `chat_blocks` (the ACP
     [chat journal](#rest-api): one row per `(session_id, turn, seq)` block),
     `session_acp_metadata` (the latest provider-advertised composer controls,

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -236,6 +236,48 @@ branch's `slack` wiring tag server-side; the bot token itself never reaches
 the agent, the same separation the GitHub trigger keeps between an agent's
 `GH_TOKEN` and any App-level credential.
 
+Adding `"thread": {"channel": "C…", "thread_ts": "…"}` posts to one of the
+session's *routed* threads instead (see [Automation-delivered
+threads](#automation-delivered-threads)). The route is the authorization: a
+thread that was never delivered to this branch is refused, so the field selects
+among the session's own threads rather than granting it the workspace. The
+`slack_reply` MCP tool takes the same optional `thread`.
+
+## Automation-delivered threads
+
+A `POST /api/runs` body may carry `"slack": {"channel": "C…", "thread_ts": "…"}`
+— the thread the caller announced this delivery in. loom **routes** that thread
+to whichever session the run lands on, and from then on the thread and the
+session are joined in both directions:
+
+- The session may reply into the thread (`thread` on the reply route above).
+- An `@marinbot` mention in the thread is delivered into that session's
+  conversation and acknowledged with 👀, rather than launching a second session
+  on top of it. A routed thread needs no repository: the session already exists,
+  so `slack.default_repo` is not consulted.
+
+This is a **many-to-one** relation, which is why it is not the `slack` tag.
+That tag fixes *one* thread as a session's status-card home, the right model for
+a session born from a conversation. An operator session is the other shape: one
+long-lived session fed alerts through an [automation
+channel](configuration.md), each alert announced in its own thread. Its `slack`
+tag is deliberately left alone — a single card cannot follow a session that is
+triaging several incidents at once — so a routed thread gets explicit replies
+rather than a live trail.
+
+Routes are delivery records, not caller-chosen grants: loom writes one only
+where it accepted a run for that thread, the workspace is always loom's own, and
+`channel`/`thread_ts` are shape-checked (a `#channel-name` is rejected — Slack
+ids only). Re-delivering the same alert is idempotent. `followups_routed` in
+`GET /api/slack/status` counts mentions delivered this way, which is how a
+working alert conversation is distinguished from one quietly launching a
+duplicate session per reply.
+
+The intended consumer is Marin's Grafana bridge: it posts the alert to Slack,
+creates the run with that thread, and the operator session answers in-thread —
+see the [Marin `infra/grafana`
+runbook](https://github.com/marin-community/marin/tree/main/infra/grafana).
+
 ## Slack app configuration
 
 Under **Settings → Socket Mode**, enable it and generate an app-level token


### PR DESCRIPTION
An automation run may now name the Slack thread its delivery was announced in, via `slack: {channel, thread_ts}` on `POST /api/runs`. Loom routes that thread to whichever session the run lands on, joining the two in both directions: the session may reply into the thread, and an `@marinbot` mention there is delivered into that session's conversation instead of launching a second session on top of it. A routed thread needs no repository, so `slack.default_repo` is not consulted for one.

This is many-to-one, which is why it is not the `slack` branch tag. That tag fixes one thread as a session's status-card home, the right model for a session born from a conversation. An operator session is the other shape: one long-lived session fed alerts through an automation channel, each alert announced in its own thread. Its tag is left alone — a single status card cannot follow a session triaging several incidents at once — so routed threads receive explicit replies instead of a live trail.

Routes are delivery records, not caller-chosen grants. Loom writes one only where it accepted a run for that thread; the workspace is always its own, resolved from `auth.test` rather than the caller; and channel and ts are shape-checked, so a `#channel-name` is refused rather than posted to whatever Slack resolves it to. `POST /api/branches/{id}/slack/reply` and the `slack_reply` MCP tool take an optional `thread`, authorized against that branch's routes, so the field selects among a session's own threads rather than granting the workspace.

Continuation previously resolved a thread's session by derived branch name (`weaver/slack-<hash>` under `slack.default_repo`), which no automation-launched session matches, so an operator replying under an alert would have launched a duplicate session on that thread. Routes are consulted first; an unrouted thread, a slash command, or an archived session all fall through to the ordinary launch path, so reviving an old alert thread still works.

`followups_routed` in `GET /api/slack/status` counts mentions delivered this way, separating a working alert conversation from one quietly launching a session per reply.

The consumer is Marin's Grafana bridge, which posts the alert and creates the run naming that thread (marin-community/marin#8050). Nothing changes for a deployment that sends no `slack` field.

## Testing

`cargo test --workspace --lib --bins` and the 11 representative integration journeys pass, as does `scripts/pre-commit.sh`. New coverage: the route store (thread resolution, many threads to one session, refusal of an unrouted thread, redelivery and takeover), thread-ref parsing (Slack ids and ts accepted; channel names, lowercase ids, and malformed ts rejected), the routing decision (a mention under a routed alert finds the session; unrouted threads, slash commands, and archived sessions fall through), and an integration test that the reply route refuses an unrouted or malformed thread before any Slack call.

The Playwright suite was not run locally — this clone has no `e2e/node_modules`, and the change touches one computed string in `SlackPanel.vue` plus a type. CI covers it.

`scripts/lint-review.py` ran and reported one finding, a speculative `for_branch` query with no caller, removed in the second commit.

The third commit fixes a race unrelated to this change, in `recover_restarts_a_poisoned_live_acp_runtime`, which failed CI here. It polled for the `agent_message` and then counted `turn_end` blocks on that snapshot; `turn_end` is journaled after `agent_message`, so the count could read 3 while the fourth was in flight. It now polls for the closing `turn_end`, as the rest of the file does. It is separable if you would rather it landed on its own.