### PR TITLE
fix(loom): validate session base before launch

### DIFF
--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -848,6 +848,12 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
         (existing_branch.to_string(), work_dir)
     } else {
         // Create `weaver/<slug>` with a unique suffix.
+        if !git::revision_exists(&repo_root, &base).await {
+            return Err(ProvisionError::invalid(format!(
+                "base revision '{base}' was not found in repository '{}'; choose a branch, remote-tracking branch, tag, or commit that exists in this repository",
+                repo_root.display()
+            )));
+        }
         let explicit = req.name.as_deref().map(str::trim).filter(|n| !n.is_empty());
         let base_slug = branch_mod::slugify(explicit.unwrap_or(title.as_str()));
         tracing::debug!(base_slug = %base_slug, base = %base, "creating new branch for session");

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -849,9 +849,8 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
     } else {
         // Create `weaver/<slug>` with a unique suffix.
         if !git::revision_exists(&repo_root, &base).await {
-            return Err(ProvisionError::invalid(format!(
-                "base revision '{base}' was not found in repository '{}'; choose a branch, remote-tracking branch, tag, or commit that exists in this repository",
-                repo_root.display()
+            return Err(ProvisionError::invalid(git::missing_revision_message(
+                &repo_root, &base,
             )));
         }
         let explicit = req.name.as_deref().map(str::trim).filter(|n| !n.is_empty());

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -227,6 +227,7 @@ import type {
   CustomAgent,
   CustomAgentInput,
   ManagedRepo,
+  RepoRevisionValidation,
   Thread,
   NewThreadBody,
   Comment,
@@ -287,6 +288,12 @@ export const listRepos = () => get('/repos') as Promise<ManagedRepo[]>;
 /** Register a repo (a GitHub `owner/name` slug or clone URL) in the managed
  *  store / allowlist (`POST /api/repos`). Returns the stored mapping. */
 export const registerRepo = (repo: string) => post('/repos', { repo }) as Promise<ManagedRepo>;
+
+/** Check that a proposed worktree base resolves to a commit in a local repo. */
+export const validateRepoRevision = (cwd: string, revision: string) => {
+  const params = new URLSearchParams({ cwd, revision });
+  return get(`/repos/revisions/validate?${params}`) as Promise<RepoRevisionValidation>;
+};
 
 // --- Your GitHub token (per-user) ------------------------------------------
 

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -11,6 +11,7 @@ import {
   post,
   registerRepo,
   resolveSessionLaunch,
+  validateRepoRevision,
 } from '../api';
 import type {
   AgentMetadata,
@@ -87,6 +88,10 @@ const branchActiveOption = ref(-1);
 const branches = ref<RepoBranch[]>([]);
 const branchesError = ref('');
 let branchesReqId = 0;
+const baseValidationError = ref('');
+const validatingBase = ref(false);
+let baseValidationReqId = 0;
+let baseValidationTimer: ReturnType<typeof setTimeout> | undefined;
 
 function slugify(s: string): string {
   return s
@@ -298,6 +303,35 @@ watch([repo, branchMode], ([, mode]) => {
   if (mode === 'existing') loadBranches();
 });
 
+function scheduleBaseValidation() {
+  if (baseValidationTimer) clearTimeout(baseValidationTimer);
+  const request = ++baseValidationReqId;
+  baseValidationError.value = '';
+  const cwd = repo.value.trim();
+  const revision = base.value.trim();
+  if (branchMode.value !== 'new' || !cwd || !revision || looksLikeRemoteRepo(cwd)) {
+    validatingBase.value = false;
+    return;
+  }
+  validatingBase.value = true;
+  baseValidationTimer = setTimeout(async () => {
+    baseValidationTimer = undefined;
+    try {
+      const result = await validateRepoRevision(cwd, revision);
+      if (request === baseValidationReqId && !result.valid) {
+        baseValidationError.value =
+          result.message ?? `Base revision '${revision}' was not found in this repository.`;
+      }
+    } catch (cause) {
+      if (request === baseValidationReqId) baseValidationError.value = (cause as Error).message;
+    } finally {
+      if (request === baseValidationReqId) validatingBase.value = false;
+    }
+  }, 180);
+}
+
+watch([repo, base, branchMode], scheduleBaseValidation, { flush: 'sync' });
+
 function resetForm() {
   repo.value = '';
   title.value = '';
@@ -318,6 +352,13 @@ function resetForm() {
   error.value = '';
   resolveError.value = '';
   branchesError.value = '';
+  baseValidationError.value = '';
+  validatingBase.value = false;
+  ++baseValidationReqId;
+  if (baseValidationTimer) {
+    clearTimeout(baseValidationTimer);
+    baseValidationTimer = undefined;
+  }
   repoError.value = '';
   scratchError.value = '';
   ++resolveRequest;
@@ -652,6 +693,8 @@ const createBlockReason = computed(() => {
     return 'Add a task title or goal before creating the session.';
   if (branchMode.value === 'existing' && !existingBranch.value.trim())
     return 'Choose the existing branch to reuse.';
+  if (validatingBase.value) return 'Checking that the base revision exists in this repository.';
+  if (baseValidationError.value) return baseValidationError.value;
   if (scratchError.value) return scratchError.value;
   if (repoRegistrations.value > 0) return 'Wait for repository registration to finish.';
   if (cloneBusy.value) return 'Wait for the new profile to finish saving.';
@@ -877,6 +920,17 @@ onActivated(() => void refreshLaunchData());
                 <p class="mt-1 text-xs text-faint">
                   Leave blank to fork from a freshly-fetched
                   <code>origin/&lt;default branch&gt;</code>.
+                </p>
+                <p v-if="validatingBase" class="mt-1 text-xs text-faint" aria-live="polite">
+                  Checking base revision…
+                </p>
+                <p
+                  v-else-if="baseValidationError"
+                  class="mt-1 text-xs text-block"
+                  role="alert"
+                  data-testid="base-validation-error"
+                >
+                  {{ baseValidationError }}
                 </p>
               </div>
             </div>

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -320,7 +320,7 @@ function scheduleBaseValidation() {
       const result = await validateRepoRevision(cwd, revision);
       if (request === baseValidationReqId && !result.valid) {
         baseValidationError.value =
-          result.message ?? `Base revision '${revision}' was not found in this repository.`;
+          result.message ?? 'The selected base revision could not be validated.';
       }
     } catch (cause) {
       if (request === baseValidationReqId) baseValidationError.value = (cause as Error).message;

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -974,6 +974,13 @@ export interface ManagedRepo {
   created_at: string;
 }
 
+/** Result of checking a proposed worktree fork point in a local repository. */
+export interface RepoRevisionValidation {
+  valid: boolean;
+  repo_root: string;
+  message: string | null;
+}
+
 /** One per-repo environment variable's metadata (`/api/repos/env`). Mirrors
  *  loom's `repo_env::RepoEnvVar`. The value is **write-only**: it is set via PUT
  *  but never returned (these hold per-repo secrets), so only the name and last

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -999,6 +999,7 @@ pub fn router(state: AppState) -> Router {
         .route("/repos", get(list_repos).post(register_repo))
         .route("/repos/recent", get(recent_repos))
         .route("/repos/branches", get(repo_branches))
+        .route("/repos/revisions/validate", get(validate_repo_revision))
         .route(
             "/repos/issues",
             get(list_repo_issues).post(create_repo_issue),

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -758,9 +758,7 @@ pub(super) struct RevisionValidation {
     message: Option<String>,
 }
 
-/// Validate a user-entered worktree fork point without creating a branch or
-/// worktree. The creation drawer uses this while the base field is editable;
-/// provisioning repeats the check to keep the mutation boundary authoritative.
+/// Check whether a worktree fork point resolves without modifying the repo.
 pub(super) async fn validate_repo_revision(
     Query(q): Query<RevisionValidationQuery>,
 ) -> ApiResult<Json<RevisionValidation>> {
@@ -770,12 +768,7 @@ pub(super) async fn validate_repo_revision(
         .map_err(|e| AppError::bad_request(e.to_string()))?;
     let revision = q.revision.trim();
     let valid = !revision.is_empty() && git::revision_exists(&repo_root, revision).await;
-    let message = (!valid).then(|| {
-        format!(
-            "Base revision '{revision}' was not found in repository '{}'. Choose a branch, remote-tracking branch, tag, or commit that exists in this repository.",
-            repo_root.display()
-        )
-    });
+    let message = (!valid).then(|| git::missing_revision_message(&repo_root, revision));
     Ok(Json(RevisionValidation {
         valid,
         repo_root: repo_root.display().to_string(),

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -744,3 +744,41 @@ pub(super) async fn repo_branches(
     });
     Ok(Json(out))
 }
+
+#[derive(Debug, Deserialize)]
+pub(super) struct RevisionValidationQuery {
+    cwd: String,
+    revision: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct RevisionValidation {
+    valid: bool,
+    repo_root: String,
+    message: Option<String>,
+}
+
+/// Validate a user-entered worktree fork point without creating a branch or
+/// worktree. The creation drawer uses this while the base field is editable;
+/// provisioning repeats the check to keep the mutation boundary authoritative.
+pub(super) async fn validate_repo_revision(
+    Query(q): Query<RevisionValidationQuery>,
+) -> ApiResult<Json<RevisionValidation>> {
+    let cwd = PathBuf::from(&q.cwd);
+    let repo_root = git::repo_root(&cwd)
+        .await
+        .map_err(|e| AppError::bad_request(e.to_string()))?;
+    let revision = q.revision.trim();
+    let valid = !revision.is_empty() && git::revision_exists(&repo_root, revision).await;
+    let message = (!valid).then(|| {
+        format!(
+            "Base revision '{revision}' was not found in repository '{}'. Choose a branch, remote-tracking branch, tag, or commit that exists in this repository.",
+            repo_root.display()
+        )
+    });
+    Ok(Json(RevisionValidation {
+        valid,
+        repo_root: repo_root.display().to_string(),
+        message,
+    }))
+}

--- a/crates/loom/tests/integration/branches.rs
+++ b/crates/loom/tests/integration/branches.rs
@@ -373,6 +373,27 @@ async fn attach_to_existing_branch() {
         "main should be listed as current, got {arr:?}"
     );
 
+    let valid_base = client
+        .get(&format!(
+            "/api/repos/revisions/validate?cwd={cwd}&revision=main"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(valid_base["valid"], true);
+    assert_eq!(valid_base["message"], serde_json::Value::Null);
+
+    let missing_base = client
+        .get(&format!(
+            "/api/repos/revisions/validate?cwd={cwd}&revision=agent/missing-upstream-worktree"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(missing_base["valid"], false);
+    assert!(missing_base["message"]
+        .as_str()
+        .unwrap()
+        .contains("was not found in repository"));
+
     // A branch with no worktree gets a fresh .worktrees/<slug>.
     sh(&repo, "git", &["branch", "feature/x", "main"]);
     let attached = client

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -197,9 +197,6 @@ async fn has_remote(dir: &Path, name: &str) -> bool {
 }
 
 /// Whether `rev` resolves to a commit in this repo.
-///
-/// This is public so launch surfaces can validate a user-supplied fork point
-/// before attempting to create a worktree.
 pub async fn revision_exists(dir: &Path, rev: &str) -> bool {
     git(
         dir,
@@ -212,6 +209,13 @@ pub async fn revision_exists(dir: &Path, rev: &str) -> bool {
     )
     .await
     .is_ok()
+}
+
+pub fn missing_revision_message(dir: &Path, rev: &str) -> String {
+    format!(
+        "Base revision '{rev}' was not found in repository '{}'. Choose a branch, remote-tracking branch, tag, or commit available there; if it exists in another clone, use that repository instead.",
+        dir.display()
+    )
 }
 
 /// The default branch on `origin` (e.g. `main`), resolved locally and cheaply:

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -197,7 +197,10 @@ async fn has_remote(dir: &Path, name: &str) -> bool {
 }
 
 /// Whether `rev` resolves to a commit in this repo.
-async fn commit_exists(dir: &Path, rev: &str) -> bool {
+///
+/// This is public so launch surfaces can validate a user-supplied fork point
+/// before attempting to create a worktree.
+pub async fn revision_exists(dir: &Path, rev: &str) -> bool {
     git(
         dir,
         &[
@@ -230,7 +233,7 @@ async fn origin_default_branch(dir: &Path) -> Option<String> {
         }
     }
     for cand in ["main", "master"] {
-        if commit_exists(dir, &format!("origin/{cand}")).await {
+        if revision_exists(dir, &format!("origin/{cand}")).await {
             tracing::debug!(dir = %dir.display(), default_branch = cand, "resolved origin default branch by probing candidates");
             return Some(cand.to_string());
         }
@@ -263,7 +266,7 @@ pub async fn default_base(dir: &Path) -> Result<String> {
         let fetch_result = git(dir, &["fetch", "origin", &default]).await;
         tracing::debug!(dir = %dir.display(), branch = %default, ok = fetch_result.is_ok(), "fetch of default branch completed");
         let remote_ref = format!("origin/{default}");
-        if commit_exists(dir, &remote_ref).await {
+        if revision_exists(dir, &remote_ref).await {
             tracing::debug!(dir = %dir.display(), base = %remote_ref, "using fresh origin default as launch base");
             return Ok(remote_ref);
         }
@@ -779,7 +782,7 @@ mod tests {
         // commit is now reachable via origin.
         clone(&bare_url, &dest, None).await.unwrap();
         assert!(
-            commit_exists(&dest, &second).await,
+            revision_exists(&dest, &second).await,
             "fetch pulled the new remote commit into the existing clone"
         );
     }

--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -103,6 +103,29 @@ test.describe('creating a session via the UI form', () => {
     await expect(page.getByTestId('action-open-editor')).toBeVisible();
   });
 
+  test('rejects a missing base revision while the creation form remains editable', async ({
+    page,
+    weaver,
+  }) => {
+    await page.goto(`${weaver.baseUrl}/sessions/new`);
+    await page.getByPlaceholder(repoPlaceholder).fill(weaver.repoPath);
+    await page.getByPlaceholder('Add a /health endpoint').fill('Fork from upstream work');
+    await page.getByText('Advanced branch controls').click();
+
+    const base = page.locator('#launch-base-branch');
+    await base.fill('agent/missing-upstream-worktree');
+    await expect(page.getByTestId('base-validation-error')).toContainText(
+      'was not found in repository',
+    );
+    await expect(page.getByTestId('create-session')).toBeDisabled();
+    await expect(base).toBeEditable();
+    await expect(page).toHaveURL(`${weaver.baseUrl}/sessions/new`);
+
+    await base.fill('main');
+    await expect(page.getByTestId('base-validation-error')).toBeHidden();
+    await expect(page.getByTestId('create-session')).toBeEnabled();
+  });
+
   test('refreshes added, edited, and deleted profiles without losing the cached draft', async ({
     page,
     weaver,


### PR DESCRIPTION
Validate explicit session base revisions through a read-only repository endpoint while the launch form is still editable. Missing revisions now show an actionable inline error, block creation until corrected, and explain how to handle a revision that lives in another clone.

Repeat the validation at the provisioning boundary so API and CLI launches fail clearly before attempting git worktree creation.