### PR TITLE
fix(loom): preserve mid-turn messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ composition, and bounded Scratch drop target as the CLI.
 
 `poll` reads lifecycle and attention, `wait` blocks until completion or human
 attention, `send` delivers immediate control input, and `interrupt` stops the
-current turn. For ACP, a supported live turn is steered; otherwise Loom safely
-cancels/restarts or queues through the conversation contract. Session commands
-accept an id, branch id, branch name, or `repo:branch`.
+current turn. For ACP, immediate control input cancels and restarts, while the
+conversation composer durably queues feedback behind a live turn. Session
+commands accept an id, branch id, branch name, or `repo:branch`.
 
 The session title is one canonical, unqualified task label; fleet views add its
 Group only when they need a qualified `Group / Task` name. Loom records whether
@@ -245,14 +245,14 @@ the workbench header.
 Every session detail has a **Conversation** tab that renders the agent's chat
 with the model — user turns, replies, thinking, and tool calls — live and
 (via the archive capture below) still there to review after the terminal is gone.
-For ACP sessions, a prompt submitted while the agent is working steers the live
-turn when the adapter supports steering; otherwise loom safely queues it as the
-next turn. Unseen queued feedback can be pulled back into the composer with its
-**Edit** action or ArrowUp from an empty composer. The live status names visible
+For ACP sessions, a prompt submitted while the agent is working is durably
+queued for the next turn. Unseen queued feedback can be pulled back into the
+composer with its **Edit** action or ArrowUp from an empty composer, or sent
+immediately with **Stop & send**. The live status names visible
 thinking, writing, or tool activity and reports how long it has been since the
 agent produced an observable update; quiet time is not guessed to mean stuck.
-Cross-session `loom session send` is immediate control input instead: it steers
-a supported live turn, or cancels that turn and starts the message as a new one.
+Cross-session `loom session send` is immediate control input instead: it cancels
+a live turn and starts the message as a new one.
 
 Whenever a session is archived — by the Archive button or automatically on merge
 — loom first captures that conversation to disk: it finds the agent's transcript

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -505,13 +505,10 @@ fn preferred_mode(modes: &[Value]) -> Option<String> {
     })
 }
 
-/// How a prompt was accepted plus the turn it belongs to — the `POST /prompt`
-/// 202 body. `steered` is true only when the adapter injected it into the
-/// already-running turn; unsupported adapters retain the durable queue.
-#[derive(Debug, Clone, Serialize)]
+/// Whether a prompt was queued or started, plus the turn it belongs to.
+#[derive(Debug, Clone)]
 pub struct PromptAck {
     pub queued: bool,
-    pub steered: bool,
     pub turn: Option<i64>,
 }
 
@@ -544,27 +541,6 @@ pub struct AcpMetadata {
     pub commands: Vec<Value>,
     pub config_options: Vec<Value>,
     pub modes: Vec<Value>,
-    /// Whether the adapter advertised a steering extension whose turn lifecycle
-    /// loom can safely own. The browser uses this observed, normalized capability
-    /// instead of optimistically probing a private method that may not exist.
-    pub steering_supported: bool,
-}
-
-const CLAUDE_AGENT_ACP: &str = "@agentclientprotocol/claude-agent-acp";
-
-/// Normalize the private steering capability to the lifecycle contract loom
-/// requires. claude-agent-acp through 0.66 can acknowledge an injected steer,
-/// reject the owning `session/prompt`, then stream the steered answer after the
-/// turn has ended (upstream issue #934). The adapter does not yet advertise a
-/// capability that distinguishes a fixed lifecycle, so keep its messages on
-/// loom's durable next-turn queue meanwhile. Other adapters retain their
-/// advertised behavior.
-fn reliable_steering(init: &wire::InitializeResult) -> bool {
-    init.meta.steering.supported
-        && init
-            .agent_info
-            .as_ref()
-            .is_none_or(|agent| agent.name != CLAUDE_AGENT_ACP)
 }
 
 /// A live session's control surface, held in the [`AcpRegistry`]: send commands
@@ -588,27 +564,20 @@ impl AcpHandle {
         self.metadata.lock().unwrap().clone()
     }
 
-    /// Send a user message: dispatched as a `session/prompt` when idle, steered
-    /// into a live turn when the adapter advertises support, or appended to the
-    /// durable queue otherwise.
+    /// Send a user message: dispatched as a `session/prompt` when idle or
+    /// appended to the durable next-turn queue while the agent is working.
     pub async fn prompt(
         &self,
         text: String,
         by: Option<String>,
-        force_steer: bool,
         resources: Vec<Value>,
     ) -> Result<PromptAck> {
-        let delivery = if force_steer {
-            PromptDelivery::ForceSteer
-        } else {
-            PromptDelivery::Queue
-        };
-        self.send_prompt(text, by, delivery, resources).await
+        self.send_prompt(text, by, PromptDelivery::Queue, resources)
+            .await
     }
 
     /// Deliver a cross-session send without leaving it behind a live turn:
-    /// steer when the adapter supports it, otherwise cancel the current turn
-    /// and start the message normally.
+    /// cancel the current turn and start the message normally.
     pub async fn send_now(
         &self,
         text: String,
@@ -641,10 +610,9 @@ impl AcpHandle {
             .map_err(|_| anyhow!("acp task dropped the reply"))?
     }
 
-    /// Send the current durable next-turn queue now: promote it when the adapter
-    /// advertises steering, otherwise cancel the live turn and start it normally.
-    /// The task reads the queue itself so the browser cannot accidentally send
-    /// stale or partial text.
+    /// Send the current durable next-turn queue now, cancelling a live turn
+    /// first when necessary. The task reads the queue itself so the browser
+    /// cannot accidentally send stale or partial text.
     pub async fn force_pending(&self, by: Option<String>) -> Result<PromptAck> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
@@ -906,7 +874,6 @@ impl AcpRegistry {
                     if acknowledge {
                         let _ = reply.send(Ok(PromptAck {
                             queued: false,
-                            steered: false,
                             turn: Some(0),
                         }));
                     } else {
@@ -946,7 +913,6 @@ impl AcpRegistry {
                     let _ = prompts.send((text, by));
                     let _ = reply.send(Ok(PromptAck {
                         queued: false,
-                        steered: false,
                         turn: Some(0),
                     }));
                 }
@@ -1193,9 +1159,7 @@ pub async fn attach(state: &AcpCtx, session_id: &str) -> Result<()> {
 enum PromptDelivery {
     /// Preserve the conversation composer's queue-first behavior.
     Queue,
-    /// Require the adapter's steering extension and surface rejection.
-    ForceSteer,
-    /// Cross-session control: steer, or cancel and restart as a fallback.
+    /// Cross-session control: cancel and restart immediately.
     Immediate,
 }
 
@@ -1398,23 +1362,6 @@ struct PendingPerm {
     frame_seq: u64,
 }
 
-/// A `_session/steering` request waiting for the adapter's acceptance response.
-struct PendingSteer {
-    text: String,
-    by: Option<String>,
-    turn: i64,
-    delivery: PromptDelivery,
-    /// Exact durable queue prefix promoted by this request. Consumed only after
-    /// the adapter accepts steering, preserving messages appended behind it.
-    promoted_queue: Option<String>,
-    resources: Vec<Value>,
-    /// Forced and immediate delivery wait for the adapter's final answer. An
-    /// ordinary composer prompt is acknowledged as durably queued before
-    /// steering starts, so it carries no waiting HTTP reply and cannot lock the
-    /// composer behind a private RPC.
-    reply: Option<oneshot::Sender<Result<PromptAck>>>,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum TurnEndSource {
     MatchingPromptResponse,
@@ -1476,15 +1423,9 @@ struct Task {
     pending_config: HashMap<u64, oneshot::Sender<Result<AcpMetadata>>>,
     #[allow(dead_code)]
     load_session_cap: bool,
-    /// codex-acp advertises this experimental extension in
-    /// `_meta.steering.supported`; other adapters keep queue semantics.
-    steering_cap: bool,
-    pending_steers: HashMap<u64, PendingSteer>,
-    /// A turn started internally by the steering extension after the previous
-    /// turn raced to completion. It has no `session/prompt` response id, so its
-    /// end is taken from codex-acp's `session_info_update` idle edge.
+    /// A recovered adapter-owned turn with no prompt response id. Normal turns
+    /// are closed by their prompt response instead.
     external_turn: bool,
-    pending_external: Option<PendingSteer>,
     /// A cancelled turn may be followed by the adapter's presentation-only
     /// "Conversation interrupted" prose after the next turn has already begun.
     /// Consume that one notice rather than journaling it under the wrong turn.
@@ -1557,10 +1498,7 @@ impl Task {
             pending_mode: HashMap::new(),
             pending_config: HashMap::new(),
             load_session_cap: false,
-            steering_cap: false,
-            pending_steers: HashMap::new(),
             external_turn: false,
-            pending_external: None,
             pending_interrupt_notice_through: None,
             suppress_journal: false,
             highest_seq: 0,
@@ -1616,7 +1554,6 @@ impl Task {
         let turns_dispatched = if max_seq < 0 { 0 } else { current_turn + 1 };
 
         let metadata = Self::load_persisted_metadata(&state.db, &session.id).await?;
-        let steering_cap = metadata.steering_supported;
         Ok(Self {
             db: state.db.clone(),
             bus: state.bus.clone(),
@@ -1646,10 +1583,7 @@ impl Task {
             pending_mode: HashMap::new(),
             pending_config: HashMap::new(),
             load_session_cap: false,
-            steering_cap,
-            pending_steers: HashMap::new(),
             external_turn,
-            pending_external: None,
             pending_interrupt_notice_through: None,
             suppress_journal: false,
             highest_seq: session.acp_ack_seq.max(0) as u64,
@@ -1824,17 +1758,6 @@ impl Task {
         let res = res.ok_or_else(|| anyhow!("initialize failed: {err:?}"))?;
         if let Ok(init) = serde_json::from_value::<wire::InitializeResult>(res) {
             self.load_session_cap = init.agent_capabilities.load_session;
-            self.steering_cap = reliable_steering(&init);
-            if init.meta.steering.supported && !self.steering_cap {
-                let agent = init.agent_info.as_ref();
-                tracing::warn!(
-                    session = %self.session_id,
-                    agent = agent.map(|info| info.name.as_str()).unwrap_or("unknown"),
-                    version = agent.map(|info| info.version.as_str()).unwrap_or("unknown"),
-                    "ignoring ACP steering capability with unsafe prompt ownership"
-                );
-            }
-            self.metadata.lock().unwrap().steering_supported = self.steering_cap;
         }
 
         match &launch.new_or_load {
@@ -2385,11 +2308,6 @@ impl Task {
         let Some(id) = inc.id.as_ref().and_then(Value::as_u64) else {
             return;
         };
-        if let Some(pending) = self.pending_steers.remove(&id) {
-            self.on_steering_response(pending, inc.result, inc.error)
-                .await;
-            return;
-        }
         if let Some(pending) = self.pending_mode.remove(&id) {
             let result = if let Some(error) = inc.error {
                 Err(anyhow!("session/set_mode failed: {error}"))
@@ -2551,6 +2469,7 @@ impl Task {
         // client that reacts to the event sees a consistent `live_turn`.
         self.turn_live = false;
         self.inflight_prompt = None;
+        self.external_turn = false;
         self.effective_mode = None;
         let _ = session::set_inflight(&self.db, &self.session_id, None).await;
         self.emit(
@@ -2566,21 +2485,6 @@ impl Task {
         // turn feedback they have not seen acknowledged into another running
         // turn; leave the durable queue visible until they explicitly send it.
         if stop == "cancelled" {
-            return;
-        }
-
-        // The steering extension may have raced this boundary and started the
-        // user's message as a fresh adapter-owned turn. Adopt it before the
-        // ordinary durable queue so prompts retain their arrival order.
-        if let Some(pending) = self.pending_external.take() {
-            self.begin_external_turn(pending).await;
-            return;
-        }
-
-        // A steering request can finish just after the original prompt. Let its
-        // response decide whether the adapter already started the next turn
-        // before dispatching any later, durably queued message.
-        if !self.pending_steers.is_empty() {
             return;
         }
 
@@ -2717,144 +2621,6 @@ impl Task {
         }
     }
 
-    async fn on_steering_response(
-        &mut self,
-        pending: PendingSteer,
-        result: Option<Value>,
-        error: Option<Value>,
-    ) {
-        let outcome = result
-            .and_then(|v| serde_json::from_value::<wire::SteeringResult>(v).ok())
-            .map(|r| r.outcome);
-        match (outcome, error) {
-            (Some(wire::SteeringOutcome::Injected), None) => {
-                self.consume_promoted_queue(&pending).await;
-                // A steer belongs to the live turn rather than opening another
-                // item in the turn index. Journal it only after the adapter has
-                // accepted it; a rejected extension falls back without leaving
-                // a phantom message in the transcript.
-                self.current_turn = pending.turn;
-                // The steering response is ordered after everything the adapter
-                // emitted before accepting the user's message. Commit any prose
-                // already visible over SSE before assigning the prompt its
-                // journal sequence, or a later buffer flush moves that earlier
-                // response below the user's follow-up on refresh.
-                self.flush_buf().await;
-                let by = pending.by.map(Value::from).unwrap_or(Value::Null);
-                self.journal_block(
-                    kind::USER_MESSAGE,
-                    json!({
-                        "text": pending.text,
-                        "by": by,
-                        "steered": true,
-                        "resources": pending.resources,
-                    }),
-                )
-                .await;
-                if let Some(reply) = pending.reply {
-                    let _ = reply.send(Ok(PromptAck {
-                        queued: false,
-                        steered: true,
-                        turn: Some(pending.turn),
-                    }));
-                }
-                if !self.turn_live {
-                    self.dispatch_pending_prompt().await;
-                }
-            }
-            (Some(wire::SteeringOutcome::StartedNewTurn), None) => {
-                self.consume_promoted_queue(&pending).await;
-                if self.turn_live {
-                    // codex-acp waits for its old prompt to settle before taking
-                    // this branch. Keep the request until loom consumes that
-                    // prompt response, then adopt the already-started turn.
-                    self.pending_external = Some(pending);
-                } else {
-                    self.begin_external_turn(pending).await;
-                }
-            }
-            (outcome, error) => {
-                tracing::warn!(
-                    session = %self.session_id,
-                    ?outcome,
-                    ?error,
-                    "steering failed"
-                );
-                match pending.delivery {
-                    PromptDelivery::Queue => self.fallback_prompt(pending).await,
-                    PromptDelivery::ForceSteer => {
-                        let detail = error
-                            .map(|e| e.to_string())
-                            .unwrap_or_else(|| format!("adapter returned {outcome:?}"));
-                        if let Some(reply) = pending.reply {
-                            let _ =
-                                reply.send(Err(anyhow!("adapter rejected forced steer: {detail}")));
-                        }
-                    }
-                    PromptDelivery::Immediate => {
-                        let result = self
-                            .restart_prompt(pending.text, pending.by, pending.resources)
-                            .await;
-                        if let Some(reply) = pending.reply {
-                            let _ = reply.send(result);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    async fn consume_promoted_queue(&self, pending: &PendingSteer) {
-        let Some(promoted) = pending.promoted_queue.as_deref() else {
-            return;
-        };
-        if let Err(error) =
-            session::consume_pending_prompt(&self.db, &self.session_id, promoted).await
-        {
-            // The adapter has already accepted the feedback, so continue the
-            // turn and make the durability failure loud. A healthy database
-            // preserves any messages appended behind the promoted prefix.
-            tracing::error!(
-                session = %self.session_id,
-                %error,
-                "steered queued feedback but could not consume its durable copy"
-            );
-        } else {
-            match session::read_pending_prompt(&self.db, &self.session_id).await {
-                Ok(remaining) => {
-                    self.emit_queue((!remaining.trim().is_empty()).then_some(remaining.as_str()));
-                }
-                Err(error) => tracing::error!(
-                    session = %self.session_id,
-                    %error,
-                    "consumed steered feedback but could not refresh the queue view"
-                ),
-            }
-        }
-    }
-
-    async fn fallback_prompt(&mut self, pending: PendingSteer) {
-        let ack = if pending.promoted_queue.is_some() {
-            if self.turn_live {
-                Ok(PromptAck {
-                    queued: true,
-                    steered: false,
-                    turn: Some(self.current_turn),
-                })
-            } else {
-                self.start_pending_prompt(pending.by).await
-            }
-        } else if self.turn_live {
-            self.queue_prompt(&pending.text, &pending.resources).await
-        } else {
-            self.start_prompt(pending.text, pending.by, pending.resources)
-                .await
-        };
-        if let Some(reply) = pending.reply {
-            let _ = reply.send(ack);
-        }
-    }
-
     async fn restart_prompt(
         &mut self,
         text: String,
@@ -2868,27 +2634,13 @@ impl Task {
     }
 
     async fn queue_prompt(&self, text: &str, resources: &[Value]) -> Result<PromptAck> {
-        self.queue_prompt_with_value(text, resources)
-            .await
-            .map(|(ack, _)| ack)
-    }
-
-    async fn queue_prompt_with_value(
-        &self,
-        text: &str,
-        resources: &[Value],
-    ) -> Result<(PromptAck, String)> {
         let queued = queued_prompt_text(text, resources);
         let pending = session::append_pending_prompt(&self.db, &self.session_id, &queued).await?;
         self.emit_queue(Some(&pending));
-        Ok((
-            PromptAck {
-                queued: true,
-                steered: false,
-                turn: Some(self.current_turn),
-            },
-            pending,
-        ))
+        Ok(PromptAck {
+            queued: true,
+            turn: Some(self.current_turn),
+        })
     }
 
     async fn start_pending_prompt(&mut self, by: Option<String>) -> Result<PromptAck> {
@@ -2913,69 +2665,8 @@ impl Task {
         self.start_turn(text, by, resources).await?;
         Ok(PromptAck {
             queued: false,
-            steered: false,
             turn: Some(self.current_turn),
         })
-    }
-
-    async fn begin_external_turn(&mut self, pending: PendingSteer) {
-        let turn = if self.turns_dispatched > 0 {
-            self.current_turn + 1
-        } else {
-            self.current_turn
-        };
-        self.effective_mode = self.current_mode.clone();
-        let inflight = json!({
-            "turn": turn,
-            "external": true,
-            "mode": self.effective_mode,
-        })
-        .to_string();
-        let persisted = session::set_inflight(&self.db, &self.session_id, Some(&inflight)).await;
-        if let Err(e) = persisted {
-            if let Some(reply) = pending.reply {
-                let _ = reply.send(Err(e));
-            }
-            return;
-        }
-        self.current_turn = turn;
-        if self
-            .pending_interrupt_notice_through
-            .is_some_and(|through| self.current_turn > through)
-        {
-            self.pending_interrupt_notice_through = None;
-        }
-        self.next_seq = 0;
-        self.turns_dispatched += 1;
-        self.turn_live = true;
-        self.external_turn = true;
-        self.emit(
-            "turn",
-            json!({
-                "turn": self.current_turn,
-                "state": "started",
-                "effective_mode": self.effective_mode,
-            }),
-        );
-        let by = pending.by.map(Value::from).unwrap_or(Value::Null);
-        self.journal_block(
-            kind::USER_MESSAGE,
-            json!({
-                "text": pending.text,
-                "by": by,
-                "steered": false,
-                "resources": pending.resources,
-            }),
-        )
-        .await;
-        crate::status::record_acp_lifecycle(&self.db, &self.bus, &self.session_id, "working").await;
-        if let Some(reply) = pending.reply {
-            let _ = reply.send(Ok(PromptAck {
-                queued: false,
-                steered: false,
-                turn: Some(self.current_turn),
-            }));
-        }
     }
 
     async fn start_turn(
@@ -3363,16 +3054,6 @@ impl Task {
             // turn and its direct successor so unrelated future prose is never
             // mistaken for adapter chrome if this adapter emits no notice.
             self.pending_interrupt_notice_through = Some(self.current_turn + 1);
-            for (_, pending) in self.pending_steers.drain() {
-                if let Some(reply) = pending.reply {
-                    let _ = reply.send(Err(anyhow!("turn was cancelled")));
-                }
-            }
-            if let Some(pending) = self.pending_external.take() {
-                if let Some(reply) = pending.reply {
-                    let _ = reply.send(Err(anyhow!("turn was cancelled")));
-                }
-            }
             // Cancellation is a client-owned boundary. Some adapters do not
             // answer the cancelled prompt, so settle loom's journal and
             // lifecycle immediately after the notification lands.
@@ -3407,160 +3088,55 @@ impl Task {
                 resources,
                 reply,
             } => {
-                if self.turn_live {
-                    if self.steering_cap
-                        && self.pending_steers.is_empty()
-                        && self.pending_external.is_none()
-                    {
-                        let id = self.next_id();
-                        let request = wire::request_line(
-                            id,
-                            method::SESSION_STEERING,
-                            wire::steering_params(&self.acp_session_id, &text, &resources),
-                        );
-                        if delivery != PromptDelivery::Queue {
-                            // Explicit steering reports the adapter's real answer
-                            // and does not also leave a queued copy behind if the
-                            // private extension is rejected.
-                            match self.stream.write(&request).await {
-                                Ok(()) => {
-                                    self.pending_steers.insert(
-                                        id,
-                                        PendingSteer {
-                                            text,
-                                            by,
-                                            turn: self.current_turn,
-                                            delivery,
-                                            promoted_queue: None,
-                                            resources,
-                                            reply: Some(reply),
-                                        },
-                                    );
-                                }
-                                Err(error) => {
-                                    let result = if delivery == PromptDelivery::Immediate {
-                                        self.restart_prompt(text, by, resources).await
-                                    } else {
-                                        Err(error)
-                                    };
-                                    let _ = reply.send(result);
-                                }
-                            }
+                match delivery {
+                    PromptDelivery::Queue => {
+                        let ack = if self.turn_live {
+                            // A failed queue write must surface — a 202 that
+                            // silently dropped the prompt would be worse than an
+                            // error.
+                            self.queue_prompt(&text, &resources).await
                         } else {
-                            // Durability and the HTTP acknowledgement come before
-                            // the private steering RPC. If the adapter hangs,
-                            // rejects, or disappears, the message remains visibly
-                            // queued and the browser can keep accepting feedback.
-                            match self.queue_prompt_with_value(&text, &resources).await {
-                                Ok((queued_ack, promoted_queue)) => {
-                                    match self.stream.write(&request).await {
-                                        Ok(()) => {
-                                            let _ = reply.send(Ok(queued_ack));
-                                            self.pending_steers.insert(
-                                                id,
-                                                PendingSteer {
-                                                    text,
-                                                    by,
-                                                    turn: self.current_turn,
-                                                    delivery,
-                                                    promoted_queue: Some(promoted_queue),
-                                                    resources,
-                                                    reply: None,
-                                                },
-                                            );
-                                        }
-                                        Err(error) => {
-                                            tracing::warn!(session = %self.session_id, %error,
-                                                "steering write failed; feedback remains queued");
-                                            let _ = reply.send(Ok(queued_ack));
-                                        }
+                            match session::read_pending_prompt(&self.db, &self.session_id).await {
+                                Ok(pending) if !pending.trim().is_empty() => {
+                                    // A stopped turn can leave earlier feedback
+                                    // waiting. Append the new input and send the
+                                    // whole backlog in arrival order.
+                                    match self.queue_prompt(&text, &resources).await {
+                                        Ok(_) => self.start_pending_prompt(by).await,
+                                        Err(error) => Err(error),
                                     }
                                 }
-                                Err(error) => {
-                                    let _ = reply.send(Err(error));
-                                }
+                                Ok(_) => self.start_prompt(text, by, resources).await,
+                                Err(error) => Err(error),
                             }
-                        }
-                    } else {
-                        match delivery {
-                            PromptDelivery::Queue => {
-                                // A failed queue write must surface — a 202 that
-                                // silently dropped the prompt would be worse
-                                // than an error.
-                                let ack = self.queue_prompt(&text, &resources).await;
-                                let _ = reply.send(ack);
-                            }
-                            PromptDelivery::ForceSteer => {
-                                let message = if self.steering_cap {
-                                    "another steer is still pending; retry when it settles"
-                                } else {
-                                    "this agent does not support steering; queue the feedback or stop and send it"
-                                };
-                                let _ = reply.send(Err(anyhow!(message)));
-                            }
-                            PromptDelivery::Immediate => {
-                                let ack = self.restart_prompt(text, by, resources).await;
-                                let _ = reply.send(ack);
-                            }
-                        }
+                        };
+                        let _ = reply.send(ack);
                     }
-                } else {
-                    let ack = self.start_prompt(text, by, resources).await;
-                    let _ = reply.send(ack);
+                    PromptDelivery::Immediate => {
+                        let ack = self.restart_prompt(text, by, resources).await;
+                        let _ = reply.send(ack);
+                    }
                 }
             }
             Command::ForcePending { by, reply } => {
-                if !self.pending_steers.is_empty() || self.pending_external.is_some() {
-                    let _ = reply.send(Err(anyhow!(
-                        "another steer is still pending; retry when it settles"
-                    )));
-                } else {
-                    let queued =
-                        match session::read_pending_prompt(&self.db, &self.session_id).await {
-                            Ok(queued) => queued,
-                            Err(error) => {
-                                let _ = reply.send(Err(error));
-                                return;
-                            }
-                        };
-                    if queued.trim().is_empty() {
-                        let _ = reply.send(Err(anyhow!("there is no queued feedback to send")));
-                    } else if !self.turn_live {
-                        let result = self.start_pending_prompt(by).await;
-                        let _ = reply.send(result);
-                    } else if !self.steering_cap {
-                        let result = match self.cancel_live_turn().await {
-                            Ok(()) => self.start_pending_prompt(by).await,
-                            Err(error) => Err(error),
-                        };
-                        let _ = reply.send(result);
-                    } else {
-                        let id = self.next_id();
-                        let request = wire::request_line(
-                            id,
-                            method::SESSION_STEERING,
-                            wire::steering_params(&self.acp_session_id, &queued, &[]),
-                        );
-                        match self.stream.write(&request).await {
-                            Ok(()) => {
-                                self.pending_steers.insert(
-                                    id,
-                                    PendingSteer {
-                                        text: queued.clone(),
-                                        by,
-                                        turn: self.current_turn,
-                                        delivery: PromptDelivery::ForceSteer,
-                                        promoted_queue: Some(queued),
-                                        resources: Vec::new(),
-                                        reply: Some(reply),
-                                    },
-                                );
-                            }
-                            Err(error) => {
-                                let _ = reply.send(Err(error));
-                            }
-                        }
+                let queued = match session::read_pending_prompt(&self.db, &self.session_id).await {
+                    Ok(queued) => queued,
+                    Err(error) => {
+                        let _ = reply.send(Err(error));
+                        return;
                     }
+                };
+                if queued.trim().is_empty() {
+                    let _ = reply.send(Err(anyhow!("there is no queued feedback to send")));
+                } else if !self.turn_live {
+                    let result = self.start_pending_prompt(by).await;
+                    let _ = reply.send(result);
+                } else {
+                    let result = match self.cancel_live_turn().await {
+                        Ok(()) => self.start_pending_prompt(by).await,
+                        Err(error) => Err(error),
+                    };
+                    let _ = reply.send(result);
                 }
             }
             Command::NotifyPending { reply } => {
@@ -3570,13 +3146,11 @@ impl Task {
                 if self.turn_live {
                     let _ = reply.send(Ok(PromptAck {
                         queued: true,
-                        steered: false,
                         turn: Some(self.current_turn),
                     }));
                 } else if self.dispatch_review_inbox().await {
                     let _ = reply.send(Ok(PromptAck {
                         queued: false,
-                        steered: false,
                         turn: Some(self.current_turn),
                     }));
                 } else {
@@ -3586,25 +3160,15 @@ impl Task {
                 }
             }
             Command::RetractPending { reply } => {
-                // A steering RPC may already have handed this text to the
-                // adapter even though its durable fallback is still visible.
-                // Once that request is in flight, claiming the text is editable
-                // would be a lie: the eventual response can consume or run it.
-                if !self.pending_steers.is_empty() || self.pending_external.is_some() {
-                    let _ = reply.send(Err(anyhow!(
-                        "queued feedback is already being steered; wait for it to settle"
-                    )));
-                } else {
-                    let result = session::take_pending_prompt(&self.db, &self.session_id)
-                        .await
-                        .and_then(|pending| {
-                            pending.ok_or_else(|| anyhow!("there is no queued feedback to edit"))
-                        });
-                    if result.is_ok() {
-                        self.emit_queue(None);
-                    }
-                    let _ = reply.send(result);
+                let result = session::take_pending_prompt(&self.db, &self.session_id)
+                    .await
+                    .and_then(|pending| {
+                        pending.ok_or_else(|| anyhow!("there is no queued feedback to edit"))
+                    });
+                if result.is_ok() {
+                    self.emit_queue(None);
                 }
+                let _ = reply.send(result);
             }
             Command::Cancel { reply } => {
                 let _ = reply.send(self.cancel_live_turn().await);

--- a/crates/loom-agent/src/acp/wire.rs
+++ b/crates/loom-agent/src/acp/wire.rs
@@ -62,8 +62,6 @@ pub mod method {
     pub const SESSION_NEW: &str = "session/new";
     pub const SESSION_LOAD: &str = "session/load";
     pub const SESSION_PROMPT: &str = "session/prompt";
-    /// Experimental codex-acp extension for adding input to the active turn.
-    pub const SESSION_STEERING: &str = "_session/steering";
     pub const SESSION_CANCEL: &str = "session/cancel";
     pub const SESSION_SET_MODE: &str = "session/set_mode";
     pub const SESSION_SET_CONFIG_OPTION: &str = "session/set_config_option";
@@ -163,8 +161,8 @@ pub enum SessionUpdate {
         meta: UsageMeta,
     },
     /// codex-acp's thread lifecycle. Loom normally owns turn boundaries through
-    /// the `session/prompt` response; this closes the rare turn that the
-    /// steering extension starts internally after racing an end-of-turn.
+    /// the `session/prompt` response; this closes a recovered adapter-owned turn
+    /// that has no prompt response id.
     SessionInfoUpdate {
         #[serde(default, rename = "_meta")]
         meta: SessionInfoMeta,
@@ -395,27 +393,12 @@ pub struct PromptResult {
     pub stop_reason: String,
 }
 
-/// The `initialize` result — the standard agent capabilities plus extension
-/// metadata advertised by individual adapters.
+/// The `initialize` result capabilities loom uses.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeResult {
     #[serde(default)]
     pub agent_capabilities: AgentCapabilities,
-    #[serde(default)]
-    pub agent_info: Option<AgentInfo>,
-    #[serde(default, rename = "_meta")]
-    pub meta: InitializeMeta,
-}
-
-/// Identity reported by the ACP adapter during initialization.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AgentInfo {
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub version: String,
 }
 
 /// The subset of agent capabilities loom checks.
@@ -424,33 +407,6 @@ pub struct AgentInfo {
 pub struct AgentCapabilities {
     #[serde(default)]
     pub load_session: bool,
-}
-
-/// Adapter-specific capabilities carried in the initialize result's `_meta`.
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct InitializeMeta {
-    #[serde(default)]
-    pub steering: SteeringCapability,
-}
-
-/// The codex-acp steering capability (`_meta.steering.supported`).
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct SteeringCapability {
-    #[serde(default)]
-    pub supported: bool,
-}
-
-/// The result of codex-acp's `_session/steering` extension.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub enum SteeringOutcome {
-    Injected,
-    StartedNewTurn,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct SteeringResult {
-    pub outcome: SteeringOutcome,
 }
 
 // ---------------------------------------------------------------------------
@@ -501,11 +457,6 @@ pub fn prompt_params(session_id: &str, text: &str, resources: &[Value]) -> Value
         "sessionId": session_id,
         "prompt": prompt,
     })
-}
-
-/// codex-acp `_session/steering` params using ACP's ordinary prompt shape.
-pub fn steering_params(session_id: &str, text: &str, resources: &[Value]) -> Value {
-    prompt_params(session_id, text, resources)
 }
 
 /// `session/cancel` notification params.
@@ -858,22 +809,9 @@ mod tests {
 
         let init: InitializeResult = serde_json::from_value(json!({
             "agentCapabilities": { "loadSession": true },
-            "agentInfo": {
-                "name": "@agentclientprotocol/claude-agent-acp",
-                "version": "0.66.0"
-            },
-            "_meta": { "steering": { "supported": true } },
         }))
         .unwrap();
         assert!(init.agent_capabilities.load_session);
-        let agent = init.agent_info.unwrap();
-        assert_eq!(agent.name, "@agentclientprotocol/claude-agent-acp");
-        assert_eq!(agent.version, "0.66.0");
-        assert!(init.meta.steering.supported);
-
-        let steer: SteeringResult =
-            serde_json::from_value(json!({ "outcome": "startedNewTurn" })).unwrap();
-        assert_eq!(steer.outcome, SteeringOutcome::StartedNewTurn);
     }
 
     #[test]
@@ -884,16 +822,6 @@ mod tests {
         assert_eq!(v["method"], "initialize");
         assert_eq!(v["id"], 1);
         assert_eq!(v["params"]["protocolVersion"], 1);
-
-        let steer = request_line(
-            2,
-            method::SESSION_STEERING,
-            steering_params("sess-1", "pivot", &[]),
-        );
-        let v: Value = serde_json::from_slice(&steer[..steer.len() - 1]).unwrap();
-        assert_eq!(v["method"], "_session/steering");
-        assert_eq!(v["params"]["sessionId"], "sess-1");
-        assert_eq!(v["params"]["prompt"][0]["text"], "pivot");
 
         let resource = json!({
             "type": "resource_link",

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -1489,12 +1489,7 @@ async fn forward_acp_followup(
         .get(session_id)
         .ok_or_else(|| anyhow!("session has no live ACP task"))?;
     handle
-        .prompt(
-            prompt.to_string(),
-            Some("slack".to_string()),
-            false,
-            Vec::new(),
-        )
+        .prompt(prompt.to_string(), Some("slack".to_string()), Vec::new())
         .await
         .context("sending follow-up to ACP conversation")?;
     Ok(())

--- a/crates/loom-store/src/session.rs
+++ b/crates/loom-store/src/session.rs
@@ -1402,28 +1402,6 @@ pub async fn take_pending_prompt(db: &Db, id: &str) -> Result<Option<String>> {
     Ok(Some(pending))
 }
 
-/// Remove a promoted prefix from the durable queue without dropping messages
-/// appended behind it while the steering request was in flight.
-pub async fn consume_pending_prompt(db: &Db, id: &str, promoted: &str) -> Result<()> {
-    let current = read_pending_prompt(db, id).await?;
-    // Canonically '' (never NULL) when the whole queue was promoted — the column
-    // is `NOT NULL DEFAULT ''` on long-lived databases.
-    let remaining: &str = if current == promoted {
-        ""
-    } else if let Some(rest) = current.strip_prefix(promoted) {
-        rest.strip_prefix("\n\n")
-            .ok_or_else(|| anyhow!("queued prompt changed while it was being steered"))?
-    } else {
-        bail!("queued prompt changed while it was being steered");
-    };
-    sqlx::query("UPDATE sessions SET pending_prompt = ? WHERE id = ?")
-        .bind(remaining)
-        .bind(id)
-        .execute(db)
-        .await?;
-    Ok(())
-}
-
 pub async fn delete(db: &Db, id: &str) -> Result<Option<i64>> {
     let mut tx = weaver_core::db::begin_immediate(db).await?;
     let had_placement: bool = sqlx::query_scalar(
@@ -1935,21 +1913,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn consuming_a_promoted_prompt_preserves_later_queue_entries() {
-        let db = crate::db::connect_in_memory().await.unwrap();
-        let branch = branch_id(&db, "weaver/queue").await;
-        insert(&db, &new_session("queue", &branch, None))
-            .await
-            .unwrap();
-        append_pending_prompt(&db, "queue", "first").await.unwrap();
-        append_pending_prompt(&db, "queue", "second").await.unwrap();
-
-        consume_pending_prompt(&db, "queue", "first").await.unwrap();
-
-        assert_eq!(read_pending_prompt(&db, "queue").await.unwrap(), "second");
-    }
-
-    #[tokio::test]
     async fn handoff_replaces_profile_and_clears_provider_state() {
         let db = crate::db::connect_in_memory().await.unwrap();
         let branch = branch_id(&db, "weaver/handoff").await;
@@ -2089,11 +2052,6 @@ mod tests {
             Some(""),
             "cleared to '', not NULL"
         );
-
-        // consume of the whole queue and a full handoff must clear the same way.
-        append_pending_prompt(&db, "drain", "again").await.unwrap();
-        consume_pending_prompt(&db, "drain", "again").await.unwrap();
-        assert_eq!(read_pending_prompt(&db, "drain").await.unwrap(), "");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -577,8 +577,8 @@ export const getSessionChat = (id: string, before?: { turn: number; seq: number 
 };
 
 /** Send a user message to an ACP session. Returns 202 with
- *  `{ queued, steered: false, turn }`: a live turn keeps the message in the
- *  durable next-turn queue. */
+ *  `{ queued, turn }`: a live turn keeps the message in the durable next-turn
+ *  queue. */
 export const promptSession = (id: string, text: string, by?: string, files: string[] = []) =>
   post(`/sessions/${id}/prompt`, {
     text,

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -577,29 +577,20 @@ export const getSessionChat = (id: string, before?: { turn: number; seq: number 
 };
 
 /** Send a user message to an ACP session. Returns 202 with
- *  `{ queued, steered, turn }`: a live turn is steered when the adapter supports
- *  it, with the durable next-turn queue retained as the fallback. */
-export const promptSession = (
-  id: string,
-  text: string,
-  by?: string,
-  forceSteer = false,
-  files: string[] = [],
-) =>
+ *  `{ queued, steered: false, turn }`: a live turn keeps the message in the
+ *  durable next-turn queue. */
+export const promptSession = (id: string, text: string, by?: string, files: string[] = []) =>
   post(`/sessions/${id}/prompt`, {
     text,
     by,
-    force_steer: forceSteer,
     files,
   }) as Promise<PromptAck>;
 
-/** Send all durable next-turn feedback now: steer when the adapter advertises
- * support, otherwise stop the live turn and start one normal queued turn. */
+/** Send all durable next-turn feedback now, stopping a live turn first. */
 export const forceQueuedSession = (id: string, by?: string) =>
   post(`/sessions/${id}/prompt`, {
     text: '',
     by,
-    force_steer: true,
     force_queued: true,
     files: [],
   }) as Promise<PromptAck>;

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -102,10 +102,8 @@ const emptyMetadata = (): AcpMetadata => ({
   commands: [],
   config_options: [],
   modes: [],
-  steering_supported: false,
 });
 const metadata = ref<AcpMetadata>(emptyMetadata());
-const steeringSupported = computed(() => metadata.value.steering_supported);
 
 // The live mode, seeded from the session and advanced by `mode_change` blocks or
 // a local set — so the composer chip reads true without a refetch.
@@ -444,7 +442,7 @@ async function onAttachmentPick(event: Event) {
   }
 }
 
-async function submitPrompt(forceSteer = false) {
+async function submitPrompt() {
   if (!draft.value.trim() || sending.value || editingQueued.value || uploadingAttachment.value)
     return;
   const local = localCommand(draft.value);
@@ -466,7 +464,7 @@ async function submitPrompt(forceSteer = false) {
   optimistic.value.push(pending);
   autoFollow();
   try {
-    await promptSession(id.value, text, undefined, forceSteer, [...selectedFiles.value]);
+    await promptSession(id.value, text, undefined, [...selectedFiles.value]);
     const index = optimistic.value.findIndex((o) => o.key === pending.key);
     if (index >= 0) optimistic.value.splice(index, 1);
     draft.value = '';
@@ -1648,14 +1646,12 @@ function goTo(anchor: string) {
                     :disabled="sending || editingQueued"
                     :title="
                       turnLive
-                        ? steeringSupported
-                          ? 'Inject all queued feedback into the running turn now'
-                          : 'Stop the running turn and send all queued feedback as the next turn'
+                        ? 'Stop the running turn and send all queued feedback as the next turn'
                         : 'Start a new turn with all queued feedback'
                     "
                     @click="forceQueued"
                   >
-                    {{ turnLive ? (steeringSupported ? 'Force now' : 'Stop & send') : 'Send now' }}
+                    {{ turnLive ? 'Stop & send' : 'Send now' }}
                   </button>
                 </span>
               </header>
@@ -1744,7 +1740,7 @@ function goTo(anchor: string) {
       v-if="composerVisible"
       class="acp-composer"
       data-testid="acp-composer"
-      @submit.prevent="submitPrompt(false)"
+      @submit.prevent="submitPrompt()"
     >
       <p
         v-if="sendError"
@@ -1951,17 +1947,6 @@ function goTo(anchor: string) {
         <div class="acp-composer-right">
           <AgentUsage v-if="model.usage" :usage="model.usage" />
           <span class="acp-send-hint">Enter to send · Shift+Enter for a new line</span>
-          <button
-            v-if="turnLive && steeringSupported"
-            type="button"
-            class="btn-secondary px-3 py-1 text-xs"
-            data-testid="acp-composer-force-steer"
-            :disabled="sending || editingQueued || uploadingAttachment || !draft.trim()"
-            title="Inject this feedback into the running turn"
-            @click="submitPrompt(true)"
-          >
-            Force steer
-          </button>
           <button
             v-if="turnLive"
             type="button"

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -443,8 +443,6 @@ export interface AcpMetadata {
   commands: AcpCommand[];
   config_options: AcpConfigOption[];
   modes: AcpMode[];
-  /** Adapter-advertised support for the private steering extension. */
-  steering_supported: boolean;
 }
 
 // -- block payloads (by kind) --
@@ -572,8 +570,9 @@ export interface SseQueue {
   pending_prompt: string | null;
 }
 
-/** `POST /sessions/{id}/prompt` 202 body: whether the message steered the live
- *  turn, queued behind it, or started normally, plus the turn it belongs to. */
+/** `POST /sessions/{id}/prompt` 202 body: whether the message queued behind a
+ *  live turn or started normally, plus the turn it belongs to. `steered` stays
+ *  in the compatibility response and is always false. */
 export interface PromptAck {
   queued: boolean;
   steered: boolean;

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -571,11 +571,9 @@ export interface SseQueue {
 }
 
 /** `POST /sessions/{id}/prompt` 202 body: whether the message queued behind a
- *  live turn or started normally, plus the turn it belongs to. `steered` stays
- *  in the compatibility response and is always false. */
+ *  live turn or started normally, plus the turn it belongs to. */
 export interface PromptAck {
   queued: boolean;
-  steered: boolean;
   turn: number | null;
 }
 

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -453,8 +453,8 @@ enum SessionCmd {
         #[arg(long)]
         lifecycle_only: bool,
     },
-    /// Deliver a message to a session now. ACP sessions steer a supported live
-    /// turn, or stop it and start the message as a new turn.
+    /// Deliver a message to a session now. ACP sessions stop a live turn and
+    /// start the message as a new turn.
     Send {
         /// Session key: id, branch id, branch name, or `repo:branch`.
         session: String,

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -278,7 +278,7 @@ async fn prompt_channel_run(
         .clone()
         .expect("channel runs require a goal");
     if let Err(error) = handle
-        .prompt(goal.clone(), Some(by.clone()), false, Vec::new())
+        .prompt(goal.clone(), Some(by.clone()), Vec::new())
         .await
     {
         crate::runs::waiting(&st.db, &run.id).await.ok();

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1762,9 +1762,9 @@ pub(super) async fn send_session(
     Json(req): Json<SendReq>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
-    // A cross-session send must not sit behind an ACP turn indefinitely. Steer
-    // a supported live turn; otherwise cancel it and immediately start this
-    // message as a fresh turn, while keeping the same `nudge` audit.
+    // A cross-session send must not sit behind an ACP turn indefinitely. Cancel
+    // a live turn and immediately start this message as a fresh turn, while
+    // keeping the same `nudge` audit.
     if session.protocol == "acp" {
         let handle = require_acp_task(&st, &session)?;
         let by = author_or_manual(req.by.as_deref());
@@ -1785,7 +1785,7 @@ pub(super) async fn send_session(
             "sent": true,
             "submitted": true,
             "queued": ack.queued,
-            "steered": ack.steered,
+            "steered": false,
             "turn": ack.turn,
         })));
     }
@@ -1874,7 +1874,7 @@ pub(super) async fn preview_session(
 //
 // The conversation-first surface for ACP sessions: the journaled transcript
 // (`/chat`), its live delta stream (`/chat/stream`), and the drive routes a
-// person or watch uses — a steering/queueing send (`/prompt`), a
+// person or watch uses — a durable queueing send (`/prompt`), a
 // permission answer (`/permissions/{request_id}`), and a mode change (`/mode`).
 // ---------------------------------------------------------------------------
 
@@ -2018,8 +2018,6 @@ pub(super) struct PromptBody {
     pub text: String,
     #[serde(default)]
     pub by: Option<String>,
-    #[serde(default)]
-    pub force_steer: bool,
     /// Promote the server's durable next-turn queue instead of sending `text`.
     /// This keeps the action race-free when the browser is showing queued copy.
     #[serde(default)]
@@ -2136,9 +2134,9 @@ async fn prompt_resources(work_dir: &str, files: &[String]) -> ApiResult<Vec<Val
 }
 
 /// Send a user message to an ACP session: dispatched as a `session/prompt` when
-/// idle, steered into a live turn when supported, or appended to the durable
-/// queue otherwise. Returns 202 `{ queued, steered, turn }`. Every send records
-/// a `nudge` event (the audit rule).
+/// idle or appended to the durable queue while a turn is live. Returns 202
+/// `{ queued, steered: false, turn }`. Every send records a `nudge` event (the
+/// audit rule).
 pub(super) async fn prompt_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
@@ -2158,12 +2156,7 @@ pub(super) async fn prompt_session(
     } else {
         let resources = prompt_resources(&session.work_dir, &req.files).await?;
         handle
-            .prompt(
-                req.text.clone(),
-                Some(by.clone()),
-                req.force_steer,
-                resources,
-            )
+            .prompt(req.text.clone(), Some(by.clone()), resources)
             .await
     }
     .map_err(|e| AppError::conflict(e.to_string()))?;
@@ -2180,7 +2173,7 @@ pub(super) async fn prompt_session(
         StatusCode::ACCEPTED,
         Json(json!({
             "queued": ack.queued,
-            "steered": ack.steered,
+            "steered": false,
             "turn": ack.turn,
         })),
     ))
@@ -2188,7 +2181,7 @@ pub(super) async fn prompt_session(
 
 /// Pull unseen next-turn feedback back out of the durable queue for editing.
 /// The ACP task owns the consume so this action is serialized with automatic
-/// dispatch at a turn boundary and with steering responses.
+/// dispatch at a turn boundary.
 pub(super) async fn retract_queued_prompt(
     State(st): State<AppState>,
     Path(key): Path<String>,

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1785,7 +1785,6 @@ pub(super) async fn send_session(
             "sent": true,
             "submitted": true,
             "queued": ack.queued,
-            "steered": false,
             "turn": ack.turn,
         })));
     }
@@ -2135,8 +2134,7 @@ async fn prompt_resources(work_dir: &str, files: &[String]) -> ApiResult<Vec<Val
 
 /// Send a user message to an ACP session: dispatched as a `session/prompt` when
 /// idle or appended to the durable queue while a turn is live. Returns 202
-/// `{ queued, steered: false, turn }`. Every send records a `nudge` event (the
-/// audit rule).
+/// `{ queued, turn }`. Every send records a `nudge` event (the audit rule).
 pub(super) async fn prompt_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
@@ -2173,7 +2171,6 @@ pub(super) async fn prompt_session(
         StatusCode::ACCEPTED,
         Json(json!({
             "queued": ack.queued,
-            "steered": false,
             "turn": ack.turn,
         })),
     ))

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -42,9 +42,6 @@ let sessionId = null;
 let sessionCounter = 0;
 let cancelled = false;
 const steeringSupported = process.env.FAKE_ACP_STEERING === "1";
-const forceSteeringNewTurn = process.env.FAKE_ACP_STEERING_FORCE_NEW_TURN === "1";
-const brokenSteeringBoundary = process.env.FAKE_ACP_STEERING_BOUNDARY_ERROR === "1";
-const steeringDelayMs = Number(process.env.FAKE_ACP_STEERING_DELAY_MS || "0");
 const agentName = process.env.FAKE_ACP_AGENT_NAME || "fake-acp-agent";
 const agentVersion = process.env.FAKE_ACP_AGENT_VERSION || "1.0.0";
 const loadPermission = process.env.FAKE_ACP_LOAD_PERMISSION || "";
@@ -57,13 +54,9 @@ const summaryOutput =
   process.env.FAKE_ACP_SUMMARY_OUTPUT_B64 === undefined
     ? undefined
     : Buffer.from(process.env.FAKE_ACP_SUMMARY_OUTPUT_B64, "base64").toString("utf8");
-let promptActive = false;
-let activePromptId = null;
 let promptEpoch = 0;
 let promptResources = [];
 let poisoned = false;
-const steeringQueue = [];
-let deferredSteering = null;
 const pending = new Map(); // our request id -> resolver awaiting the client's response
 
 function send(obj) {
@@ -71,13 +64,6 @@ function send(obj) {
 }
 function respond(id, result) {
   send({ jsonrpc: JSONRPC, id, result });
-}
-function rejectMethod(id, method) {
-  send({
-    jsonrpc: JSONRPC,
-    id,
-    error: { code: -32601, message: `Method not found: ${method}`, data: { method } },
-  });
 }
 function notify(update) {
   send({ jsonrpc: JSONRPC, method: "session/update", params: { sessionId, update } });
@@ -331,16 +317,8 @@ async function runToken(tok) {
 
 async function handlePrompt(id, params) {
   const epoch = ++promptEpoch;
-  activePromptId = id;
   cancelled = false;
-  promptActive = true;
   promptResources = (params.prompt || []).filter((b) => b.type === "resource_link");
-  if (steeringSupported) {
-    notify({
-      sessionUpdate: "session_info_update",
-      _meta: { codex: { threadStatus: { type: "active" } } },
-    });
-  }
   // The script is the prompt's first paragraph only. A real launch prompt
   // appends orientation prose (the entrance note, which echoes the session
   // title — i.e. the script itself) after a blank line; parsing past it would
@@ -351,7 +329,6 @@ async function handlePrompt(id, params) {
     .split("\n\n")[0];
   if (text === "poison") poisoned = true;
   if (poisoned) {
-    promptActive = false;
     if (id !== null) {
       send({
         jsonrpc: JSONRPC,
@@ -365,7 +342,6 @@ async function handlePrompt(id, params) {
     if (fixedOutput.length > 0) {
       notify({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: fixedOutput } });
     }
-    promptActive = false;
     if (id !== null) respond(id, { stopReason: "end_turn" });
     return;
   }
@@ -376,7 +352,6 @@ async function handlePrompt(id, params) {
         content: { type: "text", text: summaryOutput },
       });
     }
-    promptActive = false;
     if (id !== null) respond(id, { stopReason: "end_turn" });
     return;
   }
@@ -384,68 +359,11 @@ async function handlePrompt(id, params) {
     if (cancelled) break;
     if (tok.length === 0) continue;
     await runToken(tok);
-    // A broken steering boundary models claude-agent-acp rejecting the owning
-    // prompt while its injected replacement continues on the same SDK stream.
+    // An immediate cancel-and-restart can begin another prompt while this
+    // handler is still unwinding its cancellable sleep.
     if (epoch !== promptEpoch) return;
-    while (steeringQueue.length > 0 && !cancelled) {
-      const steering = steeringQueue.shift();
-      for (const steeringToken of steering.split("|")) {
-        if (steeringToken.length > 0) await runToken(steeringToken);
-      }
-    }
   }
-  promptActive = false;
-  activePromptId = null;
   if (id !== null) respond(id, { stopReason: cancelled ? "cancelled" : "end_turn" });
-  if (steeringSupported) {
-    notify({
-      sessionUpdate: "session_info_update",
-      _meta: { codex: { threadStatus: { type: "idle" } } },
-    });
-  }
-  if (deferredSteering !== null) {
-    const next = deferredSteering;
-    deferredSteering = null;
-    void handlePrompt(null, next.params);
-    respond(next.id, { outcome: "startedNewTurn" });
-  }
-}
-
-async function handleSteering(id, params) {
-  if (steeringDelayMs > 0) await sleep(steeringDelayMs);
-  const text = (params.prompt || []).map((b) => b.text || "").join("");
-  if (!promptActive || forceSteeringNewTurn) {
-    if (promptActive) {
-      deferredSteering = { id, params };
-    } else {
-      void handlePrompt(null, params);
-      respond(id, { outcome: "startedNewTurn" });
-    }
-    return;
-  }
-  notify({ sessionUpdate: "user_message_chunk", content: { type: "text", text } });
-  if (brokenSteeringBoundary) {
-    respond(id, { outcome: "injected" });
-    const interrupted = activePromptId;
-    ++promptEpoch;
-    promptActive = false;
-    activePromptId = null;
-    if (interrupted !== null) {
-      send({
-        jsonrpc: JSONRPC,
-        id: interrupted,
-        error: {
-          code: -32603,
-          message:
-            "Internal error: [ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
-        },
-      });
-    }
-    void handlePrompt(null, params);
-    return;
-  }
-  steeringQueue.push(text);
-  respond(id, { outcome: "injected" });
 }
 
 function handleMessage(msg) {
@@ -498,10 +416,6 @@ function handleMessage(msg) {
       break;
     case "session/prompt":
       void handlePrompt(msg.id, msg.params);
-      break;
-    case "_session/steering":
-      if (steeringSupported) void handleSteering(msg.id, msg.params);
-      else rejectMethod(msg.id, msg.method);
       break;
     case "session/cancel":
       cancelled = true;

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1409,7 +1409,6 @@ async fn advertised_private_steering_still_uses_the_durable_queue() {
         .await
         .unwrap();
     assert_eq!(first["queued"], false);
-    assert_eq!(first["steered"], false);
 
     let second = ts
         .client
@@ -1420,7 +1419,6 @@ async fn advertised_private_steering_still_uses_the_durable_queue() {
         .await
         .unwrap();
     assert_eq!(second["queued"], true);
-    assert_eq!(second["steered"], false, "response: {second}");
     assert_eq!(second["turn"], 0);
 
     let queued = session_mod::get(&ts.state.db, "acp-ignore-steering")
@@ -1443,12 +1441,7 @@ async fn advertised_private_steering_still_uses_the_durable_queue() {
         block["turn"] == 1
             && block["kind"] == "user_message"
             && block["payload"]["text"] == "say:second"
-            && !block["payload"]["steered"].as_bool().unwrap_or(false)
     }));
-    assert!(
-        chat["metadata"].get("steering_supported").is_none(),
-        "the removed private capability must not be exposed to the browser"
-    );
 }
 
 /// Sending the durable queue now cancels the current turn and starts one normal
@@ -1485,7 +1478,6 @@ async fn prompt_stops_and_sends_the_durable_queue() {
         .await
         .unwrap();
     assert_eq!(sent["queued"], false);
-    assert_eq!(sent["steered"], false, "response: {sent}");
 
     let session = session_mod::get(&ts.state.db, "acp-stop-and-send")
         .await
@@ -1534,7 +1526,6 @@ async fn session_send_restarts_a_live_turn() {
         .await
         .unwrap();
     assert_eq!(sent["queued"], false, "response: {sent}");
-    assert_eq!(sent["steered"], false, "response: {sent}");
     assert_eq!(sent["turn"], 1, "the replacement opens the next turn");
 
     let chat = poll_chat(&ts, "acp-send-restart", Duration::from_secs(10), |blocks| {
@@ -1949,7 +1940,6 @@ async fn next_prompt_preserves_feedback_queued_before_an_interrupt() {
         .await
         .unwrap();
     assert_eq!(sent["queued"], false);
-    assert_eq!(sent["steered"], false);
 
     let chat = poll_chat(&ts, "acp-stop-queue", Duration::from_secs(10), |blocks| {
         blocks.iter().any(|block| {

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -395,7 +395,6 @@ async fn composer_metadata_and_config_options_round_trip() {
     start_new(&ts, "acp-meta", None, None).await;
 
     let metadata = poll_metadata(&ts, "acp-meta", Duration::from_secs(5)).await;
-    assert_eq!(metadata["steering_supported"], false);
     let commands = metadata["commands"].as_array().unwrap();
     assert!(commands.iter().any(|command| command["name"] == "resume"));
     assert!(commands.iter().any(|command| {
@@ -1385,42 +1384,38 @@ async fn queue_consume_failure_does_not_dispatch_or_replay() {
     );
 }
 
-/// 4b. A steering-capable adapter durably queues a mid-turn prompt, acknowledges
-/// it immediately, then consumes the queue after the adapter accepts injection.
+/// Adapter-specific private steering must not bypass the durable queue. The
+/// incident behind this regression had codex-acp acknowledge and display two
+/// steers that Codex never added to its conversation history.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn prompt_steers_a_live_turn_when_advertised() {
+async fn advertised_private_steering_still_uses_the_durable_queue() {
     let ts = TestServer::start().await;
     start_new_with_env(
         &ts,
-        "acp-steer",
+        "acp-ignore-steering",
         None,
         None,
         vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
     )
     .await;
 
-    let initial = ts.client.get("/api/sessions/acp-steer/chat").await.unwrap();
-    assert_eq!(initial["metadata"]["steering_supported"], true);
-
     let first = ts
         .client
         .post(
-            "/api/sessions/acp-steer/prompt",
-            json!({ "text": "wait:1500|say:first" }),
+            "/api/sessions/acp-ignore-steering/prompt",
+            json!({ "text": "wait:500|say:first" }),
         )
         .await
         .unwrap();
     assert_eq!(first["queued"], false);
     assert_eq!(first["steered"], false);
 
-    // Relay writes are ordered: the fake marks the first prompt active before
-    // it receives this steering request.
     let second = ts
         .client
         .post(
-            "/api/sessions/acp-steer/prompt",
-            json!({ "text": "say:changed course" }),
+            "/api/sessions/acp-ignore-steering/prompt",
+            json!({ "text": "say:second" }),
         )
         .await
         .unwrap();
@@ -1428,88 +1423,15 @@ async fn prompt_steers_a_live_turn_when_advertised() {
     assert_eq!(second["steered"], false, "response: {second}");
     assert_eq!(second["turn"], 0);
 
-    let chat = poll_chat(&ts, "acp-steer", Duration::from_secs(10), |blocks| {
-        count_kind(blocks, "turn_end") >= 1
-            && blocks.iter().any(|b| {
-                b["kind"] == "agent_message" && b["payload"]["text"] == "changed coursefirst"
-            })
-    })
-    .await;
-    let blocks = chat["blocks"].as_array().unwrap();
-    assert_eq!(count_kind(blocks, "turn_end"), 1);
-    assert!(blocks.iter().any(|b| {
-        b["kind"] == "user_message"
-            && b["turn"] == 0
-            && b["payload"]["text"] == "say:changed course"
-            && b["payload"]["steered"] == true
-    }));
-    let session = session_mod::get(&ts.state.db, "acp-steer")
+    let queued = session_mod::get(&ts.state.db, "acp-ignore-steering")
         .await
         .unwrap()
         .unwrap();
-    assert!(
-        session.pending_prompt.as_deref().unwrap_or("").is_empty(),
-        "a successful steer consumes its durable queue copy"
-    );
-}
-
-/// claude-agent-acp can acknowledge `injected`, reject the owning prompt with
-/// an interrupted-result diagnostic, then stream the steered answer outside any
-/// prompt lifecycle (upstream #934). Until that adapter advertises a reliable
-/// ownership contract, loom must ignore its private capability and use the
-/// durable next-turn queue.
-#[serial]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn claude_adapter_queues_around_the_broken_steering_boundary() {
-    let ts = TestServer::start().await;
-    start_new_with_env(
-        &ts,
-        "acp-claude-steer-boundary",
-        None,
-        None,
-        vec![
-            ("FAKE_ACP_STEERING".to_string(), "1".to_string()),
-            (
-                "FAKE_ACP_STEERING_BOUNDARY_ERROR".to_string(),
-                "1".to_string(),
-            ),
-            (
-                "FAKE_ACP_AGENT_NAME".to_string(),
-                "@agentclientprotocol/claude-agent-acp".to_string(),
-            ),
-            ("FAKE_ACP_AGENT_VERSION".to_string(), "0.66.0".to_string()),
-        ],
-    )
-    .await;
-
-    let initial = ts
-        .client
-        .get("/api/sessions/acp-claude-steer-boundary/chat")
-        .await
-        .unwrap();
-    assert_eq!(initial["metadata"]["steering_supported"], false);
-
-    ts.client
-        .post(
-            "/api/sessions/acp-claude-steer-boundary/prompt",
-            json!({ "text": "wait:300|say:first" }),
-        )
-        .await
-        .unwrap();
-    let queued = ts
-        .client
-        .post(
-            "/api/sessions/acp-claude-steer-boundary/prompt",
-            json!({ "text": "say:second" }),
-        )
-        .await
-        .unwrap();
-    assert_eq!(queued["queued"], true);
-    assert_eq!(queued["steered"], false);
+    assert_eq!(queued.pending_prompt.as_deref(), Some("say:second"));
 
     let chat = poll_chat_state(
         &ts,
-        "acp-claude-steer-boundary",
+        "acp-ignore-steering",
         Duration::from_secs(10),
         |chat| {
             chat["live_turn"].is_null()
@@ -1517,90 +1439,29 @@ async fn claude_adapter_queues_around_the_broken_steering_boundary() {
         },
     )
     .await;
-    let blocks = chat["blocks"].as_array().unwrap();
-    assert!(blocks.iter().all(|block| {
-        block["kind"] != "turn_end" || block["payload"]["stop_reason"] == "end_turn"
-    }));
-    assert!(blocks.iter().any(|block| {
+    assert!(chat["blocks"].as_array().unwrap().iter().any(|block| {
         block["turn"] == 1
             && block["kind"] == "user_message"
             && block["payload"]["text"] == "say:second"
             && !block["payload"]["steered"].as_bool().unwrap_or(false)
     }));
-    assert!(blocks.iter().any(|block| {
-        block["turn"] == 1
-            && block["kind"] == "agent_message"
-            && block["payload"]["text"] == "second"
-    }));
+    assert!(
+        chat["metadata"].get("steering_supported").is_none(),
+        "the removed private capability must not be exposed to the browser"
+    );
 }
 
-/// Ordinary sends must not hold the HTTP response (and browser composer) behind
-/// a delayed private steering RPC. The queue is the immediate durable receipt;
-/// adapter acceptance later promotes it into the live turn.
+/// Sending the durable queue now cancels the current turn and starts one normal
+/// prompt with the combined feedback.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn prompt_ack_does_not_wait_for_steering() {
+async fn prompt_stops_and_sends_the_durable_queue() {
     let ts = TestServer::start().await;
-    start_new_with_env(
-        &ts,
-        "acp-steer-delay",
-        None,
-        None,
-        vec![
-            ("FAKE_ACP_STEERING".to_string(), "1".to_string()),
-            ("FAKE_ACP_STEERING_DELAY_MS".to_string(), "1000".to_string()),
-        ],
-    )
-    .await;
-    ts.client
-        .post(
-            "/api/sessions/acp-steer-delay/prompt",
-            json!({ "text": "wait:1800|say:first" }),
-        )
-        .await
-        .unwrap();
-
-    let ack = tokio::time::timeout(
-        Duration::from_millis(300),
-        ts.client.post(
-            "/api/sessions/acp-steer-delay/prompt",
-            json!({ "text": "say:feedback" }),
-        ),
-    )
-    .await
-    .expect("the send acknowledgement must not wait for steering")
-    .unwrap();
-    assert_eq!(ack["queued"], true);
-    let queued = ts
-        .client
-        .get("/api/sessions/acp-steer-delay/chat")
-        .await
-        .unwrap();
-    assert_eq!(queued["pending_prompt"], "say:feedback");
-
-    poll_chat_state(&ts, "acp-steer-delay", Duration::from_secs(10), |chat| {
-        chat["pending_prompt"].is_null()
-            && chat["blocks"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|b| b["kind"] == "user_message" && b["payload"]["steered"] == true)
-    })
-    .await;
-}
-
-/// An adapter that does not advertise steering must never be probed with the
-/// private extension. Sending its durable queue now cancels the current turn
-/// and starts one normal prompt with the combined feedback.
-#[serial]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn prompt_stops_and_sends_queue_without_steering_capability() {
-    let ts = TestServer::start().await;
-    start_new(&ts, "acp-force-steer", None, None).await;
+    start_new(&ts, "acp-stop-and-send", None, None).await;
 
     ts.client
         .post(
-            "/api/sessions/acp-force-steer/prompt",
+            "/api/sessions/acp-stop-and-send/prompt",
             json!({ "text": "wait:1200|say:first" }),
         )
         .await
@@ -1608,7 +1469,7 @@ async fn prompt_stops_and_sends_queue_without_steering_capability() {
     let queued = ts
         .client
         .post(
-            "/api/sessions/acp-force-steer/prompt",
+            "/api/sessions/acp-stop-and-send/prompt",
             json!({ "text": "say:feedback" }),
         )
         .await
@@ -1618,7 +1479,7 @@ async fn prompt_stops_and_sends_queue_without_steering_capability() {
     let sent = ts
         .client
         .post(
-            "/api/sessions/acp-force-steer/prompt",
+            "/api/sessions/acp-stop-and-send/prompt",
             json!({ "text": "", "force_queued": true }),
         )
         .await
@@ -1626,17 +1487,22 @@ async fn prompt_stops_and_sends_queue_without_steering_capability() {
     assert_eq!(sent["queued"], false);
     assert_eq!(sent["steered"], false, "response: {sent}");
 
-    let session = session_mod::get(&ts.state.db, "acp-force-steer")
+    let session = session_mod::get(&ts.state.db, "acp-stop-and-send")
         .await
         .unwrap()
         .unwrap();
     assert!(session.pending_prompt.as_deref().unwrap_or("").is_empty());
 
-    let chat = poll_chat(&ts, "acp-force-steer", Duration::from_secs(10), |blocks| {
-        blocks
-            .iter()
-            .any(|block| block["kind"] == "agent_message" && block["payload"]["text"] == "feedback")
-    })
+    let chat = poll_chat(
+        &ts,
+        "acp-stop-and-send",
+        Duration::from_secs(10),
+        |blocks| {
+            blocks.iter().any(|block| {
+                block["kind"] == "agent_message" && block["payload"]["text"] == "feedback"
+            })
+        },
+    )
     .await;
     assert!(chat["blocks"].as_array().unwrap().iter().any(|block| {
         block["kind"] == "turn_end" && block["payload"]["stop_reason"] == "cancelled"
@@ -1644,11 +1510,11 @@ async fn prompt_stops_and_sends_queue_without_steering_capability() {
 }
 
 /// Cross-session `/send` is control-plane input, not ordinary composer
-/// feedback. Without steering support it must cancel a live turn and start the
-/// message immediately instead of leaving it in the durable next-turn queue.
+/// feedback. It cancels a live turn and starts the message immediately instead
+/// of leaving it in the durable next-turn queue.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn session_send_restarts_a_live_turn_without_steering() {
+async fn session_send_restarts_a_live_turn() {
     let ts = TestServer::start().await;
     start_new(&ts, "acp-send-restart", None, None).await;
 
@@ -1691,131 +1557,6 @@ async fn session_send_restarts_a_live_turn_without_steering() {
     }));
 }
 
-/// A steering-capable ACP adapter receives cross-session `/send` input in the
-/// live turn, preserving its work while still avoiding the next-turn queue.
-#[serial]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn session_send_steers_a_live_turn_when_supported() {
-    let ts = TestServer::start().await;
-    start_new_with_env(
-        &ts,
-        "acp-send-steer",
-        None,
-        None,
-        vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
-    )
-    .await;
-
-    ts.client
-        .post(
-            "/api/sessions/acp-send-steer/prompt",
-            json!({ "text": "wait:1200|say:first" }),
-        )
-        .await
-        .unwrap();
-    let sent = ts
-        .client
-        .post(
-            "/api/sessions/acp-send-steer/send",
-            json!({ "text": "say:changed course" }),
-        )
-        .await
-        .unwrap();
-    assert_eq!(sent["queued"], false, "response: {sent}");
-    assert_eq!(sent["steered"], true, "response: {sent}");
-    assert_eq!(sent["turn"], 0);
-
-    let chat = poll_chat(&ts, "acp-send-steer", Duration::from_secs(10), |blocks| {
-        count_kind(blocks, "turn_end") == 1
-            && blocks.iter().any(|block| {
-                block["kind"] == "agent_message"
-                    && block["payload"]["text"] == "changed coursefirst"
-            })
-    })
-    .await;
-    assert!(chat["pending_prompt"].is_null());
-    let blocks = chat["blocks"].as_array().unwrap();
-    assert_eq!(count_kind(blocks, "turn_end"), 1);
-    assert!(blocks.iter().any(|block| {
-        block["turn"] == 0
-            && block["kind"] == "user_message"
-            && block["payload"]["text"] == "say:changed course"
-            && block["payload"]["steered"] == true
-    }));
-}
-
-/// Prose observed before the adapter accepts a steer must remain before that
-/// user prompt in the durable journal. The prose is still only an in-memory
-/// consolidation buffer when the steering response arrives, which used to let
-/// the prompt take the earlier sequence number and jump above the response on
-/// refresh.
-#[serial]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn steered_prompt_follows_already_streamed_agent_prose() {
-    let ts = TestServer::start().await;
-    start_new_with_env(
-        &ts,
-        "acp-steer-order",
-        None,
-        None,
-        vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
-    )
-    .await;
-    let mut events = ts.state.acp.get("acp-steer-order").unwrap().subscribe();
-
-    ts.client
-        .post(
-            "/api/sessions/acp-steer-order/prompt",
-            json!({ "text": "say:BEFORE|wait:1000|say:AFTER" }),
-        )
-        .await
-        .unwrap();
-    let streamed = drain_events(&mut events, Duration::from_secs(5), |event| {
-        event.event == "delta" && event.data["text"] == "ORE"
-    })
-    .await;
-    assert!(
-        streamed
-            .iter()
-            .any(|event| event.event == "delta" && event.data["text"] == "ORE"),
-        "the pre-steer response never streamed: {streamed:?}"
-    );
-
-    let sent = ts
-        .client
-        .post(
-            "/api/sessions/acp-steer-order/send",
-            json!({ "text": "say:STEER" }),
-        )
-        .await
-        .unwrap();
-    assert_eq!(sent["steered"], true, "response: {sent}");
-
-    let chat = poll_chat(&ts, "acp-steer-order", Duration::from_secs(10), |blocks| {
-        count_kind(blocks, "turn_end") == 1
-    })
-    .await;
-    let authored: Vec<(&str, &str)> = chat["blocks"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .filter_map(|block| {
-            let kind = block["kind"].as_str()?;
-            matches!(kind, "user_message" | "agent_message")
-                .then(|| (kind, block["payload"]["text"].as_str().unwrap_or("")))
-        })
-        .collect();
-    assert_eq!(
-        authored,
-        vec![
-            ("user_message", "say:BEFORE|wait:1000|say:AFTER"),
-            ("agent_message", "BEFORE"),
-            ("user_message", "say:STEER"),
-            ("agent_message", "STEERAFTER"),
-        ]
-    );
-}
-
 /// Composer-selected files are resolved inside the worktree and forwarded as
 /// ACP resource_link blocks, not left as adapter-specific `@file` prose.
 #[serial]
@@ -1848,66 +1589,6 @@ async fn prompt_forwards_validated_file_resources() {
     .await;
     assert!(chat["blocks"].as_array().unwrap().iter().any(|b| {
         b["kind"] == "user_message" && b["payload"]["resources"][0]["name"] == "context.txt"
-    }));
-}
-
-/// 4c. If a turn ends during injection, codex-acp starts the message itself and
-/// reports `startedNewTurn`; loom adopts and closes that adapter-owned turn.
-#[serial]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn prompt_adopts_a_turn_started_by_steering() {
-    let ts = TestServer::start().await;
-    start_new_with_env(
-        &ts,
-        "acp-steer-race",
-        None,
-        None,
-        vec![
-            ("FAKE_ACP_STEERING".to_string(), "1".to_string()),
-            (
-                "FAKE_ACP_STEERING_FORCE_NEW_TURN".to_string(),
-                "1".to_string(),
-            ),
-        ],
-    )
-    .await;
-
-    ts.client
-        .post(
-            "/api/sessions/acp-steer-race/prompt",
-            json!({ "text": "wait:300|say:first" }),
-        )
-        .await
-        .unwrap();
-    // Relay writes are ordered, so the forced steering race is deterministic
-    // without a wall-clock delay.
-    let second = ts
-        .client
-        .post(
-            "/api/sessions/acp-steer-race/prompt",
-            json!({ "text": "wait:100|say:second" }),
-        )
-        .await
-        .unwrap();
-    assert_eq!(second["queued"], true);
-    assert_eq!(second["steered"], false);
-    assert_eq!(second["turn"], 0);
-
-    let chat = poll_chat_state(&ts, "acp-steer-race", Duration::from_secs(10), |chat| {
-        chat["live_turn"].is_null()
-            && count_kind(chat["blocks"].as_array().unwrap(), "turn_end") == 2
-    })
-    .await;
-    assert_eq!(chat["live_turn"], Value::Null);
-    let blocks = chat["blocks"].as_array().unwrap();
-    assert!(blocks.iter().any(|b| {
-        b["kind"] == "user_message"
-            && b["turn"] == 1
-            && b["payload"]["text"] == "wait:100|say:second"
-            && b["payload"]["steered"] == false
-    }));
-    assert!(blocks.iter().any(|b| {
-        b["kind"] == "agent_message" && b["turn"] == 1 && b["payload"]["text"] == "second"
     }));
 }
 
@@ -2219,7 +1900,7 @@ async fn interrupt_notice_does_not_leak_below_the_restarted_turn() {
 /// the idle state.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn interrupt_leaves_queued_feedback_idle_until_sent() {
+async fn next_prompt_preserves_feedback_queued_before_an_interrupt() {
     let ts = TestServer::start().await;
     start_new(&ts, "acp-stop-queue", None, None).await;
 
@@ -2263,7 +1944,7 @@ async fn interrupt_leaves_queued_feedback_idle_until_sent() {
         .client
         .post(
             "/api/sessions/acp-stop-queue/prompt",
-            json!({ "text": "", "force_queued": true }),
+            json!({ "text": "say:continue" }),
         )
         .await
         .unwrap();
@@ -2282,7 +1963,7 @@ async fn interrupt_leaves_queued_feedback_idle_until_sent() {
     assert!(chat["blocks"].as_array().unwrap().iter().any(|block| {
         block["kind"] == "user_message"
             && block["turn"] == 1
-            && block["payload"]["text"] == "say:after stop"
+            && block["payload"]["text"] == "say:after stop\n\nsay:continue"
     }));
 }
 

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -572,8 +572,8 @@ impl Client {
     }
 
     /// Type a message into a session's agent pane, submitting it by default
-    /// (`POST /api/sessions/{key}/send`). ACP responses also report whether the
-    /// message steered the live turn or queued for the next one.
+    /// (`POST /api/sessions/{key}/send`). For ACP, this cancels a live turn and
+    /// starts the message as a normal turn.
     pub async fn nudge(&self, key: &str, req: &SendReq) -> Result<Value> {
         let body = serde_json::to_value(req)?;
         self.post(&format!("/api/sessions/{}/send", Self::seg(key)), body)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -358,7 +358,7 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/sessions/{id}/preview?lines=N` | capture the screen as `{screen}`; `lines` adds scrollback above the visible screen (for an `acp` session, `{screen}` is the last `lines` journal blocks rendered as compact text) |
 | `GET /api/sessions/{id}/chat` | The newest 200 blocks of the ACP session's DB-backed journal, `older_cursor`, live-turn state, pending prompt, effective mode, and durable composer metadata (the last provider-advertised controls remain after provider exit/restart); pass the cursor as `before_turn` + `before_seq` to page backward |
 | `GET /api/sessions/{id}/chat/stream` | SSE tail of the live journal: `block` (a committed block), `delta` (a streaming message/thought chunk), `tool` (a live tool-call update), `turn` (started / ended), `resync` (the bounded live buffer overran; reload the durable snapshot) |
-| `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, steered: false, turn}` — dispatch a user message as a `session/prompt`; while a turn is live, append it to the durable next-turn queue |
+| `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, turn}` — dispatch a user message as a `session/prompt`; while a turn is live, append it to the durable next-turn queue |
 | `DELETE /api/sessions/{id}/prompt` | atomically retract unseen next-turn feedback and return `{text}` for editing; 409 when the current ACP state has no queue available to retract |
 | `POST /api/sessions/{id}/permissions/{request_id}` | `{option_id}` → answer an open permission request (200 / 404 unknown / 409 already resolved) |
 | `PUT /api/sessions/{id}/mode` | `{mode_id}` → change the ACP session's permission mode (`session/set_mode`), journaled as a `mode_change` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,12 +353,12 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/sessions/{id}/history` | a bounded newest-tail page of provider-neutral records in chronological display order; `before`, `limit`, and `kinds` own backward pagination/filtering |
 | `GET /api/sessions/{id}/history/search` | case-insensitive literal `q` search over the same session-scoped records and cursor/filter contract |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ the session's tapestry PTY (the interaction surface) |
-| `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a live turn is steered when supported, otherwise cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
+| `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a live turn is cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
 | `POST /api/sessions/{id}/interrupt` | stop the current turn — a break (Escape) to the terminal for a `terminal` session, `session/cancel` for an `acp` one |
 | `GET /api/sessions/{id}/preview?lines=N` | capture the screen as `{screen}`; `lines` adds scrollback above the visible screen (for an `acp` session, `{screen}` is the last `lines` journal blocks rendered as compact text) |
 | `GET /api/sessions/{id}/chat` | The newest 200 blocks of the ACP session's DB-backed journal, `older_cursor`, live-turn state, pending prompt, effective mode, and durable composer metadata (the last provider-advertised controls remain after provider exit/restart); pass the cursor as `before_turn` + `before_seq` to page backward |
 | `GET /api/sessions/{id}/chat/stream` | SSE tail of the live journal: `block` (a committed block), `delta` (a streaming message/thought chunk), `tool` (a live tool-call update), `turn` (started / ended), `resync` (the bounded live buffer overran; reload the durable snapshot) |
-| `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, steered, turn}` — dispatch a user message as a `session/prompt`; a live turn uses a lifecycle-safe advertised steering extension, with the durable next-turn queue as fallback |
+| `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, steered: false, turn}` — dispatch a user message as a `session/prompt`; while a turn is live, append it to the durable next-turn queue |
 | `DELETE /api/sessions/{id}/prompt` | atomically retract unseen next-turn feedback and return `{text}` for editing; 409 when the current ACP state has no queue available to retract |
 | `POST /api/sessions/{id}/permissions/{request_id}` | `{option_id}` → answer an open permission request (200 / 404 unknown / 409 already resolved) |
 | `PUT /api/sessions/{id}/mode` | `{mode_id}` → change the ACP session's permission mode (`session/set_mode`), journaled as a `mode_change` |
@@ -484,8 +484,8 @@ let an agent or script type into, interrupt, or read back a child session
 uniformly. For a `terminal` session each requires a live terminal (else 409). An
 `acp` session has no PTY, so the same verbs map onto the protocol — keeping the
 CLI (`loom session {send,interrupt,preview}`) and its `nudge` audit uniform across
-backends: `send` delegates to the prompt path (steered when supported, otherwise
-cancelled and restarted with the message), `interrupt` is a `session/cancel`,
+backends: `send` cancels a live turn and starts the message as a normal prompt,
+`interrupt` is a `session/cancel`,
 and `preview` renders the last journal blocks as compact plain text instead of
 a vt100 screen capture.
 

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -66,10 +66,11 @@ An ACP session leads with **Conversation**, followed by **Shells** and
 **Review**. A terminal-backed session leads with **Agent**, followed by
 **Conversation** and **Review**. There is no Overview tab.
 
-Conversation is the durable operator/agent exchange. Mid-turn feedback steers
-when the adapter supports it and otherwise queues for the next turn. Unseen
-queued text can be retracted into the composer for editing without rewriting
-already-dispatched history. Permission requests and runtime controls stay in
+Conversation is the durable operator/agent exchange. Mid-turn feedback queues
+for the next turn; **Stop & send** cancels the current turn when the feedback
+needs to run immediately. Unseen queued text can be retracted into the composer
+for editing without rewriting already-dispatched history. Permission requests
+and runtime controls stay in
 the conversation that produced them; elapsed quiet time is evidence, not an
 automatic “stuck” verdict.
 

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -48,7 +48,6 @@ async function defineFakeAcpAgent(
   weaver: WeaverFixture,
   name: string,
   label: string,
-  steering = false,
 ): Promise<void> {
   const res = await fetch(`${weaver.baseUrl}/api/agents/custom`, {
     method: 'POST',
@@ -57,7 +56,7 @@ async function defineFakeAcpAgent(
       name,
       label,
       setup: '',
-      launch: `${steering ? 'FAKE_ACP_STEERING=1 ' : ''}node ${FAKE_AGENT}`,
+      launch: `node ${FAKE_AGENT}`,
       resume: '',
       reports_status: false,
       protocol: 'acp',
@@ -73,14 +72,14 @@ async function defineFakeAcpAgent(
  *  brought it up as `protocol='acp'`, else null (the acp axis isn't wired yet). */
 async function launchAcpSession(
   weaver: WeaverFixture,
-  opts: { goal: string; mode?: string; name?: string; steering?: boolean },
+  opts: { goal: string; mode?: string; name?: string },
 ): Promise<Session | null> {
   // The fake adapter is launched by the custom agent's `launch` command. The
   // `protocol` axis marks it ACP rather than a PTY TUI (added by the lifecycle
   // phase; ignored by the current backend, which is exactly why the probe below
   // detects support).
-  const agent = opts.steering === false ? 'acp-fake-no-steer' : 'acp-fake';
-  await defineFakeAcpAgent(weaver, agent, 'ACP fake', opts.steering !== false);
+  const agent = 'acp-fake';
+  await defineFakeAcpAgent(weaver, agent, 'ACP fake');
 
   const res = await fetch(`${weaver.baseUrl}/api/sessions`, {
     method: 'POST',
@@ -104,7 +103,7 @@ async function launchAcpSession(
 async function openAcp(
   page: Page,
   weaver: WeaverFixture,
-  opts: { goal: string; mode?: string; name?: string; steering?: boolean },
+  opts: { goal: string; mode?: string; name?: string },
 ): Promise<Session> {
   const s = await launchAcpSession(weaver, opts);
   test.skip(s === null, SKIP_MSG);
@@ -463,7 +462,6 @@ test.describe('acp conversation', () => {
             commands: [],
             config_options: [],
             modes: [],
-            steering_supported: false,
           },
         },
       });
@@ -602,7 +600,6 @@ test.describe('acp conversation', () => {
     await openAcp(page, weaver, {
       goal: 'say:ready',
       name: 'acp-stop-settles',
-      steering: false,
     });
     const input = page.getByTestId('acp-composer-input');
     await input.fill('wait:5000|say:unreached');
@@ -674,23 +671,6 @@ test.describe('acp conversation', () => {
     await expect(page.getByTestId('acp-recover')).toBeHidden();
   });
 
-  test('force steer is offered only when the agent advertises it', async ({ page, weaver }) => {
-    await openAcp(page, weaver, {
-      goal: 'say:ready',
-      name: 'acp-force-ui',
-      steering: false,
-    });
-    const input = page.getByTestId('acp-composer-input');
-    await input.fill('wait:2500|say:first turn done');
-    await page.getByTestId('acp-composer-send').click();
-    await expect(page.getByTestId('acp-working')).toBeVisible({
-      timeout: 15_000,
-    });
-
-    await input.fill('say:feedback now');
-    await expect(page.getByTestId('acp-composer-force-steer')).toBeHidden();
-  });
-
   test('ordinary feedback says when the running agent has not seen it yet', async ({
     page,
     weaver,
@@ -698,7 +678,6 @@ test.describe('acp conversation', () => {
     await openAcp(page, weaver, {
       goal: 'say:ready',
       name: 'acp-queue-ui',
-      steering: false,
     });
     const input = page.getByTestId('acp-composer-input');
     await input.fill('wait:5000|say:first turn done');
@@ -741,7 +720,6 @@ test.describe('acp conversation', () => {
     await openAcp(page, weaver, {
       goal: 'say:ready',
       name: 'acp-edit-queue-ui',
-      steering: false,
     });
     const input = page.getByTestId('acp-composer-input');
     // Keep the turn live comfortably beyond parallel-run scheduling jitter so
@@ -823,36 +801,6 @@ test.describe('acp conversation', () => {
       page.getByTestId('acp-conversation').getByText('scratch/long-notes.txt', { exact: true }),
     ).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId('acp-attachment-pill')).toHaveCount(0);
-  });
-
-  test('the composer steers a prompt into a live turn', async ({ page, weaver }) => {
-    await openAcp(page, weaver, { goal: 'say:ready' });
-    const input = page.getByTestId('acp-composer-input');
-
-    // A first prompt that stays in flight (the `wait`).
-    await input.fill('wait:1500|say:first turn done');
-    await page.getByTestId('acp-composer-send').click();
-    await expect(page.getByTestId('acp-working')).toBeVisible({
-      timeout: 15_000,
-    });
-    await expect(page.getByTestId('acp-composer-force-steer')).toBeVisible();
-
-    // A second prompt sent mid-turn is injected into the active turn.
-    await input.fill('say:second turn');
-    await page.getByTestId('acp-composer-send').click();
-    await expect(page.getByTestId('acp-steered').filter({ hasText: /^steered turn/ })).toBeVisible({
-      timeout: 15_000,
-    });
-
-    // The steer is handled before that same turn ends.
-    await expect(
-      page.getByTestId('acp-conversation').getByText('second turnfirst turn done', { exact: true }),
-    ).toBeVisible({ timeout: 20_000 });
-    // One rule for the launch goal and one for this interaction: the steer did
-    // not create a third turn.
-    await expect(page.getByTestId('acp-turn-rule')).toHaveCount(2, {
-      timeout: 20_000,
-    });
   });
 
   test('discovers slash commands from the agent and forwards them', async ({ page, weaver }) => {

--- a/e2e/tests/event-stream.spec.ts
+++ b/e2e/tests/event-stream.spec.ts
@@ -60,7 +60,7 @@ async function launchAcpSession(
       name: 'acp-fake',
       label: 'ACP fake',
       setup: '',
-      launch: `FAKE_ACP_STEERING=1 node ${FAKE_AGENT}`,
+      launch: `node ${FAKE_AGENT}`,
       resume: '',
       reports_status: false,
       protocol: 'acp',


### PR DESCRIPTION
Remove Loom's use of the private `_session/steering` ACP extension. The adapter could acknowledge a steer and Loom would journal it even when the provider never committed that message to its conversation history, leaving later turns unaware of feedback that appeared delivered.

Mid-turn composer messages now always enter Loom's durable next-turn queue. **Stop & send** cancels the active turn before dispatching the queue as a normal ACP prompt, while cross-session control input cancels and restarts immediately. If a user stops manually and then sends another prompt, Loom appends it behind the existing backlog and drains the messages in arrival order.

Remove the steering capability, private RPC, force-steer UI, queue-promotion bookkeeping, and adapter-owned new-turn machinery. Historical steered rows remain readable, and recovery still settles an adapter-owned turn persisted by a server from before this change.