### PR TITLE
fix(loom): flush background task output

### DIFF
--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -2223,11 +2223,28 @@ impl Task {
                     .await;
                 }
             }
-            SessionUpdate::UsageUpdate { used, size, cost } => {
+            SessionUpdate::UsageUpdate {
+                used,
+                size,
+                cost,
+                meta,
+            } => {
                 // Usage is metadata, not a prose boundary. Flushing here split
                 // replies into tiny blocks when an adapter reported it often.
                 // ACP requires both context fields; silently ignore a malformed
                 // legacy update instead of publishing a misleading 0/0 meter.
+                //
+                // One update is a real boundary: claude-agent-acp emits a
+                // cost-bearing `task-notification` after an autonomous
+                // background-task continuation. There is no matching
+                // `session/prompt` response to close that output, so without
+                // honoring this marker its final prose stays only in the live
+                // chunk buffer until the next tool/message boundary.
+                let closes_task_notification = cost.is_some()
+                    && meta
+                        .claude_origin
+                        .as_ref()
+                        .is_some_and(|origin| origin.kind == "task-notification");
                 if let (Some(used), Some(size)) = (used, size) {
                     let usage = AcpUsage {
                         used,
@@ -2242,6 +2259,23 @@ impl Task {
                         serde_json::to_value(usage).unwrap_or(Value::Null),
                     )
                     .await;
+                }
+                if closes_task_notification {
+                    self.flush_buf().await;
+                    // A late delta makes the browser show a live continuation.
+                    // The original prompt already ended, so mirror that durable
+                    // truth after settling the shadow without writing a second
+                    // `turn_end` block for the same turn.
+                    if !self.turn_live {
+                        self.emit(
+                            "turn",
+                            json!({
+                                "turn": self.current_turn,
+                                "state": "ended",
+                                "stop_reason": "end_turn",
+                            }),
+                        );
+                    }
                 }
             }
             SessionUpdate::SessionInfoUpdate { meta } => {
@@ -3122,6 +3156,13 @@ impl Task {
         // The cap gate sits before any turn state advances, so a refusal leaves
         // the counters, the journal, and any queued prompt untouched.
         self.refuse_if_turn_capped().await?;
+        // An adapter may produce an autonomous continuation after the preceding
+        // prompt response. Keep any still-open prose on that preceding turn
+        // even when a new prompt races its explicit adapter boundary.
+        self.flush_buf().await;
+        if self.journal_failed {
+            bail!("could not persist buffered ACP output before starting a new turn");
+        }
         if self.turns_dispatched > 0 {
             self.current_turn += 1;
             self.next_seq = 0;

--- a/crates/loom-agent/src/acp/wire.rs
+++ b/crates/loom-agent/src/acp/wire.rs
@@ -159,6 +159,8 @@ pub enum SessionUpdate {
         size: Option<u64>,
         #[serde(default)]
         cost: Option<UsageCost>,
+        #[serde(default, rename = "_meta")]
+        meta: UsageMeta,
     },
     /// codex-acp's thread lifecycle. Loom normally owns turn boundaries through
     /// the `session/prompt` response; this closes the rare turn that the
@@ -188,6 +190,21 @@ pub enum SessionUpdate {
 pub struct UsageCost {
     pub amount: f64,
     pub currency: String,
+}
+
+/// Adapter provenance attached to a usage update. Claude's ACP adapter uses a
+/// cost-bearing `task-notification` update as the only terminal boundary for an
+/// autonomous continuation triggered by a completed background task; unlike a
+/// human prompt, that continuation has no `session/prompt` response.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct UsageMeta {
+    #[serde(default, rename = "_claude/origin")]
+    pub claude_origin: Option<UsageOrigin>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UsageOrigin {
+    pub kind: String,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -721,12 +738,33 @@ mod tests {
         }))
         .unwrap();
         match usage {
-            SessionUpdate::UsageUpdate { used, size, cost } => {
+            SessionUpdate::UsageUpdate {
+                used,
+                size,
+                cost,
+                meta,
+            } => {
                 assert_eq!(used, Some(41000));
                 assert_eq!(size, Some(200000));
                 let cost = cost.unwrap();
                 assert_eq!(cost.amount, 1.25);
                 assert_eq!(cost.currency, "USD");
+                assert!(meta.claude_origin.is_none());
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+
+        let task_usage: SessionUpdate = serde_json::from_value(json!({
+            "sessionUpdate": "usage_update",
+            "used": 42000,
+            "size": 200000,
+            "cost": { "amount": 1.5, "currency": "USD" },
+            "_meta": { "_claude/origin": { "kind": "task-notification" } },
+        }))
+        .unwrap();
+        match task_usage {
+            SessionUpdate::UsageUpdate { meta, .. } => {
+                assert_eq!(meta.claude_origin.unwrap().kind, "task-notification")
             }
             other => panic!("wrong variant: {other:?}"),
         }

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -18,6 +18,10 @@
 //   toolfail[:title]     a tool_call that ends with status `failed`
 //   plan                 a plan update with two entries
 //   usage:USED:SIZE      a usage_update
+//   task-notification:MS:TEXT
+//                        after the prompt response, stream TEXT as an autonomous
+//                        Claude background-task continuation and close it with
+//                        Claude's cost-bearing task-notification usage marker
 //   wait:MS              sleep MS ms (cancellable) — for queueing/interrupt/crash tests
 //   permission:NAME      a session/request_permission that BLOCKS the turn until the
 //                        client answers (exercises both auto-answer and REST-answer)
@@ -281,6 +285,28 @@ async function runToken(tok) {
   } else if (tok.startsWith("usage:")) {
     const [, used, size] = tok.split(":");
     notify({ sessionUpdate: "usage_update", used: Number(used), size: Number(size) });
+  } else if (tok.startsWith("task-notification:")) {
+    const [, delay, ...textParts] = tok.split(":");
+    const text = textParts.join(":");
+    setTimeout(async () => {
+      const half = Math.ceil(text.length / 2);
+      notify({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: text.slice(0, half) },
+      });
+      await sleep(5);
+      notify({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: text.slice(half) },
+      });
+      notify({
+        sessionUpdate: "usage_update",
+        used: 42,
+        size: 1000,
+        cost: { amount: 0.01, currency: "USD" },
+        _meta: { "_claude/origin": { kind: "task-notification" } },
+      });
+    }, Number(delay));
   } else if (tok.startsWith("wait:")) {
     await sleepCancellable(Number(tok.slice(5)));
   } else if (tok.startsWith("permission:")) {

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -749,6 +749,100 @@ async fn chat_stream_route_delivers_sse() {
     );
 }
 
+/// 1c. claude-agent-acp can finish the owning prompt, then autonomously resume
+/// when a background task completes. That continuation has no prompt response;
+/// its cost-bearing task-notification usage update is the only terminal
+/// boundary. The final prose must become durable immediately and must not ride
+/// the next user's first tool/message boundary into the next turn.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn claude_task_notification_flushes_autonomous_prose() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-task-notification", None, None).await;
+    let mut rx = ts
+        .state
+        .acp
+        .get("acp-task-notification")
+        .unwrap()
+        .subscribe();
+
+    ts.client
+        .post(
+            "/api/sessions/acp-task-notification/prompt",
+            json!({ "text": "task-notification:100:background finished" }),
+        )
+        .await
+        .unwrap();
+
+    let saw_background_block = std::cell::Cell::new(false);
+    let events = drain_events(&mut rx, Duration::from_secs(5), |event| {
+        if event.event == "block"
+            && event.data["turn"] == 0
+            && event.data["kind"] == "agent_message"
+            && event.data["payload"]["text"] == "background finished"
+        {
+            saw_background_block.set(true);
+        }
+        saw_background_block.get()
+            && event.event == "turn"
+            && event.data["turn"] == 0
+            && event.data["state"] == "ended"
+    })
+    .await;
+    assert!(events.iter().any(|event| {
+        event.event == "block"
+            && event.data["turn"] == 0
+            && event.data["kind"] == "agent_message"
+            && event.data["payload"]["text"] == "background finished"
+    }));
+
+    let chat = poll_chat_state(
+        &ts,
+        "acp-task-notification",
+        Duration::from_secs(5),
+        |chat| {
+            chat["live_turn"].is_null()
+                && chat["blocks"].as_array().unwrap().iter().any(|block| {
+                    block["turn"] == 0
+                        && block["kind"] == "agent_message"
+                        && block["payload"]["text"] == "background finished"
+                })
+        },
+    )
+    .await;
+    assert_eq!(
+        count_kind(chat["blocks"].as_array().unwrap(), "turn_end"),
+        1,
+        "the task-notification settles the existing turn without duplicating its durable end"
+    );
+
+    ts.client
+        .post(
+            "/api/sessions/acp-task-notification/prompt",
+            json!({ "text": "say:next turn" }),
+        )
+        .await
+        .unwrap();
+    let chat = poll_chat(
+        &ts,
+        "acp-task-notification",
+        Duration::from_secs(5),
+        |blocks| {
+            blocks.iter().any(|block| {
+                block["turn"] == 1
+                    && block["kind"] == "agent_message"
+                    && block["payload"]["text"] == "next turn"
+            })
+        },
+    )
+    .await;
+    assert!(chat["blocks"].as_array().unwrap().iter().any(|block| {
+        block["turn"] == 0
+            && block["kind"] == "agent_message"
+            && block["payload"]["text"] == "background finished"
+    }));
+}
+
 /// 2. Tool call: a live `tool` SSE, then one journaled `tool_call` block at a
 ///    terminal status carrying the diff content.
 #[serial]


### PR DESCRIPTION
Claude's ACP adapter can emit autonomous output after a background task completes, after the owning prompt has already returned. Its only completion signal is a cost-bearing usage update tagged as a task notification. Loom ignored that marker, leaving final prose in memory until the next tool or message boundary and then journaling it under the next turn.

Recognize the task-notification marker as a boundary, durably flush buffered prose, and settle the live SSE state when no prompt is active. Flush any residual prose before advancing to a new turn as a race guard. Extend the scripted ACP adapter and integration suite with the captured notification shape and verify the output remains on the original turn.

Loom session: http://127.0.0.1:7878/s/9e1qw354