### PR TITLE
Make blocked automation launches retryable

### DIFF
--- a/crates/loom-store/src/runs.rs
+++ b/crates/loom-store/src/runs.rs
@@ -190,7 +190,8 @@ pub async fn route_channel(db: &Db, run_id: &str) -> Result<ChannelAction> {
         {
             if owner.owner_run_id == run.id {
                 sqlx::query(
-                    "UPDATE automation_runs SET status = 'running', session_id = ?, updated_at = ?
+                    "UPDATE automation_runs
+                     SET status = 'running', session_id = ?, summary = '', updated_at = ?
                      WHERE id = ?",
                 )
                 .bind(&owner.session_id)
@@ -263,7 +264,7 @@ pub async fn route_channel(db: &Db, run_id: &str) -> Result<ChannelAction> {
             .await?;
             sqlx::query(
                 "UPDATE automation_runs
-                 SET status = 'creating', session_id = ?, updated_at = ?
+                 SET status = 'creating', session_id = ?, summary = '', updated_at = ?
                  WHERE id = ?",
             )
             .bind(&session_id)
@@ -322,7 +323,7 @@ pub async fn list_for(db: &Db, subject: Option<&str>) -> Result<Vec<Run>> {
 /// the caller uses the `false` result to tear down its late-created session.
 pub async fn launched(db: &Db, id: &str, session_id: &str) -> Result<bool> {
     Ok(sqlx::query(
-        "UPDATE automation_runs SET status = 'running', updated_at = ?
+        "UPDATE automation_runs SET status = 'running', summary = '', updated_at = ?
          WHERE id = ? AND session_id = ?
            AND status IN ('creating', 'waiting', 'delivering')",
     )
@@ -366,11 +367,12 @@ pub async fn claim_stale_delivery(db: &Db, id: &str) -> Result<bool> {
         == 1)
 }
 
-pub async fn waiting(db: &Db, id: &str) -> Result<bool> {
+pub async fn waiting(db: &Db, id: &str, summary: &str) -> Result<bool> {
     Ok(sqlx::query(
-        "UPDATE automation_runs SET status = 'waiting', updated_at = ?
+        "UPDATE automation_runs SET status = 'waiting', summary = ?, updated_at = ?
          WHERE id = ? AND status IN ('creating', 'delivering', 'waiting')",
     )
+    .bind(summary)
     .bind(now_iso())
     .bind(id)
     .execute(db)

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -129,6 +129,8 @@ export const setSessionGithubAccess = (
 /** Durable automation launch reservations, including failures that never
  *  produced a usable session (`GET /api/runs`). */
 export const listRuns = () => get('/runs') as Promise<AutomationRun[]>;
+export const retryRun = (id: string) =>
+  post(`/runs/${encodeURIComponent(id)}/retry`) as Promise<AutomationRun>;
 export const archiveSession = (id: string) => post(`/sessions/${encodeURIComponent(id)}/archive`);
 export const removeSession = (id: string) => del(`/sessions/${encodeURIComponent(id)}`);
 export const clearSessionTag = (id: string, key: string) =>

--- a/crates/loom/frontend/src/components/AutomationRunRow.vue
+++ b/crates/loom/frontend/src/components/AutomationRunRow.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, useId, watch } from 'vue';
-import { archiveSession, removeSession } from '../api';
+import { archiveSession, removeSession, retryRun } from '../api';
 import type { AutomationRun } from '../types';
 import type { UnmatchedRunProjection } from '../lib/automationSessions';
+import { unmatchedRunTitle } from '../lib/automationRunLabels';
 import { exactTime, timeAgo } from '../lib/time';
 import ConfirmDialog from './ConfirmDialog.vue';
 import StatusBadge from './StatusBadge.vue';
@@ -18,12 +19,8 @@ const pendingAction = ref<'archive' | 'remove' | ''>('');
 const canArchive = computed(
   () => props.run.status !== 'cancelled' && props.run.status !== 'completed',
 );
-
-const title = computed(() => {
-  if (props.projection === 'intervention') return `Launch ${props.run.status}`;
-  if (props.projection === 'history') return `Run ${props.run.status}`;
-  return `Provisioning · ${props.run.status}`;
-});
+const canRetry = computed(() => props.run.status === 'waiting' && props.run.channel !== null);
+const title = computed(() => unmatchedRunTitle(props.run, props.projection));
 
 async function act(name: string, fn: () => Promise<void>) {
   open.value = false;
@@ -36,6 +33,12 @@ async function act(name: string, fn: () => Promise<void>) {
   } finally {
     busy.value = '';
   }
+}
+
+function retry() {
+  void act('retry', async () => {
+    await retryRun(props.run.id);
+  });
 }
 
 function requestConfirmation(action: 'archive' | 'remove') {
@@ -107,6 +110,16 @@ function onKeydown(event: KeyboardEvent) {
         {{ timeAgo(run.updated_at) }}
       </time>
     </div>
+    <button
+      v-if="canRetry"
+      type="button"
+      data-testid="run-action-retry"
+      class="shrink-0 rounded border border-line bg-surface px-2 py-1 text-xs font-medium text-fg transition-colors hover:bg-subtle disabled:opacity-50"
+      :disabled="!!busy"
+      @click="retry"
+    >
+      {{ busy === 'retry' ? 'Retrying…' : 'Retry launch' }}
+    </button>
     <div class="relative z-10 shrink-0">
       <button
         ref="trigger"

--- a/crates/loom/frontend/src/lib/automationRunLabels.ts
+++ b/crates/loom/frontend/src/lib/automationRunLabels.ts
@@ -1,0 +1,13 @@
+import type { AutomationRun } from '../types';
+import type { UnmatchedRunProjection } from './automationSessions';
+
+export function unmatchedRunTitle(
+  run: Pick<AutomationRun, 'status'>,
+  projection: UnmatchedRunProjection,
+): string {
+  if (projection === 'intervention') {
+    return run.status === 'waiting' ? 'Launch blocked' : `Launch ${run.status}`;
+  }
+  if (projection === 'history') return `Run ${run.status}`;
+  return `Provisioning · ${run.status}`;
+}

--- a/crates/loom/frontend/src/lib/automationSessions.test.mjs
+++ b/crates/loom/frontend/src/lib/automationSessions.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { unmatchedRunTitle } from './automationRunLabels.ts';
+
+test('waiting launch reservations are presented as blocked', () => {
+  assert.equal(unmatchedRunTitle({ status: 'waiting' }, 'intervention'), 'Launch blocked');
+});
+
+test('other unmatched run projections retain their lifecycle labels', () => {
+  assert.equal(unmatchedRunTitle({ status: 'failed' }, 'intervention'), 'Launch failed');
+  assert.equal(
+    unmatchedRunTitle({ status: 'creating' }, 'provisioning'),
+    'Provisioning · creating',
+  );
+  assert.equal(unmatchedRunTitle({ status: 'completed' }, 'history'), 'Run completed');
+});

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -225,17 +225,19 @@ async fn launch_run(
                         }
                     }
                 }
-                LaunchFailure::Retryable => match crate::runs::waiting(&st.db, &run.id).await {
-                    Ok(owned) => owned,
-                    Err(record_error) => {
-                        tracing::warn!(
-                            run = %run.id,
-                            error = %record_error,
-                            "could not return automation launch to waiting"
-                        );
-                        true
+                LaunchFailure::Retryable => {
+                    match crate::runs::waiting(&st.db, &run.id, &error.to_string()).await {
+                        Ok(owned) => owned,
+                        Err(record_error) => {
+                            tracing::warn!(
+                                run = %run.id,
+                                error = %record_error,
+                                "could not return automation launch to waiting"
+                            );
+                            true
+                        }
                     }
-                },
+                }
             };
             if !still_owned {
                 remove_late_session(st, &run.session_id).await;
@@ -254,18 +256,14 @@ async fn prompt_channel_run(
         .await?
         .filter(|session| session.status == "running" && session.protocol == "acp")
     else {
-        crate::runs::waiting(&st.db, &run.id).await.ok();
-        return Err(AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "automation channel session is not ready; retry this delivery",
-        ));
+        let message = "automation channel session is not ready; retry this delivery";
+        crate::runs::waiting(&st.db, &run.id, message).await.ok();
+        return Err(AppError::new(StatusCode::SERVICE_UNAVAILABLE, message));
     };
     let Some(handle) = st.acp.get(&session.id) else {
-        crate::runs::waiting(&st.db, &run.id).await.ok();
-        return Err(AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "automation channel session is being adopted; retry this delivery",
-        ));
+        let message = "automation channel session is being adopted; retry this delivery";
+        crate::runs::waiting(&st.db, &run.id, message).await.ok();
+        return Err(AppError::new(StatusCode::SERVICE_UNAVAILABLE, message));
     };
     let channel = run
         .channel
@@ -281,11 +279,9 @@ async fn prompt_channel_run(
         .stop_and_send(goal.clone(), Some(by.clone()), Vec::new())
         .await
     {
-        crate::runs::waiting(&st.db, &run.id).await.ok();
-        return Err(AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("automation channel rejected the update: {error}"),
-        ));
+        let message = format!("automation channel rejected the update: {error}");
+        crate::runs::waiting(&st.db, &run.id, &message).await.ok();
+        return Err(AppError::new(StatusCode::SERVICE_UNAVAILABLE, message));
     }
     crate::events::record(
         &st.db,
@@ -520,6 +516,40 @@ pub(super) async fn get_run(
         return Err(AppError::new(StatusCode::FORBIDDEN, "run access forbidden"));
     }
     Ok(Json(run.into()))
+}
+
+pub(super) async fn retry_run(
+    State(st): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<RunView>> {
+    let run = crate::runs::get(&st.db, &id)
+        .await?
+        .ok_or_else(|| AppError::not_found("automation run"))?;
+    let profiles = match &principal.grant {
+        Grant::Admin | Grant::User => vec![run.profile.clone()],
+        Grant::Automation { subject, profiles }
+            if subject == &run.actor_subject
+                && profiles.iter().any(|profile| profile == &run.profile) =>
+        {
+            profiles.clone()
+        }
+        Grant::Automation { .. } | Grant::Session { .. } => {
+            return Err(AppError::new(StatusCode::FORBIDDEN, "run retry forbidden"));
+        }
+    };
+    if run.status != "waiting" {
+        return Err(AppError::conflict(
+            "automation run is not waiting for retry",
+        ));
+    }
+    if run.channel.is_none() {
+        return Err(AppError::conflict(
+            "automation run does not use a retryable channel",
+        ));
+    }
+    let subject = run.actor_subject.clone();
+    dispatch_channel_run(&st, subject, profiles, run).await
 }
 
 #[cfg(test)]

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -1105,6 +1105,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/auth/federations/{id}", delete(remove_federation))
         .route("/runs", get(list_runs).post(create_run))
+        .route("/runs/{id}/retry", post(retry_run))
         .route("/runs/{id}", get(get_run))
         .route("/auth/password", post(set_own_password))
         // The caller's own GitHub token (a fine-grained PAT), injected as

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -733,6 +733,112 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
 }
 
 #[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capacity_blocked_automation_launch_can_be_retried() {
+    let _adapter = EnvVarGuard::set(
+        "WEAVER_CLAUDE_ACP_CMD",
+        &crate::fixtures::fake_acp_agent_cmd(),
+    );
+    let _github_token = EnvVarGuard::set("GH_TOKEN", "test-token");
+    let ts = TestServer::start().await;
+    ts.client
+        .post(
+            "/api/profiles",
+            json!({
+                "name": "single-ops",
+                "description": "single operations intake",
+                "agent_kind": "claude",
+                "protocol": "acp",
+                "mode": "default",
+                "class": "automation",
+                "strict": true,
+                "env_clear": true,
+                "max_concurrent": 1,
+                "turn_budget": 20,
+                "prelude": "none"
+            }),
+        )
+        .await
+        .unwrap();
+
+    let first = ts
+        .client
+        .post(
+            "/api/runs",
+            json!({
+                "profile": "single-ops",
+                "source": "grafana",
+                "channel": "first",
+                "idempotency_key": "capacity:first",
+                "session": {
+                    "cwd": ts.cwd(),
+                    "title": "First operator",
+                    "goal": "hold the only profile slot"
+                }
+            }),
+        )
+        .await
+        .unwrap();
+
+    let blocked = ts
+        .client
+        .post(
+            "/api/runs",
+            json!({
+                "profile": "single-ops",
+                "source": "grafana",
+                "channel": "second",
+                "idempotency_key": "capacity:second",
+                "session": {
+                    "cwd": ts.cwd(),
+                    "title": "Second operator",
+                    "goal": "wait for profile capacity"
+                }
+            }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        blocked
+            .to_string()
+            .contains("profile 'single-ops' has reached its max_concurrent limit (1)"),
+        "capacity error should reach the caller: {blocked}"
+    );
+
+    let runs = ts.client.get("/api/runs").await.unwrap();
+    let blocked = runs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|run| run["idempotency_key"] == "capacity:second")
+        .unwrap();
+    assert_eq!(blocked["status"], "waiting");
+    assert_eq!(
+        blocked["summary"],
+        "profile 'single-ops' has reached its max_concurrent limit (1)"
+    );
+    let blocked_id = blocked["id"].as_str().unwrap().to_string();
+    let initial_session_id = blocked["session_id"].as_str().unwrap().to_string();
+
+    ts.client
+        .post(
+            &format!(
+                "/api/sessions/{}/archive",
+                first["session_id"].as_str().unwrap()
+            ),
+            json!({}),
+        )
+        .await
+        .unwrap();
+    let retried = ts.client.retry_run(&blocked_id).await.unwrap();
+
+    assert_eq!(retried.id, blocked_id);
+    assert_eq!(retried.status, "running");
+    assert_eq!(retried.summary, "");
+    assert_ne!(retried.session_id, initial_session_id);
+}
+
+#[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn deployment_reconcile_rest_journey() {
     let ts = TestServer::start_api_only().await;

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -1512,6 +1512,15 @@ impl Client {
         self.send_typed(Method::POST, "/api/runs", Some(req)).await
     }
 
+    pub async fn retry_run(&self, id: &str) -> Result<RunView> {
+        self.send_typed::<Value, RunView>(
+            Method::POST,
+            &format!("/api/runs/{}/retry", Self::seg(id)),
+            None,
+        )
+        .await
+    }
+
     /// List the user-managed API tokens (`GET /api/auth/tokens`).
     pub async fn list_tokens(&self) -> Result<Vec<TokenView>> {
         self.get_typed("/api/auth/tokens").await

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -18,9 +18,14 @@ stateDiagram-v2
     [*] --> Created: session row created
 
     Reserved --> Created: provisioning reaches session creation
-    Reserved --> FailedAttempt: validation / capacity / repository failure
+    Reserved --> RetryableAttempt: channel launch blocked
+    Reserved --> FailedAttempt: one-shot launch failure
     Reserved --> CancelledAttempt: archive
     Reserved --> Removed: remove
+    RetryableAttempt --> Created: retry succeeds
+    RetryableAttempt --> RetryableAttempt: retry remains blocked
+    RetryableAttempt --> CancelledAttempt: archive
+    RetryableAttempt --> Removed: remove
     FailedAttempt --> CancelledAttempt: archive
     FailedAttempt --> Removed: remove
     CancelledAttempt --> Removed: remove history
@@ -54,6 +59,7 @@ stateDiagram-v2
     Adopting --> Running: resume complete
 
     state "Launch failed" as FailedAttempt
+    state "Launch blocked" as RetryableAttempt
     state "Launch cancelled" as CancelledAttempt
     state "Deleted" as Removed
 ```
@@ -78,10 +84,17 @@ recoverable stable state before ordinary supervisor reconciliation.
 liveness: `creating`, `waiting`, `delivering`, `running`, `failed`,
 `cancelled`, or `completed`.
 
+A channel run that cannot launch stays `waiting` with the failure reason in its
+summary. Redelivering the original request with the same idempotency key or
+calling `POST /api/runs/{id}/retry` retries that durable attempt. Retry resolves
+the profile again and rechecks its concurrency limit; it does not bypass launch
+policy. A successful retry clears the stale failure summary.
+
 ## Actions
 
 - **Adopt** recreates a missing supervisor for an orphaned worktree.
 - **Recover** recreates an archived worktree and resumes its agent.
+- **Retry launch** retries a waiting channel run against current profile capacity.
 - **Archive** tears down terminal, debug shells, editor, credentials, and
   worktree while keeping the session/attempt and branch history.
 - **Remove** performs the same teardown and deletes the durable record. A


### PR DESCRIPTION
Persist the provisioning error when a channel automation run returns to waiting, and clear it after a successful launch. Unmatched waiting reservations render as “Launch blocked” with the exact reason and a Retry launch action; POST /api/runs/{id}/retry retries the durable run and rechecks current profile policy and capacity.

The 2026-08-17 fork-ferry run admitted three sessions at the profile limit and left the fourth as an unexplained waiting intervention. Retry remains explicit through caller redelivery or the operator action; Loom does not run a background admission queue. Production profile capacity and critical storage routing are aligned in marin-community/marin#8376.