### PR TITLE
fix(loom): finish archives after request disconnects

### DIFF
--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -14,6 +14,7 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use tokio::sync::oneshot;
 
 /// Why a lifecycle operation refused, when the reason is the caller's to fix.
 ///
@@ -132,15 +133,29 @@ pub async fn auto_archive(
 
 /// Manual archive entry point. Refresh after acquiring the lifecycle lock so a
 /// request queued behind adoption/recovery acts on the completed state rather
-/// than the stale row it resolved before waiting.
+/// than the stale row it resolved before waiting. The operation runs in a
+/// server-owned task because dropping an HTTP request future must not cancel
+/// teardown after its durable transition has been recorded.
 pub async fn archive(st: &AppState, session: &Session, _branch: &Branch) -> Result<Vec<String>> {
-    let _lifecycle = crate::runtime::LIFECYCLE_LOCK.lock().await;
-    let Some((current_session, current_branch)) =
-        session_mod::with_branch(&st.db, &session.id).await?
-    else {
-        return Err(anyhow!("session not found"));
-    };
-    archive_locked(st, &current_session, &current_branch).await
+    let st = st.clone();
+    let session_id = session.id.clone();
+    let (result_tx, result_rx) = oneshot::channel();
+    weaver_core::spawn_boxed(Box::pin(async move {
+        let result = async {
+            let _lifecycle = crate::runtime::LIFECYCLE_LOCK.lock().await;
+            let Some((current_session, current_branch)) =
+                session_mod::with_branch(&st.db, &session_id).await?
+            else {
+                return Err(anyhow!("session not found"));
+            };
+            archive_locked(&st, &current_session, &current_branch).await
+        }
+        .await;
+        let _ = result_tx.send(result);
+    }));
+    result_rx
+        .await
+        .map_err(|_| anyhow!("archive task stopped before reporting its result"))?
 }
 
 pub fn require_no_transition(session: &Session) -> Result<()> {

--- a/crates/loom/tests/integration/archive.rs
+++ b/crates/loom/tests/integration/archive.rs
@@ -3,9 +3,11 @@
 //! weaver history, and clears the attention tag.
 
 use std::path::Path;
+use std::time::Duration;
 
 use serde_json::json;
 use serial_test::serial;
+use tokio::io::AsyncWriteExt;
 
 use loom::backend;
 
@@ -79,6 +81,67 @@ async fn archive_captures_the_conversation_log() {
     let iris: serde_json::Value = serde_json::from_str(&raw_json).unwrap();
     assert_eq!(iris["source"], "claude");
     assert_eq!(iris["messages"].as_array().unwrap().len(), 2);
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn archive_survives_request_disconnect() {
+    let ts = TestServer::start().await;
+    let created = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "archive after disconnect", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = created["id"].as_str().unwrap().to_string();
+    let work_dir = created["work_dir"].as_str().unwrap().to_string();
+
+    // A raw connection lets the test close the transport without waiting for a
+    // response, matching a browser navigation or reverse-proxy disconnect.
+    let mut connection = tokio::net::TcpStream::connect(ts.addr).await.unwrap();
+    let request = format!(
+        "POST /api/sessions/{id}/archive HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}",
+        ts.addr
+    );
+    connection.write_all(request.as_bytes()).await.unwrap();
+    connection.flush().await.unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let session = loom::session::get(&ts.state.db, &id)
+                .await
+                .unwrap()
+                .unwrap();
+            if session.lifecycle_transition.as_deref() == Some("archiving") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("archive should start");
+
+    drop(connection);
+
+    let archived = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let session = loom::session::get(&ts.state.db, &id)
+                .await
+                .unwrap()
+                .unwrap();
+            if session.status == "archived" {
+                break session;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("archive should finish after its request disconnects");
+
+    assert!(archived.lifecycle_transition.is_none());
+    assert!(!Path::new(&work_dir).exists());
 }
 
 #[serial]


### PR DESCRIPTION
Keep manual archive teardown alive when the initiating HTTP request disconnects. Previously, dropping the Axum handler could cancel archive after `git worktree remove` deleted the directory but before Loom committed `archived`, leaving retries blocked by a durable `archiving` transition.

Run archive under a server-owned task while preserving the synchronous response for connected clients. A transport-disconnect regression verifies that the worktree is removed and the transition clears.

Incident record: https://echo.oa.dev/wiki/104
