### PR TITLE
feat(loom): broker app tokens for interactive profiles

### DIFF
--- a/crates/loom-forge/src/repo.rs
+++ b/crates/loom-forge/src/repo.rs
@@ -241,6 +241,30 @@ pub async fn is_allowlisted(db: &Db, repo_root: &Path) -> Result<bool> {
     Ok(allowed)
 }
 
+/// Resolve the GitHub slug for a repository without requiring GitHub
+/// credentials. Managed clones use their registered identity; local checkouts
+/// fall back to parsing the configured `origin` URL.
+pub async fn github_slug_for_root(db: &Db, repo_root: &Path) -> Result<Option<String>> {
+    let target = repo_root
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.to_path_buf());
+    if let Some(slug) = list_registered(db)
+        .await?
+        .into_iter()
+        .find_map(|registered| {
+            let path = PathBuf::from(&registered.path);
+            (path.canonicalize().unwrap_or(path) == target).then_some(registered.slug)
+        })
+    {
+        return Ok(Some(slug));
+    }
+    let remote = match git::remote_url(repo_root, "origin").await {
+        Ok(remote) => remote,
+        Err(_) => return Ok(None),
+    };
+    Ok(parse_slug(&remote).ok().map(|slug| slug.slug()))
+}
+
 /// How a managed-repo resolution can fail, so the web layer maps each cause to
 /// the right HTTP status.
 #[derive(Debug)]
@@ -395,6 +419,30 @@ mod tests {
 
         // A dot is legal inside a name (e.g. `repo.js`).
         assert_eq!(parse_slug("acme/repo.js").unwrap().name, "repo.js");
+    }
+
+    #[tokio::test]
+    async fn resolves_a_local_checkout_slug_without_github_credentials() {
+        let db = connect_in_memory().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        run_git(dir.path(), &["init", "-q", "-b", "main"]).await;
+        run_git(
+            dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:marin-community/marin.git",
+            ],
+        )
+        .await;
+        assert_eq!(
+            github_slug_for_root(&db, dir.path())
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("marin-community/marin")
+        );
     }
 
     #[test]

--- a/crates/loom-forge/src/repo.rs
+++ b/crates/loom-forge/src/repo.rs
@@ -221,6 +221,16 @@ pub async fn get_registered(db: &Db, slug: &str) -> Result<Option<ManagedRepo>> 
     Ok(row)
 }
 
+async fn registered_for_root(db: &Db, repo_root: &Path) -> Result<Option<ManagedRepo>> {
+    let target = repo_root
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.to_path_buf());
+    Ok(list_registered(db).await?.into_iter().find(|registered| {
+        let path = PathBuf::from(&registered.path);
+        path.canonicalize().unwrap_or(path) == target
+    }))
+}
+
 /// Whether `repo_root` is an allowlisted (registered) managed repo — the gate
 /// that decides whether a session's committed `.weaver/config.toml` `[setup]`
 /// script may run. A registered repo's stored `path` is the managed clone
@@ -230,13 +240,7 @@ pub async fn get_registered(db: &Db, slug: &str) -> Result<Option<ManagedRepo>> 
 /// allowlisted, and its setup script is never executed (the design's privileged
 /// code-execution boundary, §6.4).
 pub async fn is_allowlisted(db: &Db, repo_root: &Path) -> Result<bool> {
-    let target = repo_root
-        .canonicalize()
-        .unwrap_or_else(|_| repo_root.to_path_buf());
-    let allowed = list_registered(db).await?.into_iter().any(|registered| {
-        let path = PathBuf::from(&registered.path);
-        path.canonicalize().unwrap_or(path) == target
-    });
+    let allowed = registered_for_root(db, repo_root).await?.is_some();
     tracing::debug!(repo = %repo_root.display(), allowed, "checked repo allowlist");
     Ok(allowed)
 }
@@ -245,18 +249,8 @@ pub async fn is_allowlisted(db: &Db, repo_root: &Path) -> Result<bool> {
 /// credentials. Managed clones use their registered identity; local checkouts
 /// fall back to parsing the configured `origin` URL.
 pub async fn github_slug_for_root(db: &Db, repo_root: &Path) -> Result<Option<String>> {
-    let target = repo_root
-        .canonicalize()
-        .unwrap_or_else(|_| repo_root.to_path_buf());
-    if let Some(slug) = list_registered(db)
-        .await?
-        .into_iter()
-        .find_map(|registered| {
-            let path = PathBuf::from(&registered.path);
-            (path.canonicalize().unwrap_or(path) == target).then_some(registered.slug)
-        })
-    {
-        return Ok(Some(slug));
+    if let Some(registered) = registered_for_root(db, repo_root).await? {
+        return Ok(Some(registered.slug));
     }
     let remote = match git::remote_url(repo_root, "origin").await {
         Ok(remote) => remote,

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -2,7 +2,7 @@
 
 use crate::Db;
 
-pub const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub token configured. Add your personal GitHub token in Settings > Account, or configure a write-only GH_TOKEN on the selected profile.";
+pub const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub credential configured. Add your personal GitHub token in Settings > Account, allowlist this repository for the selected profile's GitHub App credential, or configure a write-only GH_TOKEN on the profile.";
 
 /// External lifecycle work (terminal supervisors + git worktrees) cannot share
 /// a SQLite transaction. Serialize those operations process-wide, then use
@@ -112,6 +112,24 @@ pub fn set_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
     }
 }
 
+/// Resolve a profile's App-token allowlist into the repositories stamped on
+/// one session. Automation profiles intentionally retain their complete list
+/// for cross-repository work. Interactive sessions receive only their current
+/// repository, and only when the profile explicitly allowlists it.
+pub fn session_github_repositories(
+    class: &str,
+    configured: &[String],
+    current_repo: Option<&str>,
+) -> Vec<String> {
+    if class != "interactive" {
+        return configured.to_vec();
+    }
+    current_repo
+        .filter(|repo| configured.iter().any(|candidate| candidate == repo))
+        .map(|repo| vec![repo.to_string()])
+        .unwrap_or_default()
+}
+
 fn env_has_key(env: &[(String, String)], name: &str) -> bool {
     env.iter().any(|(key, _)| key == name)
 }
@@ -132,7 +150,7 @@ pub async fn github_token_available(
     env: &[(String, String)],
     created_by: Option<&str>,
     runtime: &str,
-    restricted_github_app: Option<&crate::github_app::GithubApp>,
+    github_app: Option<&crate::github_app::GithubApp>,
 ) -> anyhow::Result<bool> {
     if crate::agent::builtin_agent_type(runtime).is_none() {
         return Ok(true);
@@ -155,7 +173,7 @@ pub async fn github_token_available(
     {
         return Ok(true);
     }
-    if let Some(app) = restricted_github_app {
+    if let Some(app) = github_app {
         if app.is_configured().await {
             return Ok(true);
         }
@@ -280,6 +298,28 @@ mod tests {
         let mut producer = Vec::new();
         apply_user_github_token(&db, &mut producer, None).await;
         assert!(producer.is_empty());
+    }
+
+    #[test]
+    fn interactive_github_credentials_are_scoped_to_the_current_repository() {
+        let configured = vec![
+            "Open-Athena/marinmirror".to_string(),
+            "marin-community/marin".to_string(),
+        ];
+        assert_eq!(
+            session_github_repositories("interactive", &configured, Some("marin-community/marin")),
+            ["marin-community/marin"]
+        );
+        assert!(session_github_repositories(
+            "interactive",
+            &configured,
+            Some("marin-community/loom")
+        )
+        .is_empty());
+        assert_eq!(
+            session_github_repositories("automation", &configured, None),
+            configured
+        );
     }
 
     #[serial_test::serial]

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -9,7 +9,7 @@ use weaver_core::branch::{self as branch_mod, Branch};
 use weaver_core::BoxFut;
 
 use crate::session::{self as session_mod, Session};
-use crate::{agent, backend, custom_agents, events, runtime, AppState};
+use crate::{agent, backend, custom_agents, events, repo, runtime, AppState};
 
 const HANDOFF_SUMMARY_CHARS: usize = 32 * 1024;
 const HANDOFF_RECENT_MESSAGES: usize = 8;
@@ -188,6 +188,7 @@ struct HandoffPlan {
     model: String,
     effort: String,
     mode: String,
+    class: String,
     profile: String,
     profile_revision: i64,
     profile_lifetime: i64,
@@ -342,6 +343,7 @@ async fn legacy_handoff_plan(
         model: model.clone(),
         effort: effort.clone(),
         mode: mode.clone(),
+        class: session.class.clone(),
         profile: session.profile.clone(),
         profile_revision: session.profile_revision,
         profile_lifetime: session.profile_lifetime,
@@ -432,7 +434,7 @@ async fn handoff_session_inner(
         .to_string();
     let _profile_permit = st.launch_gate.acquire_profile(&permit_profile).await;
     let _resolver_permit = st.launch_gate.acquire_resolver().await;
-    let plan = if let Some(selection) = selection {
+    let mut plan = if let Some(selection) = selection {
         let resolved = match resolve_handoff_selection(st, &session, &selection).await {
             Ok(resolved) => resolved,
             Err(HandoffError::BadRequest(message)) if req.expected_resolver_revision.is_some() => {
@@ -473,6 +475,7 @@ async fn handoff_session_inner(
             model: resolved.view.model.clone(),
             effort: resolved.view.effort.clone(),
             mode: resolved.view.mode.clone(),
+            class: resolved.view.class.clone(),
             profile: resolved.profile.name.clone(),
             profile_revision: resolved.profile.revision,
             profile_lifetime: resolved.profile.lifetime,
@@ -511,6 +514,19 @@ async fn handoff_session_inner(
             "handoff target matches the current runtime profile",
         ));
     }
+    // Resolve every fallible launch input before quiescing the current task.
+    let repo_root = PathBuf::from(&branch.repo_root);
+    let configured_github_repositories: Vec<String> =
+        serde_json::from_str(&plan.github_repositories)
+            .map_err(|error| HandoffError::bad_request(error.to_string()))?;
+    let current_github_repo = repo::github_slug_for_root(&st.db, &repo_root).await?;
+    let session_github_repositories = runtime::session_github_repositories(
+        &plan.class,
+        &configured_github_repositories,
+        current_github_repo.as_deref(),
+    );
+    plan.github_repositories = serde_json::to_string(&session_github_repositories)
+        .map_err(|error| HandoffError::bad_request(error.to_string()))?;
     let handoff_policy = session_mod::SessionHandoffPolicy {
         agent_kind: target.clone(),
         model: model.clone(),
@@ -531,9 +547,6 @@ async fn handoff_session_inner(
         mcp_access: plan.mcp_access.clone(),
         launch_snapshot: plan.launch_snapshot.clone(),
     };
-
-    // Resolve every fallible launch input before quiescing the current task.
-    let repo_root = PathBuf::from(&branch.repo_root);
     let work_dir = PathBuf::from(&session.work_dir);
     if !work_dir.exists() {
         return Err(HandoffError::bad_request(format!(
@@ -558,14 +571,15 @@ async fn handoff_session_inner(
         extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
     }
     runtime::apply_user_github_token(&st.db, &mut extra_env, session.created_by.as_deref()).await;
-    // Restricted sessions return before this handoff path, so an App credential
-    // cannot be relevant here.
+    let github_app = (!session_github_repositories.is_empty())
+        .then(|| st.trigger.app())
+        .flatten();
     if !runtime::github_token_available(
         &st.db,
         &extra_env,
         session.created_by.as_deref(),
         &target,
-        None,
+        github_app,
     )
     .await?
     {

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -637,12 +637,26 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
     tracing::debug!(repo_root = %repo_root.display(), "loaded repo config");
 
     // A GitHub App token is repository-scoped. A managed slug gives both the
-    // preflight and issue seeding an exact installation target; a local path
-    // must keep using an explicitly supplied session credential.
+    // preflight and issue seeding an exact installation target; local paths
+    // resolve their registered identity or origin without contacting GitHub.
     let managed_slug = req
         .repo
         .as_deref()
         .and_then(|repo| crate::repo::parse_slug(repo).ok());
+    let current_github_repo = match managed_slug.as_ref() {
+        Some(repo) => Some(repo.slug()),
+        None => repo::github_slug_for_root(&st.db, &repo_root).await?,
+    };
+    let configured_github_repositories = launch_profile
+        .github_repositories()
+        .map_err(|error| ProvisionError::invalid(error.to_string()))?;
+    let session_github_repositories = crate::runtime::session_github_repositories(
+        &class,
+        &configured_github_repositories,
+        current_github_repo.as_deref(),
+    );
+    let stamped_github_repositories = serde_json::to_string(&session_github_repositories)
+        .map_err(|error| ProvisionError::invalid(error.to_string()))?;
     let runtime = agent.clone();
     tracing::debug!(agent = %agent, runtime = %runtime, "resolved agent runtime");
     // The resolved launch environment: selected profile < per-repo repo_env <
@@ -674,7 +688,9 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
     apply_user_github_token(&st.db, &mut extra_env, created_by.as_deref()).await;
 
     tracing::debug!(model = %model, effort = %effort, protocol = %protocol, "resolved and validated model/effort/protocol");
-    let restricted_github_app = if launch_profile.restricted && managed_slug.is_some() {
+    let github_app = if (!session_github_repositories.is_empty())
+        || (launch_profile.restricted && managed_slug.is_some())
+    {
         st.trigger.app()
     } else {
         None
@@ -684,7 +700,7 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
         &extra_env,
         created_by.as_deref(),
         &runtime,
-        restricted_github_app,
+        github_app,
     )
     .await?
     {
@@ -972,7 +988,7 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
         turn_budget: resolved.view.policy.turn_budget.unwrap_or(0),
         prelude: launch_profile.prelude.clone(),
         restricted: launch_profile.restricted,
-        github_repositories: launch_profile.github_repositories.clone(),
+        github_repositories: stamped_github_repositories,
         allowed_tools: stamped_allowed_tools.clone(),
         mcp_access: stamped_mcp_access,
         launch_snapshot,

--- a/crates/loom-policy/src/profile.rs
+++ b/crates/loom-policy/src/profile.rs
@@ -151,27 +151,28 @@ async fn validate_input(
     {
         bail!("GitHub repositories must be clean owner/name identifiers (maximum {MAX_GITHUB_REPOSITORIES})");
     }
-    if input
-        .github_repositories
-        .first()
-        .and_then(|repository| repository.split_once('/'))
-        .is_some_and(|(owner, _)| {
-            input.github_repositories.iter().any(|repository| {
-                repository
-                    .split_once('/')
-                    .is_none_or(|(candidate, _)| candidate != owner)
+    if input.class.trim() == "automation"
+        && input
+            .github_repositories
+            .first()
+            .and_then(|repository| repository.split_once('/'))
+            .is_some_and(|(owner, _)| {
+                input.github_repositories.iter().any(|repository| {
+                    repository
+                        .split_once('/')
+                        .is_none_or(|(candidate, _)| candidate != owner)
+                })
             })
-        })
     {
-        bail!("GitHub repositories must use one owner");
+        bail!("automation-profile GitHub repositories must use one owner");
     }
     if !input.github_repositories.is_empty()
-        && !(input.strict
-            && input.env_clear
-            && input.class.trim() == "automation"
-            && !input.restricted)
+        && input.class.trim() == "automation"
+        && !(input.strict && input.env_clear && !input.restricted)
     {
-        bail!("GitHub repository credentials require a strict env-cleared automation profile");
+        bail!(
+            "automation-profile GitHub repository credentials require a strict env-cleared non-restricted profile"
+        );
     }
     if input.allowed_tools.len() > 64
         || input.allowed_tools.iter().any(|rule| {
@@ -1281,7 +1282,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn github_credentials_require_a_safe_profile_and_canonical_repositories() {
+    async fn github_credentials_are_scoped_by_profile_class() {
         let db = crate::db::connect_in_memory().await.unwrap();
         let mut input = get(&db, DEFAULT_PROFILE)
             .await
@@ -1289,10 +1290,18 @@ mod tests {
             .unwrap()
             .as_input()
             .unwrap();
-        input.github_repositories = vec!["marin-community/marin".to_string()];
-        assert!(upsert(&db, &input).await.is_err());
+        input.github_repositories = vec![
+            "Open-Athena/marinmirror".to_string(),
+            "marin-community/marin".to_string(),
+        ];
+        let interactive = upsert(&db, &input).await.unwrap();
+        assert_eq!(
+            interactive.github_repositories().unwrap(),
+            ["Open-Athena/marinmirror", "marin-community/marin"]
+        );
 
         input.class = "automation".to_string();
+        assert!(upsert(&db, &input).await.is_err());
         input.strict = true;
         input.env_clear = true;
         input.github_repositories = vec![

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -2679,6 +2679,14 @@ async fn handoff_replaces_provider_and_continues_the_journal() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn canonical_handoff_selects_a_strict_profile_and_rejects_class_mismatch() {
     let ts = TestServer::start().await;
+    loom::repo::register(
+        &ts.state.db,
+        "marin-community/marin",
+        "https://github.com/marin-community/marin.git",
+        &ts.repo_path().canonicalize().unwrap().to_string_lossy(),
+    )
+    .await
+    .unwrap();
     seed_acp_agent(&ts, "canonical-a").await;
     seed_acp_agent(&ts, "canonical-b").await;
     for (name, agent, class) in [
@@ -2700,6 +2708,11 @@ async fn canonical_handoff_selects_a_strict_profile_and_rejects_class_mismatch()
                     "env_clear": class == "automation",
                     "max_concurrent": 2,
                     "prelude": "weaver",
+                    "github_repositories": if class == "interactive" {
+                        json!(["Open-Athena/marinmirror", "marin-community/marin"])
+                    } else {
+                        json!([])
+                    },
                     "mcp_access": { "mode": "none", "groups": [] }
                 }),
             )
@@ -2780,6 +2793,13 @@ async fn canonical_handoff_selects_a_strict_profile_and_rejects_class_mismatch()
         handed["profile_revision"], preview["profile_revision"],
         "the reviewed strict target revision is stamped"
     );
+    let github_repositories: String =
+        sqlx::query_scalar("SELECT policy_github_repositories FROM sessions WHERE id = ?")
+            .bind(id)
+            .fetch_one(&ts.state.db)
+            .await
+            .unwrap();
+    assert_eq!(github_repositories, r#"["marin-community/marin"]"#);
 }
 
 #[serial]

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -169,8 +169,8 @@ async fn session_creation_waits_for_the_repository_launch_gate() {
         .unwrap();
 }
 
-/// A real agent launch needs either the launching user's GitHub token or a
-/// default GH_TOKEN source. Without one, reject before provisioning anything.
+/// A real agent launch needs a user token, a profile token, or an allowlisted
+/// GitHub App credential. Without one, reject before provisioning anything.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn real_agent_without_github_token_is_rejected_before_provisioning() {
@@ -191,7 +191,7 @@ async fn real_agent_without_github_token_is_rejected_before_provisioning() {
         .unwrap_err()
         .to_string();
     assert!(
-        err.contains("server returned 428") && err.contains("No GitHub token configured"),
+        err.contains("server returned 428") && err.contains("No GitHub credential configured"),
         "unexpected error: {err}"
     );
 

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -21,6 +21,12 @@ impl EnvVarGuard {
         std::env::remove_var(name);
         Self { name, value }
     }
+
+    fn set(name: &'static str, new_value: &str) -> Self {
+        let value = std::env::var_os(name);
+        std::env::set_var(name, new_value);
+        Self { name, value }
+    }
 }
 
 impl Drop for EnvVarGuard {
@@ -198,6 +204,79 @@ async fn real_agent_without_github_token_is_rejected_before_provisioning() {
         !ts.repo_path().join(".worktrees").exists(),
         "rejected launch should not create a worktree directory"
     );
+}
+
+/// An interactive profile can use the configured GitHub App as its default
+/// credential while stamping only the current allowlisted repository.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interactive_profile_brokers_its_current_github_repository() {
+    let _ambient = EnvVarGuard::unset("GH_TOKEN");
+    let _adapter = EnvVarGuard::set(
+        "WEAVER_CODEX_ACP_CMD",
+        &crate::fixtures::fake_acp_agent_cmd(),
+    );
+    let ts = TestServer::start().await;
+    let repo_root = ts.repo_path().canonicalize().unwrap();
+    loom::repo::register(
+        &ts.state.db,
+        "marin-community/marin",
+        "https://github.com/marin-community/marin.git",
+        &repo_root.to_string_lossy(),
+    )
+    .await
+    .unwrap();
+    let mut profile = loom::profile::get(&ts.state.db, loom::profile::DEFAULT_PROFILE)
+        .await
+        .unwrap()
+        .unwrap()
+        .as_input()
+        .unwrap();
+    profile.github_repositories = vec![
+        "Open-Athena/marinmirror".to_string(),
+        "marin-community/marin".to_string(),
+    ];
+    loom::profile::upsert(&ts.state.db, &profile).await.unwrap();
+    weaver_core::config::apply(
+        &ts.state.db,
+        &[
+            (
+                loom::github_app::APP_ID_KEY.to_string(),
+                Some("123456".to_string()),
+            ),
+            (
+                loom::github_app::APP_PRIVATE_KEY_KEY.to_string(),
+                Some("configured-for-preflight".to_string()),
+            ),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let session = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "use brokered credentials",
+                "cwd": ts.cwd(),
+                "agent": "codex",
+            }),
+        )
+        .await
+        .unwrap();
+    let id = session["id"].as_str().unwrap();
+    let repositories: String =
+        sqlx::query_scalar("SELECT policy_github_repositories FROM sessions WHERE id = ?")
+            .bind(id)
+            .fetch_one(&ts.state.db)
+            .await
+            .unwrap();
+    assert_eq!(repositories, r#"["marin-community/marin"]"#);
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
 }
 
 /// With an `origin` remote present, a launch that doesn't pin `--base` forks the

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -196,6 +196,11 @@ async fn has_remote(dir: &Path, name: &str) -> bool {
     present
 }
 
+/// The configured URL for one git remote, without contacting the remote.
+pub async fn remote_url(dir: &Path, name: &str) -> Result<String> {
+    git(dir, &["remote", "get-url", name]).await
+}
+
 /// Whether `rev` resolves to a commit in this repo.
 pub async fn revision_exists(dir: &Path, rev: &str) -> bool {
     git(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,13 +62,15 @@ starter text lives under `crates/loom-policy/profiles/<name>/instructions.md`.
 The origin profiles are opt-in so an upgrade does not silently change the
 environment or runtime used by existing triggers.
 
-A strict, environment-cleared automation profile may declare
-`github_repositories`. Inside sessions launched from that profile, `git` and
-`gh` transparently request a short-lived GitHub App installation token from
-Loom. Loom stamps the repository list on the session and limits the token to
-those repositories with contents, issues, and pull-request write access. It
-does not grant Actions or workflow-file access. The configured GitHub App must
-be installed on every listed repository, and all entries must use one owner.
+Profiles may declare `github_repositories`. Inside sessions launched from such
+a profile, `git` and `gh` transparently request a short-lived GitHub App
+installation token from Loom. Interactive profiles use the list as an
+allowlist and stamp only the session's current repository. Strict,
+environment-cleared automation profiles retain the complete list for reviewed
+cross-repository workflows, so their entries must use one owner. Tokens grant
+contents, issues, and pull-request write access, but not Actions or workflow
+file access. The configured GitHub App must be installed on every listed
+repository.
 
 ```yaml
 profiles:


### PR DESCRIPTION
Allow interactive profiles to declare GitHub repository allowlists and stamp only the current repository onto each session. When a personal GH_TOKEN is absent, the existing git and gh wrappers can use Loom's short-lived GitHub App installation token; a personal token retains precedence.\n\nResolve repository identity from managed registration or the local origin without requiring credentials, and preserve the narrowed scope across provider handoffs. This restores a shared GitHub identity for ordinary and trigger-launched sessions while keeping automation profiles' reviewed cross-repository behavior unchanged.