### PR TITLE
fix(loom): isolate session teardown paths

### DIFF
--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -1392,6 +1392,15 @@ impl TurnEndSource {
     }
 }
 
+#[derive(Debug)]
+enum TaskStopReason {
+    AgentExit,
+    CommandChannelClosed,
+    Handoff,
+    JournalFailure,
+    RelayClosed,
+}
+
 struct Task {
     db: Db,
     /// The loom event bus — used to drive the turn-boundary status/idle lifecycle
@@ -1403,7 +1412,6 @@ struct Task {
     generation: u64,
     session_id: String,
     branch_id: String,
-    #[allow(dead_code)]
     relay_name: String,
     acp_session_id: String,
     events_tx: broadcast::Sender<SseEvent>,
@@ -2008,7 +2016,7 @@ impl Task {
         // Consume interval's immediate first tick; the handshake already
         // flushed everything safe before the main loop starts.
         ack_tick.tick().await;
-        loop {
+        let stop_reason = loop {
             tokio::select! {
                 ev = self.stream.recv() => match ev {
                     Some(RelayEvent::Frame { seq, payload }) => {
@@ -2019,14 +2027,14 @@ impl Task {
                             Err(e) => tracing::warn!(session = %self.session_id, error = %e, "unparseable acp frame"),
                         }
                         if self.journal_replay_needed() {
-                            break;
+                            break TaskStopReason::JournalFailure;
                         }
                     }
                     Some(RelayEvent::Exit { status }) => {
                         self.on_exit(status).await;
-                        break;
+                        break TaskStopReason::AgentExit;
                     }
-                    None => break,
+                    None => break TaskStopReason::RelayClosed,
                 },
                 cmd = cmd_rx.recv() => match cmd {
                     Some(Command::PrepareHandoff { reply }) => {
@@ -2039,7 +2047,7 @@ impl Task {
                             match chat::list(&self.db, &self.session_id).await {
                                 Ok(snapshot) => {
                                     handoff_reply = Some((reply, snapshot));
-                                    break;
+                                    break TaskStopReason::Handoff;
                                 }
                                 Err(error) => {
                                     let _ = reply.send(Err(error));
@@ -2050,10 +2058,10 @@ impl Task {
                     Some(c) => {
                         self.on_command(c).await;
                         if self.journal_replay_needed() {
-                            break;
+                            break TaskStopReason::JournalFailure;
                         }
                     }
-                    None => break,
+                    None => break TaskStopReason::CommandChannelClosed,
                 },
                 _ = ack_tick.tick() => {
                     if let Err(e) = self.maybe_ack().await {
@@ -2061,12 +2069,17 @@ impl Task {
                     }
                 },
             }
-        }
+        };
         self.registry.remove_own(&self.session_id, self.generation);
         if let Some((reply, snapshot)) = handoff_reply {
             let _ = reply.send(Ok(snapshot));
         }
-        tracing::info!(session = %self.session_id, "acp task stopped");
+        tracing::info!(
+            session = %self.session_id,
+            relay = %self.relay_name,
+            reason = ?stop_reason,
+            "acp task stopped"
+        );
     }
 
     fn journal_replay_needed(&self) -> bool {

--- a/crates/loom-ctx/src/runner.rs
+++ b/crates/loom-ctx/src/runner.rs
@@ -32,7 +32,6 @@ const SESSION_NAME_LABEL: &str = "dev.loom.session";
 const SESSION_CONTAINER_PREFIX: &str = "loom-session-";
 const CONTAINER_HOME: &str = "/home/app";
 const CONTAINER_WEAVER_HOME: &str = "/home/app/.weaver";
-const CONTAINER_SOCKET_DIR: &str = "/home/app/.weaver/sock";
 const CONTAINER_SESSION_SLUG_LENGTH: usize = 48;
 const CONTAINER_SESSION_HASH_LENGTH: usize = 12;
 const BYTES_PER_GIB: u64 = 1024 * 1024 * 1024;
@@ -141,20 +140,7 @@ impl ContainerRunner {
         match self.docker.remove_container(container, Some(options)).await {
             Ok(()) => Ok(()),
             Err(error) if docker_not_found(&error) => Ok(()),
-            Err(error) if docker_conflict(&error) => {
-                for _ in 0..40 {
-                    match self.docker.inspect_container(container, None).await {
-                        Err(inspect_error) if docker_not_found(&inspect_error) => return Ok(()),
-                        Err(inspect_error) => {
-                            return Err(inspect_error).with_context(|| {
-                                format!("checking removal of session container {container}")
-                            })
-                        }
-                        Ok(_) => tokio::time::sleep(std::time::Duration::from_millis(25)).await,
-                    }
-                }
-                Err(error).with_context(|| format!("removing session container {container}"))
-            }
+            Err(error) if docker_removal_in_progress(&error) => Ok(()),
             Err(error) => {
                 Err(error).with_context(|| format!("removing session container {container}"))
             }
@@ -236,7 +222,6 @@ impl ContainerRunner {
             stdin_once: Some(false),
             env: Some(vec![
                 format!("WEAVER_HOME={CONTAINER_WEAVER_HOME}"),
-                format!("WEAVER_TAPESTRY_DIR={CONTAINER_SOCKET_DIR}"),
                 "RUST_BACKTRACE=1".to_string(),
             ]),
             cmd: Some(vec![
@@ -633,13 +618,15 @@ fn docker_not_found(error: &DockerError) -> bool {
     )
 }
 
-fn docker_conflict(error: &DockerError) -> bool {
+fn docker_removal_in_progress(error: &DockerError) -> bool {
     matches!(
         error,
         DockerError::DockerResponseServerError {
             status_code: 409,
-            ..
-        }
+            message,
+        } if message == "removal already in progress"
+            || (message.contains("removal of container")
+                && message.contains("is already in progress"))
     )
 }
 
@@ -766,6 +753,7 @@ mod tests {
             .contains(&"/var/run/docker.sock:/var/run/docker.sock".to_string()));
 
         let rendered = serde_json::to_string(&body).unwrap();
+        assert!(!rendered.contains("WEAVER_TAPESTRY_DIR"));
         assert!(!rendered.contains("super-secret"));
         assert!(!rendered.contains("API_TOKEN"));
         assert!(!rendered.contains("agent --secret"));
@@ -806,7 +794,7 @@ mod tests {
     }
 
     #[test]
-    fn only_docker_404_is_absence() {
+    fn recognizes_idempotent_docker_removal_responses() {
         assert!(docker_not_found(&DockerError::DockerResponseServerError {
             status_code: 404,
             message: "missing".to_string(),
@@ -816,13 +804,29 @@ mod tests {
             message: "daemon failed".to_string(),
         }));
         assert!(!docker_not_found(&DockerError::RequestTimeoutError));
-        assert!(docker_conflict(&DockerError::DockerResponseServerError {
-            status_code: 409,
-            message: "removal already in progress".to_string(),
-        }));
-        assert!(!docker_conflict(&DockerError::DockerResponseServerError {
-            status_code: 500,
-            message: "daemon failed".to_string(),
-        }));
+        assert!(docker_removal_in_progress(
+            &DockerError::DockerResponseServerError {
+                status_code: 409,
+                message: "removal of container abc is already in progress".to_string(),
+            }
+        ));
+        assert!(docker_removal_in_progress(
+            &DockerError::DockerResponseServerError {
+                status_code: 409,
+                message: "removal already in progress".to_string(),
+            }
+        ));
+        assert!(!docker_removal_in_progress(
+            &DockerError::DockerResponseServerError {
+                status_code: 409,
+                message: "container is running".to_string(),
+            }
+        ));
+        assert!(!docker_removal_in_progress(
+            &DockerError::DockerResponseServerError {
+                status_code: 500,
+                message: "removal already in progress".to_string(),
+            }
+        ));
     }
 }

--- a/crates/loom-watch/src/monitor.rs
+++ b/crates/loom-watch/src/monitor.rs
@@ -21,6 +21,7 @@ use weaver_core::config as core_config;
 use weaver_core::BoxFut;
 
 const TICK: Duration = Duration::from_millis(1500);
+const RUNTIME_START_GRACE_SECS: i64 = 10;
 
 /// The retention reaper runs at most once every this many monitor ticks
 /// (~90s at the 1.5s tick) — archiving is heavyweight next to the per-tick work.
@@ -131,6 +132,9 @@ async fn run_inner(state: AppState) {
                     last_event,
                 )
                 .await;
+            }
+            if runtime_starting(session, now) {
+                continue;
             }
             if !backend::has_session(&session.term_session).await {
                 if session.status == "orphaned" {
@@ -399,6 +403,11 @@ fn parse_iso(ts: &str) -> Option<DateTime<Utc>> {
         .map(|dt| dt.with_timezone(&Utc))
 }
 
+fn runtime_starting(session: &Session, now: DateTime<Utc>) -> bool {
+    parse_iso(&session.created_at)
+        .is_some_and(|created_at| (now - created_at).num_seconds() < RUNTIME_START_GRACE_SECS)
+}
+
 /// Reflect a Claude lifecycle hook (`working` / `waiting` / `idle`) onto the
 /// active session and its branch, broadcasting only what actually changed.
 /// Returns the new event watermark (it records its own bus events). `None` when
@@ -469,7 +478,7 @@ fn normalize_screen(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_stale, normalize_screen, Session};
+    use super::{is_stale, normalize_screen, runtime_starting, Session};
     use chrono::{Duration, Utc};
     use weaver_core::tags;
 
@@ -554,6 +563,18 @@ mod tests {
         // An unparseable timestamp is treated as not stale rather than panicking.
         let bad = session_with_activity(Some("not-a-time"), "also-bad");
         assert!(!is_stale(&bad, 0, now));
+    }
+
+    #[test]
+    fn orphan_detection_waits_for_runtime_startup() {
+        let now = Utc::now();
+        let iso = |time: chrono::DateTime<Utc>| time.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+
+        let starting = session_with_activity(None, &iso(now - Duration::seconds(2)));
+        assert!(runtime_starting(&starting, now));
+
+        let missing = session_with_activity(None, &iso(now - Duration::seconds(11)));
+        assert!(!runtime_starting(&missing, now));
     }
 
     #[test]

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -191,6 +191,16 @@ impl AppError {
     fn not_found(what: &str) -> Self {
         Self::new(StatusCode::NOT_FOUND, format!("{what} not found"))
     }
+    fn internal(message: impl Into<String>, error: impl Into<anyhow::Error>) -> Self {
+        let error = error.into();
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+            details: None,
+            fields: None,
+            source_chain: Some(format!("{error:?}")),
+        }
+    }
     fn with_details(mut self, details: Value) -> Self {
         self.details = Some(details);
         self
@@ -1134,6 +1144,25 @@ pub fn router(state: AppState) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn internal_error_separates_user_message_from_operator_context() {
+        let error = AppError::internal(
+            "Could not finish archiving session abc. Retry in a moment.",
+            anyhow::anyhow!("docker removal failed"),
+        );
+
+        assert_eq!(error.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            error.message(),
+            "Could not finish archiving session abc. Retry in a moment."
+        );
+        assert!(error
+            .source_chain
+            .as_deref()
+            .unwrap()
+            .contains("docker removal failed"));
+    }
 
     #[test]
     fn is_immutable_asset_matches_rspack_content_hashed_files() {

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1100,7 +1100,15 @@ pub(super) async fn archive_session(
         Err(error) => return Err(error),
     };
     tracing::debug!(key = %key, session = %session.id, "handling archive session request");
-    let warnings = archive(&st, &session, &branch).await?;
+    let warnings = archive(&st, &session, &branch).await.map_err(|error| {
+        AppError::internal(
+            format!(
+                "Could not finish archiving session {}. Its branch and conversation are safe; retry in a moment.",
+                session.id
+            ),
+            error,
+        )
+    })?;
     Ok(Json(json!({
         "archived": true,
         "kind": "session",

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -383,15 +383,19 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
 
       // Per-worker env: every spawned process (loom + weaver hooks) sees the same
       // WEAVER_HOME / WEAVER_DB so they share one database. The private WEAVER_HOME
-      // also scopes the tapestry control sockets (`$WEAVER_HOME/sock`), so a
-      // worker's terminals never collide with another worker's or the user's real
-      // sessions. WEAVER_TAPESTRY_BIN points loom at the sibling supervisor binary
-      // built alongside it.
+      // also scopes the Tapestry control sockets, so a worker's terminals never
+      // collide with another worker's or the user's real sessions. Set both the
+      // socket directory and local runner explicitly because a suite launched
+      // inside Loom inherits the production container's placement variables.
+      // WEAVER_TAPESTRY_BIN points loom at the sibling supervisor binary built
+      // alongside it.
       const childEnv: NodeJS.ProcessEnv = {
         ...process.env,
         WEAVER_HOME: weaverHome,
         WEAVER_DB: dbPath,
+        WEAVER_TAPESTRY_DIR: join(weaverHome, "sock"),
         WEAVER_TAPESTRY_BIN: join(CARGO_TARGET_DIR, "debug", "tapestry"),
+        LOOM_RUNNER: "local",
         RUST_LOG: "loom=warn,weaver_core=warn",
         // Seed an operator: loom refuses to boot with no owner configured, and
         // loopback trust authenticates every test request as this primary user


### PR DESCRIPTION
Nested Loom test servers launched inside a production session inherited the container's WEAVER_TAPESTRY_DIR. Their empty test database then classified the real production supervisors as unowned and stopped the whole session fleet. Keep nested test servers on a private socket directory and local runner, and let session containers derive their socket directory from WEAVER_HOME instead of exporting a sticky override.

Treat Docker's exact already-removing response as successful idempotent cleanup so archive retries can finish. Archive failures now preserve operator detail while telling users their branch and conversation are safe. New sessions receive a short runtime-start grace before orphan detection, and ACP task shutdown logs include the relay and stop reason.