### PR TITLE
fix(loom): follow terminal output on session return

### DIFF
--- a/crates/loom/frontend/src/components/AgentTerminal.vue
+++ b/crates/loom/frontend/src/components/AgentTerminal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, nextTick } from 'vue';
+import { ref, onMounted, onActivated, onUnmounted, nextTick } from 'vue';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
@@ -376,6 +376,10 @@ onMounted(async () => {
   document.addEventListener('visibilitychange', onVisible);
   connect();
 });
+
+// Session pages stay warm while the operator jumps around the fleet. Returning
+// to one should show what the agent is doing now, not an old scrollback position.
+onActivated(() => term?.scrollToBottom());
 
 onUnmounted(() => {
   disposed = true;

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -423,4 +423,49 @@ test.describe('session detail view', () => {
       timeout: 20_000,
     });
   });
+
+  test('returns to the end of terminal scrollback after leaving a session', async ({
+    page,
+    weaver,
+  }) => {
+    const s = await weaver.seedSession({
+      goal: 'Keep the latest output in view',
+      name: 'term-return',
+    });
+    await page.goto(`${weaver.baseUrl}/s/${s.id}`);
+    await expect(page.getByTestId('term-status')).toHaveCount(0, { timeout: 20_000 });
+
+    const sent = await fetch(`${weaver.baseUrl}/api/sessions/${s.id}/send`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'seq 1 200', submit: true }),
+    });
+    expect(sent.ok).toBe(true);
+
+    // xterm 6 uses a model-backed custom scrollbar rather than native
+    // scrollTop. Its slider position is the rendered view of that model.
+    const scrollable = page.locator('.xterm-scrollable-element');
+    const scrollbar = scrollable.locator('> .scrollbar.vertical');
+    const slider = scrollbar.locator('> .slider');
+    const sliderPosition = () =>
+      slider.evaluate((element) => ({
+        top: (element as HTMLElement).offsetTop,
+        max:
+          (element.parentElement as HTMLElement).clientHeight -
+          (element as HTMLElement).offsetHeight,
+      }));
+    await expect(scrollbar).toHaveClass(/visible/);
+
+    await scrollable.hover();
+    await page.mouse.wheel(0, -10_000);
+    await expect.poll(async () => (await sliderPosition()).top).toBeLessThan(10);
+
+    await page.locator('[data-rail="sessions"]').click();
+    await page.goBack();
+    await expect(page).toHaveURL(`${weaver.baseUrl}/s/${s.id}`);
+    await expect.poll(async () => {
+      const { top, max } = await sliderPosition();
+      return max - top;
+    }).toBeLessThan(10);
+  });
 });


### PR DESCRIPTION
Cached session terminals kept an old scrollback position when returning from another view or session, hiding the agent's latest output. Move the warm xterm buffer to its end on activation while preserving the existing connection and normal in-session scrolling behavior.

Add an end-to-end regression that fills terminal scrollback, leaves the cached session, and verifies the return lands on the newest output.