### PR TITLE
feat(loom): broker scoped GitHub App tokens

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -245,9 +245,23 @@ cat > /usr/local/bin/git-credential-ghtoken <<'SH'
 # git invokes the helper for get/store/erase; only `get` returns a credential,
 # and store/erase must exit 0 or git warns about a failing helper.
 [ "$1" = get ] || exit 0
-printf 'username=x-access-token\npassword=%s\n' "$GH_TOKEN"
+token="$GH_TOKEN"
+if [ -z "$token" ] && [ -n "$LOOM_SESSION_ID" ] && [ -n "$LOOM_TOKEN" ]; then
+  token="$(/usr/local/bin/weaver github-token)" || exit $?
+fi
+[ -n "$token" ] || exit 0
+printf 'username=x-access-token\npassword=%s\n' "$token"
 SH
 chmod +x /usr/local/bin/git-credential-ghtoken
+cat > /usr/local/bin/gh <<'SH'
+#!/bin/sh
+if [ -z "$GH_TOKEN" ] && [ -n "$LOOM_SESSION_ID" ] && [ -n "$LOOM_TOKEN" ]; then
+  GH_TOKEN="$(/usr/local/bin/weaver github-token)" || exit $?
+  export GH_TOKEN
+fi
+exec /usr/bin/gh "$@"
+SH
+chmod +x /usr/local/bin/gh
 git config --system credential.https://github.com.helper ghtoken
 git config --system url.https://github.com/.insteadOf git@github.com:
 git config --system url.https://github.com/.insteadOf ssh://git@github.com/

--- a/crates/loom-agent/src/agent.rs
+++ b/crates/loom-agent/src/agent.rs
@@ -740,9 +740,9 @@ async fn start_terminal(
 ) -> Result<AgentInstance> {
     let loom_exe = std::env::current_exe().ok();
     let weaver_dir = loom_exe.as_deref().and_then(Path::parent);
-    // The session environment loom injects (WEAVER_API/WEAVER_BRANCH/LOOM_TOKEN +
-    // operator vars) — the same set the ACP relay launch delivers (see
-    // [`session_env`] / [`build_acp_launch`]).
+    // The session environment loom injects (WEAVER_API/WEAVER_BRANCH, session
+    // credentials, and operator vars) — the same set the ACP relay launch
+    // delivers (see [`session_env`] / [`build_acp_launch`]).
     let env_owned = session_env(ctx.server_addr, ctx.branch_id, ctx.extra_env);
     let env: Vec<(&str, &str)> = env_owned
         .iter()
@@ -790,8 +790,8 @@ pub fn read_local_token() -> Option<String> {
 
 /// The session environment loom injects into an agent process — the same set for
 /// the terminal (PTY) and ACP (relay) backends. `extra_env` carries the freshly
-/// minted session-bound `LOOM_TOKEN`; the machine-local admin token is never
-/// injected into an agent.
+/// minted session-bound `LOOM_TOKEN` and `LOOM_SESSION_ID`; the machine-local
+/// admin token is never injected into an agent.
 pub fn session_env(
     server_addr: &str,
     branch_id: &str,
@@ -984,7 +984,7 @@ pub async fn build_acp_launch(
     };
 
     let mut env = session_env(spec.server_addr, spec.branch_id, spec.extra_env);
-    env.push(("LOOM_SESSION_ID".to_string(), spec.session_id.to_string()));
+    push_env_default(&mut env, "LOOM_SESSION_ID", spec.session_id);
     if spec.restricted {
         // GitHub mutations are performed by Loom's server-side restricted tool
         // endpoint. The adapter and model never receive the credential.

--- a/crates/loom-core/src/launch.rs
+++ b/crates/loom-core/src/launch.rs
@@ -407,6 +407,7 @@ pub async fn resolve(
             turn_budget: Some(turn_budget),
             prelude: profile.prelude.clone(),
             instructions: profile.instructions.clone(),
+            github_repositories: profile.github_repositories()?,
             runtime_permissions: runtime_permissions.clone(),
             mcp_policy: SessionMcpPolicyView::from(&mcp_policy),
         },

--- a/crates/loom-forge/src/github_app.rs
+++ b/crates/loom-forge/src/github_app.rs
@@ -15,7 +15,7 @@
 //!    App can't be driven by a stranger's install (complementing the managed-repo
 //!    table from #95).
 //! 3. **Exchange the JWT for an installation access token**
-//!    (`POST /app/installations/{id}/access_tokens`), **cached per installation
+//!    (`POST /app/installations/{id}/access_tokens`), **cached by exact scope
 //!    with its expiry** and refreshed once stale ([`GithubApp::installation_token`]).
 //!
 //! [`GithubApp`] implements the [`GithubApi`] gateway the trigger calls for the
@@ -107,6 +107,12 @@ struct CachedToken {
     expires_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum TokenScope {
+    Installation(i64),
+    Repositories(Vec<String>),
+}
+
 impl CachedToken {
     /// Whether this token is still safe to use at `now` (with a refresh margin).
     fn is_fresh(&self, now: DateTime<Utc>) -> bool {
@@ -165,8 +171,8 @@ pub struct GithubApp {
     http: reqwest::Client,
     /// REST base (no trailing slash). `https://api.github.com` in production.
     api_base: String,
-    /// Per-installation token cache, keyed by installation id.
-    tokens: Mutex<HashMap<i64, CachedToken>>,
+    /// Installation tokens cached by their exact repository scope.
+    tokens: Mutex<HashMap<TokenScope, CachedToken>>,
     /// The ambient-`GH_TOKEN` gateway used when the App is not configured.
     fallback: Arc<dyn GithubApi>,
 }
@@ -265,11 +271,14 @@ impl GithubApp {
     /// expiry. The cached-token fast path holds the lock only briefly and never
     /// across the network call.
     pub async fn installation_token(&self, installation_id: i64) -> Result<String> {
-        if let Some(token) = self.cached_token(installation_id) {
+        let scope = TokenScope::Installation(installation_id);
+        if let Some(token) = self.cached_token(&scope) {
             return Ok(token);
         }
         let jwt = self.current_jwt().await?;
-        let fresh = self.fetch_installation_token(&jwt, installation_id).await?;
+        let fresh = self
+            .fetch_installation_token(&jwt, installation_id, &[])
+            .await?;
         tracing::info!(
             installation = installation_id,
             expires_at = %fresh.expires_at,
@@ -279,15 +288,15 @@ impl GithubApp {
         self.tokens
             .lock()
             .expect("token cache mutex poisoned")
-            .insert(installation_id, fresh);
+            .insert(scope, fresh);
         Ok(token)
     }
 
     /// The cached token for `installation_id`, if one is present and still fresh.
-    fn cached_token(&self, installation_id: i64) -> Option<String> {
+    fn cached_token(&self, scope: &TokenScope) -> Option<String> {
         let now = Utc::now();
         let map = self.tokens.lock().expect("token cache mutex poisoned");
-        map.get(&installation_id)
+        map.get(scope)
             .filter(|t| t.is_fresh(now))
             .map(|t| t.token.clone())
     }
@@ -298,17 +307,29 @@ impl GithubApp {
         &self,
         jwt: &str,
         installation_id: i64,
+        repositories: &[String],
     ) -> Result<CachedToken> {
         let url = format!(
-            "{}/app/installations/{installation_id}/access_tokens",
-            self.api_base
+            "{}/app/installations/{}/access_tokens",
+            self.api_base, installation_id
         );
-        let resp = self
+        let mut request = self
             .http
             .post(&url)
             .header(reqwest::header::ACCEPT, GH_ACCEPT)
             .header("X-GitHub-Api-Version", GH_API_VERSION)
-            .bearer_auth(jwt)
+            .bearer_auth(jwt);
+        if !repositories.is_empty() {
+            request = request.json(&serde_json::json!({
+                "repositories": repositories,
+                "permissions": {
+                    "contents": "write",
+                    "issues": "write",
+                    "pull_requests": "write"
+                }
+            }));
+        }
+        let resp = request
             .send()
             .await
             .context("requesting an installation access token")?;
@@ -332,6 +353,49 @@ impl GithubApp {
     pub async fn token_for_repo(&self, owner: &str, name: &str) -> Result<String> {
         let installation_id = self.installation_id(owner, name).await?;
         self.installation_token(installation_id).await
+    }
+
+    /// Mint a token constrained to the named repositories and the fixed
+    /// contents/issues/pull-requests write policy used by automation profiles.
+    pub async fn token_for_repositories(&self, repositories: &[String]) -> Result<String> {
+        if repositories.is_empty() {
+            bail!("GitHub repository allowlist is empty");
+        }
+        let mut slugs = repositories
+            .iter()
+            .map(|repository| crate::repo::parse_slug(repository).map_err(anyhow::Error::msg))
+            .collect::<Result<Vec<_>>>()?;
+        slugs.sort_by_key(crate::repo::RepoSlug::slug);
+        slugs.dedup();
+        let owner = slugs[0].owner.clone();
+        if slugs.iter().any(|slug| slug.owner != owner) {
+            bail!("GitHub repository allowlist must use one owner");
+        }
+        let scope =
+            TokenScope::Repositories(slugs.iter().map(crate::repo::RepoSlug::slug).collect());
+        if let Some(token) = self.cached_token(&scope) {
+            return Ok(token);
+        }
+        let installation_id = self
+            .installation_id(&slugs[0].owner, &slugs[0].name)
+            .await?;
+        for slug in &slugs[1..] {
+            let candidate = self.installation_id(&slug.owner, &slug.name).await?;
+            if candidate != installation_id {
+                bail!("GitHub repositories do not share one App installation");
+            }
+        }
+        let names = slugs.into_iter().map(|slug| slug.name).collect::<Vec<_>>();
+        let jwt = self.current_jwt().await?;
+        let fresh = self
+            .fetch_installation_token(&jwt, installation_id, &names)
+            .await?;
+        let token = fresh.token.clone();
+        self.tokens
+            .lock()
+            .expect("token cache mutex poisoned")
+            .insert(scope, fresh);
+        Ok(token)
     }
 
     async fn issue_json(&self, owner: &str, name: &str, number: i64) -> Result<serde_json::Value> {
@@ -650,6 +714,7 @@ pub mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use axum::body::Bytes;
     use axum::extract::{Json, Path, State};
     use axum::http::{HeaderMap, StatusCode};
     use axum::routing::{get, patch, post};
@@ -753,6 +818,8 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     /// the expiry it stamps on them, and the comments it received.
     struct MockState {
         token_mints: AtomicUsize,
+        installation_lookups: AtomicUsize,
+        token_requests: Mutex<Vec<Value>>,
         /// Offset from now stamped as the token's `expires_at` (seconds). Negative
         /// → already expired, to exercise refresh.
         expiry_offset_secs: i64,
@@ -766,6 +833,8 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         fn new(expiry_offset_secs: i64) -> Arc<Self> {
             Arc::new(Self {
                 token_mints: AtomicUsize::new(0),
+                installation_lookups: AtomicUsize::new(0),
+                token_requests: Mutex::new(Vec::new()),
                 expiry_offset_secs,
                 comments: Mutex::new(Vec::new()),
                 updates: Mutex::new(Vec::new()),
@@ -782,15 +851,22 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     /// comment a human deleted.
     const MOCK_DELETED_COMMENT_ID: i64 = 404_404;
 
-    async fn mock_access_tokens(State(s): State<Arc<MockState>>) -> Json<Value> {
+    async fn mock_access_tokens(State(s): State<Arc<MockState>>, body: Bytes) -> Json<Value> {
         s.token_mints.fetch_add(1, Ordering::SeqCst);
+        s.token_requests.lock().unwrap().push(if body.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&body).unwrap()
+        });
         let exp = Utc::now() + Duration::seconds(s.expiry_offset_secs);
         Json(json!({ "token": MOCK_INSTALLATION_TOKEN, "expires_at": exp.to_rfc3339() }))
     }
 
     async fn mock_installation(
+        State(s): State<Arc<MockState>>,
         Path((owner, _name)): Path<(String, String)>,
     ) -> Result<Json<Value>, StatusCode> {
+        s.installation_lookups.fetch_add(1, Ordering::SeqCst);
         // Simulate "the App is not installed on this repo" for a sentinel owner.
         if owner == "uninstalled" {
             return Err(StatusCode::NOT_FOUND);
@@ -996,6 +1072,34 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             mock.token_mints.load(Ordering::SeqCst),
             1,
             "the second call reused the cached token"
+        );
+    }
+
+    #[tokio::test]
+    async fn repository_token_is_downscoped_and_cached_by_allowlist() {
+        let mock = MockState::new(3600);
+        let base = spawn_mock(mock.clone()).await;
+        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let repositories = vec![
+            "marin-community/marin".to_string(),
+            "marin-community/vllm".to_string(),
+        ];
+
+        app.token_for_repositories(&repositories).await.unwrap();
+        app.token_for_repositories(&repositories).await.unwrap();
+
+        assert_eq!(mock.token_mints.load(Ordering::SeqCst), 1);
+        assert_eq!(mock.installation_lookups.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            mock.token_requests.lock().unwrap().as_slice(),
+            &[json!({
+                "repositories": ["marin", "vllm"],
+                "permissions": {
+                    "contents": "write",
+                    "issues": "write",
+                    "pull_requests": "write"
+                }
+            })]
         );
     }
 

--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -100,6 +100,7 @@ pub async fn rotate_session_token(
     )
     .await?;
     set_env(env, "LOOM_TOKEN", token);
+    set_env(env, "LOOM_SESSION_ID", session.id.clone());
     Ok(())
 }
 
@@ -503,6 +504,7 @@ pub async fn create_warm_session(
             turn_budget: resolved.view.policy.turn_budget.unwrap_or(0),
             prelude: launch_profile.prelude.clone(),
             restricted: launch_profile.restricted,
+            github_repositories: launch_profile.github_repositories.clone(),
             allowed_tools: stamped_allowed_tools.clone(),
             mcp_access: stamped_mcp_access,
             launch_snapshot,
@@ -516,6 +518,7 @@ pub async fn create_warm_session(
     let session_token =
         crate::auth::create_session_token(&st.db, None, &session_id, &branch.id).await?;
     set_env(&mut extra_env, "LOOM_TOKEN", session_token);
+    set_env(&mut extra_env, "LOOM_SESSION_ID", session_id.clone());
     tracing::info!(watch = %watch.id, session = %session_id, agent = %agent, protocol = %protocol, work_dir = %work_dir.display(), "launching warm session agent");
     let launch_result = if protocol == "acp" {
         match agent::build_acp_launch(

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -199,6 +199,7 @@ struct HandoffPlan {
     instructions: String,
     restricted: bool,
     strict: bool,
+    github_repositories: String,
     allowed_tools: String,
     mcp_access: String,
     launch_snapshot: String,
@@ -352,6 +353,7 @@ async fn legacy_handoff_plan(
         instructions,
         restricted: session.policy_restricted,
         strict: session.policy_strict,
+        github_repositories: session.policy_github_repositories.clone(),
         allowed_tools: session.policy_allowed_tools.clone(),
         mcp_access: session.policy_mcp_access.clone(),
         launch_snapshot: legacy_handoff_snapshot(
@@ -482,6 +484,7 @@ async fn handoff_session_inner(
             instructions: resolved.profile.instructions.clone(),
             restricted: resolved.profile.restricted,
             strict: resolved.profile.strict,
+            github_repositories: resolved.profile.github_repositories.clone(),
             allowed_tools: serde_json::to_string(&resolved.runtime_permissions)
                 .map_err(|error| HandoffError::bad_request(error.to_string()))?,
             mcp_access: serde_json::to_string(&resolved.mcp_policy)
@@ -523,6 +526,7 @@ async fn handoff_session_inner(
         turn_budget: plan.turn_budget,
         prelude: plan.prelude.clone(),
         restricted: plan.restricted,
+        github_repositories: plan.github_repositories.clone(),
         allowed_tools: plan.allowed_tools.clone(),
         mcp_access: plan.mcp_access.clone(),
         launch_snapshot: plan.launch_snapshot.clone(),
@@ -623,6 +627,7 @@ async fn handoff_session_inner(
     )
     .await?;
     runtime::set_env(&mut extra_env, "LOOM_TOKEN", staged_token.value.clone());
+    runtime::set_env(&mut extra_env, "LOOM_SESSION_ID", session.id.clone());
     let mut launch = match agent::build_acp_launch(
         &st.db,
         &agent::AcpLaunchSpec {

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -972,6 +972,7 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
         turn_budget: resolved.view.policy.turn_budget.unwrap_or(0),
         prelude: launch_profile.prelude.clone(),
         restricted: launch_profile.restricted,
+        github_repositories: launch_profile.github_repositories.clone(),
         allowed_tools: stamped_allowed_tools.clone(),
         mcp_access: stamped_mcp_access,
         launch_snapshot,
@@ -1193,6 +1194,7 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
         crate::auth::create_session_token(&st.db, created_by.as_deref(), &session_id, &branch.id)
             .await?;
     set_env(&mut extra_env, "LOOM_TOKEN", session_token);
+    set_env(&mut extra_env, "LOOM_SESSION_ID", session_id.clone());
     let session = if protocol == "acp" {
         // The ACP path inserts the row *first* — `acp::start` binds a relay to it
         // and reads it back — then brings up the headless adapter over the relay.

--- a/crates/loom-policy/src/automation.rs
+++ b/crates/loom-policy/src/automation.rs
@@ -659,6 +659,7 @@ mod tests {
                 prelude: "weaver".to_string(),
                 instructions: String::new(),
                 restricted: false,
+                github_repositories: vec![],
                 allowed_tools: vec![],
                 mcp_access: weaver_api::McpAccess::default(),
             },

--- a/crates/loom-policy/src/profile.rs
+++ b/crates/loom-policy/src/profile.rs
@@ -49,6 +49,20 @@ const ORIGIN_PROFILE_STARTERS: &[(&str, &str, &str)] = &[
 const DEFAULT_PROFILE_INSTRUCTIONS: &str = include_str!("../profiles/default/instructions.md");
 
 const MAX_PROFILE_INSTRUCTIONS_BYTES: usize = 64 * 1024;
+const MAX_GITHUB_REPOSITORIES: usize = 64;
+
+fn valid_github_repository(value: &str) -> bool {
+    let mut parts = value.split('/');
+    let valid_part = |part: &str| {
+        !part.is_empty()
+            && part != "."
+            && part != ".."
+            && part
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    };
+    matches!((parts.next(), parts.next(), parts.next()), (Some(owner), Some(name), None) if valid_part(owner) && valid_part(name))
+}
 
 fn is_restricted_mcp_tool_set(rule: &str) -> bool {
     crate::mcp::is_tool_set(rule)
@@ -128,6 +142,36 @@ async fn validate_input(
             "profile instructions must be at most {} bytes",
             MAX_PROFILE_INSTRUCTIONS_BYTES
         );
+    }
+    if input.github_repositories.len() > MAX_GITHUB_REPOSITORIES
+        || input
+            .github_repositories
+            .iter()
+            .any(|repository| !valid_github_repository(repository))
+    {
+        bail!("GitHub repositories must be clean owner/name identifiers (maximum {MAX_GITHUB_REPOSITORIES})");
+    }
+    if input
+        .github_repositories
+        .first()
+        .and_then(|repository| repository.split_once('/'))
+        .is_some_and(|(owner, _)| {
+            input.github_repositories.iter().any(|repository| {
+                repository
+                    .split_once('/')
+                    .is_none_or(|(candidate, _)| candidate != owner)
+            })
+        })
+    {
+        bail!("GitHub repositories must use one owner");
+    }
+    if !input.github_repositories.is_empty()
+        && !(input.strict
+            && input.env_clear
+            && input.class.trim() == "automation"
+            && !input.restricted)
+    {
+        bail!("GitHub repository credentials require a strict env-cleared automation profile");
     }
     if input.allowed_tools.len() > 64
         || input.allowed_tools.iter().any(|rule| {
@@ -288,6 +332,9 @@ async fn normalized_input(
 ) -> Result<(ProfileInput, weaver_api::McpPolicySnapshot)> {
     let name = input.name.trim();
     let (protocol, mode, mcp_policy) = validate_input(db, input).await?;
+    let mut github_repositories = input.github_repositories.clone();
+    github_repositories.sort();
+    github_repositories.dedup();
     let normalized = ProfileInput {
         name: name.to_string(),
         description: input.description.trim().to_string(),
@@ -306,6 +353,7 @@ async fn normalized_input(
         prelude: input.prelude.trim().to_string(),
         instructions: input.instructions.trim().to_string(),
         restricted: input.restricted,
+        github_repositories,
         allowed_tools: input.allowed_tools.clone(),
         mcp_access: input.mcp_access.clone(),
     };
@@ -324,6 +372,7 @@ pub async fn create(db: &Db, input: &ProfileInput) -> Result<CreateProfileOutcom
     let (normalized, mcp_policy) = normalized_input(db, input).await?;
     let name = normalized.name.as_str();
     let ambient = serde_json::to_string(&normalized.ambient_allowlist)?;
+    let github_repositories = serde_json::to_string(&normalized.github_repositories)?;
     let allowed_tools = serde_json::to_string(&normalized.allowed_tools)?;
     let mcp_access = serde_json::to_string(&normalized.mcp_access)?;
     let mcp_policy_json = serde_json::to_string(&mcp_policy)?;
@@ -344,7 +393,7 @@ pub async fn create(db: &Db, input: &ProfileInput) -> Result<CreateProfileOutcom
              description = ?, agent_kind = ?, model = ?, effort = ?, protocol = ?,
              mode = ?, class = ?, strict = ?, env_clear = ?, ambient_allowlist = ?,
              idle_archive_secs = ?, max_concurrent = ?, turn_budget = ?, prelude = ?,
-             instructions = ?, restricted = ?, allowed_tools = ?, mcp_access = ?, mcp_policy = ?,
+             instructions = ?, restricted = ?, github_repositories = ?, allowed_tools = ?, mcp_access = ?, mcp_policy = ?,
              retired = 0, lifetime = lifetime + 1,
              revision = revision + 1, updated_at = ?
              WHERE name = ? AND retired = 1",
@@ -365,6 +414,7 @@ pub async fn create(db: &Db, input: &ProfileInput) -> Result<CreateProfileOutcom
         .bind(&normalized.prelude)
         .bind(&normalized.instructions)
         .bind(normalized.restricted)
+        .bind(&github_repositories)
         .bind(&allowed_tools)
         .bind(&mcp_access)
         .bind(&mcp_policy_json)
@@ -384,8 +434,8 @@ pub async fn create(db: &Db, input: &ProfileInput) -> Result<CreateProfileOutcom
              (name, description, agent_kind, model, effort, protocol, mode, class,
               strict, env_clear, ambient_allowlist, idle_archive_secs, max_concurrent,
               turn_budget, revision, created_at, updated_at, prelude, instructions, restricted,
-              allowed_tools, mcp_access, mcp_policy)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)",
+              github_repositories, allowed_tools, mcp_access, mcp_policy)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(name)
         .bind(&normalized.description)
@@ -406,6 +456,7 @@ pub async fn create(db: &Db, input: &ProfileInput) -> Result<CreateProfileOutcom
         .bind(&normalized.prelude)
         .bind(&normalized.instructions)
         .bind(normalized.restricted)
+        .bind(&github_repositories)
         .bind(&allowed_tools)
         .bind(&mcp_access)
         .bind(&mcp_policy_json)
@@ -425,6 +476,7 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
     let (normalized, mcp_policy) = normalized_input(db, input).await?;
     let name = normalized.name.as_str();
     let ambient = serde_json::to_string(&normalized.ambient_allowlist)?;
+    let github_repositories = serde_json::to_string(&normalized.github_repositories)?;
     let allowed_tools = serde_json::to_string(&normalized.allowed_tools)?;
     let mcp_access = serde_json::to_string(&normalized.mcp_access)?;
     let mcp_policy_json = serde_json::to_string(&mcp_policy)?;
@@ -448,7 +500,11 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
                 || normalized.class != "automation"
                 || (existing.restricted && !normalized.restricted)
                 || widens_restricted_tools
-                || widens_allowlist(&existing.ambient_names()?, &normalized.ambient_allowlist))
+                || widens_allowlist(&existing.ambient_names()?, &normalized.ambient_allowlist)
+                || widens_allowlist(
+                    &existing.github_repositories()?,
+                    &normalized.github_repositories,
+                ))
         {
             bail!("cannot weaken a profile referenced by automation sessions");
         }
@@ -465,8 +521,8 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
          (name, description, agent_kind, model, effort, protocol, mode, class,
           strict, env_clear, ambient_allowlist, idle_archive_secs, max_concurrent,
           turn_budget, revision, created_at, updated_at, prelude, instructions, restricted,
-          allowed_tools, mcp_access, mcp_policy)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)
+          github_repositories, allowed_tools, mcp_access, mcp_policy)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(name) DO UPDATE SET
           description=excluded.description, agent_kind=excluded.agent_kind,
           model=excluded.model, effort=excluded.effort, protocol=excluded.protocol,
@@ -476,6 +532,7 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
           max_concurrent=excluded.max_concurrent, turn_budget=excluded.turn_budget,
           prelude=excluded.prelude, instructions=excluded.instructions,
           restricted=excluded.restricted,
+          github_repositories=excluded.github_repositories,
           allowed_tools=excluded.allowed_tools, mcp_access=excluded.mcp_access,
           mcp_policy=excluded.mcp_policy, retired=0,
           lifetime=CASE
@@ -503,6 +560,7 @@ pub async fn upsert(db: &Db, input: &ProfileInput) -> Result<Profile> {
     .bind(&normalized.prelude)
     .bind(&normalized.instructions)
     .bind(normalized.restricted)
+    .bind(github_repositories)
     .bind(allowed_tools)
     .bind(mcp_access)
     .bind(mcp_policy_json)
@@ -543,6 +601,7 @@ pub async fn update_expected(
     let (normalized, mcp_policy) = normalized_input(db, input).await?;
     let name = normalized.name.as_str();
     let ambient = serde_json::to_string(&normalized.ambient_allowlist)?;
+    let github_repositories = serde_json::to_string(&normalized.github_repositories)?;
     let allowed_tools = serde_json::to_string(&normalized.allowed_tools)?;
     let mcp_access = serde_json::to_string(&normalized.mcp_access)?;
     let mcp_policy_json = serde_json::to_string(&mcp_policy)?;
@@ -587,7 +646,11 @@ pub async fn update_expected(
             || normalized.class != "automation"
             || (existing.restricted && !normalized.restricted)
             || widens_restricted_tools
-            || widens_allowlist(&existing.ambient_names()?, &normalized.ambient_allowlist))
+            || widens_allowlist(&existing.ambient_names()?, &normalized.ambient_allowlist)
+            || widens_allowlist(
+                &existing.github_repositories()?,
+                &normalized.github_repositories,
+            ))
     {
         bail!("cannot weaken a profile referenced by automation sessions");
     }
@@ -596,7 +659,7 @@ pub async fn update_expected(
          description = ?, agent_kind = ?, model = ?, effort = ?, protocol = ?,
          mode = ?, class = ?, strict = ?, env_clear = ?, ambient_allowlist = ?,
          idle_archive_secs = ?, max_concurrent = ?, turn_budget = ?, prelude = ?,
-         instructions = ?, restricted = ?, allowed_tools = ?, mcp_access = ?, mcp_policy = ?,
+         instructions = ?, restricted = ?, github_repositories = ?, allowed_tools = ?, mcp_access = ?, mcp_policy = ?,
          retired = 0, revision = revision + 1, updated_at = ?
          WHERE name = ? AND revision = ?",
     )
@@ -616,6 +679,7 @@ pub async fn update_expected(
     .bind(&normalized.prelude)
     .bind(&normalized.instructions)
     .bind(normalized.restricted)
+    .bind(github_repositories)
     .bind(allowed_tools)
     .bind(mcp_access)
     .bind(mcp_policy_json)
@@ -703,6 +767,7 @@ pub async fn create_clone_prepared(
     }
     let target_name = normalized.name.as_str();
     let ambient = serde_json::to_string(&normalized.ambient_allowlist)?;
+    let github_repositories = serde_json::to_string(&normalized.github_repositories)?;
     let allowed_tools = serde_json::to_string(&normalized.allowed_tools)?;
     let mcp_access = serde_json::to_string(&normalized.mcp_access)?;
     let now = now_iso();
@@ -738,7 +803,7 @@ pub async fn create_clone_prepared(
              description = ?, agent_kind = ?, model = ?, effort = ?, protocol = ?,
              mode = ?, class = ?, strict = ?, env_clear = ?, ambient_allowlist = ?,
              idle_archive_secs = ?, max_concurrent = ?, turn_budget = ?, prelude = ?,
-             instructions = ?, restricted = ?, allowed_tools = ?, mcp_access = ?, mcp_policy = ?,
+             instructions = ?, restricted = ?, github_repositories = ?, allowed_tools = ?, mcp_access = ?, mcp_policy = ?,
              retired = 0, lifetime = lifetime + 1,
              revision = revision + 1, updated_at = ?
              WHERE name = ? AND retired = 1",
@@ -759,6 +824,7 @@ pub async fn create_clone_prepared(
         .bind(&normalized.prelude)
         .bind(&normalized.instructions)
         .bind(normalized.restricted)
+        .bind(&github_repositories)
         .bind(&allowed_tools)
         .bind(&mcp_access)
         .bind(serde_json::to_string(&current_mcp_policy)?)
@@ -776,8 +842,8 @@ pub async fn create_clone_prepared(
              (name, description, agent_kind, model, effort, protocol, mode, class,
               strict, env_clear, ambient_allowlist, idle_archive_secs, max_concurrent,
               turn_budget, revision, created_at, updated_at, prelude, instructions, restricted,
-              allowed_tools, mcp_access, mcp_policy)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)",
+              github_repositories, allowed_tools, mcp_access, mcp_policy)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(target_name)
         .bind(&normalized.description)
@@ -798,6 +864,7 @@ pub async fn create_clone_prepared(
         .bind(&normalized.prelude)
         .bind(&normalized.instructions)
         .bind(normalized.restricted)
+        .bind(github_repositories)
         .bind(allowed_tools)
         .bind(mcp_access)
         .bind(serde_json::to_string(&current_mcp_policy)?)
@@ -1122,6 +1189,7 @@ pub async fn normalize_default(db: &Db) -> Result<()> {
         prelude: current.prelude.clone(),
         instructions: current.instructions.clone(),
         restricted: current.restricted,
+        github_repositories: current.github_repositories().unwrap_or_default(),
         allowed_tools: current.allowed_tool_rules().unwrap_or_default(),
         mcp_access: current.mcp_access().unwrap_or_default(),
     };
@@ -1209,6 +1277,42 @@ mod tests {
 
         input.mcp_access.groups = vec!["github".to_string()];
         input.protocol = "terminal".to_string();
+        assert!(upsert(&db, &input).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn github_credentials_require_a_safe_profile_and_canonical_repositories() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let mut input = get(&db, DEFAULT_PROFILE)
+            .await
+            .unwrap()
+            .unwrap()
+            .as_input()
+            .unwrap();
+        input.github_repositories = vec!["marin-community/marin".to_string()];
+        assert!(upsert(&db, &input).await.is_err());
+
+        input.class = "automation".to_string();
+        input.strict = true;
+        input.env_clear = true;
+        input.github_repositories = vec![
+            "marin-community/vllm".to_string(),
+            "marin-community/marin".to_string(),
+            "marin-community/vllm".to_string(),
+        ];
+        let saved = upsert(&db, &input).await.unwrap();
+        assert_eq!(
+            saved.github_repositories().unwrap(),
+            ["marin-community/marin", "marin-community/vllm"]
+        );
+
+        input.github_repositories = vec!["https://github.com/marin-community/marin".to_string()];
+        assert!(upsert(&db, &input).await.is_err());
+
+        input.github_repositories = vec![
+            "marin-community/marin".to_string(),
+            "other/vllm".to_string(),
+        ];
         assert!(upsert(&db, &input).await.is_err());
     }
 

--- a/crates/loom-store/migrations/0023_profile_github_repositories.sql
+++ b/crates/loom-store/migrations/0023_profile_github_repositories.sql
@@ -1,0 +1,5 @@
+ALTER TABLE profiles
+ADD COLUMN github_repositories TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE sessions
+ADD COLUMN policy_github_repositories TEXT NOT NULL DEFAULT '[]';

--- a/crates/loom-store/src/db.rs
+++ b/crates/loom-store/src/db.rs
@@ -120,6 +120,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "profile-instructions",
         include_str!("../migrations/0022_profile_instructions.sql"),
     ),
+    (
+        23,
+        "profile-github-repositories",
+        include_str!("../migrations/0023_profile_github_repositories.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);

--- a/crates/loom-store/src/profile_data.rs
+++ b/crates/loom-store/src/profile_data.rs
@@ -29,6 +29,8 @@ pub struct Profile {
     /// Organization-owned instructions appended to the opening prompt.
     pub instructions: String,
     pub restricted: bool,
+    /// JSON array in storage; parsed through [`Profile::github_repositories`].
+    pub github_repositories: String,
     /// JSON array in storage; parsed through [`Profile::allowed_tool_rules`].
     pub allowed_tools: String,
     /// Provider-neutral MCP selection JSON.
@@ -58,6 +60,11 @@ impl Profile {
         serde_json::from_str(&self.allowed_tools).context("invalid profile allowed tools")
     }
 
+    pub fn github_repositories(&self) -> Result<Vec<String>> {
+        serde_json::from_str(&self.github_repositories)
+            .context("invalid profile GitHub repository allowlist")
+    }
+
     pub fn mcp_access(&self) -> Result<weaver_api::McpAccess> {
         serde_json::from_str(&self.mcp_access).context("invalid profile MCP access")
     }
@@ -85,6 +92,7 @@ impl Profile {
             prelude: self.prelude.clone(),
             instructions: self.instructions.clone(),
             restricted: self.restricted,
+            github_repositories: self.github_repositories()?,
             allowed_tools: self.allowed_tool_rules()?,
             mcp_access: self.mcp_access()?,
         })
@@ -125,6 +133,8 @@ pub struct ProfileInput {
     pub instructions: String,
     #[serde(default)]
     pub restricted: bool,
+    #[serde(default)]
+    pub github_repositories: Vec<String>,
     #[serde(default, alias = "runtime_permissions")]
     pub allowed_tools: Vec<String>,
     #[serde(default)]

--- a/crates/loom-store/src/session.rs
+++ b/crates/loom-store/src/session.rs
@@ -120,6 +120,7 @@ pub struct Session {
     pub policy_turn_budget: i64,
     pub policy_prelude: String,
     pub policy_restricted: bool,
+    pub policy_github_repositories: String,
     pub policy_allowed_tools: String,
     pub policy_mcp_access: String,
     /// Canonical source-redacted launch resolution JSON. Empty only for rows
@@ -156,7 +157,7 @@ const SESSION_COLUMNS: &str = "\
     class, turn_count, tracking_issue_id, profile, launch_mode, profile_revision, \
     profile_lifetime, policy_strict, policy_env_clear, policy_ambient_allowlist, \
     policy_idle_archive_secs, policy_turn_budget, policy_prelude, policy_restricted, \
-    policy_allowed_tools, policy_mcp_access, launch_snapshot, creator_kind, creator_subject, \
+    policy_github_repositories, policy_allowed_tools, policy_mcp_access, launch_snapshot, creator_kind, creator_subject, \
     parent_session_id, automation_run_id, mutation_revision";
 
 fn select_sessions(suffix: &str) -> String {
@@ -232,6 +233,7 @@ pub struct SessionLaunchPolicy {
     pub turn_budget: i64,
     pub prelude: String,
     pub restricted: bool,
+    pub github_repositories: String,
     pub allowed_tools: String,
     pub mcp_access: String,
     pub launch_snapshot: String,
@@ -258,6 +260,7 @@ pub struct SessionHandoffPolicy {
     pub turn_budget: i64,
     pub prelude: String,
     pub restricted: bool,
+    pub github_repositories: String,
     pub allowed_tools: String,
     pub mcp_access: String,
     pub launch_snapshot: String,
@@ -286,6 +289,7 @@ impl SessionLaunchPolicy {
             turn_budget: 0,
             prelude: "weaver".to_string(),
             restricted: false,
+            github_repositories: "[]".to_string(),
             allowed_tools: "[]".to_string(),
             mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[]}"#
                 .to_string(),
@@ -562,10 +566,10 @@ pub(crate) async fn insert_with_layout_revision(
           profile, launch_mode, profile_revision, profile_lifetime, policy_strict,
           policy_env_clear,
           policy_ambient_allowlist, policy_idle_archive_secs, policy_turn_budget,
-          policy_prelude, policy_restricted, policy_allowed_tools, policy_mcp_access,
+          policy_prelude, policy_restricted, policy_github_repositories, policy_allowed_tools, policy_mcp_access,
           launch_snapshot, creator_kind, creator_subject, parent_session_id, automation_run_id)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&s.id)
     .bind(&s.branch_id)
@@ -596,6 +600,7 @@ pub(crate) async fn insert_with_layout_revision(
     .bind(policy.turn_budget)
     .bind(&policy.prelude)
     .bind(policy.restricted)
+    .bind(&policy.github_repositories)
     .bind(&policy.allowed_tools)
     .bind(&policy.mcp_access)
     .bind(&policy.launch_snapshot)
@@ -1284,7 +1289,7 @@ pub async fn prepare_handoff(
              profile_lifetime = ?, policy_strict = ?, policy_env_clear = ?,
              policy_ambient_allowlist = ?,
              policy_idle_archive_secs = ?, policy_turn_budget = ?,
-             policy_prelude = ?, policy_restricted = ?,
+             policy_prelude = ?, policy_restricted = ?, policy_github_repositories = ?,
              policy_allowed_tools = ?, policy_mcp_access = ?,
              launch_snapshot = ?,
              mutation_revision = mutation_revision + 1
@@ -1305,6 +1310,7 @@ pub async fn prepare_handoff(
     .bind(policy.turn_budget)
     .bind(&policy.prelude)
     .bind(policy.restricted)
+    .bind(&policy.github_repositories)
     .bind(&policy.allowed_tools)
     .bind(&policy.mcp_access)
     .bind(&policy.launch_snapshot)
@@ -1947,6 +1953,7 @@ mod tests {
             turn_budget: 0,
             prelude: "weaver".to_string(),
             restricted: false,
+            github_repositories: "[]".to_string(),
             allowed_tools: "[]".to_string(),
             mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[]}"#
                 .to_string(),
@@ -2002,6 +2009,7 @@ mod tests {
             turn_budget: 0,
             prelude: "none".to_string(),
             restricted: false,
+            github_repositories: "[]".to_string(),
             allowed_tools: "[]".to_string(),
             mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[]}"#
                 .to_string(),

--- a/crates/loom-watch/src/monitor.rs
+++ b/crates/loom-watch/src/monitor.rs
@@ -518,6 +518,7 @@ mod tests {
             policy_turn_budget: 0,
             policy_prelude: "weaver".to_string(),
             policy_restricted: false,
+            policy_github_repositories: "[]".to_string(),
             policy_allowed_tools: "[]".to_string(),
             policy_mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[]}"#
                 .to_string(),

--- a/crates/loom/frontend/src/components/ProfileEditor.vue
+++ b/crates/loom/frontend/src/components/ProfileEditor.vue
@@ -89,6 +89,7 @@ watch(
   () => draft.value.restricted,
   (restricted) => {
     if (!restricted) return;
+    draft.value.github_repositories = [];
     if (draft.value.mcp_access.mode === 'all') {
       draft.value.mcp_access = { mode: 'none', groups: [] };
       return;
@@ -327,6 +328,25 @@ watch(
         @input="
           draft.ambient_allowlist = ($event.target as HTMLInputElement).value
             .split(',')
+            .map((value) => value.trim())
+            .filter(Boolean)
+        "
+      />
+    </div>
+
+    <div class="grid min-w-0 gap-1 sm:col-span-2">
+      <label class="text-xs" :for="`${uid}-github-repositories`">
+        GitHub App repositories (owner/name, one per line)
+      </label>
+      <textarea
+        :id="`${uid}-github-repositories`"
+        :value="draft.github_repositories.join('\n')"
+        :disabled="disabled || draft.restricted"
+        rows="3"
+        class="min-w-0 rounded bg-input px-2 py-1.5 font-mono"
+        @input="
+          draft.github_repositories = ($event.target as HTMLTextAreaElement).value
+            .split('\n')
             .map((value) => value.trim())
             .filter(Boolean)
         "

--- a/crates/loom/frontend/src/components/ProfilesPanel.vue
+++ b/crates/loom/frontend/src/components/ProfilesPanel.vue
@@ -31,6 +31,7 @@ function editable(profile: Profile): ProfileInput {
     ...input,
     expected_revision: profile.revision,
     ambient_allowlist: [...input.ambient_allowlist],
+    github_repositories: [...input.github_repositories],
     runtime_permissions: [...input.runtime_permissions],
     mcp_access: { ...input.mcp_access, groups: [...input.mcp_access.groups] },
   };
@@ -86,6 +87,7 @@ function add() {
     prelude: 'weaver',
     instructions: '',
     restricted: false,
+    github_repositories: [],
     runtime_permissions: [],
     mcp_access: { mode: 'none', groups: [] },
   };

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -1275,6 +1275,7 @@ export interface Profile {
   prelude: 'weaver' | 'none';
   instructions: string;
   restricted: boolean;
+  github_repositories: string[];
   runtime_permissions: string[];
   mcp_access: McpAccess;
   lifetime: number;
@@ -1348,6 +1349,7 @@ export interface ResolvedLaunchPolicy {
   turn_budget: number | null;
   prelude: string;
   instructions: string;
+  github_repositories: string[];
   runtime_permissions: string[];
   mcp_policy: SessionMcpPolicy;
 }

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -2317,6 +2317,7 @@ async fn run_profile(cmd: ProfileCmd) -> Result<()> {
                     prelude: opts.prelude,
                     instructions,
                     restricted: opts.restricted,
+                    github_repositories: Vec::new(),
                     runtime_permissions: opts.runtime_permission,
                     mcp_access: parse_mcp_access(&opts.mcp)?,
                     expected_revision: None,

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -874,6 +874,7 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{id}/send", post(send_session))
         .route("/sessions/{id}/interrupt", post(interrupt_session))
         .route("/sessions/{id}/preview", get(preview_session))
+        .route("/sessions/{id}/github-token", post(github_token))
         // The ACP chat journal + live stream, and the ACP drive routes (a
         // `session/prompt` queueing send, a permission answer, a mode change).
         .route("/sessions/{id}/chat", get(get_session_chat))

--- a/crates/loom/src/web/profiles.rs
+++ b/crates/loom/src/web/profiles.rs
@@ -31,6 +31,7 @@ pub(super) fn input(req: ProfileReq, name: String) -> ProfileInput {
         prelude: req.prelude,
         instructions: req.instructions,
         restricted: req.restricted,
+        github_repositories: req.github_repositories,
         allowed_tools: req.runtime_permissions,
         mcp_access: req.mcp_access,
     }
@@ -53,6 +54,9 @@ pub(super) async fn view(st: &AppState, profile: Profile) -> ApiResult<ProfileVi
     let runtime_permissions = profile
         .allowed_tool_rules()
         .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let github_repositories = profile
+        .github_repositories()
+        .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let mcp_access = profile
         .mcp_access()
         .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -74,6 +78,7 @@ pub(super) async fn view(st: &AppState, profile: Profile) -> ApiResult<ProfileVi
         prelude: profile.prelude,
         instructions: profile.instructions,
         restricted: profile.restricted,
+        github_repositories,
         runtime_permissions,
         mcp_access,
         lifetime: profile.lifetime,

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -10,11 +10,13 @@ use std::process::Stdio;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
-    Json,
+    Extension, Json,
 };
 use serde::Deserialize;
 use tokio::process::Command;
-use weaver_api::{RestrictedGithubToolReq, RestrictedGithubToolView};
+use weaver_api::{GithubTokenView, RestrictedGithubToolReq, RestrictedGithubToolView};
+
+use crate::auth::{Grant, Principal};
 
 use super::{ApiResult, AppError, AppState};
 
@@ -26,6 +28,51 @@ struct ToolArguments {
     body: Option<String>,
     #[serde(default)]
     title: Option<String>,
+}
+
+fn principal_owns_session(principal: &Principal, id: &str) -> bool {
+    matches!(&principal.grant, Grant::Session { session_id, .. } if session_id == id)
+}
+
+pub(super) async fn github_token(
+    State(st): State<AppState>,
+    Path(id): Path<String>,
+    Extension(principal): Extension<Principal>,
+) -> ApiResult<Json<GithubTokenView>> {
+    if !principal_owns_session(&principal, &id) {
+        return Err(AppError::new(
+            StatusCode::FORBIDDEN,
+            "only the session itself may request its GitHub credential",
+        ));
+    }
+    let session = crate::session::get(&st.db, &id)
+        .await?
+        .ok_or_else(|| AppError::not_found("session"))?;
+    let repositories: Vec<String> = serde_json::from_str(&session.policy_github_repositories)
+        .map_err(|error| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+    if repositories.is_empty() {
+        return Err(AppError::new(
+            StatusCode::FORBIDDEN,
+            "session profile has no GitHub repository credential",
+        ));
+    }
+    let app = st.trigger.app().ok_or_else(|| {
+        AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub App credential is unavailable",
+        )
+    })?;
+    if !app.is_configured().await {
+        return Err(AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub App credential is unavailable",
+        ));
+    }
+    let token = app
+        .token_for_repositories(&repositories)
+        .await
+        .map_err(|error| AppError::new(StatusCode::BAD_GATEWAY, error.to_string()))?;
+    Ok(Json(GithubTokenView { token }))
 }
 
 async fn restricted_github_token(
@@ -249,7 +296,40 @@ mod tests {
     use axum::http::StatusCode;
     use serde_json::json;
 
-    use super::{restricted_github_token, validate_arguments};
+    use super::{principal_owns_session, restricted_github_token, validate_arguments};
+    use crate::auth::{AuthVia, Grant, Principal};
+
+    fn principal(grant: Grant) -> Principal {
+        Principal {
+            username: "test".to_string(),
+            github_login: None,
+            via: AuthVia::Token,
+            grant,
+            automation_context: None,
+        }
+    }
+
+    #[test]
+    fn github_token_is_available_only_to_the_exact_session_principal() {
+        assert!(principal_owns_session(
+            &principal(Grant::Session {
+                session_id: "session-1".to_string(),
+                branch_id: "branch-1".to_string(),
+            }),
+            "session-1"
+        ));
+        assert!(!principal_owns_session(
+            &principal(Grant::Session {
+                session_id: "parent".to_string(),
+                branch_id: "branch-1".to_string(),
+            }),
+            "child"
+        ));
+        assert!(!principal_owns_session(
+            &principal(Grant::Admin),
+            "session-1"
+        ));
+    }
 
     #[test]
     fn only_the_fixed_mcp_tools_map_to_permissions() {

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -276,6 +276,7 @@ async fn seed_classed_session(
             turn_budget: if class == "automation" { 1 } else { 0 },
             prelude: "weaver".to_string(),
             restricted: false,
+            github_repositories: "[]".to_string(),
             allowed_tools: "[]".to_string(),
             mcp_access: r#"{"selection":{"mode":"none","groups":[]},"capability_sets":[]}"#
                 .to_string(),

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -18,13 +18,13 @@ use crate::dto::{
     CreateReviewReq, CreateSessionGroupReq, CreateSessionSpaceReq, CreateTokenReq, CreateWatchReq,
     CreatedTokenView, CustomMcpReq, CustomMcpView, DeleteSessionGroupReq, DeleteSessionSpaceReq,
     DeploymentReq, DeploymentView, DiagnosticsView, EffectiveProfileView, EnsureResumptionCueReq,
-    ExpectedReviewRevisionReq, FederationReq, FederationView, HandoffReq, HistoryPageView,
-    IssueActionsReq, IssueActionsResult, IssueView, McpRegistryView, MoveSessionsReq,
-    NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq, ProfileProbeView,
-    ProfileReq, ProfileView, PutProfileEnvReq, ReadinessView, ReorderSessionLayoutReq,
-    ResolveLaunchReq, ResolveReviewCommentReq, ResolvedLaunchView, RestoreSessionGroupsReq,
-    ResumptionCueView, ReviewCommentDto, ReviewDto, RunReq, RunView, RunWatchReq,
-    ScratchLimitsView, SearchSessionsOptions, SendReq, SessionGroupPreferenceReq,
+    ExpectedReviewRevisionReq, FederationReq, FederationView, GithubTokenView, HandoffReq,
+    HistoryPageView, IssueActionsReq, IssueActionsResult, IssueView, McpRegistryView,
+    MoveSessionsReq, NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq,
+    ProfileProbeView, ProfileReq, ProfileView, PutProfileEnvReq, ReadinessView,
+    ReorderSessionLayoutReq, ResolveLaunchReq, ResolveReviewCommentReq, ResolvedLaunchView,
+    RestoreSessionGroupsReq, ResumptionCueView, ReviewCommentDto, ReviewDto, RunReq, RunView,
+    RunWatchReq, ScratchLimitsView, SearchSessionsOptions, SendReq, SessionGroupPreferenceReq,
     SessionLayoutView, SessionPlacementSelectorKind, SessionView, SetChannelReadMarkerReq,
     SetChannelSubscriptionReq, SetSessionPlacementDefaultReq, SetTagsReq, SetTitleGenerationReq,
     SettingsEnvelope, SubmitReviewReq, TagReq, ThreadDto, TokenView, UpdateReviewCommentReq,
@@ -156,6 +156,15 @@ impl Client {
     }
 
     // -- Sessions ---------------------------------------------------------
+
+    pub async fn github_token(&self, session_id: &str) -> Result<GithubTokenView> {
+        self.send_typed::<Value, GithubTokenView>(
+            Method::POST,
+            &format!("/api/sessions/{}/github-token", Self::seg(session_id)),
+            None,
+        )
+        .await
+    }
 
     /// List active non-automation sessions (`GET /api/sessions`).
     pub async fn list_sessions(&self) -> Result<Vec<SessionView>> {

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -609,6 +609,8 @@ pub struct ProfileView {
     #[serde(default)]
     pub restricted: bool,
     #[serde(default)]
+    pub github_repositories: Vec<String>,
+    #[serde(default)]
     pub runtime_permissions: Vec<String>,
     #[serde(default)]
     pub mcp_access: McpAccess,
@@ -885,6 +887,8 @@ pub struct ResolvedLaunchPolicyView {
     pub prelude: String,
     #[serde(default)]
     pub instructions: String,
+    #[serde(default)]
+    pub github_repositories: Vec<String>,
     pub runtime_permissions: Vec<String>,
     pub mcp_policy: SessionMcpPolicyView,
 }
@@ -1011,6 +1015,9 @@ pub struct ProfileReq {
     pub instructions: String,
     #[serde(default)]
     pub restricted: bool,
+    /// Repositories for which Loom may broker a short-lived GitHub App token.
+    #[serde(default)]
+    pub github_repositories: Vec<String>,
     /// Provider-specific fallback permissions. New integrations should use
     /// `mcp_access`; `allowed_tools` remains a read-compatible input alias.
     #[serde(default, alias = "allowed_tools")]
@@ -1021,6 +1028,12 @@ pub struct ProfileReq {
     /// interactive editors always send the revision they loaded.
     #[serde(default)]
     pub expected_revision: Option<i64>,
+}
+
+/// A short-lived GitHub App installation token brokered for one session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GithubTokenView {
+    pub token: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -121,6 +121,9 @@ enum Cmd {
         #[arg(long)]
         event: String,
     },
+    /// Print a refreshable GitHub App token for the current session.
+    #[command(hide = true)]
+    GithubToken,
     /// Get or list configuration. Settings are written by operators via
     /// `loom config set` or the settings pane — not from here.
     Config {
@@ -469,6 +472,7 @@ async fn run() -> Result<()> {
         Cmd::Log { limit } => cmd_log(limit).await,
         Cmd::Chatlog { file, json } => cmd_chatlog(file, json),
         Cmd::Hook { event } => cmd_hook(event).await,
+        Cmd::GithubToken => cmd_github_token().await,
         Cmd::Config { cmd } => cmd_config(cmd).await,
         Cmd::Completions { shell } => {
             let mut cmd = Cli::command();
@@ -518,6 +522,14 @@ fn channel_key(explicit: Option<String>) -> Result<String> {
         bail!("no channel selected and $LOOM_SESSION_ID is not set — pass --channel <id>");
     }
     Ok(key.to_string())
+}
+
+async fn cmd_github_token() -> Result<()> {
+    let session_id =
+        std::env::var("LOOM_SESSION_ID").map_err(|_| anyhow!("$LOOM_SESSION_ID is not set"))?;
+    let credential = client().github_token(&session_id).await?;
+    println!("{}", credential.token);
+    Ok(())
 }
 
 /// The resolved attention level for a branch: the `attention` tag's value, or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,29 @@ starter text lives under `crates/loom-policy/profiles/<name>/instructions.md`.
 The origin profiles are opt-in so an upgrade does not silently change the
 environment or runtime used by existing triggers.
 
+A strict, environment-cleared automation profile may declare
+`github_repositories`. Inside sessions launched from that profile, `git` and
+`gh` transparently request a short-lived GitHub App installation token from
+Loom. Loom stamps the repository list on the session and limits the token to
+those repositories with contents, issues, and pull-request write access. It
+does not grant Actions or workflow-file access. The configured GitHub App must
+be installed on every listed repository, and all entries must use one owner.
+
+```yaml
+profiles:
+  - profile:
+      name: external-update
+      agent_kind: codex
+      protocol: acp
+      class: automation
+      strict: true
+      env_clear: true
+      github_repositories:
+        - marin-community/marin
+        - marin-community/vllm
+    env: []
+```
+
 Apply it through the authenticated local CLI:
 
 ```sh


### PR DESCRIPTION
Let strict, environment-cleared automation profiles declare a repository allowlist and stamp it onto each session. Session-scoped git and gh commands can then obtain a cached, short-lived GitHub App installation token limited to those repositories and contents, issues, and pull-request write permissions.

Keep the App private key in Loom and reject token requests from admins, automation credentials, parent sessions, restricted profiles, and sessions without the stamped policy. This gives unattended workflows renewable credentials without storing a long-lived PAT or granting Actions or workflow-file permissions.