### PR TITLE
fix(loom): render codex edits as line diffs

### DIFF
--- a/crates/loom/frontend/src/components/ToolContentPreview.vue
+++ b/crates/loom/frontend/src/components/ToolContentPreview.vue
@@ -1,25 +1,15 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, useId, watch } from 'vue';
 import type { ToolContent } from '../types';
+import { changedDiffLines } from '../lib/toolDiff';
 
 const props = defineProps<{
   content: ToolContent;
   title: string;
 }>();
 
-interface DiffLine {
-  sign: '-' | '+';
-  text: string;
-}
-
-function diffLines(content: Extract<ToolContent, { type: 'diff' }>): DiffLine[] {
-  const lines: DiffLine[] = [];
-  const push = (sign: '-' | '+', body: string) => {
-    for (const line of body.replace(/\n$/, '').split('\n')) lines.push({ sign, text: line });
-  };
-  if (content.old) push('-', content.old);
-  push('+', content.new);
-  return lines;
+function diffLines(content: Extract<ToolContent, { type: 'diff' }>) {
+  return changedDiffLines(content.old, content.new);
 }
 
 const imageSrc = computed(() => {

--- a/crates/loom/frontend/src/lib/toolDiff.test.mjs
+++ b/crates/loom/frontend/src/lib/toolDiff.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { changedDiffLines } from './toolDiff.ts';
+
+test('whole-file snapshots render only the lines changed by an edit', () => {
+  const oldText = ['use axum::Router;', '', 'fn route() {', '    old_handler();', '}', ''].join(
+    '\n',
+  );
+  const newText = ['use axum::Router;', '', 'fn route() {', '    new_handler();', '}', ''].join(
+    '\n',
+  );
+
+  assert.deepEqual(changedDiffLines(oldText, newText), [
+    { sign: '-', text: '    old_handler();' },
+    { sign: '+', text: '    new_handler();' },
+  ]);
+});
+
+test('insertions and deletions remain ordered around unchanged lines', () => {
+  assert.deepEqual(
+    changedDiffLines('alpha\nremove\nmiddle\nomega\n', 'alpha\nmiddle\nadd\nomega\n'),
+    [
+      { sign: '-', text: 'remove' },
+      { sign: '+', text: 'add' },
+    ],
+  );
+});
+
+test('a missing old snapshot is displayed as a newly added file', () => {
+  assert.deepEqual(changedDiffLines(null, 'first\nsecond\n'), [
+    { sign: '+', text: 'first' },
+    { sign: '+', text: 'second' },
+  ]);
+});
+
+test('identical snapshots have no changed lines', () => {
+  assert.deepEqual(changedDiffLines('same\n', 'same\n'), []);
+});
+
+test('a blank line in a new file remains visible', () => {
+  assert.deepEqual(changedDiffLines(null, '\n'), [{ sign: '+', text: '' }]);
+});

--- a/crates/loom/frontend/src/lib/toolDiff.ts
+++ b/crates/loom/frontend/src/lib/toolDiff.ts
@@ -1,0 +1,83 @@
+export interface DiffLine {
+  sign: '-' | '+';
+  text: string;
+}
+
+function textLines(text: string): string[] {
+  if (!text) return [];
+  const withoutFinalNewline = text.endsWith('\n') ? text.slice(0, -1) : text;
+  return withoutFinalNewline.split('\n');
+}
+
+/**
+ * Return only the changed lines between the before and after snapshots in an
+ * ACP diff content block. Providers such as Codex send the complete file in
+ * oldText/newText; treating those snapshots as ready-made diff hunks makes a
+ * one-line edit look like a whole-file replacement.
+ */
+export function changedDiffLines(oldText: string | null, newText: string): DiffLine[] {
+  const before = oldText === null ? [] : textLines(oldText);
+  const after = textLines(newText);
+
+  if (oldText === null) return after.map((text) => ({ sign: '+', text }));
+
+  // Myers' shortest-edit-path algorithm. Its work scales with the size of the
+  // edit rather than the size of the file, which suits full snapshots carrying
+  // a handful of changed lines. The trace contains only edit diagonals, so
+  // unchanged thousand-line spans do not make it quadratic.
+  const max = before.length + after.length;
+  const trace: Map<number, number>[] = [];
+  let frontier = new Map<number, number>([[1, 0]]);
+
+  for (let distance = 0; distance <= max; distance += 1) {
+    trace.push(new Map(frontier));
+    const next = new Map<number, number>();
+
+    for (let diagonal = -distance; diagonal <= distance; diagonal += 2) {
+      const down = frontier.get(diagonal + 1) ?? -1;
+      const right = frontier.get(diagonal - 1) ?? -1;
+      let x = diagonal === -distance || (diagonal !== distance && right < down) ? down : right + 1;
+      let y = x - diagonal;
+
+      while (x < before.length && y < after.length && before[x] === after[y]) {
+        x += 1;
+        y += 1;
+      }
+      next.set(diagonal, x);
+
+      if (x >= before.length && y >= after.length) {
+        const edits: DiffLine[] = [];
+        let editX = before.length;
+        let editY = after.length;
+
+        for (let d = distance; d >= 0; d -= 1) {
+          const previous = trace[d];
+          const k = editX - editY;
+          const previousDown = previous.get(k + 1) ?? -1;
+          const previousRight = previous.get(k - 1) ?? -1;
+          const previousK = k === -d || (k !== d && previousRight < previousDown) ? k + 1 : k - 1;
+          const previousX = previous.get(previousK) ?? 0;
+          const previousY = previousX - previousK;
+
+          while (editX > previousX && editY > previousY) {
+            editX -= 1;
+            editY -= 1;
+          }
+          if (d === 0) break;
+          if (editX === previousX) {
+            edits.push({ sign: '+', text: after[editY - 1] });
+            editY -= 1;
+          } else {
+            edits.push({ sign: '-', text: before[editX - 1] });
+            editX -= 1;
+          }
+        }
+
+        return edits.reverse();
+      }
+    }
+    frontier = next;
+  }
+
+  return [];
+}

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -261,7 +261,14 @@ async function runToken(tok) {
     const toolCallId = "call-" + kind + "-" + Math.floor(Math.random() * 100000);
     const content =
       kind === "edit"
-        ? [{ type: "diff", path: "/w/file.rs", oldText: "old line\n", newText: "new line\n" }]
+        ? [
+            {
+              type: "diff",
+              path: "/w/file.rs",
+              oldText: "fn unchanged() {}\nold line\n// unchanged tail\n",
+              newText: "fn unchanged() {}\nnew line\n// unchanged tail\n",
+            },
+          ]
         : [{ type: "content", content: { type: "text", text: "done" } }];
     notify({
       sessionUpdate: "tool_call",

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -885,9 +885,9 @@ async fn tool_call_live_then_journaled() {
         .as_array()
         .unwrap();
     assert!(
-        content
-            .iter()
-            .any(|c| c["type"] == "diff" && c["new"] == "new line\n"),
+        content.iter().any(|c| c["type"] == "diff"
+            && c["old"] == "fn unchanged() {}\nold line\n// unchanged tail\n"
+            && c["new"] == "fn unchanged() {}\nnew line\n// unchanged tail\n"),
         "the diff content survived: {content:?}"
     );
 

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -176,7 +176,10 @@ test.describe('acp conversation', () => {
     await expect(head).toBeVisible();
     await expect(page.getByTestId('acp-diff')).toBeHidden();
     await head.click();
-    await expect(page.getByTestId('acp-diff')).toContainText('new line');
+    const diff = page.getByTestId('acp-diff');
+    await expect(diff).toContainText('- old line');
+    await expect(diff).toContainText('+ new line');
+    await expect(diff).not.toContainText('unchanged');
 
     // The bounded preview can expand into a full-screen code viewer and closes
     // with Escape, returning focus to the expansion control.


### PR DESCRIPTION
Codex ACP edit events carry complete before/after file snapshots. The conversation preview treated each snapshot as a ready-made diff side, making a one-line edit look like a whole-file replacement.

Compute a shortest line edit script at render time and omit unchanged lines while leaving the journal and API payload untouched. Extend the ACP fixture and browser coverage to exercise full-file snapshots and verify storage remains verbatim.

Agent lint review skipped: small, low-risk presentation-only change with no storage or wire-contract changes.