### PR TITLE
fix(loom): trigger sessions from submitted PR reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,16 +315,17 @@ Polling is a quiet no-op for repositories without a GitHub remote, or wherever
 
 ### Trigger sessions from issues
 
-Include **`@loom`** in a GitHub issue body or issue/PR comment when creating it,
-or add the mention later by editing the body, and loom launches a session
-against that repo, seeded from the issue, then replies with a link to it. GitHub
-delivers the request to
+Include **`@loom`** in a GitHub issue body, issue/PR comment, or submitted PR
+review, or add the mention later by editing an issue or comment body, and loom
+launches a session against that repo, seeded from the issue, then replies with a
+link to it. GitHub delivers the request to
 `POST /api/github/webhook`, which verifies the delivery's HMAC signature and
 authorizes the requester against the **approved-user allowlist** (the same
 people who can sign in to loom — repo write access is not itself a grant). Set
 `LOOM_GITHUB_WEBHOOK_SECRET` and point a repo/org webhook at
-`{base}/api/github/webhook` (issues and issue-comment events,
-`application/json`). See [docs/github-trigger.md](docs/github-trigger.md).
+`{base}/api/github/webhook` (issues, issue-comment, and pull-request-review
+events, `application/json`). See
+[docs/github-trigger.md](docs/github-trigger.md).
 
 ## Server address
 

--- a/crates/loom-forge/src/github_manifest.rs
+++ b/crates/loom-forge/src/github_manifest.rs
@@ -75,11 +75,12 @@ pub struct ManifestInput<'a> {
 /// hand-registration steps in `docs/github-trigger.md` "Create the App":
 /// webhook URL + secret placeholder (GitHub mints the secret itself and
 /// returns it in the conversion — no `hook_attributes.secret` needed),
-/// Issues/Contents write + Metadata read, subscribed to `issue_comment` and
-/// `issues`, plus `callback_urls` so the App's own client id/secret also serves
-/// loom's "Sign in with GitHub" login — the same `/login/oauth/authorize` and
-/// `/login/oauth/access_token` endpoints [`crate::auth::github_oauth`] already
-/// speaks work unchanged for a GitHub App's user-to-server OAuth.
+/// Issues/Contents write + Metadata read, subscribed to `issue_comment`,
+/// `issues`, and `pull_request_review`, plus `callback_urls` so the App's own
+/// client id/secret also serves loom's "Sign in with GitHub" login — the same
+/// `/login/oauth/authorize` and `/login/oauth/access_token` endpoints
+/// [`crate::auth::github_oauth`] already speaks work unchanged for a GitHub
+/// App's user-to-server OAuth.
 pub fn manifest_json(input: &ManifestInput) -> Value {
     let base = input.base_url.trim_end_matches('/');
     json!({
@@ -89,7 +90,7 @@ pub fn manifest_json(input: &ManifestInput) -> Value {
         "redirect_url": input.redirect_url,
         "callback_urls": [format!("{base}/api/auth/github/callback")],
         "public": false,
-        "default_events": ["issue_comment", "issues"],
+        "default_events": ["issue_comment", "issues", "pull_request_review"],
         "default_permissions": {
             "actions": "write",
             "contents": "write",
@@ -356,7 +357,7 @@ mod tests {
         assert_eq!(m["public"], false);
         assert_eq!(
             m["default_events"],
-            serde_json::json!(["issue_comment", "issues"])
+            serde_json::json!(["issue_comment", "issues", "pull_request_review"])
         );
         assert_eq!(
             m["default_permissions"],

--- a/crates/loom-forge/src/github_trigger.rs
+++ b/crates/loom-forge/src/github_trigger.rs
@@ -1,7 +1,7 @@
-//! The inbound GitHub trigger: a webhook that turns an `@loom` issue body or
-//! issue/PR comment into a session and replies with its URL (shared-loom design
-//! §6.3). This is the **untrusted-input boundary** — the receiver is exposed to
-//! the internet, so every step here is a gate:
+//! The inbound GitHub trigger: a webhook that turns an `@loom` issue body,
+//! issue/PR comment, or submitted PR review into a session and replies with its
+//! URL (shared-loom design §6.3). This is the **untrusted-input boundary** — the
+//! receiver is exposed to the internet, so every step here is a gate:
 //!
 //! 1. **Authenticate the delivery cryptographically.** GitHub signs each
 //!    delivery with HMAC-SHA256 over the raw body; [`verify_signature`] checks it
@@ -9,8 +9,8 @@
 //!    rejected before its body is even parsed.
 //! 2. **Dedupe** on the `X-GitHub-Delivery` GUID ([`record_delivery`]) so a
 //!    replayed or GitHub-retried delivery never launches a second session.
-//! 3. **Filter** to new or body-edited `issue_comment` and `issues` events,
-//!    ignoring the bot's own events.
+//! 3. **Filter** to new or body-edited `issue_comment` and `issues` events, plus
+//!    submitted `pull_request_review` events, ignoring the bot's own events.
 //! 4. **Match** the trigger phrase ([`is_trigger`]) — a standalone mention
 //!    newly introduced into the request prose, quotes and code excluded.
 //! 5. **Authorize the requester** ([`authorize`]) against loom's approved-user
@@ -263,8 +263,8 @@ fn closing_run(chars: &[char], from: usize, run: usize) -> Option<usize> {
     None
 }
 
-/// A normalized trigger request from a new or edited issue body or issue/PR
-/// comment.
+/// A normalized trigger request from an issue body, issue/PR comment, or
+/// submitted PR review.
 #[derive(Debug)]
 pub struct TriggerEvent {
     pub issue: IssuePayload,
@@ -287,6 +287,7 @@ pub enum TriggerSource {
     CommentEdited,
     IssueOpened,
     IssueEdited,
+    PullRequestReviewSubmitted,
 }
 
 /// The raw `issue_comment` webhook payload, narrowed to fields used here.
@@ -310,6 +311,31 @@ struct IssuesEvent {
     sender: UserPayload,
     #[serde(default)]
     changes: Option<ChangesPayload>,
+}
+
+/// The raw `pull_request_review` webhook payload, narrowed to fields used here.
+#[derive(Debug, Deserialize)]
+struct PullRequestReviewEvent {
+    action: String,
+    pull_request: PullRequestPayload,
+    review: ReviewPayload,
+    repository: RepoPayload,
+    sender: UserPayload,
+}
+
+#[derive(Debug, Deserialize)]
+struct PullRequestPayload {
+    number: i64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewPayload {
+    #[serde(default)]
+    body: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -426,6 +452,29 @@ impl TriggerEvent {
                         user: event.sender,
                         comment_id: None,
                         source,
+                    },
+                }))
+            }
+            "pull_request_review" => {
+                let event: PullRequestReviewEvent =
+                    serde_json::from_slice(body).context("parsing pull_request_review payload")?;
+                if event.action != "submitted" {
+                    return Ok(None);
+                }
+                Ok(Some(Self {
+                    issue: IssuePayload {
+                        number: event.pull_request.number,
+                        title: event.pull_request.title,
+                        body: event.pull_request.body,
+                        pull_request: Some(serde_json::Value::Null),
+                    },
+                    repository: event.repository,
+                    request: TriggerRequest {
+                        body: event.review.body.unwrap_or_default(),
+                        previous_body: None,
+                        user: event.sender,
+                        comment_id: None,
+                        source: TriggerSource::PullRequestReviewSubmitted,
                     },
                 }))
             }

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -132,8 +132,9 @@ pub(super) async fn github_webhook(
         }
     }
 
-    // 3. Normalize new requests and body edits. Other event kinds and actions
-    //    (including deletes and setup pings) are acknowledged and ignored.
+    // 3. Normalize new requests, body edits, and submitted reviews. Other event
+    //    kinds and actions (including deletes and setup pings) are acknowledged
+    //    and ignored.
     let event_kind = headers
         .get("x-github-event")
         .and_then(|v| v.to_str().ok())
@@ -650,6 +651,15 @@ fn trigger_goal(
             ),
             String::new(),
         ),
+        github_trigger::TriggerSource::PullRequestReviewSubmitted => (
+            format!(
+                "You've been tagged into GitHub {kind} #{number} of {repo} ({url}) via a submitted review by @{author}."
+            ),
+            format!(
+                "\n\n## Triggering review\n{}",
+                event.request_body().trim()
+            ),
+        ),
     };
     format!(
         "{introduction}\n\n## {title_kind}\n{}\n\n{body}{trigger_context}\n\n## How to respond\n{respond}",
@@ -678,6 +688,7 @@ async fn forward_trigger_to_session(
         github_trigger::TriggerSource::CommentEdited => "edited comment",
         github_trigger::TriggerSource::IssueOpened => "request in the issue body",
         github_trigger::TriggerSource::IssueEdited => "edited request in the issue body",
+        github_trigger::TriggerSource::PullRequestReviewSubmitted => "submitted review",
     };
     let note = format!(
         "New {phrase} {source} from @{author} on {thread} #{number}:\n\n{}\n\n\

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -1,8 +1,9 @@
-//! The inbound GitHub trigger end-to-end over HTTP: a signed `issue_comment` or
-//! `issues` delivery to `POST /api/github/webhook` turns `@loom work on this`
-//! into a session and replies with its URL. The security boundary is exercised
-//! here — a bad/missing signature is a hard 401, a replay is a no-op, and a
-//! non-trigger or unauthorized request launches nothing.
+//! The inbound GitHub trigger end-to-end over HTTP: a signed `issue_comment`,
+//! `issues`, or `pull_request_review` delivery to `POST /api/github/webhook`
+//! turns `@loom work on this` into a session and replies with its URL. The
+//! security boundary is exercised here — a bad/missing signature is a hard 401,
+//! a replay is a no-op, and a non-trigger or unauthorized request launches
+//! nothing.
 //!
 //! No network and no real `gh`: the clone source is a *local bare repo* and the
 //! GitHub gateway (permission check + reply) is a recording fake installed into
@@ -204,6 +205,28 @@ fn trigger_body_pr(login: &str, number: i64, comment: &str) -> Vec<u8> {
             "pull_request": {"url": "https://api.github.com/repos/acme/widgets/pulls/7"}
         },
         "comment": {"body": comment, "user": {"login": login}},
+        "repository": {"full_name": "acme/widgets"},
+        "sender": {"login": login}
+    })
+    .to_string()
+    .into_bytes()
+}
+
+/// A `pull_request_review.submitted` event with a review body from `login`.
+fn submitted_review_event(login: &str, number: i64, review_body: &str) -> Vec<u8> {
+    json!({
+        "action": "submitted",
+        "pull_request": {
+            "number": number,
+            "title": "Fix the tests",
+            "body": "they are red"
+        },
+        "review": {
+            "id": 3001,
+            "body": review_body,
+            "state": "commented",
+            "user": {"login": login}
+        },
         "repository": {"full_name": "acme/widgets"},
         "sender": {"login": login}
     })
@@ -1101,6 +1124,42 @@ async fn pr_trigger_attaches_to_pr_head_branch() {
     );
 
     let id = sessions[0]["id"].as_str().unwrap().to_string();
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+/// A submitted PR review mention launches a session on the PR head.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn submitted_pr_review_mention_triggers_a_session() {
+    let (ts, fake) = boot().await;
+    let _remotes = prepare_repo(&ts).await;
+    *fake.pr_head.lock().unwrap() = Some(loom::github_trigger::PrHead {
+        head_ref: "feature".to_string(),
+        cross_repo: false,
+    });
+
+    let body = submitted_review_event("rjpower", 7, "@loom fix the review comments");
+    assert_eq!(
+        post_event(
+            &ts,
+            "pull_request_review",
+            "d-pr-review",
+            Some(sign(SECRET, &body)),
+            &body,
+        )
+        .await
+        .status(),
+        200
+    );
+    wait_for_sessions(&ts, 1).await;
+
+    let sessions = ts.client.get("/api/sessions").await.unwrap();
+    assert_eq!(sessions[0]["branch"]["branch"].as_str(), Some("feature"));
+
+    let id = sessions[0]["id"].as_str().unwrap();
     ts.client
         .delete(&format!("/api/sessions/{id}"))
         .await

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -1,8 +1,9 @@
 # GitHub trigger (`@loom`)
 
-loom turns a request in an issue body or an issue/PR comment into a session.
-Include **`@loom`** when opening the issue or posting the comment, or add it later
-by editing either body. loom launches a session against that repo — attached to
+loom turns a request in an issue body, issue/PR comment, or submitted PR review
+into a session. Include **`@loom`** when opening the issue, posting the comment,
+or submitting the review, or add it later by editing an issue or comment body.
+loom launches a session against that repo — attached to
 the PR's own branch (so the agent's commits land on the PR) or, for an issue, a
 stable `weaver/issue-<n>` branch — seeded with the thread's context, and replies
 with a link to the live session (`On it — {base}/s/{id}`). That reply is the
@@ -18,20 +19,20 @@ anything is launched.
 
 ## How it works
 
-GitHub delivers `issues/opened`, `issues/edited`, `issue_comment/created`, and
-`issue_comment/edited` events to `POST /api/github/webhook`. The receiver, in
-order:
+GitHub delivers `issues/opened`, `issues/edited`, `issue_comment/created`,
+`issue_comment/edited`, and `pull_request_review/submitted` events to
+`POST /api/github/webhook`. The receiver, in order:
 
 1. **Verifies the signature.** It recomputes HMAC-SHA256 over the raw request
    body with the webhook secret and constant-time-compares it to
    `X-Hub-Signature-256`. A missing or wrong signature is rejected with **401**.
 2. **Dedupes** on `X-GitHub-Delivery`. A replayed or GitHub-retried delivery is a
    no-op, so a repeat never launches a second session.
-3. **Filters** to new or body-edited `issues` and `issue_comment` events. Title
-   edits, deletions, other events, and the bot's own requests (set
-   `github.bot_login`) are ignored.
-4. **Matches a newly introduced trigger.** The issue body or comment must tag the
-   trigger phrase (`github.trigger_phrase`, default `@loom`), matched
+3. **Filters** to new or body-edited `issues` and `issue_comment` events and
+   submitted `pull_request_review` events. Title edits, deletions, other events,
+   and the bot's own requests (set `github.bot_login`) are ignored.
+4. **Matches a newly introduced trigger.** The issue, comment, or review body
+   must tag the trigger phrase (`github.trigger_phrase`, default `@loom`), matched
    case-insensitively **anywhere** in its prose — `please @loom rebase this`
    fires just as `@loom rebase this` does. For an edit, the previous body must
    not already contain a matching trigger. This prevents an unrelated edit from
@@ -42,30 +43,30 @@ order:
    code, fenced or inline, so text asking whether `` `@loom` `` still works
    launches nothing. The mention must stand alone — `@loom-bot` and
    `me@loom.dev` are not `@loom`.
-5. **Authorizes the requester.** The issue opener, commenter, or editor who
-   introduced the mention must be an [approved loom user](#who-can-trigger) —
-   the *same* allowlist that gates signing in to the app. Repo write access is
+5. **Authorizes the requester.** The issue opener, commenter, reviewer, or editor
+   who introduced the mention must be an [approved loom user](#who-can-trigger)
+   — the *same* allowlist that gates signing in to the app. Repo write access is
    **not** by itself a grant. An unapproved requester gets a one-line "request
    access" reply — rather than a silent drop, so they know to ask instead of
    assuming loom is broken. A per-repo rate limit bounds both the launch and
    that reply against request spam.
 6. **Resolves the repo** through the [managed repo store](#which-repos) — an
    approved user's trigger on any repo the App is installed on registers it — and
-   picks the branch to work on: a **pull request** comment attaches the session's
-   worktree to the PR's head branch, so the agent's commits push straight to the
-   PR; an **issue** body or comment gets a stable `weaver/issue-<n>` branch. (A
-   PR from a fork, whose head loom can't push to, falls back to a fresh branch.)
+   picks the branch to work on: a **pull request** comment or review attaches the
+   session's worktree to the PR's head branch, so the agent's commits push
+   straight to the PR; an **issue** body or comment gets a stable
+   `weaver/issue-<n>` branch. (A PR from a fork, whose head loom can't push to,
+   falls back to a fresh branch.)
 7. **Reuses or creates.** If an active session already owns that branch, the new
    request is forwarded into it (a nudge in its terminal) rather than launching a
    duplicate. Otherwise loom creates the session with `github.profile` (default
-   `default`), seeded with the issue/PR title, body, and triggering comment when
-   applicable, plus the fixed thread reply and terminal-status contract.
+   `default`), seeded with the issue/PR title, body, and triggering request, plus
+   the fixed thread reply and terminal-status contract.
 8. **Replies** on the thread with the session URL. A forwarded comment is
-   acknowledged with a 👀 **reaction** on the triggering comment instead — seen,
-   passed along, no ack comment accumulating on an active thread. When the
-   reaction can't land (no comment id in the delivery, or a token that can't
-   react), or the request came from an issue body, loom uses the ack comment so
-   the feedback isn't lost.
+   acknowledged with a 👀 **reaction** on the triggering comment — seen, passed
+   along, no ack comment accumulating on an active thread. When the reaction
+   can't land (no comment id in the delivery, a token that can't react, an issue
+   body, or a review), loom uses the ack comment so the feedback isn't lost.
 
 Steps 6–8 (clone, create-or-forward, reply) run in a **detached task**: the
 handler returns `200` as soon as the gates pass. Cloning a large repo can outlast
@@ -137,9 +138,10 @@ not retry a delivery loom handled without launching.
 The people who can trigger `@loom` are exactly the people who can sign in to
 loom: the **approved users** (the `users` table). One allowlist governs both
 surfaces — being approved lets someone sign in *and* drive the trigger from an
-issue body or comment, including by editing in the mention; no one else can do
-either. Write access to the repo is **not** by itself a grant, so opening a repo
-to loom never hands the trigger to everyone who can push to it.
+issue body, comment, or submitted review, including by editing a body to add the
+mention; no one else can do either. Write access to the repo is **not** by itself
+a grant, so opening a repo to loom never hands the trigger to everyone who can
+push to it.
 
 The first approved user is seeded from `LOOM_OWNER_GITHUB` on a fresh database.
 Manage the rest in **Settings → People & security** or over the API (set
@@ -181,8 +183,8 @@ Add a webhook on the repo or org (**Settings → Webhooks → Add webhook**):
   URL (the same one `auth.base_url` names).
 - **Content type** — `application/json`.
 - **Secret** — the same value as `LOOM_GITHUB_WEBHOOK_SECRET`.
-- **Events** — "Let me select individual events" → **Issues** and **Issue
-  comments**.
+- **Events** — "Let me select individual events" → **Issues**, **Issue
+  comments**, and **Pull request reviews**.
 
 Until `LOOM_GITHUB_WEBHOOK_SECRET` is set the endpoint rejects every delivery
 (it cannot verify a signature without it).
@@ -194,8 +196,9 @@ two ways:
 
 - **An approved user triggers on it.** When an approved user opens an issue with
   `@loom` in its body, edits an issue to add `@loom`, or creates or edits a
-  comment to add `@loom`, on a repo where the [GitHub App](#the-github-app) is
-  installed, loom registers that repo automatically and launches. The *person*
+  comment to add `@loom`, or submits a PR review containing `@loom`, on a repo
+  where the [GitHub App](#the-github-app) is installed, loom registers that repo
+  automatically and launches. The *person*
   is the trust boundary — since only an approved user can trigger, a stranger
   installing the public App on their own repo changes nothing. The App
   installation scopes *which* repos loom can reach; the approved-user gate
@@ -214,10 +217,10 @@ launches nothing.
 ### Optional settings
 
 - `github.trigger_phrase` — the phrase that tags loom (default `@loom`). Matched
-  case-insensitively anywhere in an issue body or comment's prose, as a
+  case-insensitively anywhere in an issue, comment, or review body, as a
   standalone mention ([step 4](#how-it-works)) — both `@loom rebase onto main`
-  and `can you rebase this, @loom?` trigger when created or newly introduced by
-  an edit. Settable in **Settings → GitHub** or `loom config set
+  and `can you rebase this, @loom?` trigger in a new request or when introduced
+  by an edit. Settable in **Settings → GitHub** or `loom config set
   github.trigger_phrase "…"`.
 - `github.bot_login` (or `LOOM_GITHUB_BOT_LOGIN`) — a GitHub login whose own
   requests are ignored, so a bot account can post without re-triggering itself.
@@ -284,9 +287,13 @@ Apps → New GitHub App**:
   - **Metadata** — Read-only (mandatory; granted automatically).
   - **Pull requests** — Read & write (open and update pull requests).
   - **Workflows** — Read & write (push changes under `.github/workflows`).
-- **Subscribe to events** — **Issues** and **Issue comment**.
+- **Subscribe to events** — **Issues**, **Issue comment**, and **Pull request
+  review**.
 - After creating it, **generate a private key** (downloads a `.pem`) and note the
   **App ID**.
+
+Apps created before submitted-review triggers were supported must add **Pull
+request review** to their subscribed events once.
 
 Then **install** the App on each repo (or org) loom should act on — the
 installation is what authorizes a repo to trigger.
@@ -319,19 +326,19 @@ the gates above. Debugging is one question: *did the delivery arrive, and which
 gate did it hit?* Work through it in order:
 
 1. **Was the request the right shape?** It must be an issue body
-   (`issues/opened` or a body-changing `issues/edited`) or a PR/issue
+   (`issues/opened` or a body-changing `issues/edited`), a PR/issue
    **conversation** comment (`issue_comment/created` or
-   `issue_comment/edited`) that newly introduces the trigger phrase in its prose
-   — a mention that sits only inside a quote or a code span is ignored by design
-   ([step 4](#how-it-works)). An inline code-review comment and a review summary
-   are different events loom does not subscribe to, so `@loom` in those never
-   fires.
+   `issue_comment/edited`), or a submitted PR review
+   (`pull_request_review/submitted`) that newly introduces the trigger phrase in
+   its prose — a mention that sits only inside a quote or a code span is ignored
+   by design ([step 4](#how-it-works)). An inline code-review comment is a
+   different event loom does not subscribe to, so `@loom` in one never fires.
 
 2. **Did GitHub deliver it, and what did loom answer?** The GitHub App's
    **Settings → Advanced → Recent Deliveries** (or the repo/org webhook's) shows
    every delivery, its payload, and loom's HTTP response:
    - *no delivery* — the App is not installed on the repo, or it was not a
-     subscribed `issues` or `issue_comment` event;
+     subscribed `issues`, `issue_comment`, or `pull_request_review` event;
    - *401* — the webhook secret loom holds does not match the one GitHub signs
      with;
    - *200 but nothing launched* — it hit a gate (below), or the launch is still


### PR DESCRIPTION
Accept trigger mentions in `pull_request_review/submitted` bodies and route them through Loom's existing PR authorization and launch path. On https://github.com/marin-community/marin/pull/8337, a review-body `@weaverbot` mention did nothing; repeating the request as an issue comment launched a session. The same symptom was reported from https://github.com/marin-community/marin/pull/7897 in https://github.com/marin-community/marin/issues/7902.

Subscribe newly created GitHub Apps to `pull_request_review` and document the one-time event subscription needed for existing Apps. Inline review comments remain unsupported because GitHub delivers them as `pull_request_review_comment`.
