### PR TITLE
fix(loom): steer automated messages when supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ composition, and bounded Scratch drop target as the CLI.
 
 `poll` reads lifecycle and attention, `wait` blocks until completion or human
 attention, `send` delivers immediate control input, and `interrupt` stops the
-current turn. For ACP, immediate control input cancels and restarts, while the
-conversation composer durably queues feedback behind a live turn. Session
-commands accept an id, branch id, branch name, or `repo:branch`.
+current turn. For ACP, immediate control input steers a supported live turn and
+otherwise cancels and restarts; the conversation composer durably queues
+feedback behind a live turn. Session commands accept an id, branch id, branch
+name, or `repo:branch`.
 
 The session title is one canonical, unqualified task label; fleet views add its
 Group only when they need a qualified `Group / Task` name. Loom records whether
@@ -251,8 +252,8 @@ composer with its **Edit** action or ArrowUp from an empty composer, or sent
 immediately with **Stop & send**. The live status names visible
 thinking, writing, or tool activity and reports how long it has been since the
 agent produced an observable update; quiet time is not guessed to mean stuck.
-Cross-session `loom session send` is immediate control input instead: it cancels
-a live turn and starts the message as a new one.
+Cross-session `loom session send` is immediate control input instead: it steers
+a supported live turn, or cancels that turn and starts the message as a new one.
 
 Whenever a session is archived — by the Archive button or automatically on merge
 — loom first captures that conversation to disk: it finds the agent's transcript

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -541,6 +541,8 @@ pub struct AcpMetadata {
     pub commands: Vec<Value>,
     pub config_options: Vec<Value>,
     pub modes: Vec<Value>,
+    /// Whether this adapter accepts injected input during a live turn.
+    pub steering_supported: bool,
 }
 
 /// A live session's control surface, held in the [`AcpRegistry`]: send commands
@@ -576,8 +578,8 @@ impl AcpHandle {
             .await
     }
 
-    /// Deliver a cross-session send without leaving it behind a live turn:
-    /// cancel the current turn and start the message normally.
+    /// Deliver injected input without leaving it behind a live turn: steer when
+    /// supported, otherwise cancel the current turn and start normally.
     pub async fn send_now(
         &self,
         text: String,
@@ -1362,6 +1364,15 @@ struct PendingPerm {
     frame_seq: u64,
 }
 
+/// An automated message waiting for the adapter's steering response.
+struct PendingSteer {
+    text: String,
+    by: Option<String>,
+    turn: i64,
+    resources: Vec<Value>,
+    reply: oneshot::Sender<Result<PromptAck>>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum TurnEndSource {
     MatchingPromptResponse,
@@ -1425,9 +1436,13 @@ struct Task {
     pending_config: HashMap<u64, oneshot::Sender<Result<AcpMetadata>>>,
     #[allow(dead_code)]
     load_session_cap: bool,
+    steering_cap: bool,
+    pending_steers: HashMap<u64, PendingSteer>,
     /// A recovered adapter-owned turn with no prompt response id. Normal turns
     /// are closed by their prompt response instead.
     external_turn: bool,
+    /// A steer that raced the old turn boundary and was accepted as a new turn.
+    pending_external: Option<PendingSteer>,
     /// A cancelled turn may be followed by the adapter's presentation-only
     /// "Conversation interrupted" prose after the next turn has already begun.
     /// Consume that one notice rather than journaling it under the wrong turn.
@@ -1505,7 +1520,10 @@ impl Task {
             pending_mode: HashMap::new(),
             pending_config: HashMap::new(),
             load_session_cap: false,
+            steering_cap: false,
+            pending_steers: HashMap::new(),
             external_turn: false,
+            pending_external: None,
             pending_interrupt_notice_through: None,
             automatic_dispatch_paused: false,
             suppress_journal: false,
@@ -1567,6 +1585,7 @@ impl Task {
         let turns_dispatched = if max_seq < 0 { 0 } else { current_turn + 1 };
 
         let metadata = Self::load_persisted_metadata(&state.db, &session.id).await?;
+        let steering_cap = metadata.steering_supported;
         Ok(Self {
             db: state.db.clone(),
             bus: state.bus.clone(),
@@ -1596,7 +1615,10 @@ impl Task {
             pending_mode: HashMap::new(),
             pending_config: HashMap::new(),
             load_session_cap: false,
+            steering_cap,
+            pending_steers: HashMap::new(),
             external_turn,
+            pending_external: None,
             pending_interrupt_notice_through: None,
             automatic_dispatch_paused,
             suppress_journal: false,
@@ -1772,6 +1794,8 @@ impl Task {
         let res = res.ok_or_else(|| anyhow!("initialize failed: {err:?}"))?;
         if let Ok(init) = serde_json::from_value::<wire::InitializeResult>(res) {
             self.load_session_cap = init.agent_capabilities.load_session;
+            self.steering_cap = init.meta.steering.supported;
+            self.metadata.lock().unwrap().steering_supported = self.steering_cap;
         }
 
         match &launch.new_or_load {
@@ -2322,6 +2346,11 @@ impl Task {
         let Some(id) = inc.id.as_ref().and_then(Value::as_u64) else {
             return;
         };
+        if let Some(pending) = self.pending_steers.remove(&id) {
+            self.on_steering_response(pending, inc.result, inc.error)
+                .await;
+            return;
+        }
         if let Some(pending) = self.pending_mode.remove(&id) {
             let result = if let Some(error) = inc.error {
                 Err(anyhow!("session/set_mode failed: {error}"))
@@ -2508,6 +2537,18 @@ impl Task {
             return;
         }
 
+        // Steering can race the old prompt's response. If the adapter already
+        // opened the injected message as a new turn, adopt it before ordinary
+        // queued composer feedback. Otherwise let the steering response decide
+        // whether to inject or fall back before dispatching that queue.
+        if let Some(pending) = self.pending_external.take() {
+            self.begin_external_turn(pending).await;
+            return;
+        }
+        if !self.pending_steers.is_empty() {
+            return;
+        }
+
         self.dispatch_pending_prompt().await;
     }
 
@@ -2647,6 +2688,65 @@ impl Task {
         }
     }
 
+    async fn on_steering_response(
+        &mut self,
+        pending: PendingSteer,
+        result: Option<Value>,
+        error: Option<Value>,
+    ) {
+        let outcome = result
+            .and_then(|value| serde_json::from_value::<wire::SteeringResult>(value).ok())
+            .map(|result| result.outcome);
+        match (outcome, error) {
+            (Some(wire::SteeringOutcome::Injected), None) => {
+                // The adapter accepted this as input to the current turn. Flush
+                // earlier streamed prose before assigning the injected message
+                // its durable sequence.
+                self.current_turn = pending.turn;
+                self.flush_buf().await;
+                let by = pending.by.map(Value::from).unwrap_or(Value::Null);
+                self.journal_block(
+                    kind::USER_MESSAGE,
+                    json!({
+                        "text": pending.text,
+                        "by": by,
+                        "steered": true,
+                        "resources": pending.resources,
+                    }),
+                )
+                .await;
+                self.automatic_dispatch_paused = false;
+                let _ = pending.reply.send(Ok(PromptAck {
+                    queued: false,
+                    turn: Some(pending.turn),
+                }));
+                if !self.turn_live {
+                    self.dispatch_pending_prompt().await;
+                }
+            }
+            (Some(wire::SteeringOutcome::StartedNewTurn), None) => {
+                if self.turn_live {
+                    self.pending_external = Some(pending);
+                } else {
+                    self.begin_external_turn(pending).await;
+                }
+            }
+            (outcome, error) => {
+                tracing::warn!(
+                    session = %self.session_id,
+                    ?outcome,
+                    ?error,
+                    "steering failed; restarting the turn"
+                );
+                let result = self
+                    .restart_prompt(pending.text, pending.by, pending.resources)
+                    .await;
+                self.resume_automatic_dispatch_on(&result);
+                let _ = pending.reply.send(result);
+            }
+        }
+    }
+
     async fn restart_prompt(
         &mut self,
         text: String,
@@ -2693,6 +2793,55 @@ impl Task {
             queued: false,
             turn: Some(self.current_turn),
         })
+    }
+
+    async fn begin_external_turn(&mut self, pending: PendingSteer) {
+        let turn = if self.turns_dispatched > 0 {
+            self.current_turn + 1
+        } else {
+            self.current_turn
+        };
+        self.effective_mode = self.current_mode.clone();
+        let inflight = json!({
+            "turn": turn,
+            "external": true,
+            "mode": self.effective_mode,
+        })
+        .to_string();
+        if let Err(error) = session::set_inflight(&self.db, &self.session_id, Some(&inflight)).await
+        {
+            let _ = pending.reply.send(Err(error));
+            return;
+        }
+        self.current_turn = turn;
+        self.next_seq = 0;
+        self.turns_dispatched += 1;
+        self.turn_live = true;
+        self.external_turn = true;
+        self.automatic_dispatch_paused = false;
+        self.emit(
+            "turn",
+            json!({
+                "turn": turn,
+                "state": "started",
+                "effective_mode": self.effective_mode,
+            }),
+        );
+        let by = pending.by.map(Value::from).unwrap_or(Value::Null);
+        self.journal_block(
+            kind::USER_MESSAGE,
+            json!({
+                "text": pending.text,
+                "by": by,
+                "resources": pending.resources,
+            }),
+        )
+        .await;
+        crate::status::record_acp_lifecycle(&self.db, &self.bus, &self.session_id, "working").await;
+        let _ = pending.reply.send(Ok(PromptAck {
+            queued: false,
+            turn: Some(turn),
+        }));
     }
 
     async fn start_turn(
@@ -3076,6 +3225,12 @@ impl Task {
             .await;
         if result.is_ok() && self.turn_live {
             self.automatic_dispatch_paused = true;
+            for (_, pending) in self.pending_steers.drain() {
+                let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
+            }
+            if let Some(pending) = self.pending_external.take() {
+                let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
+            }
             // The adapter notice belongs to the cancelled turn even when it
             // arrives after an immediate restart. Bound suppression to that
             // turn and its direct successor so unrelated future prose is never
@@ -3147,9 +3302,41 @@ impl Task {
                         let _ = reply.send(ack);
                     }
                     PromptDelivery::Immediate => {
-                        let ack = self.restart_prompt(text, by, resources).await;
-                        self.resume_automatic_dispatch_on(&ack);
-                        let _ = reply.send(ack);
+                        if self.turn_live
+                            && self.steering_cap
+                            && self.pending_steers.is_empty()
+                            && self.pending_external.is_none()
+                        {
+                            let id = self.next_id();
+                            let request = wire::request_line(
+                                id,
+                                method::SESSION_STEERING,
+                                wire::steering_params(&self.acp_session_id, &text, &resources),
+                            );
+                            match self.stream.write(&request).await {
+                                Ok(()) => {
+                                    self.pending_steers.insert(
+                                        id,
+                                        PendingSteer {
+                                            text,
+                                            by,
+                                            turn: self.current_turn,
+                                            resources,
+                                            reply,
+                                        },
+                                    );
+                                }
+                                Err(_) => {
+                                    let ack = self.restart_prompt(text, by, resources).await;
+                                    self.resume_automatic_dispatch_on(&ack);
+                                    let _ = reply.send(ack);
+                                }
+                            }
+                        } else {
+                            let ack = self.restart_prompt(text, by, resources).await;
+                            self.resume_automatic_dispatch_on(&ack);
+                            let _ = reply.send(ack);
+                        }
                     }
                 }
             }
@@ -3278,6 +3465,12 @@ impl Task {
 
     async fn on_exit(&mut self, status: Option<i32>) {
         tracing::warn!(session = %self.session_id, ?status, "acp agent exited");
+        for (_, pending) in self.pending_steers.drain() {
+            let _ = pending.reply.send(Err(anyhow!("acp agent exited")));
+        }
+        if let Some(pending) = self.pending_external.take() {
+            let _ = pending.reply.send(Err(anyhow!("acp agent exited")));
+        }
         self.settle_inflight_review(
             crate::review_inbox::ReviewClaimSettlement::Abandoned,
             "ACP process exit",

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -3225,12 +3225,7 @@ impl Task {
             .await;
         if result.is_ok() && self.turn_live {
             self.automatic_dispatch_paused = true;
-            for (_, pending) in self.pending_steers.drain() {
-                let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
-            }
-            if let Some(pending) = self.pending_external.take() {
-                let _ = pending.reply.send(Err(anyhow!("turn was cancelled")));
-            }
+            self.fail_pending_steers("turn was cancelled");
             // The adapter notice belongs to the cancelled turn even when it
             // arrives after an immediate restart. Bound suppression to that
             // turn and its direct successor so unrelated future prose is never
@@ -3264,6 +3259,15 @@ impl Task {
     fn resume_automatic_dispatch_on<T>(&mut self, explicit_send: &Result<T>) {
         if explicit_send.is_ok() {
             self.automatic_dispatch_paused = false;
+        }
+    }
+
+    fn fail_pending_steers(&mut self, reason: &'static str) {
+        for (_, pending) in self.pending_steers.drain() {
+            let _ = pending.reply.send(Err(anyhow!(reason)));
+        }
+        if let Some(pending) = self.pending_external.take() {
+            let _ = pending.reply.send(Err(anyhow!(reason)));
         }
     }
 
@@ -3465,12 +3469,7 @@ impl Task {
 
     async fn on_exit(&mut self, status: Option<i32>) {
         tracing::warn!(session = %self.session_id, ?status, "acp agent exited");
-        for (_, pending) in self.pending_steers.drain() {
-            let _ = pending.reply.send(Err(anyhow!("acp agent exited")));
-        }
-        if let Some(pending) = self.pending_external.take() {
-            let _ = pending.reply.send(Err(anyhow!("acp agent exited")));
-        }
+        self.fail_pending_steers("acp agent exited");
         self.settle_inflight_review(
             crate::review_inbox::ReviewClaimSettlement::Abandoned,
             "ACP process exit",

--- a/crates/loom-agent/src/acp/wire.rs
+++ b/crates/loom-agent/src/acp/wire.rs
@@ -62,6 +62,8 @@ pub mod method {
     pub const SESSION_NEW: &str = "session/new";
     pub const SESSION_LOAD: &str = "session/load";
     pub const SESSION_PROMPT: &str = "session/prompt";
+    /// Experimental codex-acp extension for adding input to the active turn.
+    pub const SESSION_STEERING: &str = "_session/steering";
     pub const SESSION_CANCEL: &str = "session/cancel";
     pub const SESSION_SET_MODE: &str = "session/set_mode";
     pub const SESSION_SET_CONFIG_OPTION: &str = "session/set_config_option";
@@ -393,12 +395,14 @@ pub struct PromptResult {
     pub stop_reason: String,
 }
 
-/// The `initialize` result capabilities loom uses.
+/// The `initialize` result capabilities loom uses, plus adapter extensions.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeResult {
     #[serde(default)]
     pub agent_capabilities: AgentCapabilities,
+    #[serde(default, rename = "_meta")]
+    pub meta: InitializeMeta,
 }
 
 /// The subset of agent capabilities loom checks.
@@ -407,6 +411,30 @@ pub struct InitializeResult {
 pub struct AgentCapabilities {
     #[serde(default)]
     pub load_session: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct InitializeMeta {
+    #[serde(default)]
+    pub steering: SteeringCapability,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SteeringCapability {
+    #[serde(default)]
+    pub supported: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SteeringOutcome {
+    Injected,
+    StartedNewTurn,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SteeringResult {
+    pub outcome: SteeringOutcome,
 }
 
 // ---------------------------------------------------------------------------
@@ -457,6 +485,11 @@ pub fn prompt_params(session_id: &str, text: &str, resources: &[Value]) -> Value
         "sessionId": session_id,
         "prompt": prompt,
     })
+}
+
+/// codex-acp `_session/steering` params use ACP's ordinary prompt shape.
+pub fn steering_params(session_id: &str, text: &str, resources: &[Value]) -> Value {
+    prompt_params(session_id, text, resources)
 }
 
 /// `session/cancel` notification params.
@@ -809,9 +842,15 @@ mod tests {
 
         let init: InitializeResult = serde_json::from_value(json!({
             "agentCapabilities": { "loadSession": true },
+            "_meta": { "steering": { "supported": true } },
         }))
         .unwrap();
         assert!(init.agent_capabilities.load_session);
+        assert!(init.meta.steering.supported);
+
+        let steer: SteeringResult =
+            serde_json::from_value(json!({ "outcome": "startedNewTurn" })).unwrap();
+        assert_eq!(steer.outcome, SteeringOutcome::StartedNewTurn);
     }
 
     #[test]
@@ -831,6 +870,15 @@ mod tests {
         let params = prompt_params("sess-1", "review this", &[resource]);
         assert_eq!(params["prompt"][1]["type"], "resource_link");
         assert_eq!(params["prompt"][1]["name"], "src/main.rs");
+
+        let line = request_line(
+            2,
+            method::SESSION_STEERING,
+            steering_params("sess-1", "pivot", &[]),
+        );
+        let v: Value = serde_json::from_slice(&line[..line.len() - 1]).unwrap();
+        assert_eq!(v["method"], "_session/steering");
+        assert_eq!(v["params"]["prompt"][0]["text"], "pivot");
 
         let resp = response_line(&json!(7), permission_selected("allow-once"));
         let v: Value = serde_json::from_slice(&resp[..resp.len() - 1]).unwrap();

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -1478,8 +1478,8 @@ fn followup_prompt(trigger: &Trigger, instruction: &str) -> String {
     )
 }
 
-/// Send an ACP prompt through the registered task so it is journaled and either
-/// started or durably queued according to the conversation's current state.
+/// Send an ACP follow-up as immediate injected input: steer a supported live
+/// turn, otherwise stop it and start the message as a fresh turn.
 async fn forward_acp_followup(
     registry: &crate::acp::AcpRegistry,
     session_id: &str,
@@ -1489,7 +1489,7 @@ async fn forward_acp_followup(
         .get(session_id)
         .ok_or_else(|| anyhow!("session has no live ACP task"))?;
     handle
-        .prompt(prompt.to_string(), Some("slack".to_string()), Vec::new())
+        .send_now(prompt.to_string(), Some("slack".to_string()), Vec::new())
         .await
         .context("sending follow-up to ACP conversation")?;
     Ok(())

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -102,6 +102,7 @@ const emptyMetadata = (): AcpMetadata => ({
   commands: [],
   config_options: [],
   modes: [],
+  steering_supported: false,
 });
 const metadata = ref<AcpMetadata>(emptyMetadata());
 

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -443,6 +443,7 @@ export interface AcpMetadata {
   commands: AcpCommand[];
   config_options: AcpConfigOption[];
   modes: AcpMode[];
+  steering_supported: boolean;
 }
 
 // -- block payloads (by kind) --

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -278,7 +278,7 @@ async fn prompt_channel_run(
         .clone()
         .expect("channel runs require a goal");
     if let Err(error) = handle
-        .prompt(goal.clone(), Some(by.clone()), Vec::new())
+        .send_now(goal.clone(), Some(by.clone()), Vec::new())
         .await
     {
         crate::runs::waiting(&st.db, &run.id).await.ok();

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1762,9 +1762,9 @@ pub(super) async fn send_session(
     Json(req): Json<SendReq>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
-    // A cross-session send must not sit behind an ACP turn indefinitely. Cancel
-    // a live turn and immediately start this message as a fresh turn, while
-    // keeping the same `nudge` audit.
+    // A cross-session send must not sit behind an ACP turn indefinitely. Steer
+    // the live turn when supported, otherwise cancel it and immediately start
+    // this message as a fresh turn, while keeping the same `nudge` audit.
     if session.protocol == "acp" {
         let handle = require_acp_task(&st, &session)?;
         let by = author_or_manual(req.by.as_deref());

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -54,6 +54,8 @@ const summaryOutput =
   process.env.FAKE_ACP_SUMMARY_OUTPUT_B64 === undefined
     ? undefined
     : Buffer.from(process.env.FAKE_ACP_SUMMARY_OUTPUT_B64, "base64").toString("utf8");
+let promptActive = false;
+const steeringQueue = [];
 let promptEpoch = 0;
 let promptResources = [];
 let poisoned = false;
@@ -64,6 +66,13 @@ function send(obj) {
 }
 function respond(id, result) {
   send({ jsonrpc: JSONRPC, id, result });
+}
+function rejectMethod(id, method) {
+  send({
+    jsonrpc: JSONRPC,
+    id,
+    error: { code: -32601, message: `Method not found: ${method}` },
+  });
 }
 function notify(update) {
   send({ jsonrpc: JSONRPC, method: "session/update", params: { sessionId, update } });
@@ -318,6 +327,7 @@ async function runToken(tok) {
 async function handlePrompt(id, params) {
   const epoch = ++promptEpoch;
   cancelled = false;
+  promptActive = true;
   promptResources = (params.prompt || []).filter((b) => b.type === "resource_link");
   // The script is the prompt's first paragraph only. A real launch prompt
   // appends orientation prose (the entrance note, which echoes the session
@@ -362,8 +372,26 @@ async function handlePrompt(id, params) {
     // An immediate cancel-and-restart can begin another prompt while this
     // handler is still unwinding its cancellable sleep.
     if (epoch !== promptEpoch) return;
+    while (steeringQueue.length > 0 && !cancelled) {
+      const steering = steeringQueue.shift();
+      for (const steeringToken of steering.split("|")) {
+        if (steeringToken.length > 0) await runToken(steeringToken);
+      }
+    }
   }
+  promptActive = false;
   if (id !== null) respond(id, { stopReason: cancelled ? "cancelled" : "end_turn" });
+}
+
+function handleSteering(id, params) {
+  const text = (params.prompt || []).map((block) => block.text || "").join("");
+  if (!promptActive) {
+    void handlePrompt(null, params);
+    respond(id, { outcome: "startedNewTurn" });
+    return;
+  }
+  steeringQueue.push(text);
+  respond(id, { outcome: "injected" });
 }
 
 function handleMessage(msg) {
@@ -416,6 +444,10 @@ function handleMessage(msg) {
       break;
     case "session/prompt":
       void handlePrompt(msg.id, msg.params);
+      break;
+    case "_session/steering":
+      if (steeringSupported) handleSteering(msg.id, msg.params);
+      else rejectMethod(msg.id, msg.method);
       break;
     case "session/cancel":
       cancelled = true;

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1548,6 +1548,60 @@ async fn session_send_restarts_a_live_turn() {
     }));
 }
 
+/// Automated `/send` input uses the adapter's steering extension when it is
+/// available, keeping the agent's current work alive instead of cancelling it.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_send_steers_a_supported_live_turn() {
+    let ts = TestServer::start().await;
+    start_new_with_env(
+        &ts,
+        "acp-send-steer",
+        None,
+        None,
+        vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
+    )
+    .await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-send-steer/prompt",
+            json!({ "text": "wait:1200|say:first" }),
+        )
+        .await
+        .unwrap();
+    let sent = ts
+        .client
+        .post(
+            "/api/sessions/acp-send-steer/send",
+            json!({ "text": "say:injected" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(sent["queued"], false, "response: {sent}");
+    assert_eq!(sent["turn"], 0, "steering stays in the live turn");
+
+    let chat = poll_chat(&ts, "acp-send-steer", Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message"
+                && block["payload"]["text"]
+                    .as_str()
+                    .is_some_and(|text| text.contains("injected"))
+        })
+    })
+    .await;
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 0
+            && block["kind"] == "user_message"
+            && block["payload"]["text"] == "say:injected"
+            && block["payload"]["steered"] == true
+    }));
+    assert!(!blocks.iter().any(|block| {
+        block["kind"] == "turn_end" && block["payload"]["stop_reason"] == "cancelled"
+    }));
+}
+
 /// Composer-selected files are resolved inside the worktree and forwarded as
 /// ACP resource_link blocks, not left as adapter-specific `@file` prose.
 #[serial]

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -572,8 +572,8 @@ impl Client {
     }
 
     /// Type a message into a session's agent pane, submitting it by default
-    /// (`POST /api/sessions/{key}/send`). For ACP, this cancels a live turn and
-    /// starts the message as a normal turn.
+    /// (`POST /api/sessions/{key}/send`). For ACP, this steers a supported live
+    /// turn and otherwise cancels it before starting a normal turn.
     pub async fn nudge(&self, key: &str, req: &SendReq) -> Result<Value> {
         let body = serde_json::to_value(req)?;
         self.post(&format!("/api/sessions/{}/send", Self::seg(key)), body)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -484,7 +484,8 @@ let an agent or script type into, interrupt, or read back a child session
 uniformly. For a `terminal` session each requires a live terminal (else 409). An
 `acp` session has no PTY, so the same verbs map onto the protocol — keeping the
 CLI (`loom session {send,interrupt,preview}`) and its `nudge` audit uniform across
-backends: `send` cancels a live turn and starts the message as a normal prompt,
+backends: `send` steers a supported live turn, otherwise cancels it and starts
+the message as a normal prompt,
 `interrupt` is a `session/cancel`,
 and `preview` renders the last journal blocks as compact plain text instead of
 a vt100 screen capture.

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -462,6 +462,7 @@ test.describe('acp conversation', () => {
             commands: [],
             config_options: [],
             modes: [],
+            steering_supported: false,
           },
         },
       });


### PR DESCRIPTION
Route automated ACP messages through immediate delivery instead of the conversation composer's durable queue. Supported adapters receive steering input on the live turn; unavailable or rejected steering falls back to cancelling the turn and starting the message normally. Slack follow-ups and automation channel updates use the same path, while user message-box prompts retain their existing queue behavior.

Loom session: http://127.0.0.1:7878/s/3g1smuyu