### PR TITLE
fix(loom): keep operator shell on server host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,8 @@ jobs:
       - name: Verify session survival outside the launcher
         env:
           LOOM_DOCKER_TEST_IMAGE: loom-ci:${{ github.sha }}
-        run: >-
-          cargo test -p loom --test docker_runner
-          docker_runner_supervisor_outlives_its_launcher
-          --locked -- --ignored --exact
+        run: |
+          cargo build -p tapestry --locked
+          cargo test -p loom --test docker_runner \
+            docker_runner_supervisor_outlives_its_launcher \
+            --locked -- --ignored --exact

--- a/crates/loom-core/src/shell.rs
+++ b/crates/loom-core/src/shell.rs
@@ -5,11 +5,13 @@
 //!
 //! * The **operator scratch shell** ([`SHELL_SESSION`]): a single persistent
 //!   shell, not tied to any branch or worktree, running in the container user's
-//!   `$HOME`. Its purpose is one-time operator setup that would otherwise need
-//!   `docker exec -it weaver …` — most concretely `gcloud auth login`, whose
-//!   credentials land in the `CLOUDSDK_CONFIG` volume and so survive recreates
-//!   (see the Dockerfile / docker-compose.yml). Spawned lazily by [`ensure`],
-//!   reset with [`restart`].
+//!   `$HOME`. It always runs beside the Loom server, bypassing the Docker session
+//!   runner, so operators can inspect the control-plane container and its sibling
+//!   session containers through the Docker socket. It also handles one-time
+//!   setup that would otherwise need `docker exec -it loom …` — most concretely
+//!   `gcloud auth login`, whose credentials land in the `CLOUDSDK_CONFIG` volume
+//!   and so survive recreates (see the Dockerfile / docker-compose.yml). Spawned
+//!   lazily by [`ensure`], reset with [`restart`].
 //!
 //! * Per-session **debug shells** ([`ensure_debug`]): one or more login shells
 //!   in the session agent's runner placement (the same container with the
@@ -54,7 +56,7 @@ fn shell_cwd() -> PathBuf {
 /// [`agent_env`] vars, and (for a per-session debug shell) the session's
 /// `WEAVER_BRANCH`. The script just `exec`s the login shell via
 /// [`agent::bare_shell_script`] (no inner agent command); the env is delivered
-/// out of band by [`backend::new_session`], not `export`-ed into the script, so
+/// out of band by the [`backend`] launch helpers, not `export`-ed into the script, so
 /// secrets stay off argv. This is a plain shell, not an agent, so it does not go
 /// through the agent launch path.
 async fn shell_script(st: &Ctx, branch_id: Option<&str>) -> (String, Vec<(String, String)>) {
@@ -94,15 +96,7 @@ pub async fn ensure(st: &Ctx) -> Result<()> {
     let (script, env) = shell_script(st, None).await;
     let cwd = shell_cwd();
     tracing::info!(session = SHELL_SESSION, cwd = %cwd.display(), "spawning operator scratch shell");
-    backend::new_session(
-        SHELL_SESSION,
-        &cwd,
-        &script,
-        &env_refs(&env),
-        false,
-        backend::memory_max_gb(&st.db).await,
-    )
-    .await
+    backend::new_session_on_host(SHELL_SESSION, &cwd, &script, &env_refs(&env), false).await
 }
 
 /// Reset the scratch shell: kill the current supervisor (best-effort) and bring

--- a/crates/loom-ctx/src/backend.rs
+++ b/crates/loom-ctx/src/backend.rs
@@ -122,7 +122,31 @@ pub async fn new_session(
     env_clear: bool,
     memory_max_gb: u64,
 ) -> Result<()> {
-    new_session_with_placement(name, cwd, script, env, env_clear, memory_max_gb, None).await
+    new_session_with_placement(
+        name,
+        cwd,
+        script,
+        env,
+        env_clear,
+        memory_max_gb,
+        SessionPlacement::Configured,
+    )
+    .await
+}
+
+/// Create a detached PTY session directly beside the Loom server process.
+///
+/// This intentionally bypasses the configured runner and its per-session
+/// memory cgroup. It is reserved for the operator scratch shell, whose purpose
+/// is to inspect and administer the Loom control-plane host/container itself.
+pub async fn new_session_on_host(
+    name: &str,
+    cwd: &std::path::Path,
+    script: &str,
+    env: &[(&str, &str)],
+    env_clear: bool,
+) -> Result<()> {
+    new_session_with_placement(name, cwd, script, env, env_clear, 0, SessionPlacement::Host).await
 }
 
 /// Create a detached PTY session in the same runner placement as `owner`.
@@ -146,9 +170,15 @@ pub async fn new_session_colocated(
         env,
         env_clear,
         memory_max_gb,
-        Some(owner),
+        SessionPlacement::Colocated(owner),
     )
     .await
+}
+
+enum SessionPlacement<'a> {
+    Configured,
+    Host,
+    Colocated(&'a str),
 }
 
 async fn new_session_with_placement(
@@ -158,7 +188,7 @@ async fn new_session_with_placement(
     env: &[(&str, &str)],
     env_clear: bool,
     memory_max_gb: u64,
-    owner: Option<&str>,
+    placement: SessionPlacement<'_>,
 ) -> Result<()> {
     tracing::info!(session = %name, cwd = %cwd.display(), memory_max_gb, "spawning terminal session");
     let script = match memory_max_gb {
@@ -178,9 +208,12 @@ async fn new_session_with_placement(
         segment_max_bytes: None,
         supervisor_bin: supervisor_bin.as_deref(),
     };
-    let result = match owner {
-        Some(owner) => runner::spawn_colocated(&options, memory_max_gb, owner).await,
-        None => runner::spawn(&options, memory_max_gb).await,
+    let result = match placement {
+        SessionPlacement::Configured => runner::spawn(&options, memory_max_gb).await,
+        SessionPlacement::Host => runner::spawn_on_host(&options).await,
+        SessionPlacement::Colocated(owner) => {
+            runner::spawn_colocated(&options, memory_max_gb, owner).await
+        }
     };
     match &result {
         Ok(()) => tracing::info!(session = %name, "terminal session spawned"),

--- a/crates/loom-ctx/src/runner.rs
+++ b/crates/loom-ctx/src/runner.rs
@@ -584,6 +584,17 @@ pub async fn spawn(opts: &tapestry::LaunchOptions<'_>, memory_max_gb: u64) -> Re
         .await
 }
 
+/// Start a supervisor directly on the Loom host, bypassing the configured
+/// session placement backend.
+///
+/// The operator scratch shell uses this escape hatch so a Docker-backed Loom
+/// exposes the control-plane container itself rather than creating another
+/// isolated session container. Agent and per-session shell placement must keep
+/// using [`spawn`] or [`spawn_colocated`].
+pub async fn spawn_on_host(opts: &tapestry::LaunchOptions<'_>) -> Result<()> {
+    ProcessRunner.start(opts, 0, None).await
+}
+
 /// Start a supervisor in the same placement container as `owner`. Local-process
 /// placement has no container boundary, so this is equivalent to [`spawn`].
 pub async fn spawn_colocated(

--- a/crates/loom/frontend/src/views/Shell.vue
+++ b/crates/loom/frontend/src/views/Shell.vue
@@ -3,10 +3,12 @@ import { ref } from 'vue';
 import AgentTerminal from '../components/AgentTerminal.vue';
 import { restartShell } from '../api';
 
-// The operator scratch shell: one persistent login shell running inside the
-// container, attached over the same terminal bridge agent sessions use. It's
-// for one-time setup that would otherwise need `docker exec` — most usefully
-// `gcloud auth login`, whose credentials persist in the gcloud config volume.
+// The operator scratch shell: one persistent login shell running beside the
+// Loom server, attached over the same terminal bridge agent sessions use. In a
+// Docker deployment this is the control-plane container rather than an isolated
+// session container, so it can inspect the deployment through the Docker socket.
+// It is also useful for one-time setup such as `gcloud auth login`, whose
+// credentials persist in the gcloud config volume.
 //
 // AgentTerminal is keyed so "Restart" (which kills + respawns the supervisor)
 // forces a fresh socket: bumping the key remounts the component, reconnecting
@@ -37,9 +39,9 @@ async function restart() {
       <div class="min-w-0">
         <h1 class="text-sm font-semibold text-fg">Shell</h1>
         <p class="text-xs text-muted">
-          A login shell inside the container — for one-time setup like
-          <code class="rounded bg-code px-1 py-0.5 text-[11px]">gcloud auth login</code>. It
-          persists across restarts.
+          A login shell beside the Loom server — inspect the deployment or run setup like
+          <code class="rounded bg-code px-1 py-0.5 text-[11px]">gcloud auth login</code>. Setup
+          state persists across restarts.
         </p>
       </div>
       <button

--- a/crates/loom/tests/docker_runner.rs
+++ b/crates/loom/tests/docker_runner.rs
@@ -61,6 +61,18 @@ fn configure(root: &Path, session: &str) {
     std::env::set_var(SESSION_ENV, session);
 }
 
+async fn wait_for_screen(session: &str, markers: &[&str]) -> String {
+    let mut screen = String::new();
+    for _ in 0..200 {
+        screen = loom::backend::capture(session, 0).await.unwrap();
+        if markers.iter().all(|marker| screen.contains(marker)) {
+            return screen;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("{session} never printed {markers:?}; terminal output:\n{screen}");
+}
+
 #[test]
 #[serial]
 fn docker_runner_child() {
@@ -169,26 +181,10 @@ fn docker_runner_supervisor_outlives_its_launcher() {
     let runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.block_on(async {
         assert!(tapestry::Client::is_alive(&session).await);
-        let mut owner_screen = String::new();
-        for _ in 0..200 {
-            owner_screen = loom::backend::capture(&session, 0).await.unwrap();
-            if owner_screen.contains("runner-ready") && owner_screen.contains("200") {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-        }
-        assert!(owner_screen.contains("runner-ready"));
-        assert!(owner_screen.contains("200"));
+        let owner_screen = wait_for_screen(&session, &["runner-ready", "200"]).await;
 
         let host_session = format!("{session}-host-shell");
-        let mut host_screen = String::new();
-        for _ in 0..200 {
-            host_screen = loom::backend::capture(&host_session, 0).await.unwrap();
-            if host_screen.contains("host-shell-ready") {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-        }
+        let host_screen = wait_for_screen(&host_session, &["host-shell-ready"]).await;
 
         let colocated = format!("{session}-shell");
         let options = tapestry::LaunchOptions {
@@ -207,14 +203,7 @@ fn docker_runner_supervisor_outlives_its_launcher() {
             .await
             .unwrap();
 
-        let mut shell_screen = String::new();
-        for _ in 0..200 {
-            shell_screen = loom::backend::capture(&colocated, 0).await.unwrap();
-            if shell_screen.contains("shell-ready") {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-        }
+        let shell_screen = wait_for_screen(&colocated, &["shell-ready"]).await;
         let owner_host = owner_screen
             .split("owner-host=")
             .nth(1)

--- a/crates/loom/tests/docker_runner.rs
+++ b/crates/loom/tests/docker_runner.rs
@@ -1,10 +1,11 @@
 //! Manual container-runner lifecycle test.
 //!
 //! Build the test image with `HOST_UID=$(id -u)` and `HOST_GID=$(id -g)`, then
-//! run `cargo test -p loom --test docker_runner -- --ignored`. The regular suite
-//! stays Docker-free. This smoke covers placement, launcher death, shared socket
-//! access, colocating a second supervisor, keeping the operator shell on the
-//! launcher host, and a callback over the configured sibling network.
+//! run `cargo build -p tapestry && cargo test -p loom --test docker_runner --
+//! --ignored`. The regular suite stays Docker-free. This smoke covers placement,
+//! launcher death, shared socket access, colocating a second supervisor, keeping
+//! the operator shell on the launcher host, and a callback over the configured
+//! sibling network.
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -61,6 +62,15 @@ fn configure(root: &Path, session: &str) {
     std::env::set_var(SESSION_ENV, session);
 }
 
+fn tapestry_bin() -> PathBuf {
+    std::env::current_exe()
+        .unwrap()
+        .parent()
+        .and_then(Path::parent)
+        .unwrap()
+        .join("tapestry")
+}
+
 async fn wait_for_screen(session: &str, markers: &[&str]) -> String {
     let mut screen = String::new();
     for _ in 0..200 {
@@ -99,6 +109,12 @@ fn docker_runner_child() {
         loom::runner::spawn(&options, 1).await.unwrap();
 
         let host_session = format!("{session}-host-shell");
+        let supervisor_bin = tapestry_bin();
+        assert!(
+            supervisor_bin.is_file(),
+            "tapestry binary missing at {}; run `cargo build -p tapestry` first",
+            supervisor_bin.display()
+        );
         let host_options = tapestry::LaunchOptions {
             name: &host_session,
             cwd: &root,
@@ -109,7 +125,7 @@ fn docker_runner_child() {
             rows: 24,
             mode: tapestry::Mode::Pty,
             segment_max_bytes: None,
-            supervisor_bin: None,
+            supervisor_bin: Some(&supervisor_bin),
         };
         loom::runner::spawn_on_host(&host_options).await.unwrap();
     });

--- a/crates/loom/tests/docker_runner.rs
+++ b/crates/loom/tests/docker_runner.rs
@@ -3,8 +3,8 @@
 //! Build the test image with `HOST_UID=$(id -u)` and `HOST_GID=$(id -g)`, then
 //! run `cargo test -p loom --test docker_runner -- --ignored`. The regular suite
 //! stays Docker-free. This smoke covers placement, launcher death, shared socket
-//! access, colocating a second supervisor, and a callback over the configured
-//! sibling network.
+//! access, colocating a second supervisor, keeping the operator shell on the
+//! launcher host, and a callback over the configured sibling network.
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -85,6 +85,21 @@ fn docker_runner_child() {
             supervisor_bin: None,
         };
         loom::runner::spawn(&options, 1).await.unwrap();
+
+        let host_session = format!("{session}-host-shell");
+        let host_options = tapestry::LaunchOptions {
+            name: &host_session,
+            cwd: &root,
+            script: "printf 'host-shell-ready host=%s\\n' \"$(cat /etc/hostname)\"; sleep 60",
+            env: &[],
+            env_clear: false,
+            cols: 80,
+            rows: 24,
+            mode: tapestry::Mode::Pty,
+            segment_max_bytes: None,
+            supervisor_bin: None,
+        };
+        loom::runner::spawn_on_host(&host_options).await.unwrap();
     });
 }
 
@@ -165,6 +180,16 @@ fn docker_runner_supervisor_outlives_its_launcher() {
         assert!(owner_screen.contains("runner-ready"));
         assert!(owner_screen.contains("200"));
 
+        let host_session = format!("{session}-host-shell");
+        let mut host_screen = String::new();
+        for _ in 0..200 {
+            host_screen = loom::backend::capture(&host_session, 0).await.unwrap();
+            if host_screen.contains("host-shell-ready") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
         let colocated = format!("{session}-shell");
         let options = tapestry::LaunchOptions {
             name: &colocated,
@@ -200,12 +225,24 @@ fn docker_runner_supervisor_outlives_its_launcher() {
             .nth(1)
             .and_then(|tail| tail.split_whitespace().next())
             .expect("shell should print its container hostname");
+        let host_shell_host = host_screen
+            .split("host-shell-ready host=")
+            .nth(1)
+            .and_then(|tail| tail.split_whitespace().next())
+            .expect("host shell should print the launcher's hostname");
         assert_eq!(
             colocated_host, owner_host,
             "colocated supervisor should run in the owner's container"
         );
+        assert_ne!(
+            host_shell_host, owner_host,
+            "host supervisor should bypass the session container"
+        );
 
         loom::backend::kill_session_and_wait(&colocated)
+            .await
+            .unwrap();
+        loom::backend::kill_session_and_wait(&host_session)
             .await
             .unwrap();
         loom::backend::kill_session_and_wait(&session)

--- a/crates/loom/tests/integration/shell.rs
+++ b/crates/loom/tests/integration/shell.rs
@@ -36,16 +36,15 @@ async fn connect_session_shell(addr: &std::net::SocketAddr, id: &str, idx: u32) 
 async fn await_shell_ready(term: &mut TermWs, marker: &str) {
     let cmd = format!("echo {marker}$((6 * 7))\n");
     let want = format!("{marker}42");
+    let mut output = String::new();
     for _ in 0..15 {
         send_input(term, &cmd).await;
-        if drain_until(term, &want, Duration::from_secs(1))
-            .await
-            .contains(&want)
-        {
+        output = drain_until(term, &want, Duration::from_secs(1)).await;
+        if output.contains(&want) {
             return;
         }
     }
-    panic!("scratch shell never came up");
+    panic!("scratch shell never came up; terminal output:\n{output}");
 }
 
 #[serial]

--- a/deploy/standalone/docker-compose.yml
+++ b/deploy/standalone/docker-compose.yml
@@ -58,7 +58,8 @@ services:
       # container. Auxiliary supervisors such as its debug shells are colocated
       # there. The containers share the durable home/tool volumes and control
       # socket; recreating this control-plane service therefore leaves live
-      # sessions up.
+      # sessions up. The global operator Shell deliberately stays in this
+      # control-plane container so it can inspect the deployment as a whole.
       LOOM_RUNNER: docker
       LOOM_SESSION_IMAGE: ${LOOM_IMAGE:-loom:latest}
       LOOM_SESSION_HOME_VOLUME: loom_loom_home

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -333,6 +333,7 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/scratch/limits`; `GET POST DELETE /api/sessions/{id}/scratch` | shared Scratch contract and live list/drop/remove: 20 files, 25 MiB each, 50 MiB decoded total; accepted dotfiles count, while `.gitignore` is reserved |
 | `GET /api/sessions/{id}/files?q=…` | bounded worktree resource search for ACP `@file` completion; the old browser file editor routes are gone |
 | `GET /api/sessions/{id}/ide-info`; `ANY /api/sessions/{id}/ide[/…]` | availability probe and authenticated same-origin HTTP/WebSocket proxy for the optional code-server side panel |
+| `GET /api/shell/terminal`; `POST /api/shell/restart` | open or reset the global operator shell; it runs beside the Loom server rather than through the configured session runner |
 | `GET /api/sessions/{id}/shells`; `DELETE /api/sessions/{id}/shell/{idx}`; `GET /api/sessions/{id}/shell/{idx}/terminal` | list, close, or open per-session debug shells through WebSocket |
 | `GET /api/sessions/{id}/artifacts` | list the branch's [artifacts](artifacts.md) plus repo-shared ones |
 | `GET PUT /api/sessions/{id}/artifacts/{name}` | read content + projected refs (`rev=N` for a revision) / write a user edit as a new revision |
@@ -540,6 +541,11 @@ Details → Advanced, not as the primary file or work surface.
   `done`/`error` sessions remain owners, and the monitor handles the
   inverse mismatch by marking a session row with no supervisor `orphaned`.
   See [Session lifecycle](session-lifecycle.md).
+- **Shell placement follows purpose:** with the Docker runner, each agent owns a
+  sibling session container and its per-session debug shells are colocated
+  there. The global operator Shell is the deliberate exception: its supervisor
+  runs beside `loom server run`, giving operators the control-plane container's
+  process/filesystem view and its Docker-socket view of sibling sessions.
 
 ## Status & tags
 


### PR DESCRIPTION
Run the global operator Shell supervisor directly beside the Loom server instead of sending it through the configured Docker session runner. This gives operators the control-plane container's process and filesystem view plus Docker-socket access to sibling agent containers, while per-session debug shells remain colocated with their agents.\n\nAdd explicit host placement in the terminal backend, cover the placement boundary in the Docker smoke, and describe the distinction in the UI and deployment architecture.\n\nWeaver session: http://127.0.0.1:7878/s/8lqub534