### PR TITLE
fix(mcp): drop the profile MCP snapshot check

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,6 @@ loom settings list
 loom profile ls
 loom profile show default
 loom profile show ops --effective
-loom profile probe ops
 loom mcp ls
 loom mcp show mcp/github/comment@v1
 loom profile add ops --agent codex --mcp github,messaging

--- a/crates/loom-agent/src/mcp/mod.rs
+++ b/crates/loom-agent/src/mcp/mod.rs
@@ -354,52 +354,6 @@ fn selected_for_groups(set: &McpCapabilitySetView, groups: &[String]) -> bool {
         || (set.name == "loom/sessions/write@v1" && groups.iter().any(|group| group == "messaging"))
 }
 
-/// Report whether an exact profile snapshot is still launchable. Profiles
-/// remain inspectable when a set is retired or a custom server is disabled,
-/// but a new session must not silently substitute current registry content.
-pub async fn snapshot_errors(
-    db: &crate::Db,
-    snapshot: &weaver_api::McpPolicySnapshot,
-) -> Result<Vec<String>> {
-    let current = registry();
-    let custom = list_custom(db).await?;
-    let mut errors = Vec::new();
-    for pinned in &snapshot.capability_sets {
-        match current
-            .capability_sets
-            .iter()
-            .find(|candidate| candidate.name == pinned.name)
-        {
-            None => errors.push(format!(
-                "built-in capability set '{}' is no longer supported",
-                pinned.name
-            )),
-            Some(candidate) if candidate != pinned => errors.push(format!(
-                "built-in capability set '{}' changed (pinned {}, current {}); save the profile to reconcile it",
-                pinned.name, pinned.digest, candidate.digest
-            )),
-            Some(_) => {}
-        }
-    }
-    for pinned in &snapshot.custom_servers {
-        match custom
-            .iter()
-            .find(|candidate| candidate.identity == pinned.identity)
-        {
-            None => errors.push(format!(
-                "custom MCP '{}' was removed; save the profile to reconcile it",
-                pinned.identity
-            )),
-            Some(candidate) if !candidate.enabled => errors.push(format!(
-                "custom MCP '{}' is disabled; enable it or save the profile to reconcile it",
-                pinned.identity
-            )),
-            Some(_) => {}
-        }
-    }
-    Ok(errors)
-}
-
 pub async fn resolve_access(
     db: &crate::Db,
     access: &weaver_api::McpAccess,
@@ -991,24 +945,6 @@ mod tests {
         )
         .await
         .is_err());
-    }
-
-    #[tokio::test]
-    async fn changed_builtin_content_invalidates_a_pinned_profile_snapshot() {
-        let db = crate::db::connect_in_memory().await.unwrap();
-        let mut snapshot = super::resolve_access(
-            &db,
-            &weaver_api::McpAccess {
-                mode: "groups".into(),
-                groups: vec!["github".into()],
-            },
-        )
-        .await
-        .unwrap();
-        snapshot.capability_sets[0].digest = "sha256:stale".to_string();
-        let errors = super::snapshot_errors(&db, &snapshot).await.unwrap();
-        assert_eq!(errors.len(), 1);
-        assert!(errors[0].contains("save the profile to reconcile"));
     }
 
     #[test]

--- a/crates/loom-core/src/launch.rs
+++ b/crates/loom-core/src/launch.rs
@@ -302,7 +302,7 @@ pub async fn resolve(
     }
 
     let mcp_policy = profile.mcp_policy_snapshot()?;
-    let mut errors = crate::mcp::snapshot_errors(db, &mcp_policy).await?;
+    let mut errors = Vec::new();
     let runtime_permissions =
         crate::profile::effective_allowed_tool_rules_for(&profile, &mcp_policy)?;
     if protocol != "acp"

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1400,8 +1400,6 @@ enum ProfileCmd {
         #[arg(long)]
         effective: bool,
     },
-    /// Validate and resolve a profile without launching a session.
-    Probe { name: String },
     /// Resolve the exact launch snapshot, including provenance and capacity.
     Resolve {
         name: String,
@@ -3005,13 +3003,6 @@ async fn run_profile(cmd: ProfileCmd) -> Result<()> {
                     serde_json::to_string_pretty(&client.get_profile(&name).await?)?
                 }
             );
-        }
-        ProfileCmd::Probe { name } => {
-            let probe = client.probe_profile(&name).await?;
-            println!("{}", serde_json::to_string_pretty(&probe)?);
-            if !probe.ok {
-                bail!("profile probe failed");
-            }
         }
         ProfileCmd::Resolve {
             name,

--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -1081,7 +1081,6 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/profiles", get(list_profiles).post(create_profile))
         .route("/profiles/{name}/effective", get(effective_profile))
-        .route("/profiles/{name}/probe", post(probe_profile))
         .route("/profiles/{name}/clone", post(clone_profile))
         .route(
             "/profiles/{name}",

--- a/crates/loom/src/web/profiles.rs
+++ b/crates/loom/src/web/profiles.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use weaver_api::{
     CloneProfileReq, EffectiveProfileView, LaunchSelection, McpServerProcessView, ProfileEnvView,
-    ProfileProbeView, ProfileReq, ProfileView, PutProfileEnvReq,
+    ProfileReq, ProfileView, PutProfileEnvReq,
 };
 
 use crate::profile::{self, Profile, ProfileInput};
@@ -144,22 +144,6 @@ pub(super) async fn effective_profile(
         .await?
         .ok_or_else(|| AppError::not_found("profile"))?;
     Ok(Json(effective(&st, item).await?))
-}
-
-pub(super) async fn probe_profile(
-    State(st): State<AppState>,
-    Path(name): Path<String>,
-) -> ApiResult<Json<ProfileProbeView>> {
-    let item = profile::get(&st.db, &name)
-        .await?
-        .ok_or_else(|| AppError::not_found("profile"))?;
-    let effective = effective(&st, item).await?;
-    let errors = crate::mcp::snapshot_errors(&st.db, &effective.mcp_policy).await?;
-    Ok(Json(ProfileProbeView {
-        ok: errors.is_empty(),
-        effective,
-        errors,
-    }))
 }
 
 pub(super) async fn create_profile(

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -332,13 +332,6 @@ print("custom tests passed")
         effective["mcp_servers"][0]["args"],
         json!(["mcp", "serve-custom", "/ops/status"])
     );
-    let probe = ts
-        .client
-        .post("/api/profiles/custom-tools/probe", json!({}))
-        .await
-        .unwrap();
-    assert_eq!(probe["ok"], true);
-
     let source_v2 = source.replace("Return a value.", "Return a pinned value.");
     let edited = ts
         .client
@@ -396,13 +389,6 @@ print("custom tests passed")
         .unwrap();
     assert_eq!(disabled["identity"], "/ops/status");
     assert_eq!(disabled["revision"], 3);
-    let probe = ts
-        .client
-        .post("/api/profiles/custom-tools/probe", json!({}))
-        .await
-        .unwrap();
-    assert_eq!(probe["ok"], false);
-    assert!(probe["errors"][0].as_str().unwrap().contains("is disabled"));
 
     let response = reqwest::Client::new()
         .delete(format!("http://{}/api/mcps/custom/ops/status", ts.addr))

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -28,16 +28,15 @@ use crate::dto::{
     ExpectedReviewRevisionReq, FederationReq, FederationView, GithubTokenView, HandoffReq,
     HistoryPageView, IssueActionsReq, IssueActionsResult, IssueView, McpRegistryView,
     MoveSessionsReq, NewCommentBody, NewThreadBody, PatchIssueReq, PatchSessionReq, PatchWatchReq,
-    PermissionRequestView, ProfileProbeView, ProfileReq, ProfileView, PutProfileEnvReq,
-    ReadinessView, ReorderSessionLayoutReq, ResolveLaunchReq, ResolveReviewCommentReq,
-    ResolvedLaunchView, RestoreSessionGroupsReq, ResumptionCueView, ReviewCommentDto, ReviewDto,
-    RunReq, RunView, RunWatchReq, ScratchLimitsView, SearchSessionsOptions, SelfContextView,
-    SendReq, SessionCatchupView, SessionGithubAccessView, SessionGroupPreferenceReq,
-    SessionLayoutView, SessionPlacementSelectorKind, SessionView, SetChannelReadMarkerReq,
-    SetChannelSubscriptionReq, SetSessionGithubAccessReq, SetSessionPlacementDefaultReq,
-    SetTagsReq, SetTitleGenerationReq, SettingsEnvelope, SubmitReviewReq, TagReq, ThreadDto,
-    TokenView, UpdateReviewCommentReq, UpdateReviewReq, UpdateSessionGroupReq,
-    UpdateSessionSpaceReq, WatchView,
+    PermissionRequestView, ProfileReq, ProfileView, PutProfileEnvReq, ReadinessView,
+    ReorderSessionLayoutReq, ResolveLaunchReq, ResolveReviewCommentReq, ResolvedLaunchView,
+    RestoreSessionGroupsReq, ResumptionCueView, ReviewCommentDto, ReviewDto, RunReq, RunView,
+    RunWatchReq, ScratchLimitsView, SearchSessionsOptions, SelfContextView, SendReq,
+    SessionCatchupView, SessionGithubAccessView, SessionGroupPreferenceReq, SessionLayoutView,
+    SessionPlacementSelectorKind, SessionView, SetChannelReadMarkerReq, SetChannelSubscriptionReq,
+    SetSessionGithubAccessReq, SetSessionPlacementDefaultReq, SetTagsReq, SetTitleGenerationReq,
+    SettingsEnvelope, SubmitReviewReq, TagReq, ThreadDto, TokenView, UpdateReviewCommentReq,
+    UpdateReviewReq, UpdateSessionGroupReq, UpdateSessionSpaceReq, WatchView,
 };
 
 /// A client for one loom server, identified by its base URL.
@@ -1445,15 +1444,6 @@ impl Client {
     pub async fn effective_profile(&self, name: &str) -> Result<EffectiveProfileView> {
         self.get_typed(&format!("/api/profiles/{}/effective", Self::seg(name)))
             .await
-    }
-
-    pub async fn probe_profile(&self, name: &str) -> Result<ProfileProbeView> {
-        self.send_typed::<(), _>(
-            Method::POST,
-            &format!("/api/profiles/{}/probe", Self::seg(name)),
-            None,
-        )
-        .await
     }
 
     pub async fn create_profile(&self, req: &ProfileReq) -> Result<ProfileView> {

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -805,13 +805,6 @@ pub struct EffectiveProfileView {
     pub mcp_servers: Vec<McpServerProcessView>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProfileProbeView {
-    pub ok: bool,
-    pub effective: EffectiveProfileView,
-    pub errors: Vec<String>,
-}
-
 /// Fields a caller may layer over a named profile for one launch. Presence is
 /// significant: an omitted (or blank agent) field inherits while an explicit
 /// empty model or effort selects the agent's own default.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -900,7 +900,7 @@ only teaches stock `git` and `gh` how to ask for them.
 **MCP/profile control plane.** A profile stores `mcp_access` as `none`, `all`,
 or an explicit group list. Saving resolves the trusted builtin registry and
 enabled, validated custom definitions and pins the exact result to that profile
-revision. Launch validates availability, copies the capability
+revision. Launch copies the capability
 identities/digests and custom source revisions into
 `sessions.policy_mcp_access`, and gives every ACP runtime native `mcpServers`
 descriptors whose subprocess tool surfaces are filtered to the stamped rules.

--- a/docs/mcp-profiles.md
+++ b/docs/mcp-profiles.md
@@ -120,7 +120,6 @@ loom mcp show mcp/github/comment@v1
 loom mcp add /engineering/search/docs --file server.py --tests test_mcp.py
 loom profile add ops --agent codex --mcp github,messaging
 loom profile show ops --effective
-loom profile probe ops
 ```
 
 Settings exposes the same registry and resolved profile views. API and CLI reads


### PR DESCRIPTION
## Problem

Restarting Loom after an update and starting a session produced a wall of
warnings, one per builtin capability set, and blocked the launch:

```
• built-in capability set 'mcp/channel/read@v1' changed (pinned sha256:7c3a36…, current sha256:7c3a36…); save the profile to reconcile it
```

The two digests it names are identical.

## Fix

Delete the check. `snapshot_errors` compared the whole `McpCapabilitySetView`
field by field, so adding `deprecated_by` (#309) made every profile saved by an
older binary "changed" on a field the digest never covered — hence the same sha
on both sides.

But the message was not the problem. Builtins are Loom's own code, and the
binary that computes the recorded digest is the same one comparing against it;
`rules_for_snapshot` has always expanded capability *names* through the live
registry, so the recorded content was never an input to what a session may call.
Nobody starting a session wants to be asked whether a hash moved.

`POST /api/profiles/{name}/probe` and `loom profile probe` existed to run this
check, so they go too — `GET /profiles/{name}/effective` already returns the
resolved policy they wrapped.

Net **+12 / −135**.

## Note

This also drops the launch-time complaint about a custom MCP that was removed or
disabled after a profile pinned it. Removal was already refused while a profile
pins the server (`custom_mcp::remove`); disabling one no longer stops profiles
that already recorded its source. Say the word if you want that one back — it is
a different animal from a builtin digest, since custom source is operator-written.

## Testing

- `./scripts/pre-commit.sh` ✅
- `./scripts/test-representative.sh` ✅ (its Playwright leg can't run in this
  worktree — `e2e/node_modules` isn't installed; no frontend change here, CI
  covers it)
- `cargo test -p loom --test integration profiles` ✅ (probe assertions removed
  with the endpoint)
- Agent lint review: no findings