### PR TITLE
fix(loom): send live composer feedback immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ select those profiles together.
 `poll` reads lifecycle and attention, `wait` blocks until completion or human
 attention, `send` delivers immediate control input, and `interrupt` stops the
 current turn. For ACP, immediate control input steers a supported live turn and
-otherwise cancels and restarts; the conversation composer durably queues
-feedback behind a live turn. Session commands accept an id, branch id, branch
+otherwise cancels and restarts; the conversation composer uses the same
+immediate delivery behavior. Session commands accept an id, branch id, branch
 name, or `repo:branch`.
 
 The session title is one canonical, unqualified task label; fleet views add its
@@ -259,14 +259,16 @@ the workbench header.
 Every session detail has a **Conversation** tab that renders the agent's chat
 with the model — user turns, replies, thinking, and tool calls — live and
 (via the archive capture below) still there to review after the terminal is gone.
-For ACP sessions, a prompt submitted while the agent is working is durably
-queued for the next turn. Unseen queued feedback can be pulled back into the
-composer with its **Edit** action or ArrowUp from an empty composer, or sent
-immediately with **Stop & send**. The live status names visible
-thinking, writing, or tool activity and reports how long it has been since the
-agent produced an observable update; quiet time is not guessed to mean stuck.
-Cross-session `loom session send` is immediate control input instead: it steers
-a supported live turn, or cancels that turn and starts the message as a new one.
+For ACP sessions, the conversation composer sends immediately: it steers an
+adapter that supports live input, or stops an unsteerable turn and starts the
+message as the next turn. Feedback queued by another client stays visible and
+can be pulled back into the composer with its **Edit** action or ArrowUp from an
+empty composer, or sent immediately with **Stop & send**. The live status names
+visible thinking, writing, or tool activity and reports how long it has been
+since the agent produced an observable update; quiet time is not guessed to mean
+stuck. Cross-session `loom session send` uses the same immediate policy: it
+steers a supported live turn, or cancels that turn and starts the message as a
+new one.
 
 Whenever a session is archived — by the Archive button or automatically on merge
 — loom first captures that conversation to disk: it finds the agent's transcript

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -576,13 +576,13 @@ export const getSessionChat = (id: string, before?: { turn: number; seq: number 
   return get(`/sessions/${id}/chat${query}`) as Promise<ChatSnapshot>;
 };
 
-/** Send a user message to an ACP session. Returns 202 with
- *  `{ queued, turn }`: a live turn keeps the message in the durable next-turn
- *  queue. */
+/** Send a user message to an ACP session now. A supported live turn is steered;
+ *  an unsteerable live turn is stopped and replaced. */
 export const promptSession = (id: string, text: string, by?: string, files: string[] = []) =>
   post(`/sessions/${id}/prompt`, {
     text,
     by,
+    send_now: true,
     files,
   }) as Promise<PromptAck>;
 

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -571,8 +571,8 @@ export interface SseQueue {
   pending_prompt: string | null;
 }
 
-/** `POST /sessions/{id}/prompt` 202 body: whether the message queued behind a
- *  live turn or started normally, plus the turn it belongs to. */
+/** `POST /sessions/{id}/prompt` 202 body: whether the message queued, plus the
+ *  turn it belongs to. */
 export interface PromptAck {
   queued: boolean;
   turn: number | null;

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2017,6 +2017,10 @@ pub(super) struct PromptBody {
     pub text: String,
     #[serde(default)]
     pub by: Option<String>,
+    /// Deliver this user message immediately: steer a supported live turn, or
+    /// cancel and replace an unsteerable one.
+    #[serde(default)]
+    pub send_now: bool,
     /// Promote the server's durable next-turn queue instead of sending `text`.
     /// This keeps the action race-free when the browser is showing queued copy.
     #[serde(default)]
@@ -2132,9 +2136,11 @@ async fn prompt_resources(work_dir: &str, files: &[String]) -> ApiResult<Vec<Val
     Ok(out)
 }
 
-/// Send a user message to an ACP session: dispatched as a `session/prompt` when
-/// idle or appended to the durable queue while a turn is live. Returns 202
-/// `{ queued, turn }`. Every send records a `nudge` event (the audit rule).
+/// Send a user message to an ACP session. A normal request is dispatched when
+/// idle or appended to the durable queue while a turn is live; `send_now`
+/// instead steers a supported live turn or cancels and replaces an unsteerable
+/// one. Returns 202 `{ queued, turn }`. Every send records a `nudge` event (the
+/// audit rule).
 pub(super) async fn prompt_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
@@ -2153,9 +2159,15 @@ pub(super) async fn prompt_session(
         handle.force_pending(Some(by.clone())).await
     } else {
         let resources = prompt_resources(&session.work_dir, &req.files).await?;
-        handle
-            .prompt(req.text.clone(), Some(by.clone()), resources)
-            .await
+        if req.send_now {
+            handle
+                .send_now(req.text.clone(), Some(by.clone()), resources)
+                .await
+        } else {
+            handle
+                .prompt(req.text.clone(), Some(by.clone()), resources)
+                .await
+        }
     }
     .map_err(|e| AppError::conflict(e.to_string()))?;
     events::record(
@@ -2163,7 +2175,12 @@ pub(super) async fn prompt_session(
         &st.bus,
         &branch.id,
         "nudge",
-        json!({ "by": by, "text": audit_text, "promoted_queue": req.force_queued }),
+        json!({
+            "by": by,
+            "text": audit_text,
+            "send_now": req.send_now,
+            "promoted_queue": req.force_queued,
+        }),
     )
     .await
     .ok();

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1501,6 +1501,53 @@ async fn prompt_stops_and_sends_the_durable_queue() {
     }));
 }
 
+/// The conversation composer requests immediate delivery by default. Without
+/// steering support, that is one atomic stop-and-replace operation rather than
+/// a queue write followed by a second promotion request.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prompt_send_now_restarts_an_unsteerable_live_turn() {
+    let ts = TestServer::start().await;
+    start_new(&ts, "acp-prompt-now", None, None).await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-prompt-now/prompt",
+            json!({ "text": "wait:1200|say:stale" }),
+        )
+        .await
+        .unwrap();
+    let sent = ts
+        .client
+        .post(
+            "/api/sessions/acp-prompt-now/prompt",
+            json!({ "text": "say:replacement", "send_now": true }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(sent["queued"], false, "response: {sent}");
+    assert_eq!(sent["turn"], 1, "the replacement opens the next turn");
+
+    let chat = poll_chat(&ts, "acp-prompt-now", Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "replacement"
+        })
+    })
+    .await;
+    assert!(chat["pending_prompt"].is_null());
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 0
+            && block["kind"] == "turn_end"
+            && block["payload"]["stop_reason"] == "cancelled"
+    }));
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 1
+            && block["kind"] == "user_message"
+            && block["payload"]["text"] == "say:replacement"
+    }));
+}
+
 /// Cross-session `/send` is control-plane input, not ordinary composer
 /// feedback. It cancels a live turn and starts the message immediately instead
 /// of leaving it in the durable next-turn queue.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,12 +353,12 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/sessions/{id}/history` | a bounded newest-tail page of provider-neutral records in chronological display order; `before`, `limit`, and `kinds` own backward pagination/filtering |
 | `GET /api/sessions/{id}/history/search` | case-insensitive literal `q` search over the same session-scoped records and cursor/filter contract |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ the session's tapestry PTY (the interaction surface) |
-| `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a live turn is cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
+| `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a supported live turn is steered, otherwise it is cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
 | `POST /api/sessions/{id}/interrupt` | stop the current turn — a break (Escape) to the terminal for a `terminal` session, `session/cancel` for an `acp` one |
 | `GET /api/sessions/{id}/preview?lines=N` | capture the screen as `{screen}`; `lines` adds scrollback above the visible screen (for an `acp` session, `{screen}` is the last `lines` journal blocks rendered as compact text) |
 | `GET /api/sessions/{id}/chat` | The newest 200 blocks of the ACP session's DB-backed journal, `older_cursor`, live-turn state, pending prompt, effective mode, and durable composer metadata (the last provider-advertised controls remain after provider exit/restart); pass the cursor as `before_turn` + `before_seq` to page backward |
 | `GET /api/sessions/{id}/chat/stream` | SSE tail of the live journal: `block` (a committed block), `delta` (a streaming message/thought chunk), `tool` (a live tool-call update), `turn` (started / ended), `resync` (the bounded live buffer overran; reload the durable snapshot) |
-| `POST /api/sessions/{id}/prompt` | `{text}` → 202 `{queued, turn}` — dispatch a user message as a `session/prompt`; while a turn is live, append it to the durable next-turn queue |
+| `POST /api/sessions/{id}/prompt` | `{text, send_now?}` → 202 `{queued, turn}` — dispatch a user message as a `session/prompt`; the default queues behind a live turn, while `send_now` steers when supported or cancels and replaces an unsteerable turn |
 | `DELETE /api/sessions/{id}/prompt` | atomically retract unseen next-turn feedback and return `{text}` for editing; 409 when the current ACP state has no queue available to retract |
 | `POST /api/sessions/{id}/permissions/{request_id}` | `{option_id}` → answer an open permission request (200 / 404 unknown / 409 already resolved) |
 | `PUT /api/sessions/{id}/mode` | `{mode_id}` → change the ACP session's permission mode (`session/set_mode`), journaled as a `mode_change` |

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -66,10 +66,11 @@ An ACP session leads with **Conversation**, followed by **Shells** and
 **Review**. A terminal-backed session leads with **Agent**, followed by
 **Conversation** and **Review**. There is no Overview tab.
 
-Conversation is the durable operator/agent exchange. Mid-turn feedback queues
-for the next turn; **Stop & send** cancels the current turn when the feedback
-needs to run immediately. Unseen queued text can be retracted into the composer
-for editing without rewriting already-dispatched history. Permission requests
+Conversation is the durable operator/agent exchange. Mid-turn composer feedback
+steers adapters that support live input; otherwise it stops the current turn and
+starts the feedback as the next turn. Unseen text queued by another client can
+still be retracted into the composer for editing without rewriting
+already-dispatched history, or promoted with **Stop & send**. Permission requests
 and runtime controls stay in
 the conversation that produced them; elapsed quiet time is evidence, not an
 automatic “stuck” verdict.

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -113,6 +113,18 @@ async function openAcp(
   return s!;
 }
 
+/** Exercise the durable queue contract directly. The conversation composer is
+ * immediate by default, but queued feedback from another client remains an
+ * editable, promotable part of the UI. */
+async function queueAcpPrompt(weaver: WeaverFixture, session: Session, text: string): Promise<void> {
+  const res = await fetch(`${weaver.baseUrl}/api/sessions/${session.id}/prompt`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) throw new Error(`queueing ACP prompt failed: ${await res.text()}`);
+}
+
 test.describe('acp conversation', () => {
   test('opens the first worktree shell from the keyboard', async ({ page, weaver }) => {
     await openAcp(page, weaver, {
@@ -598,7 +610,7 @@ test.describe('acp conversation', () => {
     page,
     weaver,
   }) => {
-    await openAcp(page, weaver, {
+    const session = await openAcp(page, weaver, {
       goal: 'say:ready',
       name: 'acp-stop-settles',
     });
@@ -608,9 +620,7 @@ test.describe('acp conversation', () => {
     await expect(page.getByTestId('acp-working')).toBeVisible({
       timeout: 15_000,
     });
-
-    await input.fill('say:after stop');
-    await page.getByTestId('acp-composer-send').click();
+    await queueAcpPrompt(weaver, session, 'say:after stop');
     await expect(page.getByTestId('acp-queued')).toHaveText('queued · agent hasn’t seen this yet');
 
     await page.getByTestId('acp-composer-stop').click();
@@ -672,7 +682,7 @@ test.describe('acp conversation', () => {
     await expect(page.getByTestId('acp-recover')).toBeHidden();
   });
 
-  test('ordinary feedback says when the running agent has not seen it yet', async ({
+  test('composer stops and sends when the running agent cannot steer', async ({
     page,
     weaver,
   }) => {
@@ -689,28 +699,10 @@ test.describe('acp conversation', () => {
 
     await input.fill('say:queued feedback');
     await page.getByTestId('acp-composer-send').click();
-    await expect(page.getByTestId('acp-queued')).toHaveText('queued · agent hasn’t seen this yet');
-    await input.fill('say:and another thought');
-    await page.getByTestId('acp-composer-send').click();
-    await expect(page.getByTestId('acp-pending')).toHaveCount(1);
-    await expect(page.getByTestId('acp-pending')).toContainText('queued feedback');
-    await expect(page.getByTestId('acp-pending')).toContainText('and another thought');
-    await page.reload();
-    await expect(page.getByTestId('acp-queued')).toHaveText('queued · agent hasn’t seen this yet');
-    const forceNow = page.getByTestId('acp-force-queued').last();
-    await expect(forceNow).toBeEnabled();
-    await expect(forceNow).toHaveText('Stop & send');
-    await page.screenshot({
-      path: test.info().outputPath('acp-queued-feedback.png'),
-    });
-    await forceNow.click();
-
     await expect(page.getByTestId('acp-queued')).toBeHidden();
+    await expect(page.getByTestId('acp-turn-rule').filter({ hasText: 'cancelled' })).toHaveCount(1);
     await expect(
       page.getByTestId('acp-conversation').getByText('queued feedback', { exact: true }),
-    ).toBeVisible({ timeout: 20_000 });
-    await expect(
-      page.getByTestId('acp-conversation').getByText('say:and another thought', { exact: true }),
     ).toBeVisible({ timeout: 20_000 });
   });
 
@@ -718,7 +710,7 @@ test.describe('acp conversation', () => {
     page,
     weaver,
   }) => {
-    await openAcp(page, weaver, {
+    const session = await openAcp(page, weaver, {
       goal: 'say:ready',
       name: 'acp-edit-queue-ui',
     });
@@ -730,9 +722,7 @@ test.describe('acp conversation', () => {
     await expect(page.getByTestId('acp-working')).toBeVisible({
       timeout: 15_000,
     });
-
-    await input.fill('say:before edit');
-    await page.getByTestId('acp-composer-send').click();
+    await queueAcpPrompt(weaver, session, 'say:before edit');
     const editQueued = page.getByTestId('acp-edit-queued');
     await expect(editQueued).toBeEnabled();
 
@@ -743,8 +733,8 @@ test.describe('acp conversation', () => {
     await expect(page.getByTestId('acp-pending')).toBeHidden();
     await expect(input).toHaveValue('say:before edit');
 
-    await input.fill('say:after edit');
-    await page.getByTestId('acp-composer-send').click();
+    await input.fill('');
+    await queueAcpPrompt(weaver, session, 'say:after edit');
     const pending = page.getByTestId('acp-pending');
     await expect(pending).toContainText('say:after edit');
     await expect(pending).not.toContainText('say:before edit');


### PR DESCRIPTION
Make the ACP conversation composer request immediate delivery. Supported adapters steer the active turn; unsupported adapters cancel and replace it, eliminating the extra Stop & send click.

Keep the durable queue as the REST default for other clients and preserve the existing queue edit and promotion controls, with integration and UI journey coverage for both paths.