### PR TITLE
Make Weaver status explicit and reachable from Codex

### DIFF
--- a/.agents/skills/pull-request.md
+++ b/.agents/skills/pull-request.md
@@ -152,11 +152,11 @@ change first. Never silently absorb a failure.
 
 Once CI is green, address any comments already present. Fix clear comments in a
 new commit and reply in-thread; if one is genuinely unclear, raise `weaver
-status attention "<question>"`. Do not poll for future reviews or wait for
-them.
+status set --tag attention --message "<question>"`. Do not poll for future
+reviews or wait for them.
 
 Keep status `ok` while CI runs. Once CI is green and comments already present
-are handled, raise `weaver status attention "ready for review"` and hand off.
+are handled, raise `weaver status set --tag attention --message "ready for review"` and hand off.
 Close the tracking issue when the PR is open and the work is genuinely done —
 not before.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ when you're ready to land. The rules it enforces:
   more than the local gate (Playwright `e2e/`, CodeQL, a clean-checkout SPA
   build). After pushing, block on `gh pr checks <n> --watch --fail-fast`, fix
   failures until green, and address any comments already present. Only **then**
-  raise `weaver status attention "ready for review"` and hand off to the
+  raise `weaver status set --tag attention --message "ready for review"` and hand off to the
   coordinator/human final reviewer; while CI runs you are `ok`, not done.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Inside a worktree, the compact agent loop is:
 
 ```sh
 weaver summary
-weaver status ok "implementing the API"
+weaver status set --tag ok --message "implementing the API"
 weaver channel read
 weaver artifact write design design.md
 weaver channel send "ready for review"
@@ -200,9 +200,10 @@ the ACP Conversation surface rather than becoming guessed lifecycle state.
 The **attention** axis is the agent's own signal of whether it needs you:
 `ok` (going fine, or blocked on something external like a CI run or PR review),
 `attention` (a question, a decision, "ready for review"), or `blocked` (stuck,
-needs help). Agents set it with `weaver status <level> "<message>"`, which
-records both the level and a one-line current-state message; a bare
-`weaver status <level>` changes the level and keeps the last message. The
+needs help). Agents set it with
+`weaver status set --tag <level> --message "<message>"`, which records both the
+level and a one-line current-state message; omitting `--message` changes the
+level and keeps the last message. `weaver status get` reads the current value. The
 dashboard shows both and lets you filter for sessions that need a human. It
 replaces the old guessed working/waiting/idle indicator, which was often wrong —
 e.g. it read "idle" while the agent was actually waiting on a background

--- a/crates/loom-agent/src/agent.rs
+++ b/crates/loom-agent/src/agent.rs
@@ -1147,7 +1147,11 @@ async fn codex_acp_cmd(db: &Db) -> String {
 /// approval policy. Loom must receive those requests in order to apply its
 /// deterministic one-shot approval policy, so the default reviewer is `user`
 /// (the ACP client) rather than Codex's model reviewer. An explicit reviewer in
-/// `CODEX_CONFIG` wins over that default.
+/// `CODEX_CONFIG` wins over that default. Weaver commands still need to reach
+/// Loom from inside that sandbox, so agent mode also enables Codex's network
+/// proxy with only Loom's known local hostnames allowed. This avoids granting
+/// arbitrary outbound network access just to make the session control plane
+/// usable.
 fn configure_codex_acp(
     env: &mut Vec<(String, String)>,
     model: &str,
@@ -1169,6 +1173,14 @@ fn configure_codex_acp(
         config
             .entry("approvals_reviewer".to_string())
             .or_insert_with(|| json!("user"));
+
+        let sandbox = config
+            .entry("sandbox_workspace_write".to_string())
+            .or_insert_with(|| json!({}));
+        let sandbox = sandbox
+            .as_object_mut()
+            .ok_or_else(|| anyhow!("CODEX_CONFIG.sandbox_workspace_write must be a JSON object"))?;
+        sandbox.insert("network_access".to_string(), json!(true));
     }
     let features = config
         .entry("features".to_string())
@@ -1177,6 +1189,29 @@ fn configure_codex_acp(
         .as_object_mut()
         .ok_or_else(|| anyhow!("CODEX_CONFIG.features must be a JSON object"))?;
     features.insert("apps".to_string(), json!(false));
+    if codex_mode.trim() == CODEX_AGENT_MODE {
+        let proxy = features
+            .entry("network_proxy".to_string())
+            .or_insert_with(|| json!({}));
+        if proxy.is_boolean() {
+            *proxy = json!({});
+        }
+        let proxy = proxy
+            .as_object_mut()
+            .ok_or_else(|| anyhow!("CODEX_CONFIG.features.network_proxy must be a JSON object"))?;
+        proxy.insert("enabled".to_string(), json!(true));
+        let domains = proxy
+            .entry("domains".to_string())
+            .or_insert_with(|| json!({}));
+        let domains = domains.as_object_mut().ok_or_else(|| {
+            anyhow!("CODEX_CONFIG.features.network_proxy.domains must be a JSON object")
+        })?;
+        // Local launches use loopback. ContainerRunner overrides WEAVER_API to
+        // the `loom` Docker-network alias when it delivers the launch spec.
+        for host in ["127.0.0.1", "localhost", "loom"] {
+            domains.insert(host.to_string(), json!("allow"));
+        }
+    }
 
     env.retain(|(name, _)| name != "CODEX_CONFIG");
     env.push((
@@ -2519,8 +2554,16 @@ mod tests {
         .unwrap();
         assert_eq!(config["model"], "operator");
         assert_eq!(config["approvals_reviewer"], "user");
+        assert_eq!(config["sandbox_workspace_write"]["network_access"], true);
         assert_eq!(config["features"]["shell_snapshot"], true);
         assert_eq!(config["features"]["apps"], false);
+        assert_eq!(config["features"]["network_proxy"]["enabled"], true);
+        for host in ["127.0.0.1", "localhost", "loom"] {
+            assert_eq!(
+                config["features"]["network_proxy"]["domains"][host],
+                "allow"
+            );
+        }
     }
 
     #[test]
@@ -2543,6 +2586,14 @@ mod tests {
             assert!(
                 config.get("approvals_reviewer").is_none(),
                 "{mode} must not set a default reviewer"
+            );
+            assert!(
+                config.get("sandbox_workspace_write").is_none(),
+                "{mode} must not change sandbox networking"
+            );
+            assert!(
+                config["features"].get("network_proxy").is_none(),
+                "{mode} must not start the sandbox network proxy"
             );
         }
     }

--- a/crates/loom-forge/src/github.rs
+++ b/crates/loom-forge/src/github.rs
@@ -173,7 +173,7 @@ pub fn parse_wiring(value: &str) -> Option<(String, i64)> {
 
 /// One rendered bullet of the status trail: the level's dot, the time, the
 /// level name when loud, and the message. Events with nothing to say (a bare
-/// `weaver status ok`) render `None`.
+/// `weaver status set --tag ok`) render `None`.
 fn status_bullet(event: &weaver_core::events::Event) -> Option<String> {
     let value = event.data["value"].as_str().unwrap_or_default();
     let note = event.data["note"].as_str().unwrap_or_default().trim();
@@ -1760,7 +1760,7 @@ mod tests {
                 data: json!({ "key": "idle", "value": "idle", "note": "", "by": "loom" }),
                 created_at: "2026-07-18T21:05:00.000Z".to_string(),
             },
-            // A bare `weaver status ok` (no message) says nothing new.
+            // A status update without a message says nothing new.
             status_event("", "", "agent"),
             status_event("blocked", "build broken", "agent"),
         ];

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -1396,7 +1396,7 @@ fn entrance_note(tracking_issue: Option<i64>) -> String {
     if let Some(id) = tracking_issue {
         note.push_str(&format!(
             " This session is tracked as weaver issue #{id}: keep `weaver \
-             status <level> \"<message>\"` honest as you work, and run `weaver \
+             status set --tag <level> --message \"<message>\"` honest as you work, and run `weaver \
              issue close {id}` once the task is complete (e.g. the PR is open) \
              so whoever launched you knows you are done."
         ));

--- a/crates/loom/src/web/branches.rs
+++ b/crates/loom/src/web/branches.rs
@@ -149,7 +149,7 @@ const CALM_STATUS: &str = "ok";
 /// Set the agent's attention level and current-state message in one call:
 /// validate the level, write the description when a message is given,
 /// set-or-clear the `attention` tag, and record exactly one `tag` event —
-/// what `weaver status <level> [message]` has always done against the local
+/// what `weaver status set --tag <level> [--message <message>]` does against the local
 /// database in one process, reproduced server-side so a networked CLI gets
 /// the same one-event, effectively-atomic semantics.
 pub(super) async fn set_branch_status(

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -88,10 +88,19 @@ impl Client {
         }
         let resp = req.send().await.map_err(|e| {
             if e.is_connect() {
-                anyhow!(
-                    "cannot reach loom at {} — no active loom session (start the server with `loom server start`, or check $WEAVER_API)",
-                    self.base
-                )
+                let sandbox_hint = std::env::var("CODEX_SANDBOX_NETWORK_DISABLED")
+                    .is_ok_and(|value| value != "0");
+                if sandbox_hint {
+                    anyhow!(
+                        "cannot reach loom at {} — the server may be unavailable (start it with `loom server start`, or check $WEAVER_API), or Codex's network sandbox may have blocked this command; run `weaver` directly (not through `sh -c`/`bash -c`) so its command rule applies",
+                        self.base
+                    )
+                } else {
+                    anyhow!(
+                        "cannot reach loom at {} — no active loom session (start the server with `loom server start`, or check $WEAVER_API)",
+                        self.base
+                    )
+                }
             } else {
                 anyhow!("request to {url} failed: {e}")
             }

--- a/crates/weaver-core/WEAVER.md
+++ b/crates/weaver-core/WEAVER.md
@@ -24,8 +24,8 @@ weaver replays it for you automatically.
   outstanding tasks, and what to do next.
 - `weaver artifact get goal` — the task this branch was created for. Update it
   with `weaver artifact write goal <file|->` as your understanding evolves.
-- `weaver status <level> "<message>"` — your single status channel; see
-  "Signalling your status".
+- `weaver status get` / `weaver status set --tag <level> --message "<message>"`
+  — read or update your single status channel; see "Signalling your status".
 - `weaver channel read` — read this session's durable goal, messages, and
   status/result history. `weaver channel send "<message>" --channel <id>`
   talks to another visible session; `wait --channel <id>` blocks for its next
@@ -111,9 +111,10 @@ repository and worktree before handing work off.
 
 ## Signalling your status
 
-The user scans the dashboard for sessions that need them. Report with
-`weaver status <level> "<message>"` — the level is the "does this need me?"
-signal, the message the current state:
+The user scans the dashboard for sessions that need them. Report with `weaver
+status set --tag <level> --message "<message>"` — the tag is the "does this need
+me?" signal, and the message is the current state. Read it back with `weaver
+status get`:
 
 - `ok` — progressing normally, **or** waiting on something external that is
   not the user (CI, a PR review, a long workflow). No action needed.
@@ -121,12 +122,11 @@ signal, the message the current state:
 - `blocked` — stuck; you need help to proceed.
 
 Set it as your situation changes — raise it before finishing a turn expecting
-the user, drop back to `ok` once you are moving. A bare `weaver status ok`
-lowers the level and keeps the last message. The trail of these messages is
+the user, drop back to `ok` once you are moving. Omitting `--message` lowers or
+raises the tag while keeping the last message. The trail of these messages is
 your progress log: record decisions and hand-off points by setting status, not
 in separate notes — the dashboard's activity feed renders the trail, and on a
-session wired to GitHub it is mirrored publicly (see "Working a GitHub
-issue").
+session wired to GitHub it is mirrored publicly (see "Working a GitHub issue").
 
 Under the hood, status appends a typed message to your channel and retains a
 compatibility **tag** on your branch — a single `(key, value)` annotation with
@@ -148,8 +148,9 @@ moved on since it was set.
 - Ask the user in plain prose when a product choice genuinely matters. ACP
   runtime permission requests are answerable in Conversation; do not turn an
   ordinary product decision into a runtime permission card or an ad hoc
-  terminal TUI. State the question as text, set `weaver status attention
-  "<the question>"`, and continue on your best safe assumption when possible.
+  terminal TUI. State the question as text, run `weaver status set --tag
+  attention --message "<the question>"`, and continue on your best safe
+  assumption when possible.
 
 ## Your environment
 
@@ -192,7 +193,7 @@ thread; they don't read this terminal.
 - **Comment when you need a person.** A question, a design to review, the
   finished result — post it with `gh issue comment <n>` / `gh pr comment <n>`
   (comment edits notify no one; a real comment does), and raise
-  `weaver status attention "<question>"` so the dashboard agrees. Then
+  `weaver status set --tag attention --message "<question>"` so the dashboard agrees. Then
   continue on your best assumption rather than idling.
 - **Say which board a number belongs to.** Weaver issues and GitHub issues
   number separately; on a GitHub thread `#12` is theirs, so describe weaver

--- a/crates/weaver/src/bin/weaver.rs
+++ b/crates/weaver/src/bin/weaver.rs
@@ -31,23 +31,34 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+enum StatusCmd {
+    /// Print the current attention level and message.
+    Get,
+    /// Update the attention level and optional current-state message.
+    Set {
+        /// Attention level: `ok`, `attention`, or `blocked`.
+        #[arg(long)]
+        tag: String,
+        /// Current-state message, e.g. "Wired up routes; tests pass".
+        #[arg(long, default_value = "")]
+        message: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum Cmd {
-    /// Report the agent's status, or read it back.
+    /// Read or update the agent's status.
     ///
     /// This is the agent's single channel for telling the dashboard how it is
-    /// doing. With no arguments it prints the title, goal, status, and
-    /// open-issue count. Given a level (`ok`, `attention`, or `blocked`) and an
-    /// optional message, it sets both at once: the level drives what the
-    /// dashboard surfaces and filters on, and the message is the current-state
-    /// note shown beside it. Use `attention` to ask the user to look ("ready
-    /// for review", a question) and `blocked` when stuck and needing help; `ok`
-    /// covers both progressing normally and being blocked on something external
-    /// (a CI run, a PR review) that is not the user.
+    /// doing. `get` prints the title, goal, status, and open-issue count. `set`
+    /// updates the attention level and optional current-state message together.
+    /// Use `attention` to ask the user to look ("ready for review", a question)
+    /// and `blocked` when stuck and needing help; `ok` covers both progressing
+    /// normally and waiting on something external (a CI run, a PR review) that
+    /// is not the user.
     Status {
-        /// Attention level: `ok`, `attention`, or `blocked`. Omit to read.
-        level: Option<String>,
-        /// Current-state message, e.g. "Wired up routes; tests pass".
-        message: Vec<String>,
+        #[command(subcommand)]
+        cmd: StatusCmd,
     },
     /// Read, set, or clear a tag on a session.
     ///
@@ -483,7 +494,10 @@ async fn main() {
 async fn run() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
-        Cmd::Status { level, message } => cmd_status(level, message.join(" ")).await,
+        Cmd::Status { cmd } => match cmd {
+            StatusCmd::Get => cmd_status(None, String::new()).await,
+            StatusCmd::Set { tag, message } => cmd_status(Some(tag), message).await,
+        },
         Cmd::Tag { cmd } => cmd_tag(cmd).await,
         Cmd::Summary => cmd_summary().await,
         Cmd::Readme => cmd_readme().await,
@@ -691,7 +705,7 @@ async fn render_summary(client: &Client, b: &BranchView) -> Result<String> {
     } else {
         format!("{attention} — {}", b.description)
     };
-    let _ = writeln!(out, "Status:  {status}  (weaver status)");
+    let _ = writeln!(out, "Status:  {status}  (weaver status get)");
     if let Some(wiring) = github_wiring_of(b) {
         let _ = writeln!(
             out,
@@ -862,7 +876,7 @@ async fn render_summary(client: &Client, b: &BranchView) -> Result<String> {
     // The current status (where work was left off) is already on the `Status:`
     // line above, sourced from the status-description trail.
     out.push('\n');
-    let _ = writeln!(out, "Next steps:  (weaver log · weaver status)");
+    let _ = writeln!(out, "Next steps:  (weaver log · weaver status get)");
     let _ = writeln!(out, "  - {}", next_action_hint(&open, &delegated));
     Ok(out)
 }
@@ -1075,8 +1089,8 @@ fn github_wiring_of(b: &BranchView) -> Option<&str> {
 /// `blocked` set it. One call to loom (`POST /branches/{id}/status`), which
 /// writes the description, sets or clears the tag, and records a single `tag`
 /// event atomically server-side. An empty message leaves the previous message
-/// in place — `weaver status ok` just lowers the level without wiping what the
-/// agent last said.
+/// in place — `weaver status set --tag ok` just lowers the level without wiping
+/// what the agent last said.
 async fn cmd_status_write(client: &Client, key: &str, level: &str, message: &str) -> Result<()> {
     let level = level.trim().to_ascii_lowercase();
     // `ok` is a valid *input* (return to calm) but is never stored — it clears
@@ -2116,7 +2130,7 @@ fn read_hook_source() -> Option<String> {
 fn compact_replay(b: &BranchView, summary: &str) -> String {
     let summary = summary.trim_end();
     format!(
-        "Context was just compacted — you are still in a **weaver session** on branch `{branch}` (a detached agent workstream in a git worktree; the user reviews asynchronously via the loom dashboard, not this terminal). Re-orientation:\n\n{summary}\n\nReminders: keep your status honest with `weaver status <ok|attention|blocked> \"<message>\"`; never block on an interactive TUI prompt — state the question as plain text and raise `weaver status attention`; finish by opening a PR (`gh pr create`) rather than merging, and `weaver issue close <id>` your tracking issue when the work is done. Run `weaver readme` for the full weaver workflow guide.\n",
+        "Context was just compacted — you are still in a **weaver session** on branch `{branch}` (a detached agent workstream in a git worktree; the user reviews asynchronously via the loom dashboard, not this terminal). Re-orientation:\n\n{summary}\n\nReminders: keep your status honest with `weaver status set --tag <ok|attention|blocked> --message \"<message>\"`; never block on an interactive TUI prompt — state the question as plain text and raise `weaver status set --tag attention --message \"<question>\"`; finish by opening a PR (`gh pr create`) rather than merging, and `weaver issue close <id>` your tracking issue when the work is done. Run `weaver readme` for the full weaver workflow guide.\n",
         branch = b.branch,
     )
 }

--- a/crates/weaver/tests/agent_cli.rs
+++ b/crates/weaver/tests/agent_cli.rs
@@ -157,7 +157,7 @@ async fn goal_artifact_write_syncs_the_branch_goal() {
     env.run_with_stdin(&["artifact", "write", "goal"], "ship the thing\n");
     let out = env.run(&["artifact", "show", "goal"]);
     assert_eq!(out.trim(), "ship the thing");
-    let out = env.run(&["status"]);
+    let out = env.run(&["status", "get"]);
     assert!(out.contains("goal:        ship the thing"), "status: {out}");
 }
 
@@ -369,7 +369,7 @@ async fn issue_ls_separates_branch_work_from_repo_backlog() {
     );
 
     // The badge counts only this branch's claimed work, not the backlog.
-    let out = env.run(&["status"]);
+    let out = env.run(&["status", "get"]);
     assert!(out.contains("open issues: 1"), "status: {out}");
 }
 
@@ -381,7 +381,14 @@ async fn issue_show_includes_the_working_branch_status() {
     let env = Env::start().await;
     env.run(&["issue", "add", "the", "sub-task"]);
     // The current branch claims it; give the branch a live status.
-    env.run(&["status", "blocked", "build", "is", "broken"]);
+    env.run(&[
+        "status",
+        "set",
+        "--tag",
+        "blocked",
+        "--message",
+        "build is broken",
+    ]);
     let out = env.run(&["issue", "show", "1"]);
     assert!(
         out.contains("working:"),
@@ -496,7 +503,7 @@ async fn summary_orients_an_agent_on_the_branch() {
     env.run_with_stdin(&["artifact", "write", "goal"], "ship the feature\n");
     env.run(&["issue", "add", "wire", "up", "routes"]);
     env.run(&["issue", "add", "add", "tests"]);
-    env.run(&["status", "ok", "routes", "wired"]);
+    env.run(&["status", "set", "--tag", "ok", "--message", "routes wired"]);
 
     let out = env.run(&["summary"]);
     assert!(out.contains("ship the feature"), "summary: {out}");
@@ -511,7 +518,7 @@ async fn summary_orients_an_agent_on_the_branch() {
     // Every section advertises the command that drills into it.
     for hint in [
         "(weaver artifact get goal)",
-        "(weaver status)",
+        "(weaver status get)",
         "(weaver issue ls)",
         "weaver artifact",
         "weaver log",
@@ -820,7 +827,7 @@ async fn session_start_hook_after_compaction_replays_the_concise_summary() {
     let env = Env::start().await;
     env.run_with_stdin(&["artifact", "write", "goal"], "ship the feature\n");
     env.run(&["issue", "add", "wire", "up", "routes"]);
-    env.run(&["status", "ok", "routes", "wired"]);
+    env.run(&["status", "set", "--tag", "ok", "--message", "routes wired"]);
 
     let payload = r#"{"hook_event_name":"SessionStart","source":"compact"}"#;
     let out = env.run_with_stdin(&["hook", "--event", "session-start"], payload);
@@ -867,11 +874,11 @@ async fn session_start_hook_after_compaction_replays_the_concise_summary() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
-async fn set_status_with_no_id_reports_current_branch() {
+async fn get_status_reports_current_branch() {
     let env = Env::start().await;
     env.run_with_stdin(&["artifact", "write", "goal"], "do the thing\n");
     env.run(&["issue", "add", "step", "one"]);
-    let out = env.run(&["status"]);
+    let out = env.run(&["status", "get"]);
     assert!(out.contains("branch:      feature-test"), "status: {out}");
     assert!(out.contains("goal:        do the thing"), "status: {out}");
     assert!(out.contains("open issues: 1"), "status: {out}");
@@ -884,21 +891,28 @@ async fn set_status_with_no_id_reports_current_branch() {
 async fn set_status_sets_level_and_message() {
     let env = Env::start().await;
     // Declare a level with a message, then read it back.
-    let out = env.run(&["status", "attention", "Waiting", "for", "PR", "feedback"]);
+    let out = env.run(&[
+        "status",
+        "set",
+        "--tag",
+        "attention",
+        "--message",
+        "Waiting for PR feedback",
+    ]);
     assert!(
         out.contains("attention — Waiting for PR feedback"),
         "set output: {out}"
     );
 
-    let out = env.run(&["status"]);
+    let out = env.run(&["status", "get"]);
     assert!(
         out.contains("status:      attention — Waiting for PR feedback"),
         "status read: {out}"
     );
 
     // A new message replaces the old one.
-    env.run(&["status", "ok", "back", "to", "work"]);
-    let out = env.run(&["status"]);
+    env.run(&["status", "set", "--tag", "ok", "--message", "back to work"]);
+    let out = env.run(&["status", "get"]);
     assert!(
         out.contains("status:      ok — back to work"),
         "status read: {out}"
@@ -906,8 +920,8 @@ async fn set_status_sets_level_and_message() {
 
     // A bare level change keeps the last message (the message is the persistent
     // current-state note; only the level is volatile).
-    env.run(&["status", "blocked"]);
-    let out = env.run(&["status"]);
+    env.run(&["status", "set", "--tag", "blocked"]);
+    let out = env.run(&["status", "get"]);
     assert!(
         out.contains("status:      blocked — back to work"),
         "message should persist across a bare level change: {out}"
@@ -930,7 +944,14 @@ async fn set_status_sets_level_and_message() {
 async fn triage_tag_marks_a_session_without_touching_attention() {
     let env = Env::start().await;
     // The agent declares its own attention about itself.
-    env.run(&["status", "blocked", "build", "broke"]);
+    env.run(&[
+        "status",
+        "set",
+        "--tag",
+        "blocked",
+        "--message",
+        "build broke",
+    ]);
 
     // No triage tag until a watch looks.
     let out = env.run(&["tag", "ls", "--session", "feature-test"]);
@@ -967,7 +988,7 @@ async fn triage_tag_marks_a_session_without_touching_attention() {
         out.contains("attention = blocked"),
         "agent attention must survive a triage write: {out}"
     );
-    let out = env.run(&["status"]);
+    let out = env.run(&["status", "get"]);
     assert!(
         out.contains("status:      blocked — build broke"),
         "the resolved status reads the agent's attention tag: {out}"
@@ -1047,14 +1068,21 @@ async fn tag_set_ls_rm_roundtrip() {
     assert!(out.contains("(no tags)"), "tag rm cleared it: {out}");
 }
 
-/// `status ok` clears the agent's `attention` tag (returns to calm) while
+/// `status set --tag ok` clears the agent's `attention` tag (returns to calm) while
 /// leaving the branch `description` in place.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn set_status_ok_clears_attention_tag_but_keeps_description() {
     let env = Env::start().await;
     // Raise attention with a message.
-    env.run(&["status", "attention", "ready", "for", "review"]);
+    env.run(&[
+        "status",
+        "set",
+        "--tag",
+        "attention",
+        "--message",
+        "ready for review",
+    ]);
     let out = env.run(&["tag", "ls"]);
     assert!(
         out.contains("attention = attention"),
@@ -1062,13 +1090,13 @@ async fn set_status_ok_clears_attention_tag_but_keeps_description() {
     );
 
     // Return to calm — the attention tag is cleared, the description survives.
-    env.run(&["status", "ok"]);
+    env.run(&["status", "set", "--tag", "ok"]);
     let out = env.run(&["tag", "ls"]);
     assert!(
         !out.contains("attention ="),
-        "status ok should clear the attention tag: {out}"
+        "calm status should clear the attention tag: {out}"
     );
-    let out = env.run(&["status"]);
+    let out = env.run(&["status", "get"]);
     assert!(
         out.contains("status:      ok — ready for review"),
         "ok must keep the last description beside the calm level: {out}"
@@ -1079,13 +1107,28 @@ async fn set_status_ok_clears_attention_tag_but_keeps_description() {
 #[serial]
 async fn set_status_rejects_unknown_level() {
     let env = Env::start().await;
-    let out = env.run_raw(&["status", "bogus"]);
+    let out = env.run_raw(&["status", "set", "--tag", "bogus"]);
     assert!(!out.status.success(), "unknown level should fail");
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("unknown status 'bogus'"),
         "stderr: {stderr}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn status_requires_an_explicit_get_or_set_verb() {
+    let env = Env::start().await;
+    for args in [&["status"][..], &["status", "attention"][..]] {
+        let out = env.run_raw(args);
+        assert!(!out.status.success(), "legacy status syntax should fail");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("Usage: weaver status <COMMAND>"),
+            "stderr: {stderr}"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -591,11 +591,19 @@ tracking.
 (the agent runs in a PTY loom drives by keystroke) or `acp` (a headless adapter
 loom drives over the [Agent Client Protocol](https://agentclientprotocol.com)).
 The builtins are `terminal`; a custom agent carries its own `custom_agents.protocol`
-column. A create may **override** to `acp` where the agent allows it (Claude opts
-in; Codex rejects it, as `codex-acp` is a later phase), and the resolved protocol
-is stamped on the `sessions` row at create, immutable thereafter. The row's
+column. A create may **override** to `acp` where the agent allows it (both Claude
+and Codex opt in), and the resolved protocol is stamped on the `sessions` row at
+create, immutable thereafter. The row's
 protocol — not the agent kind — is what every downstream path (launch, lifecycle,
 drive routes, adopt, archive) branches on.
+
+Codex ACP's `agent` mode uses the workspace-write sandbox. Loom sets
+`sandbox_workspace_write.network_access` and enables Codex's network proxy with
+only `127.0.0.1`, `localhost`, and the ContainerRunner's `loom` network alias
+allowed. This lets the injected `$WEAVER_API` remain usable for status,
+artifacts, and channels without opening arbitrary shell-command egress. A plain
+workspace-write `network_access = true` without the proxy would be broader than
+the control-plane requirement.
 
 **Lifecycle** is driven by that protocol. A `terminal` session's lifecycle rides
 Claude Code's hooks, so that path merges a `hooks` block into the worktree's
@@ -642,17 +650,17 @@ loud self-report still wins the badge. We don't try to mechanically separate
 good-enough idle signal, and the status watch upgrades it when warranted (below).
 
 The **`attention` tag** is otherwise the agent's own call, set via `weaver
-status <level> ["<message>"]`. That calls `POST /api/branches/{key}/status`,
+status set --tag <level> [--message "<message>"]`. That calls `POST /api/branches/{key}/status`,
 which writes the tag (and, when a message is given, the `description`) and
 records a `tag` event the monitor re-broadcasts over SSE, atomically in one
 request — `ok` clears the tag, the two loud levels upsert it. The message rides
 the event as its `note`, so the event log carries the full **status trail** —
 the progress log the dashboard's activity feed renders, `weaver log` prints,
 and a GitHub-wired session mirrors publicly (see [GitHub
-integration](#github-integration)). A bare `weaver
-status <level>` changes only the level and keeps the last message. Last write
-wins, so an explicit declaration overrides the hook-inferred default. The
-general `weaver tag set|rm|ls` group writes any key the same way, over the
+integration](#github-integration)). Omitting `--message` changes only the level
+and keeps the last message. Last write wins, so an explicit declaration
+overrides the hook-inferred default. The general `weaver tag set|rm|ls` group
+writes any key the same way, over the
 branch-scoped `PUT`/`DELETE /api/branches/{key}/tags/{key}` routes; the
 session-scoped `PUT`/`DELETE /api/sessions/{id}/tags/{key}` routes serve the
 UI. Watches replace their complete author-scoped set through one

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -88,7 +88,7 @@ jump to the session.
 The "On it" reply doubles as the thread's live view of the session. At launch
 the trigger **wires** the branch to the thread — a quiet `github` tag whose
 value is `owner/name#number` — and records the reply's comment id. From then
-on, every `weaver status <level> "<message>"` the agent writes re-renders that
+on, every `weaver status set --tag <level> --message "<message>"` the agent writes re-renders that
 comment:
 
 > On it — {base}/s/{id}

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -69,8 +69,9 @@ frame it receives, in order:
 The "On it" reply doubles as the thread's live view of the session, exactly
 as the GitHub comment does. At launch the trigger wires the branch to the
 thread — a `slack` tag whose value is `team_id/channel_id/thread_ts` — and
-records the card message's `ts`. From then on, every `weaver status <level>
-"<message>"` the agent writes re-renders that message via `chat.update`:
+records the card message's `ts`. From then on, every `weaver status set --tag
+<level> --message "<message>"` the agent writes re-renders that message via
+`chat.update`:
 
 > On it — <{base}/s/{id}>
 >

--- a/e2e/fixtures/weaver.ts
+++ b/e2e/fixtures/weaver.ts
@@ -680,10 +680,16 @@ export const test = base.extend<{ weaver: WeaverFixture }, WorkerFixtures>({
       },
 
       async setStatus(session, level, message) {
-        // `weaver status <level> [message]` writes the branch's `attention`
-        // tag (clearing it on `ok`) and current-state message, appending a typed
-        // channel item and recording a `tag` event.
-        const args = ["status", level, ...(message ? [message] : [])];
+        // `weaver status set` writes the branch's `attention` tag (clearing it
+        // on `ok`) and current-state message, appending a typed channel item and
+        // recording a `tag` event.
+        const args = [
+          "status",
+          "set",
+          "--tag",
+          level,
+          ...(message ? ["--message", message] : []),
+        ];
         execFileSync(WEAVER_BINARY, args, {
           env: { ...childEnv, WEAVER_BRANCH: session.branch.id },
           stdio: "pipe",


### PR DESCRIPTION
## Summary

- give `weaver status` a strict `get` / `set --tag ... [--message ...]` interface and remove the old shorthand
- enable Codex sandbox networking through an exact Loom-host allowlist (`127.0.0.1`, `localhost`, and the container alias `loom`)
- improve connection diagnostics and update all agent-facing guidance, tests, and E2E fixtures

## Why

The observed artifact/status failures were command-shape-dependent: direct `weaver` calls reached Loom, while shell-wrapped calls were blocked by the Codex network sandbox. The network proxy keeps Weaver control-plane access available without broadly allowing public outbound destinations.

## Testing

- `./scripts/pre-commit.sh`
- `./scripts/test-representative.sh`
- focused Weaver CLI, Codex ACP configuration, ACP launch, and Playwright status tests
- `scripts/lint-review.py` (no findings)