### PR TITLE
fix(loom): deliver artifact reviews immediately

### DIFF
--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -638,8 +638,9 @@ impl AcpHandle {
     }
 
     /// Notice immutable submitted feedback in the protected conversation inbox.
-    /// Start it when idle; while a turn is live, leave it queued for the normal
-    /// turn boundary. The editable prompt lane is never read or modified here.
+    /// Start it immediately unless Stop has paused automatic work or another
+    /// protected review already owns the live turn. The editable prompt lane is
+    /// never read or modified here.
     pub async fn notify_pending(&self) -> Result<PromptAck> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
@@ -2580,19 +2581,18 @@ impl Task {
         self.dispatch_pending_prompt().await;
     }
 
-    async fn dispatch_review_inbox(&mut self) -> bool {
+    async fn claim_pending_review(
+        &self,
+    ) -> Option<(crate::review_inbox::ReviewInboxItem, ActiveReviewClaim)> {
         if self.automatic_dispatch_paused {
-            return false;
+            return None;
         }
         if self.refuse_if_turn_capped().await.is_err() {
-            return false;
+            return None;
         }
-        let Some(active_claim) = self
+        let active_claim = self
             .registry
-            .activate_review_claim(&self.session_id, self.generation)
-        else {
-            return false;
-        };
+            .activate_review_claim(&self.session_id, self.generation)?;
         let item = match crate::review_inbox::claim_review_inbox(
             &self.db,
             &self.branch_id,
@@ -2609,12 +2609,17 @@ impl Task {
                     %error,
                     "could not claim protected review feedback"
                 );
-                return false;
+                return None;
             }
         };
-        let Some(item) = item else {
-            return false;
-        };
+        item.map(|item| (item, active_claim))
+    }
+
+    async fn dispatch_claimed_review(
+        &mut self,
+        item: crate::review_inbox::ReviewInboxItem,
+        active_claim: ActiveReviewClaim,
+    ) -> bool {
         match self.start_review_turn(&item, active_claim).await {
             Ok(outcome) if outcome.blocks_followup_dispatch() => {
                 if let crate::review_inbox::ReviewTurnStartOutcome::TransportWrittenUnpersisted {
@@ -2669,6 +2674,13 @@ impl Task {
                 ..
             }) => unreachable!("held review outcomes matched the dispatch gate"),
         }
+    }
+
+    async fn dispatch_review_inbox(&mut self) -> bool {
+        let Some((item, active_claim)) = self.claim_pending_review().await else {
+            return false;
+        };
+        self.dispatch_claimed_review(item, active_claim).await
     }
 
     async fn dispatch_pending_prompt(&mut self) {
@@ -3410,14 +3422,48 @@ impl Task {
             }
             Command::NotifyPending { reply } => {
                 // Submitted review feedback lives in the protected inbox, not
-                // the user-editable pending prompt. A live task picks it up at
-                // its next turn boundary; an idle task can start it now.
-                if self.turn_live || self.automatic_dispatch_paused {
+                // the user-editable pending prompt. Submission is user input:
+                // replace ordinary live work with one visible review turn
+                // instead of hiding it behind an arbitrarily long boundary.
+                // A wake for the review already in flight is only a retry of
+                // the notifier and must never interrupt that same review.
+                if self.inflight_review.is_some() || self.automatic_dispatch_paused {
                     let _ = reply.send(Ok(PromptAck {
                         queued: true,
                         turn: Some(self.current_turn),
                     }));
-                } else if self.dispatch_review_inbox().await {
+                    return;
+                }
+                let Some((item, active_claim)) = self.claim_pending_review().await else {
+                    let _ = reply.send(Err(anyhow!(
+                        "there is no protected review feedback ready to send"
+                    )));
+                    return;
+                };
+                if self.turn_live {
+                    if let Err(error) = self.cancel_live_turn().await {
+                        if let Err(release_error) = crate::review_inbox::release_review_inbox(
+                            &self.db,
+                            &item.delivery_key,
+                            &item.claim_token,
+                        )
+                        .await
+                        {
+                            tracing::error!(
+                                session = %self.session_id,
+                                delivery_key = %item.delivery_key,
+                                error = %release_error,
+                                "could not release protected review after cancellation failure"
+                            );
+                        }
+                        let _ = reply.send(Err(error));
+                        return;
+                    }
+                    // This cancellation is the review submission's own clear
+                    // turn boundary, not a standalone Stop request.
+                    self.automatic_dispatch_paused = false;
+                }
+                if self.dispatch_claimed_review(item, active_claim).await {
                     let _ = reply.send(Ok(PromptAck {
                         queued: false,
                         turn: Some(self.current_turn),

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -2281,6 +2281,108 @@ async fn interrupting_a_review_turn_does_not_redeliver_it() {
     assert_eq!(state, "consumed");
 }
 
+/// Submitting a review is user input, so it replaces an ordinary long-running
+/// turn immediately. The protected inbox still gives that replacement exactly
+/// one visible delivery across later background wakes.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn review_notification_replaces_an_ordinary_live_turn_once() {
+    let ts = TestServer::start().await;
+    let id = "acp-live-review";
+    let delivery_key = "review:replace-live";
+    let payload = "say:review-received";
+    start_new(&ts, id, None, None).await;
+    ts.client
+        .post(
+            &format!("/api/sessions/{id}/prompt"),
+            json!({ "text": "wait:30000|say:stale-work" }),
+        )
+        .await
+        .unwrap();
+    insert_protected_review(&ts, id, delivery_key, payload).await;
+
+    let sent = ts
+        .state
+        .acp
+        .get(id)
+        .unwrap()
+        .notify_pending()
+        .await
+        .unwrap();
+    assert!(!sent.queued);
+    assert_eq!(sent.turn, Some(1));
+
+    let chat = poll_chat(&ts, id, Duration::from_secs(5), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "review-received"
+        })
+    })
+    .await;
+    let blocks = chat["blocks"].as_array().unwrap();
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 0
+            && block["kind"] == "turn_end"
+            && block["payload"]["stop_reason"] == "cancelled"
+    }));
+    assert_eq!(
+        blocks
+            .iter()
+            .filter(|block| {
+                block["kind"] == "user_message" && block["payload"]["delivery_key"] == delivery_key
+            })
+            .count(),
+        1
+    );
+
+    loom::review_delivery::drain(&ts.state).await.unwrap();
+    let after_retry = ts
+        .client
+        .get(&format!("/api/sessions/{id}/chat"))
+        .await
+        .unwrap();
+    assert_eq!(
+        after_retry["blocks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|block| {
+                block["kind"] == "user_message" && block["payload"]["delivery_key"] == delivery_key
+            })
+            .count(),
+        1
+    );
+
+    ts.client
+        .post(
+            &format!("/api/sessions/{id}/prompt"),
+            json!({ "text": "wait:30000|say:must-survive" }),
+        )
+        .await
+        .unwrap();
+    ts.state
+        .acp
+        .get(id)
+        .unwrap()
+        .notify_pending()
+        .await
+        .unwrap_err();
+    let ordinary = ts
+        .client
+        .get(&format!("/api/sessions/{id}/chat"))
+        .await
+        .unwrap();
+    assert_eq!(ordinary["live_turn"], 2);
+    assert!(!ordinary["blocks"].as_array().unwrap().iter().any(|block| {
+        block["turn"] == 2
+            && block["kind"] == "turn_end"
+            && block["payload"]["stop_reason"] == "cancelled"
+    }));
+    ts.client
+        .post(&format!("/api/sessions/{id}/interrupt"), json!({}))
+        .await
+        .unwrap();
+}
+
 /// Stop also fences protected feedback that was queued behind some other turn.
 /// Background notifications leave it queued until a new explicit user send
 /// clears the stop boundary.
@@ -2299,6 +2401,10 @@ async fn interrupt_pauses_automatic_review_dispatch_until_an_explicit_send() {
         )
         .await
         .unwrap();
+    ts.client
+        .post(&format!("/api/sessions/{id}/interrupt"), json!({}))
+        .await
+        .unwrap();
     insert_protected_review(&ts, id, delivery_key, payload).await;
     let queued = ts
         .state
@@ -2310,10 +2416,6 @@ async fn interrupt_pauses_automatic_review_dispatch_until_an_explicit_send() {
         .unwrap();
     assert!(queued.queued);
 
-    ts.client
-        .post(&format!("/api/sessions/{id}/interrupt"), json!({}))
-        .await
-        .unwrap();
     assert!(ts.state.acp.stop(id), "the stopped task was registered");
     tokio::time::sleep(Duration::from_millis(150)).await;
     acp::attach(&ts.state.acp_ctx(), id)

--- a/crates/loom/tests/integration/reviews.rs
+++ b/crates/loom/tests/integration/reviews.rs
@@ -644,16 +644,6 @@ async fn acp_delivery_has_one_protected_crash_boundary_and_can_rehome() {
         )
         .await
         .unwrap();
-    assert_eq!(
-        ts.client
-            .post(
-                "/api/sessions/acp-review/prompt",
-                json!({ "text": "say:editable feedback" }),
-            )
-            .await
-            .unwrap()["queued"],
-        true
-    );
 
     let draft = draft_with_comment(&ts, &session, "Protected immutable feedback.").await;
     let payload = draft.message.clone();
@@ -669,13 +659,6 @@ async fn acp_delivery_has_one_protected_crash_boundary_and_can_rehome() {
         .await
         .unwrap();
     assert_eq!(submitted.delivery_state, "delivered");
-    assert_eq!(
-        ts.client
-            .delete("/api/sessions/acp-review/prompt")
-            .await
-            .unwrap()["text"],
-        "say:editable feedback"
-    );
     let chat = poll_review_turn(&ts, &session.id, &payload).await;
     let protected = chat["blocks"]
         .as_array()
@@ -734,6 +717,13 @@ async fn acp_delivery_has_one_protected_crash_boundary_and_can_rehome() {
             "/api/sessions/acp-review-rehome/prompt",
             json!({ "text": "wait:30000|say:keep-busy" }),
         )
+        .await
+        .unwrap();
+    // A standalone Stop deliberately pauses automatic delivery. This leaves
+    // the subsequently submitted review in the protected inbox so a successor
+    // can prove the cross-runtime rehome path.
+    ts.client
+        .post("/api/sessions/acp-review-rehome/interrupt", json!({}))
         .await
         .unwrap();
     let rehomed = draft_with_comment(&ts, &original, "Rehome this immutable review.").await;

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -119,9 +119,12 @@ may mutate or discard draft content.
 ACP delivery enters a protected conversation inbox separate from retractable
 operator prompts. Inbox consumption, journal delivery key, and live-turn claim
 share one logical boundary so recovery cannot start a second turn for a review
-already recorded in the journal. Offline delivery remains queued without
-consuming an attempt, and fenced leases prevent a stale worker from regressing
-state. Terminal delivery is at-least-once.
+already recorded in the journal. A newly submitted review replaces ordinary
+live ACP work with one visible review turn instead of waiting behind an
+unbounded agent turn; a standalone Stop still pauses automatic delivery, and a
+retry never interrupts the review already in flight. Offline delivery remains
+queued without consuming an attempt, and fenced leases prevent a stale worker
+from regressing state. Terminal delivery is at-least-once.
 
 If the reviewed artifact is later removed, submitted history remains readable by
 stable review ID. Legacy artifact discussion threads are accepted only as


### PR DESCRIPTION
Submitted artifact reviews were durable but invisible while an ACP turn remained live. The production incident left feedback queued for 53 minutes, until a later user message finally created the boundary that dispatched it.

Claim ready review feedback before changing the conversation, then replace ordinary live work with one protected review turn. Retry notifications cannot interrupt the review already in flight or later unrelated work, stable delivery keys continue to prevent duplicate visible turns, and a standalone Stop still pauses automatic delivery.

The ACP and staged-review integration journeys cover immediate delivery, duplicate wakes, interruption, Stop, crash recovery, and runtime rehome.