### PR TITLE
fix(loom): restart ACP turns for conversation input

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ select those profiles together.
 `poll` reads lifecycle and attention, `wait` blocks until completion or human
 attention, `send` delivers immediate external control input, and `interrupt`
 stops the current turn. For ACP, external input always cancels and restarts;
-the conversation composer tries live steering and falls back to the same
-stop-and-send behavior when the model is behind a tool or permission. Session
-commands accept an id, branch id, branch name, or `repo:branch`.
+the conversation composer uses the same stop-and-send behavior so a message
+cannot sit behind work the model selected concurrently. Session commands accept
+an id, branch id, branch name, or `repo:branch`.
 
 The session title is one canonical, unqualified task label; fleet views add its
 Group only when they need a qualified `Group / Task` name. Loom records whether
@@ -263,15 +263,14 @@ the workbench header.
 Every session detail has a **Conversation** tab that renders the agent's chat
 with the model — user turns, replies, thinking, and tool calls — live and
 (via the archive capture below) still there to review after the terminal is gone.
-For ACP sessions, the conversation composer sends immediately: it steers a
-receptive adapter, or stops a turn blocked behind a tool or permission and
-starts the message as the next turn. Feedback queued by another client stays
-visible and can be pulled back into the composer with its **Edit** action or
-ArrowUp from an empty composer, or sent immediately with **Stop & send**. The
+For ACP sessions, the conversation composer sends immediately: it stops a live
+turn and starts the message as the next turn. Feedback queued by another client
+stays visible and can be pulled back into the composer with its **Edit** action
+or ArrowUp from an empty composer, or sent immediately with **Stop & send**. The
 live status names visible thinking, writing, or tool activity and reports how
 long it has been since the agent produced an observable update; quiet time is
-not guessed to mean stuck. Cross-session `loom session send` always cancels a
-live turn and starts the message as a new one.
+not guessed to mean stuck. Cross-session `loom session send` uses the same
+stop-and-send behavior.
 
 Whenever a session is archived — by the Archive button or automatically on merge
 — loom first captures that conversation to disk: it finds the agent's transcript

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -579,8 +579,8 @@ impl AcpHandle {
             .await
     }
 
-    /// Deliver external control input now by cancelling a live turn and
-    /// starting the message normally.
+    /// Deliver immediate input by cancelling a live turn and starting the
+    /// message normally.
     pub async fn stop_and_send(
         &self,
         text: String,
@@ -1163,7 +1163,7 @@ pub async fn attach(state: &AcpCtx, session_id: &str) -> Result<()> {
 enum PromptDelivery {
     /// Preserve the conversation composer's queue-first behavior.
     Queue,
-    /// Cross-session control: cancel and restart immediately.
+    /// Immediate input: cancel and restart immediately.
     StopAndSend,
 }
 

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -541,7 +541,8 @@ pub struct AcpMetadata {
     pub commands: Vec<Value>,
     pub config_options: Vec<Value>,
     pub modes: Vec<Value>,
-    /// Whether this adapter accepts injected input during a live turn.
+    /// Whether this adapter advertises injected live-turn input. Loom exposes
+    /// the provider metadata but uses normal prompt boundaries for delivery.
     pub steering_supported: bool,
 }
 
@@ -575,18 +576,6 @@ impl AcpHandle {
         resources: Vec<Value>,
     ) -> Result<PromptAck> {
         self.send_prompt(text, by, PromptDelivery::Queue, resources)
-            .await
-    }
-
-    /// Deliver conversation input now: steer a receptive live turn, otherwise
-    /// cancel the current turn and start normally.
-    pub async fn steer_or_restart(
-        &self,
-        text: String,
-        by: Option<String>,
-        resources: Vec<Value>,
-    ) -> Result<PromptAck> {
-        self.send_prompt(text, by, PromptDelivery::SteerOrRestart, resources)
             .await
     }
 
@@ -1174,9 +1163,6 @@ pub async fn attach(state: &AcpCtx, session_id: &str) -> Result<()> {
 enum PromptDelivery {
     /// Preserve the conversation composer's queue-first behavior.
     Queue,
-    /// User conversation input: steer a receptive live turn, or cancel and
-    /// restart when the adapter cannot consume a steer immediately.
-    SteerOrRestart,
     /// Cross-session control: cancel and restart immediately.
     StopAndSend,
 }
@@ -1380,15 +1366,6 @@ struct PendingPerm {
     frame_seq: u64,
 }
 
-/// A user-console message waiting for the adapter's steering response.
-struct PendingSteer {
-    text: String,
-    by: Option<String>,
-    turn: i64,
-    resources: Vec<Value>,
-    reply: oneshot::Sender<Result<PromptAck>>,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum TurnEndSource {
     MatchingPromptResponse,
@@ -1460,13 +1437,9 @@ struct Task {
     pending_config: HashMap<u64, oneshot::Sender<Result<AcpMetadata>>>,
     #[allow(dead_code)]
     load_session_cap: bool,
-    steering_cap: bool,
-    pending_steers: HashMap<u64, PendingSteer>,
     /// A recovered adapter-owned turn with no prompt response id. Normal turns
     /// are closed by their prompt response instead.
     external_turn: bool,
-    /// A steer that raced the old turn boundary and was accepted as a new turn.
-    pending_external: Option<PendingSteer>,
     /// A cancelled turn may be followed by the adapter's presentation-only
     /// "Conversation interrupted" prose after the next turn has already begun.
     /// Consume that one notice rather than journaling it under the wrong turn.
@@ -1544,10 +1517,7 @@ impl Task {
             pending_mode: HashMap::new(),
             pending_config: HashMap::new(),
             load_session_cap: false,
-            steering_cap: false,
-            pending_steers: HashMap::new(),
             external_turn: false,
-            pending_external: None,
             pending_interrupt_notice_through: None,
             automatic_dispatch_paused: false,
             suppress_journal: false,
@@ -1609,7 +1579,6 @@ impl Task {
         let turns_dispatched = if max_seq < 0 { 0 } else { current_turn + 1 };
 
         let metadata = Self::load_persisted_metadata(&state.db, &session.id).await?;
-        let steering_cap = metadata.steering_supported;
         Ok(Self {
             db: state.db.clone(),
             bus: state.bus.clone(),
@@ -1639,10 +1608,7 @@ impl Task {
             pending_mode: HashMap::new(),
             pending_config: HashMap::new(),
             load_session_cap: false,
-            steering_cap,
-            pending_steers: HashMap::new(),
             external_turn,
-            pending_external: None,
             pending_interrupt_notice_through: None,
             automatic_dispatch_paused,
             suppress_journal: false,
@@ -1818,8 +1784,7 @@ impl Task {
         let res = res.ok_or_else(|| anyhow!("initialize failed: {err:?}"))?;
         if let Ok(init) = serde_json::from_value::<wire::InitializeResult>(res) {
             self.load_session_cap = init.agent_capabilities.load_session;
-            self.steering_cap = init.meta.steering.supported;
-            self.metadata.lock().unwrap().steering_supported = self.steering_cap;
+            self.metadata.lock().unwrap().steering_supported = init.meta.steering.supported;
         }
 
         match &launch.new_or_load {
@@ -2375,11 +2340,6 @@ impl Task {
         let Some(id) = inc.id.as_ref().and_then(Value::as_u64) else {
             return;
         };
-        if let Some(pending) = self.pending_steers.remove(&id) {
-            self.on_steering_response(pending, inc.result, inc.error)
-                .await;
-            return;
-        }
         if let Some(pending) = self.pending_mode.remove(&id) {
             let result = if let Some(error) = inc.error {
                 Err(anyhow!("session/set_mode failed: {error}"))
@@ -2566,18 +2526,6 @@ impl Task {
             return;
         }
 
-        // Steering can race the old prompt's response. If the adapter already
-        // opened the injected message as a new turn, adopt it before ordinary
-        // queued composer feedback. Otherwise let the steering response decide
-        // whether to inject or fall back before dispatching that queue.
-        if let Some(pending) = self.pending_external.take() {
-            self.begin_external_turn(pending).await;
-            return;
-        }
-        if !self.pending_steers.is_empty() {
-            return;
-        }
-
         self.dispatch_pending_prompt().await;
     }
 
@@ -2728,67 +2676,6 @@ impl Task {
         }
     }
 
-    async fn on_steering_response(
-        &mut self,
-        pending: PendingSteer,
-        result: Option<Value>,
-        error: Option<Value>,
-    ) {
-        let outcome = result
-            .and_then(|value| serde_json::from_value::<wire::SteeringResult>(value).ok())
-            .map(|result| result.outcome);
-        match (outcome, error) {
-            (Some(wire::SteeringOutcome::Injected), None)
-                if self.tools.is_empty() && self.pending_perms.is_empty() =>
-            {
-                // The adapter accepted this as input to the current turn. Flush
-                // earlier streamed prose before assigning the injected message
-                // its durable sequence.
-                self.current_turn = pending.turn;
-                self.flush_buf().await;
-                let by = pending.by.map(Value::from).unwrap_or(Value::Null);
-                self.journal_block(
-                    kind::USER_MESSAGE,
-                    json!({
-                        "text": pending.text,
-                        "by": by,
-                        "steered": true,
-                        "resources": pending.resources,
-                    }),
-                )
-                .await;
-                self.automatic_dispatch_paused = false;
-                let _ = pending.reply.send(Ok(PromptAck {
-                    queued: false,
-                    turn: Some(pending.turn),
-                }));
-                if !self.turn_live {
-                    self.dispatch_pending_prompt().await;
-                }
-            }
-            (Some(wire::SteeringOutcome::StartedNewTurn), None) => {
-                if self.turn_live {
-                    self.pending_external = Some(pending);
-                } else {
-                    self.begin_external_turn(pending).await;
-                }
-            }
-            (outcome, error) => {
-                tracing::warn!(
-                    session = %self.session_id,
-                    ?outcome,
-                    ?error,
-                    "steering was unavailable or blocked; restarting the turn"
-                );
-                let result = self
-                    .restart_prompt(pending.text, pending.by, pending.resources)
-                    .await;
-                self.resume_automatic_dispatch_on(&result);
-                let _ = pending.reply.send(result);
-            }
-        }
-    }
-
     async fn restart_prompt(
         &mut self,
         text: String,
@@ -2835,55 +2722,6 @@ impl Task {
             queued: false,
             turn: Some(self.current_turn),
         })
-    }
-
-    async fn begin_external_turn(&mut self, pending: PendingSteer) {
-        let turn = if self.turns_dispatched > 0 {
-            self.current_turn + 1
-        } else {
-            self.current_turn
-        };
-        self.effective_mode = self.current_mode.clone();
-        let inflight = json!({
-            "turn": turn,
-            "external": true,
-            "mode": self.effective_mode,
-        })
-        .to_string();
-        if let Err(error) = session::set_inflight(&self.db, &self.session_id, Some(&inflight)).await
-        {
-            let _ = pending.reply.send(Err(error));
-            return;
-        }
-        self.current_turn = turn;
-        self.next_seq = 0;
-        self.turns_dispatched += 1;
-        self.turn_live = true;
-        self.external_turn = true;
-        self.automatic_dispatch_paused = false;
-        self.emit(
-            "turn",
-            json!({
-                "turn": turn,
-                "state": "started",
-                "effective_mode": self.effective_mode,
-            }),
-        );
-        let by = pending.by.map(Value::from).unwrap_or(Value::Null);
-        self.journal_block(
-            kind::USER_MESSAGE,
-            json!({
-                "text": pending.text,
-                "by": by,
-                "resources": pending.resources,
-            }),
-        )
-        .await;
-        crate::status::record_acp_lifecycle(&self.db, &self.bus, &self.session_id, "working").await;
-        let _ = pending.reply.send(Ok(PromptAck {
-            queued: false,
-            turn: Some(turn),
-        }));
     }
 
     async fn start_turn(
@@ -3267,7 +3105,6 @@ impl Task {
             .await;
         if result.is_ok() && self.turn_live {
             self.automatic_dispatch_paused = true;
-            self.fail_pending_steers("turn was cancelled");
             // The adapter notice belongs to the cancelled turn even when it
             // arrives after an immediate restart. Bound suppression to that
             // turn and its direct successor so unrelated future prose is never
@@ -3304,15 +3141,6 @@ impl Task {
         }
     }
 
-    fn fail_pending_steers(&mut self, reason: &'static str) {
-        for (_, pending) in self.pending_steers.drain() {
-            let _ = pending.reply.send(Err(anyhow!(reason)));
-        }
-        if let Some(pending) = self.pending_external.take() {
-            let _ = pending.reply.send(Err(anyhow!(reason)));
-        }
-    }
-
     async fn on_command(&mut self, cmd: Command) {
         match cmd {
             Command::Prompt {
@@ -3346,49 +3174,6 @@ impl Task {
                         };
                         self.resume_automatic_dispatch_on(&ack);
                         let _ = reply.send(ack);
-                    }
-                    PromptDelivery::SteerOrRestart => {
-                        if self.turn_live
-                            && self.steering_cap
-                            // Adapters accept the private steering RPC while the
-                            // model is blocked behind a tool or permission, but
-                            // cancellation can then discard that unconsumed
-                            // in-memory steer. Start a durable prompt instead.
-                            && self.tools.is_empty()
-                            && self.pending_perms.is_empty()
-                            && self.pending_steers.is_empty()
-                            && self.pending_external.is_none()
-                        {
-                            let id = self.next_id();
-                            let request = wire::request_line(
-                                id,
-                                method::SESSION_STEERING,
-                                wire::steering_params(&self.acp_session_id, &text, &resources),
-                            );
-                            match self.stream.write(&request).await {
-                                Ok(()) => {
-                                    self.pending_steers.insert(
-                                        id,
-                                        PendingSteer {
-                                            text,
-                                            by,
-                                            turn: self.current_turn,
-                                            resources,
-                                            reply,
-                                        },
-                                    );
-                                }
-                                Err(_) => {
-                                    let ack = self.restart_prompt(text, by, resources).await;
-                                    self.resume_automatic_dispatch_on(&ack);
-                                    let _ = reply.send(ack);
-                                }
-                            }
-                        } else {
-                            let ack = self.restart_prompt(text, by, resources).await;
-                            self.resume_automatic_dispatch_on(&ack);
-                            let _ = reply.send(ack);
-                        }
                     }
                     PromptDelivery::StopAndSend => {
                         let ack = self.restart_prompt(text, by, resources).await;
@@ -3556,7 +3341,6 @@ impl Task {
 
     async fn on_exit(&mut self, status: Option<i32>) {
         tracing::warn!(session = %self.session_id, ?status, "acp agent exited");
-        self.fail_pending_steers("acp agent exited");
         self.settle_inflight_review(
             crate::review_inbox::ReviewClaimSettlement::Abandoned,
             "ACP process exit",

--- a/crates/loom-agent/src/acp/wire.rs
+++ b/crates/loom-agent/src/acp/wire.rs
@@ -62,8 +62,6 @@ pub mod method {
     pub const SESSION_NEW: &str = "session/new";
     pub const SESSION_LOAD: &str = "session/load";
     pub const SESSION_PROMPT: &str = "session/prompt";
-    /// Experimental codex-acp extension for adding input to the active turn.
-    pub const SESSION_STEERING: &str = "_session/steering";
     pub const SESSION_CANCEL: &str = "session/cancel";
     pub const SESSION_SET_MODE: &str = "session/set_mode";
     pub const SESSION_SET_CONFIG_OPTION: &str = "session/set_config_option";
@@ -425,18 +423,6 @@ pub struct SteeringCapability {
     pub supported: bool,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub enum SteeringOutcome {
-    Injected,
-    StartedNewTurn,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct SteeringResult {
-    pub outcome: SteeringOutcome,
-}
-
 // ---------------------------------------------------------------------------
 // Request params builders (client → agent)
 // ---------------------------------------------------------------------------
@@ -485,11 +471,6 @@ pub fn prompt_params(session_id: &str, text: &str, resources: &[Value]) -> Value
         "sessionId": session_id,
         "prompt": prompt,
     })
-}
-
-/// codex-acp `_session/steering` params use ACP's ordinary prompt shape.
-pub fn steering_params(session_id: &str, text: &str, resources: &[Value]) -> Value {
-    prompt_params(session_id, text, resources)
 }
 
 /// `session/cancel` notification params.
@@ -847,10 +828,6 @@ mod tests {
         .unwrap();
         assert!(init.agent_capabilities.load_session);
         assert!(init.meta.steering.supported);
-
-        let steer: SteeringResult =
-            serde_json::from_value(json!({ "outcome": "startedNewTurn" })).unwrap();
-        assert_eq!(steer.outcome, SteeringOutcome::StartedNewTurn);
     }
 
     #[test]
@@ -870,15 +847,6 @@ mod tests {
         let params = prompt_params("sess-1", "review this", &[resource]);
         assert_eq!(params["prompt"][1]["type"], "resource_link");
         assert_eq!(params["prompt"][1]["name"], "src/main.rs");
-
-        let line = request_line(
-            2,
-            method::SESSION_STEERING,
-            steering_params("sess-1", "pivot", &[]),
-        );
-        let v: Value = serde_json::from_slice(&line[..line.len() - 1]).unwrap();
-        assert_eq!(v["method"], "_session/steering");
-        assert_eq!(v["params"]["prompt"][0]["text"], "pivot");
 
         let resp = response_line(&json!(7), permission_selected("allow-once"));
         let v: Value = serde_json::from_slice(&resp[..resp.len() - 1]).unwrap();

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -589,8 +589,7 @@ export const getSessionChat = (id: string, before?: { turn: number; seq: number 
   return get(`/sessions/${id}/chat${query}`) as Promise<ChatSnapshot>;
 };
 
-/** Send a user message to an ACP session now. A receptive live turn is steered;
- *  a turn blocked behind a tool or permission is stopped and replaced. */
+/** Send a user message to an ACP session now, stopping and replacing a live turn. */
 export const promptSession = (id: string, text: string, by?: string, files: string[] = []) =>
   post(`/sessions/${id}/prompt`, {
     text,

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -2030,8 +2030,8 @@ pub(super) struct PromptBody {
     pub text: String,
     #[serde(default)]
     pub by: Option<String>,
-    /// Deliver this user message immediately: steer a receptive live turn, or
-    /// cancel and replace one blocked behind a tool or permission.
+    /// Deliver this user message immediately by cancelling any live turn and
+    /// starting the message as a normal prompt.
     #[serde(default)]
     pub send_now: bool,
     /// Promote the server's durable next-turn queue instead of sending `text`.
@@ -2151,9 +2151,9 @@ async fn prompt_resources(work_dir: &str, files: &[String]) -> ApiResult<Vec<Val
 
 /// Send a user message to an ACP session. A normal request is dispatched when
 /// idle or appended to the durable queue while a turn is live; `send_now`
-/// instead steers a receptive live turn or cancels and replaces one blocked at
-/// a tool/permission boundary. Returns 202 `{ queued, turn }`. Every send records
-/// a `nudge` event (the audit rule).
+/// instead cancels any live turn and starts the message as a normal prompt.
+/// Returns 202 `{ queued, turn }`. Every send records a `nudge` event (the audit
+/// rule).
 pub(super) async fn prompt_session(
     State(st): State<AppState>,
     Path(key): Path<String>,
@@ -2174,7 +2174,7 @@ pub(super) async fn prompt_session(
         let resources = prompt_resources(&session.work_dir, &req.files).await?;
         if req.send_now {
             handle
-                .steer_or_restart(req.text.clone(), Some(by.clone()), resources)
+                .stop_and_send(req.text.clone(), Some(by.clone()), resources)
                 .await
         } else {
             handle

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1595,11 +1595,13 @@ async fn session_send_restarts_a_live_turn() {
     }));
 }
 
-/// User-console feedback uses a supported adapter's steering extension while
-/// the model is receptive, keeping the current work alive.
+/// User-console feedback remains preemptive when the adapter advertises its
+/// private steering extension. An `injected` response only proves the adapter
+/// queued the message; the model can still enter a long tool call before it
+/// observes that input, so immediate delivery must stop and replace the turn.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn prompt_send_now_steers_a_receptive_live_turn() {
+async fn prompt_send_now_restarts_a_steerable_live_turn() {
     let ts = TestServer::start().await;
     start_new_with_env(
         &ts,
@@ -1626,32 +1628,30 @@ async fn prompt_send_now_steers_a_receptive_live_turn() {
         .await
         .unwrap();
     assert_eq!(sent["queued"], false, "response: {sent}");
-    assert_eq!(sent["turn"], 0, "steering stays in the live turn");
+    assert_eq!(sent["turn"], 1, "the replacement opens the next turn");
 
     let chat = poll_chat(&ts, "acp-prompt-steer", Duration::from_secs(10), |blocks| {
-        blocks.iter().any(|block| {
-            block["kind"] == "agent_message"
-                && block["payload"]["text"]
-                    .as_str()
-                    .is_some_and(|text| text.contains("injected"))
-        })
+        blocks
+            .iter()
+            .any(|block| block["kind"] == "agent_message" && block["payload"]["text"] == "injected")
     })
     .await;
     let blocks = chat["blocks"].as_array().unwrap();
     assert!(blocks.iter().any(|block| {
         block["turn"] == 0
+            && block["kind"] == "turn_end"
+            && block["payload"]["stop_reason"] == "cancelled"
+    }));
+    assert!(blocks.iter().any(|block| {
+        block["turn"] == 1
             && block["kind"] == "user_message"
             && block["payload"]["text"] == "say:injected"
-            && block["payload"]["steered"] == true
-    }));
-    assert!(!blocks.iter().any(|block| {
-        block["kind"] == "turn_end" && block["payload"]["stop_reason"] == "cancelled"
+            && block["payload"].get("steered").is_none()
     }));
 }
 
-/// codex-acp acknowledges steering while the model is blocked in a tool, but a
-/// later cancellation can discard that unconsumed in-memory input. User-console
-/// feedback therefore falls back to one normal stop-and-send at that boundary.
+/// User-console feedback stops and replaces a tool-blocked turn without probing
+/// the adapter's private steering extension first.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn prompt_send_now_restarts_a_tool_blocked_live_turn() {

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -75,12 +75,12 @@ Artifacts stays one tap away; Agent, Changes, and ACP Shells remain available
 from More without occupying primary navigation.
 
 Conversation is the durable operator/agent exchange. Mid-turn composer feedback
-steers a receptive adapter. When a tool or permission blocks the model from
-consuming a steer, Loom stops the current turn and starts the feedback as the
-next turn. Unseen queued text can still be retracted into the composer for
-editing without rewriting already-dispatched history, or promoted with **Stop &
-send**. Permission requests and runtime controls stay in the conversation that
-produced them; elapsed quiet time is evidence, not an automatic “stuck” verdict.
+stops the current turn and starts as the next turn, so it cannot sit behind work
+the model selected concurrently. Unseen queued text can still be retracted into
+the composer for editing without rewriting already-dispatched history, or
+promoted with **Stop & send**. Permission requests and runtime controls stay in
+the conversation that produced them; elapsed quiet time is evidence, not an
+automatic “stuck” verdict.
 
 Review contains **Changes** and **Artifacts**. Both use the same staged review
 workflow:


### PR DESCRIPTION
Immediate messages from the ACP Conversation now cancel any live turn and start a fresh prompt, matching cross-session control input. Adapter steering only confirms in-memory queueing, so the model could begin a long wait_for tool call before observing a user's correction.

The unused private steering request state machine is removed while the advertised capability remains read-only metadata and recovery for already-persisted external turns remains intact. Integration coverage verifies steer-capable, unsteerable, and tool-blocked turns all produce a cancelled boundary followed by the replacement turn.