### PR TITLE
fix(github): grant workflow-capable session tokens

### DIFF
--- a/crates/loom-forge/src/github_app.rs
+++ b/crates/loom-forge/src/github_app.rs
@@ -323,9 +323,11 @@ impl GithubApp {
             request = request.json(&serde_json::json!({
                 "repositories": repositories,
                 "permissions": {
+                    "actions": "write",
                     "contents": "write",
                     "issues": "write",
-                    "pull_requests": "write"
+                    "pull_requests": "write",
+                    "workflows": "write"
                 }
             }));
         }
@@ -355,8 +357,8 @@ impl GithubApp {
         self.installation_token(installation_id).await
     }
 
-    /// Mint a token constrained to the named repositories and the fixed
-    /// contents/issues/pull-requests write policy used by automation profiles.
+    /// Mint a token constrained to the named repositories and the fixed write
+    /// policy used by session profiles, including Actions and workflow files.
     pub async fn token_for_repositories(&self, repositories: &[String]) -> Result<String> {
         if repositories.is_empty() {
             bail!("GitHub repository allowlist is empty");
@@ -1095,9 +1097,11 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
             &[json!({
                 "repositories": ["marin", "vllm"],
                 "permissions": {
+                    "actions": "write",
                     "contents": "write",
                     "issues": "write",
-                    "pull_requests": "write"
+                    "pull_requests": "write",
+                    "workflows": "write"
                 }
             })]
         );

--- a/crates/loom-forge/src/github_manifest.rs
+++ b/crates/loom-forge/src/github_manifest.rs
@@ -91,9 +91,12 @@ pub fn manifest_json(input: &ManifestInput) -> Value {
         "public": false,
         "default_events": ["issue_comment", "issues"],
         "default_permissions": {
-            "issues": "write",
+            "actions": "write",
             "contents": "write",
-            "metadata": "read"
+            "issues": "write",
+            "metadata": "read",
+            "pull_requests": "write",
+            "workflows": "write"
         }
     })
 }
@@ -355,9 +358,17 @@ mod tests {
             m["default_events"],
             serde_json::json!(["issue_comment", "issues"])
         );
-        assert_eq!(m["default_permissions"]["issues"], "write");
-        assert_eq!(m["default_permissions"]["contents"], "write");
-        assert_eq!(m["default_permissions"]["metadata"], "read");
+        assert_eq!(
+            m["default_permissions"],
+            serde_json::json!({
+                "actions": "write",
+                "contents": "write",
+                "issues": "write",
+                "metadata": "read",
+                "pull_requests": "write",
+                "workflows": "write"
+            })
+        );
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,9 +68,9 @@ installation token from Loom. Interactive profiles use the list as an
 allowlist and stamp only the session's current repository. Strict,
 environment-cleared automation profiles retain the complete list for reviewed
 cross-repository workflows, so their entries must use one owner. Tokens grant
-contents, issues, and pull-request write access, but not Actions or workflow
-file access. The configured GitHub App must be installed on every listed
-repository.
+write access to repository contents, issues, pull requests, Actions, and
+workflow files. The configured GitHub App must have those permissions and be
+installed on every listed repository.
 
 ```yaml
 profiles:

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -277,9 +277,12 @@ Apps → New GitHub App**:
   the same `auth.base_url` names) and the **Secret** to the value you put in
   `LOOM_GITHUB_WEBHOOK_SECRET`.
 - **Repository permissions:**
+  - **Actions** — Read & write (inspect and operate workflow runs).
   - **Issues** — Read & write (read the comment, post the reply).
   - **Contents** — Read & write (clone the repo, and push the work branch).
   - **Metadata** — Read-only (mandatory; granted automatically).
+  - **Pull requests** — Read & write (open and update pull requests).
+  - **Workflows** — Read & write (push changes under `.github/workflows`).
 - **Subscribe to events** — **Issues** and **Issue comment**.
 - After creating it, **generate a private key** (downloads a `.pem`) and note the
   **App ID**.


### PR DESCRIPTION
Loom repository-scoped GitHub App credentials omitted Actions and Workflows permissions, so GitHub rejected session pushes that changed `.github/workflows` even when the App installation had those grants.\n\nRequest Actions and Workflows write access when minting repository-scoped tokens, add the same permissions to the App manifest for new installations, and document the required App configuration.