### PR TITLE
feat(loom): add human roles and reorganize settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,10 +374,11 @@ TLS-terminating reverse proxy. Access is then gated three ways:
   A fresh install approves exactly one user — whichever GitHub login you set as
   `LOOM_OWNER_GITHUB` before first run. There is no default; leave it unset and
   no owner is seeded, so GitHub sign-in won't work until it's set. Add more
-  users, set your password, and configure GitHub sign-in under **Settings →
-  Account**.
+  users and roles under **Settings → People & security**, set your password
+  under **Settings → Account**, and configure GitHub sign-in under **Settings →
+  Integrations**.
 - **Personal API tokens** for remote CLIs and other trusted clients. Mint one
-  under **Settings → Tokens** or from a locally authenticated CLI:
+  under **Settings → Account** or from a locally authenticated CLI:
 
   ```sh
   loom token add laptop --expires-days 30  # prints the secret once
@@ -410,7 +411,7 @@ TLS-terminating reverse proxy. Access is then gated three ways:
 
 To configure **GitHub sign-in**: register an OAuth app on GitHub with the
 callback `https://loom.example.com/api/auth/github/callback`, then paste its
-client id and secret into Settings → Connections (or set `LOOM_GITHUB_CLIENT_ID` /
+client id and secret into Settings → Integrations (or set `LOOM_GITHUB_CLIENT_ID` /
 `LOOM_GITHUB_CLIENT_SECRET`).
 
 Behind a **same-host reverse proxy** the proxy's forwarded requests appear to

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ TLS-terminating reverse proxy. Access is then gated three ways:
 
 To configure **GitHub sign-in**: register an OAuth app on GitHub with the
 callback `https://loom.example.com/api/auth/github/callback`, then paste its
-client id and secret into Settings → Account (or set `LOOM_GITHUB_CLIENT_ID` /
+client id and secret into Settings → Connections (or set `LOOM_GITHUB_CLIENT_ID` /
 `LOOM_GITHUB_CLIENT_SECRET`).
 
 Behind a **same-host reverse proxy** the proxy's forwarded requests appear to

--- a/crates/loom-ctx/src/logs.rs
+++ b/crates/loom-ctx/src/logs.rs
@@ -44,6 +44,162 @@ pub struct LogLine {
     pub message: String,
 }
 
+/// Redacts credentials from log lines before they are shown to a non-admin
+/// user. Admins retain the raw operator log; callers construct this with the
+/// deployment's known secret values for the user-facing view.
+#[derive(Debug, Clone)]
+pub struct LogRedactor {
+    known_secrets: Vec<String>,
+}
+
+impl LogRedactor {
+    /// Build a redactor from secret values already resolved by the caller.
+    pub fn new(secrets: impl IntoIterator<Item = String>) -> Self {
+        let mut known_secrets: Vec<String> = secrets
+            .into_iter()
+            .filter(|secret| secret.trim().len() >= 4)
+            .collect();
+        known_secrets.sort();
+        known_secrets.dedup();
+        known_secrets.sort_by_key(|secret| std::cmp::Reverse(secret.len()));
+        Self { known_secrets }
+    }
+
+    /// Return the same structured line with only its free-form message scrubbed.
+    pub fn redact(&self, mut line: LogLine) -> LogLine {
+        line.message = self.redact_message(&line.message);
+        line
+    }
+
+    fn redact_message(&self, message: &str) -> String {
+        let mut redacted = message.to_string();
+        for secret in &self.known_secrets {
+            redacted = redacted.replace(secret, "<redacted>");
+        }
+        redact_labeled_values(redact_prefixed_tokens(redacted))
+    }
+}
+
+fn redact_prefixed_tokens(mut text: String) -> String {
+    const PREFIXES: [&str; 13] = [
+        "github_pat_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+        "ghp_",
+        "loom_",
+        "xoxb-",
+        "xoxp-",
+        "xoxa-",
+        "xoxs-",
+        "sk-ant-",
+        "sk-proj-",
+    ];
+    for prefix in PREFIXES {
+        let mut from = 0;
+        while let Some(relative) = text[from..].find(prefix) {
+            let start = from + relative;
+            let token_end = start
+                + text[start..]
+                    .find(|character: char| {
+                        !character.is_ascii_alphanumeric() && !matches!(character, '_' | '-' | '.')
+                    })
+                    .unwrap_or(text.len() - start);
+            text.replace_range(start..token_end, "<redacted-token>");
+            from = start + "<redacted-token>".len();
+        }
+    }
+    text
+}
+
+fn redact_labeled_values(mut text: String) -> String {
+    const LABELS: [&str; 13] = [
+        "authorization",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+        "webhook_secret",
+        "private_key",
+        "api_key",
+        "password",
+        "passwd",
+        "credential",
+        "token",
+        "secret",
+        "cookie",
+    ];
+    for label in LABELS {
+        let mut from = 0;
+        loop {
+            let lower = text[from..].to_ascii_lowercase();
+            let Some(relative) = lower.find(label) else {
+                break;
+            };
+            let start = from + relative;
+            let before = text[..start].chars().next_back();
+            let after = text[start + label.len()..].chars().next();
+            if before.is_some_and(|character| character.is_ascii_alphanumeric())
+                || after.is_some_and(|character| character.is_ascii_alphanumeric())
+            {
+                from = start + label.len();
+                continue;
+            }
+
+            let mut cursor = start + label.len();
+            if text[cursor..].starts_with(['\'', '"']) {
+                cursor += 1;
+            }
+            cursor += text[cursor..]
+                .find(|character: char| !character.is_ascii_whitespace())
+                .unwrap_or(text.len() - cursor);
+            if !text[cursor..].starts_with(['=', ':']) {
+                from = start + label.len();
+                continue;
+            }
+            cursor += 1;
+            cursor += text[cursor..]
+                .find(|character: char| !character.is_ascii_whitespace())
+                .unwrap_or(text.len() - cursor);
+            if cursor == text.len() {
+                break;
+            }
+
+            let quote = text[cursor..]
+                .chars()
+                .next()
+                .filter(|character| matches!(character, '\'' | '"'));
+            let value_start = cursor + quote.map_or(0, char::len_utf8);
+            let value_end = if let Some(quote) = quote {
+                text[value_start..]
+                    .find(quote)
+                    .map_or(text.len(), |relative| value_start + relative)
+            } else if text[value_start..]
+                .to_ascii_lowercase()
+                .starts_with("bearer ")
+            {
+                let token_start = value_start + "bearer ".len();
+                token_start
+                    + text[token_start..]
+                        .find(is_unquoted_value_delimiter)
+                        .unwrap_or(text.len() - token_start)
+            } else {
+                value_start
+                    + text[value_start..]
+                        .find(is_unquoted_value_delimiter)
+                        .unwrap_or(text.len() - value_start)
+            };
+            text.replace_range(value_start..value_end, "<redacted>");
+            from = value_start + "<redacted>".len();
+        }
+    }
+    text
+}
+
+fn is_unquoted_value_delimiter(character: char) -> bool {
+    character.is_ascii_whitespace() || matches!(character, ',' | ';' | '&' | '}' | ']')
+}
+
 /// The shared log store: a bounded ring buffer for the snapshot plus a broadcast
 /// channel for live subscribers. Mirrors [`weaver_core::events::EventBus`].
 pub struct LogBuffer {
@@ -303,5 +459,44 @@ mod tests {
             fields: " session=abc repo=acme/widgets".into(),
         };
         assert_eq!(v.finish(), "launched session session=abc repo=acme/widgets");
+    }
+
+    #[test]
+    fn user_log_redaction_masks_known_and_structural_secrets() {
+        let redactor = LogRedactor::new(["arbitrary-deployment-credential".to_string()]);
+        let line = LogLine {
+            seq: 7,
+            ts: "t".into(),
+            level: "WARN".into(),
+            target: "test".into(),
+            message: concat!(
+                "known=arbitrary-deployment-credential ",
+                "github=github_pat_abc123 slack=xoxb-secret-value ",
+                "authorization=Bearer opaque-bearer ",
+                "body={\"access_token\":\"opaque-json-token\"} ",
+                "MY_SECRET=new-secret-after-stream-open"
+            )
+            .into(),
+        };
+
+        let redacted = redactor.redact(line);
+        for secret in [
+            "arbitrary-deployment-credential",
+            "github_pat_abc123",
+            "xoxb-secret-value",
+            "opaque-bearer",
+            "opaque-json-token",
+            "new-secret-after-stream-open",
+        ] {
+            assert!(!redacted.message.contains(secret), "leaked {secret}");
+        }
+        assert_eq!(redacted.seq, 7);
+        assert_eq!(redacted.target, "test");
+    }
+
+    #[test]
+    fn user_log_redaction_preserves_benign_diagnostics() {
+        let message = "secret rotation succeeded method=GET path=/api/status";
+        assert_eq!(LogRedactor::new([]).redact_message(message), message);
     }
 }

--- a/crates/loom-forge/src/github_trigger.rs
+++ b/crates/loom-forge/src/github_trigger.rs
@@ -1078,7 +1078,7 @@ mod tests {
         let db = crate::db::connect_in_memory().await.unwrap();
         // An approved loom user (their GitHub login is on the `users` allowlist —
         // the same one that gates sign-in) may trigger, with no GitHub call.
-        auth::add_user(&db, "alice", Some("alice-gh"), None)
+        auth::add_user(&db, "alice", Some("alice-gh"), None, auth::UserRole::Admin)
             .await
             .unwrap();
         assert!(authorize(&db, "alice-gh").await);

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -2,7 +2,7 @@
 
 use crate::Db;
 
-pub const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub credential configured. Add your personal GitHub token in Settings > Account, allowlist this repository for the selected profile's GitHub App credential, or configure a write-only GH_TOKEN on the profile.";
+pub const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub credential configured. Add your personal GitHub token in Settings > Access, allowlist this repository for the selected profile's GitHub App credential, or configure a write-only GH_TOKEN on the profile.";
 
 /// External lifecycle work (terminal supervisors + git worktrees) cannot share
 /// a SQLite transaction. Serialize those operations process-wide, then use

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -149,7 +149,7 @@ pub struct Actor(ActorKind);
 impl Actor {
     pub fn from_principal(principal: &Principal, delegated: bool) -> Self {
         match &principal.grant {
-            Grant::Admin => Self(ActorKind::Admin {
+            Grant::Admin | Grant::User => Self(ActorKind::Admin {
                 username: principal.username.clone(),
                 delegated,
             }),

--- a/crates/loom-policy/src/auth.rs
+++ b/crates/loom-policy/src/auth.rs
@@ -31,6 +31,7 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sqlx::Row;
+use std::collections::HashMap;
 use weaver_core::db::iso_in_days;
 
 use crate::db::{now_iso, Db};
@@ -84,6 +85,7 @@ impl AuthVia {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Grant {
     Admin,
+    User,
     Automation {
         subject: String,
         profiles: Vec<String>,
@@ -107,6 +109,18 @@ pub struct Principal {
 impl Principal {
     pub fn is_admin(&self) -> bool {
         matches!(self.grant, Grant::Admin)
+    }
+
+    pub fn is_human(&self) -> bool {
+        matches!(self.grant, Grant::Admin | Grant::User)
+    }
+
+    pub fn user_role(&self) -> Option<UserRole> {
+        match self.grant {
+            Grant::Admin => Some(UserRole::Admin),
+            Grant::User => Some(UserRole::User),
+            Grant::Automation { .. } | Grant::Session { .. } => None,
+        }
     }
 }
 
@@ -177,12 +191,40 @@ fn verify_password(password: &str, stored: &str) -> bool {
 // Users (the approved-operator allowlist)
 // ---------------------------------------------------------------------------
 
-/// One approved operator.
+/// A persisted human role. Existing rows migrate to `admin`; newly approved
+/// people default to `user`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[serde(rename_all = "lowercase")]
+#[sqlx(type_name = "TEXT", rename_all = "lowercase")]
+pub enum UserRole {
+    Admin,
+    #[default]
+    User,
+}
+
+impl UserRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Admin => "admin",
+            Self::User => "user",
+        }
+    }
+
+    fn grant(self) -> Grant {
+        match self {
+            Self::Admin => Grant::Admin,
+            Self::User => Grant::User,
+        }
+    }
+}
+
+/// One approved Loom user.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct User {
     pub username: String,
     pub github_login: Option<String>,
     pub password_hash: Option<String>,
+    pub role: UserRole,
     pub created_at: String,
 }
 
@@ -195,7 +237,7 @@ impl User {
 
 pub async fn get_user(db: &Db, username: &str) -> Result<Option<User>> {
     let row = sqlx::query_as::<_, User>(
-        "SELECT username, github_login, password_hash, created_at FROM users WHERE username = ?",
+        "SELECT username, github_login, password_hash, role, created_at FROM users WHERE username = ?",
     )
     .bind(username)
     .fetch_optional(db)
@@ -208,7 +250,7 @@ pub async fn get_user(db: &Db, username: &str) -> Result<Option<User>> {
 /// callback runs: an unknown GitHub identity has no row and is rejected.
 pub async fn user_by_github(db: &Db, login: &str) -> Result<Option<User>> {
     let row = sqlx::query_as::<_, User>(
-        "SELECT username, github_login, password_hash, created_at FROM users
+        "SELECT username, github_login, password_hash, role, created_at FROM users
          WHERE github_login IS NOT NULL AND lower(github_login) = lower(?)",
     )
     .bind(login)
@@ -278,7 +320,7 @@ pub async fn commit_identity(db: &Db, username: &str) -> Result<Option<CommitIde
 
 pub async fn list_users(db: &Db) -> Result<Vec<User>> {
     let rows = sqlx::query_as::<_, User>(
-        "SELECT username, github_login, password_hash, created_at FROM users ORDER BY created_at, username",
+        "SELECT username, github_login, password_hash, role, created_at FROM users ORDER BY created_at, username",
     )
     .fetch_all(db)
     .await?;
@@ -302,35 +344,122 @@ pub async fn add_user(
     username: &str,
     github_login: Option<&str>,
     password: Option<&str>,
+    role: UserRole,
 ) -> Result<()> {
     let password_hash = match password {
         Some(p) => Some(hash_password(p)?),
         None => None,
     };
-    sqlx::query("INSERT INTO users (username, github_login, password_hash) VALUES (?, ?, ?)")
-        .bind(username)
-        .bind(github_login)
-        .bind(password_hash)
-        .execute(db)
-        .await
-        .with_context(|| format!("adding user '{username}'"))?;
+    sqlx::query(
+        "INSERT INTO users (username, github_login, password_hash, role) VALUES (?, ?, ?, ?)",
+    )
+    .bind(username)
+    .bind(github_login)
+    .bind(password_hash)
+    .bind(role)
+    .execute(db)
+    .await
+    .with_context(|| format!("adding user '{username}'"))?;
     Ok(())
 }
 
-/// Remove an approved user, refusing to delete the last one (which would lock
-/// everyone out). Returns whether a row was removed.
-pub async fn remove_user(db: &Db, username: &str) -> Result<bool> {
-    let count: i64 = sqlx::query("SELECT COUNT(*) AS n FROM users")
-        .fetch_one(db)
+/// Change one user's human role without allowing the deployment to lose its
+/// last administrator. Browser sessions and personal tokens resolve this row
+/// on every request, so the new grant takes effect immediately.
+pub async fn set_user_role(db: &Db, username: &str, role: UserRole) -> Result<()> {
+    let mut tx = db.begin().await?;
+    let current = sqlx::query_scalar::<_, UserRole>("SELECT role FROM users WHERE username = ?")
+        .bind(username)
+        .fetch_optional(&mut *tx)
         .await?
-        .get("n");
-    if count <= 1 {
-        return Err(anyhow!("cannot remove the only approved user"));
+        .ok_or_else(|| anyhow!("no such user '{username}'"))?;
+    if current == UserRole::Admin && role != UserRole::Admin {
+        let admins =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM users WHERE role = 'admin'")
+                .fetch_one(&mut *tx)
+                .await?;
+        if admins <= 1 {
+            return Err(anyhow!("cannot demote the only administrator"));
+        }
+    }
+    sqlx::query("UPDATE users SET role = ? WHERE username = ?")
+        .bind(role)
+        .bind(username)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+pub async fn user_preferences(db: &Db, username: &str) -> Result<HashMap<String, String>> {
+    let rows = sqlx::query("SELECT key, value FROM user_preferences WHERE username = ?")
+        .bind(username)
+        .fetch_all(db)
+        .await?;
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.get("key"), row.get("value")))
+        .collect())
+}
+
+pub async fn apply_user_preferences(
+    db: &Db,
+    username: &str,
+    changes: &[(String, Option<String>)],
+) -> Result<()> {
+    let mut tx = db.begin().await?;
+    for (key, value) in changes {
+        if let Some(value) = value {
+            sqlx::query(
+                "INSERT INTO user_preferences (username, key, value, updated_at)
+                 VALUES (?, ?, ?, ?)
+                 ON CONFLICT(username, key) DO UPDATE SET
+                   value = excluded.value,
+                   updated_at = excluded.updated_at",
+            )
+            .bind(username)
+            .bind(key)
+            .bind(value)
+            .bind(now_iso())
+            .execute(&mut *tx)
+            .await?;
+        } else {
+            sqlx::query("DELETE FROM user_preferences WHERE username = ? AND key = ?")
+                .bind(username)
+                .bind(key)
+                .execute(&mut *tx)
+                .await?;
+        }
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Remove an approved user without allowing the deployment to lose its last
+/// administrator. Returns whether a row was removed.
+pub async fn remove_user(db: &Db, username: &str) -> Result<bool> {
+    let mut tx = db.begin().await?;
+    let Some(role) = sqlx::query_scalar::<_, UserRole>("SELECT role FROM users WHERE username = ?")
+        .bind(username)
+        .fetch_optional(&mut *tx)
+        .await?
+    else {
+        return Ok(false);
+    };
+    if role == UserRole::Admin {
+        let admins =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM users WHERE role = 'admin'")
+                .fetch_one(&mut *tx)
+                .await?;
+        if admins <= 1 {
+            return Err(anyhow!("cannot remove the only administrator"));
+        }
     }
     let res = sqlx::query("DELETE FROM users WHERE username = ?")
         .bind(username)
-        .execute(db)
+        .execute(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(res.rows_affected() > 0)
 }
 
@@ -367,7 +496,7 @@ pub async fn verify_login(db: &Db, username: &str, password: &str) -> Result<Opt
             username: user.username,
             github_login: user.github_login,
             via: AuthVia::Session,
-            grant: Grant::Admin,
+            grant: user.role.grant(),
             automation_context: None,
         }))
     } else {
@@ -384,7 +513,7 @@ pub async fn loopback_principal(db: &Db) -> Result<Option<Principal>> {
         username: u.username,
         github_login: u.github_login,
         via: AuthVia::Loopback,
-        grant: Grant::Admin,
+        grant: u.role.grant(),
         automation_context: None,
     }))
 }
@@ -412,7 +541,7 @@ pub async fn create_session(db: &Db, username: &str) -> Result<String> {
 pub async fn lookup_session(db: &Db, cookie: &str) -> Result<Option<Principal>> {
     let hash = sha256_hex(cookie);
     let row = sqlx::query(
-        "SELECT s.username AS username, u.github_login AS github_login
+        "SELECT s.username AS username, u.github_login AS github_login, u.role AS role
          FROM auth_sessions s JOIN users u ON u.username = s.username
          WHERE s.token_hash = ? AND s.expires_at > ?",
     )
@@ -424,7 +553,7 @@ pub async fn lookup_session(db: &Db, cookie: &str) -> Result<Option<Principal>> 
         username: r.get("username"),
         github_login: r.get("github_login"),
         via: AuthVia::Session,
-        grant: Grant::Admin,
+        grant: r.get::<UserRole, _>("role").grant(),
         automation_context: None,
     }))
 }
@@ -530,11 +659,12 @@ async fn get_token(db: &Db, id: &str) -> Result<Option<TokenInfo>> {
 
 /// Every user-managed token (the machine 'local' token is infrastructure and is
 /// omitted), newest first.
-pub async fn list_tokens(db: &Db) -> Result<Vec<TokenInfo>> {
+pub async fn list_tokens(db: &Db, username: &str) -> Result<Vec<TokenInfo>> {
     let rows = sqlx::query_as::<_, TokenInfo>(
         "SELECT id, name, prefix, created_at, last_used_at, expires_at FROM api_tokens
-         WHERE kind = 'pat' ORDER BY created_at DESC",
+         WHERE kind = 'pat' AND username = ? ORDER BY created_at DESC",
     )
+    .bind(username)
     .fetch_all(db)
     .await?;
     Ok(rows)
@@ -542,9 +672,10 @@ pub async fn list_tokens(db: &Db) -> Result<Vec<TokenInfo>> {
 
 /// Revoke a token by id. Refuses the machine 'local' token. Returns whether a
 /// (revocable) row was removed.
-pub async fn revoke_token(db: &Db, id: &str) -> Result<bool> {
-    let res = sqlx::query("DELETE FROM api_tokens WHERE id = ? AND kind = 'pat'")
+pub async fn revoke_token(db: &Db, username: &str, id: &str) -> Result<bool> {
+    let res = sqlx::query("DELETE FROM api_tokens WHERE id = ? AND username = ? AND kind = 'pat'")
         .bind(id)
+        .bind(username)
         .execute(db)
         .await?;
     Ok(res.rows_affected() > 0)
@@ -571,7 +702,7 @@ pub async fn lookup_token(db: &Db, token: &str) -> Result<Option<Principal>> {
     let hash = sha256_hex(token);
     let row = sqlx::query(
         "SELECT t.id AS id, t.username AS username, u.github_login AS github_login,
-                t.grant_json AS grant_json
+                u.role AS role, t.kind AS kind, t.grant_json AS grant_json
          FROM api_tokens t JOIN users u ON u.username = t.username
          WHERE t.token_hash = ? AND (t.expires_at IS NULL OR t.expires_at > ?)
            AND (
@@ -590,12 +721,17 @@ pub async fn lookup_token(db: &Db, token: &str) -> Result<Option<Principal>> {
         return Ok(None);
     };
     let id: String = row.get("id");
-    let grant_json: String = row.get("grant_json");
-    let grant: Grant = match serde_json::from_str(&grant_json) {
-        Ok(grant) => grant,
-        Err(error) => {
-            tracing::warn!(token_id = %id, %error, "rejecting token with invalid grant metadata");
-            return Ok(None);
+    let kind: String = row.get("kind");
+    let grant = if kind == TokenKind::Pat.as_str() || kind == TokenKind::Local.as_str() {
+        row.get::<UserRole, _>("role").grant()
+    } else {
+        let grant_json: String = row.get("grant_json");
+        match serde_json::from_str(&grant_json) {
+            Ok(grant) => grant,
+            Err(error) => {
+                tracing::warn!(token_id = %id, %error, "rejecting token with invalid grant metadata");
+                return Ok(None);
+            }
         }
     };
     let _ = sqlx::query("UPDATE api_tokens SET last_used_at = ? WHERE id = ?")
@@ -1049,7 +1185,9 @@ mod tests {
         let db = connect_in_memory_with_owner("rjpower").await;
         assert_eq!(primary_user(&db).await.unwrap().as_deref(), Some("rjpower"));
         let u = user_by_github(&db, "RJPower").await.unwrap();
-        assert_eq!(u.map(|u| u.username), Some("rjpower".to_string()));
+        let u = u.unwrap();
+        assert_eq!(u.username, "rjpower");
+        assert_eq!(u.role, UserRole::Admin);
     }
 
     #[tokio::test]
@@ -1072,7 +1210,9 @@ mod tests {
         assert_eq!(id.email, "4242+rjpower@users.noreply.github.com");
 
         // A password-only operator has no GitHub identity to attribute to.
-        add_user(&db, "localonly", None, Some("pw")).await.unwrap();
+        add_user(&db, "localonly", None, Some("pw"), UserRole::User)
+            .await
+            .unwrap();
         assert!(commit_identity(&db, "localonly").await.unwrap().is_none());
     }
 
@@ -1089,10 +1229,90 @@ mod tests {
         assert_eq!(p.username, "rjpower");
         assert_eq!(p.via, AuthVia::Token);
 
-        assert_eq!(list_tokens(&db).await.unwrap().len(), 1);
-        assert!(revoke_token(&db, &info.id).await.unwrap());
+        assert_eq!(list_tokens(&db, "rjpower").await.unwrap().len(), 1);
+        assert!(revoke_token(&db, "rjpower", &info.id).await.unwrap());
         assert!(lookup_token(&db, &plain).await.unwrap().is_none());
-        assert!(list_tokens(&db).await.unwrap().is_empty());
+        assert!(list_tokens(&db, "rjpower").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn human_credentials_follow_role_changes_and_tokens_are_private() {
+        let db = connect_in_memory_with_owner("rjpower").await;
+        add_user(
+            &db,
+            "alice",
+            Some("alice-gh"),
+            Some("alice-password"),
+            UserRole::User,
+        )
+        .await
+        .unwrap();
+        let cookie = create_session(&db, "alice").await.unwrap();
+        let (alice_token, alice_info) =
+            create_token(&db, "alice", "alice-cli", None).await.unwrap();
+        let (_, owner_info) = create_token(&db, "rjpower", "owner-cli", None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            lookup_session(&db, &cookie).await.unwrap().unwrap().grant,
+            Grant::User
+        );
+        assert_eq!(
+            lookup_token(&db, &alice_token)
+                .await
+                .unwrap()
+                .unwrap()
+                .grant,
+            Grant::User
+        );
+        assert_eq!(list_tokens(&db, "alice").await.unwrap().len(), 1);
+        assert!(!revoke_token(&db, "alice", &owner_info.id).await.unwrap());
+
+        set_user_role(&db, "alice", UserRole::Admin).await.unwrap();
+        assert_eq!(
+            lookup_session(&db, &cookie).await.unwrap().unwrap().grant,
+            Grant::Admin
+        );
+        assert_eq!(
+            lookup_token(&db, &alice_token)
+                .await
+                .unwrap()
+                .unwrap()
+                .grant,
+            Grant::Admin
+        );
+
+        set_user_role(&db, "rjpower", UserRole::User).await.unwrap();
+        assert!(set_user_role(&db, "alice", UserRole::User).await.is_err());
+        assert!(revoke_token(&db, "alice", &alice_info.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn personal_preferences_apply_and_reset_per_user() {
+        let db = connect_in_memory_with_owner("rjpower").await;
+        add_user(&db, "alice", None, None, UserRole::User)
+            .await
+            .unwrap();
+        apply_user_preferences(
+            &db,
+            "rjpower",
+            &[("terminal.theme".to_string(), Some("light".to_string()))],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            user_preferences(&db, "rjpower").await.unwrap(),
+            HashMap::from([("terminal.theme".to_string(), "light".to_string())])
+        );
+        assert!(user_preferences(&db, "alice").await.unwrap().is_empty());
+
+        apply_user_preferences(&db, "rjpower", &[("terminal.theme".to_string(), None)])
+            .await
+            .unwrap();
+        assert!(user_preferences(&db, "rjpower").await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -1136,7 +1356,7 @@ mod tests {
                 branch_id: branch.id,
             }
         );
-        assert_eq!(list_tokens(&db).await.unwrap().len(), 0);
+        assert_eq!(list_tokens(&db, "rjpower").await.unwrap().len(), 0);
         crate::session::set_status(&db, "s1", "archived")
             .await
             .unwrap();
@@ -1170,9 +1390,9 @@ mod tests {
                 .unwrap();
         // Authenticates, but never appears in the user-facing list…
         assert!(lookup_token(&db, &plain).await.unwrap().is_some());
-        assert!(list_tokens(&db).await.unwrap().is_empty());
+        assert!(list_tokens(&db, "rjpower").await.unwrap().is_empty());
         // …and the revoke route can't remove it.
-        assert!(!revoke_token(&db, &info.id).await.unwrap());
+        assert!(!revoke_token(&db, "rjpower", &info.id).await.unwrap());
         assert!(lookup_token(&db, &plain).await.unwrap().is_some());
     }
 
@@ -1208,12 +1428,13 @@ mod tests {
             .unwrap()
             .is_none());
 
-        add_user(&db, "alice", Some("alice-gh"), None)
+        add_user(&db, "alice", Some("alice-gh"), None, UserRole::User)
             .await
             .unwrap();
         assert_eq!(list_users(&db).await.unwrap().len(), 2);
+        assert!(remove_user(&db, "rjpower").await.is_err());
         assert!(remove_user(&db, "alice").await.unwrap());
-        // The last remaining user can't be removed.
+        // The last remaining administrator can't be removed.
         assert!(remove_user(&db, "rjpower").await.is_err());
     }
 

--- a/crates/loom-store/migrations/0025_user_roles_preferences.sql
+++ b/crates/loom-store/migrations/0025_user_roles_preferences.sql
@@ -1,0 +1,12 @@
+ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user'
+    CHECK (role IN ('admin', 'user'));
+
+UPDATE users SET role = 'admin';
+
+CREATE TABLE user_preferences (
+    username   TEXT NOT NULL REFERENCES users(username) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (username, key)
+);

--- a/crates/loom-store/src/db.rs
+++ b/crates/loom-store/src/db.rs
@@ -130,6 +130,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "channel-delivery-bindings",
         include_str!("../migrations/0024_channel_delivery_bindings.sql"),
     ),
+    (
+        25,
+        "user-roles-preferences",
+        include_str!("../migrations/0025_user_roles_preferences.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -321,7 +326,7 @@ async fn seed_owner(pool: &Db) -> Result<()> {
         return Ok(());
     };
     sqlx::query(
-        "INSERT INTO users (username, github_login) VALUES (?, ?)
+        "INSERT INTO users (username, github_login, role) VALUES (?, ?, 'admin')
          ON CONFLICT DO NOTHING",
     )
     .bind(&owner)
@@ -479,6 +484,48 @@ mod tests {
         .execute(&db)
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn role_migration_promotes_existing_users_and_creates_preferences() {
+        let db = core_connect_in_memory().await.unwrap();
+        migrate_through(&db, 24).await;
+        sqlx::query("INSERT INTO users (username, github_login) VALUES ('alice', 'alice-gh')")
+            .execute(&db)
+            .await
+            .unwrap();
+
+        LOOM_STREAM.apply_pending(&db).await.unwrap();
+
+        let role: String = sqlx::query_scalar("SELECT role FROM users WHERE username = 'alice'")
+            .fetch_one(&db)
+            .await
+            .unwrap();
+        assert_eq!(role, "admin");
+        sqlx::query("INSERT INTO users (username) VALUES ('bob')")
+            .execute(&db)
+            .await
+            .unwrap();
+        let new_role: String = sqlx::query_scalar("SELECT role FROM users WHERE username = 'bob'")
+            .fetch_one(&db)
+            .await
+            .unwrap();
+        assert_eq!(new_role, "user");
+        sqlx::query(
+            "INSERT INTO user_preferences (username, key, value)
+             VALUES ('alice', 'terminal.theme', 'light')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        let value: String = sqlx::query_scalar(
+            "SELECT value FROM user_preferences
+             WHERE username = 'alice' AND key = 'terminal.theme'",
+        )
+        .fetch_one(&db)
+        .await
+        .unwrap();
+        assert_eq!(value, "light");
     }
 
     #[tokio::test]

--- a/crates/loom-watch/src/watch.rs
+++ b/crates/loom-watch/src/watch.rs
@@ -1028,7 +1028,7 @@ async fn spawn_script(
     }
     // github watches shell out to `gh` (reading PR labels/state) from this
     // otherwise env-stripped process; hand them the operator's `GH_TOKEN`
-    // (Settings → Environment) so those reads authenticate. Set after the strip so
+    // (Settings → Agents & profiles) so those reads authenticate. Set after the strip so
     // it wins. Nothing else from the agent env leaks in — a watch still reaches the
     // fleet only through the REST API.
     if let Some(token) = crate::agent_env::get(&state.db, "GH_TOKEN").await {

--- a/crates/loom/frontend/src/App.vue
+++ b/crates/loom/frontend/src/App.vue
@@ -45,57 +45,59 @@ watch(authed, (ok) => (ok ? startFleetPoll() : stopFleetPoll()), { immediate: tr
 const route = useRoute();
 const router = useRouter();
 const commands = useCommandRegistry();
-const globalCommands = computed<Command[]>(() => [
-  {
-    id: 'global.help',
-    label: 'Show keyboard shortcuts',
-    keys: ['?'],
-    hint: true,
-    run: commands.toggleHelp,
-  },
-  {
-    id: 'global.sessions',
-    label: 'Go to Sessions',
-    keys: ['g s'],
-    run: () => void router.push('/'),
-  },
-  {
-    id: 'global.channels',
-    label: 'Go to Channels',
-    keys: ['g c'],
-    run: () => void router.push('/channels'),
-  },
-  {
-    id: 'global.issues',
-    label: 'Go to backlog',
-    keys: ['g i'],
-    run: () => void router.push('/issues'),
-  },
-  {
-    id: 'global.watches',
-    label: 'Go to Watches',
-    keys: ['g w'],
-    run: () => void router.push('/watches'),
-  },
-  {
-    id: 'global.shell',
-    label: 'Go to Shell',
-    keys: ['g h'],
-    run: () => void router.push('/shell'),
-  },
-  {
-    id: 'global.settings',
-    label: 'Go to Settings',
-    keys: ['g ,'],
-    run: () => void router.push('/settings'),
-  },
-  {
-    id: 'global.new-session',
-    label: 'New session',
-    keys: ['n'],
-    run: () => void router.push('/sessions/new'),
-  },
-]);
+const globalCommands = computed<Command[]>(() =>
+  [
+    {
+      id: 'global.help',
+      label: 'Show keyboard shortcuts',
+      keys: ['?'],
+      hint: true,
+      run: commands.toggleHelp,
+    },
+    {
+      id: 'global.sessions',
+      label: 'Go to Sessions',
+      keys: ['g s'],
+      run: () => void router.push('/'),
+    },
+    {
+      id: 'global.channels',
+      label: 'Go to Channels',
+      keys: ['g c'],
+      run: () => void router.push('/channels'),
+    },
+    {
+      id: 'global.issues',
+      label: 'Go to backlog',
+      keys: ['g i'],
+      run: () => void router.push('/issues'),
+    },
+    {
+      id: 'global.watches',
+      label: 'Go to Watches',
+      keys: ['g w'],
+      run: () => void router.push('/watches'),
+    },
+    {
+      id: 'global.shell',
+      label: 'Go to Shell',
+      keys: ['g h'],
+      run: () => void router.push('/shell'),
+    },
+    {
+      id: 'global.settings',
+      label: 'Go to Settings',
+      keys: ['g ,'],
+      run: () => void router.push('/settings'),
+    },
+    {
+      id: 'global.new-session',
+      label: 'New session',
+      keys: ['n'],
+      run: () => void router.push('/sessions/new'),
+    },
+  ].filter((command) => command.id !== 'global.shell' || me.role === 'admin'),
+);
 useCommandScope('global', 'Global', globalCommands, -100);
 useCommandDispatcher();
 const BASE_TITLE = 'Weaver';

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -693,7 +693,16 @@ export const restartShell = () => post('/shell/restart');
 
 // --- Authentication --------------------------------------------------------
 
-import type { Me, Token, CreatedToken, User, GithubConfig, SlackStatus } from './types';
+import type {
+  Me,
+  Token,
+  CreatedToken,
+  User,
+  UserRole,
+  UserPreferencesEnvelope,
+  GithubConfig,
+  SlackStatus,
+} from './types';
 
 /** Who the caller is + which sign-in methods to offer. Never 401s. */
 export const getMe = () => get('/auth/me') as Promise<Me>;
@@ -726,15 +735,32 @@ export const setPassword = (newPassword: string) =>
 export const listUsers = () => get('/auth/users') as Promise<User[]>;
 
 /** Approve a new operator (GitHub login and/or password). */
-export const addUser = (username: string, githubLogin?: string, password?: string) =>
+export const addUser = (
+  username: string,
+  githubLogin: string | undefined,
+  password: string | undefined,
+  role: UserRole,
+) =>
   post('/auth/users', {
     username,
     github_login: githubLogin || null,
     password: password || null,
+    role,
   }) as Promise<User>;
+
+/** Change an approved user's role. */
+export const setUserRole = (username: string, role: UserRole) =>
+  put(`/auth/users/${encodeURIComponent(username)}/role`, { role }) as Promise<User>;
 
 /** Remove an approved operator. */
 export const removeUser = (username: string) => del(`/auth/users/${encodeURIComponent(username)}`);
+
+/** Effective preferences for the signed-in user. */
+export const getPreferences = () => get('/preferences') as Promise<UserPreferencesEnvelope>;
+
+/** Set personal overrides; null clears a key back to its deployment value. */
+export const patchPreferences = (changes: Record<string, string | null>) =>
+  patch('/preferences', changes) as Promise<UserPreferencesEnvelope>;
 
 /** The GitHub App / sign-in config (secret withheld). */
 export const getGithubConfig = () => get('/auth/github/config') as Promise<GithubConfig>;

--- a/crates/loom/frontend/src/auth.ts
+++ b/crates/loom/frontend/src/auth.ts
@@ -12,6 +12,7 @@ const EMPTY: Me = {
   username: null,
   github_login: null,
   via: null,
+  role: null,
   methods: { password: true, github: false },
 };
 

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -3,11 +3,10 @@ import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import * as api from '../api';
 import { me, doLogout } from '../auth';
-import type { User } from '../types';
 import { confirmAction } from '../lib/confirmation';
 
 // Personal account and access management. Deployment connections such as the
-// Loom GitHub App live in Connections instead.
+// Loom GitHub App lives in Integrations instead.
 const router = useRouter();
 const error = ref('');
 const notice = ref('');
@@ -102,69 +101,12 @@ async function clearMyGithubToken() {
   });
 }
 
-// -- Approved users ---------------------------------------------------------
-const users = ref<User[]>([]);
-const newUser = ref('');
-const newUserGithub = ref('');
-const newUserPassword = ref('');
-
-async function loadUsers() {
-  try {
-    users.value = await api.listUsers();
-  } catch (e) {
-    fail(e);
-  }
-}
-
-async function addUser() {
-  if (!newUser.value.trim()) return;
-  busy.value = true;
-  try {
-    await api.addUser(
-      newUser.value.trim(),
-      newUserGithub.value.trim() || undefined,
-      newUserPassword.value || undefined,
-    );
-    newUser.value = '';
-    newUserGithub.value = '';
-    newUserPassword.value = '';
-    ok('User approved.');
-    await loadUsers();
-  } catch (e) {
-    fail(e);
-  } finally {
-    busy.value = false;
-  }
-}
-
-async function removeUser(u: User) {
-  await confirmAction({
-    title: `Remove approved user "${u.username}"?`,
-    description: 'They will lose dashboard and API access immediately.',
-    confirmLabel: 'Remove user',
-    danger: true,
-    action: async () => {
-      busy.value = true;
-      try {
-        await api.removeUser(u.username);
-        ok('User removed.');
-        await loadUsers();
-      } finally {
-        busy.value = false;
-      }
-    },
-  });
-}
-
 async function logout() {
   await doLogout();
   router.push('/login');
 }
 
-onMounted(() => {
-  loadMyGithubToken();
-  loadUsers();
-});
+onMounted(loadMyGithubToken);
 </script>
 
 <template>
@@ -182,7 +124,7 @@ onMounted(() => {
           <p class="text-sm font-medium">{{ me.username }}</p>
           <p class="text-2xs text-faint">
             <template v-if="me.github_login">GitHub: {{ me.github_login }} · </template>
-            via {{ me.via }}
+            {{ me.role === 'admin' ? 'Admin' : 'User' }} · via {{ me.via }}
           </p>
         </div>
         <button class="btn-secondary px-2.5 py-1 text-xs" @click="logout">Sign out</button>
@@ -274,70 +216,6 @@ onMounted(() => {
             Clear
           </button>
         </div>
-      </div>
-    </section>
-
-    <!-- Approved users -->
-    <section>
-      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
-        Approved users
-      </h2>
-      <p class="text-2xs text-faint mb-1.5">
-        Everyone allowed near loom. An approved user can sign in here, and — if their GitHub login
-        is on file — trigger a session by commenting
-        <code class="font-mono">@loom</code> on a GitHub PR or issue.
-      </p>
-      <div class="overflow-hidden rounded-md border border-line bg-surface">
-        <div
-          v-for="u in users"
-          :key="u.username"
-          class="flex items-center gap-3 border-b border-line px-3 py-2.5 last:border-0"
-        >
-          <div class="min-w-0 flex-1">
-            <p class="truncate text-sm font-medium">{{ u.username }}</p>
-            <p class="text-2xs text-faint">
-              <template v-if="u.github_login">GitHub: {{ u.github_login }}</template>
-              <template v-else>no GitHub login</template>
-              · {{ u.has_password ? 'password set' : 'no password' }}
-            </p>
-          </div>
-          <button
-            v-if="u.username !== me.username"
-            class="btn-secondary px-2.5 py-1 text-xs"
-            :disabled="busy"
-            @click="removeUser(u)"
-          >
-            Remove
-          </button>
-          <span v-else class="text-2xs text-faint">you</span>
-        </div>
-      </div>
-
-      <div class="mt-2 flex flex-wrap items-end gap-2">
-        <input
-          v-model="newUser"
-          placeholder="Username"
-          class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
-        />
-        <input
-          v-model="newUserGithub"
-          placeholder="GitHub login (optional)"
-          class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
-        />
-        <input
-          v-model="newUserPassword"
-          type="password"
-          autocomplete="new-password"
-          placeholder="Password (optional)"
-          class="rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
-        />
-        <button
-          class="btn-primary px-3 py-1.5 text-xs"
-          :disabled="busy || !newUser.trim()"
-          @click="addUser"
-        >
-          Approve user
-        </button>
       </div>
     </section>
   </div>

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import * as api from '../api';
 import { me, doLogout } from '../auth';
-import type { User, GithubConfig } from '../types';
+import type { User } from '../types';
 import { confirmAction } from '../lib/confirmation';
 
-// Account + access management: who you are, your password, the approved-user
-// allowlist, and the single GitHub App that backs loom — its OAuth client powers
-// "Continue with GitHub", and the same App drives the `@loom` trigger.
+// Personal account and access management. Deployment connections such as the
+// Loom GitHub App live in Connections instead.
 const router = useRouter();
 const error = ref('');
 const notice = ref('');
@@ -53,7 +52,11 @@ async function savePassword() {
 // A personal fine-grained PAT, injected as GH_TOKEN into the sessions this user
 // launches, so their agents' `git push` / `gh` act as them (not the shared
 // ambient token). Write-only: we render only whether it's set, never the value.
-const PAT_CREATE_URL = 'https://github.com/settings/personal-access-tokens/new';
+const PAT_CREATE_URL =
+  'https://github.com/settings/personal-access-tokens/new' +
+  '?name=Loom' +
+  '&description=Interactive%20Loom%20sessions' +
+  '&contents=write&issues=write&pull_requests=write';
 const ghToken = ref('');
 const ghTokenStatus = ref<api.GithubTokenStatus | null>(null);
 
@@ -83,7 +86,7 @@ async function clearMyGithubToken() {
   await confirmAction({
     title: 'Remove your personal GitHub token?',
     description:
-      "New interactive sessions will use their profile's credential, if configured. Existing sessions are unchanged.",
+      "New interactive sessions will use an explicit session credential or the selected profile's GitHub App access. Existing sessions are unchanged.",
     confirmLabel: 'Remove token',
     danger: true,
     action: async () => {
@@ -153,48 +156,6 @@ async function removeUser(u: User) {
   });
 }
 
-// -- GitHub App -------------------------------------------------------------
-// One GitHub App backs loom: its OAuth client id/secret power "Continue with
-// GitHub", and the same App's id + private key power the `@loom` trigger. The
-// usual way to set it up is `loom setup github-app`; the id/secret below stay
-// editable for the manual path (or a login-only classic OAuth app).
-const gh = ref<GithubConfig | null>(null);
-const ghClientId = ref('');
-const ghClientSecret = ref('');
-
-// The App's public GitHub page, when we know its slug (recorded by
-// `loom setup github-app`). A hand-configured App has an id but no slug.
-const appUrl = computed(() =>
-  gh.value?.app_slug ? `https://github.com/apps/${gh.value.app_slug}` : '',
-);
-
-async function loadGithub() {
-  try {
-    gh.value = await api.getGithubConfig();
-    ghClientId.value = gh.value.client_id;
-  } catch (e) {
-    fail(e);
-  }
-}
-
-async function saveGithub() {
-  busy.value = true;
-  try {
-    // Send the secret only when the field was filled, so an empty field leaves
-    // the stored secret intact.
-    gh.value = await api.setGithubConfig(
-      ghClientId.value.trim(),
-      ghClientSecret.value ? ghClientSecret.value : undefined,
-    );
-    ghClientSecret.value = '';
-    ok('GitHub sign-in updated.');
-  } catch (e) {
-    fail(e);
-  } finally {
-    busy.value = false;
-  }
-}
-
 async function logout() {
   await doLogout();
   router.push('/login');
@@ -203,7 +164,6 @@ async function logout() {
 onMounted(() => {
   loadMyGithubToken();
   loadUsers();
-  loadGithub();
 });
 </script>
 
@@ -269,19 +229,23 @@ onMounted(() => {
       </h2>
       <div class="rounded-md border border-line bg-surface px-3 py-2.5">
         <p class="text-xs text-muted mb-2">
-          A fine-grained token your ordinary interactive sessions use for
+          A personal fine-grained token your ordinary interactive sessions use for
           <code class="font-mono">git push</code> and <code class="font-mono">gh</code>, so your
-          agents act as you. Restricted automation uses the GitHub App instead.
+          agents act as you. It takes precedence over explicit session and profile GitHub
+          credentials.
           <a class="text-accent underline" :href="PAT_CREATE_URL" target="_blank" rel="noopener">
             Create one</a
           >
-          with <span class="font-medium">Contents</span> and
-          <span class="font-medium">Pull requests</span> read/write on the repos you work in.
+          with <span class="font-medium">Contents</span>, <span class="font-medium">Issues</span>,
+          and <span class="font-medium">Pull requests</span> read/write. Repository selection and
+          permissions are separate; choose the repositories your sessions use. Add
+          <span class="font-medium">Workflows</span> read/write only when sessions must edit
+          <code class="font-mono">.github/workflows</code>.
           <span :class="ghTokenStatus?.set ? 'text-accent' : 'text-faint'">
             {{
               ghTokenStatus?.set
                 ? 'Set.'
-                : 'Not set — interactive sessions use their profile credential, if configured.'
+                : 'Not set — interactive sessions use an explicit session credential, then the selected profile’s GitHub App access.'
             }}
           </span>
         </p>
@@ -308,75 +272,6 @@ onMounted(() => {
             @click="clearMyGithubToken"
           >
             Clear
-          </button>
-        </div>
-      </div>
-    </section>
-
-    <!-- GitHub App -->
-    <section>
-      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">GitHub App</h2>
-      <div class="rounded-md border border-line bg-surface px-3 py-2.5">
-        <!-- App identity: one App powers both sign-in and the @loom trigger. -->
-        <div v-if="gh?.app_configured" class="mb-2">
-          <p class="text-sm">
-            <span class="text-accent">✓</span>
-            <a
-              v-if="appUrl"
-              :href="appUrl"
-              target="_blank"
-              rel="noopener"
-              class="font-medium text-accent hover:underline"
-              >{{ gh.app_slug }}</a
-            >
-            <span v-else class="font-medium">GitHub App</span>
-            <span class="text-faint"> · App ID {{ gh.app_id }}</span>
-          </p>
-          <p class="text-xs text-muted mt-0.5">
-            One GitHub App powers both sign-in and the <code class="font-mono">@loom</code> trigger.
-            Manage it with <code class="font-mono">loom setup github-app</code>.
-          </p>
-        </div>
-        <p v-else class="text-xs text-muted mb-2">
-          No GitHub App configured. Run
-          <code class="font-mono">loom setup github-app --base-url &lt;your loom URL&gt;</code>
-          to register one — it wires up sign-in and the <code class="font-mono">@loom</code>
-          trigger in a single step. You can also paste sign-in credentials manually below.
-        </p>
-
-        <!-- Sign-in (OAuth) credentials: the App's OAuth client, editable for
-             the manual path or a login-only classic OAuth app. -->
-        <p class="text-2xs font-semibold uppercase tracking-wider text-muted mt-3 mb-1">
-          Sign-in credentials
-        </p>
-        <p class="text-xs text-muted mb-2">
-          <template v-if="gh?.app_configured">The same App's</template>
-          <template v-else>The</template>
-          OAuth client, with callback
-          <code class="font-mono">{{ gh?.callback_path }}</code
-          >. Powers "Continue with GitHub".
-          <span :class="gh?.configured ? 'text-accent' : 'text-faint'">
-            {{ gh?.configured ? 'Configured.' : 'Not configured.' }}
-          </span>
-        </p>
-        <div class="space-y-2">
-          <input
-            v-model="ghClientId"
-            placeholder="Client ID"
-            class="w-full rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
-          />
-          <input
-            v-model="ghClientSecret"
-            type="password"
-            :placeholder="gh?.configured ? 'Client secret (leave blank to keep)' : 'Client secret'"
-            class="w-full rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
-          />
-          <button
-            class="btn-primary px-3 py-1.5 text-xs"
-            :disabled="busy || !ghClientId.trim()"
-            @click="saveGithub"
-          >
-            Save
           </button>
         </div>
       </div>

--- a/crates/loom/frontend/src/components/AppRail.vue
+++ b/crates/loom/frontend/src/components/AppRail.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
+import { me } from '../auth';
 import { theme, toggleTheme } from '../theme';
 
 // The workbench nav rail — the app's only chrome besides the status bar
@@ -85,6 +86,9 @@ const SETTINGS: RailItem = {
 };
 
 const active = computed(() => (item: RailItem) => item.match(route.path));
+const visibleMain = computed(() =>
+  MAIN.filter((item) => item.to !== '/shell' || me.role === 'admin'),
+);
 </script>
 
 <template>
@@ -114,7 +118,7 @@ const active = computed(() => (item: RailItem) => item.match(route.path));
     </router-link>
 
     <router-link
-      v-for="item in MAIN"
+      v-for="item in visibleMain"
       :key="item.to"
       :to="item.to"
       :title="item.title ?? item.label"

--- a/crates/loom/frontend/src/components/AppearancePanel.vue
+++ b/crates/loom/frontend/src/components/AppearancePanel.vue
@@ -3,8 +3,8 @@ import { ref, computed, reactive, onMounted, onUnmounted, watch, nextTick } from
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
-import { get, patch } from '../api';
-import type { SettingsEnvelope, SettingView } from '../types';
+import { getPreferences, patchPreferences } from '../api';
+import type { UserPreferenceView } from '../types';
 import {
   FONT_CHOICES,
   fontStack,
@@ -19,7 +19,8 @@ import {
 // The terminal Appearance pane: theme, font, and size for the in-browser
 // terminal, with a live xterm preview that renders exactly what a real terminal
 // will. Self-contained like the other settings panels — it fetches and patches
-// `/settings` directly rather than routing through the parent's drafts.
+// the personal-preferences API directly rather than routing through the
+// deployment settings drafts.
 
 const THEME_KEY = 'terminal.theme';
 const FONT_KEY = 'terminal.font';
@@ -47,7 +48,7 @@ const SAMPLE = [
   '\x1b[1;32m➜\x1b[0m \x1b[1;36m~/weaver\x1b[0m ',
 ].join('\r\n');
 
-const stored = ref<Record<string, SettingView>>({});
+const stored = ref<Record<string, UserPreferenceView>>({});
 const draft = reactive<Record<string, string>>({
   [THEME_KEY]: 'dark',
   [FONT_KEY]: 'plex',
@@ -67,10 +68,10 @@ let disposed = false;
 const sizeNumber = computed(() => clampFontSize(Number(draft[SIZE_KEY])));
 
 const dirty = computed(() => KEYS.some((k) => draft[k] !== stored.value[k]?.value));
-const allInherited = computed(() => KEYS.every((k) => stored.value[k]?.source !== 'runtime'));
+const allInherited = computed(() => KEYS.every((k) => !stored.value[k]?.is_overridden));
 
-function adopt(settings: SettingView[]) {
-  const byKey: Record<string, SettingView> = {};
+function adopt(settings: UserPreferenceView[]) {
+  const byKey: Record<string, UserPreferenceView> = {};
   for (const s of settings) if (KEYS.includes(s.key)) byKey[s.key] = s;
   stored.value = byKey;
   for (const k of KEYS) if (byKey[k]) draft[k] = byKey[k].value;
@@ -78,8 +79,8 @@ function adopt(settings: SettingView[]) {
 
 async function load() {
   try {
-    const res = (await get('/settings')) as SettingsEnvelope;
-    adopt(res.settings);
+    const res = await getPreferences();
+    adopt(res.preferences);
     error.value = '';
   } catch (e) {
     error.value = (e as Error).message;
@@ -88,8 +89,8 @@ async function load() {
   }
 }
 
-function patchBody(reset: boolean): Record<string, string | null> {
-  return Object.fromEntries(KEYS.map((k) => [k, reset ? null : draft[k]]));
+function patchBody(keys: string[], reset: boolean): Record<string, string | null> {
+  return Object.fromEntries(keys.map((key) => [key, reset ? null : draft[key]]));
 }
 
 async function commit(body: Record<string, string | null>, done: string) {
@@ -97,8 +98,8 @@ async function commit(body: Record<string, string | null>, done: string) {
   error.value = '';
   notice.value = '';
   try {
-    const res = (await patch('/settings', body)) as SettingsEnvelope;
-    adopt(res.settings);
+    const res = await patchPreferences(body);
+    adopt(res.preferences);
     notice.value = done;
   } catch (e) {
     error.value = (e as Error).message;
@@ -111,11 +112,12 @@ async function save() {
   if (!dirty.value) return;
   // Normalise the size to the clamped value we actually apply before saving.
   draft[SIZE_KEY] = String(sizeNumber.value);
-  await commit(patchBody(false), 'Saved terminal appearance.');
+  const changed = KEYS.filter((key) => draft[key] !== stored.value[key]?.value);
+  await commit(patchBody(changed, false), 'Saved your terminal preferences.');
 }
 
 async function resetDefaults() {
-  await commit(patchBody(true), 'Cleared terminal appearance overrides.');
+  await commit(patchBody(KEYS, true), 'Restored deployment terminal defaults.');
 }
 
 function nudgeSize(delta: number) {
@@ -324,10 +326,10 @@ onUnmounted(() => {
         <button
           class="btn-secondary px-3 py-1.5 text-xs disabled:opacity-50"
           :disabled="busy || allInherited || !loaded"
-          title="Clear runtime overrides and inherit deployment or built-in values"
+          title="Clear your overrides and inherit deployment defaults"
           @click="resetDefaults"
         >
-          Clear overrides
+          Use deployment defaults
         </button>
         <span v-if="dirty" class="text-2xs text-faint"
           >Unsaved changes — applies to terminals opened after saving.</span

--- a/crates/loom/frontend/src/components/EnvPanel.vue
+++ b/crates/loom/frontend/src/components/EnvPanel.vue
@@ -105,7 +105,7 @@ const add = () =>
 <template>
   <div>
     <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
-      Default profile environment
+      Default profile non-secret environment
     </h2>
     <p class="mb-3 text-xs text-faint">
       Variables exported into new sessions that use the default profile. Other profiles use their

--- a/crates/loom/frontend/src/components/GithubConnectionPanel.vue
+++ b/crates/loom/frontend/src/components/GithubConnectionPanel.vue
@@ -54,7 +54,7 @@ onMounted(load);
       <p class="text-xs text-faint">
         Deployment-owned integration for GitHub sign-in, <code class="font-mono">@loom</code>
         triggers, and short-lived repository credentials. Personal GitHub tokens remain under
-        <span class="font-medium">Access</span>.
+        <span class="font-medium">Account</span>.
       </p>
     </div>
     <p v-if="error" class="text-sm text-block">{{ error }}</p>

--- a/crates/loom/frontend/src/components/GithubConnectionPanel.vue
+++ b/crates/loom/frontend/src/components/GithubConnectionPanel.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import * as api from '../api';
+import type { GithubConfig } from '../types';
+
+const gh = ref<GithubConfig | null>(null);
+const ghClientId = ref('');
+const ghClientSecret = ref('');
+const error = ref('');
+const notice = ref('');
+const busy = ref(false);
+
+const appUrl = computed(() =>
+  gh.value?.app_slug ? `https://github.com/apps/${gh.value.app_slug}` : '',
+);
+
+async function load() {
+  try {
+    gh.value = await api.getGithubConfig();
+    ghClientId.value = gh.value.client_id;
+    error.value = '';
+  } catch (cause) {
+    error.value = (cause as Error).message;
+  }
+}
+
+async function save() {
+  busy.value = true;
+  error.value = '';
+  notice.value = '';
+  try {
+    gh.value = await api.setGithubConfig(
+      ghClientId.value.trim(),
+      ghClientSecret.value || undefined,
+    );
+    ghClientSecret.value = '';
+    notice.value = 'GitHub connection updated.';
+  } catch (cause) {
+    error.value = (cause as Error).message;
+  } finally {
+    busy.value = false;
+  }
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <section class="space-y-2" data-testid="github-connection-panel">
+    <div>
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
+        Loom GitHub App
+      </h2>
+      <p class="text-xs text-faint">
+        Deployment-owned integration for GitHub sign-in, <code class="font-mono">@loom</code>
+        triggers, and short-lived repository credentials. Personal GitHub tokens remain under
+        <span class="font-medium">Access</span>.
+      </p>
+    </div>
+    <p v-if="error" class="text-sm text-block">{{ error }}</p>
+    <p v-if="notice" class="text-sm text-accent">{{ notice }}</p>
+    <div class="rounded-md border border-line bg-surface px-3 py-2.5">
+      <div v-if="gh?.app_configured" class="mb-2">
+        <p class="text-sm">
+          <span class="text-accent">✓</span>
+          <a
+            v-if="appUrl"
+            :href="appUrl"
+            target="_blank"
+            rel="noopener"
+            class="font-medium text-accent hover:underline"
+            >{{ gh.app_slug }}</a
+          >
+          <span v-else class="font-medium">GitHub App</span>
+          <span class="text-faint"> · App ID {{ gh.app_id }}</span>
+        </p>
+        <p class="text-xs text-muted mt-0.5">
+          Manage the App, its installations, and its private credentials with
+          <code class="font-mono">loom setup github-app</code> or deployment IaC.
+        </p>
+      </div>
+      <p v-else class="text-xs text-muted mb-2">
+        No GitHub App configured. Run
+        <code class="font-mono">loom setup github-app --base-url &lt;your loom URL&gt;</code>
+        to register one for sign-in and the <code class="font-mono">@loom</code> trigger. You can
+        also paste sign-in credentials below.
+      </p>
+
+      <p class="text-2xs font-semibold uppercase tracking-wider text-muted mt-3 mb-1">
+        Sign-in credentials
+      </p>
+      <p class="text-xs text-muted mb-2">
+        <template v-if="gh?.app_configured">The same App's</template>
+        <template v-else>The</template>
+        OAuth client, with callback <code class="font-mono">{{ gh?.callback_path }}</code
+        >. Powers "Continue with GitHub".
+        <span :class="gh?.configured ? 'text-accent' : 'text-faint'">
+          {{ gh?.configured ? 'Configured.' : 'Not configured.' }}
+        </span>
+      </p>
+      <div class="space-y-2">
+        <input
+          v-model="ghClientId"
+          placeholder="Client ID"
+          class="w-full rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+        />
+        <input
+          v-model="ghClientSecret"
+          type="password"
+          :placeholder="gh?.configured ? 'Client secret (leave blank to keep)' : 'Client secret'"
+          class="w-full rounded bg-input px-2 py-1 text-sm outline-none focus:ring-1 ring-accent"
+        />
+        <button
+          class="btn-primary px-3 py-1.5 text-xs"
+          :disabled="busy || !ghClientId.trim()"
+          @click="save"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/crates/loom/frontend/src/components/LogsPanel.vue
+++ b/crates/loom/frontend/src/components/LogsPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue';
 import * as api from '../api';
+import { me } from '../auth';
 import { openTopic, type TopicHandle } from '../lib/eventStream';
 import type { Diagnostics, LogLine, ServerStatus, TaskRecord } from '../types';
 
@@ -8,7 +9,8 @@ import type { Diagnostics, LogLine, ServerStatus, TaskRecord } from '../types';
 // that go to stdout / `docker compose logs`, but readable from the browser so an
 // operator can debug a Docker deploy (a failed session recovery, a webhook that
 // got rejected) without shelling into the container. Snapshot on open, then a
-// live SSE tail. Operator-only on the server; server logs can carry secrets.
+// live SSE tail. Admins receive the raw operator log; the server redacts known
+// and credential-shaped secrets before returning these lines to user roles.
 
 // Newest lines live at the end. Cap the client-side list so a long-lived panel
 // can't grow without bound; the server ring buffer holds ~2000 anyway.
@@ -94,8 +96,7 @@ async function loadSnapshot() {
     const [snap, st, diag] = await Promise.all([
       api.getLogs(2000),
       api.getServerStatus(),
-      // Diagnostics require the admin grant. Keep the operator-visible log and
-      // status snapshot useful when that optional request is forbidden or down.
+      // Keep the log and status snapshot useful when diagnostics are down.
       api.getDiagnostics().catch(() => null),
     ]);
     lines.value = snap;
@@ -483,11 +484,18 @@ onUnmounted(() => {
     </section>
 
     <!-- Server logs -->
-    <h2 class="mb-1.5 text-2xs font-semibold uppercase tracking-wider text-muted">Server logs</h2>
+    <div class="mb-1.5 flex items-center gap-2">
+      <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted">Server logs</h2>
+      <span v-if="me.role === 'user'" class="pill">secrets redacted</span>
+    </div>
     <p class="mb-3 text-xs text-faint">
       The running server's log stream, live. The same lines go to
       <code>docker compose logs</code>; this is a read-only mirror so you can debug from the
-      browser. May contain secrets — visible to approved operators only.
+      browser.
+      <template v-if="me.role === 'user'">
+        Known deployment credentials and token-shaped values are redacted.
+      </template>
+      <template v-else> Administrators see the raw operator stream. </template>
     </p>
 
     <!-- Controls -->

--- a/crates/loom/frontend/src/components/NewSessionDrawer.vue
+++ b/crates/loom/frontend/src/components/NewSessionDrawer.vue
@@ -26,6 +26,7 @@ import type {
 } from '../types';
 import LaunchOverrides from './LaunchOverrides.vue';
 import ScratchPicker from './ScratchPicker.vue';
+import { me } from '../auth';
 
 const emit = defineEmits<{
   close: [];
@@ -1013,7 +1014,8 @@ onActivated(() => void refreshLaunchData());
             <div class="flex items-center justify-between gap-3">
               <label class="text-xs font-medium text-fg" for="launch-profile">Profile</label>
               <RouterLink
-                to="/settings"
+                v-if="me.role === 'admin'"
+                to="/settings?tab=agents"
                 class="text-xs text-accent hover:underline"
                 @click="creating && $event.preventDefault()"
               >
@@ -1081,7 +1083,7 @@ onActivated(() => void refreshLaunchData());
         </p>
 
         <section
-          v-if="hasLaunchChanges && resolved"
+          v-if="me.role === 'admin' && hasLaunchChanges && resolved"
           class="min-w-0 space-y-2 rounded-md border border-line bg-surface p-3"
         >
           <h3 class="text-xs font-medium text-fg">Keep these settings</h3>
@@ -1133,7 +1135,7 @@ onActivated(() => void refreshLaunchData());
             </div>
           </template>
         </section>
-        <p v-if="cloneNotice" class="text-xs text-ok">{{ cloneNotice }}</p>
+        <p v-if="me.role === 'admin' && cloneNotice" class="text-xs text-ok">{{ cloneNotice }}</p>
       </aside>
     </fieldset>
 

--- a/crates/loom/frontend/src/components/UsersPanel.vue
+++ b/crates/loom/frontend/src/components/UsersPanel.vue
@@ -1,0 +1,193 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import * as api from '../api';
+import { loadMe, me } from '../auth';
+import type { User, UserRole } from '../types';
+import { confirmAction } from '../lib/confirmation';
+
+const users = ref<User[]>([]);
+const newUser = ref('');
+const newUserGithub = ref('');
+const newUserPassword = ref('');
+const newUserRole = ref<UserRole>('user');
+const busy = ref('');
+const error = ref('');
+const notice = ref('');
+
+async function load() {
+  try {
+    users.value = await api.listUsers();
+    error.value = '';
+  } catch (cause) {
+    error.value = (cause as Error).message;
+  }
+}
+
+async function add() {
+  const username = newUser.value.trim();
+  if (!username || busy.value) return;
+  busy.value = 'add';
+  error.value = '';
+  notice.value = '';
+  try {
+    await api.addUser(
+      username,
+      newUserGithub.value.trim() || undefined,
+      newUserPassword.value || undefined,
+      newUserRole.value,
+    );
+    newUser.value = '';
+    newUserGithub.value = '';
+    newUserPassword.value = '';
+    newUserRole.value = 'user';
+    notice.value = `${username} approved.`;
+    await load();
+  } catch (cause) {
+    error.value = (cause as Error).message;
+  } finally {
+    busy.value = '';
+  }
+}
+
+async function changeRole(user: User, role: UserRole) {
+  if (role === user.role || busy.value) return;
+  busy.value = `role:${user.username}`;
+  error.value = '';
+  notice.value = '';
+  try {
+    const updated = await api.setUserRole(user.username, role);
+    users.value = users.value.map((entry) =>
+      entry.username === updated.username ? updated : entry,
+    );
+    if (user.username === me.username) await loadMe();
+    notice.value = `${user.username} is now ${role}.`;
+  } catch (cause) {
+    error.value = (cause as Error).message;
+  } finally {
+    busy.value = '';
+  }
+}
+
+async function remove(user: User) {
+  await confirmAction({
+    title: `Remove approved user "${user.username}"?`,
+    description: 'They will lose dashboard and API access immediately.',
+    confirmLabel: 'Remove user',
+    danger: true,
+    action: async () => {
+      busy.value = `remove:${user.username}`;
+      error.value = '';
+      notice.value = '';
+      try {
+        await api.removeUser(user.username);
+        users.value = users.value.filter((entry) => entry.username !== user.username);
+        notice.value = `${user.username} removed.`;
+      } finally {
+        busy.value = '';
+      }
+    },
+  });
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <section class="space-y-3">
+    <div>
+      <h2 class="mb-1 text-2xs font-semibold uppercase tracking-wider text-muted">
+        Approved users
+      </h2>
+      <p class="text-xs text-faint">
+        Users can operate sessions, repositories, and reviews, and inspect watches and diagnostics.
+        Admins can also change deployment-wide policy, integrations, watches, and access.
+      </p>
+    </div>
+    <p v-if="error" class="text-sm text-block" role="alert">{{ error }}</p>
+    <p v-if="notice" class="text-sm text-accent">{{ notice }}</p>
+
+    <div class="overflow-hidden rounded-md border border-line bg-surface">
+      <div
+        v-for="user in users"
+        :key="user.username"
+        class="flex flex-wrap items-center gap-3 border-b border-line px-3 py-2.5 last:border-0"
+      >
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-sm font-medium">
+            {{ user.username }}
+            <span v-if="user.username === me.username" class="text-2xs font-normal text-faint"
+              >you</span
+            >
+          </p>
+          <p class="text-2xs text-faint">
+            {{ user.github_login ? `GitHub: ${user.github_login}` : 'no GitHub login' }} ·
+            {{ user.has_password ? 'password set' : 'no password' }}
+          </p>
+        </div>
+        <select
+          :value="user.role"
+          :disabled="Boolean(busy)"
+          :aria-label="`Role for ${user.username}`"
+          class="rounded bg-input px-2 py-1 text-xs"
+          @change="changeRole(user, ($event.target as HTMLSelectElement).value as UserRole)"
+        >
+          <option value="user">User</option>
+          <option value="admin">Admin</option>
+        </select>
+        <button
+          v-if="user.username !== me.username"
+          class="btn-secondary px-2.5 py-1 text-xs"
+          :disabled="Boolean(busy)"
+          @click="remove(user)"
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+
+    <div class="grid gap-2 rounded-md border border-line bg-surface p-3 md:grid-cols-2">
+      <label class="text-2xs text-muted">
+        Username
+        <input
+          v-model="newUser"
+          placeholder="Username"
+          class="mt-1 w-full rounded bg-input px-2 py-1.5 text-sm"
+        />
+      </label>
+      <label class="text-2xs text-muted">
+        GitHub login
+        <input
+          v-model="newUserGithub"
+          placeholder="Optional"
+          class="mt-1 w-full rounded bg-input px-2 py-1.5 text-sm"
+        />
+      </label>
+      <label class="text-2xs text-muted">
+        Initial password
+        <input
+          v-model="newUserPassword"
+          type="password"
+          autocomplete="new-password"
+          placeholder="Optional"
+          class="mt-1 w-full rounded bg-input px-2 py-1.5 text-sm"
+        />
+      </label>
+      <label class="text-2xs text-muted">
+        Role
+        <select v-model="newUserRole" class="mt-1 w-full rounded bg-input px-2 py-1.5 text-sm">
+          <option value="user">User — normal Loom operation</option>
+          <option value="admin">Admin — deployment configuration</option>
+        </select>
+      </label>
+      <div class="md:col-span-2">
+        <button
+          class="btn-primary px-3 py-1.5 text-xs"
+          :disabled="Boolean(busy) || !newUser.trim()"
+          @click="add"
+        >
+          Approve user
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/crates/loom/frontend/src/lib/terminalConfig.ts
+++ b/crates/loom/frontend/src/lib/terminalConfig.ts
@@ -1,14 +1,14 @@
-// Terminal appearance: the single place that turns the `terminal.*` server
-// settings into concrete xterm.js options (palette, font stack, size). Both the
+// Terminal appearance: the single place that turns the signed-in user's
+// effective `terminal.*` preferences into concrete xterm.js options. Both the
 // live terminal (`AgentTerminal.vue`) and the settings preview
 // (`AppearancePanel.vue`) resolve through here, so what the preview shows is
 // exactly what a real terminal renders.
 
 import type { ITheme } from '@xterm/xterm';
 import { get } from '../api';
-import type { SettingsEnvelope, SettingView } from '../types';
+import type { UserPreferencesEnvelope } from '../types';
 
-// Terminal palettes, selected by the `terminal.theme` setting. The dark palette
+// Terminal palettes, selected by the `terminal.theme` preference. The dark palette
 // keeps xterm's own ANSI colours (they already assume a dark terminal) but sits
 // on the UI's recessed-panel tone rather than pure black, so the pane reads as
 // part of the workbench instead of a hole in it. The light palette (Solarized
@@ -46,7 +46,7 @@ export function themeFor(name: string | undefined): ITheme {
   return name === 'light' ? LIGHT_THEME : DARK_THEME;
 }
 
-// Font tokens the `terminal.font` setting stores, mapped to concrete stacks. The
+// Font tokens the `terminal.font` preference stores, mapped to concrete stacks. The
 // bundled faces (imported in main.ts) lead their stack; the platform monospace
 // stack is the last-resort fallback and the whole of the `system` choice.
 export type FontToken = 'plex' | 'jetbrains' | 'system';
@@ -92,13 +92,15 @@ export interface TerminalConfig {
   fontSize: number;
 }
 
-function valueOf(settings: SettingView[], key: string, fallback: string): string {
+type TerminalSetting = { key: string; value: string };
+
+function valueOf(settings: TerminalSetting[], key: string, fallback: string): string {
   return settings.find((s) => s.key === key)?.value?.trim() || fallback;
 }
 
-// Turn a settings snapshot into resolved xterm options. Pure — pass live
-// `/settings` values or in-flight drafts; the preview uses the same path.
-export function resolveTerminalConfig(settings: SettingView[]): TerminalConfig {
+// Turn a preference snapshot into resolved xterm options. Pure — the preview
+// uses the same path as live terminals.
+export function resolveTerminalConfig(settings: TerminalSetting[]): TerminalConfig {
   const themeToken = valueOf(settings, 'terminal.theme', DEFAULT_THEME);
   const fontToken = valueOf(settings, 'terminal.font', DEFAULT_FONT);
   const fontSize = clampFontSize(
@@ -113,20 +115,18 @@ export function resolveTerminalConfig(settings: SettingView[]): TerminalConfig {
   };
 }
 
-// The dark, default-everything config — the safe fallback when `/settings` is
+// The dark, default-everything config — the safe fallback when `/preferences` is
 // slow or unreachable, and the base a live terminal opens with before the fetch
 // lands.
 export function defaultTerminalConfig(): TerminalConfig {
   return resolveTerminalConfig([]);
 }
 
-// Best-effort fetch + resolve of the configured terminal appearance. Any
-// failure (offline, a stale server missing the keys) falls back to the dark
-// defaults.
+// Best-effort fetch + resolve of the signed-in user's terminal preferences.
 export async function fetchTerminalConfig(): Promise<TerminalConfig> {
   try {
-    const res = (await get('/settings')) as SettingsEnvelope;
-    return resolveTerminalConfig(res.settings);
+    const res = (await get('/preferences')) as UserPreferencesEnvelope;
+    return resolveTerminalConfig(res.preferences);
   } catch {
     return defaultTerminalConfig();
   }

--- a/crates/loom/frontend/src/main.ts
+++ b/crates/loom/frontend/src/main.ts
@@ -56,7 +56,7 @@ const router = createRouter({
     { path: '/channels/:id', component: Channels, props: true, meta: { title: 'Channels' } },
     { path: '/watches', component: Watches, meta: { title: 'Watches' } },
     { path: '/watches/:id', component: Watches, props: true, meta: { title: 'Watches' } },
-    { path: '/shell', component: Shell, meta: { title: 'Shell' } },
+    { path: '/shell', component: Shell, meta: { title: 'Shell', admin: true } },
     { path: '/settings', component: Settings, meta: { title: 'Settings' } },
   ],
 });
@@ -68,9 +68,11 @@ router.beforeEach(async (to) => {
     return { path: '/sessions/new' };
   }
   if (to.meta.public) return true;
-  if (me.authenticated) return true;
-  if (await loadMe()) return true;
-  return { path: '/login', query: to.fullPath === '/' ? {} : { redirect: to.fullPath } };
+  if (!me.authenticated && !(await loadMe())) {
+    return { path: '/login', query: to.fullPath === '/' ? {} : { redirect: to.fullPath } };
+  }
+  if (to.meta.admin && me.role !== 'admin') return { path: '/' };
+  return true;
 });
 
 // A 401 mid-session (an expired cookie) flips us back to the login screen.

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -1214,7 +1214,24 @@ export interface SettingsEnvelope {
   settings: SettingView[];
 }
 
+export interface UserPreferenceView {
+  key: string;
+  label: string;
+  description: string;
+  kind: SettingKind;
+  options: string[];
+  value: string;
+  inherited_value: string;
+  is_overridden: boolean;
+}
+
+export interface UserPreferencesEnvelope {
+  preferences: UserPreferenceView[];
+}
+
 // --- Authentication --------------------------------------------------------
+
+export type UserRole = 'admin' | 'user';
 
 /** Which sign-in methods the login screen should offer. Mirrors weaver-api's
  *  `AuthMethods`. */
@@ -1231,6 +1248,7 @@ export interface Me {
   github_login: string | null;
   /** How they authenticated: `loopback` | `token` | `session` | null. */
   via: string | null;
+  role: UserRole | null;
   methods: AuthMethods;
 }
 
@@ -1255,6 +1273,7 @@ export interface User {
   username: string;
   github_login: string | null;
   has_password: boolean;
+  role: UserRole;
   created_at: string;
 }
 

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -15,81 +15,93 @@ import McpPanel from '../components/McpPanel.vue';
 import CustomAgentsPanel from '../components/CustomAgentsPanel.vue';
 import AppearancePanel from '../components/AppearancePanel.vue';
 import SettingFieldRow from '../components/SettingFieldRow.vue';
+import UsersPanel from '../components/UsersPanel.vue';
+import { me } from '../auth';
 
 const route = useRoute();
 const router = useRouter();
 
 type Category =
+  | 'account'
+  | 'preferences'
+  | 'diagnostics'
+  | 'people'
   | 'agents'
-  | 'sessions'
-  | 'github'
-  | 'watches'
-  | 'workspace'
-  | 'environment'
-  | 'access'
-  | 'diagnostics';
+  | 'integrations'
+  | 'runtime'
+  | 'automation';
+
+type CategoryScope = 'personal' | 'user' | 'admin';
 
 interface CategoryItem {
   id: Category;
   label: string;
   groups?: string[];
   summary: string;
+  scope: CategoryScope;
 }
 
 const categories: CategoryItem[] = [
   {
-    id: 'agents',
-    label: 'Agents',
-    groups: ['Agents', 'Metadata'],
-    summary: 'Launch profiles, MCP capabilities, custom agents, and bounded metadata assistance.',
+    id: 'account',
+    label: 'Account',
+    summary: 'Your identity, password, personal GitHub credential, and API tokens.',
+    scope: 'personal',
   },
   {
-    id: 'sessions',
-    label: 'Sessions',
-    groups: ['Server', 'Sessions'],
-    summary: 'Server recovery, launch-time behavior, setup budgets, and conversation logs.',
-  },
-  {
-    id: 'github',
-    label: 'Connections',
-    groups: ['GitHub', 'Slack'],
-    summary:
-      'Deployment-owned GitHub and Slack integrations, trigger behavior, and connection state.',
-  },
-  {
-    id: 'watches',
-    label: 'Watches',
-    groups: ['Watch'],
-    summary: 'Fleet watcher defaults and engine-level safety controls.',
-  },
-  {
-    id: 'workspace',
-    label: 'Workspace',
-    groups: ['Editor'],
-    summary: 'Embedded editor behavior plus terminal appearance and typography.',
-  },
-  {
-    id: 'environment',
-    label: 'Session environment',
-    summary:
-      'Readable, non-secret environment variables exported into future default-profile sessions.',
-  },
-  {
-    id: 'access',
-    label: 'Access',
-    groups: ['Authentication'],
-    summary: 'Personal identity, approved users, browser authentication, and API tokens.',
+    id: 'preferences',
+    label: 'Preferences',
+    summary: 'Your terminal appearance, with deployment defaults available at any time.',
+    scope: 'personal',
   },
   {
     id: 'diagnostics',
     label: 'Diagnostics',
+    summary: 'Background tasks, server logs, and build status for debugging this deployment.',
+    scope: 'user',
+  },
+  {
+    id: 'people',
+    label: 'People & security',
+    groups: ['Authentication'],
+    summary: 'Approved users, roles, sign-in policy, and deployment authentication.',
+    scope: 'admin',
+  },
+  {
+    id: 'agents',
+    label: 'Agents & profiles',
+    groups: ['Agents', 'Metadata'],
     summary:
-      'Background tasks, live server logs, and build status for debugging this loom deployment.',
+      'Launch profiles, shared session environment, MCP capabilities, custom agents, and metadata assistance.',
+    scope: 'admin',
+  },
+  {
+    id: 'integrations',
+    label: 'Integrations',
+    groups: ['GitHub', 'Slack'],
+    summary: 'Deployment-owned GitHub and Slack connections and trigger behavior.',
+    scope: 'admin',
+  },
+  {
+    id: 'runtime',
+    label: 'Runtime',
+    groups: ['Server', 'Sessions', 'Editor', 'Appearance'],
+    summary:
+      'Server recovery, session launch behavior, setup budgets, editor defaults, and inherited terminal defaults.',
+    scope: 'admin',
+  },
+  {
+    id: 'automation',
+    label: 'Automation',
+    groups: ['Watch', 'Automation'],
+    summary: 'Watcher defaults, automation credentials, and engine-level safety controls.',
+    scope: 'admin',
   },
 ];
 
 function categoryFromQuery(q: unknown): Category {
-  return categories.some((item) => item.id === q) ? (q as Category) : 'agents';
+  const match = categories.find((item) => item.id === q);
+  return match && (match.scope !== 'admin' || me.role === 'admin') ? match.id : 'account';
 }
 
 const category = ref<Category>(categoryFromQuery(route.query.tab));
@@ -104,17 +116,39 @@ const busy = ref('');
 const currentCategory = computed(
   () => categories.find((item) => item.id === category.value) ?? categories[0],
 );
+const personalCategories = computed(() => categories.filter((item) => item.scope === 'personal'));
+const userCategories = computed(() => categories.filter((item) => item.scope === 'user'));
+const adminCategories = computed(() =>
+  me.role === 'admin' ? categories.filter((item) => item.scope === 'admin') : [],
+);
 
 watch(
   () => route.query.tab,
   (q) => (category.value = categoryFromQuery(q)),
 );
 
+watch(
+  () => me.role,
+  () => {
+    const next = categoryFromQuery(route.query.tab);
+    category.value = next;
+    if (next === 'account' && route.query.tab) {
+      router.replace({ query: { ...route.query, tab: undefined } });
+    }
+  },
+);
+
 function setCategory(next: Category) {
   category.value = next;
   router.replace({
-    query: { ...route.query, tab: next === 'agents' ? undefined : next },
+    query: { ...route.query, tab: next === 'account' ? undefined : next },
   });
+}
+
+function scopeLabel(scope: CategoryScope): string {
+  if (scope === 'admin') return 'Administration';
+  if (scope === 'user') return 'All users';
+  return 'Personal';
 }
 
 const groupedSettings = computed(() => {
@@ -262,7 +296,14 @@ function durationOptions(s: SettingView): { label: string; value: string }[] {
   ];
 }
 
-onMounted(load);
+onMounted(() => {
+  const next = categoryFromQuery(route.query.tab);
+  category.value = next;
+  if (next === 'account' && route.query.tab && route.query.tab !== 'account') {
+    router.replace({ query: { ...route.query, tab: undefined } });
+  }
+  load();
+});
 </script>
 
 <template>
@@ -275,59 +316,67 @@ onMounted(load);
 
     <div class="grid min-h-0 flex-1 gap-4 lg:grid-cols-[13rem_minmax(0,58rem)]">
       <aside class="min-w-0">
-        <div class="overflow-hidden rounded-md border border-line bg-surface">
-          <button
-            v-for="item in categories"
-            :key="item.id"
-            type="button"
-            :data-testid="
-              item.id === 'environment'
-                ? 'settings-tab-env'
-                : item.id === 'access'
-                  ? 'settings-tab-access'
-                  : `settings-category-${item.id}`
-            "
-            class="flex w-full items-center gap-2 border-b border-line border-l-2 px-3 py-2 text-left text-sm last:border-b-0"
-            :class="
-              category === item.id
-                ? 'border-l-accent bg-input font-medium text-fg'
-                : 'border-l-transparent text-muted hover:bg-subtle hover:text-fg'
-            "
-            @click="setCategory(item.id)"
-          >
-            {{ item.label }}
-          </button>
-        </div>
+        <template
+          v-for="section in [
+            { label: 'Personal', items: personalCategories },
+            { label: 'Operations', items: userCategories },
+            { label: 'Administration', items: adminCategories },
+          ]"
+          :key="section.label"
+        >
+          <div v-if="section.items.length" class="mb-4">
+            <p class="mb-1 px-1 text-2xs font-semibold uppercase tracking-wider text-faint">
+              {{ section.label }}
+            </p>
+            <div class="overflow-hidden rounded-md border border-line bg-surface">
+              <button
+                v-for="item in section.items"
+                :key="item.id"
+                type="button"
+                :data-testid="`settings-category-${item.id}`"
+                class="flex w-full items-center gap-2 border-b border-line border-l-2 px-3 py-2 text-left text-sm last:border-b-0"
+                :class="
+                  category === item.id
+                    ? 'border-l-accent bg-input font-medium text-fg'
+                    : 'border-l-transparent text-muted hover:bg-subtle hover:text-fg'
+                "
+                @click="setCategory(item.id)"
+              >
+                {{ item.label }}
+              </button>
+            </div>
+          </div>
+        </template>
       </aside>
 
       <main class="min-w-0">
         <header class="mb-3 border-b border-line pb-2">
           <div class="flex items-center gap-2">
             <h2 class="text-base font-semibold tracking-tight">{{ currentCategory.label }}</h2>
-            <span
-              v-if="currentCategory.groups?.length"
-              class="rounded bg-input px-1.5 py-0.5 font-mono text-2xs text-faint"
-            >
-              {{ currentCategory.groups?.join(' + ') }}
+            <span class="rounded bg-input px-1.5 py-0.5 text-2xs text-faint">
+              {{ scopeLabel(currentCategory.scope) }}
             </span>
           </div>
           <p class="mt-0.5 text-xs text-muted">{{ currentCategory.summary }}</p>
         </header>
 
-        <EnvPanel v-if="category === 'environment'" />
-        <LogsPanel v-else-if="category === 'diagnostics'" />
+        <LogsPanel v-if="category === 'diagnostics'" />
 
         <div v-else class="space-y-3">
           <template v-if="category === 'agents'">
             <ProfilesPanel :key="profilesKey" />
+            <EnvPanel />
             <McpPanel />
             <CustomAgentsPanel :agents="customAgents" @reload="reloadAgents" />
           </template>
-          <AccountPanel v-if="category === 'access'" />
-          <GithubConnectionPanel v-if="category === 'github'" />
-          <TokensPanel v-if="category === 'access'" />
-          <AppearancePanel v-if="category === 'workspace'" />
-          <SlackPanel v-if="category === 'github'" />
+          <template v-if="category === 'account'">
+            <AccountPanel />
+            <TokensPanel />
+          </template>
+          <AppearancePanel v-if="category === 'preferences'" />
+          <UsersPanel v-if="category === 'people'" />
+          <GithubConnectionPanel v-if="category === 'integrations'" />
+          <SlackPanel v-if="category === 'integrations'" />
 
           <section
             v-if="currentSettings.length"
@@ -414,9 +463,7 @@ onMounted(load);
           </section>
 
           <p
-            v-if="
-              !currentSettings.length && !error && category !== 'access' && category !== 'workspace'
-            "
+            v-if="currentCategory.groups?.length && !currentSettings.length && !error"
             class="text-sm text-muted"
           >
             Loading…

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -127,16 +127,15 @@ watch(
   (q) => (category.value = categoryFromQuery(q)),
 );
 
-watch(
-  () => me.role,
-  () => {
-    const next = categoryFromQuery(route.query.tab);
-    category.value = next;
-    if (next === 'account' && route.query.tab) {
-      router.replace({ query: { ...route.query, tab: undefined } });
-    }
-  },
-);
+function syncCategoryAccess() {
+  const next = categoryFromQuery(route.query.tab);
+  category.value = next;
+  if (next === 'account' && route.query.tab) {
+    router.replace({ query: { ...route.query, tab: undefined } });
+  }
+}
+
+watch(() => me.role, syncCategoryAccess);
 
 function setCategory(next: Category) {
   category.value = next;
@@ -297,11 +296,7 @@ function durationOptions(s: SettingView): { label: string; value: string }[] {
 }
 
 onMounted(() => {
-  const next = categoryFromQuery(route.query.tab);
-  category.value = next;
-  if (next === 'account' && route.query.tab && route.query.tab !== 'account') {
-    router.replace({ query: { ...route.query, tab: undefined } });
-  }
+  syncCategoryAccess();
   load();
 });
 </script>

--- a/crates/loom/frontend/src/views/Settings.vue
+++ b/crates/loom/frontend/src/views/Settings.vue
@@ -6,6 +6,7 @@ import type { CustomAgent, SettingsEnvelope, SettingView } from '../types';
 import ToggleSwitch from '../components/ToggleSwitch.vue';
 import TokensPanel from '../components/TokensPanel.vue';
 import AccountPanel from '../components/AccountPanel.vue';
+import GithubConnectionPanel from '../components/GithubConnectionPanel.vue';
 import SlackPanel from '../components/SlackPanel.vue';
 import EnvPanel from '../components/EnvPanel.vue';
 import LogsPanel from '../components/LogsPanel.vue';
@@ -53,8 +54,7 @@ const categories: CategoryItem[] = [
     label: 'Connections',
     groups: ['GitHub', 'Slack'],
     summary:
-      'GitHub and Slack integrations: PR polling, merge archiving, issue-comment and ' +
-      '`/marinbot` launch triggers, and their connection state.',
+      'Deployment-owned GitHub and Slack integrations, trigger behavior, and connection state.',
   },
   {
     id: 'watches',
@@ -70,14 +70,15 @@ const categories: CategoryItem[] = [
   },
   {
     id: 'environment',
-    label: 'Environment',
-    summary: 'Readable environment variables exported into future default-profile sessions.',
+    label: 'Session environment',
+    summary:
+      'Readable, non-secret environment variables exported into future default-profile sessions.',
   },
   {
     id: 'access',
     label: 'Access',
     groups: ['Authentication'],
-    summary: 'Identity, approved users, browser authentication, GitHub App, and API tokens.',
+    summary: 'Personal identity, approved users, browser authentication, and API tokens.',
   },
   {
     id: 'diagnostics',
@@ -323,6 +324,7 @@ onMounted(load);
             <CustomAgentsPanel :agents="customAgents" @reload="reloadAgents" />
           </template>
           <AccountPanel v-if="category === 'access'" />
+          <GithubConnectionPanel v-if="category === 'github'" />
           <TokensPanel v-if="category === 'access'" />
           <AppearancePanel v-if="category === 'workspace'" />
           <SlackPanel v-if="category === 'github'" />

--- a/crates/loom/frontend/src/views/Watches.vue
+++ b/crates/loom/frontend/src/views/Watches.vue
@@ -44,6 +44,7 @@ import {
   GRANTABLE_CAPABILITIES,
 } from '../lib/watch';
 import { useCommandScope, type Command } from '../lib/commands';
+import { me } from '../auth';
 
 // Named so App.vue's <keep-alive :include> keeps this view warm across nav.
 defineOptions({ name: 'Watches' });
@@ -55,6 +56,7 @@ defineOptions({ name: 'Watches' });
 // every row is a `WatchView`, every control a REST call.
 const props = defineProps<{ id?: string }>();
 const router = useRouter();
+const canManage = computed(() => me.role === 'admin');
 
 const watches = ref<Watch[]>([]);
 const programs = ref<ProgramView[]>([]);
@@ -228,6 +230,7 @@ function adopt(w: Watch) {
 }
 
 async function toggleEnabled(w: Watch) {
+  if (!canManage.value) return;
   busy.value = true;
   error.value = '';
   try {
@@ -240,7 +243,7 @@ async function toggleEnabled(w: Watch) {
 }
 
 async function run(dry: boolean) {
-  if (!selected.value) return;
+  if (!canManage.value || !selected.value) return;
   busy.value = true;
   error.value = '';
   try {
@@ -260,7 +263,7 @@ async function run(dry: boolean) {
 
 async function remove() {
   const w = selected.value;
-  if (!w || isBuiltin(w)) return;
+  if (!canManage.value || !w || isBuiltin(w)) return;
   await confirmAction({
     title: `Delete watch "${w.name}"?`,
     description: 'Its configuration and recorded rounds will be permanently removed.',
@@ -305,6 +308,7 @@ function syncDraft(w: Watch) {
 }
 
 function startEdit() {
+  if (!canManage.value) return;
   if (selected.value) syncDraft(selected.value);
   editing.value = true;
 }
@@ -315,7 +319,7 @@ function cancelEdit() {
 
 async function saveConfig() {
   const w = selected.value;
-  if (!w) return;
+  if (!canManage.value || !w) return;
   busy.value = true;
   error.value = '';
   notice.value = '';
@@ -382,6 +386,7 @@ function resetForm() {
 }
 
 async function openCreate() {
+  if (!canManage.value) return;
   resetForm();
   creatingNew.value = true;
   await nextTick();
@@ -427,7 +432,7 @@ const watchCommands = computed<Command[]>(() => [
     id: 'watches.new',
     label: 'New watch',
     keys: ['n'],
-    enabled: () => !creatingNew.value,
+    enabled: () => canManage.value && !creatingNew.value,
     run: openCreate,
   },
 ]);
@@ -450,7 +455,7 @@ function applyProgramDefaults(programRef: string) {
 }
 
 async function create() {
-  if (!form.name.trim()) return;
+  if (!canManage.value || !form.name.trim()) return;
   creating.value = true;
   error.value = '';
   try {
@@ -567,6 +572,7 @@ onActivated(() => {
         <code>loom watch</code>
       </span>
       <button
+        v-if="canManage"
         type="button"
         data-testid="watch-new"
         class="ml-auto px-2.5 py-1 text-xs font-medium"
@@ -578,6 +584,14 @@ onActivated(() => {
     </div>
 
     <p v-if="error" class="border-b border-line px-5 py-2 text-sm text-block">{{ error }}</p>
+    <p
+      v-if="!canManage"
+      class="border-b border-line bg-surface px-5 py-2 text-xs text-faint"
+      data-testid="watch-readonly"
+    >
+      Watch definitions and runs are managed by administrators. Activity, scripts, and configuration
+      remain visible for debugging.
+    </p>
 
     <div class="flex min-h-0 flex-1">
       <!-- Master: one row per watch. -->
@@ -853,7 +867,7 @@ onActivated(() => {
               >
               <OutcomeBadge :outcome="selected.last_outcome" />
               <div class="ml-auto flex items-center gap-2">
-                <label class="mr-1 flex items-center gap-2 text-xs text-muted">
+                <label v-if="canManage" class="mr-1 flex items-center gap-2 text-xs text-muted">
                   <ToggleSwitch
                     :model-value="selected.enabled"
                     :disabled="busy"
@@ -862,7 +876,11 @@ onActivated(() => {
                   />
                   {{ selected.enabled ? 'Active' : 'Off' }}
                 </label>
+                <span v-else class="mr-1 text-xs text-muted">
+                  {{ selected.enabled ? 'Active' : 'Off' }}
+                </span>
                 <button
+                  v-if="canManage"
                   type="button"
                   data-testid="watch-run"
                   :disabled="busy"
@@ -872,6 +890,7 @@ onActivated(() => {
                   Run now
                 </button>
                 <button
+                  v-if="canManage"
                   type="button"
                   data-testid="watch-dryrun"
                   :disabled="busy"
@@ -1100,7 +1119,7 @@ onActivated(() => {
               <div class="mb-3 flex items-center justify-between">
                 <h3 class="text-2xs font-semibold uppercase tracking-wider text-muted">Config</h3>
                 <button
-                  v-if="!editing"
+                  v-if="canManage && !editing"
                   type="button"
                   data-testid="watch-edit"
                   class="btn-secondary px-2.5 py-1 text-xs font-medium"
@@ -1108,7 +1127,7 @@ onActivated(() => {
                 >
                   Edit
                 </button>
-                <div v-else class="flex gap-2">
+                <div v-else-if="canManage" class="flex gap-2">
                   <button
                     type="button"
                     data-testid="watch-save"
@@ -1250,7 +1269,7 @@ onActivated(() => {
             </section>
 
             <!-- Deletion: custom watches only; builtins re-seed on boot. -->
-            <section v-if="!isBuiltin(selected)" class="mt-5">
+            <section v-if="canManage && !isBuiltin(selected)" class="mt-5">
               <button
                 type="button"
                 data-testid="watch-delete"

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -2639,7 +2639,7 @@ async fn cmd_setup_init() -> Result<()> {
         println!("  '{login}' isn't a valid GitHub login (letters, digits, and hyphens only).");
     };
     if loom::auth::get_user(&db, &owner).await?.is_none() {
-        loom::auth::add_user(&db, &owner, Some(&owner), None)
+        loom::auth::add_user(&db, &owner, Some(&owner), None, loom::auth::UserRole::Admin)
             .await
             .with_context(|| format!("seeding the bootstrap operator '{owner}'"))?;
     }
@@ -3104,15 +3104,21 @@ async fn cmd_setup_github_app(opts: GithubAppOpts) -> Result<()> {
     // live to the running daemon here, and to loom.toml (`LOOM_OWNER_GITHUB`)
     // below for a fresh DB. Their triggers on any repo the App is installed on
     // auto-register it — so an org install needs no separate owner allowlist.
-    // Add more people in Settings → Approved users.
+    // Add more people in Settings → People & security.
     if loom::auth::get_user(&db, owner_login).await?.is_none() {
-        loom::auth::add_user(&db, owner_login, Some(owner_login), None)
-            .await
-            .context("approving the bootstrap operator")?;
+        loom::auth::add_user(
+            &db,
+            owner_login,
+            Some(owner_login),
+            None,
+            loom::auth::UserRole::Admin,
+        )
+        .await
+        .context("approving the bootstrap operator")?;
     }
     println!(
         "Approved '{owner_login}' — they can sign in and trigger sessions. Add more in \
-         Settings → Approved users."
+         Settings → People & security."
     );
 
     let updates: Vec<(&str, &str)> = vec![
@@ -3220,7 +3226,7 @@ async fn cmd_setup_secrets(opts: SecretsOpts) -> Result<()> {
     println!();
     println!(
         "Stored {} on the default profile — future sessions using that profile get them \
-         (Settings → Environment in the web UI, or `GET /api/env`).",
+         (Settings → Agents & profiles in the web UI, or `GET /api/env`).",
         stored.join(", ")
     );
     println!(

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -569,9 +569,15 @@ mod tests {
             ensure_bootstrap_operator(&db).await.is_err(),
             "no operator must refuse boot"
         );
-        crate::auth::add_user(&db, "alice", Some("alice"), None)
-            .await
-            .unwrap();
+        crate::auth::add_user(
+            &db,
+            "alice",
+            Some("alice"),
+            None,
+            crate::auth::UserRole::Admin,
+        )
+        .await
+        .unwrap();
         assert!(
             ensure_bootstrap_operator(&db).await.is_ok(),
             "a seeded operator must allow boot"

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 use sqlx::Row;
 use weaver_api::{
     AddUserReq, AuthMethods, CreateTokenReq, CreatedTokenView, GithubConfigView, LoginReq, MeView,
-    SetGithubConfigReq, SetPasswordReq, TokenView, UserView,
+    SetGithubConfigReq, SetPasswordReq, SetUserRoleReq, TokenView, UserRole, UserView,
 };
 
 use crate::auth::{self, Grant, Principal};
@@ -160,6 +160,7 @@ pub(super) async fn grant_allows(
     }
     match &principal.grant {
         Grant::Admin => true,
+        Grant::User => user_grant_allows(method, path),
         Grant::Automation { subject, .. } => {
             if path == "/runs" || path.starts_with("/runs/") {
                 return true;
@@ -219,6 +220,35 @@ pub(super) async fn grant_allows(
                 )
         }
     }
+}
+
+fn user_grant_allows(method: &axum::http::Method, path: &str) -> bool {
+    if path == "/auth/users"
+        || path.starts_with("/auth/users/")
+        || path == "/auth/github/config"
+        || path == "/auth/automation-token"
+        || path == "/auth/federations"
+        || path.starts_with("/auth/federations/")
+        || path == "/deployment/reconcile"
+        || path == "/shell/terminal"
+        || path == "/shell/restart"
+    {
+        return false;
+    }
+    if matches!(*method, axum::http::Method::GET | axum::http::Method::HEAD) {
+        return true;
+    }
+    !(path == "/settings"
+        || path == "/env"
+        || path.starts_with("/env/")
+        || path == "/profiles"
+        || path.starts_with("/profiles/")
+        || path == "/agents/custom"
+        || path.starts_with("/agents/custom/")
+        || path == "/mcps/custom"
+        || path.starts_with("/mcps/custom/")
+        || path == "/watches"
+        || path.starts_with("/watches/"))
 }
 
 /// Pull the token out of an `Authorization: Bearer <token>` header.
@@ -402,6 +432,7 @@ pub(super) async fn auth_me(
     Json(match principal {
         Some(p) => MeView {
             authenticated: true,
+            role: p.user_role().map(user_role_view),
             username: Some(p.username),
             github_login: p.github_login,
             via: Some(p.via.as_str().to_string()),
@@ -409,6 +440,7 @@ pub(super) async fn auth_me(
         },
         None => MeView {
             authenticated: false,
+            role: None,
             username: None,
             github_login: None,
             via: None,
@@ -534,8 +566,11 @@ fn token_view(info: auth::TokenInfo) -> TokenView {
 }
 
 /// `GET /api/auth/tokens` — the user-managed API tokens.
-pub(super) async fn list_tokens(State(st): State<AppState>) -> ApiResult<Json<Vec<TokenView>>> {
-    let tokens = auth::list_tokens(&st.db).await?;
+pub(super) async fn list_tokens(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+) -> ApiResult<Json<Vec<TokenView>>> {
+    let tokens = auth::list_tokens(&st.db, &principal.username).await?;
     Ok(Json(tokens.into_iter().map(token_view).collect()))
 }
 
@@ -569,10 +604,11 @@ pub(super) async fn create_token(
 /// `DELETE /api/auth/tokens/{id}` — revoke a token.
 pub(super) async fn revoke_token(
     State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
     Path(id): Path<String>,
 ) -> ApiResult<StatusCode> {
-    if auth::revoke_token(&st.db, &id).await? {
-        tracing::info!(id = %id, "api token revoked");
+    if auth::revoke_token(&st.db, &principal.username, &id).await? {
+        tracing::info!(username = %principal.username, id = %id, "api token revoked");
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(AppError::not_found("token"))
@@ -650,7 +686,22 @@ fn user_view(u: auth::User) -> UserView {
         username: u.username,
         github_login: u.github_login,
         has_password,
+        role: user_role_view(u.role),
         created_at: u.created_at,
+    }
+}
+
+fn user_role_view(role: auth::UserRole) -> UserRole {
+    match role {
+        auth::UserRole::Admin => UserRole::Admin,
+        auth::UserRole::User => UserRole::User,
+    }
+}
+
+fn user_role_input(role: UserRole) -> auth::UserRole {
+    match role {
+        UserRole::Admin => auth::UserRole::Admin,
+        UserRole::User => auth::UserRole::User,
     }
 }
 
@@ -687,11 +738,34 @@ pub(super) async fn add_user(
             ));
         }
     }
-    auth::add_user(&st.db, username, github, password)
-        .await
-        .map_err(|e| AppError::bad_request(format!("could not add user: {e}")))?;
+    auth::add_user(
+        &st.db,
+        username,
+        github,
+        password,
+        user_role_input(body.role),
+    )
+    .await
+    .map_err(|e| AppError::bad_request(format!("could not add user: {e}")))?;
     tracing::info!(username, "operator added");
     let user = auth::get_user(&st.db, username)
+        .await?
+        .ok_or_else(|| AppError::not_found("user"))?;
+    Ok(Json(user_view(user)))
+}
+
+/// `PUT /api/auth/users/{username}/role` — update one human role. Existing
+/// cookies and personal tokens observe the change on their next request.
+pub(super) async fn set_user_role(
+    State(st): State<AppState>,
+    Path(username): Path<String>,
+    Json(body): Json<SetUserRoleReq>,
+) -> ApiResult<Json<UserView>> {
+    auth::set_user_role(&st.db, &username, user_role_input(body.role))
+        .await
+        .map_err(|error| AppError::bad_request(error.to_string()))?;
+    tracing::info!(username, role = ?body.role, "user role updated");
+    let user = auth::get_user(&st.db, &username)
         .await?
         .ok_or_else(|| AppError::not_found("user"))?;
     Ok(Json(user_view(user)))

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -95,7 +95,7 @@ fn run_identity(
     requested_profile: &str,
 ) -> ApiResult<(String, Vec<String>)> {
     match &principal.grant {
-        Grant::Admin => Ok((
+        Grant::Admin | Grant::User => Ok((
             principal.username.clone(),
             vec![requested_profile.to_string()],
         )),
@@ -492,7 +492,7 @@ pub(super) async fn list_runs(
     Extension(principal): Extension<Principal>,
 ) -> ApiResult<Json<Vec<RunView>>> {
     let subject = match &principal.grant {
-        Grant::Admin => None,
+        Grant::Admin | Grant::User => None,
         Grant::Automation { subject, .. } => Some(subject.as_str()),
         Grant::Session { .. } => {
             return Err(AppError::new(StatusCode::FORBIDDEN, "run access forbidden"))

--- a/crates/loom/src/web/channels.rs
+++ b/crates/loom/src/web/channels.rs
@@ -40,7 +40,7 @@ pub(super) fn principal_subject(principal: &Principal) -> Subject {
     match &principal.grant {
         Grant::Session { session_id, .. } => Subject::new(SubjectKind::Session, session_id),
         Grant::Automation { subject, .. } => Subject::new(SubjectKind::Automation, subject),
-        Grant::Admin => Subject::new(SubjectKind::User, &principal.username),
+        Grant::Admin | Grant::User => Subject::new(SubjectKind::User, &principal.username),
     }
 }
 
@@ -413,7 +413,7 @@ pub(super) async fn set_channel_subscription(
                         "a session may subscribe only itself or a descendant",
                     ));
                 }
-            } else if !principal.is_admin() {
+            } else if !principal.is_human() {
                 return Err(AppError::new(
                     StatusCode::FORBIDDEN,
                     "credential may not subscribe another session",
@@ -460,7 +460,7 @@ pub(super) async fn archive_channel(
         ));
     }
     let subject = principal_subject(&principal);
-    if !principal.is_admin()
+    if !principal.is_human()
         && (channel.created_by_kind != subject.kind.as_str() || channel.created_by != subject.id)
     {
         return Err(AppError::new(

--- a/crates/loom/src/web/diagnostics.rs
+++ b/crates/loom/src/web/diagnostics.rs
@@ -1,4 +1,4 @@
-//! Operational health, Prometheus metrics, and the admin diagnostics snapshot.
+//! Operational health, Prometheus metrics, and the authenticated diagnostics snapshot.
 //!
 //! Everything here is derived from durable control-plane state. Labels are
 //! restricted to bounded operational dimensions; identities, paths, branch and
@@ -427,8 +427,8 @@ pub(super) async fn diagnostics(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,
 ) -> ApiResult<Json<DiagnosticsView>> {
-    if !principal.is_admin() {
-        return Err(AppError::new(StatusCode::FORBIDDEN, "admin grant required"));
+    if !principal.is_human() {
+        return Err(AppError::new(StatusCode::FORBIDDEN, "human grant required"));
     }
     Ok(Json(snapshot(&st.db).await?))
 }
@@ -616,7 +616,7 @@ async fn render_metrics(db: &Db, view: &DiagnosticsView) -> Result<String> {
 }
 
 /// Public scrape surface. It contains aggregates only; the richer inventory is
-/// admin-gated at `/api/diagnostics`.
+/// human-gated at `/api/diagnostics`.
 pub(super) async fn metrics(State(st): State<AppState>) -> Response {
     match metric_snapshot(&st.db).await {
         Ok(view) => match render_metrics(&st.db, &view).await {

--- a/crates/loom/src/web/eventmux.rs
+++ b/crates/loom/src/web/eventmux.rs
@@ -175,7 +175,10 @@ pub(super) async fn events_mux(
                 format!("credential grant forbids topic '{name}'"),
             ));
         }
-        streams.insert(name.to_string(), topic_stream(&st, name, topic).await);
+        streams.insert(
+            name.to_string(),
+            topic_stream(&st, &principal, name, topic).await?,
+        );
     }
 
     // Never let the merged stream terminate: an SSE response that ends puts the
@@ -189,9 +192,14 @@ pub(super) async fn events_mux(
 }
 
 /// Build one topic's stream, already framed with its topic name.
-async fn topic_stream(st: &AppState, name: &str, topic: Topic) -> TopicStream {
+async fn topic_stream(
+    st: &AppState,
+    principal: &Principal,
+    name: &str,
+    topic: Topic,
+) -> ApiResult<TopicStream> {
     let owned = name.to_string();
-    match topic {
+    let stream: TopicStream = match topic {
         Topic::Layout => {
             let stream = BroadcastStream::new(st.bus.subscribe()).filter_map(move |result| {
                 let event = result.ok()?;
@@ -203,11 +211,12 @@ async fn topic_stream(st: &AppState, name: &str, topic: Topic) -> TopicStream {
             Box::pin(stream)
         }
         Topic::Logs => {
+            let redactor = super::logview::log_redactor(&st.db, principal).await?;
             let stream =
                 BroadcastStream::new(logs::buffer().subscribe()).filter_map(move |result| {
                     // A lagged subscriber yields Err; skip the gap (the client can
                     // re-snapshot).
-                    let line = result.ok()?;
+                    let line = super::logview::redact_line(&redactor, result.ok()?);
                     Some(frame(&owned, "log", json!(line)))
                 });
             Box::pin(stream)
@@ -215,7 +224,7 @@ async fn topic_stream(st: &AppState, name: &str, topic: Topic) -> TopicStream {
         Topic::Session(key) => {
             let branch = match require_branch(&st.db, &key).await {
                 Ok(branch) => branch,
-                Err(e) => return unresolved(&owned, &e),
+                Err(e) => return Ok(unresolved(&owned, &e)),
             };
             let id = branch.id;
             let stream = BroadcastStream::new(st.bus.subscribe()).filter_map(move |result| {
@@ -231,7 +240,7 @@ async fn topic_stream(st: &AppState, name: &str, topic: Topic) -> TopicStream {
         Topic::Chat(key) => {
             let session = match require_session(&st.db, &key).await {
                 Ok((session, _)) => session,
-                Err(e) => return unresolved(&owned, &e),
+                Err(e) => return Ok(unresolved(&owned, &e)),
             };
             match st.acp.get(&session.id) {
                 Some(handle) => {
@@ -245,7 +254,8 @@ async fn topic_stream(st: &AppState, name: &str, topic: Topic) -> TopicStream {
                 None => Box::pin(tokio_stream::pending()),
             }
         }
-    }
+    };
+    Ok(stream)
 }
 
 /// A topic that could not be resolved reports one `error` frame and then goes

--- a/crates/loom/src/web/logview.rs
+++ b/crates/loom/src/web/logview.rs
@@ -1,20 +1,24 @@
-//! Operator-facing server-log endpoints: a snapshot of recent log lines and a
+//! Human-facing server-log endpoints: a snapshot of recent log lines and a
 //! live SSE tail, backed by the in-process ring buffer ([`crate::logs`]). These
-//! sit in the authenticated router, so only an approved operator can read them —
-//! server logs can carry tokens injected into agents. See docs/loom-ui or the
-//! Settings → Logs panel.
+//! sit in the authenticated router. Admins see the operator log verbatim; user
+//! roles receive the same diagnostic stream with known and token-shaped secrets
+//! redacted. See docs/loom-ui or Settings → Diagnostics.
 
 use std::convert::Infallible;
 
-use axum::extract::Query;
+use axum::extract::{Query, State};
 use axum::response::sse::{self, KeepAlive, Sse};
-use axum::Json;
+use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
 
-use crate::logs::{self, LogLine};
+use crate::auth::Principal;
+use crate::db::Db;
+use crate::logs::{self, LogLine, LogRedactor};
 use crate::tasks::{self, TaskRecord};
+
+use super::{ApiResult, AppState};
 
 #[derive(Debug, Deserialize)]
 pub(super) struct LogsQuery {
@@ -24,24 +28,104 @@ pub(super) struct LogsQuery {
 
 /// `GET /api/logs` — a snapshot of the most recent server log lines, oldest
 /// first. The UI loads this once, then follows [`logs_stream`] for new lines.
-pub(super) async fn logs_snapshot(Query(q): Query<LogsQuery>) -> Json<Vec<LogLine>> {
+pub(super) async fn logs_snapshot(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Query(q): Query<LogsQuery>,
+) -> ApiResult<Json<Vec<LogLine>>> {
     let limit = q.limit.unwrap_or(500).clamp(1, 2000);
-    Json(logs::buffer().snapshot(limit))
+    let redactor = log_redactor(&st.db, &principal).await?;
+    let lines = logs::buffer()
+        .snapshot(limit)
+        .into_iter()
+        .map(|line| redact_line(&redactor, line))
+        .collect();
+    Ok(Json(lines))
 }
 
 /// `GET /api/logs/stream` — server log lines as they are emitted (SSE). The
 /// browser authenticates with the `loom_session` cookie (EventSource can't set
 /// headers), exactly like the session-events stream.
-pub(super) async fn logs_stream() -> Sse<impl Stream<Item = Result<sse::Event, Infallible>>> {
-    let stream = BroadcastStream::new(logs::buffer().subscribe()).filter_map(|result| {
+pub(super) async fn logs_stream(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+) -> ApiResult<Sse<impl Stream<Item = Result<sse::Event, Infallible>>>> {
+    let redactor = log_redactor(&st.db, &principal).await?;
+    let stream = BroadcastStream::new(logs::buffer().subscribe()).filter_map(move |result| {
         // A lagged subscriber yields Err; skip the gap (the client can re-snapshot).
-        let line = result.ok()?;
+        let line = redact_line(&redactor, result.ok()?);
         Some(Ok(sse::Event::default()
             .event("log")
             .json_data(&line)
             .unwrap_or_default()))
     });
-    Sse::new(stream).keep_alive(KeepAlive::default())
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+pub(super) async fn log_redactor(db: &Db, principal: &Principal) -> ApiResult<Option<LogRedactor>> {
+    if principal.is_admin() {
+        return Ok(None);
+    }
+
+    let mut secrets: Vec<String> = sqlx::query_scalar("SELECT token FROM user_github_tokens")
+        .fetch_all(db)
+        .await?;
+    secrets.extend(
+        sqlx::query_scalar::<_, String>("SELECT value FROM repo_env")
+            .fetch_all(db)
+            .await?,
+    );
+    secrets.extend(
+        sqlx::query_scalar::<_, String>(
+            "SELECT value FROM profile_env
+             WHERE instr(upper(name), 'TOKEN') > 0
+                OR instr(upper(name), 'SECRET') > 0
+                OR instr(upper(name), 'PASSWORD') > 0
+                OR instr(upper(name), 'API_KEY') > 0
+                OR instr(upper(name), 'PRIVATE_KEY') > 0",
+        )
+        .fetch_all(db)
+        .await?,
+    );
+    secrets.extend(
+        sqlx::query_scalar::<_, String>(
+            "SELECT value FROM settings
+             WHERE instr(lower(key), 'token') > 0
+                OR instr(lower(key), 'secret') > 0
+                OR instr(lower(key), 'password') > 0
+                OR instr(lower(key), 'private_key') > 0
+                OR instr(lower(key), 'api_key') > 0
+             UNION ALL
+             SELECT value FROM deployment_settings
+             WHERE instr(lower(key), 'token') > 0
+                OR instr(lower(key), 'secret') > 0
+                OR instr(lower(key), 'password') > 0
+                OR instr(lower(key), 'private_key') > 0
+                OR instr(lower(key), 'api_key') > 0",
+        )
+        .fetch_all(db)
+        .await?,
+    );
+    secrets.extend(
+        std::env::vars()
+            .filter(|(name, _)| secret_environment_name(name))
+            .map(|(_, value)| value),
+    );
+    Ok(Some(LogRedactor::new(secrets)))
+}
+
+pub(super) fn redact_line(redactor: &Option<LogRedactor>, line: LogLine) -> LogLine {
+    match redactor {
+        Some(redactor) => redactor.redact(line),
+        None => line,
+    }
+}
+
+fn secret_environment_name(name: &str) -> bool {
+    let name = name.to_ascii_uppercase();
+    ["TOKEN", "SECRET", "PASSWORD", "PRIVATE_KEY", "API_KEY"]
+        .iter()
+        .any(|marker| name.contains(marker))
 }
 
 /// A small "what am I looking at" status blob for the debug panel: build and
@@ -59,7 +143,7 @@ pub(super) struct ServerStatus {
     started_at: String,
 }
 
-/// `GET /api/status` — build and process identity (operator-only).
+/// `GET /api/status` — build and process identity for human users.
 pub(super) async fn server_status() -> Json<ServerStatus> {
     Json(ServerStatus {
         version: env!("CARGO_PKG_VERSION"),
@@ -75,8 +159,8 @@ pub(super) async fn server_status() -> Json<ServerStatus> {
 }
 
 /// `GET /api/tasks` — recent detached background tasks (the GitHub-trigger
-/// launches that run off the webhook request), newest first. Operator-only, same
-/// as the log endpoints — a task label names a repo/issue an operator can act on.
+/// launches that run off the webhook request), newest first. Human-only, same as
+/// the log endpoints — a task label names a repo/issue a user can act on.
 pub(super) async fn tasks_snapshot() -> Json<Vec<TaskRecord>> {
     Json(tasks::registry().snapshot())
 }

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -19,7 +19,7 @@
 //! * `/api/issues/actions` — validate and atomically mutate a set of issues.
 //! * `/api/health` + `/api/health/live` are process-level liveness;
 //!   `/api/ready` checks the database and migration streams; `/metrics` exposes
-//!   bounded-label OpenMetrics; `/api/diagnostics` is the admin inventory.
+//!   bounded-label OpenMetrics; `/api/diagnostics` is the human-readable inventory.
 //! * `/api/repos/recent`, `/api/repos/branches`, `/api/settings` — unchanged.
 //!
 //! The `/api/hook` endpoint that used to exist is gone — agent hooks now go
@@ -1017,6 +1017,10 @@ pub fn router(state: AppState) -> Router {
             axum::routing::put(put_repo_env).delete(delete_repo_env),
         )
         .route("/settings", get(get_settings).patch(patch_settings))
+        .route(
+            "/preferences",
+            get(get_preferences).patch(patch_preferences),
+        )
         .route("/deployment/reconcile", post(reconcile_deployment))
         .route("/mcps", get(list_mcps))
         .route(
@@ -1052,9 +1056,9 @@ pub fn router(state: AppState) -> Router {
         // container, for one-time setup like `gcloud auth login`.
         .route("/shell/terminal", get(crate::terminal::shell_ws))
         .route("/shell/restart", post(restart_shell))
-        // Server logs + background tasks (Settings → Debug) — snapshot + live SSE
-        // tail + build status + the detached trigger-task list. Operator-only:
-        // server logs can carry tokens injected into agents.
+        // Server logs + background tasks (Settings → Diagnostics) — snapshot +
+        // live SSE tail + build status + the detached trigger-task list. These
+        // are available to human users for self-service debugging.
         .route("/logs", get(logs_snapshot))
         .route("/logs/stream", get(logs_stream))
         .route("/status", get(server_status))
@@ -1096,6 +1100,10 @@ pub fn router(state: AppState) -> Router {
                 .delete(delete_github_token),
         )
         .route("/auth/users", get(list_users).post(add_user))
+        .route(
+            "/auth/users/{username}/role",
+            axum::routing::put(set_user_role),
+        )
         .route("/auth/users/{username}", delete(remove_user))
         .route(
             "/auth/github/config",

--- a/crates/loom/src/web/reviews.rs
+++ b/crates/loom/src/web/reviews.rs
@@ -28,7 +28,7 @@ pub(super) struct ReviewListQuery {
 }
 
 fn require_operator(principal: &Principal) -> ApiResult<()> {
-    if principal.is_admin() {
+    if principal.is_human() {
         Ok(())
     } else {
         Err(AppError::new(
@@ -296,7 +296,7 @@ async fn list_for(
     // Session-scoped agent grants may inspect submitted compatibility feedback,
     // but never inherit their operator owner's private draft merely because the
     // username is the same.
-    let viewer = if principal.is_admin() {
+    let viewer = if principal.is_human() {
         principal.username.as_str()
     } else {
         ""

--- a/crates/loom/src/web/session_layout.rs
+++ b/crates/loom/src/web/session_layout.rs
@@ -22,13 +22,13 @@ use crate::session_layout::{self, MutationError};
 
 use super::{ApiResult, AppError, AppState};
 
-fn require_admin(principal: &Principal) -> ApiResult<()> {
-    if principal.is_admin() {
+fn require_human(principal: &Principal) -> ApiResult<()> {
+    if principal.is_human() {
         Ok(())
     } else {
         Err(AppError::new(
             StatusCode::FORBIDDEN,
-            "shared session layout requires an admin credential",
+            "shared session layout requires a human credential",
         ))
     }
 }
@@ -57,7 +57,7 @@ pub(super) async fn get_session_layout(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     Ok(Json(
         session_layout::get_layout(&st.db, &principal.username).await?,
     ))
@@ -68,7 +68,7 @@ pub(super) async fn create_session_space(
     Extension(principal): Extension<Principal>,
     Json(req): Json<CreateSessionSpaceReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::create_space(&st.db, &principal.username, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -79,7 +79,7 @@ pub(super) async fn update_session_space(
     Path(id): Path<String>,
     Json(req): Json<UpdateSessionSpaceReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::update_space(&st.db, &principal.username, &id, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -90,7 +90,7 @@ pub(super) async fn delete_session_space(
     Path(id): Path<String>,
     Json(req): Json<DeleteSessionSpaceReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::delete_space(&st.db, &principal.username, &id, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -100,7 +100,7 @@ pub(super) async fn create_session_group(
     Extension(principal): Extension<Principal>,
     Json(req): Json<CreateSessionGroupReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::create_group(&st.db, &principal.username, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -111,7 +111,7 @@ pub(super) async fn update_session_group(
     Path(id): Path<String>,
     Json(req): Json<UpdateSessionGroupReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::update_group(&st.db, &principal.username, &id, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -122,7 +122,7 @@ pub(super) async fn delete_session_group(
     Path(id): Path<String>,
     Json(req): Json<DeleteSessionGroupReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::delete_group(&st.db, &principal.username, &id, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -132,7 +132,7 @@ pub(super) async fn reorder_session_layout(
     Extension(principal): Extension<Principal>,
     Json(req): Json<ReorderSessionLayoutReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::reorder(&st.db, &principal.username, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -142,7 +142,7 @@ pub(super) async fn move_session_layout(
     Extension(principal): Extension<Principal>,
     Json(req): Json<MoveSessionsReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::move_sessions(&st.db, &principal.username, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -152,7 +152,7 @@ pub(super) async fn restore_session_layout(
     Extension(principal): Extension<Principal>,
     Json(req): Json<RestoreSessionGroupsReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::restore_groups(&st.db, &principal.username, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -163,7 +163,7 @@ pub(super) async fn set_session_group_preference(
     Path(id): Path<String>,
     Json(req): Json<SessionGroupPreferenceReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     session_layout::set_preference(&st.db, &principal.username, &id, req.collapsed)
         .await
         .map(Json)
@@ -175,7 +175,7 @@ pub(super) async fn set_session_placement_default(
     Extension(principal): Extension<Principal>,
     Json(req): Json<SetSessionPlacementDefaultReq>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::set_default(&st.db, &principal.username, &req).await;
     mutation_response(&st, &principal.username, result).await
 }
@@ -191,7 +191,7 @@ pub(super) async fn delete_session_placement_default(
     Path((kind, value)): Path<(SessionPlacementSelectorKind, String)>,
     Query(query): Query<DeleteDefaultQuery>,
 ) -> ApiResult<Json<SessionLayoutView>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let result = session_layout::delete_default(
         &st.db,
         &principal.username,
@@ -210,7 +210,7 @@ pub(super) async fn session_layout_events(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,
 ) -> ApiResult<Sse<impl Stream<Item = Result<sse::Event, Infallible>>>> {
-    require_admin(&principal)?;
+    require_human(&principal)?;
     let stream = BroadcastStream::new(st.bus.subscribe()).filter_map(|result| {
         let event = result.ok()?;
         if event.kind != "session_layout" {

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -94,10 +94,10 @@ pub(super) async fn list_sessions(
     Extension(principal): Extension<Principal>,
     Query(q): Query<ListSessionsQuery>,
 ) -> ApiResult<Json<Vec<SessionView>>> {
-    if q.managed && !principal.is_admin() {
+    if q.managed && !principal.is_human() {
         return Err(AppError::new(
             StatusCode::FORBIDDEN,
-            "admin grant required to list managed sessions",
+            "human grant required to list managed sessions",
         ));
     }
     collect_sessions(
@@ -570,7 +570,7 @@ pub(super) async fn create_session(
                 "automation credentials create sessions through /api/runs",
             ));
         }
-        crate::auth::Grant::Admin => {}
+        crate::auth::Grant::Admin | crate::auth::Grant::User => {}
     }
     let created = crate::provision::create(st.clone(), req, actor)
         .await

--- a/crates/loom/src/web/settings.rs
+++ b/crates/loom/src/web/settings.rs
@@ -1,12 +1,16 @@
-use axum::{extract::State, Json};
+use axum::{extract::State, Extension, Json};
 use serde_json::{json, Value};
-use weaver_api::SettingsEnvelope;
+use weaver_api::{SettingsEnvelope, UserPreferenceView, UserPreferencesEnvelope};
 
+use crate::auth::{self, Principal};
 use crate::config;
 use crate::db::Db;
 use crate::profile;
 
 use super::{ApiResult, AppError, AppState};
+
+const PERSONAL_PREFERENCE_KEYS: &[&str] =
+    &["terminal.theme", "terminal.font", "terminal.font_size"];
 
 // ---------------------------------------------------------------------------
 // Settings
@@ -102,6 +106,81 @@ pub(super) async fn patch_settings(
         .collect();
     tracing::info!(keys = ?keys, "settings updated");
     settings_envelope(&st.db).await
+}
+
+async fn preferences_envelope(db: &Db, username: &str) -> ApiResult<Json<UserPreferencesEnvelope>> {
+    let overrides = auth::user_preferences(db, username).await?;
+    let preferences = config::describe(db)
+        .await?
+        .into_iter()
+        .filter(|setting| PERSONAL_PREFERENCE_KEYS.contains(&setting.spec.key))
+        .map(|setting| {
+            let inherited_value = setting.value;
+            let override_value = overrides.get(setting.spec.key);
+            UserPreferenceView {
+                key: setting.spec.key.to_string(),
+                label: setting.spec.label.to_string(),
+                description: setting.spec.description.to_string(),
+                kind: setting.spec.kind.into(),
+                options: setting
+                    .spec
+                    .options
+                    .iter()
+                    .map(|option| (*option).to_string())
+                    .collect(),
+                value: override_value
+                    .cloned()
+                    .unwrap_or_else(|| inherited_value.clone()),
+                inherited_value,
+                is_overridden: override_value.is_some(),
+            }
+        })
+        .collect();
+    Ok(Json(UserPreferencesEnvelope { preferences }))
+}
+
+pub(super) async fn get_preferences(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+) -> ApiResult<Json<UserPreferencesEnvelope>> {
+    preferences_envelope(&st.db, &principal.username).await
+}
+
+pub(super) async fn patch_preferences(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Json(body): Json<serde_json::Map<String, Value>>,
+) -> ApiResult<Json<UserPreferencesEnvelope>> {
+    let mut changes = Vec::with_capacity(body.len());
+    let mut errors = serde_json::Map::new();
+    for (key, raw) in body {
+        if !PERSONAL_PREFERENCE_KEYS.contains(&key.as_str()) {
+            errors.insert(key, json!("unknown personal preference"));
+            continue;
+        }
+        let value = match raw {
+            Value::Null => None,
+            Value::String(value) => Some(value),
+            Value::Number(value) => Some(value.to_string()),
+            _ => {
+                errors.insert(key, json!("value must be a string, number, or null"));
+                continue;
+            }
+        };
+        if let Some(value) = &value {
+            if let Err(reason) = config::validate(&key, value) {
+                errors.insert(key, json!(reason));
+                continue;
+            }
+        }
+        changes.push((key, value));
+    }
+    if !errors.is_empty() {
+        return Err(AppError::bad_request("one or more preferences are invalid")
+            .with_details(Value::Object(errors)));
+    }
+    auth::apply_user_preferences(&st.db, &principal.username, &changes).await?;
+    preferences_envelope(&st.db, &principal.username).await
 }
 
 fn change_for<'a>(changes: &'a [config::Change], key: &str) -> Option<&'a Option<String>> {

--- a/crates/loom/tests/integration/auth.rs
+++ b/crates/loom/tests/integration/auth.rs
@@ -164,6 +164,257 @@ async fn loopback_trust_then_token_local_and_cookie_gate_access() {
 
 #[tokio::test]
 #[serial]
+async fn user_role_keeps_operations_and_diagnostics_but_not_administration() {
+    use futures_util::StreamExt;
+    use tracing_subscriber::prelude::*;
+
+    let ts = TestServer::start_api_only().await;
+    let http = reqwest::Client::new();
+    let added: Value = http
+        .post(url(&ts, "/api/auth/users"))
+        .json(&json!({ "username": "alice", "github_login": "alice-gh" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(added["role"], "user");
+    let (user_token, _) = loom::auth::create_token(&ts.state.db, "alice", "alice-api", None)
+        .await
+        .unwrap();
+    let (admin_token, _) = loom::auth::create_token(&ts.state.db, "rjpower", "admin-api", None)
+        .await
+        .unwrap();
+    ts.client
+        .patch("/api/settings", json!({ "auth.trust_loopback": false }))
+        .await
+        .unwrap();
+
+    let me: Value = http
+        .get(url(&ts, "/api/auth/me"))
+        .bearer_auth(&user_token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(me["role"], "user");
+
+    const LOG_MARKER: &str = "user-redaction-check-6d93";
+    const LOG_SECRET: &str = "opaque-deployment-credential-4c71";
+    loom::profile::env_set(
+        &ts.state.db,
+        loom::profile::DEFAULT_PROFILE,
+        "REDACTION_TEST_TOKEN",
+        LOG_SECRET,
+    )
+    .await
+    .unwrap();
+    let subscriber = tracing_subscriber::registry().with(loom::logs::layer());
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::warn!("{LOG_MARKER} credential={LOG_SECRET}");
+    });
+
+    let user_logs: Value = http
+        .get(url(&ts, "/api/logs"))
+        .bearer_auth(&user_token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let user_log = user_logs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|line| {
+            line["message"]
+                .as_str()
+                .is_some_and(|message| message.contains(LOG_MARKER))
+        })
+        .unwrap();
+    assert!(!user_log["message"].as_str().unwrap().contains(LOG_SECRET));
+
+    let admin_logs: Value = http
+        .get(url(&ts, "/api/logs"))
+        .bearer_auth(&admin_token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let admin_log = admin_logs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|line| {
+            line["message"]
+                .as_str()
+                .is_some_and(|message| message.contains(LOG_MARKER))
+        })
+        .unwrap();
+    assert!(admin_log["message"].as_str().unwrap().contains(LOG_SECRET));
+
+    const STREAM_MARKER: &str = "user-stream-redaction-check-1e52";
+    let stream_response = http
+        .get(url(&ts, "/api/events?topics=logs"))
+        .bearer_auth(&user_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(stream_response.status(), StatusCode::OK);
+    tracing::subscriber::with_default(
+        tracing_subscriber::registry().with(loom::logs::layer()),
+        || tracing::warn!("{STREAM_MARKER} credential={LOG_SECRET}"),
+    );
+    let mut stream = stream_response.bytes_stream();
+    let mut stream_body = String::new();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    while !stream_body.contains(STREAM_MARKER) && tokio::time::Instant::now() < deadline {
+        let remaining = deadline - tokio::time::Instant::now();
+        let Some(chunk) = tokio::time::timeout(remaining, stream.next())
+            .await
+            .unwrap()
+            .transpose()
+            .unwrap()
+        else {
+            break;
+        };
+        stream_body.push_str(&String::from_utf8_lossy(&chunk));
+    }
+    assert!(stream_body.contains(STREAM_MARKER), "{stream_body}");
+    assert!(!stream_body.contains(LOG_SECRET), "{stream_body}");
+
+    for path in [
+        "/api/sessions",
+        "/api/settings",
+        "/api/profiles",
+        "/api/agents",
+        "/api/mcps",
+        "/api/diagnostics",
+        "/api/logs",
+        "/api/status",
+        "/api/tasks",
+        "/api/session-layout",
+        "/api/watches",
+        "/api/watches/programs",
+    ] {
+        let response = http
+            .get(url(&ts, path))
+            .bearer_auth(&user_token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "user GET {path}");
+    }
+
+    let preferences: Value = http
+        .patch(url(&ts, "/api/preferences"))
+        .bearer_auth(&user_token)
+        .json(&json!({ "terminal.theme": "light" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let theme = preferences["preferences"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|preference| preference["key"] == "terminal.theme")
+        .unwrap();
+    assert_eq!(theme["value"], "light");
+    assert_eq!(theme["is_overridden"], true);
+
+    let admin_preferences: Value = http
+        .get(url(&ts, "/api/preferences"))
+        .bearer_auth(&admin_token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let admin_theme = admin_preferences["preferences"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|preference| preference["key"] == "terminal.theme")
+        .unwrap();
+    assert_eq!(admin_theme["value"], "dark");
+    assert_eq!(admin_theme["is_overridden"], false);
+
+    let tokens: Vec<Value> = http
+        .get(url(&ts, "/api/auth/tokens"))
+        .bearer_auth(&user_token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0]["name"], "alice-api");
+
+    let forbidden = [
+        (reqwest::Method::PATCH, "/api/settings"),
+        (reqwest::Method::POST, "/api/deployment/reconcile"),
+        (reqwest::Method::GET, "/api/auth/users"),
+        (reqwest::Method::GET, "/api/auth/github/config"),
+        (reqwest::Method::POST, "/api/auth/automation-token"),
+        (reqwest::Method::GET, "/api/auth/federations"),
+        (reqwest::Method::POST, "/api/profiles"),
+        (reqwest::Method::POST, "/api/agents/custom"),
+        (reqwest::Method::POST, "/api/mcps/custom"),
+        (reqwest::Method::PUT, "/api/env/SHARED_VALUE"),
+        (reqwest::Method::GET, "/api/shell/terminal"),
+        (reqwest::Method::POST, "/api/shell/restart"),
+        (reqwest::Method::POST, "/api/watches"),
+        (reqwest::Method::POST, "/api/watches/status/run"),
+    ];
+    for (method, path) in forbidden {
+        let response = http
+            .request(method, url(&ts, path))
+            .bearer_auth(&user_token)
+            .json(&json!({}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "user request {path}"
+        );
+    }
+
+    let promoted: Value = http
+        .put(url(&ts, "/api/auth/users/alice/role"))
+        .bearer_auth(&admin_token)
+        .json(&json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(promoted["role"], "admin");
+    let response = http
+        .patch(url(&ts, "/api/settings"))
+        .bearer_auth(&user_token)
+        .json(&json!({ "terminal.theme": "light" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+#[serial]
 async fn absurd_token_expiry_is_a_bad_request_not_a_panic() {
     let ts = TestServer::start().await;
     let response = reqwest::Client::new()

--- a/crates/loom/tests/integration/diagnostics.rs
+++ b/crates/loom/tests/integration/diagnostics.rs
@@ -1,4 +1,4 @@
-//! Operational endpoints: public liveness/readiness/metrics and the admin-only,
+//! Operational endpoints: public liveness/readiness/metrics and the human-readable,
 //! redacted diagnostics inventory.
 
 use reqwest::StatusCode;
@@ -65,7 +65,7 @@ async fn seed_operational_state(ts: &TestServer) {
 
 #[tokio::test]
 #[serial]
-async fn diagnostics_are_correct_redacted_and_admin_only() {
+async fn diagnostics_are_correct_redacted_and_human_only() {
     let ts = TestServer::start().await;
     seed_operational_state(&ts).await;
     let http = reqwest::Client::new();

--- a/crates/loom/tests/integration/eventmux.rs
+++ b/crates/loom/tests/integration/eventmux.rs
@@ -220,7 +220,7 @@ async fn session_token_cannot_subscribe_to_another_session() {
         .unwrap();
     assert_eq!(other.status(), StatusCode::FORBIDDEN);
 
-    // Operator-only topics stay operator-only.
+    // Human-only topics stay unavailable to scoped session credentials.
     let logs = http
         .get(events_url(&ts, "logs"))
         .bearer_auth(&token)

--- a/crates/loom/tests/integration/logs.rs
+++ b/crates/loom/tests/integration/logs.rs
@@ -1,7 +1,8 @@
-//! The operator log viewer's HTTP surface: `/api/status`, the `/api/logs`
-//! snapshot, and the `/api/logs/stream` tail. The security-critical property is
-//! that all three are operator-only (server logs can carry secrets), so we prove
-//! the shape while loopback-trusted, then lock loopback down and prove they 401.
+//! The human log viewer's HTTP surface: `/api/status`, the `/api/logs`
+//! snapshot, and the `/api/logs/stream` tail. The security-critical properties
+//! are that all three require a human role and user-role messages are redacted.
+//! This suite proves the HTTP shape and auth boundary; redaction is exercised by
+//! the `loom::logs` unit tests.
 //!
 //! (The ring-buffer *capture* is exercised by the `loom::logs` unit tests and the
 //! e2e suite against the real binary, which is where the tracing layer is
@@ -19,7 +20,7 @@ fn url(ts: &TestServer, path: &str) -> String {
 
 #[tokio::test]
 #[serial]
-async fn status_and_logs_are_shaped_and_operator_only() {
+async fn status_and_logs_are_shaped_and_human_only() {
     let ts = TestServer::start().await;
     let http = reqwest::Client::new();
 

--- a/crates/loom/tests/integration/reviews.rs
+++ b/crates/loom/tests/integration/reviews.rs
@@ -205,7 +205,7 @@ async fn api_and_cli_share_the_private_optimistic_review_contract() {
         "a same-owner session credential must not inherit the operator's draft"
     );
 
-    loom::auth::add_user(&ts.state.db, "bob", None, None)
+    loom::auth::add_user(&ts.state.db, "bob", None, None, loom::auth::UserRole::Admin)
         .await
         .unwrap();
     let (token, _) = loom::auth::create_token(&ts.state.db, "bob", "reviewer", None)

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -928,7 +928,7 @@ async fn rest_watch_lifecycle_and_validation() {
 use loom::builtins::python3_available;
 
 /// A github watch shells out to `gh` (reading PR labels/state); loom must inject
-/// the operator's `GH_TOKEN` (Settings → Environment) into the otherwise
+/// the operator's `GH_TOKEN` (Settings → Agents & profiles) into the otherwise
 /// env-stripped watch subprocess, or every github watch (pr-label, review-wait,
 /// archive-merged) is blind. The explicit inject wins over any ambient value, so
 /// the exact token reaches the process.
@@ -955,7 +955,7 @@ async fn watch_subprocess_receives_operator_gh_token() {
     )
     .await;
 
-    // Set the operator token (Settings → Environment) and fire a manual round.
+    // Set the operator token (Settings → Agents & profiles) and fire a manual round.
     loom::agent_env::set(&state.db, "GH_TOKEN", "ghtok-marker-xyz")
         .await
         .unwrap();

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -1238,7 +1238,7 @@ impl Client {
         self.get_typed("/api/ready").await
     }
 
-    /// Admin-only redacted operational inventory (`GET /api/diagnostics`).
+    /// Human-readable redacted operational inventory (`GET /api/diagnostics`).
     pub async fn diagnostics(&self) -> Result<DiagnosticsView> {
         self.get_typed("/api/diagnostics").await
     }

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -1350,7 +1350,7 @@ pub struct DiagnosticFederation {
     pub updated_at: String,
 }
 
-/// Admin-only operational snapshot returned by `/api/diagnostics`.
+/// Human-readable operational snapshot returned by `/api/diagnostics`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DiagnosticsView {
     pub sessions: Vec<DiagnosticSessionCount>,
@@ -2838,6 +2838,25 @@ pub struct SettingsEnvelope {
     pub settings: Vec<SettingView>,
 }
 
+/// One personal preference with its deployment-wide inherited value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserPreferenceView {
+    pub key: String,
+    pub label: String,
+    pub description: String,
+    pub kind: SettingKind,
+    pub options: Vec<String>,
+    pub value: String,
+    pub inherited_value: String,
+    pub is_overridden: bool,
+}
+
+/// Effective personal preferences returned by `GET` and `PATCH /api/preferences`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UserPreferencesEnvelope {
+    pub preferences: Vec<UserPreferenceView>,
+}
+
 /// Body for `POST /api/watches`. JSON-bearing fields take structured JSON
 /// (`trigger`/`scope`/`params`), which the server serializes into the stored
 /// text columns. Optional fields fall back to the model's defaults.
@@ -2906,6 +2925,15 @@ pub struct RunWatchReq {
 // Authentication
 // ---------------------------------------------------------------------------
 
+wire_enum!(UserRole {
+    Admin => "admin",
+    User => "user",
+});
+
+fn default_user_role() -> UserRole {
+    UserRole::User
+}
+
 /// Which sign-in methods the server currently offers — what the login screen
 /// renders. `password` is always available (any user can be given one);
 /// `github` is true only once an OAuth app is configured.
@@ -2926,6 +2954,8 @@ pub struct MeView {
     pub github_login: Option<String>,
     /// How they authenticated: `loopback` | `token` | `session` | null.
     pub via: Option<String>,
+    /// Persisted human role. Scoped automation/session principals have no role.
+    pub role: Option<UserRole>,
     /// The sign-in methods on offer (for the login screen).
     pub methods: AuthMethods,
 }
@@ -2982,17 +3012,26 @@ pub struct UserView {
     pub username: String,
     pub github_login: Option<String>,
     pub has_password: bool,
+    pub role: UserRole,
     pub created_at: String,
 }
 
 /// Body for `POST /api/auth/users` — approve a new operator.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddUserReq {
     pub username: String,
     #[serde(default)]
     pub github_login: Option<String>,
     #[serde(default)]
     pub password: Option<String>,
+    #[serde(default = "default_user_role")]
+    pub role: UserRole,
+}
+
+/// Body for `PUT /api/auth/users/{username}/role`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetUserRoleReq {
+    pub role: UserRole,
 }
 
 /// `GET /api/auth/github/config` — the GitHub App / sign-in setup, secret

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -299,7 +299,7 @@ To register by hand instead:
 2. Open `https://<LOOM_DOMAIN>` and **Continue with GitHub** as
    `LOOM_OWNER_GITHUB`.
 3. Once in, approve teammates, set a password for password-login, and mint
-   automation tokens under **Settings → Account / Tokens**.
+   automation tokens under **Settings → Access**.
 
 For automation, the `loom` CLI inside the container is already authenticated as
 the owner (via the machine-local token loom injects), so it works without a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,10 +263,11 @@ local SQLite.
 - **`server.json`** in `$WEAVER_HOME`: pid + bound addr, written when `loom`
   comes up. The `loom` CLI uses it to find the daemon when `WEAVER_API` is
   unset.
-- **Settings** use runtime rows in `settings`, deployment defaults in
+- **Deployment settings** use runtime rows in `settings`, deployment defaults in
   `deployment_settings`, and immutable defaults declared in
   `weaver-core::config::REGISTRY`; reads resolve in that order. Both binaries
-  use the same helpers. This is the **global** (machine/user) store; see
+  use the same helpers. Personal overrides use `user_preferences`, keyed by
+  username and preference key. See
   [configuration policy](configuration.md). **Per-repo** conventions instead
   live in a committed `.weaver/config.toml` read by
   `weaver-core::repo_config` — distinct from global settings, and resolved
@@ -297,7 +298,7 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/ready` | public structured readiness: database access plus core and loom migration versions; optional future remote runner degradation will be reported without failing the whole API |
 | `GET /metrics` | public OpenMetrics scrape derived from durable session/profile/run/migration state; labels are bounded operational dimensions and never contain session/branch/path/user/token/error values (deployments normally restrict this at the public edge) |
 | `GET /api/self` | session-credential bootstrap context: the caller's session, branch, repository root, default channel, dashboard URL, and canonical REST links |
-| `GET /api/diagnostics` | admin-only redacted counts, profile capacity, automation failures/staleness, orphan/error inventory, migration state, and non-secret federation metadata; backs Settings → Diagnostics |
+| `GET /api/diagnostics` | human-user redacted counts, profile capacity, automation failures/staleness, orphan/error inventory, migration state, and non-secret federation metadata; backs Settings → Diagnostics |
 | `GET /api/events?topics=…` | every live stream the caller names, multiplexed onto one SSE connection — the browser holds 6 per origin, so the SPA subscribes here rather than opening one EventSource per view. Topics are `layout`, `logs`, `session:{id}`, `chat:{id}`; each frame is the default `message` event carrying `{topic, event, data}`, where `event` is the name the single-stream route below uses. Every topic is authorized against the route it stands in for, so this widens no credential; an unresolvable topic reports one `error` frame on its own topic and leaves the rest streaming |
 | `POST /api/session-launches/resolve` | resolve a canonical profile selection plus one-launch overrides into concrete selectors, provenance, policy, capacity, validation, and profile/resolver revisions without provisioning |
 | `GET /api/sessions` / `POST /api/sessions` | list / create sessions (list takes `archived` — default `false` — `automation` — default `false` — and admin-only `managed` — default `false`; canonical create requires both revisions from resolve and returns 409 plus a fresh preview on drift/admission change; flattened selectors remain compatible; valid Scratch input is decoded before provisioning; visible creates atomically assign configured origin/profile placement and a same-id default channel while managed warm infrastructure has no placement or layout revision effect; create stamps `resolved_launch`; `tracking_issue` is present only for an explicit claimed/imported work item) |
@@ -307,7 +308,7 @@ route truth, including internal proxy and compatibility paths.
 | `PUT /api/channels/{id}/{subscription,read-marker}` | set the caller's observe/deliver mode or monotonic read-through sequence |
 | `GET /api/sessions/summary` | compact fleet row projection for polling and search; accepts `archived`, `archived_only`, `automation`, `q`, `status`, and `attention`, searches goal text server-side without returning goals, and omits launch/MCP/title-generation/runtime detail retained by `GET /api/sessions/{id}` |
 | `GET /api/sessions/search` | case-insensitive fleet search across qualified placement, title/prompt, repo/branch, issue/PR, tags, status, profile, and provenance; optional widening `history`, archived-only `archived_only`, `status`, and `attention` filters |
-| `GET /api/session-layout`; `GET /api/session-layout/events` | admin-only read of the ordered Spaces → Groups → Sessions model plus defaults/revision; SSE is invalidation-only and every membership/layout change emits one so clients reload canonical state |
+| `GET /api/session-layout`; `GET /api/session-layout/events` | human-user read of the ordered Spaces → Groups → Sessions model plus defaults/revision; SSE is invalidation-only and every membership/layout change emits one so clients reload canonical state |
 | `POST PATCH DELETE /api/session-layout/{spaces,groups}[/{id}]` | create/rename/delete spaces and groups; non-empty deletion requires a destination and moves sessions/defaults atomically |
 | `POST /api/session-layout/{moves,reorder,restores}` | atomic session moves, space/group reorder, and complete multi-group restore with an exact `expected_revision`; stale mutations return 409 plus the current layout |
 | `PUT /api/session-layout/groups/{id}/preference` | set the authenticated operator's collapse preference without changing shared layout revision |
@@ -335,7 +336,7 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/scratch/limits`; `GET POST DELETE /api/sessions/{id}/scratch` | shared Scratch contract and live list/drop/remove: 20 files, 25 MiB each, 50 MiB decoded total; accepted dotfiles count, while `.gitignore` is reserved |
 | `GET /api/sessions/{id}/files?q=…` | bounded worktree resource search for ACP `@file` completion; the old browser file editor routes are gone |
 | `GET /api/sessions/{id}/ide-info`; `ANY /api/sessions/{id}/ide[/…]` | availability probe and authenticated same-origin HTTP/WebSocket proxy for the optional code-server side panel |
-| `GET /api/shell/terminal`; `POST /api/shell/restart` | open or reset the global operator shell; it runs beside the Loom server rather than through the configured session runner |
+| `GET /api/shell/terminal`; `POST /api/shell/restart` | admin-only open or reset of the global operator shell; it runs beside the Loom server, can reach machine credentials, and is distinct from a user's per-session debug shells |
 | `GET /api/sessions/{id}/shells`; `DELETE /api/sessions/{id}/shell/{idx}`; `GET /api/sessions/{id}/shell/{idx}/terminal` | list, close, or open per-session debug shells through WebSocket |
 | `GET /api/sessions/{id}/artifacts` | list the branch's [artifacts](artifacts.md) plus repo-shared ones |
 | `GET PUT /api/sessions/{id}/artifacts/{name}` | read content + projected refs (`rev=N` for a revision) / write a user edit as a new revision |
@@ -373,17 +374,19 @@ route truth, including internal proxy and compatibility paths.
 | `GET POST /api/repos/issues?repo_root=…` | repo-wide board (`scope=repo\|backlog`) / create a backlog item |
 | `GET /api/repos/recent` / `GET /api/repos/branches?cwd=…` | recent repos / branches in a repo |
 | `GET /api/agents` | first-class agent types, their advertised model/effort selectors, and their execution `protocol` (`terminal`\|`acp`) — backs the create-session form and server-side validation |
-| `GET PATCH /api/settings` | settings registry |
-| `GET /api/auth/me` | caller identity + sign-in methods (public; never 401s) |
+| `GET PATCH /api/settings` | deployment settings registry; human-readable, admin-mutable |
+| `GET PATCH /api/preferences` | effective personal preferences and per-user overrides |
+| `GET /api/logs`; `GET /api/logs/stream` | human-user server-log snapshot/tail; admins receive the raw operator stream, while user roles receive known deployment credentials and token-shaped values redacted |
+| `GET /api/auth/me` | caller identity, human role, and sign-in methods (public; never 401s) |
 | `POST /api/auth/login` / `POST /api/auth/logout` | username/password login / drop the session (public) |
 | `GET /api/auth/github/{login,callback}` | the GitHub OAuth dance (public) |
-| `GET POST /api/auth/tokens` / `DELETE /api/auth/tokens/{id}` | list / mint / revoke API tokens |
+| `GET POST /api/auth/tokens` / `DELETE /api/auth/tokens/{id}` | list / mint / revoke the caller's personal API tokens |
 | `POST /api/auth/password` | set the caller's own password |
-| `GET POST /api/auth/users` / `DELETE /api/auth/users/{username}` | the approved-operator allowlist |
-| `GET PUT /api/auth/github/config` | the GitHub OAuth app config (secret write-only) |
-| `GET POST /api/watches` / `GET PATCH DELETE /api/watches/{id}` | watch CRUD (see [Watches](#watches)) |
+| `GET POST /api/auth/users`; `PUT /api/auth/users/{username}/role`; `DELETE /api/auth/users/{username}` | admin-only approved-user and role management |
+| `GET PUT /api/auth/github/config` | admin-only GitHub OAuth app config (secret write-only) |
+| `GET POST /api/watches` / `GET PATCH DELETE /api/watches/{id}` | human-readable, admin-mutable watch definitions (see [Watches](#watches)) |
 | `GET /api/watches/programs` | the builtin program registry: titles, suggested defaults, read-only script sources |
-| `POST /api/watches/{id}/run` / `GET /api/watches/{id}/runs` | fire a round now (`{dry_run}` stubs mutations) / the round-history audit |
+| `POST /api/watches/{id}/run` / `GET /api/watches/{id}/runs` | admin-only fire a round now (`{dry_run}` stubs mutations) / human-readable round-history audit |
 
 Review drafts are REST-private and emit no branch-wide event until submission;
 other tabs refresh the creator's draft when they regain focus. `ReviewDto`
@@ -843,7 +846,7 @@ request to a `Principal` three ways, in order:
   remote `loom` CLI saves with `loom login`, or that an ephemeral client passes
   in `LOOM_TOKEN`. Tokens are random secrets stored only as a SHA-256 hash
   (`api_tokens.token_hash`); the plaintext is shown once at creation. Managed
-  under Settings → Tokens or `loom token`.
+  under Settings → Account or `loom token`.
 - **Session cookie** — the opaque `loom_session` cookie set by a successful
   GitHub or username/password login, stored hashed in `auth_sessions`.
 - **Loopback trust** — a request from `127.0.0.1`/`::1` is taken to be the
@@ -856,18 +859,25 @@ request to a `Principal` three ways, in order:
 A request that resolves to none of these gets `401`; the SPA's router guard
 turns that into the login screen.
 
-**The allowlist.** `users` rows are the approved operators. A fresh database is
+**Users and roles.** `users` rows are approved human users. A fresh database is
 seeded with one owner — whichever GitHub login `LOOM_OWNER_GITHUB` names at
 first run. There is no default: leave it unset and no owner row is seeded at
 all, so GitHub login has no `users` row to match until it's set (fail closed,
 rather than seed a real maintainer login onto an internet-facing deploy).
 GitHub login only succeeds for a login that matches a `users` row; an unknown
 identity is authenticated by GitHub but rejected by loom. A user may have a
-`github_login`, a `password_hash` (argon2), or both. All approved users are
-equal — there is no role hierarchy, matching the single-operator scale.
+`github_login`, a `password_hash` (argon2), or both. The persisted role is
+`admin` or `user`. Both roles operate normal Loom work, use per-session debug
+shells, and read diagnostics, watch activity, and redacted logs. Admins
+additionally change deployment settings, integrations, profiles, federations,
+shared environment, watches, and user access; they can use the host scratch
+shell and read the raw operator log. Existing rows migrate to `admin`, while
+newly approved users default to `user`. Browser sessions and personal tokens
+resolve the current role on every request, so role changes take effect
+immediately.
 
 **GitHub OAuth** is configured per-deploy: register an OAuth app and set its id
-and secret via Settings → Connections or the `LOOM_GITHUB_CLIENT_ID` /
+and secret via Settings → Integrations or the `LOOM_GITHUB_CLIENT_ID` /
 `LOOM_GITHUB_CLIENT_SECRET` env vars. The callback is
 `<base>/api/auth/github/callback`, where `<base>` is the `auth.base_url` setting
 or, unset, `{X-Forwarded-Proto|http}://{Host}`. The login route sets a short

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -867,7 +867,7 @@ identity is authenticated by GitHub but rejected by loom. A user may have a
 equal — there is no role hierarchy, matching the single-operator scale.
 
 **GitHub OAuth** is configured per-deploy: register an OAuth app and set its id
-and secret via Settings → Account or the `LOOM_GITHUB_CLIENT_ID` /
+and secret via Settings → Connections or the `LOOM_GITHUB_CLIENT_ID` /
 `LOOM_GITHUB_CLIENT_SECRET` env vars. The callback is
 `<base>/api/auth/github/callback`, where `<base>` is the `auth.base_url` setting
 or, unset, `{X-Forwarded-Proto|http}://{Host}`. The login route sets a short

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,38 @@
 # Configuration policy
 
+## Configuration ownership
+
+Choose the configuration surface from who owns the value and how widely it
+should apply:
+
+| Owner | Configure in | Use for |
+|---|---|---|
+| User | **Settings → Access** | Personal sign-in, password, and the personal GitHub token exported into that user's future interactive sessions |
+| Session profile | **Settings → Agents → Profiles** or a deployment manifest | Agent/model policy, instructions, GitHub repository allowlists, and write-only session secrets |
+| Deployment | **Settings → Connections** for status or manual setup; deployment IaC for the production source | The Loom GitHub App, Slack App, federations, and machine-wide credentials or files |
+| Repository | `.weaver/config.toml`, `WEAVER.md`, and `AGENTS.md` | Non-secret repository setup, environment, and workflow instructions |
+
+**Settings → Session environment** is the readable, non-secret environment on
+the `default` profile. Other profiles keep their write-only environment beside
+their launch policy under **Agents**. Do not put personal tokens or deployment
+credentials in repository configuration.
+
+An ordinary interactive session selects GitHub access in this order: the
+launching user's personal token, an explicit `GH_TOKEN` from the resolved
+session environment (normally its profile), then a short-lived GitHub App token
+when the profile allowlists the current repository. The first two are exported
+as `GH_TOKEN` because `git` and `gh` expect that name; the App fallback remains
+repository-scoped and short-lived. See [Restricted GitHub
+sessions](restricted-sessions.md#github-credential-policy) for automation's
+different boundary.
+
+Files under a shared session home are deployment resources, not environment
+variables. An operator deployment may materialize them from its secret backend,
+but every session sharing that home can read them. Per-profile files require
+isolated session homes or mounts.
+
+## Registered setting precedence
+
 Loom resolves every registered setting through one explicit precedence chain:
 
 | Precedence | Source | Owned by | How to change it |
@@ -15,7 +48,7 @@ default reveals the built-in. `GET /api/settings` reports the effective
 `value`, its `source`, and any `deployment_value`; the Settings UI shows the
 same provenance.
 
-This policy applies only to registered, non-secret global settings. Secrets
+This precedence applies only to registered, non-secret global settings. Secrets
 stay in the environment, profile secret references, or the credential-specific
 store and are never returned by the settings API. Per-repository setup,
 environment, and agent defaults belong in committed `.weaver/config.toml`; a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,14 +7,27 @@ should apply:
 
 | Owner | Configure in | Use for |
 |---|---|---|
-| User | **Settings → Access** | Personal sign-in, password, and the personal GitHub token exported into that user's future interactive sessions |
-| Session profile | **Settings → Agents → Profiles** or a deployment manifest | Agent/model policy, instructions, GitHub repository allowlists, and write-only session secrets |
-| Deployment | **Settings → Connections** for status or manual setup; deployment IaC for the production source | The Loom GitHub App, Slack App, federations, and machine-wide credentials or files |
+| User | **Settings → Account** and **Preferences** | Personal sign-in, password, API and GitHub tokens, and terminal appearance |
+| Session profile | **Settings → Agents & profiles** or a deployment manifest | Agent/model policy, instructions, GitHub repository allowlists, shared environment, and write-only session secrets |
+| Deployment | The **Administration** settings; deployment IaC for the production source | Approved users and roles, the Loom GitHub App, Slack App, federations, runtime policy, and machine-wide credentials or files |
 | Repository | `.weaver/config.toml`, `WEAVER.md`, and `AGENTS.md` | Non-secret repository setup, environment, and workflow instructions |
 
-**Settings → Session environment** is the readable, non-secret environment on
-the `default` profile. Other profiles keep their write-only environment beside
-their launch policy under **Agents**. Do not put personal tokens or deployment
+The Administration section is visible only to admins. Users can launch and
+operate sessions, repositories, reviews, per-session shells, and shared layout;
+inspect watch activity, redacted server logs, and diagnostics; and manage their
+own account and preferences. Admins also manage deployment-wide policy,
+integrations, profiles, shared environment, watch definitions and runs, the raw
+operator log, the host scratch shell, and access. Existing users become admins
+when the role migration is applied; newly approved users default to the `user`
+role.
+
+Loopback trust and the machine-local token resolve the primary user's current
+role. Demoting that user while another admin exists therefore removes local
+administrative authority; keep an intentional admin path before doing so.
+
+**Settings → Agents & profiles** contains the readable, non-secret environment
+on the `default` profile. Other profiles keep their write-only environment
+beside their launch policy. Do not put personal tokens or deployment
 credentials in repository configuration.
 
 An ordinary interactive session selects GitHub access in this order: the
@@ -37,7 +50,7 @@ Loom resolves every registered setting through one explicit precedence chain:
 
 | Precedence | Source | Owned by | How to change it |
 |---|---|---|---|
-| 1 | Runtime override | operator | Settings, `PATCH /api/settings`, or `loom config set` |
+| 1 | Runtime override | admin | Administration settings, `PATCH /api/settings`, or `loom config set` |
 | 2 | Deployment default | infrastructure repository | `loom deployment apply` / `POST /api/deployment/reconcile` |
 | 3 | Built-in default | Loom release | `weaver-core::config::REGISTRY` |
 
@@ -143,7 +156,7 @@ Runtime edits take effect without rebuilding a deployment:
 loom config set slack.status_updates false
 ```
 
-The Settings page and `PATCH /api/settings` use the same validation and storage
+The Administration pages and `PATCH /api/settings` use the same validation and storage
 path. Send `null` to clear an override and inherit again:
 
 ```json

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -76,7 +76,7 @@ handler mid-clone. Each launch is tracked on **Settings → Debug** (running / d
 The reply (step 8) reaches GitHub through the [GitHub App](#the-github-app) when
 one is configured — with a short-lived, per-installation token — and otherwise
 through the `gh` CLI's ambient `GH_TOKEN`. The **session itself** acts as the
-requester: its `GH_TOKEN` is that user's personal token (**Settings → Account**),
+requester: its `GH_TOKEN` is that user's personal token (**Settings → Access**),
 falling back to its selected profile when they have none — so its pushes and
 `gh` replies use the configured session identity. Separately, the poll loop
 posts a one-time back-link comment (`Working on this in loom: {base}/s/{id}`) on

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -70,13 +70,13 @@ order:
 Steps 6–8 (clone, create-or-forward, reply) run in a **detached task**: the
 handler returns `200` as soon as the gates pass. Cloning a large repo can outlast
 GitHub's ~10s delivery timeout, and a timed-out delivery would cancel an inline
-handler mid-clone. Each launch is tracked on **Settings → Debug** (running / done
+handler mid-clone. Each launch is tracked on **Settings → Diagnostics** (running / done
 / error, with the outcome), so you can follow it after the `200`.
 
 The reply (step 8) reaches GitHub through the [GitHub App](#the-github-app) when
 one is configured — with a short-lived, per-installation token — and otherwise
 through the `gh` CLI's ambient `GH_TOKEN`. The **session itself** acts as the
-requester: its `GH_TOKEN` is that user's personal token (**Settings → Access**),
+requester: its `GH_TOKEN` is that user's personal token (**Settings → Account**),
 falling back to its selected profile when they have none — so its pushes and
 `gh` replies use the configured session identity. Separately, the poll loop
 posts a one-time back-link comment (`Working on this in loom: {base}/s/{id}`) on
@@ -142,8 +142,9 @@ either. Write access to the repo is **not** by itself a grant, so opening a repo
 to loom never hands the trigger to everyone who can push to it.
 
 The first approved user is seeded from `LOOM_OWNER_GITHUB` on a fresh database.
-Manage the rest in **Settings → Approved users** or over the API (set
-`github_login` so the person can both sign in with GitHub and trigger):
+Manage the rest in **Settings → People & security** or over the API (set
+`github_login` so the person can both sign in with GitHub and trigger; new
+users default to the normal `user` role):
 
 ```sh
 curl -X POST {base}/api/auth/users -H 'Authorization: Bearer $LOOM_TOKEN' \
@@ -337,10 +338,11 @@ gate did it hit?* Work through it in order:
    `scripts/gh_app_deliveries.py` prints the same delivery log from the command
    line (it mints an App JWT from the key in `loom.toml`).
 
-3. **Read the server logs.** The quickest path is **Settings → Debug** in the web
+3. **Read the server logs.** The quickest path is **Settings → Diagnostics** in the web
    UI — a live, filterable mirror of the server's log stream (plus the
    background-task list), so you can watch a delivery land without shelling into
-   the box (handy on the Docker deploy). The
+   the box (handy on the Docker deploy). User-role views redact known deployment
+   credentials and token-shaped values; admins receive the raw operator stream. The
    same lines go to the process stdout, so `docker compose logs -f loom` (or
    `RUST_LOG=loom=debug` for the outbound `gh`/REST calls) works too. Each gate
    logs a distinct line — look for: `signature verification failed` (401, secret

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -40,7 +40,7 @@ both use the same provider-neutral `mcp_access` contract.
 
 | Use case | Primary credential | Fallback |
 | --- | --- | --- |
-| Ordinary interactive session | Launching user's personal token from **Settings → Access** | Explicit session `GH_TOKEN`, then a profile-approved GitHub App token for the current repository |
+| Ordinary interactive session | Launching user's personal token from **Settings → Account** | Explicit session `GH_TOKEN`, then a profile-approved GitHub App token for the current repository |
 | Restricted GitHub tool | Short-lived GitHub App installation token for the session's fixed repository | Profile `GH_TOKEN` only when no App is configured |
 | GitHub Actions calling Loom | GitHub OIDC exchanged for a ten-minute Loom automation token | None |
 

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -40,7 +40,7 @@ both use the same provider-neutral `mcp_access` contract.
 
 | Use case | Primary credential | Fallback |
 | --- | --- | --- |
-| Ordinary interactive session | Launching user's personal token from **Settings → Account** | Selected profile's `GH_TOKEN`, then lower session environment layers |
+| Ordinary interactive session | Launching user's personal token from **Settings → Access** | Explicit session `GH_TOKEN`, then a profile-approved GitHub App token for the current repository |
 | Restricted GitHub tool | Short-lived GitHub App installation token for the session's fixed repository | Profile `GH_TOKEN` only when no App is configured |
 | GitHub Actions calling Loom | GitHub OIDC exchanged for a ten-minute Loom automation token | None |
 

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -179,7 +179,7 @@ Two secrets enable the integration — set **both**, or it stays idle
   It must be the **bot** token, not the user token (`xoxp-…`) issued by the same
   install. A user token authenticates, connects, and passes `auth.test` exactly
   like the bot token — but it resolves to a *person*, so loom posts as them and
-  discards every mention they type as its own. **Settings → Connections** names
+  discards every mention they type as its own. **Settings → Integrations** names
   this outright; `auth.test` returns a `bot_id` only for the bot token, and that
   is what the pane checks.
 
@@ -205,7 +205,7 @@ or incompatible profiles fall back automatically.
 
 ## Diagnosing it
 
-**Settings → Connections** shows the whole trigger path in the order the server
+**Settings → Integrations** shows the whole trigger path in the order the server
 checks it — tokens, switch, connection, identity, who can trigger, repository —
 so a broken link names itself. A live socket is not the same as a working
 integration: the connection can be up while the bot token belongs to a person,

--- a/e2e/tests/appearance.spec.ts
+++ b/e2e/tests/appearance.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../fixtures/weaver';
 
 test.describe('settings · terminal appearance', () => {
   test('live preview, save, persist, and reset', async ({ page, weaver }) => {
-    await page.goto(`${weaver.baseUrl}/settings?tab=workspace`);
+    await page.goto(`${weaver.baseUrl}/settings?tab=preferences`);
     const panel = page.getByTestId('appearance-panel');
 
     // The live preview is a real xterm instance — the same renderer a session
@@ -21,27 +21,27 @@ test.describe('settings · terminal appearance', () => {
     await page.getByTestId('font-size-input').fill('16');
     await expect(page.getByTestId('theme-light')).toHaveAttribute('aria-pressed', 'true');
     await panel.getByRole('button', { name: 'Save' }).click();
-    await expect(panel.getByText('Saved terminal appearance.')).toBeVisible();
+    await expect(panel.getByText('Saved your terminal preferences.')).toBeVisible();
 
     // The server is the source of truth — the API reflects the new values.
     const settings = (await page.evaluate(async () => {
-      const r = await fetch('/api/settings');
-      return (await r.json()).settings as { key: string; value: string }[];
+      const r = await fetch('/api/preferences');
+      return (await r.json()).preferences as { key: string; value: string }[];
     })) as { key: string; value: string }[];
     const value = (k: string) => settings.find((s) => s.key === k)?.value;
     expect(value('terminal.theme')).toBe('light');
     expect(value('terminal.font')).toBe('jetbrains');
     expect(value('terminal.font_size')).toBe('16');
 
-    // …and the selection survives a reload (the panel reads back from /settings).
+    // …and the selection survives a reload (the panel reads back from /preferences).
     await page.reload();
     await expect(page.getByTestId('theme-light')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-jetbrains')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-size-input')).toHaveValue('16');
 
     // Clearing overrides returns all three to their inherited values.
-    await panel.getByRole('button', { name: 'Clear overrides' }).click();
-    await expect(panel.getByText('Cleared terminal appearance overrides.')).toBeVisible();
+    await panel.getByRole('button', { name: 'Use deployment defaults' }).click();
+    await expect(panel.getByText('Restored deployment terminal defaults.')).toBeVisible();
     await expect(page.getByTestId('theme-dark')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-plex')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByTestId('font-size-input')).toHaveValue('13');

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,13 +1,13 @@
 import { test, expect } from '../fixtures/weaver';
 
 // The e2e server binds loopback, so the dashboard loads authenticated as the
-// owner via loopback trust (no login step). These cover the Settings → Tokens
+// owner via loopback trust (no login step). These cover the Settings → Account
 // identity UI end to end against the real API. Token lifecycle and destructive
 // confirmation share the narrow cross-feature journey in lifecycle.spec.ts.
-test.describe('settings · access identity', () => {
-  test('the Access screen shows the loopback identity', async ({ page, weaver }) => {
+test.describe('settings · account identity', () => {
+  test('the Account screen shows the loopback identity', async ({ page, weaver }) => {
     await page.goto(`${weaver.baseUrl}/settings`);
-    await page.getByTestId('settings-tab-access').click();
+    await page.getByTestId('settings-category-account').click();
     await expect(page.getByText('Signed in')).toBeVisible();
     // The seeded owner, authenticated via loopback trust.
     await expect(page.getByText('via loopback')).toBeVisible();

--- a/e2e/tests/create.spec.ts
+++ b/e2e/tests/create.spec.ts
@@ -135,17 +135,18 @@ test.describe('creating a session via the UI form', () => {
     await page.getByPlaceholder('Add a /health endpoint').fill('Keep this draft');
 
     await page.getByRole('link', { name: 'Manage profiles' }).click();
-    await expect(page).toHaveURL(`${weaver.baseUrl}/settings`);
+    await expect(page).toHaveURL(`${weaver.baseUrl}/settings?tab=agents`);
     const addProfile = page.getByRole('button', { name: '+ Add profile' });
     await expect(page.getByTestId('profile-picker')).toHaveValue('default');
     await addProfile.click();
-    await page.getByLabel('Name', { exact: true }).fill('cached-template');
-    await page.getByLabel('Description', { exact: true }).fill('first revision');
+    const profileEditor = page.getByTestId('profile-editor');
+    await profileEditor.getByLabel('Name', { exact: true }).fill('cached-template');
+    await profileEditor.getByLabel('Description', { exact: true }).fill('first revision');
     await page.getByTestId('profile-agent').selectOption('shell');
-    await page.getByLabel('Protocol', { exact: true }).selectOption('terminal');
+    await profileEditor.getByLabel('Protocol', { exact: true }).selectOption('terminal');
     await page.getByTestId('profile-save').click();
     await expect(page.getByText('Saved cached-template.')).toBeVisible();
-    await page.getByLabel('Description', { exact: true }).fill('second revision');
+    await profileEditor.getByLabel('Description', { exact: true }).fill('second revision');
     await page.getByTestId('profile-save').click();
     await expect(page.getByTestId('profile-summary')).toContainText('r2');
     await page.goBack();

--- a/e2e/tests/lifecycle.spec.ts
+++ b/e2e/tests/lifecycle.spec.ts
@@ -7,7 +7,7 @@ test.describe('session lifecycle actions', () => {
   }) => {
     await page.setViewportSize({ width: 390, height: 620 });
     await page.goto(`${weaver.baseUrl}/settings`);
-    await page.getByTestId('settings-tab-access').click();
+    await page.getByTestId('settings-category-account').click();
     await page.getByTestId('token-name').fill('narrow-flow');
     await page.getByTestId('token-create').click();
     const revoke = page.getByTestId('token-revoke');

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -17,6 +17,7 @@ test.describe("settings · profiles", () => {
     const claude = registry.agents.find((agent) => agent.kind === "claude")!;
     const codex = registry.agents.find((agent) => agent.kind === "codex")!;
     await page.goto(`${weaver.baseUrl}/settings`);
+    await page.getByTestId("settings-category-agents").click();
 
     const agent = page.getByTestId("profile-agent");
     const model = page.getByTestId("profile-model");
@@ -28,7 +29,7 @@ test.describe("settings · profiles", () => {
     ]);
 
     await agent.selectOption("claude");
-    await model.selectOption(claude.models[0].id);
+    await model.fill(claude.models[0].id);
     await agent.selectOption("codex");
     await expect(model).toHaveValue("");
     await expect(model.locator("option")).toContainText([
@@ -67,6 +68,7 @@ test.describe("settings · profiles", () => {
     weaver,
   }) => {
     await page.goto(`${weaver.baseUrl}/settings`);
+    await page.getByTestId("settings-category-agents").click();
     const mode = page.getByTestId("profile-mode");
     await expect(mode).toHaveValue("auto");
     await mode.selectOption("bypassPermissions");
@@ -125,6 +127,7 @@ for line in sys.stdin:
 `;
 
     await page.goto(`${weaver.baseUrl}/settings`);
+    await page.getByTestId("settings-category-agents").click();
     const panel = page.getByTestId("mcp-panel");
     await panel.getByRole("button", { name: "Add custom MCP" }).click();
     await panel.getByLabel("Identity").fill("/docs/search");
@@ -181,51 +184,69 @@ for line in sys.stdin:
     expect(removed.ok).toBe(true);
   });
 
-  test("overlapping settings are consolidated into workspace and access", async ({
+  test("settings separate personal use from deployment administration", async ({
     page,
     weaver,
   }) => {
     await page.goto(`${weaver.baseUrl}/settings`);
     await expect(
-      page.getByRole("button", { name: "Workspace", exact: true }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Access", exact: true }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Session environment", exact: true }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Editor", exact: true }),
-    ).toHaveCount(0);
-    await expect(
-      page.getByRole("button", { name: "Appearance", exact: true }),
-    ).toHaveCount(0);
-    await expect(
-      page.getByRole("button", { name: "Authentication", exact: true }),
-    ).toHaveCount(0);
-    await expect(
-      page.getByRole("button", { name: "Tokens", exact: true }),
-    ).toHaveCount(0);
-    await expect(
       page.getByRole("button", { name: "Account", exact: true }),
-    ).toHaveCount(0);
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Preferences", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Diagnostics", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "People & security", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Agents & profiles", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Integrations", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Runtime", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Automation", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("complementary").getByText("Personal", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("Operations", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Administration", { exact: true }),
+    ).toBeVisible();
     await expect(page.locator('[data-rail="chat"]')).toHaveCount(0);
 
-    await page.getByRole("button", { name: "Access", exact: true }).click();
-    await expect(page.getByText("Your GitHub token", { exact: true })).toBeVisible();
-    await expect(page.getByText("Loom GitHub App", { exact: true })).toHaveCount(0);
+    await expect(
+      page.getByText("Your GitHub token", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Loom GitHub App", { exact: true }),
+    ).toHaveCount(0);
     const createToken = page.getByRole("link", { name: "Create one" });
     await expect(createToken).toHaveAttribute("href", /contents=write/);
     await expect(createToken).toHaveAttribute("href", /issues=write/);
     await expect(createToken).toHaveAttribute("href", /pull_requests=write/);
 
-    await page.getByRole("button", { name: "Connections", exact: true }).click();
+    await page
+      .getByRole("button", { name: "Integrations", exact: true })
+      .click();
     await expect(page.getByTestId("github-connection-panel")).toBeVisible();
-    await expect(page.getByText("Loom GitHub App", { exact: true })).toBeVisible();
-    await expect(page.getByText("Your GitHub token", { exact: true })).toHaveCount(0);
+    await expect(
+      page.getByText("Loom GitHub App", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Your GitHub token", { exact: true }),
+    ).toHaveCount(0);
 
-    await page.getByRole("button", { name: "Agents", exact: true }).click();
+    await page
+      .getByRole("button", { name: "Agents & profiles", exact: true })
+      .click();
     expect(
       await page.getByTestId("metadata-settings").evaluate((section) => ({
         settingsVisible: [
@@ -241,5 +262,48 @@ for line in sys.stdin:
       settingsVisible: true,
       metadataProfileVisible: false,
     });
+  });
+
+  test("users see personal settings and diagnostics without admin controls", async ({
+    page,
+    weaver,
+  }) => {
+    await page.route("**/api/auth/me", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          authenticated: true,
+          username: "alice",
+          github_login: "alice-gh",
+          via: "token",
+          role: "user",
+          methods: { password: true, github: false },
+        }),
+      });
+    });
+
+    await page.goto(`${weaver.baseUrl}/settings?tab=integrations`);
+    await expect(page).toHaveURL(`${weaver.baseUrl}/settings`);
+    await expect(page.getByTestId("settings-category-account")).toBeVisible();
+    await expect(
+      page.getByTestId("settings-category-preferences"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("settings-category-diagnostics"),
+    ).toBeVisible();
+    await expect(page.getByText("Administration", { exact: true })).toHaveCount(
+      0,
+    );
+    await expect(page.getByTestId("settings-category-people")).toHaveCount(0);
+    await expect(page.getByTestId("settings-category-agents")).toHaveCount(0);
+    await expect(page.getByText("alice", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("User · via token", { exact: false }),
+    ).toBeVisible();
+    await expect(page.locator('[data-rail="shell"]')).toHaveCount(0);
+
+    await page.goto(`${weaver.baseUrl}/shell`);
+    await expect(page).toHaveURL(`${weaver.baseUrl}/`);
   });
 });

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -193,6 +193,9 @@ for line in sys.stdin:
       page.getByRole("button", { name: "Access", exact: true }),
     ).toBeVisible();
     await expect(
+      page.getByRole("button", { name: "Session environment", exact: true }),
+    ).toBeVisible();
+    await expect(
       page.getByRole("button", { name: "Editor", exact: true }),
     ).toHaveCount(0);
     await expect(
@@ -208,6 +211,21 @@ for line in sys.stdin:
       page.getByRole("button", { name: "Account", exact: true }),
     ).toHaveCount(0);
     await expect(page.locator('[data-rail="chat"]')).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Access", exact: true }).click();
+    await expect(page.getByText("Your GitHub token", { exact: true })).toBeVisible();
+    await expect(page.getByText("Loom GitHub App", { exact: true })).toHaveCount(0);
+    const createToken = page.getByRole("link", { name: "Create one" });
+    await expect(createToken).toHaveAttribute("href", /contents=write/);
+    await expect(createToken).toHaveAttribute("href", /issues=write/);
+    await expect(createToken).toHaveAttribute("href", /pull_requests=write/);
+
+    await page.getByRole("button", { name: "Connections", exact: true }).click();
+    await expect(page.getByTestId("github-connection-panel")).toBeVisible();
+    await expect(page.getByText("Loom GitHub App", { exact: true })).toBeVisible();
+    await expect(page.getByText("Your GitHub token", { exact: true })).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Agents", exact: true }).click();
     expect(
       await page.getByTestId("metadata-settings").evaluate((section) => ({
         settingsVisible: [

--- a/e2e/tests/watches.spec.ts
+++ b/e2e/tests/watches.spec.ts
@@ -4,6 +4,38 @@ import { test, expect } from '../fixtures/weaver';
 // left (active dot, name, program, outcome), and the selected watch's
 // activity log, script source, and config live in the right pane.
 test.describe('watch panel', () => {
+  test('users can inspect watches without mutation controls', async ({
+    page,
+    weaver,
+  }) => {
+    await weaver.seedWatch({ name: 'status-check' });
+    await page.route('**/api/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          authenticated: true,
+          username: 'alice',
+          github_login: 'alice-gh',
+          via: 'token',
+          role: 'user',
+          methods: { password: true, github: false },
+        }),
+      });
+    });
+
+    await page.goto(`${weaver.baseUrl}/watches`);
+    await expect(page.getByTestId('watch-readonly')).toBeVisible();
+    await expect(page.getByTestId('watch-row')).toHaveCount(1);
+    await expect(page.getByTestId('watch-new')).toHaveCount(0);
+    await expect(page.getByTestId('watch-enabled-toggle')).toHaveCount(0);
+    await expect(page.getByTestId('watch-run')).toHaveCount(0);
+    await expect(page.getByTestId('watch-dryrun')).toHaveCount(0);
+
+    await page.getByTestId('watch-tab-config').click();
+    await expect(page.getByTestId('watch-edit')).toHaveCount(0);
+  });
+
   test('shows an empty state when there are no watches', async ({ page, weaver }) => {
     await page.goto(`${weaver.baseUrl}/watches`);
     await expect(page.getByRole('heading', { name: 'Watches' })).toBeVisible();


### PR DESCRIPTION
Reorganize Settings by ownership: Personal contains Account and per-user Preferences; Operations contains Diagnostics for all human users; Administration contains People & security, Agents & profiles, Integrations, Runtime, and Automation. This makes the destination for personal PATs, deployment GitHub and Slack credentials, shared profiles, and runtime defaults explicit.

Persist admin and user roles on approved people. Existing users and the seeded owner become admins; new users default to user, and Loom refuses to remove or demote the last admin. Browser sessions and personal API tokens resolve the current role on every request, while workload and session tokens keep scoped grants. Users retain normal session, repository, review, channel, layout, per-session shell, watch-observation, and diagnostic access. Deployment settings, integrations, profiles, watch mutations, and the host scratch shell require admin; non-admin server logs are redacted.

Store terminal appearance overrides in per-user preferences with inheritance from deployment defaults. Scope personal token listing and revocation to their owner, and document the user, profile, deployment, and repository ownership split, including IaC-provisioned machine files.