### PR TITLE
feat(loom): add creator filters and session retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,11 +268,12 @@ The optional `mcp/history/self@v1` capability is a thin self-only facade over
 those routes. See [Session history and search](docs/session-history.md) for the
 record, cursor, source, and authorization contract.
 
-Once a branch's PR merges, loom archives the session automatically — tearing
-down its terminal and worktree while keeping the branch and its weaver history,
-the same as the Archive button. To keep one session until you archive it
-yourself, choose **Disable auto-archive** from that session's **Details** popover, or
-set its quiet opt-out label:
+Ordinary sessions are archived after ten days without activity by default, and
+a merged PR is archived immediately — both tear down the terminal and worktree
+while keeping the branch and its weaver history, the same as the Archive button.
+Profiles can override the idle interval (an explicit `0` disables that TTL). To
+keep one session until you archive it yourself, choose **Disable auto-archive**
+from that session's **Details** popover, or set its quiet opt-out label:
 
 ```sh
 weaver tag set auto-archive disabled

--- a/crates/loom-core/src/launch.rs
+++ b/crates/loom-core/src/launch.rs
@@ -162,7 +162,10 @@ fn normalized_selection(selection: &LaunchSelection) -> LaunchSelection {
 
 async fn policy_defaults(db: &Db, class: &str) -> (i64, i64) {
     if class != "automation" {
-        return (0, 0);
+        return (
+            weaver_core::config::DEFAULT_INTERACTIVE_IDLE_ARCHIVE_SECS,
+            0,
+        );
     }
     let idle = weaver_core::config::get(db, "automation.idle_archive_secs")
         .await
@@ -540,6 +543,11 @@ mod tests {
         assert_eq!(resolved.view.provenance.model, "agent_default");
         assert_eq!(resolved.view.provenance.effort, "agent_default");
         assert_eq!(resolved.view.provenance.protocol, "agent_default");
+        assert_eq!(
+            resolved.view.policy.idle_archive_secs,
+            Some(weaver_core::config::DEFAULT_INTERACTIVE_IDLE_ARCHIVE_SECS)
+        );
+        assert_eq!(resolved.view.provenance.idle_archive_secs, "policy_default");
     }
 
     #[tokio::test]

--- a/crates/loom-store/migrations/0021_later_space_retention.sql
+++ b/crates/loom-store/migrations/0021_later_space_retention.sql
@@ -1,0 +1,97 @@
+-- Later is a destination, not a queue operators need to scan inside every
+-- provenance space. Consolidate the legacy per-space Later groups into one
+-- top-level space and keep the compatibility `park` projection through the
+-- destination group's system key.
+UPDATE session_spaces
+SET rank = rank + 1,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now');
+
+INSERT OR IGNORE INTO session_spaces
+    (id, name, rank, system_key, created_at, updated_at)
+VALUES
+    ('space-later', 'Later', 0, 'later',
+     strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+     strftime('%Y-%m-%dT%H:%M:%fZ','now'));
+
+-- Adopt an operator-created Later space when one predates this migration.
+UPDATE session_spaces
+SET rank = 0,
+    system_key = 'later',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+WHERE name = 'Later' COLLATE NOCASE
+  AND (system_key IS NULL OR system_key = 'later');
+
+INSERT OR IGNORE INTO session_groups
+    (id, space_id, name, rank, system_key, created_at, updated_at)
+SELECT
+    'group-later-inbox', id, 'Inbox', 0, 'later',
+    strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+    strftime('%Y-%m-%dT%H:%M:%fZ','now')
+FROM session_spaces
+WHERE system_key = 'later';
+
+-- Likewise, keep an existing Inbox and make it the compatibility Later group.
+UPDATE session_groups
+SET rank = 0,
+    system_key = 'later',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+WHERE space_id = (SELECT id FROM session_spaces WHERE system_key = 'later')
+  AND name = 'Inbox' COLLATE NOCASE
+  AND (system_key IS NULL OR system_key = 'later');
+
+-- Merge each old Later queue in stable space/group/session order. Placements
+-- already in an adopted Later/Inbox participate in the same ordering.
+WITH ordered AS (
+    SELECT
+        placement.session_id,
+        ROW_NUMBER() OVER (
+            ORDER BY space.rank, group_row.rank, placement.rank, placement.session_id
+        ) - 1 AS new_rank
+    FROM session_placements placement
+    JOIN session_groups group_row ON group_row.id = placement.group_id
+    JOIN session_spaces space ON space.id = group_row.space_id
+    WHERE group_row.system_key = 'later'
+)
+UPDATE session_placements
+SET group_id = (
+        SELECT id
+        FROM session_groups
+        WHERE space_id = (SELECT id FROM session_spaces WHERE system_key = 'later')
+          AND system_key = 'later'
+    ),
+    rank = (SELECT new_rank FROM ordered WHERE ordered.session_id = session_placements.session_id),
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+WHERE session_id IN (SELECT session_id FROM ordered);
+
+UPDATE session_placement_defaults
+SET group_id = (
+    SELECT id
+    FROM session_groups
+    WHERE space_id = (SELECT id FROM session_spaces WHERE system_key = 'later')
+      AND system_key = 'later'
+)
+WHERE group_id IN (
+    SELECT id
+    FROM session_groups
+    WHERE system_key = 'later'
+      AND space_id != (SELECT id FROM session_spaces WHERE system_key = 'later')
+);
+
+DELETE FROM session_groups
+WHERE system_key = 'later'
+  AND space_id != (SELECT id FROM session_spaces WHERE system_key = 'later');
+
+-- Existing interactive sessions whose profile inherited the old disabled
+-- default should inherit the new ten-day default too. An explicit profile 0
+-- remains an opt-out, as does the per-session `auto-archive: disabled` tag.
+UPDATE sessions
+SET policy_idle_archive_secs = 864000
+WHERE class != 'automation'
+  AND COALESCE(policy_idle_archive_secs, 0) = 0
+  AND (
+      SELECT idle_archive_secs
+      FROM profiles
+      WHERE profiles.name = sessions.profile
+  ) IS NULL;
+
+UPDATE session_layout_state SET revision = revision + 1 WHERE id = 1;

--- a/crates/loom-store/src/db.rs
+++ b/crates/loom-store/src/db.rs
@@ -110,6 +110,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "slack-alert-routes",
         include_str!("../migrations/0020_slack_alert_routes.sql"),
     ),
+    (
+        21,
+        "later-space-retention",
+        include_str!("../migrations/0021_later_space_retention.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -381,8 +386,8 @@ mod tests {
                 .fetch_one(&db)
                 .await
                 .unwrap();
-        assert_eq!(spaces, 4);
-        assert_eq!(revision, 1);
+        assert_eq!(spaces, 5);
+        assert_eq!(revision, 2);
 
         let columns = table_columns(&db, "sessions").await.unwrap();
         for expected in [
@@ -739,13 +744,13 @@ mod tests {
         LOOM_STREAM.apply_pending(&db).await.unwrap();
 
         for (session, expected) in [
-            ("user", "group-user-later"),
-            ("github", "group-github-later"),
-            ("ops", "group-ops-later"),
+            ("user", "group-later-inbox"),
+            ("github", "group-later-inbox"),
+            ("ops", "group-later-inbox"),
             ("slack", "group-slack-inbox"),
             ("parent", "group-github-inbox"),
             ("child", "group-github-inbox"),
-            ("parked-child", "group-github-later"),
+            ("parked-child", "group-later-inbox"),
         ] {
             let group: String =
                 sqlx::query_scalar("SELECT group_id FROM session_placements WHERE session_id = ?")
@@ -770,12 +775,26 @@ mod tests {
         assert_eq!(inbox_order, ["newest", "manual", "oldest"]);
         let later_order: Vec<String> = sqlx::query_scalar(
             "SELECT session_id FROM session_placements
-             WHERE group_id = 'group-user-later' ORDER BY rank",
+             WHERE group_id = 'group-later-inbox' ORDER BY rank",
         )
         .fetch_all(&db)
         .await
         .unwrap();
-        assert_eq!(later_order, ["parked-recent", "user"]);
+        // Consolidation keeps the legacy space/group/session ordering stable
+        // as the per-origin Later queues become one destination.
+        assert_eq!(
+            later_order,
+            ["parked-recent", "user", "parked-child", "github", "ops"]
+        );
+        let inherited_idle_archive: i64 =
+            sqlx::query_scalar("SELECT policy_idle_archive_secs FROM sessions WHERE id = 'user'")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(
+            inherited_idle_archive,
+            weaver_core::config::DEFAULT_INTERACTIVE_IDLE_ARCHIVE_SECS
+        );
         let defaults: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM session_placement_defaults")
             .fetch_one(&db)
             .await
@@ -786,7 +805,7 @@ mod tests {
                 .fetch_one(&db)
                 .await
                 .unwrap();
-        assert_eq!(revision, 1);
+        assert_eq!(revision, 2);
         let versions: Vec<i64> =
             sqlx::query_scalar("SELECT version FROM loom_schema_migrations ORDER BY version")
                 .fetch_all(&db)

--- a/crates/loom-store/src/session_layout.rs
+++ b/crates/loom-store/src/session_layout.rs
@@ -1086,6 +1086,7 @@ mod tests {
         seed_placement(&db, "a", "group-user-inbox", 0).await;
         seed_placement(&db, "b", "group-user-inbox", 1).await;
         seed_placement(&db, "c", "group-github-inbox", 0).await;
+        let initial_revision = get_layout(&db, "operator").await.unwrap().revision;
 
         let moved = move_sessions(
             &db,
@@ -1094,12 +1095,12 @@ mod tests {
                 session_ids: vec!["b".to_string(), "a".to_string()],
                 destination_group_id: "group-github-inbox".to_string(),
                 before_session_id: Some("c".to_string()),
-                expected_revision: 1,
+                expected_revision: initial_revision,
             },
         )
         .await
         .unwrap();
-        assert_eq!(moved.revision, 2);
+        assert_eq!(moved.revision, initial_revision + 1);
         assert_eq!(order(&moved, "group-github-inbox"), ["b", "a", "c"]);
         assert!(matches!(
             move_sessions(
@@ -1109,7 +1110,7 @@ mod tests {
                     session_ids: vec!["a".to_string()],
                     destination_group_id: "group-user-inbox".to_string(),
                     before_session_id: None,
-                    expected_revision: 1,
+                    expected_revision: initial_revision,
                 },
             )
             .await,
@@ -1136,14 +1137,14 @@ mod tests {
                     session_ids: vec!["c".to_string()],
                 },
             ],
-            expected_revision: 2,
+            expected_revision: moved.revision,
         };
         assert!(matches!(
             restore_groups(&db, "operator", &restore).await,
             Err(MutationError::Internal(_))
         ));
         let unchanged = get_layout(&db, "operator").await.unwrap();
-        assert_eq!(unchanged.revision, 2);
+        assert_eq!(unchanged.revision, moved.revision);
         assert_eq!(order(&unchanged, "group-github-inbox"), ["b", "a", "c"]);
 
         sqlx::query("DROP TRIGGER fail_second_restore")
@@ -1151,7 +1152,7 @@ mod tests {
             .await
             .unwrap();
         let restored = restore_groups(&db, "operator", &restore).await.unwrap();
-        assert_eq!(restored.revision, 3);
+        assert_eq!(restored.revision, moved.revision + 1);
         assert_eq!(order(&restored, "group-user-inbox"), ["a", "b"]);
         assert_eq!(order(&restored, "group-github-inbox"), ["c"]);
     }
@@ -1159,13 +1160,14 @@ mod tests {
     #[tokio::test]
     async fn cross_space_group_moves_preflight_both_collision_kinds() {
         let db = crate::db::connect_in_memory().await.unwrap();
+        let initial_revision = get_layout(&db, "operator").await.unwrap().revision;
         let user_review = create_group(
             &db,
             "operator",
             &CreateSessionGroupReq {
                 space_id: "space-user".to_string(),
                 name: "Review".to_string(),
-                expected_revision: 1,
+                expected_revision: initial_revision,
             },
         )
         .await

--- a/crates/loom-watch/src/monitor.rs
+++ b/crates/loom-watch/src/monitor.rs
@@ -190,8 +190,8 @@ async fn run_inner(state: AppState) {
         screen_hash.retain(|k, _| alive.contains(k));
         stale_seen.retain(|k| alive.contains(k));
 
-        // 3. Retention: reap finished / long-idle automation sessions and
-        //    inactive Slack conversations, on a slower cadence than the tick.
+        // 3. Retention: reap long-idle ordinary sessions, automation work, and
+        //    Slack conversations on a slower cadence than the tick.
         reap_tick += 1;
         if reap_tick >= REAP_EVERY_TICKS {
             reap_tick = 0;
@@ -213,13 +213,13 @@ pub enum ReapReason {
     IdleTtl,
 }
 
-/// Whether the reaper may consider `session` at all: automation-class or
-/// Slack-origin, not a warm (watch-managed) session — those are exempt
-/// infrastructure — and in a non-terminal status.
+/// Whether the reaper may consider `session` at all. Warm (watch-managed)
+/// sessions are exempt infrastructure and archived rows are already gone from
+/// the active fleet; every other stable session may carry an idle TTL.
 fn reap_candidate(session: &Session) -> bool {
-    (session.class == "automation" || session.origin == "slack")
-        && session.managed_by.is_none()
-        && matches!(session.status.as_str(), "created" | "running" | "orphaned")
+    session.managed_by.is_none()
+        && session.status != "archived"
+        && session.lifecycle_transition.is_none()
 }
 
 fn retention_issue_id(session: &Session) -> Option<i64> {
@@ -613,17 +613,27 @@ mod tests {
         inflight.acp_inflight = Some("{}".to_string());
         assert_eq!(reap_decision(&inflight, true, ttl, now), None);
 
-        // Not a candidate: an ordinary interactive session, warm
-        // (watch-managed), or already in a terminal status.
+        // Ordinary interactive sessions use the same TTL path. A closed issue
+        // is never passed for them by `reap_sessions`, but their age alone is
+        // enough once their resolved policy has the ten-day default.
         let mut interactive = idle.clone();
         interactive.class = "interactive".to_string();
-        assert_eq!(reap_decision(&interactive, true, ttl, now), None);
+        assert_eq!(
+            reap_decision(&interactive, false, ttl, now),
+            Some(ReapReason::IdleTtl)
+        );
+
+        // Not a candidate: warm (watch-managed), already archived, or in the
+        // middle of another lifecycle transition.
         let mut warm = idle.clone();
         warm.managed_by = Some("w1".to_string());
         assert_eq!(reap_decision(&warm, true, ttl, now), None);
         let mut archived = idle.clone();
         archived.status = "archived".to_string();
         assert_eq!(reap_decision(&archived, true, ttl, now), None);
+        let mut transitioning = idle.clone();
+        transitioning.lifecycle_transition = Some("archiving".to_string());
+        assert_eq!(reap_decision(&transitioning, true, ttl, now), None);
     }
 
     #[test]

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -95,6 +95,7 @@ export const listSessionSummaries = (
     query?: string;
     status?: SessionSearchOptions['status'];
     attention?: SessionSearchOptions['attention'];
+    creator?: SessionSearchOptions['creator'];
   } = {},
   signal?: AbortSignal,
 ) => {
@@ -105,6 +106,7 @@ export const listSessionSummaries = (
   if (opts.query) params.set('q', opts.query);
   if (opts.status) params.set('status', opts.status);
   if (opts.attention) params.set('attention', opts.attention);
+  if (opts.creator) params.set('creator', opts.creator);
   const qs = params.toString();
   return request(`/sessions/summary${qs ? `?${qs}` : ''}`, { signal }) as Promise<SessionSummary[]>;
 };

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -322,11 +322,13 @@ export interface SessionGroupOrder {
 export type SessionSearchStatus =
   'created' | 'running' | 'orphaned' | 'done' | 'error' | 'archived';
 export type SessionSearchAttention = 'needs' | 'ok' | 'attention' | 'blocked';
+export type SessionCreatorFilter = 'mine' | 'ops' | 'mine-and-ops' | 'other-users';
 export interface SessionSearchOptions {
   history?: boolean;
   archivedOnly?: boolean;
   status?: SessionSearchStatus;
   attention?: SessionSearchAttention;
+  creator?: SessionCreatorFilter;
 }
 
 export type AutomationRunStatus =

--- a/crates/loom/frontend/src/views/SessionList.vue
+++ b/crates/loom/frontend/src/views/SessionList.vue
@@ -2,13 +2,16 @@
 import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import type {
+  AutomationRun,
   Session,
+  SessionCreatorFilter,
   SessionGroup,
   SessionSearchAttention,
   SessionSearchStatus,
   SessionSummary,
   SessionSpace,
 } from '../types';
+import { me } from '../auth';
 import AutomationRunRow from '../components/AutomationRunRow.vue';
 import ConfirmDialog from '../components/ConfirmDialog.vue';
 import SessionMailboxPreview from '../components/SessionMailboxPreview.vue';
@@ -55,10 +58,6 @@ const liveSessions = computed(() =>
 const historySessions = computed(() =>
   sessions.value.filter((session) => session.status === 'archived'),
 );
-const attentionSessions = computed(() =>
-  liveSessions.value.filter((session) => effectiveAttention(session).level !== 'ok'),
-);
-
 const view = computed<WorkbenchView>(() => {
   if (route.query.history === 'true') return 'history';
   if (route.query.view === 'attention') return 'attention';
@@ -106,30 +105,38 @@ const SEARCH_STATUSES = new Set<SessionSearchStatus>([
   'archived',
 ]);
 const SEARCH_ATTENTION = new Set<SessionSearchAttention>(['needs', 'ok', 'attention', 'blocked']);
+function enumFromQuery<T extends string>(value: unknown, allowed: Set<T>): T | undefined {
+  return typeof value === 'string' && allowed.has(value as T) ? (value as T) : undefined;
+}
 function statusFromQuery(value: unknown): SessionSearchStatus | '' {
-  return typeof value === 'string' && SEARCH_STATUSES.has(value as SessionSearchStatus)
-    ? (value as SessionSearchStatus)
-    : '';
+  return enumFromQuery(value, SEARCH_STATUSES) ?? '';
 }
 function attentionFromQuery(value: unknown): SessionSearchAttention | '' {
-  return typeof value === 'string' && SEARCH_ATTENTION.has(value as SessionSearchAttention)
-    ? (value as SessionSearchAttention)
-    : '';
+  return enumFromQuery(value, SEARCH_ATTENTION) ?? '';
 }
 const SESSION_SORTS = new Set<SessionSort>(['manual', 'name', 'activity', 'created']);
+const CREATOR_FILTERS = new Set<SessionCreatorFilter>([
+  'mine',
+  'ops',
+  'mine-and-ops',
+  'other-users',
+]);
 function sortFromQuery(value: unknown): SessionSort {
-  return typeof value === 'string' && SESSION_SORTS.has(value as SessionSort)
-    ? (value as SessionSort)
-    : 'manual';
+  return enumFromQuery(value, SESSION_SORTS) ?? 'manual';
+}
+function creatorFromQuery(value: unknown): SessionCreatorFilter | '' {
+  return enumFromQuery(value, CREATOR_FILTERS) ?? '';
 }
 const statusFilter = ref<SessionSearchStatus | ''>(statusFromQuery(route.query.status));
 const attentionFilter = ref<SessionSearchAttention | ''>(attentionFromQuery(route.query.attention));
+const creatorFilter = ref<SessionCreatorFilter | ''>(creatorFromQuery(route.query.creator));
 const sessionSort = ref<SessionSort>(sortFromQuery(route.query.sort));
 watch(
-  () => [route.query.status, route.query.attention, route.query.sort],
-  ([status, attention, sort]) => {
+  () => [route.query.status, route.query.attention, route.query.creator, route.query.sort],
+  ([status, attention, creator, sort]) => {
     statusFilter.value = statusFromQuery(status);
     attentionFilter.value = attentionFromQuery(attention);
+    creatorFilter.value = creatorFromQuery(creator);
     sessionSort.value = sortFromQuery(sort);
   },
 );
@@ -139,6 +146,7 @@ function updateFilters() {
       ...route.query,
       status: statusFilter.value || undefined,
       attention: attentionFilter.value || undefined,
+      creator: creatorFilter.value || undefined,
     },
   });
 }
@@ -198,6 +206,7 @@ function queueSearch(clearResults: boolean) {
           automation: true,
           status: statusFilter.value || undefined,
           attention: attentionFilter.value || undefined,
+          creator: creatorFilter.value || undefined,
         },
         controller.signal,
       );
@@ -215,7 +224,15 @@ function queueSearch(clearResults: boolean) {
   }, 160);
 }
 watch(
-  [searchText, includeHistory, statusFilter, attentionFilter, () => view.value, () => route.path],
+  [
+    searchText,
+    includeHistory,
+    statusFilter,
+    attentionFilter,
+    creatorFilter,
+    () => view.value,
+    () => route.path,
+  ],
   () => queueSearch(true),
   { flush: 'sync' },
 );
@@ -227,6 +244,7 @@ onActivated(() => {
 });
 
 function matchesFilters(session: SessionSummary): boolean {
+  if (!matchesCreator(session)) return false;
   if (statusFilter.value && session.status !== statusFilter.value) return false;
   const attention = effectiveAttention(session).level;
   if (attentionFilter.value === 'needs' && attention === 'ok') return false;
@@ -236,16 +254,42 @@ function matchesFilters(session: SessionSummary): boolean {
   return true;
 }
 
+const creatorScopedLiveSessions = computed(() => liveSessions.value.filter(matchesCreator));
+const creatorScopedHistorySessions = computed(() => historySessions.value.filter(matchesCreator));
+const creatorScopedAttentionSessions = computed(() =>
+  creatorScopedLiveSessions.value.filter((session) => effectiveAttention(session).level !== 'ok'),
+);
+function matchesCreator(session: SessionSummary): boolean {
+  const mine = session.created_by === me.username;
+  const ops = session.class === 'automation';
+  const otherUser = !!session.created_by && session.created_by !== me.username;
+  return matchesCreatorScope(mine, ops, otherUser);
+}
+function matchesRunCreator(run: AutomationRun): boolean {
+  const mine = run.actor_subject === me.username;
+  const otherUser = !!run.actor_subject && run.actor_subject !== me.username;
+  return matchesCreatorScope(mine, true, otherUser);
+}
+function matchesCreatorScope(mine: boolean, ops: boolean, otherUser: boolean): boolean {
+  if (creatorFilter.value === 'mine') return mine;
+  if (creatorFilter.value === 'ops') return ops;
+  if (creatorFilter.value === 'mine-and-ops') return mine || ops;
+  if (creatorFilter.value === 'other-users') return otherUser && !ops;
+  return true;
+}
+
 const baseSessions = computed(() => {
   if (searchResults.value) {
     const current = new Map(sessions.value.map((session) => [session.id, session]));
     return searchResults.value.map((result) => current.get(result.id) ?? result);
   }
-  if (view.value === 'history') return historySessions.value;
-  if (view.value === 'attention') return attentionSessions.value;
-  if (view.value === 'all') return liveSessions.value;
+  if (view.value === 'history') return creatorScopedHistorySessions.value;
+  if (view.value === 'attention') return creatorScopedAttentionSessions.value;
+  if (view.value === 'all') return creatorScopedLiveSessions.value;
   const spaceId = activeSpace.value?.id;
-  return liveSessions.value.filter((session) => session.placement?.space_id === spaceId);
+  return creatorScopedLiveSessions.value.filter(
+    (session) => session.placement?.space_id === spaceId,
+  );
 });
 const visibleSessions = computed(() => baseSessions.value.filter(matchesFilters));
 const visibleById = computed(
@@ -461,6 +505,9 @@ const provisioningRuns = computed(() =>
 const historicalRuns = computed(() =>
   unmatchedRuns.value.filter((run) => unmatchedRunProjection(run) === 'history'),
 );
+const visibleInterventionRuns = computed(() => interventionRuns.value.filter(matchesRunCreator));
+const visibleProvisioningRuns = computed(() => provisioningRuns.value.filter(matchesRunCreator));
+const visibleHistoricalRuns = computed(() => historicalRuns.value.filter(matchesRunCreator));
 const showInterventions = computed(
   () =>
     view.value === 'attention' ||
@@ -468,8 +515,8 @@ const showInterventions = computed(
 );
 const operationalRuns = computed(() =>
   view.value === 'attention'
-    ? interventionRuns.value
-    : [...interventionRuns.value, ...provisioningRuns.value].sort((left, right) =>
+    ? visibleInterventionRuns.value
+    : [...visibleInterventionRuns.value, ...visibleProvisioningRuns.value].sort((left, right) =>
         right.updated_at.localeCompare(left.updated_at),
       ),
 );
@@ -1138,6 +1185,19 @@ function scrollSpaces(direction: number) {
         <option value="ok">Calm</option>
       </select>
       <select
+        v-model="creatorFilter"
+        aria-label="Filter by creator"
+        data-testid="creator-filter"
+        class="rounded border border-line bg-input px-2 py-1.5 text-xs"
+        @change="updateFilters"
+      >
+        <option value="">Everyone</option>
+        <option value="mine-and-ops">Mine + Ops</option>
+        <option value="mine">Mine</option>
+        <option value="ops">Ops</option>
+        <option value="other-users">Other users</option>
+      </select>
+      <select
         v-model="sessionSort"
         aria-label="Sort sessions"
         data-testid="session-sort"
@@ -1188,7 +1248,7 @@ function scrollSpaces(direction: number) {
         >
           Attention
           <span class="font-mono text-2xs">{{
-            attentionSessions.length + interventionRuns.length
+            creatorScopedAttentionSessions.length + visibleInterventionRuns.length
           }}</span>
         </router-link>
         <router-link
@@ -1206,7 +1266,11 @@ function scrollSpaces(direction: number) {
         >
           {{ space.name }}
           <span class="font-mono text-2xs">
-            {{ liveSessions.filter((session) => session.placement?.space_id === space.id).length }}
+            {{
+              creatorScopedLiveSessions.filter(
+                (session) => session.placement?.space_id === space.id,
+              ).length
+            }}
           </span>
         </router-link>
         <router-link
@@ -1216,7 +1280,7 @@ function scrollSpaces(direction: number) {
           :class="view === 'all' ? 'bg-accent text-accent-fg' : 'text-muted hover:bg-subtle'"
           class="flex shrink-0 items-center gap-1.5 px-2 py-1 text-xs font-medium"
         >
-          All <span class="font-mono text-2xs">{{ liveSessions.length }}</span>
+          All <span class="font-mono text-2xs">{{ creatorScopedLiveSessions.length }}</span>
         </router-link>
         <router-link
           :to="{ path: '/', query: viewQuery('history') }"
@@ -1227,7 +1291,7 @@ function scrollSpaces(direction: number) {
         >
           History
           <span class="font-mono text-2xs">{{
-            historySessions.length + historicalRuns.length
+            creatorScopedHistorySessions.length + visibleHistoricalRuns.length
           }}</span>
         </router-link>
       </nav>
@@ -1610,13 +1674,13 @@ function scrollSpaces(direction: number) {
           </ul>
         </section>
 
-        <section v-if="view === 'history' && historicalRuns.length" class="mt-4">
+        <section v-if="view === 'history' && visibleHistoricalRuns.length" class="mt-4">
           <h2 class="mb-1.5 text-2xs font-semibold uppercase tracking-wider text-muted">
             Automation run history
           </h2>
           <ul data-testid="automation-run-history" class="rounded border border-line bg-surface">
             <AutomationRunRow
-              v-for="run in historicalRuns"
+              v-for="run in visibleHistoricalRuns"
               :key="run.id"
               :run="run"
               projection="history"
@@ -1630,7 +1694,7 @@ function scrollSpaces(direction: number) {
           v-if="
             (view !== 'space' || searchResults !== null) &&
             !smartSessions.length &&
-            !(view === 'history' && historicalRuns.length) &&
+            !(view === 'history' && visibleHistoricalRuns.length) &&
             !(showInterventions && operationalRuns.length)
           "
           class="rounded border border-dashed border-line p-6 text-center"

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -14,7 +14,7 @@ use weaver_api::{
     CreateSessionSpaceReq, DeleteSessionGroupReq, DeleteSessionSpaceReq, IssueAction,
     IssueActionsReq, MoveSessionsReq, ReorderSessionLayoutReq, RestoreSessionGroupsReq,
     ReviewAnchorDto, ReviewAnchorKindDto, ReviewSubjectKindDto, SearchSessionsOptions,
-    SessionGroupPreferenceReq, SessionLayoutItemKind, SessionLayoutView,
+    SessionCreatorFilter, SessionGroupPreferenceReq, SessionLayoutItemKind, SessionLayoutView,
     SessionPlacementSelectorKind, SessionSearchAttention, SessionSearchStatus,
     SetSessionPlacementDefaultReq, SubmitReviewReq, UpdateReviewCommentReq, UpdateReviewReq,
     UpdateSessionGroupReq, UpdateSessionSpaceReq,
@@ -511,6 +511,9 @@ enum SessionCmd {
         /// Filter the resolved attention state.
         #[arg(long)]
         attention: Option<SessionSearchAttention>,
+        /// Filter by who launched work: mine, ops, mine-and-ops, or other-users.
+        #[arg(long)]
+        creator: Option<SessionCreatorFilter>,
     },
     /// Read or edit the durable Spaces → Groups → Sessions workbench layout.
     Layout {
@@ -1300,7 +1303,7 @@ async fn run() -> Result<()> {
         Cmd::Setup { cmd } => run_setup(cmd).await,
         Cmd::Config { cmd } => run_config(cmd).await,
         Cmd::Launch(opts) => cmd_launch(opts.into()).await,
-        Cmd::Ps => cmd_ps(false, false, false, None, None, None).await,
+        Cmd::Ps => cmd_ps(PsOptions::default()).await,
         Cmd::Attach { session } => cmd_attach(session).await,
         Cmd::Open => cmd_open().await,
         Cmd::Completions { shell } => {
@@ -1669,12 +1672,23 @@ async fn run_session(cmd: SessionCmd) -> Result<()> {
         }
         SessionCmd::Ls {
             archived,
-            automation,
+            automation: _,
             managed,
             search,
             status,
             attention,
-        } => cmd_ps(archived, automation, managed, search, status, attention).await,
+            creator,
+        } => {
+            cmd_ps(PsOptions {
+                archived,
+                managed,
+                search,
+                status,
+                attention,
+                creator,
+            })
+            .await
+        }
         SessionCmd::Layout { cmd } => run_session_layout(cmd).await,
         SessionCmd::Rename { session, title } => cmd_session_rename(session, title.join(" ")).await,
         SessionCmd::RegenerateTitle { session } => cmd_session_regenerate_title(session).await,
@@ -4121,14 +4135,25 @@ async fn cmd_session_preview(key: String, lines: usize) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_ps(
+#[derive(Default)]
+struct PsOptions {
     archived: bool,
-    _automation: bool,
     managed: bool,
     search: Option<String>,
     status: Option<SessionSearchStatus>,
     attention: Option<SessionSearchAttention>,
-) -> Result<()> {
+    creator: Option<SessionCreatorFilter>,
+}
+
+async fn cmd_ps(options: PsOptions) -> Result<()> {
+    let PsOptions {
+        archived,
+        managed,
+        search,
+        status,
+        attention,
+        creator,
+    } = options;
     let client = client::default()?;
     // The compatibility GET omits automation by default; this fleet inventory
     // explicitly opts into successful automation work.
@@ -4148,8 +4173,13 @@ async fn cmd_ps(
         if let Some(search) = search {
             query.push(format!("q={}", encode_query(search)));
         }
+        if let Some(creator) = creator {
+            query.push(format!("creator={creator}"));
+        }
     }
-    let list = if !managed && (search.is_some() || status.is_some() || attention.is_some()) {
+    let list = if !managed
+        && (search.is_some() || status.is_some() || attention.is_some() || creator.is_some())
+    {
         serde_json::to_value(
             client
                 .search_sessions(&SearchSessionsOptions {
@@ -4158,6 +4188,7 @@ async fn cmd_ps(
                     archived_only: false,
                     status,
                     attention,
+                    creator,
                 })
                 .await?,
         )?

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -24,8 +24,9 @@ use crate::session::{self as session_mod, Session};
 use crate::{agent, backend, config, custom_agents, db, events, git, github, repo};
 use weaver_api::{
     CreateReq, EnsureResumptionCueReq, HandoffReq, HistoryPageView, PatchSessionReq,
-    ResumptionCueView, SearchSessionsOptions, SendReq, SessionSearchAttention, SessionSearchStatus,
-    SessionSummaryView, SessionView, SetTagsReq, SetTitleGenerationReq, TagReq,
+    ResumptionCueView, SearchSessionsOptions, SendReq, SessionCreatorFilter,
+    SessionSearchAttention, SessionSearchStatus, SessionSummaryView, SessionView, SetTagsReq,
+    SetTitleGenerationReq, TagReq,
 };
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::{Branch, TitleProvenance, TitleUpdate};
@@ -69,8 +70,9 @@ pub(super) struct ListSessionsQuery {
     /// History as disjoint views.
     #[serde(default)]
     archived: bool,
-    /// Compatibility filter for automation-class sessions. Omission retains
-    /// the historical interactive-only inventory; fleet workbenches opt in.
+    /// Compatibility filter for automation-class sessions. With no creator
+    /// scope, omission retains the historical interactive-only inventory;
+    /// explicit creator scopes select the classes they name directly.
     #[serde(default)]
     automation: Option<bool>,
     /// Include engine-managed warm sessions. This is an operator inventory
@@ -82,6 +84,9 @@ pub(super) struct ListSessionsQuery {
     /// and goal (`loom session ls --search auth`). Absent/blank matches everything.
     #[serde(default)]
     q: Option<String>,
+    /// Viewer-relative creator scope (`mine`, `ops`, their union, or other users).
+    #[serde(default)]
+    creator: Option<SessionCreatorFilter>,
 }
 
 pub(super) async fn list_sessions(
@@ -105,6 +110,8 @@ pub(super) async fn list_sessions(
             search: q.q.as_deref(),
             status: None,
             attention: None,
+            creator: q.creator,
+            viewer: &principal.username,
         },
     )
     .await
@@ -130,12 +137,15 @@ pub(super) struct ListSessionSummariesQuery {
     status: Option<SessionSearchStatus>,
     #[serde(default)]
     attention: Option<SessionSearchAttention>,
+    #[serde(default)]
+    creator: Option<SessionCreatorFilter>,
 }
 
 /// Compact polling/search contract for indexes. Full session context remains on
 /// `GET /api/sessions/{id}` and is fetched only when a row or page discloses it.
 pub(super) async fn list_session_summaries(
     State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
     Query(q): Query<ListSessionSummariesQuery>,
 ) -> ApiResult<Json<Vec<SessionSummaryView>>> {
     collect_session_summaries(
@@ -147,6 +157,8 @@ pub(super) async fn list_session_summaries(
             search: q.q.as_deref(),
             status: q.status,
             attention: q.attention,
+            creator: q.creator,
+            viewer: &principal.username,
         },
     )
     .await
@@ -158,6 +170,7 @@ pub(super) async fn list_session_summaries(
 /// result set; `archived_only=true` is the disjoint History projection.
 pub(super) async fn search_sessions(
     State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
     Query(q): Query<SearchSessionsOptions>,
 ) -> ApiResult<Json<Vec<SessionView>>> {
     collect_sessions(
@@ -170,6 +183,8 @@ pub(super) async fn search_sessions(
             search: Some(&q.query),
             status: q.status,
             attention: q.attention,
+            creator: q.creator,
+            viewer: &principal.username,
         },
     )
     .await
@@ -354,6 +369,8 @@ struct SessionCollectionFilter<'a> {
     search: Option<&'a str>,
     status: Option<SessionSearchStatus>,
     attention: Option<SessionSearchAttention>,
+    creator: Option<SessionCreatorFilter>,
+    viewer: &'a str,
 }
 
 fn search_needle(filter: &SessionCollectionFilter<'_>) -> Option<String> {
@@ -370,10 +387,23 @@ fn session_in_collection(
     filter: &SessionCollectionFilter<'_>,
     managed: bool,
 ) -> bool {
+    let mine = session.created_by.as_deref() == Some(filter.viewer);
+    let ops = session.class == "automation";
+    let other_user = session
+        .created_by
+        .as_deref()
+        .is_some_and(|creator| creator != filter.viewer);
+    let creator_matches = filter.creator.is_none_or(|creator| match creator {
+        SessionCreatorFilter::Mine => mine,
+        SessionCreatorFilter::Ops => ops,
+        SessionCreatorFilter::MineAndOps => mine || ops,
+        SessionCreatorFilter::OtherUsers => other_user && !ops,
+    });
     (managed || !warm.contains(&session.id))
         && (filter.archived || session.status != "archived")
         && (!filter.archived_only || session.status == "archived")
-        && (filter.automation || session.class != "automation")
+        && (filter.automation || filter.creator.is_some() || session.class != "automation")
+        && creator_matches
 }
 
 fn view_matches_filters(

--- a/crates/loom/tests/integration/session_layout.rs
+++ b/crates/loom/tests/integration/session_layout.rs
@@ -26,8 +26,10 @@ async fn layout_http_session_view_conflict_and_cli_share_one_contract() {
     assert_eq!(created["placement"]["group_id"], "group-user-inbox");
 
     let seeded = ts.client.get("/api/session-layout").await.unwrap();
-    assert_eq!(seeded["spaces"].as_array().unwrap().len(), 4);
-    assert_eq!(seeded["spaces"][0]["name"], "User");
+    assert_eq!(seeded["spaces"].as_array().unwrap().len(), 5);
+    assert_eq!(seeded["spaces"][0]["name"], "Later");
+    assert_eq!(seeded["spaces"][0]["system_key"], "later");
+    assert_eq!(seeded["spaces"][0]["groups"][0]["id"], "group-later-inbox");
     let slack = seeded["spaces"]
         .as_array()
         .unwrap()

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -292,6 +292,36 @@ async fn list_keeps_active_fleet_disjoint_from_archived_history_and_searches() {
         .unwrap();
     let beta_id = beta["id"].as_str().unwrap().to_string();
 
+    let ops = client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "automated ops work",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "name": "ops-work",
+                "class": "automation"
+            }),
+        )
+        .await
+        .unwrap();
+    let ops_id = ops["id"].as_str().unwrap().to_string();
+    sqlx::query(
+        "UPDATE sessions
+         SET created_by = CASE id WHEN ? THEN 'other-user' ELSE 'ops-service' END,
+             creator_kind = CASE id WHEN ? THEN 'user' ELSE 'automation' END,
+             creator_subject = CASE id WHEN ? THEN 'other-user' ELSE 'ops-service' END
+         WHERE id IN (?, ?)",
+    )
+    .bind(&beta_id)
+    .bind(&beta_id)
+    .bind(&beta_id)
+    .bind(&beta_id)
+    .bind(&ops_id)
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+
     // Archive beta — it leaves the active fleet.
     client
         .post(&format!("/api/sessions/{beta_id}/archive"), json!({}))
@@ -371,6 +401,33 @@ async fn list_keeps_active_fleet_disjoint_from_archived_history_and_searches() {
     );
     assert!(compact_hit[0]["branch"].get("goal").is_none());
 
+    // Creator scope is viewer-relative and composes with active/history and
+    // automation inventory. Ops means the durable automation class, while
+    // other-users excludes both the caller and Ops work.
+    for (creator, expected) in [
+        ("mine", vec![alpha_id.as_str()]),
+        ("ops", vec![ops_id.as_str()]),
+        ("mine-and-ops", vec![alpha_id.as_str(), ops_id.as_str()]),
+        ("other-users", vec![beta_id.as_str()]),
+    ] {
+        let scoped = client
+            .get(&format!(
+                "/api/sessions/summary?archived=true&creator={creator}"
+            ))
+            .await
+            .unwrap();
+        let mut ids: Vec<&str> = scoped
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|session| session["id"].as_str().unwrap())
+            .collect();
+        ids.sort_unstable();
+        let mut expected = expected;
+        expected.sort_unstable();
+        assert_eq!(ids, expected, "creator={creator}");
+    }
+
     // An archived session is excluded from a default search, included when asked.
     let beta_hidden = client.get("/api/sessions?q=beta").await.unwrap();
     assert!(
@@ -435,6 +492,10 @@ async fn list_keeps_active_fleet_disjoint_from_archived_history_and_searches() {
         .unwrap();
     client
         .delete(&format!("/api/sessions/{beta_id}"))
+        .await
+        .unwrap();
+    client
+        .delete(&format!("/api/sessions/{ops_id}"))
         .await
         .unwrap();
 }

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -178,6 +178,9 @@ impl Client {
         if let Some(attention) = options.attention {
             query.push(format!("attention={attention}"));
         }
+        if let Some(creator) = options.creator {
+            query.push(format!("creator={creator}"));
+        }
         self.get_typed(&format!("/api/sessions/search?{}", query.join("&")))
             .await
     }

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -407,6 +407,15 @@ wire_enum!(SessionSearchAttention {
     Blocked => "blocked",
 });
 
+// Viewer-relative creator scopes for fleet indexes. `ops` is the durable
+// automation class, independent of where an operator later moves the row.
+wire_enum!(SessionCreatorFilter {
+    Mine => "mine",
+    Ops => "ops",
+    MineAndOps => "mine-and-ops",
+    OtherUsers => "other-users",
+});
+
 /// Typed filters for `GET /api/sessions/search`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SearchSessionsOptions {
@@ -420,6 +429,8 @@ pub struct SearchSessionsOptions {
     pub status: Option<SessionSearchStatus>,
     #[serde(default)]
     pub attention: Option<SessionSearchAttention>,
+    #[serde(default)]
+    pub creator: Option<SessionCreatorFilter>,
 }
 
 /// One session's canonical position in the shared Spaces → Groups layout.

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -612,6 +612,10 @@ pub const DEFAULT_AUTOMATION_TURN_CAP: i64 = 100;
 /// still archives the session.
 pub const DEFAULT_AUTOMATION_IDLE_ARCHIVE_SECS: i64 = 28800;
 
+/// Idle TTL after which the retention reaper archives an ordinary interactive
+/// session (10 days). A profile may explicitly set 0 to disable the TTL.
+pub const DEFAULT_INTERACTIVE_IDLE_ARCHIVE_SECS: i64 = 864000;
+
 /// Idle TTL after which the retention reaper archives a Slack-origin session
 /// (24 hours). 0 disables the TTL trigger.
 pub const DEFAULT_SLACK_IDLE_ARCHIVE_SECS: i64 = 86400;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -714,7 +714,13 @@ the stage and suppresses lifecycle actions until completion. Transition claims
 are atomic across overlapping server generations, and startup reconciles a
 marker left by a process exit before normal supervisor inventory runs.
 
-**Automation lifecycle.** A `class = automation` session — every session not
+**Retention and automation lifecycle.** Ordinary interactive sessions inherit a
+ten-day idle archive policy (`864000` seconds); a profile override is stamped
+onto the session at launch, and an explicit `0` disables that TTL. The monitor
+uses durable `last_activity_at`, falls back to `created_at` for untouched work,
+and can archive completed/error rows as well as live ones once they are old.
+
+A `class = automation` session — every session not
 launched interactively by a human, excluding a watch's own warm sessions —
 carries a turn cap (`automation.turn_cap`, default `100`, `0` disables)
 counted by `sessions.turn_count`. Exceeding the cap raises a loud `blocked`

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -20,7 +20,9 @@ The rail has five stable destinations: **Sessions**, **Issues**, **Watch**,
 **Shell**, and **Settings**. Session Artifacts and Changes are not global
 destinations; they live together under that session's Review surface.
 
-Sessions is organized as shared **Spaces → Groups → Sessions**. A session has
+Sessions is organized as shared **Spaces → Groups → Sessions**. **Later** is a
+top-level space ahead of the provenance spaces, keeping deferred work out of
+each Inbox while preserving one canonical placement. A session has
 one canonical placement and one unqualified task label. A group row shows that
 label; cross-group smart views qualify it as `Group / Task`. Attention, All, and
 History are views over the same placement rather than separate ownership models.
@@ -32,9 +34,11 @@ separate Automations destination.
 GitHub and Slack triggers land in their respective Inbox spaces. Delegated
 sessions inherit their parent's placement.
 
-Search, moves, ordering, collapse preferences, and placement defaults all use
-the layout REST API. Selecting a row opens the session without changing its
-group, and returning to the workbench restores the current view.
+Search, creator scope, moves, ordering, collapse preferences, and placement
+defaults all use the session/layout REST APIs. Creator scope can show everyone,
+the signed-in operator, Ops work, their union, or other users. Selecting a row
+opens the session without changing its group, and returning to the workbench
+restores the current view.
 
 The shell polls a compact summary of active sessions. It fetches archived
 summaries only when History opens, and fetches full goal, launch, policy, and

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -185,6 +185,9 @@ export interface WeaverFixture {
   /** Mark a seeded session as engine-managed infrastructure in the worker's
    *  private database. Normal fleet inventory must hide it. */
   setManaged(id: string, managedBy?: string): Promise<void>;
+  /** Change creator attribution in the worker-private database so team-view
+   *  filters can be exercised without a second browser login flow. */
+  setCreator(id: string, username: string): Promise<void>;
   /** Flip a session's status by writing a hook event row via `weaver hook`. */
   hook(session: Session, event: "working" | "waiting" | "idle"): Promise<void>;
   /** Declare the agent's status (level + message) via `weaver status`. It
@@ -295,18 +298,22 @@ async function deleteAllSessions(baseUrl: string) {
   }
 }
 
+function quoteSqlite(value: string) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function runPrivateSql(dbPath: string, sql: string) {
+  execFileSync("sqlite3", [dbPath, `PRAGMA busy_timeout=5000; ${sql}`], {
+    stdio: "pipe",
+  });
+}
+
 /** Automation launch reservations are durable and intentionally have no
  *  product delete endpoint. Test workers own a private sqlite database, so
  *  clear that audit table directly between tests to keep run-only failures
  *  from leaking into later count assertions. */
 function deleteAllAutomationRuns(dbPath: string) {
-  execFileSync(
-    "sqlite3",
-    [dbPath, "PRAGMA busy_timeout=5000; DELETE FROM automation_runs;"],
-    {
-      stdio: "pipe",
-    },
-  );
+  runPrivateSql(dbPath, "DELETE FROM automation_runs;");
 }
 
 /** Delete every watch on a server, best-effort — watches aren't tied
@@ -646,14 +653,16 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
       },
 
       async setManaged(id, managedBy = "watch-e2e") {
-        const quote = (value: string) => `'${value.replaceAll("'", "''")}'`;
-        execFileSync(
-          "sqlite3",
-          [
-            childEnv.WEAVER_DB!,
-            `PRAGMA busy_timeout=5000; UPDATE sessions SET managed_by = ${quote(managedBy)} WHERE id = ${quote(id)};`,
-          ],
-          { stdio: "pipe" },
+        runPrivateSql(
+          childEnv.WEAVER_DB!,
+          `UPDATE sessions SET managed_by = ${quoteSqlite(managedBy)} WHERE id = ${quoteSqlite(id)};`,
+        );
+      },
+
+      async setCreator(id, username) {
+        runPrivateSql(
+          childEnv.WEAVER_DB!,
+          `UPDATE sessions SET created_by = ${quoteSqlite(username)}, creator_kind = 'user', creator_subject = ${quoteSqlite(username)} WHERE id = ${quoteSqlite(id)};`,
         );
       },
 

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -118,6 +118,57 @@ async function createFailedRun(baseUrl: string) {
 }
 
 test.describe("durable session workbench", () => {
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+  });
+
+  test("creator scope keeps mine and Ops while hiding other users", async ({
+    page,
+    weaver,
+  }) => {
+    const mine = await weaver.seedSession({
+      goal: "My interactive work",
+      name: "mine-task",
+    });
+    const other = await weaver.seedSession({
+      goal: "Another operator's work",
+      name: "other-task",
+    });
+    await weaver.setCreator(other.id, "other-operator");
+    const ops = await seedAutomationSession(weaver.baseUrl, weaver.repoPath);
+    await createFailedRun(weaver.baseUrl);
+
+    await page.goto(weaver.baseUrl);
+    const spaces = page.locator(
+      '[data-testid="space-tabs-scroll"] [data-space-id]',
+    );
+    await expect(spaces.first()).toContainText("Later");
+
+    await page.getByTestId("creator-filter").selectOption("mine-and-ops");
+    await expect(page).toHaveURL(/creator=mine-and-ops/);
+    await expect(page.locator(`[data-session-id="${mine.id}"]`)).toBeVisible();
+    await expect(page.locator(`[data-session-id="${ops.id}"]`)).toBeVisible();
+    await expect(page.locator(`[data-session-id="${other.id}"]`)).toHaveCount(
+      0,
+    );
+
+    await page.reload();
+    await expect(page.getByTestId("creator-filter")).toHaveValue(
+      "mine-and-ops",
+    );
+    await page.getByTestId("creator-filter").selectOption("mine");
+    await page.getByTestId("attention-view").click();
+    await expect(page.getByTestId("automation-run-only")).toContainText(
+      "Launch failed",
+    );
+    await page.getByTestId("creator-filter").selectOption("other-users");
+    await expect(page.getByTestId("automation-run-only")).toHaveCount(0);
+    await page.getByTestId("all-view").click();
+    await expect(page.locator(`[data-session-id="${mine.id}"]`)).toHaveCount(0);
+    await expect(page.locator(`[data-session-id="${ops.id}"]`)).toHaveCount(0);
+    await expect(page.locator(`[data-session-id="${other.id}"]`)).toBeVisible();
+  });
+
   test("terminal mailbox commands navigate rows without stealing text input", async ({
     page,
     weaver,


### PR DESCRIPTION
Add viewer-relative creator scopes to the session REST API, CLI, and workbench so operators can switch among Everyone, Mine + Ops, Mine, Ops, and Other users. The selected workbench scope is URL-backed, applies to live counts and run-only automation failures, and survives reloads.

Promote the legacy per-space Later queues into one first-ranked top-level Later space while preserving canonical placements and stable ordering.

Give interactive sessions a ten-day inactivity archive policy by default and extend the existing retention reaper to stable interactive and terminal sessions. The migration updates sessions that inherited the old disabled default while preserving explicit profile zero values and the per-session auto-archive opt-out.