### PR TITLE
fix(loom): make session stop authoritative

### DIFF
--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -3106,6 +3106,12 @@ impl Task {
         result
     }
 
+    fn resume_automatic_dispatch_on<T>(&mut self, explicit_send: &Result<T>) {
+        if explicit_send.is_ok() {
+            self.automatic_dispatch_paused = false;
+        }
+    }
+
     async fn on_command(&mut self, cmd: Command) {
         match cmd {
             Command::Prompt {
@@ -3137,16 +3143,12 @@ impl Task {
                                 Err(error) => Err(error),
                             }
                         };
-                        if ack.is_ok() {
-                            self.automatic_dispatch_paused = false;
-                        }
+                        self.resume_automatic_dispatch_on(&ack);
                         let _ = reply.send(ack);
                     }
                     PromptDelivery::Immediate => {
                         let ack = self.restart_prompt(text, by, resources).await;
-                        if ack.is_ok() {
-                            self.automatic_dispatch_paused = false;
-                        }
+                        self.resume_automatic_dispatch_on(&ack);
                         let _ = reply.send(ack);
                     }
                 }
@@ -3163,18 +3165,14 @@ impl Task {
                     let _ = reply.send(Err(anyhow!("there is no queued feedback to send")));
                 } else if !self.turn_live {
                     let result = self.start_pending_prompt(by).await;
-                    if result.is_ok() {
-                        self.automatic_dispatch_paused = false;
-                    }
+                    self.resume_automatic_dispatch_on(&result);
                     let _ = reply.send(result);
                 } else {
                     let result = match self.cancel_live_turn().await {
                         Ok(()) => self.start_pending_prompt(by).await,
                         Err(error) => Err(error),
                     };
-                    if result.is_ok() {
-                        self.automatic_dispatch_paused = false;
-                    }
+                    self.resume_automatic_dispatch_on(&result);
                     let _ = reply.send(result);
                 }
             }

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -1365,6 +1365,7 @@ struct PendingPerm {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum TurnEndSource {
     MatchingPromptResponse,
+    UserCancellation,
     Synthetic,
 }
 
@@ -1374,6 +1375,7 @@ impl TurnEndSource {
             Self::MatchingPromptResponse => {
                 crate::review_inbox::ReviewClaimSettlement::MatchingPromptResponse
             }
+            Self::UserCancellation => crate::review_inbox::ReviewClaimSettlement::UserCancelled,
             Self::Synthetic => crate::review_inbox::ReviewClaimSettlement::Abandoned,
         }
     }
@@ -1430,6 +1432,11 @@ struct Task {
     /// "Conversation interrupted" prose after the next turn has already begun.
     /// Consume that one notice rather than journaling it under the wrong turn.
     pending_interrupt_notice_through: Option<i64>,
+    /// A successful user Stop prevents every automatic source (the ordinary
+    /// queue and protected review notifier) from opening another turn. An
+    /// explicit prompt/force-send clears the latch. The newest durable
+    /// `turn_end(cancelled)` restores it when this task is re-adopted.
+    automatic_dispatch_paused: bool,
     /// Latched for the duration of a `session/load` replay: the adapter re-streams
     /// the whole conversation as `session/update` notifications, but we already
     /// hold it in the journal, so journal writes are suppressed (and the seq
@@ -1500,6 +1507,7 @@ impl Task {
             load_session_cap: false,
             external_turn: false,
             pending_interrupt_notice_through: None,
+            automatic_dispatch_paused: false,
             suppress_journal: false,
             highest_seq: 0,
             acked: 0,
@@ -1548,6 +1556,11 @@ impl Task {
             .and_then(Value::as_str)
             .map(str::to_string);
         let current_turn = live_turn.unwrap_or(max_turn);
+        let automatic_dispatch_paused = live_turn.is_none()
+            && chat::latest_stop_reason(&state.db, &session.id)
+                .await?
+                .as_deref()
+                == Some("cancelled");
         // The journal always holds at least this turn's `user_message`, so
         // `max_seq + 1` continues the turn without colliding.
         let next_seq = max_seq + 1;
@@ -1585,6 +1598,7 @@ impl Task {
             load_session_cap: false,
             external_turn,
             pending_interrupt_notice_through: None,
+            automatic_dispatch_paused,
             suppress_journal: false,
             highest_seq: session.acp_ack_seq.max(0) as u64,
             acked: session.acp_ack_seq.max(0) as u64,
@@ -2419,9 +2433,11 @@ impl Task {
         error: Option<Value>,
         source: TurnEndSource,
     ) {
-        // A synthetic cancellation is not an acknowledgement from the adapter.
-        // Release before making the task idle so the immutable prompt can retry
-        // or rehome, and never let synthetic settlement consume the claim.
+        // A provider-synthesized turn end is not an acknowledgement from the
+        // adapter. Release before making the task idle so the immutable prompt
+        // can retry or rehome. A user cancellation is different: the protected
+        // prompt is already durably journaled and Stop is authoritative, so it
+        // consumes that delivery instead of replaying it into another turn.
         let settlement = source.review_claim_settlement();
         if settlement == crate::review_inbox::ReviewClaimSettlement::Abandoned {
             self.settle_inflight_review(settlement, "synthetic turn settlement")
@@ -2457,9 +2473,13 @@ impl Task {
             self.journal_block(kind::TURN_END, json!({ "stop_reason": stop }))
                 .await;
         }
-        if settlement == crate::review_inbox::ReviewClaimSettlement::MatchingPromptResponse {
-            self.settle_inflight_review(settlement, "matching ACP prompt response")
-                .await;
+        if settlement != crate::review_inbox::ReviewClaimSettlement::Abandoned {
+            let reason = match source {
+                TurnEndSource::MatchingPromptResponse => "matching ACP prompt response",
+                TurnEndSource::UserCancellation => "authoritative user cancellation",
+                TurnEndSource::Synthetic => unreachable!("abandoned settlements run above"),
+            };
+            self.settle_inflight_review(settlement, reason).await;
         }
         self.finish_turn_state(turn, &stop).await;
     }
@@ -2492,6 +2512,9 @@ impl Task {
     }
 
     async fn dispatch_review_inbox(&mut self) -> bool {
+        if self.automatic_dispatch_paused {
+            return false;
+        }
         if self.refuse_if_turn_capped().await.is_err() {
             return false;
         }
@@ -2584,6 +2607,9 @@ impl Task {
         // handoff has re-let the session; letting it drain the queue would lose
         // the prompt against its dead relay.
         if !self.registry.is_current(&self.session_id, self.generation) {
+            return;
+        }
+        if self.automatic_dispatch_paused {
             return;
         }
         // Submitted review feedback is immutable and gets its own turn. It is
@@ -3049,6 +3075,7 @@ impl Task {
             ))
             .await;
         if result.is_ok() && self.turn_live {
+            self.automatic_dispatch_paused = true;
             // The adapter notice belongs to the cancelled turn even when it
             // arrives after an immediate restart. Bound suppression to that
             // turn and its direct successor so unrelated future prose is never
@@ -3061,7 +3088,7 @@ impl Task {
                 self.current_turn,
                 Some(json!({ "stopReason": "cancelled" })),
                 None,
-                TurnEndSource::Synthetic,
+                TurnEndSource::UserCancellation,
             )
             .await;
         }
@@ -3110,10 +3137,16 @@ impl Task {
                                 Err(error) => Err(error),
                             }
                         };
+                        if ack.is_ok() {
+                            self.automatic_dispatch_paused = false;
+                        }
                         let _ = reply.send(ack);
                     }
                     PromptDelivery::Immediate => {
                         let ack = self.restart_prompt(text, by, resources).await;
+                        if ack.is_ok() {
+                            self.automatic_dispatch_paused = false;
+                        }
                         let _ = reply.send(ack);
                     }
                 }
@@ -3130,12 +3163,18 @@ impl Task {
                     let _ = reply.send(Err(anyhow!("there is no queued feedback to send")));
                 } else if !self.turn_live {
                     let result = self.start_pending_prompt(by).await;
+                    if result.is_ok() {
+                        self.automatic_dispatch_paused = false;
+                    }
                     let _ = reply.send(result);
                 } else {
                     let result = match self.cancel_live_turn().await {
                         Ok(()) => self.start_pending_prompt(by).await,
                         Err(error) => Err(error),
                     };
+                    if result.is_ok() {
+                        self.automatic_dispatch_paused = false;
+                    }
                     let _ = reply.send(result);
                 }
             }
@@ -3143,7 +3182,7 @@ impl Task {
                 // Submitted review feedback lives in the protected inbox, not
                 // the user-editable pending prompt. A live task picks it up at
                 // its next turn boundary; an idle task can start it now.
-                if self.turn_live {
+                if self.turn_live || self.automatic_dispatch_paused {
                     let _ = reply.send(Ok(PromptAck {
                         queued: true,
                         turn: Some(self.current_turn),

--- a/crates/loom-store/src/chat.rs
+++ b/crates/loom-store/src/chat.rs
@@ -706,6 +706,22 @@ pub async fn has_turn_end(db: &Db, session_id: &str, turn: i64) -> Result<bool> 
     Ok(n > 0)
 }
 
+/// The stop reason on the newest completed turn, used when re-adopting an ACP
+/// runtime so a user-owned Stop boundary survives the loom process that
+/// recorded it.
+pub async fn latest_stop_reason(db: &Db, session_id: &str) -> Result<Option<String>> {
+    Ok(sqlx::query_scalar(
+        "SELECT json_extract(payload, '$.stop_reason')
+         FROM chat_blocks
+         WHERE session_id = ? AND kind = 'turn_end'
+         ORDER BY turn DESC, seq DESC
+         LIMIT 1",
+    )
+    .bind(session_id)
+    .fetch_optional(db)
+    .await?)
+}
+
 /// Close a turn abandoned by a vanished ACP task. The opening user block is
 /// already durable before `acp_inflight` is written; this supplies the missing
 /// terminal boundary before a replacement provider starts.

--- a/crates/loom-store/src/chat.rs
+++ b/crates/loom-store/src/chat.rs
@@ -713,11 +713,12 @@ pub async fn latest_stop_reason(db: &Db, session_id: &str) -> Result<Option<Stri
     Ok(sqlx::query_scalar(
         "SELECT json_extract(payload, '$.stop_reason')
          FROM chat_blocks
-         WHERE session_id = ? AND kind = 'turn_end'
+         WHERE session_id = ? AND kind = ?
          ORDER BY turn DESC, seq DESC
          LIMIT 1",
     )
     .bind(session_id)
+    .bind(kind::TURN_END)
     .fetch_optional(db)
     .await?)
 }

--- a/crates/loom-store/src/review_inbox.rs
+++ b/crates/loom-store/src/review_inbox.rs
@@ -36,6 +36,7 @@ pub enum ReviewTurnStartOutcome {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReviewClaimSettlement {
     MatchingPromptResponse,
+    UserCancelled,
     Abandoned,
 }
 
@@ -337,7 +338,7 @@ pub async fn settle_review_inbox_claim(
     settlement: ReviewClaimSettlement,
 ) -> Result<bool> {
     match settlement {
-        ReviewClaimSettlement::MatchingPromptResponse => {
+        ReviewClaimSettlement::MatchingPromptResponse | ReviewClaimSettlement::UserCancelled => {
             consume_review_inbox(db, delivery_key, claim_token, session_id).await
         }
         ReviewClaimSettlement::Abandoned => {

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1957,6 +1957,180 @@ async fn next_prompt_preserves_feedback_queued_before_an_interrupt() {
     }));
 }
 
+async fn insert_protected_review(
+    ts: &TestServer,
+    session_id: &str,
+    delivery_key: &str,
+    payload: &str,
+) {
+    let session = ts.client.get_session(session_id).await.unwrap();
+    let inserted = sqlx::query(
+        "INSERT INTO reviews
+            (repo_root, branch_id, session_id, subject_kind, subject_id,
+             subject_key, subject_label, subject_version, status, created_by,
+             delivery_state, delivery_key)
+         VALUES (?, ?, ?, 'artifact', ?, 'design', 'design', '1',
+                 'submitted', 'alice', 'delivered', ?)",
+    )
+    .bind(&session.branch.repo_root)
+    .bind(&session.branch.id)
+    .bind(session_id)
+    .bind(delivery_key)
+    .bind(delivery_key)
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO review_conversation_inbox
+            (delivery_key, review_id, branch_id, preferred_session_id, payload)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(delivery_key)
+    .bind(inserted.last_insert_rowid())
+    .bind(&session.branch.id)
+    .bind(session_id)
+    .bind(payload)
+    .execute(&ts.state.db)
+    .await
+    .unwrap();
+}
+
+/// A protected review has crossed its durable delivery boundary before its
+/// turn becomes visible. Stopping that turn acknowledges the delivery instead
+/// of putting the same immutable message back into the retry lane.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupting_a_review_turn_does_not_redeliver_it() {
+    let ts = TestServer::start().await;
+    let id = "acp-stop-review";
+    let delivery_key = "review:stop-once";
+    let payload = "wait:3000|say:must-not-complete";
+    start_new(&ts, id, None, None).await;
+    insert_protected_review(&ts, id, delivery_key, payload).await;
+
+    ts.state
+        .acp
+        .get(id)
+        .unwrap()
+        .notify_pending()
+        .await
+        .unwrap();
+    poll_chat(&ts, id, Duration::from_secs(5), |blocks| {
+        blocks
+            .iter()
+            .any(|block| block["kind"] == "user_message" && block["payload"]["text"] == payload)
+    })
+    .await;
+    ts.client
+        .post(&format!("/api/sessions/{id}/interrupt"), json!({}))
+        .await
+        .unwrap();
+
+    // Exercise both the direct wake and the same sweep that found the live
+    // incident. Neither may turn the consumed item back into work.
+    loom::review_delivery::drain(&ts.state).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let chat = ts
+        .client
+        .get(&format!("/api/sessions/{id}/chat"))
+        .await
+        .unwrap();
+    assert_eq!(chat["live_turn"], Value::Null);
+    assert_eq!(
+        chat["blocks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|block| {
+                block["kind"] == "user_message" && block["payload"]["text"] == payload
+            })
+            .count(),
+        1
+    );
+    let state: String =
+        sqlx::query_scalar("SELECT state FROM review_conversation_inbox WHERE delivery_key = ?")
+            .bind(delivery_key)
+            .fetch_one(&ts.state.db)
+            .await
+            .unwrap();
+    assert_eq!(state, "consumed");
+}
+
+/// Stop also fences protected feedback that was queued behind some other turn.
+/// Background notifications leave it queued until a new explicit user send
+/// clears the stop boundary.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupt_pauses_automatic_review_dispatch_until_an_explicit_send() {
+    let ts = TestServer::start().await;
+    let id = "acp-stop-review-queue";
+    let delivery_key = "review:queued-at-stop";
+    let payload = "wait:3000|say:review-finished";
+    start_new(&ts, id, None, None).await;
+    ts.client
+        .post(
+            &format!("/api/sessions/{id}/prompt"),
+            json!({ "text": "wait:3000|say:original-finished" }),
+        )
+        .await
+        .unwrap();
+    insert_protected_review(&ts, id, delivery_key, payload).await;
+    let queued = ts
+        .state
+        .acp
+        .get(id)
+        .unwrap()
+        .notify_pending()
+        .await
+        .unwrap();
+    assert!(queued.queued);
+
+    ts.client
+        .post(&format!("/api/sessions/{id}/interrupt"), json!({}))
+        .await
+        .unwrap();
+    assert!(ts.state.acp.stop(id), "the stopped task was registered");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    acp::attach(&ts.state.acp_ctx(), id)
+        .await
+        .expect("the stopped runtime can be re-adopted");
+    loom::review_delivery::drain(&ts.state).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let stopped = ts
+        .client
+        .get(&format!("/api/sessions/{id}/chat"))
+        .await
+        .unwrap();
+    assert_eq!(stopped["live_turn"], Value::Null);
+    assert_eq!(
+        stopped["blocks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|block| block["kind"] == "user_message")
+            .count(),
+        1,
+        "a background review wake must not continue after Stop"
+    );
+
+    ts.client
+        .post(
+            &format!("/api/sessions/{id}/prompt"),
+            json!({ "text": "say:resume" }),
+        )
+        .await
+        .unwrap();
+    let resumed = poll_chat(&ts, id, Duration::from_secs(5), |blocks| {
+        blocks
+            .iter()
+            .any(|block| block["kind"] == "user_message" && block["payload"]["text"] == payload)
+    })
+    .await;
+    assert!(resumed["blocks"].as_array().unwrap().iter().any(|block| {
+        block["kind"] == "user_message" && block["payload"]["text"] == "say:resume"
+    }));
+}
+
 /// The `/chat` routes reject a terminal-backend session with 409.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -2029,7 +2029,6 @@ async fn interrupting_a_review_turn_does_not_redeliver_it() {
     // Exercise both the direct wake and the same sweep that found the live
     // incident. Neither may turn the consumed item back into work.
     loom::review_delivery::drain(&ts.state).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(250)).await;
     let chat = ts
         .client
         .get(&format!("/api/sessions/{id}/chat"))
@@ -2095,7 +2094,6 @@ async fn interrupt_pauses_automatic_review_dispatch_until_an_explicit_send() {
         .await
         .expect("the stopped runtime can be re-adopted");
     loom::review_delivery::drain(&ts.state).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(250)).await;
     let stopped = ts
         .client
         .get(&format!("/api/sessions/{id}/chat"))


### PR DESCRIPTION
Stopping an ACP turn released protected artifact-review feedback back into the delivery queue. The periodic review sweep then injected the same delivery key again; the affected session recorded that review on turns 1, 3, 4, and 6.\n\nConsume an already-journaled review when its turn is explicitly stopped, and pause all automatic follow-up dispatch until the user sends new work. Restore that pause from the durable cancelled turn when Loom re-adopts the runtime so a process restart cannot erase the boundary. Add integration coverage for review cancellation, background delivery sweeps, explicit resume, and runtime recovery.\n\nSession: http://localhost:7878/s/73x6ogh5