### PR TITLE
fix(loom): recover disconnected ACP sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -349,7 +349,7 @@ if [ "${1:-}" = loom ] && [ "${2:-}" = server ]; then
       || echo "loom: WARNING: could not disable Codex account-level apps" >&2
   fi
   claude_acp_version="${CLAUDE_ACP_VERSION:-0.66.0}"
-  codex_acp_version="${CODEX_ACP_VERSION:-1.1.4}"
+  codex_acp_version="${CODEX_ACP_VERSION:-1.4.0}"
   if ! command -v claude-agent-acp >/dev/null 2>&1 \
     || ! command -v codex-acp >/dev/null 2>&1 \
     || ! npm list -g --depth=0 "@agentclientprotocol/claude-agent-acp@$claude_acp_version" >/dev/null 2>&1 \

--- a/crates/loom-agent/src/acp/mod.rs
+++ b/crates/loom-agent/src/acp/mod.rs
@@ -1387,11 +1387,33 @@ impl TurnEndSource {
 
 #[derive(Debug)]
 enum TaskStopReason {
-    AgentExit,
+    AgentExit { status: Option<i32> },
     CommandChannelClosed,
     Handoff,
     JournalFailure,
     RelayClosed,
+}
+
+impl TaskStopReason {
+    fn failure_message(&self) -> Option<String> {
+        match self {
+            Self::AgentExit { status: Some(status) } => Some(format!(
+                "The ACP agent exited unexpectedly (status {status}). Select Adopt to restart it."
+            )),
+            Self::AgentExit { status: None } => Some(
+                "The ACP agent exited unexpectedly. Select Adopt to restart it.".to_string(),
+            ),
+            Self::JournalFailure => Some(
+                "Loom could not persist ACP output. The session was detached to preserve the relay backlog; select Adopt to retry."
+                    .to_string(),
+            ),
+            Self::RelayClosed => Some(
+                "Loom lost its connection to the ACP agent. The agent may still be running; select Adopt to reconnect."
+                    .to_string(),
+            ),
+            Self::CommandChannelClosed | Self::Handoff => None,
+        }
+    }
 }
 
 struct Task {
@@ -2012,8 +2034,7 @@ impl Task {
                         }
                     }
                     Some(RelayEvent::Exit { status }) => {
-                        self.on_exit(status).await;
-                        break TaskStopReason::AgentExit;
+                        break TaskStopReason::AgentExit { status };
                     }
                     None => break TaskStopReason::RelayClosed,
                 },
@@ -2051,6 +2072,20 @@ impl Task {
                 },
             }
         };
+        let failure_message = stop_reason.failure_message();
+        if let TaskStopReason::AgentExit { .. } = stop_reason {
+            self.on_failure(
+                failure_message
+                    .as_deref()
+                    .expect("agent exit always carries a failure message"),
+            )
+            .await;
+        } else if let Some(message) = &failure_message {
+            tracing::warn!(session = %self.session_id, reason = message, "acp task failed");
+        }
+        if let Some(message) = &failure_message {
+            crate::status::record_acp_failure(&self.db, &self.bus, &self.session_id, message).await;
+        }
         self.registry.remove_own(&self.session_id, self.generation);
         if let Some((reply, snapshot)) = handoff_reply {
             let _ = reply.send(Ok(snapshot));
@@ -3339,11 +3374,11 @@ impl Task {
 
     // -- exit ---------------------------------------------------------------
 
-    async fn on_exit(&mut self, status: Option<i32>) {
-        tracing::warn!(session = %self.session_id, ?status, "acp agent exited");
+    async fn on_failure(&mut self, reason: &str) {
+        tracing::warn!(session = %self.session_id, reason, "acp task failed");
         self.settle_inflight_review(
             crate::review_inbox::ReviewClaimSettlement::Abandoned,
-            "ACP process exit",
+            "ACP task failure",
         )
         .await;
         let ending_turn = self

--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -976,6 +976,7 @@ pub async fn adopt_acp(
     // A re-adopted ACP session is live again — mark it running.
     let status = agent::initial_status(&st.db, &session.agent_kind).await;
     session_mod::set_status(&st.db, &session.id, status).await?;
+    crate::status::clear_acp_failure(&st.db, &st.bus, &branch.id).await;
     events::record(
         &st.db,
         &st.bus,

--- a/crates/loom-store/src/status.rs
+++ b/crates/loom-store/src/status.rs
@@ -9,6 +9,7 @@
 
 use serde_json::json;
 
+use crate::channels::{self, MessageKind, NewMessage, Subject, SubjectKind, Urgency};
 use crate::db::now_iso;
 use crate::db::Db;
 use crate::events;
@@ -16,6 +17,9 @@ use crate::events::EventBus;
 use crate::session::{self as session_mod, Session};
 use weaver_core::tags;
 use weaver_core::BoxFut;
+
+/// Machine-owned signal raised when Loom loses an ACP runtime unexpectedly.
+pub const ACP_RUNTIME_TAG: &str = "runtime";
 
 /// The tag mutations a work-cycle hook implies: `(key, value)` where an empty
 /// value clears the tag (absence is the calm/default state). `working` returns
@@ -236,4 +240,115 @@ pub async fn record_acp_lifecycle(db: &Db, bus: &EventBus, session_id: &str, kin
         tracing::warn!(session = %session_id, error = %e, "acp lifecycle: hook audit write failed");
     }
     let _ = promote_lifecycle(db, bus, &session, kind).await;
+}
+
+/// Detach an ACP session whose driver stopped unexpectedly and leave durable,
+/// user-facing recovery instructions in every existing status surface.
+pub async fn record_acp_failure(db: &Db, bus: &EventBus, session_id: &str, reason: &str) {
+    let session = match session_mod::get(db, session_id).await {
+        Ok(Some(session)) => session,
+        Ok(None) => return,
+        Err(error) => {
+            tracing::warn!(session = %session_id, %error, "ACP failure session lookup failed");
+            return;
+        }
+    };
+    match session_mod::mark_orphaned(db, session_id).await {
+        Ok(true) => {}
+        Ok(false) => return,
+        Err(error) => {
+            tracing::warn!(session = %session_id, %error, "could not detach failed ACP session");
+            return;
+        }
+    }
+
+    tracing::warn!(session = %session_id, branch = %session.branch_id, reason, "ACP session detached after runtime failure");
+    if let Err(error) = tags::set(
+        db,
+        &session.branch_id,
+        ACP_RUNTIME_TAG,
+        "attention",
+        reason,
+        "loom",
+    )
+    .await
+    {
+        tracing::warn!(session = %session_id, %error, "could not persist ACP runtime signal");
+    }
+    if let Err(error) = events::record(
+        db,
+        bus,
+        &session.branch_id,
+        "status",
+        json!({ "status": "orphaned", "reason": reason }),
+    )
+    .await
+    {
+        tracing::warn!(session = %session_id, %error, "could not record ACP failure status event");
+    }
+    if let Err(error) = events::record_tag(
+        db,
+        bus,
+        &session.branch_id,
+        ACP_RUNTIME_TAG,
+        "attention",
+        reason,
+        "loom",
+    )
+    .await
+    {
+        tracing::warn!(session = %session_id, %error, "could not record ACP runtime signal event");
+    }
+
+    let author = Subject::new(SubjectKind::System, "loom");
+    let idempotency_key = format!(
+        "acp-runtime-failure:{}",
+        session.acp_session_id.as_deref().unwrap_or(session_id)
+    );
+    if let Err(error) = channels::append(
+        db,
+        session_id,
+        NewMessage {
+            kind: MessageKind::Status,
+            urgency: Urgency::Attention,
+            author: &author,
+            body: reason,
+            payload: &json!({ "level": "attention", "status": "orphaned" }),
+            reply_to: None,
+            idempotency_key: Some(&idempotency_key),
+        },
+    )
+    .await
+    {
+        tracing::warn!(session = %session_id, %error, "could not append ACP failure channel status");
+    }
+}
+
+/// Clear Loom's runtime-failure signal after a successful ACP adoption.
+pub async fn clear_acp_failure(db: &Db, bus: &EventBus, branch_id: &str) {
+    let failure = match tags::get(db, branch_id, ACP_RUNTIME_TAG).await {
+        Ok(Some(failure)) if failure.set_by == "loom" => failure,
+        Ok(_) => return,
+        Err(error) => {
+            tracing::warn!(branch = %branch_id, %error, "ACP failure signal lookup failed");
+            return;
+        }
+    };
+    if let Err(error) = tags::clear(db, branch_id, ACP_RUNTIME_TAG).await {
+        tracing::warn!(branch = %branch_id, %error, "could not clear ACP failure signal");
+        return;
+    }
+    if let Err(error) = events::record_tag(
+        db,
+        bus,
+        branch_id,
+        ACP_RUNTIME_TAG,
+        "",
+        &failure.note,
+        "loom",
+    )
+    .await
+    {
+        tracing::warn!(branch = %branch_id, %error, "could not record cleared ACP failure signal");
+    }
 }

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -190,7 +190,10 @@ const surfacedLinks = computed<SurfacedLink[]>(() => {
 
 function statusEventLine(event: WeaverEvent): string {
   const data = event.data ?? {};
-  if (event.kind === 'status') return `Lifecycle → ${String(data.status ?? 'unknown')}`;
+  if (event.kind === 'status') {
+    const reason = typeof data.reason === 'string' && data.reason ? ` — ${data.reason}` : '';
+    return `Lifecycle → ${String(data.status ?? 'unknown')}${reason}`;
+  }
   const key = String(data.key ?? 'tag');
   const value = String(data.value ?? '');
   const note = typeof data.note === 'string' && data.note ? ` — ${data.note}` : '';

--- a/crates/loom/frontend/src/lib/sessionState.test.mjs
+++ b/crates/loom/frontend/src/lib/sessionState.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { effectiveAttention, messageOf } from './sessionState.ts';
+
+test('an orphaned ACP runtime surfaces Loom recovery guidance', () => {
+  const session = {
+    status: 'orphaned',
+    last_activity_at: '2026-08-18T20:00:00Z',
+    branch: {
+      description: 'Agent status from before the disconnect',
+      tags: [
+        {
+          key: 'runtime',
+          value: 'attention',
+          note: 'Loom lost its connection. Select Adopt to reconnect.',
+          set_by: 'loom',
+          set_at: '2026-08-18T20:00:00Z',
+        },
+      ],
+    },
+  };
+
+  assert.equal(messageOf(session), 'Loom lost its connection. Select Adopt to reconnect.');
+  assert.deepEqual(effectiveAttention(session), {
+    key: 'runtime',
+    level: 'attention',
+    by: 'loom',
+    raisedBy: 'watch',
+    note: 'Loom lost its connection. Select Adopt to reconnect.',
+    stale: false,
+  });
+});

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -15,6 +15,7 @@ const SEVERITY: Record<string, number> = { attention: 1, blocked: 2 };
 // longer reads as needing the user. The status watch may replace it with a real
 // loud status. Mirrors weaver-core's `IDLE_KEY`.
 export const IDLE_KEY = 'idle';
+export const ACP_RUNTIME_KEY = 'runtime';
 export const AUTO_ARCHIVE_KEY = 'auto-archive';
 export const AUTO_ARCHIVE_DISABLED_VALUE = 'disabled';
 
@@ -53,6 +54,12 @@ function isAgentTag(tag: Tag): boolean {
 // sessions so torn-down workstreams don't show stale chatter.
 export function messageOf(s: SessionSummary): string {
   if (s.status === 'archived') return '';
+  if (s.status === 'error' || s.status === 'orphaned') {
+    const runtime = (s.branch.tags ?? []).find(
+      (tag) => tag.key === ACP_RUNTIME_KEY && tag.set_by === 'loom',
+    );
+    if (runtime?.note) return runtime.note;
+  }
   return s.branch.description ?? '';
 }
 
@@ -128,14 +135,13 @@ export function effectiveAttention(s: SessionSummary): EffectiveAttention {
   };
   if (s.status === 'archived') return calm;
   const tags = loudTags(s);
-  if (tags.length) {
-    const live = tags.filter((t) => !tagStale(t, s.last_activity_at));
-    const pool = live.length ? live : tags;
-    const stale = live.length === 0;
-    const top = [...pool].sort(louder)[0];
-    if (top.value === 'blocked') return { ...markOf(s, top), stale };
-  }
+  const live = tags.filter((t) => !tagStale(t, s.last_activity_at));
+  const pool = live.length ? live : tags;
+  const stale = tags.length > 0 && live.length === 0;
+  const top = [...pool].sort(louder)[0];
+  if (top?.value === 'blocked') return { ...markOf(s, top), stale };
   if (s.status === 'error' || s.status === 'orphaned') {
+    if (top) return { ...markOf(s, top), stale };
     return {
       level: 'attention',
       raisedBy: 'watch',
@@ -146,10 +152,7 @@ export function effectiveAttention(s: SessionSummary): EffectiveAttention {
     };
   }
   if (!tags.length) return calm;
-  const live = tags.filter((t) => !tagStale(t, s.last_activity_at));
-  const pool = live.length ? live : tags;
-  const stale = live.length === 0;
-  return { ...markOf(s, [...pool].sort(louder)[0]), stale };
+  return { ...markOf(s, top), stale };
 }
 
 // One loud tag surfaced as an individually-dismissable chip. Unlike

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -336,7 +336,7 @@ pub async fn repair_acp_sessions(state: &AppState) {
                                 &session.branch_id,
                             )
                             .await;
-                            let _ = crate::events::record(
+                            if let Err(error) = crate::events::record(
                                 &state.db,
                                 &state.bus,
                                 &session.branch_id,
@@ -346,7 +346,14 @@ pub async fn repair_acp_sessions(state: &AppState) {
                                     "reason": "ACP runtime reattached",
                                 }),
                             )
-                            .await;
+                            .await
+                            {
+                                tracing::warn!(
+                                    session = %session.id,
+                                    %error,
+                                    "acp repair could not record restored session status"
+                                );
+                            }
                         }
                         Err(error) => tracing::warn!(
                             session = %session.id,

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -326,7 +326,37 @@ pub async fn repair_acp_sessions(state: &AppState) {
             continue; // dead relay — the monitor will mark it orphaned.
         }
         match crate::acp::attach(&state.acp_ctx(), &session.id).await {
-            Ok(()) => tracing::info!("acp repair: re-attached session {}", session.id),
+            Ok(()) => {
+                if session.status == "orphaned" {
+                    match session_mod::set_status(&state.db, &session.id, "running").await {
+                        Ok(()) => {
+                            crate::status::clear_acp_failure(
+                                &state.db,
+                                &state.bus,
+                                &session.branch_id,
+                            )
+                            .await;
+                            let _ = crate::events::record(
+                                &state.db,
+                                &state.bus,
+                                &session.branch_id,
+                                "status",
+                                serde_json::json!({
+                                    "status": "running",
+                                    "reason": "ACP runtime reattached",
+                                }),
+                            )
+                            .await;
+                        }
+                        Err(error) => tracing::warn!(
+                            session = %session.id,
+                            %error,
+                            "acp repair reattached the runtime but could not restore session status"
+                        ),
+                    }
+                }
+                tracing::info!("acp repair: re-attached session {}", session.id);
+            }
             Err(e) => tracing::warn!(
                 "acp repair: could not re-attach session {}: {e}",
                 session.id

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1897,11 +1897,16 @@ async fn relay_disconnect_detaches_the_session_with_recovery_feedback() {
     ts.client
         .post(
             &format!("/api/sessions/{id}/prompt"),
-            json!({ "text": "say:reconnected|wait:1000" }),
+            json!({
+                "text": "say:before-disconnect|usage:1:10|wait:1000|say:after-disconnect"
+            }),
         )
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    poll_chat(&ts, id, Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| block["kind"] == "usage")
+    })
+    .await;
 
     // Tapestry permits one live relay subscriber. A replacement subscriber
     // evicts Loom's driver while leaving the relay and ACP child alive, which is
@@ -1957,7 +1962,8 @@ async fn relay_disconnect_detaches_the_session_with_recovery_feedback() {
     );
     poll_chat(&ts, id, Duration::from_secs(10), |blocks| {
         blocks.iter().any(|block| {
-            block["kind"] == "agent_message" && block["payload"]["text"] == "reconnected"
+            block["kind"] == "agent_message"
+                && block["payload"]["text"] == "before-disconnectafter-disconnect"
         }) && blocks.iter().any(|block| block["kind"] == "turn_end")
     })
     .await;

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -1885,6 +1885,84 @@ async fn crash_recovery_replays_without_duplicates() {
     );
 }
 
+/// Losing only Loom's relay subscription must not leave a session claiming it
+/// is live while every prompt route has already lost its ACP task.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn relay_disconnect_detaches_the_session_with_recovery_feedback() {
+    let ts = TestServer::start().await;
+    let id = "acp-relay-disconnect";
+    start_new(&ts, id, None, None).await;
+    let session = session_mod::get(&ts.state.db, id).await.unwrap().unwrap();
+    ts.client
+        .post(
+            &format!("/api/sessions/{id}/prompt"),
+            json!({ "text": "say:reconnected|wait:1000" }),
+        )
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Tapestry permits one live relay subscriber. A replacement subscriber
+    // evicts Loom's driver while leaving the relay and ACP child alive, which is
+    // the production failure shape this regression covers.
+    let _replacement = backend::subscribe_relay(&session.term_session, 0)
+        .await
+        .expect("replacement relay subscriber connects");
+
+    let view = poll_view(&ts, id, Duration::from_secs(10), |view| {
+        view["status"] == "orphaned" && branch_tag_value(view, "runtime") == "attention"
+    })
+    .await;
+    assert!(!ts.state.acp.is_live(id), "the disconnected task is gone");
+    assert!(
+        backend::has_session(&session.term_session).await,
+        "the relay child remains available for adoption"
+    );
+    let runtime = view["branch"]["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tag| tag["key"] == "runtime")
+        .unwrap();
+    assert_eq!(runtime["set_by"], "loom");
+    assert!(runtime["note"]
+        .as_str()
+        .unwrap()
+        .contains("select Adopt to reconnect"));
+
+    let messages = ts
+        .client
+        .get(&format!("/api/channels/{id}/messages"))
+        .await
+        .unwrap();
+    assert!(messages.as_array().unwrap().iter().any(|message| {
+        message["kind"] == "status"
+            && message["urgency"] == "attention"
+            && message["author_kind"] == "system"
+            && message["body"]
+                .as_str()
+                .is_some_and(|body| body.contains("select Adopt to reconnect"))
+    }));
+
+    loom::server::repair_acp_sessions(&ts.state).await;
+    let adopted = poll_view(&ts, id, Duration::from_secs(10), |view| {
+        view["status"] == "running" && branch_tag_value(view, "runtime").is_empty()
+    })
+    .await;
+    assert_eq!(adopted["status"], "running");
+    assert!(
+        ts.state.acp.is_live(id),
+        "the repair loop restored the ACP driver"
+    );
+    poll_chat(&ts, id, Duration::from_secs(10), |blocks| {
+        blocks.iter().any(|block| {
+            block["kind"] == "agent_message" && block["payload"]["text"] == "reconnected"
+        }) && blocks.iter().any(|block| block["kind"] == "turn_end")
+    })
+    .await;
+}
+
 /// A relay can survive while its Loom-side task exits (for example after a
 /// journal write loses a prolonged SQLite lock race). The repair pass must
 /// re-register the driver, replay the unacked frames, and leave the session

--- a/crates/tapestry/src/client.rs
+++ b/crates/tapestry/src/client.rs
@@ -20,6 +20,7 @@ const ATTACH_BUFFER: usize = 256;
 
 /// A connected control client for one session.
 pub struct Client {
+    name: String,
     stream: UnixStream,
 }
 
@@ -31,7 +32,10 @@ impl Client {
         let stream = UnixStream::connect(&path)
             .await
             .with_context(|| format!("connecting to session {name}"))?;
-        Ok(Self { stream })
+        Ok(Self {
+            name: name.to_string(),
+            stream,
+        })
     }
 
     /// Whether a supervisor is alive for `name` — connect and ping. A stale
@@ -117,6 +121,7 @@ impl Client {
     /// streams live frames, and finally an [`RelayEvent::Exit`] once the child has
     /// exited. Only one subscriber exists at a time — this evicts any previous one.
     pub async fn subscribe(self, cursor: u64) -> Result<RelayStream> {
+        let name = self.name;
         let mut stream = self.stream;
         protocol::write_frame(&mut stream, &req::subscribe(cursor)).await?;
         let (rd, wr) = stream.into_split();
@@ -149,7 +154,14 @@ impl Client {
                         break;
                     }
                     Ok(Some(_)) => {} // ignore stray frames
-                    Ok(None) | Err(_) => break,
+                    Ok(None) => {
+                        tracing::warn!(session = %name, "relay subscription closed before child exit");
+                        break;
+                    }
+                    Err(error) => {
+                        tracing::warn!(session = %name, %error, "relay subscription read failed");
+                        break;
+                    }
                 }
             }
         }));


### PR DESCRIPTION
Unexpected ACP relay disconnects previously removed the live driver while leaving sessions marked running. Later prompts failed with `session '<id>' has no live ACP task to drive`, and neither the dashboard nor durable channel explained the failure.

Mark unexpected relay and journal failures orphaned, persist a machine-owned runtime attention tag and typed status message, and retain replayable in-flight turns. Automatic and manual reattachment clear the failure state and return the session to running. Relay logs now include the session identity, and the dashboard shows lifecycle reasons.

Update the bundled Codex ACP adapter from 1.1.4 to 1.4.0. Production recovery restored `milc9xxs` from an orphaned state on the new adapter, preserved its provider conversation, and completed a probe turn with `RECOVERED 1.4.0`.

Incident record: https://echo.oa.dev/wiki/168
