### PR TITLE
fix(loom): make GitHub credentials Loom-owned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ python/weaver-loom/.venv/
 python/weaver-loom/uv.lock
 
 # Local-only container env, rendered from loom.toml by `loom config render-env`
-# (deploy/standalone/.env — holds GH_TOKEN etc.). Never commit it: host secrets.
+# (deploy/standalone/.env — holds model/integration secrets). Never commit it.
 .env
 
 # `loom setup`'s authored config — every credential in plaintext TOML. Never

--- a/Dockerfile
+++ b/Dockerfile
@@ -257,16 +257,17 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
     ;;
   direct)
     token="$GH_TOKEN"
+    if [ -z "$token" ]; then
+      echo "Loom-managed direct GitHub auth is missing GH_TOKEN" >&2
+      exit 1
+    fi
     ;;
   disabled)
     exit 0
     ;;
   "")
-    # Compatibility for sessions created by an older Loom server.
-    token="$GH_TOKEN"
-    if [ -z "$token" ] && [ -n "$LOOM_SESSION_ID" ] && [ -n "$LOOM_TOKEN" ]; then
-      token="$(/usr/local/bin/weaver github-token)" || exit $?
-    fi
+    echo "missing LOOM_GITHUB_AUTH_MODE; this environment was not prepared by Loom" >&2
+    exit 1
     ;;
   *)
     echo "invalid LOOM_GITHUB_AUTH_MODE: $LOOM_GITHUB_AUTH_MODE" >&2
@@ -290,6 +291,10 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
     unset GITHUB_TOKEN
     ;;
   direct)
+    if [ -z "$GH_TOKEN" ]; then
+      echo "Loom-managed direct GitHub auth is missing GH_TOKEN" >&2
+      exit 1
+    fi
     unset GITHUB_TOKEN
     ;;
   disabled)
@@ -297,11 +302,8 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
     exit 1
     ;;
   "")
-    # Compatibility for sessions created by an older Loom server.
-    if [ -z "$GH_TOKEN" ] && [ -n "$LOOM_SESSION_ID" ] && [ -n "$LOOM_TOKEN" ]; then
-      GH_TOKEN="$(/usr/local/bin/weaver github-token)" || exit $?
-      export GH_TOKEN
-    fi
+    echo "missing LOOM_GITHUB_AUTH_MODE; this environment was not prepared by Loom" >&2
+    exit 1
     ;;
   *)
     echo "invalid LOOM_GITHUB_AUTH_MODE: $LOOM_GITHUB_AUTH_MODE" >&2

--- a/Dockerfile
+++ b/Dockerfile
@@ -234,31 +234,80 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
 RUN mkdir -p /opt/gcloud && chown -R "${HOST_UID}:${HOST_GID}" /opt/gcloud
 ENV CLOUDSDK_CONFIG=/opt/gcloud
 
-# Let agents `git push` over HTTPS with the injected GH_TOKEN — no mounted SSH
-# key. The bind-mounted host repos usually have `git@github.com:` SSH remotes, so
-# also rewrite GitHub SSH URLs to HTTPS: with no key in the container an SSH push
-# fails with "Permission denied (publickey)", but rewritten it rides the token
-# helper below. (Non-GitHub SSH remotes still need ~/.ssh mounted; see compose.)
+# Let agents `git push` over HTTPS with the credential selected by Loom — no
+# mounted SSH key. Loom stamps LOOM_GITHUB_AUTH_MODE on every managed session:
+# an explicit personal/profile GH_TOKEN is direct, an allowlisted GitHub App is
+# brokered through the session API, and restricted sessions are disabled. The
+# bind-mounted host repos usually have `git@github.com:` SSH remotes, so also
+# rewrite GitHub SSH URLs to HTTPS. (Non-GitHub SSH remotes still need ~/.ssh
+# mounted; see compose.)
 RUN <<'EOF'
 cat > /usr/local/bin/git-credential-ghtoken <<'SH'
 #!/bin/sh
 # git invokes the helper for get/store/erase; only `get` returns a credential,
 # and store/erase must exit 0 or git warns about a failing helper.
 [ "$1" = get ] || exit 0
-token="$GH_TOKEN"
-if [ -z "$token" ] && [ -n "$LOOM_SESSION_ID" ] && [ -n "$LOOM_TOKEN" ]; then
-  token="$(/usr/local/bin/weaver github-token)" || exit $?
-fi
+case "${LOOM_GITHUB_AUTH_MODE:-}" in
+  broker)
+    if [ -z "$LOOM_SESSION_ID" ] || [ -z "$LOOM_TOKEN" ]; then
+      echo "Loom-managed GitHub auth is missing its session credential" >&2
+      exit 1
+    fi
+    token="$(/usr/local/bin/weaver github-token)" || exit $?
+    ;;
+  direct)
+    token="$GH_TOKEN"
+    ;;
+  disabled)
+    exit 0
+    ;;
+  "")
+    # Compatibility for sessions created by an older Loom server.
+    token="$GH_TOKEN"
+    if [ -z "$token" ] && [ -n "$LOOM_SESSION_ID" ] && [ -n "$LOOM_TOKEN" ]; then
+      token="$(/usr/local/bin/weaver github-token)" || exit $?
+    fi
+    ;;
+  *)
+    echo "invalid LOOM_GITHUB_AUTH_MODE: $LOOM_GITHUB_AUTH_MODE" >&2
+    exit 1
+    ;;
+esac
 [ -n "$token" ] || exit 0
 printf 'username=x-access-token\npassword=%s\n' "$token"
 SH
 chmod +x /usr/local/bin/git-credential-ghtoken
 cat > /usr/local/bin/gh <<'SH'
 #!/bin/sh
-if [ -z "$GH_TOKEN" ] && [ -n "$LOOM_SESSION_ID" ] && [ -n "$LOOM_TOKEN" ]; then
-  GH_TOKEN="$(/usr/local/bin/weaver github-token)" || exit $?
-  export GH_TOKEN
-fi
+case "${LOOM_GITHUB_AUTH_MODE:-}" in
+  broker)
+    if [ -z "$LOOM_SESSION_ID" ] || [ -z "$LOOM_TOKEN" ]; then
+      echo "Loom-managed GitHub auth is missing its session credential" >&2
+      exit 1
+    fi
+    GH_TOKEN="$(/usr/local/bin/weaver github-token)" || exit $?
+    export GH_TOKEN
+    unset GITHUB_TOKEN
+    ;;
+  direct)
+    unset GITHUB_TOKEN
+    ;;
+  disabled)
+    echo "GitHub CLI access is disabled for this Loom session" >&2
+    exit 1
+    ;;
+  "")
+    # Compatibility for sessions created by an older Loom server.
+    if [ -z "$GH_TOKEN" ] && [ -n "$LOOM_SESSION_ID" ] && [ -n "$LOOM_TOKEN" ]; then
+      GH_TOKEN="$(/usr/local/bin/weaver github-token)" || exit $?
+      export GH_TOKEN
+    fi
+    ;;
+  *)
+    echo "invalid LOOM_GITHUB_AUTH_MODE: $LOOM_GITHUB_AUTH_MODE" >&2
+    exit 1
+    ;;
+esac
 exec /usr/bin/gh "$@"
 SH
 chmod +x /usr/local/bin/gh

--- a/Dockerfile
+++ b/Dockerfile
@@ -236,8 +236,10 @@ ENV CLOUDSDK_CONFIG=/opt/gcloud
 
 # Let agents `git push` over HTTPS with the credential selected by Loom — no
 # mounted SSH key. Loom stamps LOOM_GITHUB_AUTH_MODE on every managed session:
-# an explicit personal/profile GH_TOKEN is direct, an allowlisted GitHub App is
-# brokered through the session API, and restricted sessions are disabled. The
+# `direct` consumes only a per-user PAT that Loom injected, `broker` requests an
+# allowlisted GitHub App token through the session API, and restricted sessions
+# or sessions without either are disabled. These scripts are transport adapters;
+# Loom owns credential selection. The
 # bind-mounted host repos usually have `git@github.com:` SSH remotes, so also
 # rewrite GitHub SSH URLs to HTTPS. (Non-GitHub SSH remotes still need ~/.ssh
 # mounted; see compose.)
@@ -256,6 +258,7 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
     token="$(/usr/local/bin/weaver github-token)" || exit $?
     ;;
   direct)
+    # Loom sets direct only after injecting the launching user's Account token.
     token="$GH_TOKEN"
     if [ -z "$token" ]; then
       echo "Loom-managed direct GitHub auth is missing GH_TOKEN" >&2
@@ -291,6 +294,7 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
     unset GITHUB_TOKEN
     ;;
   direct)
+    # GH_TOKEN was injected by Loom from the launching user's Account settings.
     if [ -z "$GH_TOKEN" ]; then
       echo "Loom-managed direct GitHub auth is missing GH_TOKEN" >&2
       exit 1

--- a/README.md
+++ b/README.md
@@ -447,6 +447,10 @@ loom mcp add /engineering/search/docs --label "Docs search" \
 Strict profiles reject one-launch overrides. Environment-cleared profiles start
 from a minimal baseline plus explicit ambient, profile, and repository values.
 Environment reads expose names and source metadata, never literal secret values.
+GitHub client credentials are a separate Loom-owned path: an ordinary
+interactive session uses its launching user's optional Account PAT, otherwise
+the profile's allowlisted GitHub App access. Profile, repository, committed, and
+daemon environments cannot define `GH_TOKEN` or `GITHUB_TOKEN`.
 
 MCP selection is provider-neutral: `none`, `all`, or named groups. Saving a
 profile pins exact capability identities and revisions; registry edits cannot

--- a/README.md
+++ b/README.md
@@ -447,10 +447,10 @@ loom mcp add /engineering/search/docs --label "Docs search" \
 Strict profiles reject one-launch overrides. Environment-cleared profiles start
 from a minimal baseline plus explicit ambient, profile, and repository values.
 Environment reads expose names and source metadata, never literal secret values.
-GitHub client credentials are a separate Loom-owned path: an ordinary
-interactive session uses its launching user's optional Account PAT, otherwise
-the profile's allowlisted GitHub App access. Profile, repository, committed, and
-daemon environments cannot define `GH_TOKEN` or `GITHUB_TOKEN`.
+GitHub client credentials are selected by Loom: an ordinary interactive session
+prefers its launching user's optional Account PAT and otherwise uses the
+profile's allowlisted GitHub App access. The image's Git credential helper and
+`gh` wrapper consume that session selection.
 
 MCP selection is provider-neutral: `none`, `all`, or named groups. Saving a
 profile pins exact capability identities and revisions; registry edits cannot

--- a/crates/loom-ctx/Cargo.toml
+++ b/crates/loom-ctx/Cargo.toml
@@ -10,7 +10,7 @@ weaver-api = { path = "../weaver-api" }
 tapestry = { path = "../tapestry" }
 anyhow = "1"
 # Trait objects with async methods — the GitHub trigger's gateway abstraction
-# (`GithubApi`), so the `gh`-backed implementation and a test fake share a type.
+# (`GithubApi`), so the App-backed implementation and a test fake share a type.
 async-trait = "0.1"
 base64 = "0.22"
 bollard = { version = "0.21", default-features = false, features = ["pipe"] }

--- a/crates/loom-ctx/src/envfile.rs
+++ b/crates/loom-ctx/src/envfile.rs
@@ -108,33 +108,33 @@ mod tests {
 
     #[test]
     fn replaces_an_existing_key_in_place_and_leaves_the_rest_untouched() {
-        let input = "# a comment\nLOOM_DOMAIN=loom.example.com\nGH_TOKEN=old\nHOST_UID=1000\n";
-        let out = upsert(input, &[("GH_TOKEN", "ghp_new")]);
+        let input = "# a comment\nLOOM_DOMAIN=loom.example.com\nAPI_TOKEN=old\nHOST_UID=1000\n";
+        let out = upsert(input, &[("API_TOKEN", "new")]);
         assert_eq!(
             out,
-            "# a comment\nLOOM_DOMAIN=loom.example.com\nGH_TOKEN=ghp_new\nHOST_UID=1000\n"
+            "# a comment\nLOOM_DOMAIN=loom.example.com\nAPI_TOKEN=new\nHOST_UID=1000\n"
         );
     }
 
     #[test]
     fn appends_missing_keys_after_a_blank_separator() {
         let input = "LOOM_DOMAIN=loom.example.com\n";
-        let out = upsert(input, &[("GH_TOKEN", "ghp_new")]);
-        assert_eq!(out, "LOOM_DOMAIN=loom.example.com\n\nGH_TOKEN=ghp_new\n");
+        let out = upsert(input, &[("API_TOKEN", "new")]);
+        assert_eq!(out, "LOOM_DOMAIN=loom.example.com\n\nAPI_TOKEN=new\n");
     }
 
     #[test]
     fn does_not_double_up_the_blank_separator() {
         let input = "LOOM_DOMAIN=loom.example.com\n\n";
-        let out = upsert(input, &[("GH_TOKEN", "ghp_new")]);
-        assert_eq!(out, "LOOM_DOMAIN=loom.example.com\n\nGH_TOKEN=ghp_new\n");
+        let out = upsert(input, &[("API_TOKEN", "new")]);
+        assert_eq!(out, "LOOM_DOMAIN=loom.example.com\n\nAPI_TOKEN=new\n");
     }
 
     #[test]
     fn ignores_commented_out_keys_when_matching() {
-        let input = "# GH_TOKEN=disabled\n";
-        let out = upsert(input, &[("GH_TOKEN", "ghp_new")]);
-        assert_eq!(out, "# GH_TOKEN=disabled\n\nGH_TOKEN=ghp_new\n");
+        let input = "# API_TOKEN=disabled\n";
+        let out = upsert(input, &[("API_TOKEN", "new")]);
+        assert_eq!(out, "# API_TOKEN=disabled\n\nAPI_TOKEN=new\n");
     }
 
     #[test]

--- a/crates/loom-ctx/src/loom_config.rs
+++ b/crates/loom-ctx/src/loom_config.rs
@@ -12,12 +12,9 @@
 //! Every field resolves from **either** `loom.toml` **or** a same-named
 //! environment variable — [`resolve`] layers the process environment over
 //! whatever's on disk (env wins), the standard "env overrides a config file"
-//! expectation (the same reason `GH_TOKEN` in your shell already overrides
-//! the `gh` CLI's own stored auth). That layering only happens on the
+//! expectation. That layering only happens on the
 //! *consuming* path (`render-env`, `push-secrets`) — [`load`]/[`upsert`], the
-//! *authoring* path `loom setup` writes through, never touch the
-//! environment, so an operator's ambient `GH_TOKEN` (say, for their own `gh`
-//! usage) can't silently get baked into the committed `loom.toml`.
+//! *authoring* path `loom setup` writes through, never touch the environment.
 
 use std::path::Path;
 
@@ -60,8 +57,6 @@ pub struct LoomConfig {
     pub anthropic_api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub openai_api_key: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub gh_token: Option<String>,
     /// Slack app-level token (`xapp-…`, needs `connections:write`) — opens the
     /// Socket Mode websocket. With both this and `slack_bot_token` set, loom
     /// connects to Slack and the `/marinbot` trigger goes live.
@@ -165,12 +160,6 @@ pub static FIELDS: &[FieldSpec] = &[
         set_fn: |c, v| c.openai_api_key = Some(v),
     },
     FieldSpec {
-        env_name: "GH_TOKEN",
-        secret: true,
-        get_fn: |c| c.gh_token.as_deref(),
-        set_fn: |c, v| c.gh_token = Some(v),
-    },
-    FieldSpec {
         env_name: "LOOM_SLACK_APP_TOKEN",
         secret: true,
         get_fn: |c| c.slack_app_token.as_deref(),
@@ -240,8 +229,8 @@ pub fn resolve(path: &Path) -> Result<LoomConfig> {
 
 /// [`resolve`], plus the `ENV_NAME`s where an ambient env var overrode a
 /// *different* value already present in `path` — the footgun on a deploy
-/// workstation, where a personal `GH_TOKEN`/`ANTHROPIC_API_KEY` etc. is
-/// commonly exported and would otherwise silently outrank `loom.toml` in
+/// workstation, where an `ANTHROPIC_API_KEY` or similar setting is commonly
+/// exported and would otherwise silently outrank `loom.toml` in
 /// exactly the run that pushes secrets to the shared deploy. `render-env` and
 /// `push-secrets` (`bin/loom.rs`) use this instead of bare [`resolve`] so they
 /// can warn; a value that merely fills in a field the file never had isn't a
@@ -314,9 +303,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("loom.toml");
         upsert(&path, &[("LOOM_DOMAIN", "loom.example.com")]).unwrap();
-        let config = upsert(&path, &[("GH_TOKEN", "ghp_new")]).unwrap();
+        let config = upsert(&path, &[("OPENAI_API_KEY", "sk-new")]).unwrap();
         assert_eq!(config.domain.as_deref(), Some("loom.example.com"));
-        assert_eq!(config.gh_token.as_deref(), Some("ghp_new"));
+        assert_eq!(config.openai_api_key.as_deref(), Some("sk-new"));
     }
 
     #[test]
@@ -431,7 +420,6 @@ mod tests {
                 "LOOM_GITHUB_CLIENT_SECRET",
                 "ANTHROPIC_API_KEY",
                 "OPENAI_API_KEY",
-                "GH_TOKEN",
                 "LOOM_SLACK_APP_TOKEN",
                 "LOOM_SLACK_BOT_TOKEN",
             ]

--- a/crates/loom-forge/src/github.rs
+++ b/crates/loom-forge/src/github.rs
@@ -1,11 +1,8 @@
-//! Optional GitHub integration via the `gh` CLI. All functions degrade
-//! gracefully — callers treat errors as "GitHub unavailable".
+//! GitHub integration through Loom's configured GitHub App.
 //!
 //! Two responsibilities live here:
 //!
-//! * **Issue seeding** ([`fetch_issue`], [`repo_slug`]) and PR opening
-//!   ([`create_pr`]) — one-shot shell-outs used when a session is created.
-//! * **PR status polling** ([`poll`], [`refresh`], [`fetch_pr`]) — the
+//! * **PR status polling** ([`poll`], [`refresh`]) — the
 //!   background loop that snapshots each live session's pull request (link,
 //!   review decision, check rollup) into the `branch_github` table, and
 //!   archives a session — closing the weaver issues it was working — once its PR
@@ -18,8 +15,6 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use serde_json::json;
-use tokio::process::Command;
-use tokio::sync::OnceCell;
 
 use crate::db::{now_iso, Db};
 use crate::session::{self as session_mod, Session};
@@ -37,77 +32,6 @@ pub struct Issue {
     pub body: String,
     #[serde(default)]
     pub url: String,
-}
-
-async fn gh(dir: &Path, args: &[&str]) -> Result<String> {
-    tracing::debug!(args = %args.join(" "), dir = %dir.display(), "running gh");
-    let out = Command::new("gh")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .await
-        .map_err(|e| {
-            tracing::warn!(error = %e, "failed to spawn gh");
-            e
-        })
-        .context("failed to spawn gh (is the GitHub CLI installed?)")?;
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        tracing::warn!(
-            args = %args.join(" "),
-            code = out.status.code().unwrap_or(-1),
-            stderr = %stderr.trim(),
-            "gh command failed"
-        );
-        bail!("gh {} failed: {}", args.join(" "), stderr.trim());
-    }
-    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
-}
-
-/// `owner/name` slug for the repository at `repo_root`.
-pub async fn repo_slug(repo_root: &Path) -> Result<String> {
-    gh(
-        repo_root,
-        &[
-            "repo",
-            "view",
-            "--json",
-            "nameWithOwner",
-            "-q",
-            ".nameWithOwner",
-        ],
-    )
-    .await
-}
-
-/// Fetch an issue's title/body/url.
-pub async fn fetch_issue(repo_root: &Path, number: i64) -> Result<Issue> {
-    let json = gh(
-        repo_root,
-        &[
-            "issue",
-            "view",
-            &number.to_string(),
-            "--json",
-            "title,body,url",
-        ],
-    )
-    .await?;
-    serde_json::from_str(&json).context("parsing gh issue JSON")
-}
-
-/// Open a pull request from the workspace branch; returns the PR URL.
-pub async fn create_pr(work_dir: &Path, base: &str, title: &str, body: &str) -> Result<String> {
-    tracing::debug!(base, title, body_len = body.len(), "creating pull request");
-    let url = gh(
-        work_dir,
-        &[
-            "pr", "create", "--base", base, "--title", title, "--body", body,
-        ],
-    )
-    .await?;
-    tracing::info!(url = %url, base, "pull request created");
-    Ok(url)
 }
 
 // ---------------------------------------------------------------------------
@@ -446,8 +370,6 @@ pub async fn record_status_comment(
 
 /// The fields requested from `gh pr view --json`. Kept in one place so the parse
 /// struct and the query can't drift.
-const PR_FIELDS: &str = "number,url,state,title,isDraft,reviewDecision,mergeable,mergedAt,statusCheckRollup,headRefOid,updatedAt";
-
 /// The shape of one `gh pr view --json` record. Internal — callers see
 /// [`GithubStatus`].
 #[derive(Debug, Deserialize)]
@@ -666,133 +588,35 @@ fn review_decision_changed(prev: Option<&GithubStatus>, next: &GithubStatus) -> 
         && prev.map(|p| &p.review_decision) != Some(&next.review_decision)
 }
 
-/// Whether the `gh` CLI is usable on this machine. Probed once and cached — a
-/// missing `gh` is the common "GitHub integration off" case and shouldn't cost a
-/// process spawn on every poll.
-pub async fn gh_available() -> bool {
-    static AVAILABLE: OnceCell<bool> = OnceCell::const_new();
-    *AVAILABLE
-        .get_or_init(|| async {
-            let ok = Command::new("gh")
-                .arg("--version")
-                .output()
-                .await
-                .map(|o| o.status.success())
-                .unwrap_or(false);
-            if ok {
-                tracing::info!("gh CLI detected — GitHub PR polling available");
-            } else {
-                tracing::info!("gh CLI not found — GitHub PR polling disabled");
-            }
-            ok
-        })
-        .await
-}
-
-/// Fetch one pull request by number (or another exact `gh pr view` selector).
-/// This is used for a user-selected mapping and to follow an already-open PR
-/// through its terminal transition.
-pub async fn fetch_pr(
+async fn app_and_slug<'a>(
+    state: &'a AppState,
     repo_root: &Path,
-    selector: &str,
-    token: Option<&str>,
-) -> Result<Option<GithubStatus>> {
-    let mut cmd = Command::new("gh");
-    cmd.args(["pr", "view", selector, "--json", PR_FIELDS])
-        .current_dir(repo_root);
-    // The poll loop runs in the loom process, which carries no ambient `gh` auth
-    // (the operator's `GH_TOKEN` is session-scoped, not the server's). Without a
-    // token `gh pr view` fails and every branch's PR status stays blank — starving
-    // the pr-label / review-wait / archive-merged watches, which key off it.
-    if let Some(token) = token {
-        cmd.env("GH_TOKEN", token);
-    }
-    let out = cmd
-        .output()
-        .await
-        .context("failed to spawn gh (is the GitHub CLI installed?)")?;
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        // gh exits non-zero when the branch has no PR; that's not an error.
-        if stderr.to_lowercase().contains("no pull requests found")
-            || stderr.to_lowercase().contains("no open pull requests")
-        {
-            return Ok(None);
-        }
-        bail!("gh pr view {selector} failed: {}", stderr.trim());
-    }
-    let raw: PrJson = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
-        .context("parsing gh pr JSON")?;
-    Ok(Some(raw.into_status()))
+) -> Result<(&'a crate::github_app::GithubApp, String)> {
+    let slug = crate::repo::github_slug_for_root(&state.db, repo_root)
+        .await?
+        .context("repository has no registered GitHub identity")?;
+    let app = state.trigger.app().context("GitHub App is unavailable")?;
+    Ok((app, slug))
 }
 
-/// Discover the branch's current open PR. `gh pr view <branch>` may keep
-/// returning an old closed/merged PR forever; the list query makes "current"
-/// explicit and returns no result once the branch has no open PR.
+pub async fn fetch_pr(
+    state: &AppState,
+    repo_root: &Path,
+    number: i64,
+) -> Result<Option<GithubStatus>> {
+    let (app, slug) = app_and_slug(state, repo_root).await?;
+    let snapshots = fetch_pr_batch(app, &slug, &[], &[number]).await?;
+    Ok(snapshots.by_number.get(&number).cloned())
+}
+
 pub async fn fetch_open_pr(
+    state: &AppState,
     repo_root: &Path,
     branch: &str,
-    token: Option<&str>,
 ) -> Result<Option<GithubStatus>> {
-    let mut cmd = Command::new("gh");
-    cmd.args([
-        "pr", "list", "--head", branch, "--state", "open", "--limit", "1", "--json", PR_FIELDS,
-    ])
-    .current_dir(repo_root);
-    if let Some(token) = token {
-        cmd.env("GH_TOKEN", token);
-    }
-    let out = cmd
-        .output()
-        .await
-        .context("failed to spawn gh (is the GitHub CLI installed?)")?;
-    if !out.status.success() {
-        bail!(
-            "gh pr list --head {branch} failed: {}",
-            String::from_utf8_lossy(&out.stderr).trim()
-        );
-    }
-    let mut rows: Vec<PrJson> =
-        serde_json::from_slice(&out.stdout).context("parsing gh pr list JSON")?;
-    Ok(rows.pop().map(PrJson::into_status))
-}
-
-async fn operator_gh_environment(state: &AppState) -> (Option<String>, Option<String>) {
-    (
-        crate::agent_env::get(&state.db, "GH_TOKEN").await,
-        crate::agent_env::get(&state.db, "GH_HOST").await,
-    )
-}
-
-async fn gh_environment_for_slug(state: &AppState, slug: &str) -> (Option<String>, Option<String>) {
-    if let (Some(app), Ok(repo)) = (state.trigger.app(), crate::repo::parse_slug(slug)) {
-        if app.is_configured().await {
-            match app.token_for_repo(&repo.owner, &repo.name).await {
-                Ok(token) => return (Some(token), None),
-                Err(error) => tracing::debug!(repo = slug, %error, "GitHub App token unavailable"),
-            }
-        }
-    }
-    operator_gh_environment(state).await
-}
-
-/// The `gh` environment for one repository: its App installation token when
-/// available, otherwise the operator credential configured in Settings.
-pub async fn gh_environment(
-    state: &AppState,
-    repo_root: Option<&Path>,
-) -> (Option<String>, Option<String>) {
-    let Some(repo_root) = repo_root else {
-        return operator_gh_environment(state).await;
-    };
-    match crate::repo::github_slug_for_root(&state.db, repo_root).await {
-        Ok(Some(slug)) => gh_environment_for_slug(state, &slug).await,
-        Ok(None) => operator_gh_environment(state).await,
-        Err(error) => {
-            tracing::debug!(repo = %repo_root.display(), %error, "GitHub repository lookup failed");
-            operator_gh_environment(state).await
-        }
-    }
+    let (app, slug) = app_and_slug(state, repo_root).await?;
+    let snapshots = fetch_pr_batch(app, &slug, &[branch.to_string()], &[]).await?;
+    Ok(snapshots.by_head.get(branch).cloned())
 }
 
 /// Fetch every due branch's current open PR plus every previously-known PR in
@@ -801,35 +625,15 @@ pub async fn gh_environment(
 /// lookups keep terminal transitions visible after GitHub removes a merged or
 /// closed PR from the open-head result.
 async fn fetch_pr_batch(
-    repo_root: &Path,
+    app: &crate::github_app::GithubApp,
     slug: &str,
     heads: &[String],
     known_numbers: &[i64],
-    token: Option<&str>,
-    host: Option<&str>,
 ) -> Result<BatchSnapshots> {
     let query = build_batch_query(slug, heads, known_numbers)?;
-
-    let mut cmd = Command::new("gh");
-    cmd.args(["api", "graphql", "--raw-field", &format!("query={query}")])
-        .current_dir(repo_root);
-    if let Some(token) = token {
-        cmd.env("GH_TOKEN", token);
-    }
-    if let Some(host) = host {
-        cmd.env("GH_HOST", host);
-    }
-    let out = cmd
-        .output()
-        .await
-        .context("failed to spawn gh (is the GitHub CLI installed?)")?;
-    if !out.status.success() {
-        bail!(
-            "gh api graphql failed for {slug}: {}",
-            String::from_utf8_lossy(&out.stderr).trim()
-        );
-    }
-    parse_batch_response(&out.stdout, slug, heads, known_numbers)
+    let repo = crate::repo::parse_slug(slug).map_err(anyhow::Error::msg)?;
+    let response = app.graphql(&repo, &query).await?;
+    parse_batch_response(&response, slug, heads, known_numbers)
 }
 
 fn build_batch_query(slug: &str, heads: &[String], known_numbers: &[i64]) -> Result<String> {
@@ -1040,23 +844,22 @@ pub async fn refresh(
     archive_on_merge: bool,
 ) -> Result<Option<GithubStatus>> {
     let repo_root = PathBuf::from(&branch.repo_root);
-    let (token, _) = gh_environment(state, Some(&repo_root)).await;
     let previous = get_status(&state.db, &branch.id).await?;
     let mapping = get_mapping(&state.db, &branch.id).await?;
     let fetched = if let Some(number) = mapping {
-        fetch_pr(&repo_root, &number.to_string(), token.as_deref()).await?
+        fetch_pr(state, &repo_root, number).await?
     } else {
         // Automatic mode always asks GitHub which open PR is current instead of
         // treating yesterday's cached number as authoritative. Only when the
         // branch has no open PR do we revisit the previous number once, to
         // preserve its close/merge transition before the snapshot is cleared.
         let head = discovery_branch(session, branch).await;
-        let current = fetch_open_pr(&repo_root, &head, token.as_deref()).await?;
+        let current = fetch_open_pr(state, &repo_root, &head).await?;
         if current.is_some() {
             current
         } else if previous.as_ref().is_some_and(|pr| pr.pr_state == "OPEN") {
             let number = previous.as_ref().expect("checked above").pr_number;
-            fetch_pr(&repo_root, &number.to_string(), token.as_deref()).await?
+            fetch_pr(state, &repo_root, number).await?
         } else {
             None
         }
@@ -1342,8 +1145,8 @@ async fn close_claimed_issues(
 }
 
 /// Background loop: snapshot live sessions' PRs on an activity-aware cadence. A
-/// no-op while `github.poll` is off or `gh` is unavailable, so it is always safe
-/// to spawn. Sibling of the [`crate::monitor`] loop.
+/// no-op while `github.poll` is off or the GitHub App is unavailable, so it is
+/// always safe to spawn. Sibling of the [`crate::monitor`] loop.
 pub async fn poll(state: AppState) {
     tracing::info!(tick_s = POLL_TICK.as_secs(), "github poll loop started");
     let mut ticks = tokio::time::interval(POLL_TICK);
@@ -1359,7 +1162,10 @@ pub async fn poll(state: AppState) {
         if !config::get_bool(&state.db, "github.poll", config::DEFAULT_GITHUB_POLL).await {
             continue;
         }
-        if !gh_available().await {
+        let Some(app) = state.trigger.app() else {
+            continue;
+        };
+        if !app.is_configured().await {
             continue;
         }
         if let Err(e) = poll_once(&state, &mut last_polled).await {
@@ -1490,7 +1296,10 @@ async fn poll_once(
             }
             continue;
         };
-        let (token, host) = gh_environment_for_slug(state, &slug).await;
+        let Some(app) = state.trigger.app() else {
+            tracing::debug!(repo = %repo_root, "github batch skipped: GitHub App unavailable");
+            continue;
+        };
         let heads: Vec<String> = candidates
             .iter()
             .map(|candidate| candidate.head.clone())
@@ -1511,15 +1320,7 @@ async fn poll_once(
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();
-        let fetched = fetch_pr_batch(
-            &path,
-            &slug,
-            &heads,
-            &known_numbers,
-            token.as_deref(),
-            host.as_deref(),
-        )
-        .await;
+        let fetched = fetch_pr_batch(app, &slug, &heads, &known_numbers).await;
         for candidate in &candidates {
             last_polled.insert(candidate.branch.id.clone(), now);
         }

--- a/crates/loom-forge/src/github.rs
+++ b/crates/loom-forge/src/github.rs
@@ -1,12 +1,10 @@
 //! GitHub integration through Loom's configured GitHub App.
 //!
-//! Two responsibilities live here:
-//!
-//! * **PR status polling** ([`poll`], [`refresh`]) — the
-//!   background loop that snapshots each live session's pull request (link,
-//!   review decision, check rollup) into the `branch_github` table, and
-//!   archives a session — closing the weaver issues it was working — once its PR
-//!   merges. The snapshot rides along on `BranchView`; the dashboard renders it.
+//! It owns PR status polling ([`poll`], [`refresh`]): the background loop
+//! snapshots each live session's pull request (link, review decision, check
+//! rollup) into the `branch_github` table, and archives a session — closing the
+//! weaver issues it was working — once its PR merges. The snapshot rides along
+//! on `BranchView`; the dashboard renders it.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -40,8 +38,8 @@ pub struct Issue {
 // The latest pull-request snapshot loom found for a branch, persisted in the
 // `branch_github` table (one row per branch) and served inside `BranchView`.
 // The background `poll` loop keeps it fresh; `refresh` does one branch on
-// demand. Everything degrades to "no snapshot" when `gh` is missing or the repo
-// has no GitHub remote.
+// demand. Everything degrades to "no snapshot" when the App is unavailable or
+// the repo has no GitHub remote.
 // ---------------------------------------------------------------------------
 
 const POLL_TICK: Duration = Duration::from_secs(60);
@@ -368,10 +366,7 @@ pub async fn record_status_comment(
     .ok();
 }
 
-/// The fields requested from `gh pr view --json`. Kept in one place so the parse
-/// struct and the query can't drift.
-/// The shape of one `gh pr view --json` record. Internal — callers see
-/// [`GithubStatus`].
+/// The GraphQL pull-request shape. Internal — callers see [`GithubStatus`].
 #[derive(Debug, Deserialize)]
 struct PrJson {
     number: i64,

--- a/crates/loom-forge/src/github_app.rs
+++ b/crates/loom-forge/src/github_app.rs
@@ -1,6 +1,5 @@
-//! The GitHub **App** identity (shared-loom design §6.3): the hardening that
-//! replaces the v1 webhook's reliance on a long-lived, over-scoped ambient
-//! `GH_TOKEN` with **short-lived, least-privilege, per-installation** tokens.
+//! Loom's GitHub **App** identity (shared-loom design §6.3), which provides
+//! short-lived, least-privilege, per-installation tokens.
 //!
 //! An App is configured with an `app_id` and an RSA **private key** (a PEM,
 //! held outside the settings registry like the OAuth client secret — never
@@ -20,8 +19,8 @@
 //!
 //! [`GithubApp`] implements the [`GithubApi`] gateway the trigger calls for the
 //! commenter permission check and the issue reply, performing both over the
-//! **REST API with the installation token** instead of the `gh` CLI. Missing App
-//! configuration is an error; Loom has no PAT or ambient-token fallback.
+//! **REST API with the installation token**. App-backed operations require the
+//! App id and private key to be configured.
 
 use std::collections::HashMap;
 use std::sync::Mutex;

--- a/crates/loom-forge/src/github_app.rs
+++ b/crates/loom-forge/src/github_app.rs
@@ -20,19 +20,18 @@
 //!
 //! [`GithubApp`] implements the [`GithubApi`] gateway the trigger calls for the
 //! commenter permission check and the issue reply, performing both over the
-//! **REST API with the installation token** instead of the `gh` CLI. When the
-//! App is **not configured** it transparently **falls back** to the ambient
-//! `GH_TOKEN` path ([`GhCli`]), so the v1 flow keeps working unchanged.
+//! **REST API with the installation token** instead of the `gh` CLI. Missing App
+//! configuration is an error; Loom has no PAT or ambient-token fallback.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
 
-use crate::github_trigger::{GhCli, GithubApi, PrHead};
+use crate::github_trigger::{GithubApi, PrHead};
 use crate::repo::RepoSlug;
 use weaver_core::db::Db;
 
@@ -152,8 +151,7 @@ pub async fn app_slug(db: &Db) -> Option<String> {
     config_value(db, "LOOM_GITHUB_APP_SLUG", APP_SLUG_KEY).await
 }
 
-/// Whether the App is fully configured (both id and private key present) — the
-/// switch between the App path and the `gh`-fallback path.
+/// Whether the App is fully configured (both id and private key present).
 pub async fn is_configured(db: &Db) -> bool {
     app_id(db).await.is_some() && private_key(db).await.is_some()
 }
@@ -164,8 +162,7 @@ pub async fn is_configured(db: &Db) -> bool {
 
 /// loom's GitHub App client: mints App JWTs, exchanges them for per-installation
 /// access tokens (cached until expiry), and performs the trigger's GitHub calls
-/// over REST with those tokens — falling back to `gh` when the App is
-/// unconfigured. One instance per server, shared behind an `Arc`.
+/// over REST with those tokens. One instance per server, shared behind an `Arc`.
 pub struct GithubApp {
     db: Db,
     http: reqwest::Client,
@@ -173,19 +170,32 @@ pub struct GithubApp {
     api_base: String,
     /// Installation tokens cached by their exact repository scope.
     tokens: Mutex<HashMap<TokenScope, CachedToken>>,
-    /// The ambient-`GH_TOKEN` gateway used when the App is not configured.
-    fallback: Arc<dyn GithubApi>,
+}
+
+/// The two GitHub thread resources exposed by restricted-session tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GithubThreadKind {
+    Issue,
+    PullRequest,
+}
+
+impl GithubThreadKind {
+    fn resource(self) -> &'static str {
+        match self {
+            Self::Issue => "issues",
+            Self::PullRequest => "pulls",
+        }
+    }
 }
 
 impl GithubApp {
-    /// The production client: the real GitHub API, falling back to the `gh` CLI.
+    /// The production client for the real GitHub API.
     pub fn new(db: Db) -> Self {
-        Self::with_parts(db, DEFAULT_API_BASE.to_string(), Arc::new(GhCli))
+        Self::with_parts(db, DEFAULT_API_BASE.to_string())
     }
 
-    /// Construct with an explicit API base and fallback gateway — the seam tests
-    /// use to point at a mock GitHub and observe the fallback.
-    pub fn with_parts(db: Db, api_base: String, fallback: Arc<dyn GithubApi>) -> Self {
+    /// Construct with an explicit API base; tests point this at a mock GitHub.
+    pub fn with_parts(db: Db, api_base: String) -> Self {
         let http = reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .build()
@@ -195,7 +205,6 @@ impl GithubApp {
             http,
             api_base: api_base.trim_end_matches('/').to_string(),
             tokens: Mutex::new(HashMap::new()),
-            fallback,
         }
     }
 
@@ -213,10 +222,149 @@ impl GithubApp {
         private_key(&self.db).await
     }
 
-    /// Whether the App is fully configured (both id and private key present). The
-    /// switch between the App path and the `gh`-fallback path.
+    /// Whether the App is fully configured (both id and private key present).
     pub async fn is_configured(&self) -> bool {
         is_configured(&self.db).await
+    }
+
+    /// Execute a GraphQL query as the App installation for `repo`.
+    pub async fn graphql(&self, repo: &RepoSlug, query: &str) -> Result<Vec<u8>> {
+        let token = self.token_for_repo(&repo.owner, &repo.name).await?;
+        let response = self
+            .http
+            .post(format!("{}/graphql", self.api_base))
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(token)
+            .json(&serde_json::json!({ "query": query }))
+            .send()
+            .await
+            .context("executing GitHub GraphQL query")?;
+        let response = check_status(response, "executing GitHub GraphQL query").await?;
+        Ok(response
+            .bytes()
+            .await
+            .context("reading GitHub GraphQL response")?
+            .to_vec())
+    }
+
+    async fn repo_request(
+        &self,
+        repo: &RepoSlug,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<&serde_json::Value>,
+        action: &str,
+    ) -> Result<reqwest::Response> {
+        let token = self.token_for_repo(&repo.owner, &repo.name).await?;
+        let url = format!(
+            "{}/repos/{}/{}/{}",
+            self.api_base,
+            repo.owner,
+            repo.name,
+            path.trim_start_matches('/')
+        );
+        let mut request = self
+            .http
+            .request(method, url)
+            .header(reqwest::header::ACCEPT, GH_ACCEPT)
+            .header("X-GitHub-Api-Version", GH_API_VERSION)
+            .bearer_auth(token);
+        if let Some(body) = body {
+            request = request.json(body);
+        }
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("{action} on GitHub"))?;
+        check_status(response, action).await
+    }
+
+    /// Fetch one issue or pull request for a restricted session and return the
+    /// stable, bounded field set exposed by the MCP tool.
+    pub async fn thread_view(
+        &self,
+        repo: &RepoSlug,
+        kind: GithubThreadKind,
+        number: i64,
+    ) -> Result<serde_json::Value> {
+        let response = self
+            .repo_request(
+                repo,
+                reqwest::Method::GET,
+                &format!("{}/{number}", kind.resource()),
+                None,
+                "fetching the GitHub thread",
+            )
+            .await?;
+        let value: serde_json::Value = response
+            .json()
+            .await
+            .context("parsing the GitHub thread response")?;
+        Ok(serde_json::json!({
+            "number": value["number"],
+            "title": value["title"],
+            "body": value["body"],
+            "url": value["html_url"],
+            "state": value["state"],
+        }))
+    }
+
+    /// Add a comment to an issue or pull request. GitHub exposes comments for
+    /// both through the issue-comment endpoint.
+    pub async fn thread_comment(&self, repo: &RepoSlug, number: i64, body: &str) -> Result<()> {
+        self.repo_request(
+            repo,
+            reqwest::Method::POST,
+            &format!("issues/{number}/comments"),
+            Some(&serde_json::json!({ "body": body })),
+            "commenting on the GitHub thread",
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Edit the body and optional title of an issue or pull request.
+    pub async fn thread_edit(
+        &self,
+        repo: &RepoSlug,
+        kind: GithubThreadKind,
+        number: i64,
+        title: Option<&str>,
+        body: &str,
+    ) -> Result<()> {
+        let mut payload = serde_json::json!({ "body": body });
+        if let Some(title) = title {
+            payload["title"] = serde_json::Value::String(title.to_string());
+        }
+        self.repo_request(
+            repo,
+            reqwest::Method::PATCH,
+            &format!("{}/{number}", kind.resource()),
+            Some(&payload),
+            "editing the GitHub thread",
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Add labels to an issue or pull request. GitHub exposes PR labels through
+    /// the issue endpoint, so the caller only needs the thread number.
+    pub async fn add_thread_labels(
+        &self,
+        repo: &RepoSlug,
+        number: i64,
+        labels: &[String],
+    ) -> Result<()> {
+        self.repo_request(
+            repo,
+            reqwest::Method::POST,
+            &format!("issues/{number}/labels"),
+            Some(&serde_json::json!({ "labels": labels })),
+            "labelling the GitHub thread",
+        )
+        .await?;
+        Ok(())
     }
 
     /// A freshly-signed App JWT for the configured App.
@@ -489,14 +637,6 @@ impl GithubApp {
 #[async_trait::async_trait]
 impl GithubApi for GithubApp {
     async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64> {
-        if !self.is_configured().await {
-            tracing::debug!(
-                repo,
-                issue,
-                "app not configured; posting comment via gh fallback"
-            );
-            return self.fallback.post_issue_comment(repo, issue, body).await;
-        }
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
         let token = self.token_for_repo(&slug.owner, &slug.name).await?;
         let url = format!(
@@ -524,17 +664,6 @@ impl GithubApi for GithubApp {
     }
 
     async fn update_issue_comment(&self, repo: &str, comment_id: i64, body: &str) -> Result<bool> {
-        if !self.is_configured().await {
-            tracing::debug!(
-                repo,
-                comment_id,
-                "app not configured; updating comment via gh fallback"
-            );
-            return self
-                .fallback
-                .update_issue_comment(repo, comment_id, body)
-                .await;
-        }
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
         let token = self.token_for_repo(&slug.owner, &slug.name).await?;
         let url = format!(
@@ -560,17 +689,6 @@ impl GithubApi for GithubApp {
     }
 
     async fn react_to_comment(&self, repo: &str, comment_id: i64, content: &str) -> Result<()> {
-        if !self.is_configured().await {
-            tracing::debug!(
-                repo,
-                comment_id,
-                "app not configured; reacting via gh fallback"
-            );
-            return self
-                .fallback
-                .react_to_comment(repo, comment_id, content)
-                .await;
-        }
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
         let token = self.token_for_repo(&slug.owner, &slug.name).await?;
         let url = format!(
@@ -597,14 +715,6 @@ impl GithubApi for GithubApp {
         repo: &str,
         number: i64,
     ) -> Result<crate::github_trigger::IssueState> {
-        if !self.is_configured().await {
-            tracing::debug!(
-                repo,
-                number,
-                "app not configured; fetching issue state via gh fallback"
-            );
-            return self.fallback.issue_state(repo, number).await;
-        }
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
         let v = self.issue_json(&slug.owner, &slug.name, number).await?;
         Ok(crate::github_trigger::IssueState {
@@ -615,14 +725,6 @@ impl GithubApi for GithubApp {
     }
 
     async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
-        if !self.is_configured().await {
-            tracing::debug!(
-                repo,
-                number,
-                "app not configured; fetching pr head via gh fallback"
-            );
-            return self.fallback.pr_head(repo, number).await;
-        }
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
         let token = self.token_for_repo(&slug.owner, &slug.name).await?;
         let url = format!(
@@ -715,6 +817,7 @@ pub mod tests {
 
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     use axum::body::Bytes;
     use axum::extract::{Json, Path, State};
@@ -930,12 +1033,30 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
 
     async fn mock_issue(Path((owner, name, number)): Path<(String, String, i64)>) -> Json<Value> {
         Json(json!({
+            "number": number,
             "state": "closed",
             "title": format!("issue {number} of {owner}/{name}"),
             "body": "issue body",
             "html_url": format!("https://github.com/{owner}/{name}/issues/{number}"),
             "updated_at": "2026-07-18T12:00:00Z",
         }))
+    }
+
+    async fn mock_edit_thread(
+        Path((owner, name, number)): Path<(String, String, i64)>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        Json(json!({
+            "number": number,
+            "title": body["title"],
+            "body": body["body"],
+            "html_url": format!("https://github.com/{owner}/{name}/issues/{number}"),
+            "state": "open",
+        }))
+    }
+
+    async fn mock_labels() -> Json<Value> {
+        Json(json!([]))
     }
 
     /// Spawn the mock GitHub REST server on a random port; returns its base URL.
@@ -950,7 +1071,18 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
                 "/repos/{owner}/{name}/issues/{issue}/comments",
                 post(mock_comments),
             )
-            .route("/repos/{owner}/{name}/issues/{number}", get(mock_issue))
+            .route(
+                "/repos/{owner}/{name}/issues/{number}",
+                get(mock_issue).patch(mock_edit_thread),
+            )
+            .route(
+                "/repos/{owner}/{name}/pulls/{number}",
+                get(mock_issue).patch(mock_edit_thread),
+            )
+            .route(
+                "/repos/{owner}/{name}/issues/{number}/labels",
+                post(mock_labels),
+            )
             .route(
                 "/repos/{owner}/{name}/issues/comments/{comment_id}",
                 patch(mock_update_comment),
@@ -968,74 +1100,15 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         format!("http://{addr}")
     }
 
-    /// A recording fallback gateway, standing in for the `gh`/`GH_TOKEN` path, to
-    /// prove the App delegates to it when unconfigured.
-    #[derive(Default)]
-    struct RecordingFallback {
-        comment_calls: Mutex<Vec<(String, i64, String)>>,
-    }
-
-    #[async_trait::async_trait]
-    impl GithubApi for RecordingFallback {
-        async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64> {
-            self.comment_calls
-                .lock()
-                .unwrap()
-                .push((repo.to_string(), issue, body.to_string()));
-            Ok(7)
-        }
-
-        async fn update_issue_comment(
-            &self,
-            _repo: &str,
-            _comment_id: i64,
-            _body: &str,
-        ) -> Result<bool> {
-            Ok(true)
-        }
-
-        async fn pr_head(&self, _repo: &str, _number: i64) -> Result<PrHead> {
-            Ok(PrHead {
-                head_ref: "fallback-head".to_string(),
-                cross_repo: false,
-            })
-        }
-
-        async fn react_to_comment(
-            &self,
-            _repo: &str,
-            _comment_id: i64,
-            _content: &str,
-        ) -> Result<()> {
-            Ok(())
-        }
-
-        async fn issue_state(
-            &self,
-            _repo: &str,
-            _number: i64,
-        ) -> Result<crate::github_trigger::IssueState> {
-            Ok(crate::github_trigger::IssueState {
-                state: "open".to_string(),
-                title: "fallback".to_string(),
-                updated_at: "2026-07-18T00:00:00Z".to_string(),
-            })
-        }
-    }
-
     /// A configured `GithubApp` pointed at `api_base`, with the App id + test
     /// private key written to its (in-memory) settings — never via env, so unit
     /// tests stay parallel-safe.
-    async fn configured_app(api_base: String, fallback: Arc<dyn GithubApi>) -> GithubApp {
+    async fn configured_app(api_base: String) -> GithubApp {
         let db = crate::db::connect_in_memory().await.unwrap();
-        configured_app_for_db(db, api_base, fallback).await
+        configured_app_for_db(db, api_base).await
     }
 
-    async fn configured_app_for_db(
-        db: Db,
-        api_base: String,
-        fallback: Arc<dyn GithubApi>,
-    ) -> GithubApp {
+    async fn configured_app_for_db(db: Db, api_base: String) -> GithubApp {
         weaver_core::config::apply(
             &db,
             &[
@@ -1048,12 +1121,12 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         )
         .await
         .unwrap();
-        GithubApp::with_parts(db, api_base, fallback)
+        GithubApp::with_parts(db, api_base)
     }
 
     pub async fn configured_test_app(db: Db) -> GithubApp {
         let base = spawn_mock(MockState::new(3600)).await;
-        configured_app_for_db(db, base, Arc::new(crate::github_trigger::GhCli)).await
+        configured_app_for_db(db, base).await
     }
 
     // -- installation token exchange + caching ------------------------------
@@ -1064,7 +1137,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn installation_token_is_cached_while_fresh() {
         let mock = MockState::new(3600); // expires an hour out
         let base = spawn_mock(mock.clone()).await;
-        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let app = configured_app(base).await;
 
         let t1 = app.installation_token(42).await.unwrap();
         let t2 = app.installation_token(42).await.unwrap();
@@ -1081,7 +1154,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn repository_token_is_downscoped_and_cached_by_allowlist() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock.clone()).await;
-        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let app = configured_app(base).await;
         let repositories = vec![
             "marin-community/marin".to_string(),
             "marin-community/vllm".to_string(),
@@ -1113,7 +1186,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn installation_token_refreshes_once_expired() {
         let mock = MockState::new(-10); // already expired (inside the skew window)
         let base = spawn_mock(mock.clone()).await;
-        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let app = configured_app(base).await;
 
         app.installation_token(42).await.unwrap();
         app.installation_token(42).await.unwrap();
@@ -1131,7 +1204,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn post_issue_comment_uses_installation_token() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock.clone()).await;
-        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let app = configured_app(base).await;
 
         let id = app
             .post_issue_comment("acme/widgets", 7, "On it — http://loom/s/abc")
@@ -1155,7 +1228,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn issue_fetch_maps_github_response() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock).await;
-        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let app = configured_app(base).await;
 
         let issue = app.issue("acme", "widgets", 7).await.unwrap();
 
@@ -1168,7 +1241,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn update_issue_comment_edits_in_place_and_flags_a_deleted_comment() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock.clone()).await;
-        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let app = configured_app(base).await;
 
         let updated = app
             .update_issue_comment("acme/widgets", MOCK_COMMENT_ID, "On it — now with a trail")
@@ -1204,7 +1277,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn installed_repo_is_auto_registered() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock.clone()).await;
-        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let app = configured_app(base).await;
 
         let slug = crate::repo::parse_slug("acme/widgets").unwrap();
         assert!(
@@ -1233,7 +1306,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
     async fn uninstalled_repo_is_not_auto_registered() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock.clone()).await;
-        let app = configured_app(base, Arc::new(RecordingFallback::default())).await;
+        let app = configured_app(base).await;
 
         // The mock 404s the installation lookup for the "uninstalled" owner.
         let slug = crate::repo::parse_slug("uninstalled/evil").unwrap();
@@ -1255,7 +1328,7 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         let mock = MockState::new(3600);
         let base = spawn_mock(mock.clone()).await;
         let db = crate::db::connect_in_memory().await.unwrap();
-        let app = GithubApp::with_parts(db, base, Arc::new(RecordingFallback::default()));
+        let app = GithubApp::with_parts(db, base);
 
         let slug = crate::repo::parse_slug("acme/widgets").unwrap();
         app.ensure_installed_repo_registered(&slug).await;
@@ -1270,29 +1343,22 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALB1n9OQb2v0gQ0F0G0t0Q0G0t0Q0G0t
         assert_eq!(mock.token_mints.load(Ordering::SeqCst), 0);
     }
 
-    // -- fallback when unconfigured -----------------------------------------
+    // -- missing configuration ----------------------------------------------
 
-    /// With no App configured, the gateway falls back to the ambient-`GH_TOKEN`
-    /// path (`gh`) and never touches the REST API.
     #[tokio::test]
-    async fn falls_back_to_gh_when_unconfigured() {
-        // A mock that would record a mint if (wrongly) reached.
+    async fn unconfigured_app_fails_instead_of_using_an_ambient_credential() {
         let mock = MockState::new(3600);
         let base = spawn_mock(mock.clone()).await;
-        let fallback = Arc::new(RecordingFallback::default());
-        // An empty db and no env → not configured.
         let db = crate::db::connect_in_memory().await.unwrap();
-        let app = GithubApp::with_parts(db, base, fallback.clone());
+        let app = GithubApp::with_parts(db, base);
 
         assert!(!app.is_configured().await);
-
-        app.post_issue_comment("acme/widgets", 7, "hi")
+        let error = app
+            .post_issue_comment("acme/widgets", 7, "hi")
             .await
-            .unwrap();
-
-        // The fallback handled the reply…
-        assert_eq!(fallback.comment_calls.lock().unwrap().len(), 1);
-        // …and the REST API was never reached.
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("GitHub App id is not configured"));
         assert_eq!(mock.token_mints.load(Ordering::SeqCst), 0);
         assert!(mock.comments.lock().unwrap().is_empty());
     }

--- a/crates/loom-forge/src/github_app.rs
+++ b/crates/loom-forge/src/github_app.rs
@@ -310,18 +310,25 @@ impl GithubApp {
         }))
     }
 
-    /// Add a comment to an issue or pull request. GitHub exposes comments for
-    /// both through the issue-comment endpoint.
-    pub async fn thread_comment(&self, repo: &RepoSlug, number: i64, body: &str) -> Result<()> {
-        self.repo_request(
-            repo,
-            reqwest::Method::POST,
-            &format!("issues/{number}/comments"),
-            Some(&serde_json::json!({ "body": body })),
-            "commenting on the GitHub thread",
-        )
-        .await?;
-        Ok(())
+    /// Add a comment to an issue or pull request and return its id. GitHub
+    /// exposes comments for both through the issue-comment endpoint.
+    pub async fn thread_comment(&self, repo: &RepoSlug, number: i64, body: &str) -> Result<i64> {
+        let response = self
+            .repo_request(
+                repo,
+                reqwest::Method::POST,
+                &format!("issues/{number}/comments"),
+                Some(&serde_json::json!({ "body": body })),
+                "commenting on the GitHub thread",
+            )
+            .await?;
+        let created: serde_json::Value = response
+            .json()
+            .await
+            .context("parsing created-comment json")?;
+        created["id"]
+            .as_i64()
+            .ok_or_else(|| anyhow!("created-comment json carries no id"))
     }
 
     /// Edit the body and optional title of an issue or pull request.
@@ -638,27 +645,7 @@ impl GithubApp {
 impl GithubApi for GithubApp {
     async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64> {
         let slug = crate::repo::parse_slug(repo).map_err(|e| anyhow!(e))?;
-        let token = self.token_for_repo(&slug.owner, &slug.name).await?;
-        let url = format!(
-            "{}/repos/{}/{}/issues/{issue}/comments",
-            self.api_base, slug.owner, slug.name
-        );
-        let resp = self
-            .http
-            .post(&url)
-            .header(reqwest::header::ACCEPT, GH_ACCEPT)
-            .header("X-GitHub-Api-Version", GH_API_VERSION)
-            .bearer_auth(&token)
-            .json(&serde_json::json!({ "body": body }))
-            .send()
-            .await
-            .context("posting the issue comment")?;
-        let resp = check_status(resp, "posting the issue comment").await?;
-        let created: serde_json::Value =
-            resp.json().await.context("parsing created-comment json")?;
-        let id = created["id"]
-            .as_i64()
-            .ok_or_else(|| anyhow!("created-comment json carries no id"))?;
+        let id = self.thread_comment(&slug, issue, body).await?;
         tracing::info!(repo, issue, comment = id, "posted issue comment");
         Ok(id)
     }

--- a/crates/loom-forge/src/github_trigger.rs
+++ b/crates/loom-forge/src/github_trigger.rs
@@ -653,10 +653,10 @@ pub struct IssueState {
 /// so a test can install a fake.
 pub struct GithubTrigger {
     gh: Arc<dyn GithubApi>,
-    /// The GitHub **App** client, when production-built: the same object the
-    /// `gh` gateway points at, kept concretely so the webhook can query
-    /// installations (the implicit allowlist, §6.3). `None` when a test installs
-    /// a bare [`GithubApi`] fake via [`with_gateway`](Self::with_gateway).
+    /// The GitHub **App** client, when available: normally the same object the
+    /// gateway points at, kept concretely so the webhook can query installations
+    /// and server operations can mint credentials. Tests may pair a recording
+    /// [`GithubApi`] fake with a configured App client.
     app: Option<Arc<crate::github_app::GithubApp>>,
     /// Per-repo trigger timestamps, pruned to [`RATE_WINDOW`] on each check.
     limiter: Mutex<HashMap<String, Vec<Instant>>>,
@@ -694,14 +694,26 @@ impl GithubTrigger {
         })
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn with_gateway_and_app(
+        gh: Arc<dyn GithubApi>,
+        app: Arc<crate::github_app::GithubApp>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            gh,
+            app: Some(app),
+            limiter: Mutex::new(HashMap::new()),
+        })
+    }
+
     /// The GitHub gateway, for the permission check and the reply.
     pub fn gh(&self) -> &dyn GithubApi {
         self.gh.as_ref()
     }
 
-    /// The concrete GitHub App client when this trigger was production-built.
-    /// Callers that require credentials also check `is_configured`; tests may
-    /// install only a fake gateway and expose no App client.
+    /// The concrete GitHub App client available to server operations. Callers
+    /// that require credentials also check `is_configured`; focused trigger
+    /// unit tests may install only a fake gateway and expose no App client.
     pub fn app(&self) -> Option<&crate::github_app::GithubApp> {
         self.app.as_deref()
     }

--- a/crates/loom-forge/src/github_trigger.rs
+++ b/crates/loom-forge/src/github_trigger.rs
@@ -21,18 +21,17 @@
 //! lives in [`crate::web::github_webhook`], which has access to the session
 //! create path; the security primitives live here so they can be unit-tested in
 //! isolation. External GitHub calls (the permission check and the reply) go
-//! through the [`GithubApi`] gateway so a test can substitute a fake for `gh`.
+//! through the [`GithubApi`] gateway so tests can substitute a fake for the App.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use hmac::{Hmac, Mac};
 use serde::Deserialize;
 use sha2::Sha256;
 use std::sync::Arc;
-use tokio::process::Command;
 
 use crate::auth;
 use crate::db::Db;
@@ -610,10 +609,8 @@ pub struct PrHead {
 }
 
 /// The GitHub operations loom performs against a thread — posting and editing
-/// comments, resolving a PR's head branch — behind a trait so the `gh`-backed
-/// implementation ([`GhCli`]) and a test fake are interchangeable. The
-/// production impl is the GitHub **App** (short-lived installation tokens); the
-/// [`GhCli`] fallback uses the ambient `GH_TOKEN`.
+/// comments, resolving a PR's head branch — behind a trait so the production
+/// GitHub App implementation and test fakes are interchangeable.
 #[async_trait::async_trait]
 pub trait GithubApi: Send + Sync {
     /// Post a comment on `issue` of `repo` (`owner/name`), returning the new
@@ -651,110 +648,6 @@ pub struct IssueState {
     pub updated_at: String,
 }
 
-/// The production [`GithubApi`]: shells out to the `gh` CLI with the ambient
-/// `GH_TOKEN`.
-pub struct GhCli;
-
-#[async_trait::async_trait]
-impl GithubApi for GhCli {
-    async fn post_issue_comment(&self, repo: &str, issue: i64, body: &str) -> Result<i64> {
-        // `gh api` rather than the `gh issue comment` porcelain: the raw REST
-        // response carries the comment id (porcelain prints only an HTML URL),
-        // and the same route serves issues and pull requests alike.
-        let path = format!("repos/{repo}/issues/{issue}/comments");
-        let field = format!("body={body}");
-        let out = gh_capture(&["api", &path, "-f", &field]).await?;
-        let v: serde_json::Value =
-            serde_json::from_str(&out).context("parsing created-comment json")?;
-        let id = v["id"]
-            .as_i64()
-            .context("created-comment json carries no id")?;
-        tracing::info!(repo, issue, comment = id, "posted issue comment");
-        Ok(id)
-    }
-
-    async fn update_issue_comment(&self, repo: &str, comment_id: i64, body: &str) -> Result<bool> {
-        let path = format!("repos/{repo}/issues/comments/{comment_id}");
-        let field = format!("body={body}");
-        match gh_capture(&["api", "-X", "PATCH", &path, "-f", &field]).await {
-            Ok(_) => {
-                tracing::info!(repo, comment = comment_id, "updated issue comment");
-                Ok(true)
-            }
-            // `gh api` reports "gh: Not Found (HTTP 404)" on stderr.
-            Err(e) if e.to_string().contains("HTTP 404") => Ok(false),
-            Err(e) => Err(e),
-        }
-    }
-
-    async fn react_to_comment(&self, repo: &str, comment_id: i64, content: &str) -> Result<()> {
-        let path = format!("repos/{repo}/issues/comments/{comment_id}/reactions");
-        let field = format!("content={content}");
-        gh_capture(&["api", "-X", "POST", &path, "-f", &field]).await?;
-        tracing::info!(repo, comment = comment_id, content, "reacted to comment");
-        Ok(())
-    }
-
-    async fn issue_state(&self, repo: &str, number: i64) -> Result<IssueState> {
-        // The `issues` route serves PR threads too (state/title/updated_at are
-        // thread-level), so one call covers both kinds of tracking link.
-        let path = format!("repos/{repo}/issues/{number}");
-        let out = gh_capture(&["api", &path]).await?;
-        let v: serde_json::Value = serde_json::from_str(&out).context("parsing issue json")?;
-        Ok(IssueState {
-            state: v["state"].as_str().unwrap_or_default().to_string(),
-            title: v["title"].as_str().unwrap_or_default().to_string(),
-            updated_at: v["updated_at"].as_str().unwrap_or_default().to_string(),
-        })
-    }
-
-    async fn pr_head(&self, repo: &str, number: i64) -> Result<PrHead> {
-        let n = number.to_string();
-        let out = gh_capture(&[
-            "pr",
-            "view",
-            &n,
-            "--repo",
-            repo,
-            "--json",
-            "headRefName,isCrossRepository",
-        ])
-        .await?;
-        #[derive(Deserialize)]
-        struct View {
-            #[serde(rename = "headRefName")]
-            head_ref: String,
-            #[serde(rename = "isCrossRepository")]
-            cross_repo: bool,
-        }
-        let view: View = serde_json::from_str(&out).context("parsing `gh pr view` json")?;
-        Ok(PrHead {
-            head_ref: view.head_ref,
-            cross_repo: view.cross_repo,
-        })
-    }
-}
-
-/// Run `gh args…` (no repo working dir — every call passes `--repo` or a full
-/// API path), returning trimmed stdout. A non-zero exit is an error carrying the
-/// trimmed stderr.
-async fn gh_capture(args: &[&str]) -> Result<String> {
-    tracing::debug!(args = %args.join(" "), "running gh (trigger)");
-    let out = Command::new("gh")
-        .args(args)
-        .output()
-        .await
-        .context("failed to spawn gh (is the GitHub CLI installed?)")?;
-    if !out.status.success() {
-        bail!(
-            "gh {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&out.stderr).trim()
-        );
-    }
-    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
-}
-
 /// Shared trigger state held on [`crate::AppState`]: the GitHub gateway and
 /// the per-repo rate limiter. One instance per server; the gateway is an `Arc`
 /// so a test can install a fake.
@@ -771,8 +664,7 @@ pub struct GithubTrigger {
 
 impl GithubTrigger {
     /// The production trigger: a GitHub **App** gateway that mints short-lived
-    /// installation tokens for the permission check and reply, falling back to
-    /// the `gh` CLI (ambient `GH_TOKEN`) when the App is unconfigured.
+    /// installation tokens for the permission check and reply.
     pub fn production(db: crate::db::Db) -> Arc<Self> {
         let app = Arc::new(crate::github_app::GithubApp::new(db));
         Arc::new(Self {
@@ -807,9 +699,9 @@ impl GithubTrigger {
         self.gh.as_ref()
     }
 
-    /// The GitHub App client, when one is configured on this trigger. The
-    /// webhook uses it to treat an App-installed repo as implicitly allowlisted,
-    /// and restricted GitHub tools use its repo-scoped installation tokens.
+    /// The concrete GitHub App client when this trigger was production-built.
+    /// Callers that require credentials also check `is_configured`; tests may
+    /// install only a fake gateway and expose no App client.
     pub fn app(&self) -> Option<&crate::github_app::GithubApp> {
         self.app.as_deref()
     }

--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -43,7 +43,10 @@ impl std::error::Error for Refusal {}
 use serde_json::{json, Value};
 
 use crate::db::Db;
-use crate::runtime::{layer_launch_environment, repo_cfg_or_default, set_env};
+use crate::runtime::{
+    apply_user_github_token, layer_launch_environment, repo_cfg_or_default, set_env,
+    stamp_github_auth_mode,
+};
 use crate::session::{self as session_mod, NewSession, Session};
 use crate::AppState;
 use crate::{agent, backend, custom_agents, db, events, git, repo};
@@ -60,17 +63,17 @@ pub async fn delete_session_row(st: &AppState, session_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Build the explicit ambient baseline used when Tapestry clears inheritance.
-/// Profile/repo values win over baseline and allowlisted ambient values; loom's
-/// own session variables are injected later by `agent::session_env`.
+/// Rebuild a session's launch environment and restore its Loom-owned GitHub
+/// credential mode. Profile/repo values win over baseline and allowlisted
+/// ambient values; Loom's own session token is rotated later.
 pub async fn resume_environment(
-    db: &Db,
+    st: &AppState,
     session: &Session,
     repo_root: &std::path::Path,
     cfg: &weaver_core::repo_config::RepoConfig,
 ) -> Vec<(String, String)> {
-    let env = crate::runtime::launch_environment(
-        db,
+    let mut env = crate::runtime::launch_environment(
+        &st.db,
         repo_root,
         cfg,
         &session.profile,
@@ -78,12 +81,20 @@ pub async fn resume_environment(
         session.policy_restricted,
     )
     .await;
-    if !session.policy_env_clear {
-        return env;
+    if session.policy_env_clear {
+        let allowlist = serde_json::from_str::<Vec<String>>(&session.policy_ambient_allowlist)
+            .unwrap_or_default();
+        env = crate::profile::cleared_environment(env, &allowlist);
     }
-    let allowlist =
-        serde_json::from_str::<Vec<String>>(&session.policy_ambient_allowlist).unwrap_or_default();
-    crate::profile::cleared_environment(env, &allowlist)
+    apply_user_github_token(&st.db, &mut env, session.created_by.as_deref()).await;
+    let github_repositories =
+        serde_json::from_str::<Vec<String>>(&session.policy_github_repositories)
+            .unwrap_or_default();
+    let github_app = (!github_repositories.is_empty())
+        .then(|| st.trigger.app())
+        .flatten();
+    stamp_github_auth_mode(&mut env, github_app, session.policy_restricted).await;
+    env
 }
 
 pub async fn rotate_session_token(
@@ -391,6 +402,9 @@ pub async fn create_warm_session(
         .map_err(|error| anyhow!(Refusal::Invalid(error.to_string())))?;
     let stamped_mcp_access = serde_json::to_string(&resolved.mcp_policy)
         .map_err(|error| anyhow!(Refusal::Invalid(error.to_string())))?;
+    let github_repositories = launch_profile
+        .github_repositories()
+        .map_err(|error| anyhow!(Refusal::Invalid(error.to_string())))?;
 
     let launch_permit = st.launch_gate.acquire(&repo_root).await;
     let repo_root_str = repo_root.display().to_string();
@@ -517,6 +531,10 @@ pub async fn create_warm_session(
     .await?;
     let session_token =
         crate::auth::create_session_token(&st.db, None, &session_id, &branch.id).await?;
+    let github_app = (!github_repositories.is_empty())
+        .then(|| st.trigger.app())
+        .flatten();
+    stamp_github_auth_mode(&mut extra_env, github_app, launch_profile.restricted).await;
     set_env(&mut extra_env, "LOOM_TOKEN", session_token);
     set_env(&mut extra_env, "LOOM_SESSION_ID", session_id.clone());
     tracing::info!(watch = %watch.id, session = %session_id, agent = %agent, protocol = %protocol, work_dir = %work_dir.display(), "launching warm session agent");
@@ -817,7 +835,7 @@ pub async fn adopt_terminal_into_acp(
     let work_dir = PathBuf::from(&session.work_dir);
     let repo_root = PathBuf::from(&branch.repo_root);
     let repo_cfg = repo_cfg_or_default(&repo_root);
-    let mut extra_env = resume_environment(&st.db, session, &repo_root, &repo_cfg).await;
+    let mut extra_env = resume_environment(st, session, &repo_root, &repo_cfg).await;
     rotate_session_token(&st.db, session, &mut extra_env).await?;
     let run_dir = db::run_dir(&session.id);
     let primer_file = stamped_primer_file(&run_dir, &session.policy_prelude);
@@ -922,7 +940,7 @@ pub async fn adopt_acp(
         // The relay is gone — respawn the adapter and reopen the conversation.
         let repo_root = PathBuf::from(&branch.repo_root);
         let repo_cfg = repo_cfg_or_default(&repo_root);
-        let mut extra_env = resume_environment(&st.db, session, &repo_root, &repo_cfg).await;
+        let mut extra_env = resume_environment(st, session, &repo_root, &repo_cfg).await;
         rotate_session_token(&st.db, session, &mut extra_env).await?;
         let runtime = session.agent_kind.clone();
         let (primer_file, goal_file) = resume_prompt_files(st, session, branch).await;
@@ -1200,7 +1218,7 @@ pub async fn resume_agent(
     // provisioned; this only resumes the agent.
     let repo_root = PathBuf::from(&branch.repo_root);
     let repo_cfg = repo_cfg_or_default(&repo_root);
-    let mut extra_env = resume_environment(&st.db, session, &repo_root, &repo_cfg).await;
+    let mut extra_env = resume_environment(st, session, &repo_root, &repo_cfg).await;
     rotate_session_token(&st.db, session, &mut extra_env).await?;
     let runtime = session.agent_kind.clone();
     tracing::info!(session = %session.id, branch = %branch.id, runtime = %runtime, work_dir = %work_dir.display(), "relaunching agent terminal for resume");

--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -64,8 +64,9 @@ pub async fn delete_session_row(st: &AppState, session_id: &str) -> Result<()> {
 }
 
 /// Rebuild a session's launch environment and restore its Loom-owned GitHub
-/// credential mode. Profile/repo values win over baseline and allowlisted
-/// ambient values; Loom's own session token is rotated later.
+/// credential mode. User-configurable layers cannot supply GitHub credentials;
+/// Loom overlays the session creator's stored PAT before selecting direct or
+/// brokered App access. Loom's session token is rotated later.
 pub async fn resume_environment(
     st: &AppState,
     session: &Session,
@@ -86,14 +87,25 @@ pub async fn resume_environment(
             .unwrap_or_default();
         env = crate::profile::cleared_environment(env, &allowlist);
     }
-    apply_user_github_token(&st.db, &mut env, session.created_by.as_deref()).await;
+    let user_token_applied =
+        if crate::runtime::user_github_token_allowed(&session.class, session.policy_restricted) {
+            apply_user_github_token(&st.db, &mut env, session.created_by.as_deref()).await
+        } else {
+            false
+        };
     let github_repositories =
         serde_json::from_str::<Vec<String>>(&session.policy_github_repositories)
             .unwrap_or_default();
     let github_app = (!github_repositories.is_empty())
         .then(|| st.trigger.app())
         .flatten();
-    stamp_github_auth_mode(&mut env, github_app, session.policy_restricted).await;
+    stamp_github_auth_mode(
+        &mut env,
+        github_app,
+        session.policy_restricted,
+        user_token_applied,
+    )
+    .await;
     env
 }
 
@@ -534,7 +546,7 @@ pub async fn create_warm_session(
     let github_app = (!github_repositories.is_empty())
         .then(|| st.trigger.app())
         .flatten();
-    stamp_github_auth_mode(&mut extra_env, github_app, launch_profile.restricted).await;
+    stamp_github_auth_mode(&mut extra_env, github_app, launch_profile.restricted, false).await;
     set_env(&mut extra_env, "LOOM_TOKEN", session_token);
     set_env(&mut extra_env, "LOOM_SESSION_ID", session_id.clone());
     tracing::info!(watch = %watch.id, session = %session_id, agent = %agent, protocol = %protocol, work_dir = %work_dir.display(), "launching warm session agent");

--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -44,7 +44,7 @@ use serde_json::{json, Value};
 
 use crate::db::Db;
 use crate::runtime::{
-    apply_user_github_token, layer_launch_environment, repo_cfg_or_default, set_env,
+    configure_session_github_auth, layer_launch_environment, repo_cfg_or_default, set_env,
     stamp_github_auth_mode,
 };
 use crate::session::{self as session_mod, NewSession, Session};
@@ -87,23 +87,19 @@ pub async fn resume_environment(
             .unwrap_or_default();
         env = crate::profile::cleared_environment(env, &allowlist);
     }
-    let user_token_applied =
-        if crate::runtime::user_github_token_allowed(&session.class, session.policy_restricted) {
-            apply_user_github_token(&st.db, &mut env, session.created_by.as_deref()).await
-        } else {
-            false
-        };
     let github_repositories =
         serde_json::from_str::<Vec<String>>(&session.policy_github_repositories)
             .unwrap_or_default();
     let github_app = (!github_repositories.is_empty())
         .then(|| st.trigger.app())
         .flatten();
-    stamp_github_auth_mode(
+    configure_session_github_auth(
+        &st.db,
         &mut env,
-        github_app,
+        session.created_by.as_deref(),
+        &session.class,
         session.policy_restricted,
-        user_token_applied,
+        github_app,
     )
     .await;
     env

--- a/crates/loom-forge/src/repo.rs
+++ b/crates/loom-forge/src/repo.rs
@@ -546,8 +546,7 @@ mod tests {
     }
 
     /// An unconfigured GitHub App (`Some(&app)`, but no App id/key stored) can't
-    /// mint an installation token and must fail closed rather than silently use
-    /// ambient Git credentials.
+    /// mint the installation token required for an authenticated clone.
     #[tokio::test]
     async fn resolve_clone_fails_when_the_app_cannot_mint_a_token() {
         let db = connect_in_memory().await.unwrap();

--- a/crates/loom-forge/src/repo.rs
+++ b/crates/loom-forge/src/repo.rs
@@ -302,9 +302,8 @@ pub async fn registered_path(db: &Db, input: &str) -> std::result::Result<PathBu
 ///
 /// `app` (when the GitHub App is configured and installed on the repo) mints a
 /// short-lived installation token for the clone/fetch — least-privilege, in
-/// place of the ambient shared `GH_TOKEN` credential helper. Any failure to
-/// mint one (unconfigured App, no installation on this repo, API error) is
-/// non-fatal: it falls back to the ambient helper, same as `app: None`.
+/// place of a persisted PAT. Any failure to mint one is fatal; `app: None` is
+/// reserved for local/public test and library callers that request no credential.
 pub async fn resolve_clone(
     db: &Db,
     input: &str,
@@ -314,24 +313,17 @@ pub async fn resolve_clone(
     let (slug, registered) = registration(db, input).await?;
     let slug_str = slug.slug();
     let dest = PathBuf::from(&registered.path);
-    let token = match app {
-        Some(app) => match app.token_for_repo(&slug.owner, &slug.name).await {
-            Ok(token) => {
-                tracing::debug!(repo = %slug_str, "minted GitHub App installation token for repo");
-                Some(token)
-            }
-            Err(e) => {
-                tracing::debug!(
-                    repo = %slug_str,
-                    error = %e,
-                    "no GitHub App installation token for repo; falling back to the ambient \
-                     credential helper"
-                );
-                None
-            }
-        },
-        None => None,
-    };
+    let token =
+        match app {
+            Some(app) => Some(app.token_for_repo(&slug.owner, &slug.name).await.map_err(
+                |error| {
+                    ResolveError::Clone(format!(
+                        "minting GitHub App credential for {slug_str}: {error}"
+                    ))
+                },
+            )?),
+            None => None,
+        };
     tracing::info!(repo = %slug_str, dest = %dest.display(), authenticated = token.is_some(), "acquiring managed repo clone");
     git::clone(&registered.remote_url, &dest, token.as_deref())
         .await
@@ -554,10 +546,10 @@ mod tests {
     }
 
     /// An unconfigured GitHub App (`Some(&app)`, but no App id/key stored) can't
-    /// mint an installation token — `resolve_clone` must fall back to the
-    /// ambient credential helper rather than fail the whole clone.
+    /// mint an installation token and must fail closed rather than silently use
+    /// ambient Git credentials.
     #[tokio::test]
-    async fn resolve_clone_falls_back_when_the_app_cannot_mint_a_token() {
+    async fn resolve_clone_fails_when_the_app_cannot_mint_a_token() {
         let db = connect_in_memory().await.unwrap();
 
         let src = tempfile::tempdir().unwrap();
@@ -594,9 +586,14 @@ mod tests {
         .unwrap();
 
         let app = crate::github_app::GithubApp::new(db.clone());
-        let path = resolve_clone(&db, "acme/gizmos", Some(&app)).await.unwrap();
-        assert_eq!(path, dest);
-        assert!(dest.join(".git").exists());
+        let error = resolve_clone(&db, "acme/gizmos", Some(&app))
+            .await
+            .unwrap_err();
+        let ResolveError::Clone(message) = error else {
+            panic!("expected clone failure")
+        };
+        assert!(message.contains("GitHub App id is not configured"));
+        assert!(!dest.exists());
     }
 
     /// Run `git` in `dir` for the resolve test (the crate has no test-only git

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -190,9 +190,8 @@ pub async fn stamp_github_auth_mode(
     mode
 }
 
-/// Apply the only permitted direct credential, then stamp the adapter mode for
-/// one session. Lifecycle paths use this single entrypoint so fresh launches,
-/// resumptions, and handoffs cannot disagree about Account-token eligibility.
+/// Apply the launching user's Account PAT when the session class permits it,
+/// then stamp the adapter mode from that result and the approved App access.
 pub async fn configure_session_github_auth(
     db: &Db,
     env: &mut Vec<(String, String)>,

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -3,6 +3,29 @@
 use crate::Db;
 
 pub const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub credential configured. Add your personal GitHub token in Settings > Access, allowlist this repository for the selected profile's GitHub App credential, or configure a write-only GH_TOKEN on the profile.";
+pub const GITHUB_AUTH_MODE_ENV: &str = "LOOM_GITHUB_AUTH_MODE";
+
+/// How the image's Git/GitHub CLI adapters obtain a credential for one session.
+///
+/// This is stamped by Loom after it resolves the session environment. The
+/// adapters must not infer policy from an inherited daemon-level `GH_TOKEN`:
+/// that token belongs to the deployment, not automatically to every session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GithubAuthMode {
+    Direct,
+    Broker,
+    Disabled,
+}
+
+impl GithubAuthMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Direct => "direct",
+            Self::Broker => "broker",
+            Self::Disabled => "disabled",
+        }
+    }
+}
 
 /// External lifecycle work (terminal supervisors + git worktrees) cannot share
 /// a SQLite transaction. Serialize those operations process-wide, then use
@@ -110,6 +133,35 @@ pub fn set_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
     } else {
         env.push((name.to_string(), value));
     }
+}
+
+/// Stamp the GitHub credential policy consumed by the Docker image's `git`
+/// credential helper and `gh` wrapper.
+///
+/// A resolved session token (personal, profile, repository, or config-file)
+/// wins. Otherwise an allowed and configured GitHub App is brokered through the
+/// session-scoped Loom API. App-less deployments retain their ambient-token
+/// compatibility path, but Loom still explicitly labels that decision.
+pub async fn stamp_github_auth_mode(
+    env: &mut Vec<(String, String)>,
+    github_app: Option<&crate::github_app::GithubApp>,
+    restricted: bool,
+) -> GithubAuthMode {
+    let mode = if restricted {
+        GithubAuthMode::Disabled
+    } else if env_has_nonempty(env, "GH_TOKEN") {
+        GithubAuthMode::Direct
+    } else if let Some(app) = github_app {
+        if app.is_configured().await {
+            GithubAuthMode::Broker
+        } else {
+            GithubAuthMode::Direct
+        }
+    } else {
+        GithubAuthMode::Direct
+    };
+    set_env(env, GITHUB_AUTH_MODE_ENV, mode.as_str().to_string());
+    mode
 }
 
 /// Resolve a profile's App-token allowlist into the repositories stamped on
@@ -298,6 +350,49 @@ mod tests {
         let mut producer = Vec::new();
         apply_user_github_token(&db, &mut producer, None).await;
         assert!(producer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn github_auth_mode_is_owned_by_the_resolved_session_policy() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let app = crate::github_app::GithubApp::new(db.clone());
+
+        let mut direct = vec![("GH_TOKEN".to_string(), "personal".to_string())];
+        assert_eq!(
+            stamp_github_auth_mode(&mut direct, Some(&app), false).await,
+            GithubAuthMode::Direct
+        );
+        assert!(direct
+            .iter()
+            .any(|(name, value)| name == GITHUB_AUTH_MODE_ENV
+                && value == GithubAuthMode::Direct.as_str()));
+
+        weaver_core::config::apply(
+            &db,
+            &[
+                (
+                    crate::github_app::APP_ID_KEY.to_string(),
+                    Some("123456".to_string()),
+                ),
+                (
+                    crate::github_app::APP_PRIVATE_KEY_KEY.to_string(),
+                    Some("configured-for-mode-selection".to_string()),
+                ),
+            ],
+        )
+        .await
+        .unwrap();
+        let mut brokered = Vec::new();
+        assert_eq!(
+            stamp_github_auth_mode(&mut brokered, Some(&app), false).await,
+            GithubAuthMode::Broker
+        );
+
+        let mut restricted = vec![("GH_TOKEN".to_string(), "must-not-win".to_string())];
+        assert_eq!(
+            stamp_github_auth_mode(&mut restricted, Some(&app), true).await,
+            GithubAuthMode::Disabled
+        );
     }
 
     #[test]

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -141,7 +141,8 @@ pub fn set_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
 /// A resolved session token (personal, profile, repository, or config-file)
 /// wins. Otherwise an allowed and configured GitHub App is brokered through the
 /// session-scoped Loom API. A session with neither is disabled; the daemon's
-/// ambient credential is never promoted into a managed session.
+/// ambient credential is never promoted into a managed session. Empty explicit
+/// values mask both GitHub token variables inherited by a non-cleared runtime.
 pub async fn stamp_github_auth_mode(
     env: &mut Vec<(String, String)>,
     github_app: Option<&crate::github_app::GithubApp>,
@@ -160,6 +161,12 @@ pub async fn stamp_github_auth_mode(
     } else {
         GithubAuthMode::Disabled
     };
+    if mode != GithubAuthMode::Direct {
+        set_env(env, "GH_TOKEN", String::new());
+    }
+    // GH_TOKEN is Loom's sole direct-token input. Always mask GitHub CLI's
+    // lower-precedence alias so a daemon credential cannot become a fallback.
+    set_env(env, "GITHUB_TOKEN", String::new());
     set_env(env, GITHUB_AUTH_MODE_ENV, mode.as_str().to_string());
     mode
 }
@@ -339,7 +346,10 @@ mod tests {
         let db = crate::db::connect_in_memory().await.unwrap();
         let app = crate::github_app::GithubApp::new(db.clone());
 
-        let mut direct = vec![("GH_TOKEN".to_string(), "personal".to_string())];
+        let mut direct = vec![
+            ("GH_TOKEN".to_string(), "personal".to_string()),
+            ("GITHUB_TOKEN".to_string(), "wrong-daemon-bot".to_string()),
+        ];
         assert_eq!(
             stamp_github_auth_mode(&mut direct, Some(&app), false).await,
             GithubAuthMode::Direct
@@ -348,12 +358,23 @@ mod tests {
             .iter()
             .any(|(name, value)| name == GITHUB_AUTH_MODE_ENV
                 && value == GithubAuthMode::Direct.as_str()));
+        assert!(direct
+            .iter()
+            .any(|(name, value)| name == "GH_TOKEN" && value == "personal"));
+        assert!(direct
+            .iter()
+            .any(|(name, value)| name == "GITHUB_TOKEN" && value.is_empty()));
 
-        let mut unmanaged = Vec::new();
+        let mut unmanaged = vec![("GITHUB_TOKEN".to_string(), "wrong-daemon-bot".to_string())];
         assert_eq!(
             stamp_github_auth_mode(&mut unmanaged, Some(&app), false).await,
             GithubAuthMode::Disabled
         );
+        for name in ["GH_TOKEN", "GITHUB_TOKEN"] {
+            assert!(unmanaged
+                .iter()
+                .any(|(candidate, value)| candidate == name && value.is_empty()));
+        }
 
         weaver_core::config::apply(
             &db,
@@ -370,17 +391,28 @@ mod tests {
         )
         .await
         .unwrap();
-        let mut brokered = Vec::new();
+        let mut brokered = vec![("GITHUB_TOKEN".to_string(), "wrong-daemon-bot".to_string())];
         assert_eq!(
             stamp_github_auth_mode(&mut brokered, Some(&app), false).await,
             GithubAuthMode::Broker
         );
+        for name in ["GH_TOKEN", "GITHUB_TOKEN"] {
+            assert!(brokered
+                .iter()
+                .any(|(candidate, value)| candidate == name && value.is_empty()));
+        }
 
-        let mut restricted = vec![("GH_TOKEN".to_string(), "must-not-win".to_string())];
+        let mut restricted = vec![
+            ("GH_TOKEN".to_string(), "must-not-win".to_string()),
+            ("GITHUB_TOKEN".to_string(), "also-must-not-win".to_string()),
+        ];
         assert_eq!(
             stamp_github_auth_mode(&mut restricted, Some(&app), true).await,
             GithubAuthMode::Disabled
         );
+        assert!(restricted.iter().all(|(name, value)| {
+            !matches!(name.as_str(), "GH_TOKEN" | "GITHUB_TOKEN") || value.is_empty()
+        }));
     }
 
     #[test]

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -73,7 +73,7 @@ pub async fn layer_launch_environment(
     // Reject legacy snapshot values as well as newly configured values. This
     // guarantees that the only non-empty GH_TOKEN reaching mode selection is
     // the per-user credential overlaid later by `apply_user_github_token`.
-    env.retain(|(name, _)| !matches!(name.as_str(), "GH_TOKEN" | "GITHUB_TOKEN"));
+    env.retain(|(name, _)| !crate::agent_env::is_github_token_name(name));
     let repo_root_str = repo_root.display().to_string();
     if restricted {
         tracing::debug!(repo = %repo_root_str, profile = profile_name, "restricted launch uses profile environment only");
@@ -83,7 +83,7 @@ pub async fn layer_launch_environment(
         .await
         .unwrap_or_default()
         .into_iter()
-        .filter(|(name, _)| !matches!(name.as_str(), "GH_TOKEN" | "GITHUB_TOKEN"));
+        .filter(|(name, _)| !crate::agent_env::is_github_token_name(name));
     let config_pairs = config_env_pairs(cfg);
     if strict {
         // A strict profile's declared names are policy, not defaults. Repo
@@ -188,6 +188,25 @@ pub async fn stamp_github_auth_mode(
     set_env(env, "GITHUB_TOKEN", String::new());
     set_env(env, GITHUB_AUTH_MODE_ENV, mode.as_str().to_string());
     mode
+}
+
+/// Apply the only permitted direct credential, then stamp the adapter mode for
+/// one session. Lifecycle paths use this single entrypoint so fresh launches,
+/// resumptions, and handoffs cannot disagree about Account-token eligibility.
+pub async fn configure_session_github_auth(
+    db: &Db,
+    env: &mut Vec<(String, String)>,
+    created_by: Option<&str>,
+    class: &str,
+    restricted: bool,
+    github_app: Option<&crate::github_app::GithubApp>,
+) -> GithubAuthMode {
+    let user_token_applied = if user_github_token_allowed(class, restricted) {
+        apply_user_github_token(db, env, created_by).await
+    } else {
+        false
+    };
+    stamp_github_auth_mode(env, github_app, restricted, user_token_applied).await
 }
 
 /// Resolve a profile's App-token allowlist into the repositories stamped on

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -140,8 +140,8 @@ pub fn set_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
 ///
 /// A resolved session token (personal, profile, repository, or config-file)
 /// wins. Otherwise an allowed and configured GitHub App is brokered through the
-/// session-scoped Loom API. App-less deployments retain their ambient-token
-/// compatibility path, but Loom still explicitly labels that decision.
+/// session-scoped Loom API. A session with neither is disabled; the daemon's
+/// ambient credential is never promoted into a managed session.
 pub async fn stamp_github_auth_mode(
     env: &mut Vec<(String, String)>,
     github_app: Option<&crate::github_app::GithubApp>,
@@ -155,10 +155,10 @@ pub async fn stamp_github_auth_mode(
         if app.is_configured().await {
             GithubAuthMode::Broker
         } else {
-            GithubAuthMode::Direct
+            GithubAuthMode::Disabled
         }
     } else {
-        GithubAuthMode::Direct
+        GithubAuthMode::Disabled
     };
     set_env(env, GITHUB_AUTH_MODE_ENV, mode.as_str().to_string());
     mode
@@ -182,19 +182,9 @@ pub fn session_github_repositories(
         .unwrap_or_default()
 }
 
-fn env_has_key(env: &[(String, String)], name: &str) -> bool {
-    env.iter().any(|(key, _)| key == name)
-}
-
 fn env_has_nonempty(env: &[(String, String)], name: &str) -> bool {
     env.iter()
         .any(|(key, value)| key == name && !value.trim().is_empty())
-}
-
-fn ambient_env_has_nonempty(name: &str) -> bool {
-    std::env::var(name)
-        .map(|value| !value.trim().is_empty())
-        .unwrap_or(false)
 }
 
 pub async fn github_token_available(
@@ -213,9 +203,7 @@ pub async fn github_token_available(
     if crate::auth::get_user(db, username).await?.is_none() {
         return Ok(true);
     }
-    if env_has_nonempty(env, "GH_TOKEN")
-        || (!env_has_key(env, "GH_TOKEN") && ambient_env_has_nonempty("GH_TOKEN"))
-    {
+    if env_has_nonempty(env, "GH_TOKEN") {
         return Ok(true);
     }
     if crate::user_token::get(db, username)
@@ -252,12 +240,6 @@ mod tests {
     }
 
     impl EnvVarGuard {
-        fn unset(name: &'static str) -> Self {
-            let value = std::env::var_os(name);
-            std::env::remove_var(name);
-            Self { name, value }
-        }
-
         fn set(name: &'static str, new_value: &str) -> Self {
             let value = std::env::var_os(name);
             std::env::set_var(name, new_value);
@@ -367,6 +349,12 @@ mod tests {
             .any(|(name, value)| name == GITHUB_AUTH_MODE_ENV
                 && value == GithubAuthMode::Direct.as_str()));
 
+        let mut unmanaged = Vec::new();
+        assert_eq!(
+            stamp_github_auth_mode(&mut unmanaged, Some(&app), false).await,
+            GithubAuthMode::Disabled
+        );
+
         weaver_core::config::apply(
             &db,
             &[
@@ -420,7 +408,7 @@ mod tests {
     #[serial_test::serial]
     #[tokio::test]
     async fn github_token_preflight_covers_builtin_custom_and_app_paths() {
-        let ambient = EnvVarGuard::unset("GH_TOKEN");
+        let _ambient = EnvVarGuard::set("GH_TOKEN", "ghp_daemon_must_not_leak");
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
 
@@ -481,16 +469,10 @@ mod tests {
                 .unwrap()
         );
 
-        drop(ambient);
-        let _ambient = EnvVarGuard::set("GH_TOKEN", "ghp_ambient");
-        assert!(!github_token_available(
-            &db,
-            &[("GH_TOKEN".to_string(), " ".to_string())],
-            Some("alice"),
-            "codex",
-            None,
-        )
-        .await
-        .unwrap());
+        assert!(
+            !github_token_available(&db, &[], Some("alice"), "codex", None,)
+                .await
+                .unwrap()
+        );
     }
 }

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -70,9 +70,8 @@ pub async fn layer_launch_environment(
     strict: bool,
     restricted: bool,
 ) -> Vec<(String, String)> {
-    // Reject legacy snapshot values as well as newly configured values. This
-    // guarantees that the only non-empty GH_TOKEN reaching mode selection is
-    // the per-user credential overlaid later by `apply_user_github_token`.
+    // Clear the stock clients' reserved credential slots before Loom selects
+    // the session's Account or App identity.
     env.retain(|(name, _)| !crate::agent_env::is_github_token_name(name));
     let repo_root_str = repo_root.display().to_string();
     if restricted {
@@ -115,9 +114,8 @@ pub async fn launch_environment(
     layer_launch_environment(db, repo_root, cfg, profile_name, env, strict, restricted).await
 }
 
-/// Overlay the launching user's Loom-stored PAT after all user-configurable
-/// environment layers have been validated. This is the only path that may put
-/// a non-empty `GH_TOKEN` into a managed session environment.
+/// Load the launching user's Loom-stored PAT into the image adapter's direct
+/// credential slot after all configurable environment layers are resolved.
 pub async fn apply_user_github_token(
     db: &Db,
     env: &mut Vec<(String, String)>,
@@ -151,8 +149,7 @@ pub fn set_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
     }
 }
 
-/// Personal Account PATs are an ordinary interactive-session convenience, not
-/// an automation or restricted-session credential source.
+/// Personal Account PATs are available to ordinary interactive sessions.
 pub fn user_github_token_allowed(class: &str, restricted: bool) -> bool {
     class == "interactive" && !restricted
 }
@@ -160,9 +157,9 @@ pub fn user_github_token_allowed(class: &str, restricted: bool) -> bool {
 /// Stamp the GitHub credential policy consumed by the Docker image's `git`
 /// credential helper and `gh` wrapper.
 ///
-/// A Loom-injected per-user token selects `direct`; otherwise an allowed and
-/// configured GitHub App selects `broker`. Restricted sessions and sessions
-/// without either are disabled. Empty values mask ambient client variables.
+/// A Loom-injected per-user token selects `direct`; an allowed and configured
+/// GitHub App selects `broker`; restricted sessions select `disabled`. Client
+/// credential slots are normalized to match the selected mode.
 pub async fn stamp_github_auth_mode(
     env: &mut Vec<(String, String)>,
     github_app: Option<&crate::github_app::GithubApp>,

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -2,14 +2,14 @@
 
 use crate::Db;
 
-pub const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub credential configured. Add your personal GitHub token in Settings > Access, allowlist this repository for the selected profile's GitHub App credential, or configure a write-only GH_TOKEN on the profile.";
+pub const MISSING_GITHUB_TOKEN_MESSAGE: &str = "No GitHub credential configured for this repository. Add your personal GitHub token in Settings > Account or allowlist this repository for the selected profile's GitHub App credential.";
 pub const GITHUB_AUTH_MODE_ENV: &str = "LOOM_GITHUB_AUTH_MODE";
 
 /// How the image's Git/GitHub CLI adapters obtain a credential for one session.
 ///
 /// This is stamped by Loom after it resolves the session environment. The
-/// adapters must not infer policy from an inherited daemon-level `GH_TOKEN`:
-/// that token belongs to the deployment, not automatically to every session.
+/// adapters must not infer policy from process or profile environment. A
+/// direct token is always the launching user's Loom-stored Account token.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GithubAuthMode {
     Direct,
@@ -70,6 +70,10 @@ pub async fn layer_launch_environment(
     strict: bool,
     restricted: bool,
 ) -> Vec<(String, String)> {
+    // Reject legacy snapshot values as well as newly configured values. This
+    // guarantees that the only non-empty GH_TOKEN reaching mode selection is
+    // the per-user credential overlaid later by `apply_user_github_token`.
+    env.retain(|(name, _)| !matches!(name.as_str(), "GH_TOKEN" | "GITHUB_TOKEN"));
     let repo_root_str = repo_root.display().to_string();
     if restricted {
         tracing::debug!(repo = %repo_root_str, profile = profile_name, "restricted launch uses profile environment only");
@@ -77,12 +81,14 @@ pub async fn layer_launch_environment(
     }
     let repo_pairs = crate::repo_env::pairs(db, &repo_root_str)
         .await
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|(name, _)| !matches!(name.as_str(), "GH_TOKEN" | "GITHUB_TOKEN"));
     let config_pairs = config_env_pairs(cfg);
     if strict {
         // A strict profile's declared names are policy, not defaults. Repo
         // layers may add variables but cannot replace a profile-owned value.
-        for (name, value) in repo_pairs.into_iter().chain(config_pairs) {
+        for (name, value) in repo_pairs.chain(config_pairs) {
             if !env.iter().any(|(existing, _)| existing == &name) {
                 env.push((name, value));
             }
@@ -109,21 +115,31 @@ pub async fn launch_environment(
     layer_launch_environment(db, repo_root, cfg, profile_name, env, strict, restricted).await
 }
 
+/// Overlay the launching user's Loom-stored PAT after all user-configurable
+/// environment layers have been validated. This is the only path that may put
+/// a non-empty `GH_TOKEN` into a managed session environment.
 pub async fn apply_user_github_token(
     db: &Db,
     env: &mut Vec<(String, String)>,
     created_by: Option<&str>,
-) {
-    let Some(username) = created_by else { return };
+) -> bool {
+    let Some(username) = created_by else {
+        return false;
+    };
     match crate::user_token::get(db, username).await {
         Ok(Some(token)) if !token.trim().is_empty() => {
             set_env(env, "GH_TOKEN", token);
-            tracing::info!(%username, "applied user github token as GH_TOKEN");
+            tracing::info!(%username, "applied Loom-stored user GitHub credential");
+            true
         }
         Ok(_) => {
-            tracing::debug!(%username, "no personal github token on file, retaining session GH_TOKEN")
+            tracing::debug!(%username, "no personal GitHub token on file");
+            false
         }
-        Err(error) => tracing::warn!(%username, "failed to load user github token: {error}"),
+        Err(error) => {
+            tracing::warn!(%username, "failed to load user GitHub token: {error}");
+            false
+        }
     }
 }
 
@@ -135,22 +151,27 @@ pub fn set_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
     }
 }
 
+/// Personal Account PATs are an ordinary interactive-session convenience, not
+/// an automation or restricted-session credential source.
+pub fn user_github_token_allowed(class: &str, restricted: bool) -> bool {
+    class == "interactive" && !restricted
+}
+
 /// Stamp the GitHub credential policy consumed by the Docker image's `git`
 /// credential helper and `gh` wrapper.
 ///
-/// A resolved session token (personal, profile, repository, or config-file)
-/// wins. Otherwise an allowed and configured GitHub App is brokered through the
-/// session-scoped Loom API. A session with neither is disabled; the daemon's
-/// ambient credential is never promoted into a managed session. Empty explicit
-/// values mask both GitHub token variables inherited by a non-cleared runtime.
+/// A Loom-injected per-user token selects `direct`; otherwise an allowed and
+/// configured GitHub App selects `broker`. Restricted sessions and sessions
+/// without either are disabled. Empty values mask ambient client variables.
 pub async fn stamp_github_auth_mode(
     env: &mut Vec<(String, String)>,
     github_app: Option<&crate::github_app::GithubApp>,
     restricted: bool,
+    user_token_applied: bool,
 ) -> GithubAuthMode {
     let mode = if restricted {
         GithubAuthMode::Disabled
-    } else if env_has_nonempty(env, "GH_TOKEN") {
+    } else if user_token_applied {
         GithubAuthMode::Direct
     } else if let Some(app) = github_app {
         if app.is_configured().await {
@@ -164,8 +185,6 @@ pub async fn stamp_github_auth_mode(
     if mode != GithubAuthMode::Direct {
         set_env(env, "GH_TOKEN", String::new());
     }
-    // GH_TOKEN is Loom's sole direct-token input. Always mask GitHub CLI's
-    // lower-precedence alias so a daemon credential cannot become a fallback.
     set_env(env, "GITHUB_TOKEN", String::new());
     set_env(env, GITHUB_AUTH_MODE_ENV, mode.as_str().to_string());
     mode
@@ -189,44 +208,30 @@ pub fn session_github_repositories(
         .unwrap_or_default()
 }
 
-fn env_has_nonempty(env: &[(String, String)], name: &str) -> bool {
-    env.iter()
-        .any(|(key, value)| key == name && !value.trim().is_empty())
-}
-
-pub async fn github_token_available(
+/// A GitHub repository may be launched only when Loom can provide either the
+/// launching user's stored PAT or the selected profile's approved App access.
+pub async fn github_credential_available(
     db: &Db,
-    env: &[(String, String)],
     created_by: Option<&str>,
-    runtime: &str,
     github_app: Option<&crate::github_app::GithubApp>,
+    allow_user_token: bool,
 ) -> anyhow::Result<bool> {
-    if crate::agent::builtin_agent_type(runtime).is_none() {
-        return Ok(true);
-    }
-    let Some(username) = created_by else {
-        return Ok(true);
-    };
-    if crate::auth::get_user(db, username).await?.is_none() {
-        return Ok(true);
-    }
-    if env_has_nonempty(env, "GH_TOKEN") {
-        return Ok(true);
-    }
-    if crate::user_token::get(db, username)
-        .await?
-        .as_deref()
-        .is_some_and(|token| !token.trim().is_empty())
-    {
-        return Ok(true);
-    }
-    if let Some(app) = github_app {
-        if app.is_configured().await {
-            return Ok(true);
+    if allow_user_token {
+        if let Some(username) = created_by {
+            if crate::user_token::get(db, username)
+                .await?
+                .as_deref()
+                .is_some_and(|token| !token.trim().is_empty())
+            {
+                return Ok(true);
+            }
         }
     }
-    tracing::warn!(created_by = ?created_by, runtime = %runtime, "launch blocked: no github token available");
-    Ok(false)
+    Ok(if let Some(app) = github_app {
+        app.is_configured().await
+    } else {
+        false
+    })
 }
 
 #[cfg(test)]
@@ -241,34 +246,12 @@ mod tests {
             .unwrap();
     }
 
-    struct EnvVarGuard {
-        name: &'static str,
-        value: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(name: &'static str, new_value: &str) -> Self {
-            let value = std::env::var_os(name);
-            std::env::set_var(name, new_value);
-            Self { name, value }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.value {
-                Some(value) => std::env::set_var(self.name, value),
-                None => std::env::remove_var(self.name),
-            }
-        }
-    }
-
     #[tokio::test]
     async fn launch_environment_respects_restricted_and_strict_profiles() {
         let db = crate::db::connect_in_memory().await.unwrap();
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path();
-        crate::profile::env_set(&db, "github_comment", "GH_TOKEN", "profile-token")
+        crate::profile::env_set(&db, "github_comment", "ANTHROPIC_API_KEY", "profile-token")
             .await
             .unwrap();
         crate::repo_env::set(&db, &repo.display().to_string(), "REPO_SECRET", "leak")
@@ -280,7 +263,7 @@ mod tests {
             .insert("COMMITTED_SECRET".to_string(), "leak".to_string());
         assert_eq!(
             launch_environment(&db, repo, &restricted_cfg, "github_comment", true, true).await,
-            vec![("GH_TOKEN".to_string(), "profile-token".to_string())]
+            vec![("ANTHROPIC_API_KEY".to_string(), "profile-token".to_string())]
         );
 
         crate::profile::env_set(&db, "default", "SHARED_TOKEN", "profile")
@@ -307,10 +290,27 @@ mod tests {
             Some("profile")
         );
         assert!(!strict.iter().any(|(name, _)| name == "CARGO_TARGET_DIR"));
+
+        let legacy_snapshot = layer_launch_environment(
+            &db,
+            repo,
+            &weaver_core::repo_config::RepoConfig::default(),
+            "default",
+            vec![
+                ("GH_TOKEN".to_string(), "legacy-profile-token".to_string()),
+                ("GITHUB_TOKEN".to_string(), "legacy-alias".to_string()),
+            ],
+            false,
+            false,
+        )
+        .await;
+        assert!(legacy_snapshot
+            .iter()
+            .all(|(name, _)| { !matches!(name.as_str(), "GH_TOKEN" | "GITHUB_TOKEN") }));
     }
 
     #[tokio::test]
-    async fn user_github_token_overlay_preserves_precedence() {
+    async fn only_the_loom_stored_user_token_is_overlaid() {
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
         seed_user(&db, "bob").await;
@@ -318,27 +318,15 @@ mod tests {
             .await
             .unwrap();
 
-        let mut fresh = vec![("FOO".to_string(), "bar".to_string())];
-        apply_user_github_token(&db, &mut fresh, Some("alice")).await;
-        assert!(fresh
+        let mut alice = vec![("FOO".to_string(), "bar".to_string())];
+        assert!(apply_user_github_token(&db, &mut alice, Some("alice")).await);
+        assert!(alice
             .iter()
             .any(|(name, value)| name == "GH_TOKEN" && value == "ghp_alice"));
 
-        let mut layered = vec![("GH_TOKEN".to_string(), "shared".to_string())];
-        apply_user_github_token(&db, &mut layered, Some("alice")).await;
-        let github_tokens = layered
-            .iter()
-            .filter(|(name, _)| name == "GH_TOKEN")
-            .collect::<Vec<_>>();
-        assert_eq!(github_tokens.len(), 1);
-        assert_eq!(github_tokens[0].1, "ghp_alice");
-
-        let mut fallback = vec![("GH_TOKEN".to_string(), "shared".to_string())];
-        apply_user_github_token(&db, &mut fallback, Some("bob")).await;
-        assert_eq!(fallback[0].1, "shared");
-        let mut producer = Vec::new();
-        apply_user_github_token(&db, &mut producer, None).await;
-        assert!(producer.is_empty());
+        let mut bob = Vec::new();
+        assert!(!apply_user_github_token(&db, &mut bob, Some("bob")).await);
+        assert!(!bob.iter().any(|(name, _)| name == "GH_TOKEN"));
     }
 
     #[tokio::test]
@@ -347,34 +335,31 @@ mod tests {
         let app = crate::github_app::GithubApp::new(db.clone());
 
         let mut direct = vec![
-            ("GH_TOKEN".to_string(), "personal".to_string()),
-            ("GITHUB_TOKEN".to_string(), "wrong-daemon-bot".to_string()),
+            ("GH_TOKEN".to_string(), "loom-stored-user-token".to_string()),
+            ("GITHUB_TOKEN".to_string(), "also-wrong".to_string()),
         ];
         assert_eq!(
-            stamp_github_auth_mode(&mut direct, Some(&app), false).await,
+            stamp_github_auth_mode(&mut direct, Some(&app), false, true).await,
             GithubAuthMode::Direct
         );
         assert!(direct
             .iter()
-            .any(|(name, value)| name == GITHUB_AUTH_MODE_ENV
-                && value == GithubAuthMode::Direct.as_str()));
-        assert!(direct
-            .iter()
-            .any(|(name, value)| name == "GH_TOKEN" && value == "personal"));
+            .any(|(name, value)| { name == "GH_TOKEN" && value == "loom-stored-user-token" }));
         assert!(direct
             .iter()
             .any(|(name, value)| name == "GITHUB_TOKEN" && value.is_empty()));
 
-        let mut unmanaged = vec![("GITHUB_TOKEN".to_string(), "wrong-daemon-bot".to_string())];
+        let mut unavailable = vec![
+            ("GH_TOKEN".to_string(), "unmanaged-token".to_string()),
+            ("GITHUB_TOKEN".to_string(), "also-wrong".to_string()),
+        ];
         assert_eq!(
-            stamp_github_auth_mode(&mut unmanaged, Some(&app), false).await,
+            stamp_github_auth_mode(&mut unavailable, Some(&app), false, false).await,
             GithubAuthMode::Disabled
         );
-        for name in ["GH_TOKEN", "GITHUB_TOKEN"] {
-            assert!(unmanaged
-                .iter()
-                .any(|(candidate, value)| candidate == name && value.is_empty()));
-        }
+        assert!(unavailable.iter().all(|(name, value)| {
+            !matches!(name.as_str(), "GH_TOKEN" | "GITHUB_TOKEN") || value.is_empty()
+        }));
 
         weaver_core::config::apply(
             &db,
@@ -393,7 +378,7 @@ mod tests {
         .unwrap();
         let mut brokered = vec![("GITHUB_TOKEN".to_string(), "wrong-daemon-bot".to_string())];
         assert_eq!(
-            stamp_github_auth_mode(&mut brokered, Some(&app), false).await,
+            stamp_github_auth_mode(&mut brokered, Some(&app), false, false).await,
             GithubAuthMode::Broker
         );
         for name in ["GH_TOKEN", "GITHUB_TOKEN"] {
@@ -407,7 +392,7 @@ mod tests {
             ("GITHUB_TOKEN".to_string(), "also-must-not-win".to_string()),
         ];
         assert_eq!(
-            stamp_github_auth_mode(&mut restricted, Some(&app), true).await,
+            stamp_github_auth_mode(&mut restricted, Some(&app), true, true).await,
             GithubAuthMode::Disabled
         );
         assert!(restricted.iter().all(|(name, value)| {
@@ -435,49 +420,29 @@ mod tests {
             session_github_repositories("automation", &configured, None),
             configured
         );
+        assert!(user_github_token_allowed("interactive", false));
+        assert!(!user_github_token_allowed("automation", false));
+        assert!(!user_github_token_allowed("interactive", true));
     }
 
-    #[serial_test::serial]
     #[tokio::test]
-    async fn github_token_preflight_covers_builtin_custom_and_app_paths() {
-        let _ambient = EnvVarGuard::set("GH_TOKEN", "ghp_daemon_must_not_leak");
+    async fn github_preflight_accepts_user_token_or_configured_app() {
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
-
-        assert!(
-            !github_token_available(&db, &[], Some("alice"), "codex", None)
-                .await
-                .unwrap()
-        );
-        assert!(
-            github_token_available(&db, &[], Some("alice"), "my-custom-agent", None)
-                .await
-                .unwrap()
-        );
-        assert!(
-            github_token_available(&db, &[], Some("github-webhook (octo)"), "codex", None)
-                .await
-                .unwrap()
-        );
-
+        assert!(!github_credential_available(&db, Some("alice"), None, true)
+            .await
+            .unwrap());
         crate::user_token::set(&db, "alice", "ghp_alice")
             .await
             .unwrap();
+        assert!(github_credential_available(&db, Some("alice"), None, true)
+            .await
+            .unwrap());
         assert!(
-            github_token_available(&db, &[], Some("alice"), "claude", None)
+            !github_credential_available(&db, Some("alice"), None, false)
                 .await
                 .unwrap()
         );
-        crate::user_token::remove(&db, "alice").await.unwrap();
-        assert!(github_token_available(
-            &db,
-            &[("GH_TOKEN".to_string(), "ghp_shared".to_string())],
-            Some("alice"),
-            "codex",
-            None,
-        )
-        .await
-        .unwrap());
 
         weaver_core::config::apply(
             &db,
@@ -495,16 +460,8 @@ mod tests {
         .await
         .unwrap();
         let app = crate::github_app::GithubApp::new(db.clone());
-        assert!(
-            github_token_available(&db, &[], Some("alice"), "claude", Some(&app))
-                .await
-                .unwrap()
-        );
-
-        assert!(
-            !github_token_available(&db, &[], Some("alice"), "codex", None,)
-                .await
-                .unwrap()
-        );
+        assert!(github_credential_available(&db, None, Some(&app), false)
+            .await
+            .unwrap());
     }
 }

--- a/crates/loom-forge/src/user_token.rs
+++ b/crates/loom-forge/src/user_token.rs
@@ -1,18 +1,17 @@
 //! A user's own GitHub token (a fine-grained PAT), stored in the
 //! `user_github_tokens` table.
 //!
-//! For an ordinary interactive session, loom injects the token as `GH_TOKEN`
-//! into the session env ([`crate::provision::create`]), overriding the
-//! selected profile credential. Restricted sessions use the GitHub App (or an
-//! explicit App-less profile credential) instead. Combined with the per-user
-//! commit author identity loom already sets
-//! ([`crate::auth::commit_identity`]), ordinary pushes are attributed to them.
+//! Loom may inject this token as `GH_TOKEN` into an ordinary interactive
+//! session launched by that user. It is the only direct-token source: profile,
+//! repository, committed, and daemon environments cannot provide GitHub
+//! credentials. If no per-user token is stored, the session uses its
+//! profile-approved GitHub App credential instead. Restricted sessions never
+//! receive the personal token.
 //!
 //! The value is **write-only** over the API: callers learn only *that* a token is
-//! set and when it changed, never the token itself — the same treatment
-//! [`crate::repo_env`] gives per-repo secrets. Export into ordinary shared
-//! sessions is blast-radius reduction rather than isolation; restricted sessions
-//! avoid that export entirely.
+//! set and when it changed, never the token itself. Export into ordinary shared
+//! sessions is blast-radius reduction rather than isolation; restricted
+//! sessions avoid that export entirely.
 
 use anyhow::Result;
 use serde::Serialize;
@@ -28,8 +27,8 @@ pub struct TokenStatus {
     pub updated_at: Option<String>,
 }
 
-/// The stored token for `username`, if any. The *only* reader of the value; used
-/// at session launch and never exposed over the API.
+/// The stored token for `username`, if any. Used only while assembling the
+/// user's ordinary interactive session environment and never exposed by API.
 pub async fn get(db: &Db, username: &str) -> Result<Option<String>> {
     let row = sqlx::query("SELECT token FROM user_github_tokens WHERE username = ?")
         .bind(username)
@@ -69,7 +68,6 @@ pub async fn set(db: &Db, username: &str, token: &str) -> Result<()> {
     .bind(&now)
     .execute(db)
     .await?;
-    tracing::debug!(username, "user github token set");
     tracing::info!(username, "github token set");
     Ok(())
 }
@@ -102,7 +100,6 @@ mod tests {
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
 
-        // Absent: status reports unset, get returns None.
         assert_eq!(
             status(&db, "alice").await.unwrap(),
             TokenStatus {
@@ -112,25 +109,20 @@ mod tests {
         );
         assert!(get(&db, "alice").await.unwrap().is_none());
 
-        // Set: get returns the value; status reports set with a timestamp, but
-        // the value is only ever readable through `get` (never `status`).
         set(&db, "alice", "github_pat_abc").await.unwrap();
         assert_eq!(
             get(&db, "alice").await.unwrap().as_deref(),
             Some("github_pat_abc")
         );
-        let st = status(&db, "alice").await.unwrap();
-        assert!(st.set);
-        assert!(st.updated_at.is_some());
+        let status = status(&db, "alice").await.unwrap();
+        assert!(status.set);
+        assert!(status.updated_at.is_some());
 
-        // Upsert replaces in place.
         set(&db, "alice", "github_pat_rotated").await.unwrap();
         assert_eq!(
             get(&db, "alice").await.unwrap().as_deref(),
             Some("github_pat_rotated")
         );
-
-        // Remove, then removing again is a no-op.
         assert!(remove(&db, "alice").await.unwrap());
         assert!(!remove(&db, "alice").await.unwrap());
         assert!(get(&db, "alice").await.unwrap().is_none());
@@ -141,7 +133,6 @@ mod tests {
         let db = crate::db::connect_in_memory().await.unwrap();
         seed_user(&db, "alice").await;
         seed_user(&db, "bob").await;
-
         set(&db, "alice", "alice-tok").await.unwrap();
         set(&db, "bob", "bob-tok").await.unwrap();
 
@@ -150,8 +141,6 @@ mod tests {
             Some("alice-tok")
         );
         assert_eq!(get(&db, "bob").await.unwrap().as_deref(), Some("bob-tok"));
-
-        // Removing one leaves the other untouched.
         remove(&db, "alice").await.unwrap();
         assert!(get(&db, "alice").await.unwrap().is_none());
         assert_eq!(get(&db, "bob").await.unwrap().as_deref(), Some("bob-tok"));

--- a/crates/loom-forge/src/user_token.rs
+++ b/crates/loom-forge/src/user_token.rs
@@ -1,12 +1,10 @@
 //! A user's own GitHub token (a fine-grained PAT), stored in the
 //! `user_github_tokens` table.
 //!
-//! Loom may inject this token as `GH_TOKEN` into an ordinary interactive
-//! session launched by that user. It is the only direct-token source: profile,
-//! repository, committed, and daemon environments cannot provide GitHub
-//! credentials. If no per-user token is stored, the session uses its
-//! profile-approved GitHub App credential instead. Restricted sessions never
-//! receive the personal token.
+//! Loom selects this token for an ordinary interactive session launched by that
+//! user. Sessions use their profile-approved GitHub App credential when the
+//! Account PAT is not selected. Restricted sessions use Loom's App-backed fixed
+//! GitHub tools.
 //!
 //! The value is **write-only** over the API: callers learn only *that* a token is
 //! set and when it changed, never the token itself. Export into ordinary shared

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -639,17 +639,13 @@ async fn handoff_session_inner(
         &session.branch_id,
     )
     .await?;
-    let user_token_applied = if runtime::user_github_token_allowed(&plan.class, plan.restricted) {
-        runtime::apply_user_github_token(&st.db, &mut extra_env, session.created_by.as_deref())
-            .await
-    } else {
-        false
-    };
-    runtime::stamp_github_auth_mode(
+    runtime::configure_session_github_auth(
+        &st.db,
         &mut extra_env,
-        github_app,
+        session.created_by.as_deref(),
+        &plan.class,
         plan.restricted,
-        user_token_applied,
+        github_app,
     )
     .await;
     runtime::set_env(&mut extra_env, "LOOM_TOKEN", staged_token.value.clone());

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -570,18 +570,17 @@ async fn handoff_session_inner(
             .map_err(|error| HandoffError::bad_request(error.to_string()))?;
         extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
     }
-    runtime::apply_user_github_token(&st.db, &mut extra_env, session.created_by.as_deref()).await;
     let github_app = (!session_github_repositories.is_empty())
         .then(|| st.trigger.app())
         .flatten();
-    if !runtime::github_token_available(
-        &st.db,
-        &extra_env,
-        session.created_by.as_deref(),
-        &target,
-        github_app,
-    )
-    .await?
+    if current_github_repo.is_some()
+        && !runtime::github_credential_available(
+            &st.db,
+            session.created_by.as_deref(),
+            github_app,
+            runtime::user_github_token_allowed(&plan.class, plan.restricted),
+        )
+        .await?
     {
         return Err(HandoffError::PreconditionRequired(
             runtime::MISSING_GITHUB_TOKEN_MESSAGE.to_string(),
@@ -640,7 +639,19 @@ async fn handoff_session_inner(
         &session.branch_id,
     )
     .await?;
-    runtime::stamp_github_auth_mode(&mut extra_env, github_app, plan.restricted).await;
+    let user_token_applied = if runtime::user_github_token_allowed(&plan.class, plan.restricted) {
+        runtime::apply_user_github_token(&st.db, &mut extra_env, session.created_by.as_deref())
+            .await
+    } else {
+        false
+    };
+    runtime::stamp_github_auth_mode(
+        &mut extra_env,
+        github_app,
+        plan.restricted,
+        user_token_applied,
+    )
+    .await;
     runtime::set_env(&mut extra_env, "LOOM_TOKEN", staged_token.value.clone());
     runtime::set_env(&mut extra_env, "LOOM_SESSION_ID", session.id.clone());
     let mut launch = match agent::build_acp_launch(

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -640,6 +640,7 @@ async fn handoff_session_inner(
         &session.branch_id,
     )
     .await?;
+    runtime::stamp_github_auth_mode(&mut extra_env, github_app, plan.restricted).await;
     runtime::set_env(&mut extra_env, "LOOM_TOKEN", staged_token.value.clone());
     runtime::set_env(&mut extra_env, "LOOM_SESSION_ID", session.id.clone());
     let mut launch = match agent::build_acp_launch(

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -274,12 +274,18 @@ async fn fetch_launch_issue(
     managed_repo: Option<&crate::repo::RepoSlug>,
     number: i64,
 ) -> anyhow::Result<github::Issue> {
-    if let (Some(app), Some(repo)) = (st.trigger.app(), managed_repo) {
-        if app.is_configured().await {
-            return app.issue(&repo.owner, &repo.name, number).await;
-        }
-    }
-    github::fetch_issue(repo_root, number).await
+    let slug = match managed_repo {
+        Some(repo) => repo.clone(),
+        None => crate::repo::github_slug_for_root(&st.db, repo_root)
+            .await?
+            .and_then(|slug| crate::repo::parse_slug(&slug).ok())
+            .ok_or_else(|| anyhow::anyhow!("repository has no registered GitHub identity"))?,
+    };
+    let app = st
+        .trigger
+        .app()
+        .ok_or_else(|| anyhow::anyhow!("GitHub App is unavailable"))?;
+    app.issue(&slug.owner, &slug.name, number).await
 }
 
 /// The configured wall-clock budget for a repo setup run.
@@ -663,8 +669,7 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
     tracing::debug!(agent = %agent, runtime = %runtime, "resolved agent runtime");
     // The resolved launch environment: selected profile < per-repo repo_env <
     // the repo file's [env]. It is needed before provisioning so a real agent
-    // launch can stop cleanly when neither the user nor an environment layer
-    // provides GH_TOKEN.
+    // launch can stop cleanly when the selected profile has no App access.
     let mut extra_env = layer_launch_environment(
         &st.db,
         &repo_root,
@@ -681,14 +686,6 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
             .map_err(|e| ProvisionError::invalid(e.to_string()))?;
         extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
     }
-    // Select the launching user's GitHub credential by overlaying it as
-    // GH_TOKEN (design §6.3, "Level B"). See `apply_user_github_token` for the
-    // precedence rules. This happens before preflight. Ordinary sessions export
-    // it; a restricted ACP launch removes it from the adapter environment and
-    // its server-side GitHub tool independently resolves an App or profile
-    // credential.
-    apply_user_github_token(&st.db, &mut extra_env, created_by.as_deref()).await;
-
     tracing::debug!(model = %model, effort = %effort, protocol = %protocol, "resolved and validated model/effort/protocol");
     let github_app = if (!session_github_repositories.is_empty())
         || (launch_profile.restricted && managed_slug.is_some())
@@ -697,20 +694,20 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
     } else {
         None
     };
-    if !crate::runtime::github_token_available(
-        &st.db,
-        &extra_env,
-        created_by.as_deref(),
-        &runtime,
-        github_app,
-    )
-    .await?
+    if current_github_repo.is_some()
+        && !crate::runtime::github_credential_available(
+            &st.db,
+            created_by.as_deref(),
+            github_app,
+            crate::runtime::user_github_token_allowed(&class, launch_profile.restricted),
+        )
+        .await?
     {
         return Err(ProvisionError::CredentialRequired(
             crate::runtime::MISSING_GITHUB_TOKEN_MESSAGE.to_string(),
         ));
     }
-    tracing::debug!(runtime = %runtime, "github token availability check passed");
+    tracing::debug!(runtime = %runtime, "github app availability check passed");
 
     // Build title/goal/description; an optional GitHub issue seeds all three.
     let mut goal = req.goal.unwrap_or_default().trim().to_string();
@@ -741,7 +738,7 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
         github_issue = Some(number);
         github_repo = match managed_slug.as_ref() {
             Some(repo) => Some(repo.slug()),
-            None => github::repo_slug(&repo_root).await.ok(),
+            None => crate::repo::github_slug_for_root(&st.db, &repo_root).await?,
         };
         tracing::debug!(issue = number, github_repo = ?github_repo, "seeded session fields from github issue");
     } else if let Some(number) = req.github_issue {
@@ -1211,7 +1208,19 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
     let session_token =
         crate::auth::create_session_token(&st.db, created_by.as_deref(), &session_id, &branch.id)
             .await?;
-    stamp_github_auth_mode(&mut extra_env, github_app, launch_profile.restricted).await;
+    let user_token_applied =
+        if crate::runtime::user_github_token_allowed(&class, launch_profile.restricted) {
+            apply_user_github_token(&st.db, &mut extra_env, created_by.as_deref()).await
+        } else {
+            false
+        };
+    stamp_github_auth_mode(
+        &mut extra_env,
+        github_app,
+        launch_profile.restricted,
+        user_token_applied,
+    )
+    .await;
     set_env(&mut extra_env, "LOOM_TOKEN", session_token);
     set_env(&mut extra_env, "LOOM_SESSION_ID", session_id.clone());
     let session = if protocol == "acp" {

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -11,7 +11,9 @@ use weaver_core::tags;
 use weaver_core::BoxFut;
 
 use crate::auth::{Grant, Principal};
-use crate::runtime::{apply_user_github_token, layer_launch_environment, set_env};
+use crate::runtime::{
+    apply_user_github_token, layer_launch_environment, set_env, stamp_github_auth_mode,
+};
 use crate::scratch::{prepare_initial_scratch, scratch_note, write_prepared_initial_scratch};
 use crate::session::{self as session_mod, NewSession, Session};
 use crate::{agent, config, db, events, git, github, repo, setup, AppState, Db};
@@ -1209,6 +1211,7 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
     let session_token =
         crate::auth::create_session_token(&st.db, created_by.as_deref(), &session_id, &branch.id)
             .await?;
+    stamp_github_auth_mode(&mut extra_env, github_app, launch_profile.restricted).await;
     set_env(&mut extra_env, "LOOM_TOKEN", session_token);
     set_env(&mut extra_env, "LOOM_SESSION_ID", session_id.clone());
     let session = if protocol == "acp" {

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -11,9 +11,7 @@ use weaver_core::tags;
 use weaver_core::BoxFut;
 
 use crate::auth::{Grant, Principal};
-use crate::runtime::{
-    apply_user_github_token, layer_launch_environment, set_env, stamp_github_auth_mode,
-};
+use crate::runtime::{configure_session_github_auth, layer_launch_environment, set_env};
 use crate::scratch::{prepare_initial_scratch, scratch_note, write_prepared_initial_scratch};
 use crate::session::{self as session_mod, NewSession, Session};
 use crate::{agent, config, db, events, git, github, repo, setup, AppState, Db};
@@ -1208,17 +1206,13 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
     let session_token =
         crate::auth::create_session_token(&st.db, created_by.as_deref(), &session_id, &branch.id)
             .await?;
-    let user_token_applied =
-        if crate::runtime::user_github_token_allowed(&class, launch_profile.restricted) {
-            apply_user_github_token(&st.db, &mut extra_env, created_by.as_deref()).await
-        } else {
-            false
-        };
-    stamp_github_auth_mode(
+    configure_session_github_auth(
+        &st.db,
         &mut extra_env,
-        github_app,
+        created_by.as_deref(),
+        &class,
         launch_profile.restricted,
-        user_token_applied,
+        github_app,
     )
     .await;
     set_env(&mut extra_env, "LOOM_TOKEN", session_token);

--- a/crates/loom-store/migrations/0027_loom_owned_github_auth.sql
+++ b/crates/loom-store/migrations/0027_loom_owned_github_auth.sql
@@ -1,0 +1,5 @@
+-- GitHub credentials must come from Loom-owned state. Remove legacy profile
+-- and repository environment overrides; per-user Account tokens remain a
+-- supported override for ordinary interactive sessions.
+DELETE FROM profile_env WHERE name IN ('GH_TOKEN', 'GITHUB_TOKEN');
+DELETE FROM repo_env WHERE name IN ('GH_TOKEN', 'GITHUB_TOKEN');

--- a/crates/loom-store/src/agent_env.rs
+++ b/crates/loom-store/src/agent_env.rs
@@ -37,6 +37,11 @@ pub struct EnvVar {
 const RESERVED_PREFIXES: &[&str] = &["WEAVER_", "LOOM_"];
 const RESERVED_NAMES: &[&str] = &["GH_TOKEN", "GITHUB_TOKEN"];
 
+/// Whether `name` is one of the stock GitHub clients' credential variables.
+pub fn is_github_token_name(name: &str) -> bool {
+    RESERVED_NAMES.contains(&name)
+}
+
 /// Validate an environment-variable name. Accept the POSIX-portable identifier
 /// shape (`[A-Za-z_][A-Za-z0-9_]*`): a leading letter or underscore, then
 /// letters, digits, or underscores. This is exactly what the `export NAME=…` in
@@ -66,7 +71,7 @@ pub fn validate_name(name: &str) -> std::result::Result<(), String> {
              environment and cannot be overridden"
         ));
     }
-    if RESERVED_NAMES.contains(&name) {
+    if is_github_token_name(name) {
         return Err(format!(
             "name '{name}' is reserved: GitHub credentials are managed by Loom"
         ));

--- a/crates/loom-store/src/agent_env.rs
+++ b/crates/loom-store/src/agent_env.rs
@@ -4,9 +4,7 @@
 //! only into sessions launched with that profile, alongside loom's own
 //! `WEAVER_*` / `LOOM_TOKEN`. Other profiles have independent environment
 //! stores, and restricted profiles never inherit these values. The one-shot
-//! judgement agent runs env-stripped and gets none of them (see
-//! [`crate::agent`]); watch scripts are likewise stripped but do receive
-//! `GH_TOKEN` (via [`get`]) for legacy App-less GitHub reads.
+//! judgement agent and watch scripts run env-stripped and get none of them.
 //!
 //! This remains a flat name/value API for existing settings, setup, GitHub,
 //! watch, and shell callers, but storage lives in `profile_env` under the
@@ -33,11 +31,11 @@ pub struct EnvVar {
 
 /// Names loom owns and exports itself ([`crate::agent::launch`]). Operator vars
 /// are exported *after* these, so allowing one of these names through would let a
-/// stored value shadow `WEAVER_API`/`WEAVER_BRANCH`/`LOOM_TOKEN` and break the
-/// agent's own `loom session …` calls. We reserve the whole `WEAVER_`/`LOOM_`
-/// prefix space rather than just the current names so future loom-owned vars are
-/// covered without a matching validation change.
+/// stored value shadow Loom's control variables or GitHub credential policy.
+/// We reserve the whole `WEAVER_`/`LOOM_` prefix space plus the stock GitHub
+/// clients' token names.
 const RESERVED_PREFIXES: &[&str] = &["WEAVER_", "LOOM_"];
+const RESERVED_NAMES: &[&str] = &["GH_TOKEN", "GITHUB_TOKEN"];
 
 /// Validate an environment-variable name. Accept the POSIX-portable identifier
 /// shape (`[A-Za-z_][A-Za-z0-9_]*`): a leading letter or underscore, then
@@ -68,6 +66,11 @@ pub fn validate_name(name: &str) -> std::result::Result<(), String> {
              environment and cannot be overridden"
         ));
     }
+    if RESERVED_NAMES.contains(&name) {
+        return Err(format!(
+            "name '{name}' is reserved: GitHub credentials are managed by Loom"
+        ));
+    }
     Ok(())
 }
 
@@ -87,22 +90,6 @@ pub async fn list(db: &Db) -> Result<Vec<EnvVar>> {
             updated_at: r.get::<String, _>("updated_at"),
         })
         .collect())
-}
-
-/// One variable's value, or `None` when unset (or on a DB error — callers use
-/// this for best-effort credential lookup, where a miss and an error are the same
-/// "no value" outcome). Used by loom's *own* GitHub operations — the PR poll loop
-/// and watch scripts — which run in the server process and so don't inherit the
-/// per-session agent environment.
-pub async fn get(db: &Db, name: &str) -> Option<String> {
-    sqlx::query_scalar::<_, String>(
-        "SELECT value FROM profile_env WHERE profile_name = 'default' AND name = ?",
-    )
-    .bind(name)
-    .fetch_optional(db)
-    .await
-    .ok()
-    .flatten()
 }
 
 /// The variables as a plain `(name, value)` list — what [`crate::agent::launch`]
@@ -177,6 +164,8 @@ mod tests {
         assert!(validate_name("WEAVER_BRANCH").is_err());
         assert!(validate_name("LOOM_TOKEN").is_err());
         assert!(validate_name("WEAVER_ANYTHING").is_err());
+        assert!(validate_name("GH_TOKEN").is_err());
+        assert!(validate_name("GITHUB_TOKEN").is_err());
     }
 
     #[tokio::test]
@@ -204,17 +193,9 @@ mod tests {
             ]
         );
 
-        // `get` reads a single value; a missing key is `None`.
-        assert_eq!(
-            get(&db, "GH_HOST").await.as_deref(),
-            Some("github.internal")
-        );
-        assert_eq!(get(&db, "MISSING").await, None);
-
         assert!(remove(&db, "API_TOKEN").await.unwrap());
         // Removing again is a no-op.
         assert!(!remove(&db, "API_TOKEN").await.unwrap());
         assert_eq!(list(&db).await.unwrap().len(), 1);
-        assert_eq!(get(&db, "API_TOKEN").await, None, "gone after remove");
     }
 }

--- a/crates/loom-store/src/db.rs
+++ b/crates/loom-store/src/db.rs
@@ -140,6 +140,11 @@ const LOOM_MIGRATIONS: &[(i64, &str, &str)] = &[
         "session-github-access",
         include_str!("../migrations/0026_session_github_access.sql"),
     ),
+    (
+        27,
+        "loom-owned-github-auth",
+        include_str!("../migrations/0027_loom_owned_github_auth.sql"),
+    ),
 ];
 
 const LOOM_STREAM: Stream = Stream::new("loom_schema_migrations", LOOM_MIGRATIONS);
@@ -489,6 +494,60 @@ mod tests {
         .execute(&db)
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn github_auth_migration_removes_environment_tokens_but_keeps_user_tokens() {
+        let db = weaver_core::db::connect_in_memory().await.unwrap();
+        migrate_through(&db, 26).await;
+        sqlx::query("INSERT INTO users (username) VALUES ('alice')")
+            .execute(&db)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO user_github_tokens (username, token, updated_at)
+             VALUES ('alice', 'github_pat_alice', '2026-08-18T00:00:00Z')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO profile_env (profile_name, name, value, updated_at)
+             VALUES ('default', 'GH_TOKEN', 'legacy-profile', '2026-08-18T00:00:00Z')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO repo_env (repo_root, name, value, updated_at)
+             VALUES ('/repo', 'GITHUB_TOKEN', 'legacy-repo', '2026-08-18T00:00:00Z')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        migrate_loom(&db).await.unwrap();
+
+        let profile_tokens: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM profile_env WHERE name IN ('GH_TOKEN', 'GITHUB_TOKEN')",
+        )
+        .fetch_one(&db)
+        .await
+        .unwrap();
+        let repo_tokens: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM repo_env WHERE name IN ('GH_TOKEN', 'GITHUB_TOKEN')",
+        )
+        .fetch_one(&db)
+        .await
+        .unwrap();
+        let user_token: String =
+            sqlx::query_scalar("SELECT token FROM user_github_tokens WHERE username = 'alice'")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(profile_tokens, 0);
+        assert_eq!(repo_tokens, 0);
+        assert_eq!(user_token, "github_pat_alice");
     }
 
     #[tokio::test]

--- a/crates/loom-store/src/repo_env.rs
+++ b/crates/loom-store/src/repo_env.rs
@@ -14,7 +14,8 @@
 //! exported environment. See the shared-loom design §6.4.
 //!
 //! Names are validated as POSIX shell identifiers and may not use loom's reserved
-//! `WEAVER_`/`LOOM_` prefixes — the same rule as `agent_env`, reused via
+//! `WEAVER_`/`LOOM_` prefixes or GitHub client token names — the same rule as
+//! `agent_env`, reused via
 //! [`crate::agent_env::validate_name`], since `repo_env` is exported by the same
 //! launch script.
 

--- a/crates/loom-watch/src/watch.rs
+++ b/crates/loom-watch/src/watch.rs
@@ -807,9 +807,8 @@ fn has_pep723(source: &str) -> bool {
     source.lines().any(|l| l.trim() == "# /// script")
 }
 
-/// Whether the `uv` CLI is usable. Probed once and cached, like
-/// [`crate::github::gh_available`] — absence is normal and shouldn't cost a
-/// process spawn every round.
+/// Whether the `uv` CLI is usable. Probed once and cached because absence is
+/// normal and shouldn't cost a process spawn every round.
 async fn uv_available() -> bool {
     static AVAILABLE: tokio::sync::OnceCell<bool> = tokio::sync::OnceCell::const_new();
     *AVAILABLE
@@ -933,8 +932,8 @@ struct ScriptOutput {
 }
 
 /// Calling-agent credentials and lifecycle markers that a watch program must
-/// not inherit. Watch scripts receive only their explicit REST capability
-/// token (and the operator's GitHub token when needed).
+/// not inherit. Watch scripts receive only their explicit Loom REST capability
+/// token; GitHub state reaches builtins through Loom's API snapshots.
 const WATCH_SCRIPT_STRIPPED_ENV: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "CLAUDECODE",
@@ -942,6 +941,9 @@ const WATCH_SCRIPT_STRIPPED_ENV: &[&str] = &[
     "CLAUDE_CODE_EXECPATH",
     "CLAUDE_CODE_SESSION_ID",
     "CLAUDE_CODE_SSE_PORT",
+    "GH_HOST",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
     "WEAVER_BRANCH",
 ];
 
@@ -1026,21 +1028,6 @@ async fn spawn_script(
     for key in WATCH_SCRIPT_STRIPPED_ENV {
         command.env_remove(key);
     }
-    command.env_remove("GH_TOKEN").env_remove("GH_HOST");
-    // A reactive GitHub watch concerns one repository, so run its `gh` calls
-    // with that repo's App token; manual rounds fall back to operator auth.
-    let repo = config
-        .pointer("/trigger/repo")
-        .and_then(Value::as_str)
-        .map(std::path::Path::new);
-    let (token, host) = crate::github::gh_environment(state, repo).await;
-    if let Some(token) = token {
-        command.env("GH_TOKEN", token);
-    }
-    if let Some(host) = host {
-        command.env("GH_HOST", host);
-    }
-
     let started = std::time::Instant::now();
     let out = command.output().await.map_err(|e| {
         anyhow::anyhow!("spawning {interpreter} failed: {e} (is {interpreter} installed?)")

--- a/crates/loom-watch/watches/pr_label.py
+++ b/crates/loom-watch/watches/pr_label.py
@@ -4,7 +4,7 @@ Subscribes to `pr.opened` — it wakes when a session's PR first appears, on tha
 one branch, instead of polling every session's labels on a timer.
 """
 
-from weaver_loom import Round, WeaverError, gh_json
+from weaver_loom import Round, WeaverError
 
 DEFAULT_LABEL = "weaver"
 
@@ -25,17 +25,7 @@ def main(rnd):
             rnd.would("label", **fields)
             continue
         try:
-            gh_json(
-                [
-                    "api",
-                    "-X",
-                    "POST",
-                    f"repos/{{owner}}/{{repo}}/issues/{pr}/labels",
-                    "-f",
-                    f"labels[]={label}",
-                ],
-                cwd=branch.get("repo_root"),
-            )
+            rnd.client.add_github_labels(session["id"], [label])
         except WeaverError as e:
             rnd.would("label", **fields, note=str(e))
             continue

--- a/crates/loom/frontend/src/api.ts
+++ b/crates/loom/frontend/src/api.ts
@@ -310,24 +310,19 @@ export const validateRepoRevision = (cwd: string, revision: string) => {
 
 // --- Your GitHub token (per-user) ------------------------------------------
 
-/** Whether the signed-in user has set a personal GitHub token. The token itself
- *  is write-only — set/cleared but never read back. */
+/** Write-only status for the signed-in user's Loom-stored GitHub PAT. */
 export interface GithubTokenStatus {
   set: boolean;
   updated_at: string | null;
 }
 
-/** Whether you've set a personal GitHub token (`GET /api/auth/github-token`). */
 export const getMyGithubToken = () => get('/auth/github-token') as Promise<GithubTokenStatus>;
 
-/** Set/replace your personal GitHub token, injected as GH_TOKEN into the
- *  sessions you launch so your agents act as you (`PUT /api/auth/github-token`).
- *  Returns the refreshed status (never the token). */
+/** Store the PAT Loom will inject into this user's ordinary interactive sessions. */
 export const setMyGithubToken = (token: string) =>
   put('/auth/github-token', { token }) as Promise<GithubTokenStatus>;
 
-/** Clear your personal GitHub token; new interactive sessions retain any
- *  credential supplied by their selected profile (`DELETE /api/auth/github-token`). */
+/** Remove the PAT; new sessions fall back to profile-approved GitHub App access. */
 export const deleteMyGithubToken = () => del('/auth/github-token');
 
 interface RepoEnvEnvelope {

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -48,8 +48,8 @@ async function savePassword() {
 }
 
 // -- Your GitHub token ------------------------------------------------------
-// This is Loom-owned user state, not an ambient process credential. Loom
-// injects it only into ordinary interactive sessions launched by this user.
+// This Loom-owned Account credential is selected for ordinary interactive
+// sessions launched by this user.
 const PAT_CREATE_URL =
   'https://github.com/settings/personal-access-tokens/new' +
   '?name=Loom' +

--- a/crates/loom/frontend/src/components/AccountPanel.vue
+++ b/crates/loom/frontend/src/components/AccountPanel.vue
@@ -48,9 +48,8 @@ async function savePassword() {
 }
 
 // -- Your GitHub token ------------------------------------------------------
-// A personal fine-grained PAT, injected as GH_TOKEN into the sessions this user
-// launches, so their agents' `git push` / `gh` act as them (not the shared
-// ambient token). Write-only: we render only whether it's set, never the value.
+// This is Loom-owned user state, not an ambient process credential. Loom
+// injects it only into ordinary interactive sessions launched by this user.
 const PAT_CREATE_URL =
   'https://github.com/settings/personal-access-tokens/new' +
   '?name=Loom' +
@@ -73,7 +72,7 @@ async function saveMyGithubToken() {
   try {
     ghTokenStatus.value = await api.setMyGithubToken(ghToken.value.trim());
     ghToken.value = '';
-    ok('GitHub token saved — your new sessions will act as you.');
+    ok('GitHub token saved — your new interactive sessions will act as you.');
   } catch (e) {
     fail(e);
   } finally {
@@ -85,7 +84,7 @@ async function clearMyGithubToken() {
   await confirmAction({
     title: 'Remove your personal GitHub token?',
     description:
-      "New interactive sessions will use an explicit session credential or the selected profile's GitHub App access. Existing sessions are unchanged.",
+      "New interactive sessions will use the selected profile's GitHub App access. Existing sessions are unchanged.",
     confirmLabel: 'Remove token',
     danger: true,
     action: async () => {
@@ -164,17 +163,16 @@ onMounted(loadMyGithubToken);
       </div>
     </section>
 
-    <!-- Your GitHub token -->
     <section>
       <h2 class="text-2xs font-semibold uppercase tracking-wider text-muted mb-1.5">
         Your GitHub token
       </h2>
       <div class="rounded-md border border-line bg-surface px-3 py-2.5">
         <p class="text-xs text-muted mb-2">
-          A personal fine-grained token your ordinary interactive sessions use for
-          <code class="font-mono">git push</code> and <code class="font-mono">gh</code>, so your
-          agents act as you. It takes precedence over explicit session and profile GitHub
-          credentials.
+          An optional personal fine-grained token Loom stores for you. Loom injects it into your
+          ordinary interactive sessions so <code class="font-mono">git push</code> and
+          <code class="font-mono">gh</code> act as you. When it is not set, new sessions use the
+          selected profile’s approved GitHub App access.
           <a class="text-accent underline" :href="PAT_CREATE_URL" target="_blank" rel="noopener">
             Create one</a
           >
@@ -184,11 +182,7 @@ onMounted(loadMyGithubToken);
           <span class="font-medium">Workflows</span> read/write only when sessions must edit
           <code class="font-mono">.github/workflows</code>.
           <span :class="ghTokenStatus?.set ? 'text-accent' : 'text-faint'">
-            {{
-              ghTokenStatus?.set
-                ? 'Set.'
-                : 'Not set — interactive sessions use an explicit session credential, then the selected profile’s GitHub App access.'
-            }}
+            {{ ghTokenStatus?.set ? 'Set.' : 'Not set — using GitHub App access.' }}
           </span>
         </p>
         <div class="flex flex-wrap items-center gap-2">

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -183,8 +183,8 @@ enum Cmd {
     ///
     ///     loom setup github-app --base-url https://loom.team.dev
     ///
-    /// `loom setup secrets` prompts for paste-once agent secrets (an Anthropic
-    /// API key, a GitHub token) and stores them on the default profile. They
+    /// `loom setup secrets` prompts for paste-once model-provider secrets
+    /// (Anthropic and OpenAI API keys) and stores them on the default profile. They
     /// apply to future sessions launched with that profile:
     ///
     ///     loom setup secrets
@@ -795,7 +795,7 @@ enum WatchCmd {
 enum SetupCmd {
     /// Create the GitHub App loom uses, via GitHub's manifest flow.
     GithubApp(GithubAppOpts),
-    /// Prompt for and store default-profile agent secrets (Anthropic key, GitHub token).
+    /// Prompt for and store default-profile model-provider secrets.
     Secrets(SecretsOpts),
 }
 
@@ -2888,7 +2888,7 @@ struct ExistingApp {
 }
 
 /// Read the configured App from the settings table. `None` when no App id is
-/// stored (a fresh instance, or one that only ever used the ambient `GH_TOKEN`).
+/// stored on a fresh or incompletely configured instance.
 async fn existing_app(db: &Db) -> Option<ExistingApp> {
     let nonempty = |v: Option<String>| v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
     let id = nonempty(weaver_core::config::get(db, loom::github_app::APP_ID_KEY).await)?;
@@ -3279,9 +3279,8 @@ async fn cmd_setup_secrets(opts: SecretsOpts) -> Result<()> {
         existing_names.contains("ANTHROPIC_API_KEY"),
     )?;
     let openai = prompt_secret("OPENAI_API_KEY", existing_names.contains("OPENAI_API_KEY"))?;
-    let gh_token = prompt_secret("GH_TOKEN", existing_names.contains("GH_TOKEN"))?;
 
-    if anthropic.is_none() && openai.is_none() && gh_token.is_none() {
+    if anthropic.is_none() && openai.is_none() {
         println!("nothing entered — existing values kept unchanged");
         return Ok(());
     }
@@ -3295,34 +3294,24 @@ async fn cmd_setup_secrets(opts: SecretsOpts) -> Result<()> {
         loom::agent_env::set(&db, "OPENAI_API_KEY", v).await?;
         stored.push("OPENAI_API_KEY");
     }
-    if let Some(v) = &gh_token {
-        loom::agent_env::set(&db, "GH_TOKEN", v).await?;
-        stored.push("GH_TOKEN");
-    }
     println!();
     println!(
         "Stored {} on the default profile — future sessions using that profile get them \
          (Settings → Agents & profiles in the web UI, or `GET /api/env`).",
         stored.join(", ")
     );
-    println!(
-        "Note: the loom daemon's own process (cloning private repos, and the `gh` \
-         fallback when no GitHub App is configured) still reads these ambiently — set \
-         them as real environment variables before the daemon starts for that to apply."
-    );
-
     let mut updates: Vec<(&str, &str)> = Vec::new();
     if let Some(v) = &anthropic {
         updates.push(("ANTHROPIC_API_KEY", v.as_str()));
     }
-    if let Some(v) = &gh_token {
-        updates.push(("GH_TOKEN", v.as_str()));
+    if let Some(v) = &openai {
+        updates.push(("OPENAI_API_KEY", v.as_str()));
     }
     loom::loom_config::upsert(&opts.config.config, &updates)
         .context("writing the paste-once secrets into loom.toml")?;
     println!(
         "Also wrote them to {} — run `loom config render-env` then restart the daemon (e.g. \
-         `docker compose up -d`) to apply the ambient-process use.",
+         `docker compose up -d`) to apply them.",
         opts.config.config.display()
     );
     Ok(())
@@ -3426,7 +3415,7 @@ async fn cmd_config_set(key: String, value: String) -> Result<()> {
 
 /// Warn to stderr, naming each field, when an ambient env var silently
 /// outranked `loom.toml` for this run — the footgun a deploy workstation hits
-/// when a personal `GH_TOKEN`/`ANTHROPIC_API_KEY` etc. happens to be exported
+/// when an `ANTHROPIC_API_KEY` or similar setting happens to be exported
 /// (see `loom_config::resolve_reporting_shadows`).
 fn warn_shadowed_env(shadowed: &[&str], config_path: &std::path::Path) {
     for name in shadowed {

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -633,20 +633,16 @@ pub(super) async fn set_own_password(
 }
 
 // -- Per-user GitHub token ---------------------------------------------------
-// The caller's own GitHub token (a fine-grained PAT), injected as GH_TOKEN into
-// the sessions they launch so their agents' `git push` / `gh` act as them (see
-// `crate::user_token`). Self-service: every handler acts on the authenticated
-// principal, never an arbitrary username. Write-only — the token is never read
-// back over the API.
+// Loom stores the caller's fine-grained PAT and injects it only into ordinary
+// interactive sessions they launch. It is the sole direct credential source;
+// sessions without one use their profile-approved GitHub App credential.
+// Self-service and write-only: no endpoint ever returns the token value.
 
-/// Body for `PUT /api/auth/github-token`.
 #[derive(Debug, Deserialize)]
 pub(super) struct SetGithubTokenReq {
     token: String,
 }
 
-/// `GET /api/auth/github-token` — whether the caller has set a personal GitHub
-/// token, and when (status only; the token itself is never returned).
 pub(super) async fn get_github_token(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,
@@ -654,8 +650,6 @@ pub(super) async fn get_github_token(
     Ok(Json(user_token::status(&st.db, &principal.username).await?))
 }
 
-/// `PUT /api/auth/github-token` — set/replace the caller's personal GitHub token.
-/// Returns the refreshed status (never the token).
 pub(super) async fn set_github_token(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,
@@ -669,9 +663,6 @@ pub(super) async fn set_github_token(
     Ok(Json(user_token::status(&st.db, &principal.username).await?))
 }
 
-/// `DELETE /api/auth/github-token` — clear the caller's personal GitHub token;
-/// new interactive sessions then retain any credential supplied by the selected
-/// profile.
 pub(super) async fn delete_github_token(
     State(st): State<AppState>,
     Extension(principal): Extension<Principal>,

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -812,6 +812,10 @@ pub fn router(state: AppState) -> Router {
                 .put(set_github_session)
                 .delete(clear_github_session),
         )
+        .route(
+            "/sessions/{id}/github/labels",
+            post(add_github_session_labels),
+        )
         .route("/sessions/{id}/raw", get(raw_session))
         // Embedded VS Code (code-server), reverse-proxied per session. `ide-info`
         // is the UI's availability probe; the `ide`/`ide/`/`ide/*` routes serve
@@ -1107,8 +1111,6 @@ pub fn router(state: AppState) -> Router {
         .route("/runs", get(list_runs).post(create_run))
         .route("/runs/{id}", get(get_run))
         .route("/auth/password", post(set_own_password))
-        // The caller's own GitHub token (a fine-grained PAT), injected as
-        // GH_TOKEN into the sessions they launch so their agents act as them.
         .route(
             "/auth/github-token",
             get(get_github_token)

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -153,6 +153,24 @@ use weaver_api::{
 };
 use weaver_core::branch as branch_mod;
 use weaver_core::branch::Branch;
+
+pub(super) async fn configured_github_app(
+    st: &AppState,
+) -> ApiResult<&crate::github_app::GithubApp> {
+    let app = st.trigger.app().ok_or_else(|| {
+        AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub App credential is unavailable",
+        )
+    })?;
+    if !app.is_configured().await {
+        return Err(AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub App credential is unavailable",
+        ));
+    }
+    Ok(app)
+}
 use weaver_core::tags;
 
 // ---------------------------------------------------------------------------

--- a/crates/loom/src/web/repo_env.rs
+++ b/crates/loom/src/web/repo_env.rs
@@ -50,9 +50,9 @@ pub(super) struct PutRepoEnvBody {
 }
 
 /// `PUT /api/repos/env/{name}` — upsert one per-repo variable. The name (from the
-/// path) is validated as a shell identifier that isn't one of loom's reserved
-/// `WEAVER_`/`LOOM_` names, so it can't corrupt or shadow the launch env that
-/// exports it; the value is free-form and write-only. Returns the refreshed
+/// path) is validated as a shell identifier that isn't one of Loom's reserved
+/// control or GitHub credential names, so it can't corrupt or shadow the launch
+/// environment; the value is free-form and write-only. Returns the refreshed
 /// metadata list (no values).
 pub(super) async fn put_repo_env(
     State(st): State<AppState>,

--- a/crates/loom/src/web/repos.rs
+++ b/crates/loom/src/web/repos.rs
@@ -276,10 +276,9 @@ async fn handle_trigger(
     }
 
     // Resolve the requester to their loom user (proven to exist by `authorize`).
-    // Attributing the launch to them makes their personal GitHub token the
-    // session's `GH_TOKEN` — so its push / `gh` act as them — while preserving
-    // any credential supplied by the selected profile when no personal token
-    // is stored (see `apply_user_github_token`).
+    // Attribution governs ownership and audit and selects this user's optional
+    // Loom-stored Account PAT for the interactive session. Without one, the
+    // selected profile's allowlisted App access is used.
     let username = match crate::auth::user_by_github(&st.db, &author).await {
         Ok(Some(u)) => u.username,
         _ => {

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -48,6 +48,12 @@ pub(super) async fn github_token(
     let session = crate::session::get(&st.db, &id)
         .await?
         .ok_or_else(|| AppError::not_found("session"))?;
+    if session.policy_restricted {
+        return Err(AppError::new(
+            StatusCode::FORBIDDEN,
+            "restricted sessions may use only Loom's server-side GitHub tools",
+        ));
+    }
     let repositories = super::github_access::effective_repositories(&st.db, &session)
         .await
         .map_err(|error| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -1,11 +1,9 @@
 //! Server-side GitHub tools for restricted sessions.
 //!
 //! The agent-facing MCP bridge authenticates with the session token. This
-//! handler resolves the fixed repository and GitHub credential from durable
-//! session/profile state, validates the stamped tool grant, and invokes `gh`
-//! without a shell. Neither the repository nor the token is caller-controlled.
-
-use std::process::Stdio;
+//! handler resolves the fixed repository from durable session state, validates
+//! the stamped tool grant, and calls GitHub through Loom's App client. Neither
+//! the repository nor the credential is caller-controlled.
 
 use axum::{
     extract::{Path, State},
@@ -13,10 +11,10 @@ use axum::{
     Extension, Json,
 };
 use serde::Deserialize;
-use tokio::process::Command;
 use weaver_api::{GithubTokenView, RestrictedGithubToolReq, RestrictedGithubToolView};
 
 use crate::auth::{Grant, Principal};
+use crate::github_app::{GithubApp, GithubThreadKind};
 
 use super::{ApiResult, AppError, AppState};
 
@@ -82,42 +80,6 @@ pub(super) async fn github_token(
     Ok(Json(GithubTokenView { token }))
 }
 
-async fn restricted_github_token(
-    st: &AppState,
-    profile: &str,
-    repo: &crate::repo::RepoSlug,
-) -> ApiResult<String> {
-    if let Some(app) = st.trigger.app() {
-        if app.is_configured().await {
-            return app
-                .token_for_repo(&repo.owner, &repo.name)
-                .await
-                .map_err(|error| {
-                    AppError::new(
-                        StatusCode::BAD_GATEWAY,
-                        format!(
-                            "could not mint a GitHub App token for {}: {error}",
-                            repo.slug()
-                        ),
-                    )
-                });
-        }
-    }
-    if let Some(token) = crate::profile::env_pairs(&st.db, profile)
-        .await
-        .map_err(|error| AppError::new(StatusCode::BAD_GATEWAY, error.to_string()))?
-        .into_iter()
-        .find_map(|(name, value)| (name == "GH_TOKEN").then_some(value))
-        .filter(|value| !value.trim().is_empty())
-    {
-        return Ok(token);
-    }
-    Err(AppError::new(
-        StatusCode::SERVICE_UNAVAILABLE,
-        "restricted GitHub credential is unavailable",
-    ))
-}
-
 fn validate_arguments(tool: &str, value: serde_json::Value) -> ApiResult<ToolArguments> {
     let arguments: ToolArguments = serde_json::from_value(value)
         .map_err(|error| AppError::bad_request(format!("invalid {tool} arguments: {error}")))?;
@@ -158,70 +120,63 @@ fn validate_arguments(tool: &str, value: serde_json::Value) -> ApiResult<ToolArg
     Ok(arguments)
 }
 
-async fn invoke_gh(
-    repo: &str,
+async fn invoke_app(
+    app: &GithubApp,
+    repo: &crate::repo::RepoSlug,
     tool: &str,
     arguments: &ToolArguments,
-    token: &str,
-    config_dir: &std::path::Path,
 ) -> ApiResult<String> {
-    let number = arguments.number.to_string();
     let (kind, verb) = tool
         .split_once('_')
         .ok_or_else(|| AppError::bad_request("invalid restricted GitHub tool"))?;
-    let mut command = Command::new("gh");
-    command
-        .env_clear()
-        .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .env("GH_TOKEN", token)
-        .env("GH_CONFIG_DIR", config_dir)
-        .env("GH_PAGER", "cat")
-        .env("GH_PROMPT_DISABLED", "1")
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("NO_COLOR", "1")
-        .args([kind, verb, &number, "--repo", repo])
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    match verb {
-        "view" => {
-            command.args(["--json", "number,title,body,url,state"]);
-        }
-        "comment" => {
-            command.args(["--body", arguments.body.as_deref().unwrap_or_default()]);
-        }
-        "edit" => {
-            command.args(["--body", arguments.body.as_deref().unwrap_or_default()]);
-            if let Some(title) = arguments.title.as_deref() {
-                command.args(["--title", title]);
+    let kind = match kind {
+        "issue" => GithubThreadKind::Issue,
+        "pr" => GithubThreadKind::PullRequest,
+        _ => return Err(AppError::bad_request("invalid restricted GitHub resource")),
+    };
+    let request = async {
+        match verb {
+            "view" => {
+                let value = app.thread_view(repo, kind, arguments.number).await?;
+                serde_json::to_string(&value).map_err(anyhow::Error::from)
             }
+            "comment" => {
+                app.thread_comment(
+                    repo,
+                    arguments.number,
+                    arguments.body.as_deref().unwrap_or_default(),
+                )
+                .await?;
+                Ok(format!(
+                    "GitHub {tool} completed for {}#{}",
+                    repo.slug(),
+                    arguments.number
+                ))
+            }
+            "edit" => {
+                app.thread_edit(
+                    repo,
+                    kind,
+                    arguments.number,
+                    arguments.title.as_deref(),
+                    arguments.body.as_deref().unwrap_or_default(),
+                )
+                .await?;
+                Ok(format!(
+                    "GitHub {tool} completed for {}#{}",
+                    repo.slug(),
+                    arguments.number
+                ))
+            }
+            _ => Err(anyhow::anyhow!("invalid restricted GitHub verb")),
         }
-        _ => return Err(AppError::bad_request("invalid restricted GitHub verb")),
     }
-    let output = tokio::time::timeout(std::time::Duration::from_secs(60), command.output())
-        .await
-        .map_err(|_| AppError::new(StatusCode::GATEWAY_TIMEOUT, "GitHub tool timed out"))?
-        .map_err(|error| {
-            AppError::new(
-                StatusCode::BAD_GATEWAY,
-                format!("failed to start GitHub CLI: {error}"),
-            )
-        })?;
-    if !output.status.success() {
-        let detail = String::from_utf8_lossy(&output.stderr).replace(token, "[REDACTED]");
-        return Err(AppError::new(
+    .await;
+    request.map_err(|error| {
+        AppError::new(
             StatusCode::BAD_GATEWAY,
-            format!("GitHub {tool} failed: {}", detail.trim()),
-        ));
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout)
-        .replace(token, "[REDACTED]")
-        .trim()
-        .to_string();
-    Ok(if stdout.is_empty() {
-        format!("GitHub {tool} completed for {repo}#{}", arguments.number)
-    } else {
-        stdout
+            format!("GitHub {tool} failed: {error}"),
+        )
     })
 }
 
@@ -270,40 +225,27 @@ pub(super) async fn restricted_github_tool(
             "GitHub tool target does not match the session's linked thread",
         ));
     }
-    let token = restricted_github_token(&st, &session.profile, &repo).await?;
-    let config_dir = crate::db::run_dir(&session.id).join("restricted-gh-config");
-    tokio::fs::create_dir_all(&config_dir)
-        .await
-        .map_err(|error| {
-            AppError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("creating restricted GitHub config directory: {error}"),
-            )
-        })?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o700))
-            .await
-            .map_err(|error| {
-                AppError::new(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("securing restricted GitHub config directory: {error}"),
-                )
-            })?;
+    let app = st.trigger.app().ok_or_else(|| {
+        AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub App credential is unavailable",
+        )
+    })?;
+    if !app.is_configured().await {
+        return Err(AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub App credential is unavailable",
+        ));
     }
-    let text = invoke_gh(&repo_slug, &tool, &arguments, &token, &config_dir).await?;
+    let text = invoke_app(app, &repo, &tool, &arguments).await?;
     Ok(Json(RestrictedGithubToolView { text }))
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use axum::http::StatusCode;
     use serde_json::json;
 
-    use super::{principal_owns_session, restricted_github_token, validate_arguments};
+    use super::{principal_owns_session, validate_arguments};
     use crate::auth::{AuthVia, Grant, Principal};
 
     fn principal(grant: Grant) -> Principal {
@@ -355,42 +297,5 @@ mod tests {
         assert!(
             validate_arguments("issue_edit", json!({ "number": 7, "body": "clean body" })).is_ok()
         );
-    }
-
-    #[tokio::test]
-    async fn github_app_precedes_the_restricted_profile_credential() {
-        let db = crate::db::connect_in_memory().await.unwrap();
-        crate::profile::env_set(&db, "github_comment", "GH_TOKEN", "profile-token")
-            .await
-            .unwrap();
-        let app = Arc::new(crate::github_app::tests::configured_test_app(db.clone()).await);
-        let state = super::AppState {
-            ctx: crate::Ctx {
-                db,
-                bus: crate::events::EventBus::new(),
-                addr: "127.0.0.1:0".to_string(),
-            },
-            ide: Arc::new(crate::ide::IdeManager::new(crate::ide::ide_home())),
-            trigger: crate::github_trigger::GithubTrigger::with_app(app),
-            acp: crate::acp::AcpRegistry::new(),
-            launch_gate: crate::launch_gate::RepoLaunchGate::default(),
-        };
-        let repo = crate::repo::parse_slug("marin-community/loom").unwrap();
-
-        let resolved = restricted_github_token(&state, "github_comment", &repo)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            resolved,
-            crate::github_app::tests::MOCK_INSTALLATION_TOKEN,
-            "the App credential must override the configured profile credential"
-        );
-
-        let uninstalled = crate::repo::parse_slug("uninstalled/loom").unwrap();
-        let error = restricted_github_token(&state, "github_comment", &uninstalled)
-            .await
-            .unwrap_err();
-        assert_eq!(error.status(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -61,18 +61,7 @@ pub(super) async fn github_token(
             "session profile has no GitHub repository credential",
         ));
     }
-    let app = st.trigger.app().ok_or_else(|| {
-        AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "GitHub App credential is unavailable",
-        )
-    })?;
-    if !app.is_configured().await {
-        return Err(AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "GitHub App credential is unavailable",
-        ));
-    }
+    let app = super::configured_github_app(&st).await?;
     let token = app
         .token_for_repositories(&repositories)
         .await
@@ -225,18 +214,7 @@ pub(super) async fn restricted_github_tool(
             "GitHub tool target does not match the session's linked thread",
         ));
     }
-    let app = st.trigger.app().ok_or_else(|| {
-        AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "GitHub App credential is unavailable",
-        )
-    })?;
-    if !app.is_configured().await {
-        return Err(AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "GitHub App credential is unavailable",
-        ));
-    }
+    let app = super::configured_github_app(&st).await?;
     let text = invoke_app(app, &repo, &tool, &arguments).await?;
     Ok(Json(RestrictedGithubToolView { text }))
 }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1229,12 +1229,7 @@ pub(super) async fn add_github_session_labels(
         .ok_or_else(|| AppError::bad_request("session repository has no GitHub identity"))?;
     let repo = crate::repo::parse_slug(&slug)
         .map_err(|_| AppError::bad_request("session GitHub repository is invalid"))?;
-    let app = st.trigger.app().ok_or_else(|| {
-        AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "GitHub App credential is unavailable",
-        )
-    })?;
+    let app = super::configured_github_app(&st).await?;
     app.add_thread_labels(&repo, status.pr_number, &labels)
         .await
         .map_err(|e| github_request_error("label this pull request", e))?;

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1176,11 +1176,6 @@ pub(super) async fn refresh_github_session(
     Path(key): Path<String>,
 ) -> ApiResult<Json<SessionView>> {
     let (session, branch) = require_session(&st.db, &key).await?;
-    if !github::gh_available().await {
-        return Err(AppError::bad_request(
-            "the GitHub CLI (`gh`) is not available on the server",
-        ));
-    }
     github::refresh(&st, &session, &branch, false)
         .await
         .map_err(|e| github_request_error("refresh this pull request", e))?;
@@ -1191,6 +1186,62 @@ pub(super) async fn refresh_github_session(
 #[derive(Debug, Deserialize)]
 pub(super) struct GithubMappingBody {
     pub pr_number: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GithubLabelsBody {
+    pub labels: Vec<String>,
+}
+
+/// Add labels to the pull request currently associated with a session. Watch
+/// programs use this Loom-owned API instead of receiving a GitHub credential
+/// and invoking `gh` themselves.
+pub(super) async fn add_github_session_labels(
+    State(st): State<AppState>,
+    Path(key): Path<String>,
+    Json(req): Json<GithubLabelsBody>,
+) -> ApiResult<Json<Value>> {
+    let (_, branch) = require_session(&st.db, &key).await?;
+    if req.labels.is_empty() || req.labels.len() > 10 {
+        return Err(AppError::bad_request(
+            "GitHub labels must contain between 1 and 10 entries",
+        ));
+    }
+    let labels = req
+        .labels
+        .into_iter()
+        .map(|label| label.trim().to_string())
+        .collect::<Vec<_>>();
+    if labels
+        .iter()
+        .any(|label| label.is_empty() || label.len() > 100)
+    {
+        return Err(AppError::bad_request(
+            "each GitHub label must contain between 1 and 100 bytes",
+        ));
+    }
+    let status = github::get_status(&st.db, &branch.id)
+        .await?
+        .ok_or_else(|| AppError::bad_request("session has no associated pull request"))?;
+    let repo_root = PathBuf::from(&branch.repo_root);
+    let slug = crate::repo::github_slug_for_root(&st.db, &repo_root)
+        .await?
+        .ok_or_else(|| AppError::bad_request("session repository has no GitHub identity"))?;
+    let repo = crate::repo::parse_slug(&slug)
+        .map_err(|_| AppError::bad_request("session GitHub repository is invalid"))?;
+    let app = st.trigger.app().ok_or_else(|| {
+        AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub App credential is unavailable",
+        )
+    })?;
+    app.add_thread_labels(&repo, status.pr_number, &labels)
+        .await
+        .map_err(|e| github_request_error("label this pull request", e))?;
+    Ok(Json(json!({
+        "number": status.pr_number,
+        "labels": labels,
+    })))
 }
 
 /// Pin a session's branch to an explicit PR and fetch that PR immediately. The
@@ -1205,14 +1256,8 @@ pub(super) async fn set_github_session(
     if req.pr_number <= 0 {
         return Err(AppError::bad_request("PR number must be positive"));
     }
-    if !github::gh_available().await {
-        return Err(AppError::bad_request(
-            "the GitHub CLI (`gh`) is not available on the server",
-        ));
-    }
     let repo_root = PathBuf::from(&branch.repo_root);
-    let (token, _) = github::gh_environment(&st, Some(&repo_root)).await;
-    let snap = github::fetch_pr(&repo_root, &req.pr_number.to_string(), token.as_deref())
+    let snap = github::fetch_pr(&st, &repo_root, req.pr_number)
         .await
         .map_err(|e| github_request_error("find this pull request", e))?
         .ok_or_else(|| {
@@ -1242,10 +1287,8 @@ pub(super) async fn clear_github_session(
     let (session, branch) = require_session(&st.db, &key).await?;
     github::clear_mapping(&st.db, &branch.id).await?;
     github::clear_status(&st.db, &branch.id).await?;
-    if github::gh_available().await {
-        if let Err(e) = github::refresh(&st, &session, &branch, false).await {
-            tracing::debug!(branch = %branch.branch, error = %e, "automatic PR refresh after clearing mapping failed");
-        }
+    if let Err(e) = github::refresh(&st, &session, &branch, false).await {
+        tracing::debug!(branch = %branch.branch, error = %e, "automatic PR refresh after clearing mapping failed");
     }
     let (session, branch) = require_session(&st.db, &session.id).await?;
     Ok(Json(session_view(&st.db, &session, &branch).await?))

--- a/crates/loom/tests/docker_github_auth.rs
+++ b/crates/loom/tests/docker_github_auth.rs
@@ -94,10 +94,22 @@ fn git_helper_obeys_loom_owned_auth_mode() {
     assert!(String::from_utf8(incomplete.stderr)
         .unwrap()
         .contains("missing its session credential"));
+
+    let unmarked = run_script(&script, &[("GH_TOKEN", "wrong-daemon-bot")], &["get"]);
+    assert!(!unmarked.status.success());
+    assert!(String::from_utf8(unmarked.stderr)
+        .unwrap()
+        .contains("missing LOOM_GITHUB_AUTH_MODE"));
+
+    let incomplete_direct = run_script(&script, &[("LOOM_GITHUB_AUTH_MODE", "direct")], &["get"]);
+    assert!(!incomplete_direct.status.success());
+    assert!(String::from_utf8(incomplete_direct.stderr)
+        .unwrap()
+        .contains("missing GH_TOKEN"));
 }
 
 #[test]
-fn gh_wrapper_replaces_ambient_tokens_in_broker_mode() {
+fn gh_wrapper_obeys_loom_owned_auth_mode() {
     let script = embedded_script("/usr/local/bin/gh").replace(
         "exec /usr/bin/gh \"$@\"",
         "printf 'GH_TOKEN=%s\\nGITHUB_TOKEN=%s\\n' \"$GH_TOKEN\" \"${GITHUB_TOKEN-unset}\"",
@@ -118,4 +130,52 @@ fn gh_wrapper_replaces_ambient_tokens_in_broker_mode() {
         String::from_utf8(output.stdout).unwrap(),
         "GH_TOKEN=broker-token\nGITHUB_TOKEN=unset\n"
     );
+
+    let direct = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "direct"),
+            ("GH_TOKEN", "personal-token"),
+            ("GITHUB_TOKEN", "wrong-daemon-bot"),
+        ],
+        &["auth", "status"],
+    );
+    assert!(direct.status.success());
+    assert_eq!(
+        String::from_utf8(direct.stdout).unwrap(),
+        "GH_TOKEN=personal-token\nGITHUB_TOKEN=unset\n"
+    );
+
+    let unmarked = run_script(
+        &script,
+        &[("GH_TOKEN", "wrong-daemon-bot")],
+        &["auth", "status"],
+    );
+    assert!(!unmarked.status.success());
+    assert!(String::from_utf8(unmarked.stderr)
+        .unwrap()
+        .contains("missing LOOM_GITHUB_AUTH_MODE"));
+
+    let incomplete_direct = run_script(
+        &script,
+        &[("LOOM_GITHUB_AUTH_MODE", "direct")],
+        &["auth", "status"],
+    );
+    assert!(!incomplete_direct.status.success());
+    assert!(String::from_utf8(incomplete_direct.stderr)
+        .unwrap()
+        .contains("missing GH_TOKEN"));
+
+    let disabled = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "disabled"),
+            ("GH_TOKEN", "wrong-daemon-bot"),
+        ],
+        &["auth", "status"],
+    );
+    assert!(!disabled.status.success());
+    assert!(String::from_utf8(disabled.stderr)
+        .unwrap()
+        .contains("disabled for this Loom session"));
 }

--- a/crates/loom/tests/docker_github_auth.rs
+++ b/crates/loom/tests/docker_github_auth.rs
@@ -1,0 +1,121 @@
+//! Regression coverage for the Git/GitHub CLI adapters authored in Dockerfile.
+
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+const DOCKERFILE: &str = include_str!("../../../Dockerfile");
+
+fn embedded_script(path: &str) -> String {
+    let start = format!("cat > {path} <<'SH'\n");
+    let (_, tail) = DOCKERFILE
+        .split_once(&start)
+        .unwrap_or_else(|| panic!("missing {path} heredoc"));
+    let (script, _) = tail
+        .split_once("\nSH\n")
+        .unwrap_or_else(|| panic!("unterminated {path} heredoc"));
+    script.replace("/usr/local/bin/weaver github-token", "printf broker-token")
+}
+
+fn run_script(script: &str, env: &[(&str, &str)], args: &[&str]) -> Output {
+    let mut child = Command::new("sh")
+        .arg("-s")
+        .args(args)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .envs(env.iter().copied())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(script.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn git_helper_obeys_loom_owned_auth_mode() {
+    let script = embedded_script("/usr/local/bin/git-credential-ghtoken");
+
+    let brokered = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "broker"),
+            ("LOOM_SESSION_ID", "session"),
+            ("LOOM_TOKEN", "session-token"),
+            ("GH_TOKEN", "wrong-daemon-bot"),
+        ],
+        &["get"],
+    );
+    assert!(brokered.status.success());
+    assert_eq!(
+        String::from_utf8(brokered.stdout).unwrap(),
+        "username=x-access-token\npassword=broker-token\n"
+    );
+
+    let direct = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "direct"),
+            ("GH_TOKEN", "personal-token"),
+        ],
+        &["get"],
+    );
+    assert!(direct.status.success());
+    assert_eq!(
+        String::from_utf8(direct.stdout).unwrap(),
+        "username=x-access-token\npassword=personal-token\n"
+    );
+
+    let disabled = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "disabled"),
+            ("GH_TOKEN", "wrong-daemon-bot"),
+        ],
+        &["get"],
+    );
+    assert!(disabled.status.success());
+    assert!(disabled.stdout.is_empty());
+
+    let incomplete = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "broker"),
+            ("GH_TOKEN", "wrong-daemon-bot"),
+        ],
+        &["get"],
+    );
+    assert!(!incomplete.status.success());
+    assert!(String::from_utf8(incomplete.stderr)
+        .unwrap()
+        .contains("missing its session credential"));
+}
+
+#[test]
+fn gh_wrapper_replaces_ambient_tokens_in_broker_mode() {
+    let script = embedded_script("/usr/local/bin/gh").replace(
+        "exec /usr/bin/gh \"$@\"",
+        "printf 'GH_TOKEN=%s\\nGITHUB_TOKEN=%s\\n' \"$GH_TOKEN\" \"${GITHUB_TOKEN-unset}\"",
+    );
+    let output = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "broker"),
+            ("LOOM_SESSION_ID", "session"),
+            ("LOOM_TOKEN", "session-token"),
+            ("GH_TOKEN", "wrong-daemon-bot"),
+            ("GITHUB_TOKEN", "also-wrong"),
+        ],
+        &["auth", "status"],
+    );
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "GH_TOKEN=broker-token\nGITHUB_TOKEN=unset\n"
+    );
+}

--- a/crates/loom/tests/docker_github_auth.rs
+++ b/crates/loom/tests/docker_github_auth.rs
@@ -61,14 +61,14 @@ fn git_helper_obeys_loom_owned_auth_mode() {
         &script,
         &[
             ("LOOM_GITHUB_AUTH_MODE", "direct"),
-            ("GH_TOKEN", "personal-token"),
+            ("GH_TOKEN", "loom-stored-user-token"),
         ],
         &["get"],
     );
     assert!(direct.status.success());
     assert_eq!(
         String::from_utf8(direct.stdout).unwrap(),
-        "username=x-access-token\npassword=personal-token\n"
+        "username=x-access-token\npassword=loom-stored-user-token\n"
     );
 
     let disabled = run_script(
@@ -135,7 +135,7 @@ fn gh_wrapper_obeys_loom_owned_auth_mode() {
         &script,
         &[
             ("LOOM_GITHUB_AUTH_MODE", "direct"),
-            ("GH_TOKEN", "personal-token"),
+            ("GH_TOKEN", "loom-stored-user-token"),
             ("GITHUB_TOKEN", "wrong-daemon-bot"),
         ],
         &["auth", "status"],
@@ -143,7 +143,7 @@ fn gh_wrapper_obeys_loom_owned_auth_mode() {
     assert!(direct.status.success());
     assert_eq!(
         String::from_utf8(direct.stdout).unwrap(),
-        "GH_TOKEN=personal-token\nGITHUB_TOKEN=unset\n"
+        "GH_TOKEN=loom-stored-user-token\nGITHUB_TOKEN=unset\n"
     );
 
     let unmarked = run_script(

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -2989,7 +2989,7 @@ async fn handoff_replaces_provider_and_continues_the_journal() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn canonical_handoff_selects_a_strict_profile_and_rejects_class_mismatch() {
-    let ts = TestServer::start().await;
+    let ts = TestServer::start_with_app().await;
     loom::repo::register(
         &ts.state.db,
         "marin-community/marin",
@@ -3839,11 +3839,6 @@ async fn preview_renders_the_journal_tail_as_text() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn builtin_codex_launches_over_codex_acp() {
     let ts = TestServer::start().await;
-    // A builtin launch passes the GitHub-token gate through Loom's resolved
-    // profile environment, never through the test runner's ambient identity.
-    loom::profile::env_set(&ts.state.db, "default", "GH_TOKEN", "test-token")
-        .await
-        .unwrap();
     weaver_core::config::apply(
         &ts.state.db,
         &[("acp.codex_cmd".to_string(), Some(agent_cmd()))],

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -3838,9 +3838,12 @@ async fn preview_renders_the_journal_tail_as_text() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn builtin_codex_launches_over_codex_acp() {
-    // A builtin launch passes the GitHub-token gate; CI has no ambient token.
-    let _token = EnvVarSet::set("GH_TOKEN", "test-token");
     let ts = TestServer::start().await;
+    // A builtin launch passes the GitHub-token gate through Loom's resolved
+    // profile environment, never through the test runner's ambient identity.
+    loom::profile::env_set(&ts.state.db, "default", "GH_TOKEN", "test-token")
+        .await
+        .unwrap();
     weaver_core::config::apply(
         &ts.state.db,
         &[("acp.codex_cmd".to_string(), Some(agent_cmd()))],

--- a/crates/loom/tests/integration/auth.rs
+++ b/crates/loom/tests/integration/auth.rs
@@ -21,6 +21,51 @@ fn url(ts: &TestServer, path: &str) -> String {
 
 #[tokio::test]
 #[serial]
+async fn personal_github_token_is_self_service_and_write_only() {
+    let ts = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let endpoint = url(&ts, "/api/auth/github-token");
+
+    let initial: Value = http
+        .get(&endpoint)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(initial, json!({ "set": false, "updated_at": null }));
+
+    let stored: Value = http
+        .put(&endpoint)
+        .json(&json!({ "token": "github_pat_write_only" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(stored["set"], true);
+    assert!(stored["updated_at"].is_string());
+    assert!(!stored.to_string().contains("github_pat_write_only"));
+    assert_eq!(
+        loom::user_token::get(&ts.state.db, "rjpower")
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("github_pat_write_only")
+    );
+
+    let deleted = http.delete(&endpoint).send().await.unwrap();
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+    assert!(loom::user_token::get(&ts.state.db, "rjpower")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+#[serial]
 async fn loopback_trust_then_token_local_and_cookie_gate_access() {
     let ts = TestServer::start().await;
     let http = reqwest::Client::new();

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -196,7 +196,13 @@ impl TestServer {
         let addr = listener.local_addr().unwrap();
         let pool = db::connect(&db::default_db_path()).await.unwrap();
         let trigger = match github {
-            GithubFixture::Gateway(gh) => loom::github_trigger::GithubTrigger::with_gateway(gh),
+            GithubFixture::Gateway(gh) => {
+                let app = loom::github_app::tests::configured_test_app(pool.clone()).await;
+                loom::github_trigger::GithubTrigger::with_gateway_and_app(
+                    gh,
+                    std::sync::Arc::new(app),
+                )
+            }
             GithubFixture::ConfiguredApp => {
                 let app = loom::github_app::tests::configured_test_app(pool.clone()).await;
                 loom::github_trigger::GithubTrigger::with_app(std::sync::Arc::new(app))

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -130,6 +130,12 @@ pub struct TestServer {
     _home: TempDir,
 }
 
+enum GithubFixture {
+    Production,
+    Gateway(std::sync::Arc<dyn loom::github_trigger::GithubApi>),
+    ConfiguredApp,
+}
+
 impl Drop for TestServer {
     fn drop(&mut self) {
         // Tear down detached terminal supervisors before the home (and its
@@ -143,36 +149,31 @@ impl TestServer {
     /// answer `/api/health`. The caller must be `#[serial]`: setup writes
     /// process-global env.
     pub async fn start() -> Self {
-        Self::start_inner(None, true, false).await
+        Self::start_inner(GithubFixture::Production, true).await
     }
 
     /// Boot the REST server and database without initializing the fixture
     /// directory as a Git repository. API journeys that never provision a
     /// session should use this cheaper boundary.
     pub async fn start_api_only() -> Self {
-        Self::start_inner(None, false, false).await
+        Self::start_inner(GithubFixture::Production, false).await
     }
 
-    /// Like [`start`](Self::start) but installs `gh` as the GitHub trigger's
-    /// gateway, so the webhook suite can drive the permission check + reply with
-    /// a fake instead of the real `gh` CLI.
+    /// Like [`start`](Self::start) but installs a fake GitHub trigger gateway so
+    /// the webhook suite can drive the permission check and reply in-process.
     pub async fn start_with_github(
         gh: std::sync::Arc<dyn loom::github_trigger::GithubApi>,
     ) -> Self {
-        Self::start_inner(Some(gh), true, false).await
+        Self::start_inner(GithubFixture::Gateway(gh), true).await
     }
 
     /// Boot with a configured App client pointed at Loom's mock GitHub REST
     /// service. Used by journeys that exercise App-owned server operations.
     pub async fn start_with_app() -> Self {
-        Self::start_inner(None, true, true).await
+        Self::start_inner(GithubFixture::ConfiguredApp, true).await
     }
 
-    async fn start_inner(
-        gh: Option<std::sync::Arc<dyn loom::github_trigger::GithubApi>>,
-        initialize_repo: bool,
-        configured_app: bool,
-    ) -> Self {
+    async fn start_inner(github: GithubFixture, initialize_repo: bool) -> Self {
         // Isolate weaver state in a temp home (its own db) for the lifetime of
         // the test; that home also scopes the `tapestry` socket dir. Point loom
         // at the sibling supervisor binary.
@@ -194,14 +195,15 @@ impl TestServer {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let pool = db::connect(&db::default_db_path()).await.unwrap();
-        let trigger = match (gh, configured_app) {
-            (Some(gh), false) => loom::github_trigger::GithubTrigger::with_gateway(gh),
-            (None, true) => {
+        let trigger = match github {
+            GithubFixture::Gateway(gh) => loom::github_trigger::GithubTrigger::with_gateway(gh),
+            GithubFixture::ConfiguredApp => {
                 let app = loom::github_app::tests::configured_test_app(pool.clone()).await;
                 loom::github_trigger::GithubTrigger::with_app(std::sync::Arc::new(app))
             }
-            (None, false) => loom::github_trigger::GithubTrigger::production(pool.clone()),
-            (Some(_), true) => unreachable!("test server selects one GitHub gateway"),
+            GithubFixture::Production => {
+                loom::github_trigger::GithubTrigger::production(pool.clone())
+            }
         };
         let state = AppState {
             ctx: Ctx {

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -143,14 +143,14 @@ impl TestServer {
     /// answer `/api/health`. The caller must be `#[serial]`: setup writes
     /// process-global env.
     pub async fn start() -> Self {
-        Self::start_inner(None, true).await
+        Self::start_inner(None, true, false).await
     }
 
     /// Boot the REST server and database without initializing the fixture
     /// directory as a Git repository. API journeys that never provision a
     /// session should use this cheaper boundary.
     pub async fn start_api_only() -> Self {
-        Self::start_inner(None, false).await
+        Self::start_inner(None, false, false).await
     }
 
     /// Like [`start`](Self::start) but installs `gh` as the GitHub trigger's
@@ -159,12 +159,19 @@ impl TestServer {
     pub async fn start_with_github(
         gh: std::sync::Arc<dyn loom::github_trigger::GithubApi>,
     ) -> Self {
-        Self::start_inner(Some(gh), true).await
+        Self::start_inner(Some(gh), true, false).await
+    }
+
+    /// Boot with a configured App client pointed at Loom's mock GitHub REST
+    /// service. Used by journeys that exercise App-owned server operations.
+    pub async fn start_with_app() -> Self {
+        Self::start_inner(None, true, true).await
     }
 
     async fn start_inner(
         gh: Option<std::sync::Arc<dyn loom::github_trigger::GithubApi>>,
         initialize_repo: bool,
+        configured_app: bool,
     ) -> Self {
         // Isolate weaver state in a temp home (its own db) for the lifetime of
         // the test; that home also scopes the `tapestry` socket dir. Point loom
@@ -187,9 +194,14 @@ impl TestServer {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let pool = db::connect(&db::default_db_path()).await.unwrap();
-        let trigger = match gh {
-            Some(gh) => loom::github_trigger::GithubTrigger::with_gateway(gh),
-            None => loom::github_trigger::GithubTrigger::production(pool.clone()),
+        let trigger = match (gh, configured_app) {
+            (Some(gh), false) => loom::github_trigger::GithubTrigger::with_gateway(gh),
+            (None, true) => {
+                let app = loom::github_app::tests::configured_test_app(pool.clone()).await;
+                loom::github_trigger::GithubTrigger::with_app(std::sync::Arc::new(app))
+            }
+            (None, false) => loom::github_trigger::GithubTrigger::production(pool.clone()),
+            (Some(_), true) => unreachable!("test server selects one GitHub gateway"),
         };
         let state = AppState {
             ctx: Ctx {

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -644,7 +644,6 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
         "WEAVER_CLAUDE_ACP_CMD",
         &crate::fixtures::fake_acp_agent_cmd(),
     );
-    let _github_token = EnvVarGuard::set("GH_TOKEN", "test-token");
     let ts = TestServer::start().await;
     ts.client
         .post(
@@ -663,6 +662,9 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
                 "prelude": "none"
             }),
         )
+        .await
+        .unwrap();
+    loom::profile::env_set(&ts.state.db, "ops", "GH_TOKEN", "test-token")
         .await
         .unwrap();
 

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -487,6 +487,26 @@ async fn restricted_github_profile_launch_wires_policy_prompt_and_server_token()
         .unwrap()
         .starts_with("sha256:"));
     let id = session["id"].as_str().unwrap();
+    let stored_session = loom::session::get(&ts.state.db, id).await.unwrap().unwrap();
+    let session_token = loom::auth::create_session_token(
+        &ts.state.db,
+        stored_session.created_by.as_deref(),
+        id,
+        &stored_session.branch_id,
+    )
+    .await
+    .unwrap();
+    let token_response = reqwest::Client::new()
+        .post(format!("http://{}/api/sessions/{id}/github/token", ts.addr))
+        .bearer_auth(session_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        token_response.status(),
+        StatusCode::FORBIDDEN,
+        "restricted agents must not retrieve the server-side credential"
+    );
     assert!(ts
         .client
         .put(

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -3,7 +3,6 @@
 use reqwest::StatusCode;
 use serde_json::json;
 use serial_test::serial;
-use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
 use crate::fixtures::TestServer;
@@ -429,41 +428,12 @@ print("custom tests passed")
 
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn restricted_github_profile_launch_wires_policy_prompt_and_server_token() {
-    let dir = tempfile::tempdir().unwrap();
-    let gh = dir.path().join("gh");
-    std::fs::write(
-        &gh,
-        "#!/bin/sh\n\
-         case \"$GH_TOKEN\" in\n\
-           server-only-token) printf 'profile:' ;;\n\
-           *) exit 17 ;;\n\
-         esac\n\
-         printf '%s' \"$*\"\n",
-    )
-    .unwrap();
-    std::fs::set_permissions(&gh, std::fs::Permissions::from_mode(0o755)).unwrap();
-    let path = format!(
-        "{}:{}",
-        dir.path().display(),
-        std::env::var("PATH").unwrap_or_default()
-    );
-    let _path = EnvVarGuard::set("PATH", &path);
+async fn restricted_github_profile_launch_wires_policy_prompt_and_server_api() {
     let _adapter = EnvVarGuard::set(
         "WEAVER_CLAUDE_ACP_CMD",
         &crate::fixtures::fake_acp_agent_cmd(),
     );
-    let ts = TestServer::start().await;
-    ts.client
-        .put(
-            "/api/profiles/github_comment/env/GH_TOKEN",
-            json!({ "value": "server-only-token" }),
-        )
-        .await
-        .unwrap();
-    loom::user_token::set(&ts.state.db, "rjpower", "requester-token")
-        .await
-        .unwrap();
+    let ts = TestServer::start_with_app().await;
     let goal = "say:ready";
     let session = ts
         .client
@@ -592,14 +562,7 @@ async fn restricted_github_profile_launch_wires_policy_prompt_and_server_token()
         .await
         .unwrap();
     let text = response["text"].as_str().unwrap();
-    assert!(text.contains("profile:issue edit 7 --repo octo/fixed --body clean body"));
-    assert!(!text.contains("server-only-token"));
-    let config_mode = std::fs::metadata(loom::db::run_dir(id).join("restricted-gh-config"))
-        .unwrap()
-        .permissions()
-        .mode()
-        & 0o777;
-    assert_eq!(config_mode, 0o700);
+    assert!(text.contains("GitHub issue_edit completed for octo/fixed#7"));
 
     let second_response = ts
         .client
@@ -609,10 +572,10 @@ async fn restricted_github_profile_launch_wires_policy_prompt_and_server_token()
         )
         .await
         .unwrap();
-    assert!(second_response["text"]
-        .as_str()
-        .unwrap()
-        .contains("profile:issue view 7 --repo octo/fixed"));
+    let viewed: serde_json::Value =
+        serde_json::from_str(second_response["text"].as_str().unwrap()).unwrap();
+    assert_eq!(viewed["number"], 7);
+    assert_eq!(viewed["title"], "issue 7 of octo/fixed");
     assert!(ts
         .client
         .post(
@@ -664,10 +627,6 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
         )
         .await
         .unwrap();
-    loom::profile::env_set(&ts.state.db, "ops", "GH_TOKEN", "test-token")
-        .await
-        .unwrap();
-
     let first_request = json!({
         "profile": "ops",
         "source": "grafana",

--- a/crates/loom/tests/integration/programs/echo_env.py
+++ b/crates/loom/tests/integration/programs/echo_env.py
@@ -1,11 +1,4 @@
-"""Test fixture: echo the GH_TOKEN this watch subprocess received.
-
-Watches run env-stripped; loom injects the operator's GH_TOKEN (Settings →
-Environment) into the subprocess so github watches (pr-label, review-wait,
-archive-merged) can shell out to `gh`. This program echoes the value it was
-handed into its round summary, so an integration test can assert that injection
-end-to-end.
-"""
+"""Test fixture: expose whether a watch subprocess inherited ``GH_TOKEN``."""
 
 import os
 

--- a/crates/loom/tests/integration/repos.rs
+++ b/crates/loom/tests/integration/repos.rs
@@ -45,14 +45,26 @@ fn make_bare_remote(root: &std::path::Path) -> String {
     format!("file://{}", bare.display())
 }
 
+async fn allow_app_access(ts: &TestServer) {
+    let mut profile = loom::profile::get(&ts.state.db, loom::profile::DEFAULT_PROFILE)
+        .await
+        .unwrap()
+        .unwrap()
+        .as_input()
+        .unwrap();
+    profile.github_repositories = vec!["acme/widgets".to_string()];
+    loom::profile::upsert(&ts.state.db, &profile).await.unwrap();
+}
+
 /// Register a repo, then create a session against it by slug (no `cwd`): loom
 /// clones the registered remote into the managed store and forks the worktree
 /// from that managed checkout.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn register_then_launch_clones_into_managed_store() {
-    let ts = TestServer::start().await;
+    let ts = TestServer::start_with_app().await;
     let client = &ts.client;
+    allow_app_access(&ts).await;
 
     let remotes = tempfile::tempdir().unwrap();
     let remote_url = make_bare_remote(remotes.path());
@@ -129,8 +141,9 @@ async fn register_then_launch_clones_into_managed_store() {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn launching_into_an_unregistered_repo_registers_and_clones_it() {
-    let ts = TestServer::start().await;
+    let ts = TestServer::start_with_app().await;
     let client = &ts.client;
+    allow_app_access(&ts).await;
 
     let remotes = tempfile::tempdir().unwrap();
     let remote_url = make_bare_remote(remotes.path());

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -1,6 +1,7 @@
 //! Session lifecycle over the REST API: create → list → recent-repos → delete,
 //! plus adoption of an externally-killed session and the no-goal create path.
 
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
 use serde_json::json;
@@ -16,12 +17,6 @@ struct EnvVarGuard {
 }
 
 impl EnvVarGuard {
-    fn unset(name: &'static str) -> Self {
-        let value = std::env::var_os(name);
-        std::env::remove_var(name);
-        Self { name, value }
-    }
-
     fn set(name: &'static str, new_value: &str) -> Self {
         let value = std::env::var_os(name);
         std::env::set_var(name, new_value);
@@ -169,14 +164,23 @@ async fn session_creation_waits_for_the_repository_launch_gate() {
         .unwrap();
 }
 
-/// A real agent launch needs a user token, a profile token, or an allowlisted
-/// GitHub App credential. Without one, reject before provisioning anything.
+/// A real agent launch against a GitHub repository needs either the launching
+/// user's Account PAT or allowlisted App access. Without either, reject before
+/// provisioning anything.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn real_agent_without_github_token_is_rejected_before_provisioning() {
-    let _env = EnvVarGuard::unset("GH_TOKEN");
+async fn real_agent_without_github_access_is_rejected_before_provisioning() {
     let ts = TestServer::start().await;
     let client = &ts.client;
+    let repo_root = ts.repo_path().canonicalize().unwrap();
+    loom::repo::register(
+        &ts.state.db,
+        "marin-community/marin",
+        "https://github.com/marin-community/marin.git",
+        &repo_root.to_string_lossy(),
+    )
+    .await
+    .unwrap();
 
     let err = client
         .post(
@@ -206,12 +210,71 @@ async fn real_agent_without_github_token_is_rejected_before_provisioning() {
     );
 }
 
+/// A user's Account token is Loom's sole direct-token source. It permits an
+/// interactive GitHub launch without App access and reaches the stock client
+/// adapters together with the explicit `direct` mode stamp.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interactive_session_uses_the_launching_users_account_token() {
+    let ts = TestServer::start().await;
+    let repo_root = ts.repo_path().canonicalize().unwrap();
+    loom::repo::register(
+        &ts.state.db,
+        "marin-community/marin",
+        "https://github.com/marin-community/marin.git",
+        &repo_root.to_string_lossy(),
+    )
+    .await
+    .unwrap();
+    loom::user_token::set(&ts.state.db, "rjpower", "github_pat_test_user")
+        .await
+        .unwrap();
+
+    let capture = ts.repo_path().join("credential-capture.txt");
+    let wrapper = ts.repo_path().join("capture-acp.sh");
+    std::fs::write(
+        &wrapper,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n%s\\n' \"$LOOM_GITHUB_AUTH_MODE\" \"$GH_TOKEN\" > '{}'\nexec {}\n",
+            capture.display(),
+            crate::fixtures::fake_acp_agent_cmd(),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let _adapter = EnvVarGuard::set("WEAVER_CODEX_ACP_CMD", &wrapper.to_string_lossy());
+
+    let session = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "use my GitHub identity",
+                "cwd": ts.cwd(),
+                "agent": "codex",
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&capture).unwrap(),
+        "direct\ngithub_pat_test_user\n"
+    );
+
+    ts.client
+        .delete(&format!(
+            "/api/sessions/{}",
+            session["id"].as_str().unwrap()
+        ))
+        .await
+        .unwrap();
+}
+
 /// An interactive profile can use the configured GitHub App as its default
 /// credential while stamping only the current allowlisted repository.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn interactive_profile_brokers_its_current_github_repository() {
-    let _ambient = EnvVarGuard::unset("GH_TOKEN");
     let _adapter = EnvVarGuard::set(
         "WEAVER_CODEX_ACP_CMD",
         &crate::fixtures::fake_acp_agent_cmd(),

--- a/crates/loom/tests/integration/watches.rs
+++ b/crates/loom/tests/integration/watches.rs
@@ -93,9 +93,8 @@ fn survey_program() -> String {
     .to_string()
 }
 
-/// Fixture that echoes the `GH_TOKEN` it was handed into its summary, so a test
-/// can assert loom injects the operator's token into the (otherwise env-stripped)
-/// watch subprocess — what github watches need for their own `gh` calls.
+/// Fixture that echoes `GH_TOKEN` so a test can assert credentials do not leak
+/// into an otherwise capability-scoped watch subprocess.
 fn echo_env_program() -> String {
     concat!(
         env!("CARGO_MANIFEST_DIR"),
@@ -927,14 +926,11 @@ async fn rest_watch_lifecycle_and_validation() {
 
 use loom::builtins::python3_available;
 
-/// A github watch shells out to `gh` (reading PR labels/state); loom must inject
-/// the operator's `GH_TOKEN` (Settings → Agents & profiles) into the otherwise
-/// env-stripped watch subprocess, or every github watch (pr-label, review-wait,
-/// archive-merged) is blind. The explicit inject wins over any ambient value, so
-/// the exact token reaches the process.
+/// GitHub watches consume Loom-owned PR snapshots over the API. They must not
+/// receive raw GitHub credentials in their subprocess environment.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn watch_subprocess_receives_operator_gh_token() {
+async fn watch_subprocess_does_not_receive_github_credentials() {
     if !python3_available() {
         eprintln!("skipping: python3 not on PATH");
         return;
@@ -955,10 +951,6 @@ async fn watch_subprocess_receives_operator_gh_token() {
     )
     .await;
 
-    // Set the operator token (Settings → Agents & profiles) and fire a manual round.
-    loom::agent_env::set(&state.db, "GH_TOKEN", "ghtok-marker-xyz")
-        .await
-        .unwrap();
     let run_id = watch::fire_now(&state, &o.name, false, "manual")
         .await
         .unwrap();
@@ -968,8 +960,8 @@ async fn watch_subprocess_receives_operator_gh_token() {
         .unwrap();
     let run = runs.iter().find(|r| r.id == run_id).unwrap();
     assert_eq!(
-        run.summary, "token[ghtok-marker-xyz]",
-        "the operator's GH_TOKEN reaches the env-stripped watch subprocess"
+        run.summary, "token[]",
+        "GitHub credentials stay out of the env-stripped watch subprocess"
     );
 }
 

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -527,7 +527,7 @@ async fn happy_path_creates_session_and_replies() {
     assert_eq!(
         session["created_by"].as_str(),
         Some("rjpower"),
-        "the session is attributed to the commenting user, so its GH_TOKEN is theirs"
+        "attribution selects the commenter's Account PAT and records ownership/audit"
     );
 
     // loom replied on the triggering issue with the session URL.

--- a/crates/loom/tests/integration/webhook.rs
+++ b/crates/loom/tests/integration/webhook.rs
@@ -164,6 +164,23 @@ async fn prepare_repo(ts: &TestServer) -> tempfile::TempDir {
         .post("/api/repos", json!({ "repo": url }))
         .await
         .unwrap();
+    // The webhook's ordinary interactive session has no Account PAT in this
+    // fixture, so explicitly approve its repository for the App broker through
+    // the selected profile, just as an operator would in production.
+    let profile_name = weaver_core::config::get_or(
+        &ts.state.db,
+        "github.profile",
+        weaver_core::config::DEFAULT_GITHUB_PROFILE,
+    )
+    .await;
+    let mut profile = loom::profile::get(&ts.state.db, &profile_name)
+        .await
+        .unwrap()
+        .unwrap()
+        .as_input()
+        .unwrap();
+    profile.github_repositories = vec!["acme/widgets".to_string()];
+    loom::profile::upsert(&ts.state.db, &profile).await.unwrap();
     // The webhook builds a CreateReq with no agent, so it uses `agent.default`;
     // pin it to `shell` so the test doesn't try to launch a real claude.
     ts.client

--- a/crates/loom/tests/repo_setup.rs
+++ b/crates/loom/tests/repo_setup.rs
@@ -114,6 +114,7 @@ async fn start_server() -> (TestHome, loom::client::Client, db::Db, String) {
     )
     .await
     .unwrap();
+    let app = loom::github_app::tests::configured_test_app(pool.clone()).await;
     let state = AppState {
         ctx: Ctx {
             db: pool.clone(),
@@ -121,7 +122,7 @@ async fn start_server() -> (TestHome, loom::client::Client, db::Db, String) {
             addr: addr.to_string(),
         },
         ide: std::sync::Arc::new(loom::ide::IdeManager::new(loom::ide::ide_home())),
-        trigger: loom::github_trigger::GithubTrigger::production(pool.clone()),
+        trigger: loom::github_trigger::GithubTrigger::with_app(std::sync::Arc::new(app)),
         acp: loom::acp::AcpRegistry::new(),
         launch_gate: loom::launch_gate::RepoLaunchGate::default(),
     };
@@ -136,6 +137,25 @@ async fn start_server() -> (TestHome, loom::client::Client, db::Db, String) {
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
     (home, client, pool, addr.to_string())
+}
+
+async fn register_managed_repo(pool: &db::Db, repo_root: &Path) {
+    repo::register(
+        pool,
+        "acme/widgets",
+        "https://example/acme/widgets.git",
+        &repo_root.to_string_lossy(),
+    )
+    .await
+    .unwrap();
+    let mut profile = loom::profile::get(pool, loom::profile::DEFAULT_PROFILE)
+        .await
+        .unwrap()
+        .unwrap()
+        .as_input()
+        .unwrap();
+    profile.github_repositories = vec!["acme/widgets".to_string()];
+    loom::profile::upsert(pool, &profile).await.unwrap();
 }
 
 async fn create_shell_session(client: &client::Client, cwd: &Path) -> Value {
@@ -171,14 +191,7 @@ async fn setup_runs_for_allowlisted_repo() {
         repo_with_config("[setup]\nscript = \"echo SETUP_RAN\\ntouch setup-marker\"\n");
 
     // Allowlist the repo (register its path as a managed repo).
-    repo::register(
-        &pool,
-        "acme/widgets",
-        "https://example/acme/widgets.git",
-        &repo_root.to_string_lossy(),
-    )
-    .await
-    .unwrap();
+    register_managed_repo(&pool, &repo_root).await;
 
     let ws = create_shell_session(&client, &repo_root).await;
     let id = ws["id"].as_str().unwrap().to_string();
@@ -217,14 +230,7 @@ async fn setup_runs_for_allowlisted_repo() {
 async fn setup_failure_marks_session_error() {
     let (_home, client, pool, _addr) = start_server().await;
     let (_dir, repo_root) = repo_with_config("[setup]\nscript = \"echo BOOM\\nexit 3\"\n");
-    repo::register(
-        &pool,
-        "acme/widgets",
-        "https://example/acme/widgets.git",
-        &repo_root.to_string_lossy(),
-    )
-    .await
-    .unwrap();
+    register_managed_repo(&pool, &repo_root).await;
 
     let ws = create_shell_session(&client, &repo_root).await;
     let id = ws["id"].as_str().unwrap().to_string();
@@ -324,14 +330,7 @@ async fn env_layers_global_then_repo_then_config_file() {
     .await
     .unwrap();
 
-    repo::register(
-        &pool,
-        "acme/widgets",
-        "https://example/acme/widgets.git",
-        &repo_root.to_string_lossy(),
-    )
-    .await
-    .unwrap();
+    register_managed_repo(&pool, &repo_root).await;
 
     let ws = create_shell_session(&client, &repo_root).await;
     let id = ws["id"].as_str().unwrap().to_string();

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -3067,8 +3067,9 @@ pub struct GithubConfigView {
     /// (`/api/auth/github/callback`).
     pub callback_path: String,
     /// Whether the App identity (id **and** private key) is configured — i.e.
-    /// the `@loom` trigger acts through the App rather than the ambient
-    /// `GH_TOKEN`. The same App normally backs sign-in above.
+    /// App-backed `@loom` operations and session GitHub access are available.
+    /// Interactive sessions may instead use their launching user's Account PAT.
+    /// The same App normally backs sign-in above.
     pub app_configured: bool,
     /// The App's numeric id (public). Empty when unset.
     pub app_id: String,

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -97,10 +97,8 @@ fn token_auth_envs(token: &str) -> Vec<(&'static str, String)> {
 /// converge instead of one erroring on a populated directory.
 ///
 /// `token` authenticates this one clone/fetch with a caller-supplied credential
-/// (e.g. a GitHub App installation token) via [`token_auth_envs`]. Pass `None`
-/// to fall back to the ambient git credential helper (the deploy image wires
-/// `GH_TOKEN`) — the only behavior before per-call tokens existed, still used
-/// for repos with no App installation.
+/// (a GitHub App installation token) via [`token_auth_envs`]. `None` performs an
+/// unauthenticated operation; there is no ambient credential fallback.
 pub async fn clone(url: &str, dest: &Path, token: Option<&str>) -> Result<()> {
     let envs = token.map(token_auth_envs).unwrap_or_default();
     // An existing clone (its `.git` is present) is refreshed, not re-cloned.

--- a/crates/weaver-core/src/git.rs
+++ b/crates/weaver-core/src/git.rs
@@ -98,7 +98,7 @@ fn token_auth_envs(token: &str) -> Vec<(&'static str, String)> {
 ///
 /// `token` authenticates this one clone/fetch with a caller-supplied credential
 /// (a GitHub App installation token) via [`token_auth_envs`]. `None` performs an
-/// unauthenticated operation; there is no ambient credential fallback.
+/// unauthenticated operation.
 pub async fn clone(url: &str, dest: &Path, token: Option<&str>) -> Result<()> {
     let envs = token.map(token_auth_envs).unwrap_or_default();
     // An existing clone (its `.git` is present) is refreshed, not re-cloned.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -104,7 +104,7 @@ and why; you don't hand-edit `.env` itself.
 |---|---|---|
 | `LOOM_DOMAIN` | **yes** | Public domain Caddy serves and gets a cert for (e.g. `loom.team.dev`); `localhost` for local testing. Also seeded as `auth.base_url`. |
 | `LOOM_OWNER_GITHUB` | **yes** | GitHub login seeded as the first approved user on a fresh database — the only account that can sign in until it approves others. Approved users are also who may drive the `@loom` trigger; add more in **Settings → Approved users**. |
-| `LOOM_GITHUB_APP_ID` / `_PRIVATE_KEY` | **yes** | GitHub App identity Loom uses to mint repository-scoped installation tokens for clones, polling, replies, server-side GitHub tools, and interactive sessions whose user has no Account PAT. |
+| `LOOM_GITHUB_APP_ID` / `_PRIVATE_KEY` | **yes** | GitHub App identity Loom uses to mint repository-scoped installation tokens for clones, polling, replies, server-side GitHub tools, and profile-approved interactive sessions. |
 | `LOOM_GITHUB_WEBHOOK_SECRET` | for `@loom` | Shared secret for the inbound webhook; must match the secret on the GitHub webhook. Until set, the webhook rejects every delivery. |
 | `LOOM_SLACK_APP_TOKEN` / `LOOM_SLACK_BOT_TOKEN` | for `/marinbot` | App-level and bot OAuth tokens for the Slack Socket Mode trigger. Both unset (the default) leaves it off. See [docs/slack-trigger.md](../docs/slack-trigger.md). |
 | `ANTHROPIC_API_KEY` | for Claude | API key for the Claude agents. Alternatively log in interactively (see [first-run](#agent-authentication)). |
@@ -122,11 +122,11 @@ invocation without touching `loom.toml`, by exporting the same-named env var:
 `loom config render-env`/`push-secrets` resolve `loom.toml` *and* the process
 environment, with the environment winning (see `loom_config`'s module docs).
 
-There is no deployment `GH_TOKEN`. Loom uses its GitHub App for daemon and
-server-side GitHub operations. An ordinary interactive session uses the
-launching user's optional PAT stored under **Settings → Account**, or brokers
-the selected profile's allowlisted App access when that PAT is absent. Session
-runtimes still need their model-provider keys. Run
+Loom uses its GitHub App for daemon and server-side GitHub operations. For
+ordinary interactive sessions, users may set an Account PAT under **Settings →
+Account**; Loom prefers that identity and otherwise brokers the selected
+profile's allowlisted App access. Session runtimes also need their
+model-provider keys. Run
 `loom setup secrets --config /home/app/loom.toml` via `docker compose exec loom`
 against the running deploy, or as part of the [Quick start](#quick-start)
 sequence before first start. It prompts for `ANTHROPIC_API_KEY` and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -125,7 +125,9 @@ environment, with the environment winning (see `loom_config`'s module docs).
 `GH_TOKEN` and `ANTHROPIC_API_KEY` here cover the daemon's own ambient use
 (cloning private repos; the Claude launch-gate). The daemon's `GH_TOKEN` is not
 automatically a session's push identity: Loom explicitly selects a personal or
-profile token, or brokers an allowlisted GitHub App token, for each session.
+profile token, or brokers an allowlisted GitHub App token, for each session;
+brokered and disabled sessions receive empty token variables that mask the
+daemon environment.
 Session runtimes still need their provider keys. Run
 `loom setup secrets --config /home/app/loom.toml` via `docker compose exec loom`
 against the running deploy, or as part of the [Quick start](#quick-start)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -123,14 +123,17 @@ invocation without touching `loom.toml`, by exporting the same-named env var:
 environment, with the environment winning (see `loom_config`'s module docs).
 
 `GH_TOKEN` and `ANTHROPIC_API_KEY` here cover the daemon's own ambient use
-(cloning private repos; the Claude launch-gate). Every *session* loom launches
-also needs them — `loom setup secrets --config /home/app/loom.toml` (run via
-`docker compose exec loom` against the running deploy, or as part of the
-[Quick start](#quick-start) sequence before first start) prompts for the agent
-keys (`ANTHROPIC_API_KEY` for Claude, `OPENAI_API_KEY` for Codex) and `GH_TOKEN`,
-and stores them as operator environment variables, live for every session from
-then on, no restart. Leave a key blank to skip it. Run it in addition to (not
-instead of) rendering them into `.env` above.
+(cloning private repos; the Claude launch-gate). The daemon's `GH_TOKEN` is not
+automatically a session's push identity: Loom explicitly selects a personal or
+profile token, or brokers an allowlisted GitHub App token, for each session.
+Session runtimes still need their provider keys. Run
+`loom setup secrets --config /home/app/loom.toml` via `docker compose exec loom`
+against the running deploy, or as part of the [Quick start](#quick-start)
+sequence before first start. It prompts for `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, and `GH_TOKEN`, and stores them as operator environment
+variables, live for every session from then on, no restart. Leave a key blank to
+skip it. Run it in addition to (not instead of) rendering them into `.env`
+above.
 
 ## Security posture
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -45,9 +45,9 @@ an embedded VS Code), so the image is large and self-contained.
 - A **domain** whose DNS `A`/`AAAA` record points at the host. Caddy needs `:80`
   reachable for the ACME challenge and your domain resolving to the host *before*
   first start, or the certificate won't issue.
-- The credentials in the [env reference](#required-environment) — at minimum a
-  `GH_TOKEN`, a webhook secret, and an Anthropic key (or an interactive Claude
-  login).
+- The credentials in the [env reference](#required-environment) — the GitHub
+  App id, private key, and webhook secret, plus an Anthropic key (or an
+  interactive Claude login).
 
 ## Quick start
 
@@ -104,7 +104,7 @@ and why; you don't hand-edit `.env` itself.
 |---|---|---|
 | `LOOM_DOMAIN` | **yes** | Public domain Caddy serves and gets a cert for (e.g. `loom.team.dev`); `localhost` for local testing. Also seeded as `auth.base_url`. |
 | `LOOM_OWNER_GITHUB` | **yes** | GitHub login seeded as the first approved user on a fresh database — the only account that can sign in until it approves others. Approved users are also who may drive the `@loom` trigger; add more in **Settings → Approved users**. |
-| `GH_TOKEN` | **yes** | GitHub token loom uses to clone private repos, push branches, and reply to `@loom` requests. |
+| `LOOM_GITHUB_APP_ID` / `_PRIVATE_KEY` | **yes** | GitHub App identity Loom uses to mint repository-scoped installation tokens for clones, polling, replies, server-side GitHub tools, and interactive sessions whose user has no Account PAT. |
 | `LOOM_GITHUB_WEBHOOK_SECRET` | for `@loom` | Shared secret for the inbound webhook; must match the secret on the GitHub webhook. Until set, the webhook rejects every delivery. |
 | `LOOM_SLACK_APP_TOKEN` / `LOOM_SLACK_BOT_TOKEN` | for `/marinbot` | App-level and bot OAuth tokens for the Slack Socket Mode trigger. Both unset (the default) leaves it off. See [docs/slack-trigger.md](../docs/slack-trigger.md). |
 | `ANTHROPIC_API_KEY` | for Claude | API key for the Claude agents. Alternatively log in interactively (see [first-run](#agent-authentication)). |
@@ -122,20 +122,17 @@ invocation without touching `loom.toml`, by exporting the same-named env var:
 `loom config render-env`/`push-secrets` resolve `loom.toml` *and* the process
 environment, with the environment winning (see `loom_config`'s module docs).
 
-`GH_TOKEN` and `ANTHROPIC_API_KEY` here cover the daemon's own ambient use
-(cloning private repos; the Claude launch-gate). The daemon's `GH_TOKEN` is not
-automatically a session's push identity: Loom explicitly selects a personal or
-profile token, or brokers an allowlisted GitHub App token, for each session;
-brokered and disabled sessions receive empty token variables that mask the
-daemon environment.
-Session runtimes still need their provider keys. Run
+There is no deployment `GH_TOKEN`. Loom uses its GitHub App for daemon and
+server-side GitHub operations. An ordinary interactive session uses the
+launching user's optional PAT stored under **Settings → Account**, or brokers
+the selected profile's allowlisted App access when that PAT is absent. Session
+runtimes still need their model-provider keys. Run
 `loom setup secrets --config /home/app/loom.toml` via `docker compose exec loom`
 against the running deploy, or as part of the [Quick start](#quick-start)
-sequence before first start. It prompts for `ANTHROPIC_API_KEY`,
-`OPENAI_API_KEY`, and `GH_TOKEN`, and stores them as operator environment
-variables, live for every session from then on, no restart. Leave a key blank to
-skip it. Run it in addition to (not instead of) rendering them into `.env`
-above.
+sequence before first start. It prompts for `ANTHROPIC_API_KEY` and
+`OPENAI_API_KEY`, and stores them as operator environment variables, live for
+every session from then on, no restart. Leave a key blank to skip it. Run it in
+addition to (not instead of) rendering them into `.env` above.
 
 ## Security posture
 
@@ -331,9 +328,10 @@ docker compose exec loom codex login    # follow the prompts, then exit
 The shared Codex login is used only for model access. At startup, Loom disables
 Codex account-level apps in the container, so a GitHub connector authorized on
 that account cannot become a session's write identity. The terminal and ACP
-launch paths enforce the same setting. GitHub CLI access instead uses the
-credential Loom injects into the agent environment; restricted profiles perform
-GitHub mutations through Loom's server-side tool endpoint.
+launch paths enforce the same setting. GitHub CLI access instead uses either
+the launching user's Loom-stored Account PAT or a session-brokered App token;
+restricted profiles perform GitHub mutations through Loom's server-side
+App-backed endpoint.
 
 ## Wire the `@loom` GitHub trigger
 

--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -35,9 +35,12 @@ HOST_GID=1000
 LOOM_OWNER_GITHUB=your-github-login
 
 # ── Credentials the agents and integrations need ──────────────────────────────
-# A GitHub token loom uses to clone private repos, push branches, and reply to
-# `@loom` comments (the `gh` CLI and the git credential helper read it).
-GH_TOKEN=ghp_your_token
+# GitHub App identity for private clones, webhook replies, polling, restricted
+# tools, and brokered interactive-session access. `loom setup github-app` and
+# `loom config render-env` normally generate these; the quoted private key uses
+# literal `\n` escapes in this env-file format.
+LOOM_GITHUB_APP_ID=123456
+LOOM_GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nreplace-me\n-----END RSA PRIVATE KEY-----"
 
 # Shared secret for the inbound `@loom` webhook. MUST equal the
 # secret you configure on the GitHub webhook. Until it is set the webhook rejects

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -692,8 +692,8 @@ access from `loom github access` or Session Details, without restarting it.
 Loom validates write access against the GitHub App installation before storing
 the audited override.
 
-When the `gh` CLI is installed and authenticated, loom keeps a per-branch
-pull-request snapshot alongside the session. A second background loop
+When the GitHub App is configured, loom keeps a per-branch pull-request
+snapshot alongside the session. A second background loop
 (`github::poll`, sibling of the monitor, spawned in `server::serve`) runs on
 startup and every minute. It polls sessions active in the previous ten minutes
 on every tick, the rest of the first quiet day every ten minutes, and older live
@@ -717,8 +717,8 @@ The dashboard renders it on the session list and session header; `POST
 /api/sessions/{id}/github` forces an immediate re-poll.
 
 The loop self-gates and degrades quietly: it is always spawned but does nothing
-while the `github.poll` setting is off, `gh` is missing (probed once, cached via
-`gh_available`), or the repo has no GitHub remote (the repository batch is
+while the `github.poll` setting is off, the GitHub App is unavailable, or the
+repo has no GitHub remote (the repository batch is
 logged at debug and skipped). So it is a no-op on non-GitHub repos rather
 than a failure.
 
@@ -742,12 +742,11 @@ settings pane).
 Both settings live in `weaver-core::config::registry()` under the **GitHub**
 group.
 
-`gh`-touching logic lives in `crate::github`: `fetch_pr` (the single-PR
-shell-out used by manual refresh), `fetch_pr_batch` (the repository-wide
-background GraphQL request), `apply_refresh_result` / `apply_snapshot` (store →
-announce → maybe archive), and `poll` (the
-loop). The merge-archive decision is split into `apply_snapshot` so it is
-testable without invoking `gh`.
+GitHub snapshot logic lives in `crate::github`: `fetch_pr` (the single-PR App
+request used by manual refresh), `fetch_pr_batch` (the repository-wide App
+GraphQL request), `apply_refresh_result` / `apply_snapshot` (store → announce →
+maybe archive), and `poll` (the loop). The merge-archive decision is split into
+`apply_snapshot` so it is testable without contacting GitHub.
 
 **The status card.** A branch carrying the quiet `github` tag
 (`owner/name#number` — stamped by the `@loom` trigger, or set by hand with
@@ -877,34 +876,33 @@ rules. Repository/profile data never supplies executable MCP configuration.
 Restricted launch and recovery omit repository environment/setup and Claude
 user/project/local settings. Repository reads are path-scoped, and GitHub
 mutations use a fixed MCP bridge backed by a session-scoped REST endpoint. Loom
-uses the configured GitHub App's short-lived repository installation token
-server-side, with an explicit profile token available only to App-less
-deployments, and invokes `gh` without a shell against the session's fixed
-repository and linked thread. Personal user tokens remain exclusive to ordinary
-interactive sessions, and no credential enters the restricted agent
-environment. Allowed rules execute directly;
+uses the configured GitHub App client to call GitHub's REST API against the
+session's fixed repository and linked thread. No GitHub credential enters the
+restricted agent environment. Allowed rules execute directly;
 any remaining ACP permission request is answered with the adapter's one-shot
 rejection (or a cancelled outcome), including after `session/load`. Runtime
 handoff and permission-mode changes are forbidden. The stock `github_comment`
 profile contains the policy only; its reviewed JSON manifest is seeded when
-absent and then remains operator-editable. App-less deployments must provide
-its write-only `GH_TOKEN`.
+absent and then remains operator-editable.
 
 **Git and GitHub CLI credentials.** The Docker image installs a Git credential
 helper and a `gh` wrapper because those clients do not speak Loom's session API.
 They are transport adapters, not policy owners: every fresh, resumed, warm, or
 handed-off session receives a reserved `LOOM_GITHUB_AUTH_MODE` selected by Loom.
-`direct` uses the personal/profile `GH_TOKEN` in the resolved session
-environment, `broker` ignores inherited deployment credentials and requests the
-session's short-lived App token, and `disabled` rejects direct GitHub CLI
-access. Loom explicitly masks ambient `GH_TOKEN` and `GITHUB_TOKEN` values for
-brokered and disabled sessions, and the adapters fail closed when the reserved
-mode is absent. This prevents the daemon's clone/webhook identity from silently
-becoming an agent's push identity. Adapter registration stays in the image's
-system Git config: linked worktrees share repository-local config, agents may
-clone additional repositories, and the helper must be available before a target
-repository exists. Session selection and credentials remain Loom-owned policy;
-the image registration only teaches stock `git` and `gh` how to ask for them.
+`direct` uses the launching user's write-only PAT stored in Loom Account
+settings, `broker` requests the session's short-lived App installation token,
+and `disabled` rejects direct GitHub CLI access. Loom reserves `GH_TOKEN` and
+`GITHUB_TOKEN` from profile, repository, and committed environment
+configuration, overlays a per-user PAT only after those layers are resolved,
+and masks token variables in brokered and disabled sessions. The adapters fail
+closed when the reserved mode is absent. The `gh` wrapper exports `GH_TOKEN`
+only for the stock CLI; it is the compatibility boundary for a client that does
+not speak Loom's session API.
+Adapter registration stays in the image's system Git config: linked worktrees
+share repository-local config, agents may clone additional repositories, and
+the helper must be available before a target repository exists. Session
+selection and credentials remain Loom-owned policy; the image registration
+only teaches stock `git` and `gh` how to ask for them.
 
 **MCP/profile control plane.** A profile stores `mcp_access` as `none`, `all`,
 or an explicit group list. Saving resolves the trusted builtin registry and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -897,9 +897,14 @@ handed-off session receives a reserved `LOOM_GITHUB_AUTH_MODE` selected by Loom.
 `direct` uses the personal/profile `GH_TOKEN` in the resolved session
 environment, `broker` ignores inherited deployment credentials and requests the
 session's short-lived App token, and `disabled` rejects direct GitHub CLI
-access. An absent mode retains compatibility for sessions launched by an older
-server. This prevents the daemon's ambient clone/webhook identity from silently
-becoming an agent's push identity.
+access. Loom explicitly masks ambient `GH_TOKEN` and `GITHUB_TOKEN` values for
+brokered and disabled sessions, and the adapters fail closed when the reserved
+mode is absent. This prevents the daemon's clone/webhook identity from silently
+becoming an agent's push identity. Adapter registration stays in the image's
+system Git config: linked worktrees share repository-local config, agents may
+clone additional repositories, and the helper must be available before a target
+repository exists. Session selection and credentials remain Loom-owned policy;
+the image registration only teaches stock `git` and `gh` how to ask for them.
 
 **MCP/profile control plane.** A profile stores `mcp_access` as `none`, `all`,
 or an explicit group list. Saving resolves the trusted builtin registry and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -890,6 +890,17 @@ profile contains the policy only; its reviewed JSON manifest is seeded when
 absent and then remains operator-editable. App-less deployments must provide
 its write-only `GH_TOKEN`.
 
+**Git and GitHub CLI credentials.** The Docker image installs a Git credential
+helper and a `gh` wrapper because those clients do not speak Loom's session API.
+They are transport adapters, not policy owners: every fresh, resumed, warm, or
+handed-off session receives a reserved `LOOM_GITHUB_AUTH_MODE` selected by Loom.
+`direct` uses the personal/profile `GH_TOKEN` in the resolved session
+environment, `broker` ignores inherited deployment credentials and requests the
+session's short-lived App token, and `disabled` rejects direct GitHub CLI
+access. An absent mode retains compatibility for sessions launched by an older
+server. This prevents the daemon's ambient clone/webhook identity from silently
+becoming an agent's push identity.
+
 **MCP/profile control plane.** A profile stores `mcp_access` as `none`, `all`,
 or an explicit group list. Saving resolves the trusted builtin registry and
 enabled, validated custom definitions and pins the exact result to that profile

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -359,7 +359,7 @@ canonical space/group placement.
 `BranchView::github` is the branch's latest GitHub pull-request snapshot
 (`pr_number`, `pr_url`, `pr_state`, `pr_title`, `is_draft`, `review_decision`,
 `checks`, `mergeable`, `merged_at`, `head_sha`, `head_updated_at`, `fetched_at`),
-or `null` when GitHub polling is off, there is no PR, or `gh` is unavailable.
+or `null` when GitHub polling is off, there is no PR, or the App is unavailable.
 See [GitHub integration](#github-integration).
 
 Status is two orthogonal axes. The session's `status` is the **lifecycle**
@@ -877,8 +877,8 @@ Restricted launch and recovery omit repository environment/setup and Claude
 user/project/local settings. Repository reads are path-scoped, and GitHub
 mutations use a fixed MCP bridge backed by a session-scoped REST endpoint. Loom
 uses the configured GitHub App client to call GitHub's REST API against the
-session's fixed repository and linked thread. No GitHub credential enters the
-restricted agent environment. Allowed rules execute directly;
+session's fixed repository and linked thread. The restricted agent reaches
+GitHub only through this fixed bridge. Allowed rules execute directly;
 any remaining ACP permission request is answered with the adapter's one-shot
 rejection (or a cancelled outcome), including after `session/load`. Runtime
 handoff and permission-mode changes are forbidden. The stock `github_comment`
@@ -891,13 +891,9 @@ They are transport adapters, not policy owners: every fresh, resumed, warm, or
 handed-off session receives a reserved `LOOM_GITHUB_AUTH_MODE` selected by Loom.
 `direct` uses the launching user's write-only PAT stored in Loom Account
 settings, `broker` requests the session's short-lived App installation token,
-and `disabled` rejects direct GitHub CLI access. Loom reserves `GH_TOKEN` and
-`GITHUB_TOKEN` from profile, repository, and committed environment
-configuration, overlays a per-user PAT only after those layers are resolved,
-and masks token variables in brokered and disabled sessions. The adapters fail
-closed when the reserved mode is absent. The `gh` wrapper exports `GH_TOKEN`
-only for the stock CLI; it is the compatibility boundary for a client that does
-not speak Loom's session API.
+and `disabled` rejects direct GitHub CLI access. The adapters fail closed when
+the reserved mode is absent. The `gh` wrapper translates the selected mode into
+the stock CLI's native authentication contract for each invocation.
 Adapter registration stays in the image's system Git config: linked worktrees
 share repository-local config, agents may clone additional repositories, and
 the helper must be available before a target repository exists. Session

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,9 +33,8 @@ credentials in repository configuration.
 An ordinary interactive session uses the launching user's write-only GitHub PAT
 from **Settings → Account** when one is set. Otherwise, `git` and `gh` ask Loom
 for a short-lived GitHub App installation token, limited to repositories
-allowlisted by the selected profile. Both credentials are Loom-owned session
-policy; profile, repository, committed, and daemon environments cannot define
-`GH_TOKEN` or `GITHUB_TOKEN`. See [Restricted GitHub
+allowlisted by the selected profile. Loom presents the selected credential
+through the image's managed Git and GitHub CLI adapters. See [Restricted GitHub
 sessions](restricted-sessions.md#github-credential-policy) for automation's
 tighter tool boundary.
 
@@ -108,10 +107,10 @@ starter text lives under `crates/loom-policy/profiles/<name>/instructions.md`.
 The origin profiles are opt-in so an upgrade does not silently change the
 environment or runtime used by existing triggers.
 
-Profiles may declare `github_repositories`. When the launching user has no
-Account PAT, `git` and `gh` transparently request a short-lived GitHub App
-installation token from Loom. Interactive profiles use the list as the App
-allowlist and stamp only the session's current repository. Strict,
+Profiles may declare `github_repositories` to define the GitHub App broker's
+scope. Ordinary interactive sessions select the launching user's Account PAT
+first and use this broker when the App path is selected. Interactive profiles
+stamp only the session's current allowlisted repository. Strict,
 environment-cleared automation profiles retain the complete list for reviewed
 cross-repository workflows, so their entries must use one owner. Tokens grant
 write access to repository contents, issues, pull requests, Actions, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ should apply:
 
 | Owner | Configure in | Use for |
 |---|---|---|
-| User | **Settings → Account** and **Preferences** | Personal sign-in, password, API and GitHub tokens, and terminal appearance |
+| User | **Settings → Account** and **Preferences** | Personal sign-in, password, API tokens, optional interactive-session GitHub PAT, and terminal appearance |
 | Session profile | **Settings → Agents & profiles** or a deployment manifest | Agent/model policy, instructions, GitHub repository allowlists, shared environment, and write-only session secrets |
 | Deployment | The **Administration** settings; deployment IaC for the production source | Approved users and roles, the Loom GitHub App, Slack App, federations, runtime policy, and machine-wide credentials or files |
 | Repository | `.weaver/config.toml`, `WEAVER.md`, and `AGENTS.md` | Non-secret repository setup, environment, and workflow instructions |
@@ -30,14 +30,14 @@ on the `default` profile. Other profiles keep their write-only environment
 beside their launch policy. Do not put personal tokens or deployment
 credentials in repository configuration.
 
-An ordinary interactive session selects GitHub access in this order: the
-launching user's personal token, an explicit `GH_TOKEN` from the resolved
-session environment (normally its profile), then a short-lived GitHub App token
-when the profile allowlists the current repository. The first two are exported
-as `GH_TOKEN` because `git` and `gh` expect that name; the App fallback remains
-repository-scoped and short-lived. See [Restricted GitHub
+An ordinary interactive session uses the launching user's write-only GitHub PAT
+from **Settings → Account** when one is set. Otherwise, `git` and `gh` ask Loom
+for a short-lived GitHub App installation token, limited to repositories
+allowlisted by the selected profile. Both credentials are Loom-owned session
+policy; profile, repository, committed, and daemon environments cannot define
+`GH_TOKEN` or `GITHUB_TOKEN`. See [Restricted GitHub
 sessions](restricted-sessions.md#github-credential-policy) for automation's
-different boundary.
+tighter tool boundary.
 
 Files under a shared session home are deployment resources, not environment
 variables. An operator deployment may materialize them from its secret backend,
@@ -108,9 +108,9 @@ starter text lives under `crates/loom-policy/profiles/<name>/instructions.md`.
 The origin profiles are opt-in so an upgrade does not silently change the
 environment or runtime used by existing triggers.
 
-Profiles may declare `github_repositories`. Inside sessions launched from such
-a profile, `git` and `gh` transparently request a short-lived GitHub App
-installation token from Loom. Interactive profiles use the list as an
+Profiles may declare `github_repositories`. When the launching user has no
+Account PAT, `git` and `gh` transparently request a short-lived GitHub App
+installation token from Loom. Interactive profiles use the list as the App
 allowlist and stamp only the session's current repository. Strict,
 environment-cleared automation profiles retain the complete list for reviewed
 cross-repository workflows, so their entries must use one owner. Tokens grant

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -78,7 +78,6 @@ The reply (step 8) reaches GitHub through the [GitHub App](#the-github-app) with
 a short-lived, per-installation token. The **session itself** receives access
 from the triggering user's Loom-stored Account PAT when present, otherwise
 through Loom's App broker for the repositories its selected profile allows.
-Profile, repository, and deployment PATs are never credential sources.
 Separately, the poll loop
 posts a one-time back-link comment (`Working on this in loom: {base}/s/{id}`) on
 a session's open PR when one isn't already linked, so a reader of the PR can
@@ -235,10 +234,8 @@ signed from the App's private key (an RS256 JWT exchanged for an installation
 token via `POST /app/installations/{id}/access_tokens`) and cached until they
 near expiry.
 
-When the App is not configured, App-backed clones, polling, trigger replies,
-restricted GitHub tools, and interactive sessions without a per-user Account
-PAT fail closed. Loom never consults an ambient, profile, repository, or
-deployment PAT.
+The App id and private key are required for App-backed clones, polling, trigger
+replies, restricted GitHub tools, and brokered interactive-session access.
 
 ### Create the App
 

--- a/docs/github-trigger.md
+++ b/docs/github-trigger.md
@@ -74,12 +74,12 @@ GitHub's ~10s delivery timeout, and a timed-out delivery would cancel an inline
 handler mid-clone. Each launch is tracked on **Settings → Diagnostics** (running / done
 / error, with the outcome), so you can follow it after the `200`.
 
-The reply (step 8) reaches GitHub through the [GitHub App](#the-github-app) when
-one is configured — with a short-lived, per-installation token — and otherwise
-through the `gh` CLI's ambient `GH_TOKEN`. The **session itself** acts as the
-requester: its `GH_TOKEN` is that user's personal token (**Settings → Account**),
-falling back to its selected profile when they have none — so its pushes and
-`gh` replies use the configured session identity. Separately, the poll loop
+The reply (step 8) reaches GitHub through the [GitHub App](#the-github-app) with
+a short-lived, per-installation token. The **session itself** receives access
+from the triggering user's Loom-stored Account PAT when present, otherwise
+through Loom's App broker for the repositories its selected profile allows.
+Profile, repository, and deployment PATs are never credential sources.
+Separately, the poll loop
 posts a one-time back-link comment (`Working on this in loom: {base}/s/{id}`) on
 a session's open PR when one isn't already linked, so a reader of the PR can
 jump to the session.
@@ -117,8 +117,8 @@ The mirroring works on any session, not just triggered ones: `weaver tag set
 github owner/name#123` wires a session by hand (the card appears on its next
 status report), and `weaver tag rm github` stops the mirroring, freezing the
 comment. The card requires a configured `auth.base_url` (the session link must
-resolve for a GitHub reader) and posts through the same App-token/`gh`
-credential ladder as the reply. Two loom-internal tags do the bookkeeping —
+resolve for a GitHub reader) and posts through the same App client as the reply.
+Two loom-internal tags do the bookkeeping —
 `github.status_comment` (the comment id the card lives in) and `github.linked`
 (the PR back-link dedupe); both are machine-owned, hidden from the dashboard's
 pill row, and refused by the tag-set routes (clearing one is harmless: loom
@@ -163,11 +163,10 @@ curl -X POST {base}/api/auth/users -H 'Authorization: Bearer $LOOM_TOKEN' \
 
 ## Configure the webhook
 
-This section is the classic, App-less path: a shared secret plus a manually
-added repo/org webhook. If you're setting up the [GitHub App](#the-github-app)
-(the recommended path — `loom setup github-app` does it in one step), skip
-straight there: the App's own webhook delivers events for any repo it's
-installed on, so there's no separate webhook to add.
+The normal path is the [GitHub App](#the-github-app): `loom setup github-app`
+configures its webhook in one step, and the App delivers events for every
+repository where it is installed. The manual steps below are useful only when
+managing the same App's webhook configuration yourself.
 
 Set a shared secret in loom's environment (it is held outside the settings
 registry and never returned by `GET /api/settings`, like the OAuth client
@@ -227,19 +226,19 @@ launches nothing.
 
 ## The GitHub App
 
-A **GitHub App** is the hardened identity loom acts through. Instead of a
-long-lived, broadly-scoped shared `GH_TOKEN`, loom mints a **short-lived,
-least-privilege installation token** scoped to a single repo's installation for
-the reply, and treats the repos the App is installed on as the set it can reach
+A **GitHub App** is Loom's deployment and server-side GitHub identity. Loom
+mints a **short-lived, least-privilege installation token** scoped to a single
+repo's installation for webhook replies, polling, clones, and fixed server-side
+tools, and treats the repos the App is installed on as the set it can reach
 (the [approved-user gate](#who-can-trigger) decides whether it acts). Tokens are
 signed from the App's private key (an RS256 JWT exchanged for an installation
 token via `POST /app/installations/{id}/access_tokens`) and cached until they
 near expiry.
 
-When the App is **not configured**, loom falls back to the ambient `GH_TOKEN`
-(the `gh` CLI), so the webhook works without it. The webhook receiver and its
-security controls (HMAC, idempotency, authorization) are identical either way —
-the App only changes which credential the outbound reply uses.
+When the App is not configured, App-backed clones, polling, trigger replies,
+restricted GitHub tools, and interactive sessions without a per-user Account
+PAT fail closed. Loom never consults an ambient, profile, repository, or
+deployment PAT.
 
 ### Create the App
 
@@ -312,11 +311,10 @@ LOOM_GITHUB_APP_ID=<the App ID>
 LOOM_GITHUB_APP_PRIVATE_KEY=<the private-key PEM>
 ```
 
-With both set, loom uses the App for the reply and reaches any repo the App is
-installed on (registered on an approved user's first trigger). With either unset
-it falls back to the ambient `GH_TOKEN`. (Cloning still uses the ambient git
-credentials; granting the App **Contents** access keeps a single least-privilege
-credential set as the deploy migrates off the shared PAT.)
+With both set, loom uses the App for cloning, replies, session Git/CLI access,
+polling, and fixed server-side tools, and reaches repositories where the App is
+installed (registered on an approved user's first trigger). With either value
+unset, those operations are unavailable.
 
 ## Debugging the trigger
 

--- a/docs/mcp-profiles.md
+++ b/docs/mcp-profiles.md
@@ -108,10 +108,9 @@ Restricted profiles add a tighter trust boundary:
   context;
 - provider credentials remain in Loom and never enter the agent process.
 
-The stock `github_comment` profile carries policy, not credentials. Loom
-normally mints a short-lived repository-scoped GitHub App token while executing
-the fixed operation. An App-less deployment may configure an explicit
-least-privilege profile token as a write-only environment value.
+The stock `github_comment` profile carries policy, not credentials. Loom calls
+GitHub through its App client while executing the fixed operation, minting a
+short-lived repository-scoped installation token internally.
 
 See [Restricted sessions](restricted-sessions.md) for automation identity,
 idempotency, and deployment boundaries.

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -15,12 +15,10 @@ adapter command. New adapter families belong in `crates/loom-agent/src/mcp/` and
 be registered by Loom before a profile can select one.
 The MCP bridge calls a session-scoped Loom endpoint; Loom calls GitHub through
 its App client against the session's fixed repository and linked issue/PR
-number, so neither a general shell nor a GitHub token enters the agent process. Anything outside
-the configured Claude permission rules is rejected by Loom.
-The profile intentionally has no token in its seed. Loom uses the configured
-GitHub App's short-lived installation token for the fixed repository. If the
-App is unavailable or is not installed on that repository, the operation fails;
-there is no PAT or profile-token fallback. The stock policy lives in
+number. The agent receives the fixed GitHub tool rather than a general GitHub
+shell surface, and Loom enforces the configured Claude permission rules. Loom
+uses the configured GitHub App's short-lived installation token for the fixed
+repository. The stock policy lives in
 `crates/loom-policy/profiles/github_comment/profile.json`, not in a schema migration. Loom
 seeds a missing stock profile through normal validation and does not overwrite
 later operator edits. Custom profiles use the same REST/CLI/UI or
@@ -35,17 +33,16 @@ both use the same provider-neutral `mcp_access` contract.
 
 ## GitHub credential policy
 
-| Use case | Primary credential | Fallback |
-| --- | --- | --- |
-| Ordinary interactive session | Launching user's Loom-stored Account PAT | Short-lived GitHub App installation token scoped to the profile-approved repositories |
-| Restricted GitHub tool | Loom's App-backed REST call for the session's fixed repository | None |
-| GitHub Actions calling Loom | GitHub OIDC exchanged for a ten-minute Loom automation token | None |
+| Use case | Credential path |
+| --- | --- |
+| Ordinary interactive session | Launching user's Loom-stored Account PAT, then the App broker scoped to the profile-approved repositories |
+| Restricted GitHub tool | Loom's App-backed REST call for the session's fixed repository |
+| GitHub Actions calling Loom | GitHub OIDC exchanged for a ten-minute Loom automation token |
 
 For ordinary sessions, Loom explicitly selects the user's Account PAT or the
 App broker and stamps that choice for the image's `git` helper and `gh` wrapper.
 Restricted sessions use neither adapter: their fixed GitHub tools call Loom,
-which uses the App internally. A mint or installation failure is an error;
-restricted work never falls back to a personal or shared PAT.
+which uses the App internally.
 
 ## GitHub Actions request
 
@@ -104,10 +101,9 @@ durable ACP prompt path; a provisioning or orphaned channel returns a retryable
 error instead of acknowledging an undelivered update. Channel names accept up
 to 64 ASCII letters, digits, `.`, `_`, `:`, and `-`.
 
-Do not put `GH_TOKEN` in the request or prompt. Automation requests are stored
-for audit and idempotency. Loom resolves an App credential only while executing
-a fixed GitHub tool; the installation token is short-lived and scoped to the
-session's fixed repository.
+Automation requests carry the task prompt and are stored for audit and
+idempotency. Loom resolves the short-lived, repository-scoped App credential
+while executing a fixed GitHub tool.
 
 ## Deployment checklist
 
@@ -119,8 +115,8 @@ session's fixed repository.
    profile show github_comment` and `loom federation ls`.
 4. Run a synthetic issue through the direct API. Verify the prompt appears as
    the first turn without `WEAVER.md`, a duplicate body-hash key returns the
-   original run, no shell or code-writing tool is visible, the agent environment
-   contains no GitHub token, and only the requested GitHub mutation occurs.
+   original run, the fixed tool surface is visible, and only the requested
+   GitHub mutation occurs.
 5. Move callers to the OIDC exchange without changing their idempotency keys or
    stale-write preconditions, then roll the workflow revision out in controlled
    batches.

--- a/docs/restricted-sessions.md
+++ b/docs/restricted-sessions.md
@@ -13,17 +13,14 @@ the set into exact tool permissions when it stamps the session and launches the
 corresponding built-in adapter from its registry. Profile data cannot provide an
 adapter command. New adapter families belong in `crates/loom-agent/src/mcp/` and must
 be registered by Loom before a profile can select one.
-The MCP bridge calls a session-scoped Loom endpoint; Loom runs `gh` server-side
-against the session's fixed repository and linked issue/PR number, so neither a
-general shell nor the GitHub token enters the agent process. Anything outside
+The MCP bridge calls a session-scoped Loom endpoint; Loom calls GitHub through
+its App client against the session's fixed repository and linked issue/PR
+number, so neither a general shell nor a GitHub token enters the agent process. Anything outside
 the configured Claude permission rules is rejected by Loom.
 The profile intentionally has no token in its seed. Loom uses the configured
-GitHub App's short-lived installation token for the fixed repository. If an App
-is configured but is not installed on that repository, the operation fails
-rather than falling back to a broader credential. An App-less deployment can
-configure a least-privilege CI identity as the profile's write-only `GH_TOKEN`.
-Personal user tokens remain exclusive to ordinary interactive sessions. The
-stock policy lives in
+GitHub App's short-lived installation token for the fixed repository. If the
+App is unavailable or is not installed on that repository, the operation fails;
+there is no PAT or profile-token fallback. The stock policy lives in
 `crates/loom-policy/profiles/github_comment/profile.json`, not in a schema migration. Loom
 seeds a missing stock profile through normal validation and does not overwrite
 later operator edits. Custom profiles use the same REST/CLI/UI or
@@ -40,15 +37,15 @@ both use the same provider-neutral `mcp_access` contract.
 
 | Use case | Primary credential | Fallback |
 | --- | --- | --- |
-| Ordinary interactive session | Launching user's personal token from **Settings → Account** | Explicit session `GH_TOKEN`, then a profile-approved GitHub App token for the current repository |
-| Restricted GitHub tool | Short-lived GitHub App installation token for the session's fixed repository | Profile `GH_TOKEN` only when no App is configured |
+| Ordinary interactive session | Launching user's Loom-stored Account PAT | Short-lived GitHub App installation token scoped to the profile-approved repositories |
+| Restricted GitHub tool | Loom's App-backed REST call for the session's fixed repository | None |
 | GitHub Actions calling Loom | GitHub OIDC exchanged for a ten-minute Loom automation token | None |
 
-The same environment variable name appears inside an ordinary session because
-`git` and `gh` expect it, but the stores and trust boundaries are separate.
-When a GitHub App is configured, a mint or installation failure is an error:
-Loom does not silently widen authority by falling back to a personal or shared
-PAT.
+For ordinary sessions, Loom explicitly selects the user's Account PAT or the
+App broker and stamps that choice for the image's `git` helper and `gh` wrapper.
+Restricted sessions use neither adapter: their fixed GitHub tools call Loom,
+which uses the App internally. A mint or installation failure is an error;
+restricted work never falls back to a personal or shared PAT.
 
 ## GitHub Actions request
 
@@ -108,20 +105,13 @@ error instead of acknowledging an undelivered update. Channel names accept up
 to 64 ASCII letters, digits, `.`, `_`, `:`, and `-`.
 
 Do not put `GH_TOKEN` in the request or prompt. Automation requests are stored
-for audit and idempotency. Loom resolves a credential only while executing a
-fixed GitHub tool. Prefer the configured GitHub App, whose installation token is
-short-lived and scoped to the session's fixed repository. App-less deployments
-can put a least-privilege token in the profile's write-only environment,
-preferably as a deployment-managed Secret Manager reference. The existing
-ordinary interactive launch path uses the approved requester's stored GitHub
-token by default; restricted sessions do not.
+for audit and idempotency. Loom resolves an App credential only while executing
+a fixed GitHub tool; the installation token is short-lived and scoped to the
+session's fixed repository.
 
 ## Deployment checklist
 
 1. Configure and install the production GitHub App on each target repository.
-   For an App-less deployment, declare `github_comment` in the Pulumi profile
-   manifest with a least-privilege `GH_TOKEN` secret reference and grant the
-   Loom VM access to that secret.
 2. Add one `githubFederations` entry per approved caller workflow, constrained
    to the numeric repository id, exact workflow ref, event/ref where useful, and
    only `github_comment`.
@@ -135,6 +125,6 @@ token by default; restricted sessions do not.
    stale-write preconditions, then roll the workflow revision out in controlled
    batches.
 
-Disable the federation mapping to stop new runs. On an App-less deployment,
-removing the profile token also disables the fixed GitHub operations. Neither
-rollback affects interactive Loom sessions.
+Disable the federation mapping to stop new runs. Removing the App installation
+from a repository disables fixed GitHub operations for that repository without
+changing the session policy.

--- a/docs/slack-trigger.md
+++ b/docs/slack-trigger.md
@@ -241,8 +241,8 @@ result — post back to the wired thread through `POST
 /api/branches/{branch}/slack/reply` with `{"text": "…"}` and the session's
 `LOOM_TOKEN`. loom resolves the destination channel and thread from the
 branch's `slack` wiring tag server-side; the bot token itself never reaches
-the agent, the same separation the GitHub trigger keeps between an agent's
-`GH_TOKEN` and any App-level credential.
+the agent, the same separation used by Loom's App-backed server-side GitHub
+tools.
 
 Adding `"thread": {"channel": "C…", "thread_ts": "…"}` posts to one of the
 session's *routed* threads instead (see [Automation-delivered

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -37,7 +37,6 @@ owner_github = "your-github-login"
 # use (either can also be an interactive `claude` / `codex login` instead).
 # anthropic_api_key = ""
 # openai_api_key = ""
-# gh_token = ""
 
 # Slack Socket Mode integration (the `/marinbot` / `@marinbot` trigger) —
 # optional; unset leaves it off. Both are secrets: an app-level token

--- a/python/weaver-loom/src/weaver_loom/__init__.py
+++ b/python/weaver-loom/src/weaver_loom/__init__.py
@@ -49,7 +49,6 @@ from the weaver repo with ``uv pip install -e python/weaver-loom``.
 import json
 import os
 import random
-import subprocess
 import threading
 import time
 import urllib.error
@@ -260,39 +259,6 @@ class WorkloadCredentials:
         return token
 
 
-def gh_json(args, cwd=None, timeout=30):
-    """Run ``gh <args>`` and parse its stdout as JSON.
-
-    A watch that shells out to ``gh`` needs exactly one thing: a way to tell
-    "gh couldn't answer this one call" (worth logging and moving on) apart
-    from "our code is broken" (worth a traceback). This draws that line once:
-    every failure — gh missing, the call timing out, a non-zero exit, output
-    that isn't JSON — raises :class:`WeaverError` carrying gh's own message,
-    so a caller that wants to tolerate an unreadable PR can catch that one
-    type and *keep the reason* in its note instead of discarding it. Anything
-    that isn't a `WeaverError` (a bug in the caller's own code) is left to
-    propagate as-is.
-    """
-    try:
-        out = subprocess.run(
-            ["gh", *args], cwd=cwd, capture_output=True, text=True, timeout=timeout
-        )
-    except FileNotFoundError as e:
-        # cwd missing raises the same exception type as gh itself missing;
-        # e.filename names whichever path the OS actually failed to find.
-        what = "gh" if e.filename in (None, "gh") else e.filename
-        raise WeaverError(f"{what} not found: {e}") from e
-    except subprocess.TimeoutExpired as e:
-        raise WeaverError(f"gh {' '.join(args)} timed out after {timeout}s") from e
-    if out.returncode != 0:
-        detail = out.stderr.strip() or out.stdout.strip() or "no output"
-        raise WeaverError(f"gh {' '.join(args)}: exit {out.returncode}: {detail}")
-    try:
-        return json.loads(out.stdout)
-    except ValueError as e:
-        raise WeaverError(f"gh {' '.join(args)}: unparseable JSON: {e}") from e
-
-
 def _base_url(base=None):
     """Resolve a base URL: the argument, else ``$WEAVER_API``, else the loom
     default. A bare ``host:port`` is accepted."""
@@ -433,6 +399,11 @@ class Client:
         if by is not None:
             body["by"] = by
         return self._request("PUT", f"/sessions/{key}/tags/{tag_key}", body)
+
+    def add_github_labels(self, key, labels):
+        """Label the session's current pull request through Loom; needs ``mark``."""
+        self._gate("mark")
+        return self._request("POST", f"/sessions/{key}/github/labels", {"labels": labels})
 
     def set_tags(self, key, tags, by=None, clear=None):
         """Atomically replace this author's complete tag set on a session.

--- a/python/weaver-loom/tests/test_status_program.py
+++ b/python/weaver-loom/tests/test_status_program.py
@@ -90,7 +90,7 @@ def batches(client):
     return [c for c in client.calls if c[0] == "set_tags"]
 
 
-def test_pr_label_uses_the_trigger_repo_environment(monkeypatch, capsys):
+def test_pr_label_uses_the_loom_github_api(capsys):
     client = StubClient(
         capabilities=["mark"],
         sessions=[
@@ -104,14 +104,13 @@ def test_pr_label_uses_the_trigger_repo_environment(monkeypatch, capsys):
             }
         ],
     )
-    calls = []
-    monkeypatch.setattr(pr_label, "gh_json", lambda args, cwd=None: calls.append((args, cwd)))
+    client.add_github_labels = lambda key, labels: client.calls.append(
+        ("add_github_labels", key, labels)
+    )
     rnd = make_round(client, capabilities=client.capabilities)
     pr_label.main(rnd)
 
-    assert calls == [
-        (["api", "-X", "POST", "repos/{owner}/{repo}/issues/17/labels", "-f", "labels[]=weaver"], "/repo")
-    ]
+    assert client.calls == [("add_github_labels", "s", ["weaver"])]
     assert json.loads(capsys.readouterr().out)["actions"] == [
         {"action": "label", "session": "s", "pr": 17, "label": "weaver"}
     ]

--- a/python/weaver-loom/tests/test_weaver_loom.py
+++ b/python/weaver-loom/tests/test_weaver_loom.py
@@ -10,7 +10,6 @@ builtin scripts against a real loom.
 
 import json
 import io
-import subprocess
 import urllib.error
 import urllib.request
 
@@ -22,7 +21,6 @@ from weaver_loom import (
     Round,
     WeaverError,
     WorkloadCredentials,
-    gh_json,
     parse_judgement,
     parse_tag_recommendations,
 )
@@ -604,86 +602,6 @@ def test_preview_or_lets_other_exceptions_propagate():
     rnd.client.preview = boom
     with pytest.raises(RuntimeError):
         rnd.preview_or("s", 10)
-
-
-# -- gh_json: the "shell out to gh" pattern shared by gh-backed watches --------
-
-
-def _run_result(returncode=0, stdout="", stderr=""):
-    return subprocess.CompletedProcess(
-        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
-    )
-
-
-def test_gh_json_parses_stdout(monkeypatch):
-    monkeypatch.setattr(
-        subprocess, "run", lambda *a, **k: _run_result(stdout='{"ok": true}')
-    )
-    assert gh_json(["pr", "view"]) == {"ok": True}
-
-
-def test_gh_json_raises_weaver_error_when_gh_is_missing(monkeypatch):
-    def boom(*a, **k):
-        raise FileNotFoundError("no such file: gh")
-
-    monkeypatch.setattr(subprocess, "run", boom)
-    with pytest.raises(WeaverError, match="gh not found"):
-        gh_json(["pr", "view"])
-
-
-def test_gh_json_names_the_missing_path_when_it_is_not_gh(monkeypatch):
-    # subprocess.run(cwd=...) raises the same FileNotFoundError type when the
-    # *cwd* doesn't exist — that must not be misreported as "gh not found".
-    def boom(*a, **k):
-        raise FileNotFoundError(2, "No such file or directory", "/gone/repo")
-
-    monkeypatch.setattr(subprocess, "run", boom)
-    with pytest.raises(WeaverError, match=r"/gone/repo not found") as exc:
-        gh_json(["pr", "view"], cwd="/gone/repo")
-    assert "gh not found" not in str(exc.value)
-
-
-def test_gh_json_raises_weaver_error_on_timeout(monkeypatch):
-    def boom(*a, **k):
-        raise subprocess.TimeoutExpired(cmd="gh", timeout=30)
-
-    monkeypatch.setattr(subprocess, "run", boom)
-    with pytest.raises(WeaverError, match="timed out"):
-        gh_json(["pr", "view"])
-
-
-def test_gh_json_raises_weaver_error_with_stderr_on_nonzero_exit(monkeypatch):
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        lambda *a, **k: _run_result(returncode=1, stderr="not authenticated"),
-    )
-    with pytest.raises(WeaverError, match="not authenticated"):
-        gh_json(["pr", "view"])
-
-
-def test_gh_json_falls_back_to_stdout_when_stderr_is_empty(monkeypatch):
-    # An empty stderr on a non-zero exit must not leave the WeaverError with no
-    # diagnostic text at all — fall back to stdout, then a placeholder.
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        lambda *a, **k: _run_result(returncode=1, stdout="rate limited", stderr=""),
-    )
-    with pytest.raises(WeaverError, match="rate limited"):
-        gh_json(["pr", "view"])
-
-    monkeypatch.setattr(
-        subprocess, "run", lambda *a, **k: _run_result(returncode=1, stdout="", stderr="")
-    )
-    with pytest.raises(WeaverError, match="no output"):
-        gh_json(["pr", "view"])
-
-
-def test_gh_json_raises_weaver_error_on_bad_json(monkeypatch):
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _run_result(stdout="not json"))
-    with pytest.raises(WeaverError, match="unparseable JSON"):
-        gh_json(["pr", "view"])
 
 
 def test_set_state_rejects_non_dict():


### PR DESCRIPTION
Make Loom the sole policy owner for GitHub credentials across sessions, server operations, watches, and deployment configuration.

Ordinary interactive sessions now use the launching user Account PAT when one is stored, and otherwise broker a short-lived GitHub App token limited by the selected profile repository allowlist. Restricted and automation paths never receive the personal token. Profile, repository, committed, daemon, and IaC environments can no longer define GH_TOKEN or GITHUB_TOKEN; a migration removes those legacy environment values while preserving per-user Account tokens.

The Docker Git credential helper and gh wrapper remain transport adapters for stock clients. They accept only the Loom-stamped direct, broker, or disabled mode and fail closed when the mode or required Loom credential is absent.

Server-side cloning, webhook replies, pull-request polling, restricted GitHub tools, and built-in PR labeling now call GitHub through the App-backed Loom API. Watch subprocesses receive no GitHub token, and loom setup secrets plus standalone deployment configuration no longer expose a deployment GH_TOKEN.