### PR TITLE
perf(build): cut release rebuild 37% and binary size 32%

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustc-wrapper = "sccache"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,15 @@ members = [
 # which is fine: deps pointing *into* members don't pull the excluded crate back
 # in.
 exclude = ["crates/weaver-py"]
+
+# Workspace code is I/O-bound orchestration — git subprocesses, sqlite, HTTP —
+# so optimizing it for size rather than speed costs nothing observable and buys
+# a materially cheaper build: `z` is 17% less wall, 29% less CPU, and 21% less
+# machine code than `3` on the `loom` crate. Dependencies hold the real hot
+# paths (sqlx, serde, tokio, sha2, zstd) and stay at full optimization; they are
+# also what `package."*"` matches, so their cached artifacts stay valid.
+[profile.release]
+opt-level = "z"
+
+[profile.release.package."*"]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -25,23 +25,7 @@ this repo in Claude Code (or your agent of choice) and tell it to *"set weaver u
 for me — follow the Getting Started steps in the README."* The steps below are
 written for it to run; do them yourself if you'd rather.
 
-1. **Get a Rust toolchain and sccache.** If `cargo` isn't already on the PATH,
-   install it via [rustup](https://rustup.rs):
-
-   ```sh
-   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-   ```
-
-   Weaver keeps Cargo artifacts isolated in each worktree and uses
-   [`sccache`](https://github.com/mozilla/sccache) to reuse compilation results
-   safely across them. Install `sccache` separately and ensure its binary is on
-   the PATH; for example:
-
-   ```sh
-   CARGO_BUILD_RUSTC_WRAPPER= cargo install sccache --locked
-   ```
-
-2. **Build the tooling.** From the repo root:
+1. **Build the tooling.** From the repo root:
 
    ```sh
    cargo build
@@ -49,7 +33,7 @@ written for it to run; do them yourself if you'd rather.
 
    This produces `target/debug/weaver` and `target/debug/loom`.
 
-3. **Put both binaries on the PATH.** Symlink them into a directory already on
+2. **Put both binaries on the PATH.** Symlink them into a directory already on
    `$PATH` (e.g. `~/.local/bin`), so they stay current as you rebuild:
 
    ```sh

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -899,7 +899,7 @@ impl AcpRegistry {
                 metadata: Arc::new(Mutex::new(AcpMetadata::default())),
             },
         );
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             while let Some(command) = cmd_rx.recv().await {
                 if let Command::NotifyPending { reply } = command {
                     wakes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -914,7 +914,7 @@ impl AcpRegistry {
                     }
                 }
             }
-        });
+        }));
     }
 
     /// Register a prompt probe in place of a real session task.
@@ -937,7 +937,7 @@ impl AcpRegistry {
                 metadata: Arc::new(Mutex::new(AcpMetadata::default())),
             },
         );
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             while let Some(command) = cmd_rx.recv().await {
                 if let Command::Prompt {
                     text, by, reply, ..
@@ -951,7 +951,7 @@ impl AcpRegistry {
                     }));
                 }
             }
-        });
+        }));
     }
 
     /// Remove the session's slot only if it still holds `generation` — a task
@@ -1138,7 +1138,7 @@ async fn start_inner(
         }
     };
 
-    tokio::spawn(async move { task.run(cmd_rx).await });
+    weaver_core::spawn_boxed(Box::pin(async move { task.run(cmd_rx).await }));
     Ok(())
 }
 
@@ -1181,7 +1181,7 @@ pub async fn attach(state: &AcpCtx, session_id: &str) -> Result<()> {
             metadata: task.metadata.clone(),
         },
     );
-    tokio::spawn(async move { task.run(cmd_rx).await });
+    weaver_core::spawn_boxed(Box::pin(async move { task.run(cmd_rx).await }));
     Ok(())
 }
 

--- a/crates/loom-agent/src/agent.rs
+++ b/crates/loom-agent/src/agent.rs
@@ -15,6 +15,7 @@ use crate::backend;
 use crate::custom_agents::CustomAgent;
 use crate::db::Db;
 use weaver_core::agent::{hooks_json, HookMode};
+use weaver_core::BoxFut;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentChoice {
@@ -1629,7 +1630,19 @@ impl<'a> AgentManager<'a> {
             .await
     }
 
-    async fn run_oneshot_with(
+    /// Boxed to keep this state machine's codegen in `loom-agent` — see the
+    /// note on `loom_launch::provision::create`.
+    fn run_oneshot_with<'f>(
+        &'f self,
+        runtime: &'f str,
+        prompt: &'f str,
+        policy: OneShotPolicy<'f>,
+        timeout: Duration,
+    ) -> BoxFut<'f, Option<String>> {
+        Box::pin(self.run_oneshot_with_inner(runtime, prompt, policy, timeout))
+    }
+
+    async fn run_oneshot_with_inner(
         &self,
         runtime: &str,
         prompt: &str,

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -25,6 +25,7 @@ use anyhow::{anyhow, Context, Result};
 use futures_util::{SinkExt, StreamExt};
 use serde::Serialize;
 use serde_json::{json, Value};
+use weaver_core::BoxFut;
 use weaver_core::{config, events, tags};
 
 use crate::AppState;
@@ -858,7 +859,11 @@ pub async fn sync_status_message(state: AppState, branch_id: String) {
 
 /// One sync attempt. `true` = done (synced, or nothing to do); `false` = a
 /// transient Slack failure worth retrying.
-async fn sync_status_message_once(state: &AppState, branch_id: &str) -> bool {
+fn sync_status_message_once<'a>(state: &'a AppState, branch_id: &'a str) -> BoxFut<'a, bool> {
+    Box::pin(sync_status_message_once_inner(state, branch_id))
+}
+
+async fn sync_status_message_once_inner(state: &AppState, branch_id: &str) -> bool {
     let wired = match tags::get(&state.db, branch_id, WIRED_TAG).await {
         Ok(Some(tag)) => tag,
         Ok(None) => return true, // unwired — nothing to mirror
@@ -1039,11 +1044,11 @@ pub fn parse_thread_ref(
 /// from; adding a third surface is one line here, not another edit at five call
 /// sites.
 pub fn spawn_status_mirrors(state: AppState, branch_id: String) {
-    tokio::spawn(crate::github::sync_status_comment(
+    weaver_core::spawn_boxed(Box::pin(crate::github::sync_status_comment(
         state.clone(),
         branch_id.clone(),
-    ));
-    tokio::spawn(sync_status_message(state, branch_id));
+    )));
+    weaver_core::spawn_boxed(Box::pin(sync_status_message(state, branch_id)));
 }
 
 // ---------------------------------------------------------------------------
@@ -1249,7 +1254,19 @@ enum Outcome {
 
 /// The launch body: seed context, reuse-or-create the session, wire it, and post
 /// the card. Serialized on [`CREATE_LOCK`].
-async fn launch(
+#[allow(clippy::too_many_arguments)]
+fn launch<'a>(
+    state: &'a AppState,
+    web: &'a SlackWeb,
+    bot: &'a AuthTest,
+    trigger: &'a Trigger,
+    repo: &'a str,
+    instruction: &'a str,
+) -> BoxFut<'a, Result<Outcome>> {
+    Box::pin(launch_inner(state, web, bot, trigger, repo, instruction))
+}
+
+async fn launch_inner(
     state: &AppState,
     web: &SlackWeb,
     bot: &AuthTest,
@@ -1812,12 +1829,12 @@ async fn connect_and_run(state: &AppState) -> Result<String> {
                 };
                 match trigger {
                     Some(trigger) => {
-                        tokio::spawn(handle_trigger(
+                        weaver_core::spawn_boxed(Box::pin(handle_trigger(
                             state.clone(),
                             web.clone(),
                             bot.clone(),
                             trigger,
-                        ));
+                        )));
                     }
                     // Slack delivers every subscribed event type, so this is the
                     // ordinary case for anything that isn't an app_mention.

--- a/crates/loom-editor/src/ide.rs
+++ b/crates/loom-editor/src/ide.rs
@@ -74,9 +74,9 @@ impl Instance {
         }
         if let Some(dir) = &self.state_dir {
             let dir = dir.clone();
-            tokio::spawn(async move {
+            weaver_core::spawn_boxed(Box::pin(async move {
                 let _ = tokio::fs::remove_dir_all(dir).await;
-            });
+            }));
         }
     }
 }
@@ -344,7 +344,7 @@ async fn wait_for_port(child: &mut Child) -> Result<u16, String> {
 }
 
 fn pump_lines<R: AsyncRead + Unpin + Send + 'static>(reader: R, tx: mpsc::Sender<String>) {
-    tokio::spawn(async move {
+    weaver_core::spawn_boxed(Box::pin(async move {
         let mut lines = BufReader::new(reader).lines();
         while let Ok(Some(line)) = lines.next_line().await {
             tracing::debug!(target: "loom::ide", "{line}");
@@ -352,7 +352,7 @@ fn pump_lines<R: AsyncRead + Unpin + Send + 'static>(reader: R, tx: mpsc::Sender
             // fails fast and we keep looping to drain (not block) the pipe.
             let _ = tx.send(line).await;
         }
-    });
+    }));
 }
 
 /// Pull the port out of a `… HTTP server listening on http://127.0.0.1:34543/`
@@ -524,9 +524,9 @@ async fn proxy_ws(mut req: Request, port: u16, suffix: &str) -> Response {
         Err(_) => return (StatusCode::BAD_GATEWAY, "editor handshake failed").into_response(),
     };
     // Drive the upstream connection (with upgrade support) in the background.
-    tokio::spawn(async move {
+    weaver_core::spawn_boxed(Box::pin(async move {
         let _ = conn.with_upgrades().await;
-    });
+    }));
 
     let Ok(uri) = format!("http://127.0.0.1:{port}{suffix}").parse::<Uri>() else {
         return (StatusCode::BAD_GATEWAY, "bad upstream uri").into_response();
@@ -550,13 +550,13 @@ async fn proxy_ws(mut req: Request, port: u16, suffix: &str) -> Response {
     }
 
     let upstream_on = hyper::upgrade::on(&mut upstream_resp);
-    tokio::spawn(async move {
+    weaver_core::spawn_boxed(Box::pin(async move {
         if let (Ok(client_io), Ok(upstream_io)) = tokio::join!(client_on, upstream_on) {
             let mut client = TokioIo::new(client_io);
             let mut upstream = TokioIo::new(upstream_io);
             let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
         }
-    });
+    }));
 
     // Return the upstream's 101 verbatim (Sec-WebSocket-Accept, Upgrade,
     // Connection) so the browser completes the same handshake code-server made.

--- a/crates/loom-forge/src/github.rs
+++ b/crates/loom-forge/src/github.rs
@@ -27,6 +27,7 @@ use crate::{branch as branch_mod, config, events};
 use weaver_core::branch::Branch;
 use weaver_core::github::GithubStatus;
 use weaver_core::tags;
+use weaver_core::BoxFut;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Issue {
@@ -296,7 +297,11 @@ pub async fn sync_status_comment(state: AppState, branch_id: String) {
 /// One sync attempt. `true` means done — synced, or nothing to do (unwired, no
 /// live session, no public base); `false` is a transient GitHub failure worth
 /// retrying.
-async fn sync_status_comment_once(state: &AppState, branch_id: &str) -> bool {
+fn sync_status_comment_once<'a>(state: &'a AppState, branch_id: &'a str) -> BoxFut<'a, bool> {
+    Box::pin(sync_status_comment_once_inner(state, branch_id))
+}
+
+async fn sync_status_comment_once_inner(state: &AppState, branch_id: &str) -> bool {
     let wired = match tags::get(&state.db, branch_id, WIRED_TAG).await {
         Ok(Some(tag)) => tag,
         Ok(None) => return true,

--- a/crates/loom-forge/src/github_app.rs
+++ b/crates/loom-forge/src/github_app.rs
@@ -884,9 +884,9 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             .with_state(state);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             axum::serve(listener, app).await.unwrap();
-        });
+        }));
         format!("http://{addr}")
     }
 

--- a/crates/loom-forge/src/github_manifest.rs
+++ b/crates/loom-forge/src/github_manifest.rs
@@ -229,9 +229,9 @@ pub async fn run_local_server(
             }),
         );
 
-    tokio::spawn(async move {
+    weaver_core::spawn_boxed(Box::pin(async move {
         let _ = axum::serve(listener, app).await;
-    });
+    }));
 
     match tokio::time::timeout(timeout, rx).await {
         Ok(Ok(Ok(code))) => {
@@ -528,9 +528,9 @@ mod tests {
             axum::Router::new().route("/app-manifests/{code}/conversions", post(mock_conversion));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             axum::serve(listener, app).await.unwrap();
-        });
+        }));
         format!("http://{addr}")
     }
 
@@ -556,9 +556,9 @@ mod tests {
         let app = axum::Router::new().route("/app-manifests/{code}/conversions", post(mock_error));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             axum::serve(listener, app).await.unwrap();
-        });
+        }));
         let base = format!("http://{addr}");
         let client = reqwest::Client::new();
         let err = convert_at(&client, &base, "stale").await.unwrap_err();

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use serde_json::json;
 use weaver_api::{HandoffReq, LaunchOverrides, LaunchSelection, ResolvedLaunchView};
 use weaver_core::branch::{self as branch_mod, Branch};
+use weaver_core::BoxFut;
 
 use crate::session::{self as session_mod, Session};
 use crate::{agent, backend, custom_agents, events, runtime, AppState};
@@ -357,7 +358,17 @@ async fn legacy_handoff_plan(
 
 /// Replace the provider behind an idle ACP work session while preserving Loom's
 /// stable session/branch/worktree identity and canonical journal.
-pub async fn handoff_session(
+/// Boxed to keep this state machine's codegen in `loom-launch` — see the note
+/// on [`crate::provision::create`].
+pub fn handoff_session(
+    st: &AppState,
+    initial_session: Session,
+    req: HandoffReq,
+) -> BoxFut<'_, Result<(Session, Branch)>> {
+    Box::pin(handoff_session_inner(st, initial_session, req))
+}
+
+async fn handoff_session_inner(
     st: &AppState,
     initial_session: Session,
     req: HandoffReq,

--- a/crates/loom-launch/src/metadata_assist.rs
+++ b/crates/loom-launch/src/metadata_assist.rs
@@ -481,7 +481,7 @@ pub async fn spawn_title_generation(
     };
     mark_title_status(&db, &session.id, "running").await?;
 
-    tokio::spawn(async move {
+    weaver_core::spawn_boxed(Box::pin(async move {
         let _claim = claim;
         let status = match generate_title(&db, &acp, &session, &branch, &fence).await {
             Ok(status) => status,
@@ -506,7 +506,7 @@ pub async fn spawn_title_generation(
                 "title_generation": status,
             }),
         );
-    });
+    }));
     Ok(())
 }
 
@@ -947,12 +947,12 @@ pub async fn ensure_cue(
     let acp = acp.clone();
     let session = session.clone();
     let branch = branch.clone();
-    tokio::spawn(async move {
+    weaver_core::spawn_boxed(Box::pin(async move {
         let _claim = claim;
         if let Err(error) = generate_cue(&db, &acp, &session, &branch, force).await {
             tracing::warn!(session = %session.id, %error, "resumption cue generation failed");
         }
-    });
+    }));
     Ok(generating)
 }
 

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -8,6 +8,7 @@ use weaver_api::{CreateReq, LaunchOverrides, LaunchSelection, ResolvedLaunchView
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::{Branch, TitleProvenance};
 use weaver_core::tags;
+use weaver_core::BoxFut;
 
 use crate::auth::{Grant, Principal};
 use crate::runtime::{apply_user_github_token, layer_launch_environment, set_env};
@@ -429,7 +430,16 @@ fn create_selection(req: &CreateReq) -> Result<LaunchSelection> {
     Ok(selection.clone())
 }
 
-pub async fn create(st: AppState, req: CreateReq, actor: Actor) -> Result<Provisioned> {
+/// Boxed so this future's state machine is codegen'd here, in `loom-launch`,
+/// rather than re-instantiated in whichever crate ends up polling it. An
+/// `async fn` body is emitted where it is awaited, and every caller of this one
+/// is itself an `async fn`, so the whole chain otherwise bubbles up into the
+/// root `loom` crate — 62k lines of LLVM IR on every `loom` rebuild.
+pub fn create(st: AppState, req: CreateReq, actor: Actor) -> BoxFut<'static, Result<Provisioned>> {
+    Box::pin(create_inner(st, req, actor))
+}
+
+async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Provisioned> {
     let created_by = actor.display_creator();
     let origin = actor.origin();
     tracing::info!(

--- a/crates/loom-store/src/status.rs
+++ b/crates/loom-store/src/status.rs
@@ -15,6 +15,7 @@ use crate::events;
 use crate::events::EventBus;
 use crate::session::{self as session_mod, Session};
 use weaver_core::tags;
+use weaver_core::BoxFut;
 
 /// The tag mutations a work-cycle hook implies: `(key, value)` where an empty
 /// value clears the tag (absence is the calm/default state). `working` returns
@@ -34,7 +35,16 @@ pub fn lifecycle_mutations(kind: &str) -> Option<&'static [(&'static str, &'stat
 /// and its branch: lift the status to `running` (idempotent, never overriding a
 /// terminal state) and apply the tag mutations, recording only what actually
 /// changed. Returns the new event watermark.
-pub async fn promote_lifecycle(
+pub fn promote_lifecycle<'a>(
+    db: &'a Db,
+    bus: &'a EventBus,
+    session: &'a Session,
+    kind: &'a str,
+) -> BoxFut<'a, Option<i64>> {
+    Box::pin(promote_lifecycle_inner(db, bus, session, kind))
+}
+
+async fn promote_lifecycle_inner(
     db: &Db,
     bus: &EventBus,
     session: &Session,

--- a/crates/loom-watch/src/monitor.rs
+++ b/crates/loom-watch/src/monitor.rs
@@ -18,6 +18,7 @@ use crate::AppState;
 use crate::{backend, events};
 use weaver_core::branch as branch_mod;
 use weaver_core::config as core_config;
+use weaver_core::BoxFut;
 
 const TICK: Duration = Duration::from_millis(1500);
 
@@ -30,7 +31,11 @@ const REAP_EVERY_TICKS: u32 = 60;
 /// reaped — even when its tracking issue has closed.
 const REAP_GRACE_SECS: i64 = 900;
 
-pub async fn run(state: AppState) {
+pub fn run(state: AppState) -> BoxFut<'static, ()> {
+    Box::pin(run_inner(state))
+}
+
+async fn run_inner(state: AppState) {
     let mut screen_hash: HashMap<String, u64> = HashMap::new();
     // The session ids the monitor has already announced `stale` for, so a
     // session that stays quiet is announced once (edge-detected), not every

--- a/crates/loom-watch/src/watch.rs
+++ b/crates/loom-watch/src/watch.rs
@@ -97,9 +97,9 @@ impl Drop for InFlightGuard {
         // Drop runs in a sync context; spawn the async removal. The set is only
         // read at the top of `fire`, so a brief delay before the id clears is
         // harmless (it just keeps a finished round "in flight" for an instant).
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             set.lock().await.remove(&id);
-        });
+        }));
     }
 }
 

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -482,24 +482,27 @@ pub async fn serve(state: AppState, listener: TcpListener) -> Result<()> {
         Ok(_) => tracing::debug!("machine-local token ready"),
         Err(e) => tracing::warn!("could not prepare the machine-local token: {e}"),
     }
-    tokio::spawn(monitor::run(state.clone()));
-    tokio::spawn(repair_acp_sessions_loop(state.clone()));
-    tokio::spawn(session_manager::run(state.db.clone(), state.acp.clone()));
-    tokio::spawn(crate::review_delivery::run(state.clone()));
+    weaver_core::spawn_boxed(Box::pin(monitor::run(state.clone())));
+    weaver_core::spawn_boxed(Box::pin(repair_acp_sessions_loop(state.clone())));
+    weaver_core::spawn_boxed(Box::pin(session_manager::run(
+        state.db.clone(),
+        state.acp.clone(),
+    )));
+    weaver_core::spawn_boxed(Box::pin(crate::review_delivery::run(state.clone())));
     // The GitHub poller is always spawned; it self-gates on the `github.poll`
     // setting and on `gh` being available, so it idles cheaply when GitHub
     // integration is off or unavailable.
-    tokio::spawn(github::poll(state.clone()));
+    weaver_core::spawn_boxed(Box::pin(github::poll(state.clone())));
     // The Watch engine (timer + dispatcher). Always spawned; it self-gates
     // on the `watch.enabled` master switch, which is on by default, so a
     // default loom runs it. Turning the switch off idles it cheaply.
-    tokio::spawn(watch::run(state.clone()));
+    weaver_core::spawn_boxed(Box::pin(watch::run(state.clone())));
     // Retire embedded code-server instances that have gone idle.
-    tokio::spawn(crate::ide::reap_loop(state.editor_state()));
+    weaver_core::spawn_boxed(Box::pin(crate::ide::reap_loop(state.editor_state())));
     // The Slack Socket Mode client. Always spawned; it self-gates on token
     // presence and the `slack.enabled` switch, so an unconfigured loom idles
     // here cheaply.
-    tokio::spawn(crate::slack::run(state.clone()));
+    weaver_core::spawn_boxed(Box::pin(crate::slack::run(state.clone())));
     tracing::debug!(
         "background tasks spawned (monitor, ACP repair, session reconciler, review delivery, github poll, watch, ide reaper, slack)"
     );

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -193,7 +193,7 @@ pub(super) async fn github_webhook(
             "github-unauthorized",
             &format!("{slug_str}#{number} (@{author})"),
         );
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             let body = format!(
                 "Hi @{author} — thanks for the ping. You're not on this loom instance's \
                  access list yet, so I can't pick this up. Ask an operator to grant you \
@@ -215,7 +215,7 @@ pub(super) async fn github_webhook(
                     );
                 }
             }
-        });
+        }));
         return ok();
     }
 
@@ -238,7 +238,7 @@ pub(super) async fn github_webhook(
         "github-trigger",
         &format!("{}#{number} (@{author})", slug.slug()),
     );
-    tokio::spawn(async move {
+    weaver_core::spawn_boxed(Box::pin(async move {
         match handle_trigger(st, headers, slug, event, author, phrase).await {
             Ok(Some(id)) => {
                 crate::tasks::registry().finish(task_id, "done", &format!("session {id}"))
@@ -248,7 +248,7 @@ pub(super) async fn github_webhook(
             }
             Err(e) => crate::tasks::registry().finish(task_id, "error", &e),
         }
-    });
+    }));
     ok()
 }
 
@@ -540,10 +540,10 @@ async fn handle_trigger(
             // the new card doesn't sit bare until the next status write. A
             // fresh launch has no trail yet — the reply already is the card.
             if already_wired {
-                tokio::spawn(crate::github::sync_status_comment(
+                weaver_core::spawn_boxed(Box::pin(crate::github::sync_status_comment(
                     st.clone(),
                     created.branch.id.clone(),
-                ));
+                )));
             }
         }
         Err(e) => {

--- a/crates/tapestry/src/bin/tapestry.rs
+++ b/crates/tapestry/src/bin/tapestry.rs
@@ -46,7 +46,7 @@ usage:
 #[cfg(target_os = "linux")]
 fn reap_orphans() {
     use tokio::signal::unix::{signal, SignalKind};
-    tokio::spawn(async {
+    weaver_core::spawn_boxed(Box::pin(async {
         let Ok(mut sigchld) = signal(SignalKind::child()) else {
             tracing::warn!("cannot watch SIGCHLD; orphaned children may linger as zombies");
             return;
@@ -64,7 +64,7 @@ fn reap_orphans() {
                 }
             }
         }
-    });
+    }));
 }
 
 #[tokio::main]

--- a/crates/tapestry/src/client.rs
+++ b/crates/tapestry/src/client.rs
@@ -116,7 +116,7 @@ impl Client {
         // `send().await` back-pressures the socket (and thus the supervisor) when
         // the consumer is slow, mirroring the attach path.
         let (ev_tx, ev_rx) = mpsc::channel::<RelayEvent>(ATTACH_BUFFER);
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             let mut rd = rd;
             loop {
                 match protocol::read_frame(&mut rd).await {
@@ -143,7 +143,7 @@ impl Client {
                     Ok(None) | Err(_) => break,
                 }
             }
-        });
+        }));
 
         Ok(RelayStream { wr, ev_rx })
     }
@@ -163,7 +163,7 @@ impl Client {
         // per-subscriber channel then fills and evicts only a genuinely wedged
         // client).
         let (out_tx, out_rx) = mpsc::channel::<Vec<u8>>(ATTACH_BUFFER);
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             let mut rd = rd;
             loop {
                 match protocol::read_frame(&mut rd).await {
@@ -176,7 +176,7 @@ impl Client {
                     Ok(None) | Err(_) => break,
                 }
             }
-        });
+        }));
 
         Ok(Attach { wr, out_rx })
     }

--- a/crates/tapestry/src/supervisor.rs
+++ b/crates/tapestry/src/supervisor.rs
@@ -229,16 +229,16 @@ async fn run_pty(cfg: SupervisorConfig) -> Result<()> {
         .with_context(|| format!("binding control socket {}", socket.display()))?;
     {
         let cmd_tx = cmd_tx.clone();
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             loop {
                 match listener.accept().await {
                     Ok((stream, _)) => {
                         let cmd_tx = cmd_tx.clone();
-                        tokio::spawn(async move {
+                        weaver_core::spawn_boxed(Box::pin(async move {
                             if let Err(e) = handle_conn(stream, cmd_tx).await {
                                 tracing::debug!(error = %e, "control connection ended");
                             }
-                        });
+                        }));
                     }
                     Err(e) => {
                         tracing::debug!(error = %e, "accept failed");
@@ -246,20 +246,20 @@ async fn run_pty(cfg: SupervisorConfig) -> Result<()> {
                     }
                 }
             }
-        });
+        }));
     }
 
     // Best-effort: a termination signal kills the child and tears down cleanly.
     {
         let cmd_tx = cmd_tx.clone();
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             if let Ok(mut sig) =
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
             {
                 sig.recv().await;
                 let _ = cmd_tx.send(Cmd::Kill);
             }
-        });
+        }));
     }
 
     // --- core task ---------------------------------------------------------
@@ -775,16 +775,16 @@ mod relay {
             .with_context(|| format!("binding control socket {}", socket.display()))?;
         {
             let cmd_tx = cmd_tx.clone();
-            tokio::spawn(async move {
+            weaver_core::spawn_boxed(Box::pin(async move {
                 loop {
                     match listener.accept().await {
                         Ok((stream, _)) => {
                             let cmd_tx = cmd_tx.clone();
-                            tokio::spawn(async move {
+                            weaver_core::spawn_boxed(Box::pin(async move {
                                 if let Err(e) = handle_conn(stream, cmd_tx).await {
                                     tracing::debug!(error = %e, "relay control connection ended");
                                 }
-                            });
+                            }));
                         }
                         Err(e) => {
                             tracing::debug!(error = %e, "relay accept failed");
@@ -792,20 +792,20 @@ mod relay {
                         }
                     }
                 }
-            });
+            }));
         }
 
         // SIGTERM tears down (kills the child) like the PTY path.
         {
             let cmd_tx = cmd_tx.clone();
-            tokio::spawn(async move {
+            weaver_core::spawn_boxed(Box::pin(async move {
                 if let Ok(mut sig) =
                     tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                 {
                     sig.recv().await;
                     let _ = cmd_tx.send(Cmd::Kill);
                 }
-            });
+            }));
         }
 
         // --- core task ----------------------------------------------------
@@ -1029,7 +1029,7 @@ mod relay {
         out_tx: mpsc::Sender<Out>,
         cmd_tx: mpsc::UnboundedSender<Cmd>,
     ) -> tokio::task::JoinHandle<()> {
-        tokio::spawn(async move {
+        weaver_core::spawn_boxed(Box::pin(async move {
             let mut delivered = true;
             'replay: for path in paths {
                 for (seq, body) in read_records(&path) {
@@ -1047,7 +1047,7 @@ mod relay {
                 through,
                 delivered,
             });
-        })
+        }))
     }
 
     /// Once the child has exited *and* its stdout has drained (`!frame_open`),

--- a/crates/weaver-core/src/lib.rs
+++ b/crates/weaver-core/src/lib.rs
@@ -20,3 +20,24 @@ pub mod transcript;
 pub mod watch;
 
 pub use db::Db;
+
+/// A heap-allocated, type-erased future.
+///
+/// An `async fn`'s state machine is codegen'd wherever it is awaited, so a
+/// large one awaited from another crate lands in *that* crate's compile unit,
+/// and transitively in whichever crate finally polls the chain. Returning this
+/// instead pins the state machine to the crate that defines it: callers see a
+/// vtable, not a generic instantiation. Worth it only for the big ones — the
+/// eight largest in this workspace were 6% of `loom`'s LLVM IR and 18% of its
+/// rebuild time.
+pub type BoxFut<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// Spawn a type-erased task.
+///
+/// `tokio::spawn` is generic over the future, so every distinct future spawned
+/// stamps out its own copy of the task harness — poll, drop, join handle, and
+/// the panic-catch wrapper, ~680 lines of LLVM IR per call site. Erasing the
+/// type first collapses all of them onto one instantiation.
+pub fn spawn_boxed(fut: BoxFut<'static, ()>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(fut)
+}


### PR DESCRIPTION
Release rebuilds were spending minutes on what looked like a link step. It wasn't linking — linking is 0.43s. LTO was already off. The time was LLVM optimizing 6.16M lines of IR (492 MB) generated from 19k lines of source, and 88% of the compile was the optimizer: `opt-level=0` costs 33s CPU on the `loom` crate where `opt-level=3` costs 268s.

## Where the IR came from

An `async fn` body is codegen'd where it is **awaited**, not where it is defined, and release builds disable `share-generics` so it can't be reused from the defining crate. Every caller of the big ones was itself an `async fn`, so entire await chains bubbled up into the root crate: **24% of `loom`'s IR was code defined in sibling crates**. The single worst offender, `loom_launch::provision::create` (a 900-line `async fn`), contributed 61,765 lines of IR plus 4,808 lines of drop glue — recompiled on every `loom` edit, from a file in a different crate.

The other systematic source was `tokio::spawn`, generic over the future type, stamping out a fresh task harness — poll, drop, join handle, panic-catch — at every call site: 210,607 lines across 164 instantiations.

## Changes

- **`weaver_core::BoxFut<'a, T>`** — alias for `Pin<Box<dyn Future<Output = T> + Send + 'a>>`.
- **Eight largest cross-crate async fns boxed** — `provision::create`, `handoff::handoff_session`, `agent::run_oneshot_with`, `slack::launch`, `slack::sync_status_message_once`, `github::sync_status_comment_once`, `status::promote_lifecycle`, `monitor::run`. Each keeps its state machine in the crate that owns it; callers see a vtable. Bodies are unchanged — the wrapper delegates to an `_inner` async fn.
- **`weaver_core::spawn_boxed`** — 40 `tokio::spawn` sites type-erased onto one harness instantiation. Four sites in test code spawn futures that yield values and keep plain `tokio::spawn`.
- **`opt-level = "z"` for workspace crates**, dependencies stay at `3` via `package."*"`. Workspace code is I/O-bound orchestration (git subprocesses, sqlite, HTTP); the deps hold the hot paths. Because dependency settings are unchanged, their cached artifacts stay valid.
- **sccache dropped** — the `.cargo/config.toml` wrapper and its README step (this was already staged locally; the following README steps are renumbered).

## Measurements

`touch crates/loom/src/lib.rs && cargo build --release --bin loom`:

| | before | after |
|---|---|---|
| wall | 77.4 s | **49.0 s** (−37%) |
| CPU | 428 s | **160 s** (−63%) |
| binary `.text` | 40,620,832 | **27,754,600** (−32%) |
| binary on disk | 213.7 MB | **143.0 MB** |

Contributions in isolation, on the `loom` lib unit: boxing the eight async fns took it 46.5s → 39.0s; `spawn_boxed` took ~43s of CPU off the full rebuild at flat wall; `opt-level = "z"` is −17% wall / −29% CPU / −21% machine code against `3`.

Note the shape of that last one — IR fell only 2.9% when `provision::create` was boxed but time fell 12%, because LLVM's optimizer is superlinear in function size. Giant async fns are disproportionately expensive, not proportionally.

## Testing

`cargo test --workspace` — **837 passed, 0 failed**. `cargo clippy` and `cargo fmt --all --check` clean via the pre-commit hook. Binary smoke-tested (`loom --version`, `--help`).

The three `loom` integration targets fail locally unless the `tapestry` binary is present in the cargo build-dir; with it in place all 173 of those tests pass.

## Follow-ups not in this PR

- ~15 more boxing candidates in sibling crates, 6–9k lines of IR each (`loom-forge/lifecycle.rs`, `loom-agent/acp/mod.rs` and `loom-watch/watch.rs` each have a cluster of three).
- `serde_path_to_error` runs a second parallel deserializer instantiation for every type — 205k lines of IR (~5%) to buy field paths in error text. Worth scoping to the endpoints whose errors humans read.
- axum's handler machinery is 253k lines (5.9%) across ~200 routes, at ~1.1k lines per route. That's the price of typed handlers and probably not worth changing.
