### PR TITLE
fix(loom): preserve input across blocked steering

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ explicitly selects an origin profile. Deployment configuration can manage and
 select those profiles together.
 
 `poll` reads lifecycle and attention, `wait` blocks until completion or human
-attention, `send` delivers immediate control input, and `interrupt` stops the
-current turn. For ACP, immediate control input steers a supported live turn and
-otherwise cancels and restarts; the conversation composer uses the same
-immediate delivery behavior. Session commands accept an id, branch id, branch
-name, or `repo:branch`.
+attention, `send` delivers immediate external control input, and `interrupt`
+stops the current turn. For ACP, external input always cancels and restarts;
+the conversation composer tries live steering and falls back to the same
+stop-and-send behavior when the model is behind a tool or permission. Session
+commands accept an id, branch id, branch name, or `repo:branch`.
 
 The session title is one canonical, unqualified task label; fleet views add its
 Group only when they need a qualified `Group / Task` name. Loom records whether
@@ -263,16 +263,15 @@ the workbench header.
 Every session detail has a **Conversation** tab that renders the agent's chat
 with the model — user turns, replies, thinking, and tool calls — live and
 (via the archive capture below) still there to review after the terminal is gone.
-For ACP sessions, the conversation composer sends immediately: it steers an
-adapter that supports live input, or stops an unsteerable turn and starts the
-message as the next turn. Feedback queued by another client stays visible and
-can be pulled back into the composer with its **Edit** action or ArrowUp from an
-empty composer, or sent immediately with **Stop & send**. The live status names
-visible thinking, writing, or tool activity and reports how long it has been
-since the agent produced an observable update; quiet time is not guessed to mean
-stuck. Cross-session `loom session send` uses the same immediate policy: it
-steers a supported live turn, or cancels that turn and starts the message as a
-new one.
+For ACP sessions, the conversation composer sends immediately: it steers a
+receptive adapter, or stops a turn blocked behind a tool or permission and
+starts the message as the next turn. Feedback queued by another client stays
+visible and can be pulled back into the composer with its **Edit** action or
+ArrowUp from an empty composer, or sent immediately with **Stop & send**. The
+live status names visible thinking, writing, or tool activity and reports how
+long it has been since the agent produced an observable update; quiet time is
+not guessed to mean stuck. Cross-session `loom session send` always cancels a
+live turn and starts the message as a new one.
 
 Whenever a session is archived — by the Archive button or automatically on merge
 — loom first captures that conversation to disk: it finds the agent's transcript

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -578,15 +578,27 @@ impl AcpHandle {
             .await
     }
 
-    /// Deliver injected input without leaving it behind a live turn: steer when
-    /// supported, otherwise cancel the current turn and start normally.
-    pub async fn send_now(
+    /// Deliver conversation input now: steer a receptive live turn, otherwise
+    /// cancel the current turn and start normally.
+    pub async fn steer_or_restart(
         &self,
         text: String,
         by: Option<String>,
         resources: Vec<Value>,
     ) -> Result<PromptAck> {
-        self.send_prompt(text, by, PromptDelivery::Immediate, resources)
+        self.send_prompt(text, by, PromptDelivery::SteerOrRestart, resources)
+            .await
+    }
+
+    /// Deliver external control input now by cancelling a live turn and
+    /// starting the message normally.
+    pub async fn stop_and_send(
+        &self,
+        text: String,
+        by: Option<String>,
+        resources: Vec<Value>,
+    ) -> Result<PromptAck> {
+        self.send_prompt(text, by, PromptDelivery::StopAndSend, resources)
             .await
     }
 
@@ -1161,8 +1173,11 @@ pub async fn attach(state: &AcpCtx, session_id: &str) -> Result<()> {
 enum PromptDelivery {
     /// Preserve the conversation composer's queue-first behavior.
     Queue,
+    /// User conversation input: steer a receptive live turn, or cancel and
+    /// restart when the adapter cannot consume a steer immediately.
+    SteerOrRestart,
     /// Cross-session control: cancel and restart immediately.
-    Immediate,
+    StopAndSend,
 }
 
 enum Command {
@@ -1364,7 +1379,7 @@ struct PendingPerm {
     frame_seq: u64,
 }
 
-/// An automated message waiting for the adapter's steering response.
+/// A user-console message waiting for the adapter's steering response.
 struct PendingSteer {
     text: String,
     by: Option<String>,
@@ -2711,7 +2726,9 @@ impl Task {
             .and_then(|value| serde_json::from_value::<wire::SteeringResult>(value).ok())
             .map(|result| result.outcome);
         match (outcome, error) {
-            (Some(wire::SteeringOutcome::Injected), None) => {
+            (Some(wire::SteeringOutcome::Injected), None)
+                if self.tools.is_empty() && self.pending_perms.is_empty() =>
+            {
                 // The adapter accepted this as input to the current turn. Flush
                 // earlier streamed prose before assigning the injected message
                 // its durable sequence.
@@ -2749,7 +2766,7 @@ impl Task {
                     session = %self.session_id,
                     ?outcome,
                     ?error,
-                    "steering failed; restarting the turn"
+                    "steering was unavailable or blocked; restarting the turn"
                 );
                 let result = self
                     .restart_prompt(pending.text, pending.by, pending.resources)
@@ -3318,9 +3335,15 @@ impl Task {
                         self.resume_automatic_dispatch_on(&ack);
                         let _ = reply.send(ack);
                     }
-                    PromptDelivery::Immediate => {
+                    PromptDelivery::SteerOrRestart => {
                         if self.turn_live
                             && self.steering_cap
+                            // Adapters accept the private steering RPC while the
+                            // model is blocked behind a tool or permission, but
+                            // cancellation can then discard that unconsumed
+                            // in-memory steer. Start a durable prompt instead.
+                            && self.tools.is_empty()
+                            && self.pending_perms.is_empty()
                             && self.pending_steers.is_empty()
                             && self.pending_external.is_none()
                         {
@@ -3354,6 +3377,11 @@ impl Task {
                             self.resume_automatic_dispatch_on(&ack);
                             let _ = reply.send(ack);
                         }
+                    }
+                    PromptDelivery::StopAndSend => {
+                        let ack = self.restart_prompt(text, by, resources).await;
+                        self.resume_automatic_dispatch_on(&ack);
+                        let _ = reply.send(ack);
                     }
                 }
             }

--- a/crates/loom-deliver/src/slack.rs
+++ b/crates/loom-deliver/src/slack.rs
@@ -1492,8 +1492,8 @@ fn followup_prompt(trigger: &Trigger, instruction: &str) -> String {
     )
 }
 
-/// Send an ACP follow-up as immediate injected input: steer a supported live
-/// turn, otherwise stop it and start the message as a fresh turn.
+/// Send an external ACP follow-up immediately: stop a live turn and start the
+/// message as a fresh turn.
 async fn forward_acp_followup(
     registry: &crate::acp::AcpRegistry,
     session_id: &str,
@@ -1503,7 +1503,7 @@ async fn forward_acp_followup(
         .get(session_id)
         .ok_or_else(|| anyhow!("session has no live ACP task"))?;
     handle
-        .send_now(prompt.to_string(), Some("slack".to_string()), Vec::new())
+        .stop_and_send(prompt.to_string(), Some("slack".to_string()), Vec::new())
         .await
         .context("sending follow-up to ACP conversation")?;
     Ok(())

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -576,8 +576,8 @@ export const getSessionChat = (id: string, before?: { turn: number; seq: number 
   return get(`/sessions/${id}/chat${query}`) as Promise<ChatSnapshot>;
 };
 
-/** Send a user message to an ACP session now. A supported live turn is steered;
- *  an unsteerable live turn is stopped and replaced. */
+/** Send a user message to an ACP session now. A receptive live turn is steered;
+ *  a turn blocked behind a tool or permission is stopped and replaced. */
 export const promptSession = (id: string, text: string, by?: string, files: string[] = []) =>
   post(`/sessions/${id}/prompt`, {
     text,

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -278,7 +278,7 @@ async fn prompt_channel_run(
         .clone()
         .expect("channel runs require a goal");
     if let Err(error) = handle
-        .send_now(goal.clone(), Some(by.clone()), Vec::new())
+        .stop_and_send(goal.clone(), Some(by.clone()), Vec::new())
         .await
     {
         crate::runs::waiting(&st.db, &run.id).await.ok();

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1770,14 +1770,14 @@ pub(super) async fn send_session(
     Json(req): Json<SendReq>,
 ) -> ApiResult<Json<Value>> {
     let (session, branch) = require_session(&st.db, &key).await?;
-    // A cross-session send must not sit behind an ACP turn indefinitely. Steer
-    // the live turn when supported, otherwise cancel it and immediately start
-    // this message as a fresh turn, while keeping the same `nudge` audit.
+    // A cross-session send must not sit behind an ACP turn indefinitely or be
+    // discarded with an adapter's in-memory steer. Cancel a live turn and
+    // immediately start this message as a fresh turn, keeping the same audit.
     if session.protocol == "acp" {
         let handle = require_acp_task(&st, &session)?;
         let by = author_or_manual(req.by.as_deref());
         let ack = handle
-            .send_now(req.text.clone(), Some(by.clone()), Vec::new())
+            .stop_and_send(req.text.clone(), Some(by.clone()), Vec::new())
             .await
             .map_err(|e| AppError::conflict(e.to_string()))?;
         events::record(
@@ -2025,8 +2025,8 @@ pub(super) struct PromptBody {
     pub text: String,
     #[serde(default)]
     pub by: Option<String>,
-    /// Deliver this user message immediately: steer a supported live turn, or
-    /// cancel and replace an unsteerable one.
+    /// Deliver this user message immediately: steer a receptive live turn, or
+    /// cancel and replace one blocked behind a tool or permission.
     #[serde(default)]
     pub send_now: bool,
     /// Promote the server's durable next-turn queue instead of sending `text`.
@@ -2146,9 +2146,9 @@ async fn prompt_resources(work_dir: &str, files: &[String]) -> ApiResult<Vec<Val
 
 /// Send a user message to an ACP session. A normal request is dispatched when
 /// idle or appended to the durable queue while a turn is live; `send_now`
-/// instead steers a supported live turn or cancels and replaces an unsteerable
-/// one. Returns 202 `{ queued, turn }`. Every send records a `nudge` event (the
-/// audit rule).
+/// instead steers a receptive live turn or cancels and replaces one blocked at
+/// a tool/permission boundary. Returns 202 `{ queued, turn }`. Every send records
+/// a `nudge` event (the audit rule).
 pub(super) async fn prompt_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
@@ -2169,7 +2169,7 @@ pub(super) async fn prompt_session(
         let resources = prompt_resources(&session.work_dir, &req.files).await?;
         if req.send_now {
             handle
-                .send_now(req.text.clone(), Some(by.clone()), resources)
+                .steer_or_restart(req.text.clone(), Some(by.clone()), resources)
                 .await
         } else {
             handle

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -14,6 +14,7 @@
 //                        turn (what claude does after /compact); must NOT re-journal
 //   tool:edit[:title]    a tool_call (in_progress) then tool_call_update (completed);
 //                        an `edit` kind carries a diff, others a text content block
+//   toolwait:MS[:title]  an in-progress execute tool that waits until MS or cancellation
 //   image[:title]        a read tool whose result is an ACP image content block
 //   toolfail[:title]     a tool_call that ends with status `failed`
 //   plan                 a plan update with two entries
@@ -209,6 +210,20 @@ async function runToken(tok) {
     notify({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: tok.slice(6) } });
   } else if (tok.startsWith("echo:")) {
     notify({ sessionUpdate: "user_message_chunk", content: { type: "text", text: tok.slice(5) } });
+  } else if (tok.startsWith("toolwait:")) {
+    const [, delay, ...titleParts] = tok.split(":");
+    const toolCallId = "call-wait-" + Math.floor(Math.random() * 100000);
+    notify({
+      sessionUpdate: "tool_call",
+      toolCallId,
+      title: titleParts.join(":") || "Blocking tool",
+      kind: "execute",
+      status: "in_progress",
+    });
+    await sleepCancellable(Number(delay));
+    if (!cancelled) {
+      notify({ sessionUpdate: "tool_call_update", toolCallId, status: "completed" });
+    }
   } else if (tok.startsWith("toolfail")) {
     const title = tok.includes(":") ? tok.slice(tok.indexOf(":") + 1) : "Failing tool";
     const toolCallId = "call-fail-" + Math.floor(Math.random() * 100000);

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1501,9 +1501,9 @@ async fn prompt_stops_and_sends_the_durable_queue() {
     }));
 }
 
-/// The conversation composer requests immediate delivery by default. Without
-/// steering support, that is one atomic stop-and-replace operation rather than
-/// a queue write followed by a second promotion request.
+/// User-console feedback is immediate. Without steering support, that is one
+/// atomic stop-and-replace operation rather than a queue write followed by a
+/// second promotion request.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn prompt_send_now_restarts_an_unsteerable_live_turn() {
@@ -1595,15 +1595,15 @@ async fn session_send_restarts_a_live_turn() {
     }));
 }
 
-/// Automated `/send` input uses the adapter's steering extension when it is
-/// available, keeping the agent's current work alive instead of cancelling it.
+/// User-console feedback uses a supported adapter's steering extension while
+/// the model is receptive, keeping the current work alive.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn session_send_steers_a_supported_live_turn() {
+async fn prompt_send_now_steers_a_receptive_live_turn() {
     let ts = TestServer::start().await;
     start_new_with_env(
         &ts,
-        "acp-send-steer",
+        "acp-prompt-steer",
         None,
         None,
         vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
@@ -1612,7 +1612,7 @@ async fn session_send_steers_a_supported_live_turn() {
 
     ts.client
         .post(
-            "/api/sessions/acp-send-steer/prompt",
+            "/api/sessions/acp-prompt-steer/prompt",
             json!({ "text": "wait:1200|say:first" }),
         )
         .await
@@ -1620,15 +1620,15 @@ async fn session_send_steers_a_supported_live_turn() {
     let sent = ts
         .client
         .post(
-            "/api/sessions/acp-send-steer/send",
-            json!({ "text": "say:injected" }),
+            "/api/sessions/acp-prompt-steer/prompt",
+            json!({ "text": "say:injected", "send_now": true }),
         )
         .await
         .unwrap();
     assert_eq!(sent["queued"], false, "response: {sent}");
     assert_eq!(sent["turn"], 0, "steering stays in the live turn");
 
-    let chat = poll_chat(&ts, "acp-send-steer", Duration::from_secs(10), |blocks| {
+    let chat = poll_chat(&ts, "acp-prompt-steer", Duration::from_secs(10), |blocks| {
         blocks.iter().any(|block| {
             block["kind"] == "agent_message"
                 && block["payload"]["text"]
@@ -1646,6 +1646,131 @@ async fn session_send_steers_a_supported_live_turn() {
     }));
     assert!(!blocks.iter().any(|block| {
         block["kind"] == "turn_end" && block["payload"]["stop_reason"] == "cancelled"
+    }));
+}
+
+/// codex-acp acknowledges steering while the model is blocked in a tool, but a
+/// later cancellation can discard that unconsumed in-memory input. User-console
+/// feedback therefore falls back to one normal stop-and-send at that boundary.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prompt_send_now_restarts_a_tool_blocked_live_turn() {
+    let ts = TestServer::start().await;
+    start_new_with_env(
+        &ts,
+        "acp-prompt-tool",
+        None,
+        None,
+        vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
+    )
+    .await;
+    let mut events = ts
+        .state
+        .acp
+        .get("acp-prompt-tool")
+        .expect("task registered")
+        .subscribe();
+
+    ts.client
+        .post(
+            "/api/sessions/acp-prompt-tool/prompt",
+            json!({ "text": "toolwait:3000:PR monitor|say:stale" }),
+        )
+        .await
+        .unwrap();
+    drain_events(&mut events, Duration::from_secs(5), |event| {
+        event.event == "tool"
+            && event.data["title"] == "PR monitor"
+            && event.data["status"] == "in_progress"
+    })
+    .await;
+
+    let sent = ts
+        .client
+        .post(
+            "/api/sessions/acp-prompt-tool/prompt",
+            json!({ "text": "say:replacement", "send_now": true }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(sent["queued"], false, "response: {sent}");
+    assert_eq!(sent["turn"], 1, "the replacement opens the next turn");
+
+    let chat = poll_chat(&ts, "acp-prompt-tool", Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "replacement"
+        })
+    })
+    .await;
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 0
+            && block["kind"] == "turn_end"
+            && block["payload"]["stop_reason"] == "cancelled"
+    }));
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 1
+            && block["kind"] == "user_message"
+            && block["payload"]["text"] == "say:replacement"
+            && block["payload"].get("steered").is_none()
+    }));
+}
+
+/// External `/send` input always stops and starts a normal ACP turn, even when
+/// the adapter advertises private steering.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_send_restarts_a_steerable_live_turn() {
+    let ts = TestServer::start().await;
+    start_new_with_env(
+        &ts,
+        "acp-send-steerable",
+        None,
+        None,
+        vec![("FAKE_ACP_STEERING".to_string(), "1".to_string())],
+    )
+    .await;
+
+    ts.client
+        .post(
+            "/api/sessions/acp-send-steerable/prompt",
+            json!({ "text": "wait:1200|say:stale" }),
+        )
+        .await
+        .unwrap();
+    let sent = ts
+        .client
+        .post(
+            "/api/sessions/acp-send-steerable/send",
+            json!({ "text": "say:external" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(sent["queued"], false, "response: {sent}");
+    assert_eq!(sent["turn"], 1, "external input opens the next turn");
+
+    let chat = poll_chat(
+        &ts,
+        "acp-send-steerable",
+        Duration::from_secs(10),
+        |blocks| {
+            blocks.iter().any(|block| {
+                block["kind"] == "agent_message" && block["payload"]["text"] == "external"
+            })
+        },
+    )
+    .await;
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 0
+            && block["kind"] == "turn_end"
+            && block["payload"]["stop_reason"] == "cancelled"
+    }));
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 1
+            && block["kind"] == "user_message"
+            && block["payload"]["text"] == "say:external"
+            && block["payload"].get("steered").is_none()
     }));
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -356,12 +356,12 @@ route truth, including internal proxy and compatibility paths.
 | `GET /api/sessions/{id}/history` | a bounded newest-tail page of provider-neutral records in chronological display order; `before`, `limit`, and `kinds` own backward pagination/filtering |
 | `GET /api/sessions/{id}/history/search` | case-insensitive literal `q` search over the same session-scoped records and cursor/filter contract |
 | `GET /api/sessions/{id}/terminal` | WebSocket: xterm.js ⇄ the session's tapestry PTY (the interaction surface) |
-| `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a supported live turn is steered, otherwise it is cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
+| `POST /api/sessions/{id}/send` | deliver `{text}` to the agent (`submit`, default true, follows terminal input with Enter); for an `acp` session a live turn is cancelled and immediately replaced by a new turn, keeping the same `nudge` audit |
 | `POST /api/sessions/{id}/interrupt` | stop the current turn — a break (Escape) to the terminal for a `terminal` session, `session/cancel` for an `acp` one |
 | `GET /api/sessions/{id}/preview?lines=N` | capture the screen as `{screen}`; `lines` adds scrollback above the visible screen (for an `acp` session, `{screen}` is the last `lines` journal blocks rendered as compact text) |
 | `GET /api/sessions/{id}/chat` | The newest 200 blocks of the ACP session's DB-backed journal, `older_cursor`, live-turn state, pending prompt, effective mode, and durable composer metadata (the last provider-advertised controls remain after provider exit/restart); pass the cursor as `before_turn` + `before_seq` to page backward |
 | `GET /api/sessions/{id}/chat/stream` | SSE tail of the live journal: `block` (a committed block), `delta` (a streaming message/thought chunk), `tool` (a live tool-call update), `turn` (started / ended), `resync` (the bounded live buffer overran; reload the durable snapshot) |
-| `POST /api/sessions/{id}/prompt` | `{text, send_now?}` → 202 `{queued, turn}` — dispatch a user message as a `session/prompt`; the default queues behind a live turn, while `send_now` steers when supported or cancels and replaces an unsteerable turn |
+| `POST /api/sessions/{id}/prompt` | `{text, send_now?}` → 202 `{queued, turn}` — dispatch a user message as a `session/prompt`; the default queues behind a live turn, while `send_now` steers a receptive turn or cancels and replaces one blocked behind a tool or permission |
 | `DELETE /api/sessions/{id}/prompt` | atomically retract unseen next-turn feedback and return `{text}` for editing; 409 when the current ACP state has no queue available to retract |
 | `POST /api/sessions/{id}/permissions/{request_id}` | `{option_id}` → answer an open permission request (200 / 404 unknown / 409 already resolved) |
 | `PUT /api/sessions/{id}/mode` | `{mode_id}` → change the ACP session's permission mode (`session/set_mode`), journaled as a `mode_change` |
@@ -489,8 +489,7 @@ let an agent or script type into, interrupt, or read back a child session
 uniformly. For a `terminal` session each requires a live terminal (else 409). An
 `acp` session has no PTY, so the same verbs map onto the protocol — keeping the
 CLI (`loom session {send,interrupt,preview}`) and its `nudge` audit uniform across
-backends: `send` steers a supported live turn, otherwise cancels it and starts
-the message as a normal prompt,
+backends: `send` cancels a live turn and starts the message as a normal prompt,
 `interrupt` is a `session/cancel`,
 and `preview` renders the last journal blocks as compact plain text instead of
 a vt100 screen capture.

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -75,13 +75,12 @@ Artifacts stays one tap away; Agent, Changes, and ACP Shells remain available
 from More without occupying primary navigation.
 
 Conversation is the durable operator/agent exchange. Mid-turn composer feedback
-steers adapters that support live input; otherwise it stops the current turn and
-starts the feedback as the next turn. Unseen text queued by another client can
-still be retracted into the composer for editing without rewriting
-already-dispatched history, or promoted with **Stop & send**. Permission requests
-and runtime controls stay in
-the conversation that produced them; elapsed quiet time is evidence, not an
-automatic “stuck” verdict.
+steers a receptive adapter. When a tool or permission blocks the model from
+consuming a steer, Loom stops the current turn and starts the feedback as the
+next turn. Unseen queued text can still be retracted into the composer for
+editing without rewriting already-dispatched history, or promoted with **Stop &
+send**. Permission requests and runtime controls stay in the conversation that
+produced them; elapsed quiet time is evidence, not an automatic “stuck” verdict.
 
 Review contains **Changes** and **Artifacts**. Both use the same staged review
 workflow:


### PR DESCRIPTION
Separate user-console ACP delivery from external delivery. Console messages still use private steering while the model is receptive, but fall back to cancel-and-restart when a tool or permission blocks consumption. External `/send`, Slack follow-ups, and automation deliveries now always cancel and start a normal prompt, so an adapter acknowledgement cannot strand input in a cancelled turn.

Add regressions for receptive steering, the observed active-tool loss, and steering-capable external sessions.