### PR TITLE
fix(loom): resolve the tapestry test binary via the artifact dir

### DIFF
--- a/crates/loom/tests/docker_runner.rs
+++ b/crates/loom/tests/docker_runner.rs
@@ -13,6 +13,10 @@ use std::process::Command;
 
 use serial_test::serial;
 
+#[path = "support/tapestry.rs"]
+mod support;
+use support::tapestry_bin;
+
 const CHILD_FLAG: &str = "LOOM_DOCKER_RUNNER_CHILD";
 const ROOT_ENV: &str = "LOOM_DOCKER_RUNNER_TEST_ROOT";
 const SESSION_ENV: &str = "LOOM_DOCKER_RUNNER_TEST_SESSION";
@@ -60,15 +64,6 @@ fn configure(root: &Path, session: &str) {
     std::env::set_var("WEAVER_HOME", root.join(".weaver"));
     std::env::set_var("WEAVER_TAPESTRY_DIR", root.join(".weaver/sock"));
     std::env::set_var(SESSION_ENV, session);
-}
-
-fn tapestry_bin() -> PathBuf {
-    std::env::current_exe()
-        .unwrap()
-        .parent()
-        .and_then(Path::parent)
-        .unwrap()
-        .join("tapestry")
 }
 
 async fn wait_for_screen(session: &str, markers: &[&str]) -> String {

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -16,6 +16,10 @@ use serde_json::json;
 use tokio::net::TcpListener;
 use weaver_core::events::EventBus;
 
+#[path = "support/tapestry.rs"]
+mod support;
+use support::tapestry_bin;
+
 fn sh(dir: &Path, program: &str, args: &[&str]) {
     let status = Command::new(program)
         .args(args)
@@ -23,17 +27,6 @@ fn sh(dir: &Path, program: &str, args: &[&str]) {
         .status()
         .unwrap_or_else(|e| panic!("failed to run {program}: {e}"));
     assert!(status.success(), "{program} {args:?} failed");
-}
-
-/// The `tapestry` supervisor binary built beside this test binary (two levels up
-/// from `target/<profile>/deps/<bin>`). loom's `backend` reads
-/// `WEAVER_TAPESTRY_BIN` to launch it.
-fn tapestry_bin() -> std::path::PathBuf {
-    let exe = std::env::current_exe().expect("test executable path");
-    exe.parent()
-        .and_then(Path::parent)
-        .expect("target dir")
-        .join("tapestry")
 }
 
 /// Best-effort: kill every supervisor whose socket lives under `sock_dir` with a

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -24,6 +24,8 @@ use tokio_tungstenite::tungstenite::Message;
 use weaver_core::config as core_config;
 use weaver_core::events::EventBus;
 
+use crate::support::tapestry_bin;
+
 /// Run `program args` in `dir`, asserting it succeeds.
 pub fn sh(dir: &Path, program: &str, args: &[&str]) {
     let status = Command::new(program)
@@ -32,26 +34,6 @@ pub fn sh(dir: &Path, program: &str, args: &[&str]) {
         .status()
         .unwrap_or_else(|e| panic!("failed to run {program}: {e}"));
     assert!(status.success(), "{program} {args:?} failed");
-}
-
-/// The `tapestry` supervisor binary built alongside this test binary. The
-/// integration test runner lives at `target/<profile>/deps/<bin>`; the sibling
-/// `tapestry` binary is two levels up at `target/<profile>/tapestry`. loom's
-/// `backend` reads `WEAVER_TAPESTRY_BIN` to launch it (so it does not try to
-/// re-exec the test harness as a supervisor).
-fn tapestry_bin() -> std::path::PathBuf {
-    let exe = std::env::current_exe().expect("test executable path");
-    let bin = exe
-        .parent()
-        .and_then(Path::parent)
-        .expect("target dir")
-        .join("tapestry");
-    assert!(
-        bin.exists(),
-        "tapestry binary missing at {} — run via `cargo test --workspace` (or `cargo build -p tapestry` first)",
-        bin.display()
-    );
-    bin
 }
 
 /// Best-effort teardown: kill every supervisor whose socket lives under this

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -7,6 +7,9 @@
 //! The `hook` event → session-status path is covered separately by
 //! `tests/hook_monitor.rs`, so it is not duplicated here.
 
+#[path = "../support/tapestry.rs"]
+mod support;
+
 mod fixtures;
 
 mod acp;

--- a/crates/loom/tests/repo_setup.rs
+++ b/crates/loom/tests/repo_setup.rs
@@ -20,6 +20,10 @@ use serial_test::serial;
 use tokio::net::TcpListener;
 use weaver_core::events::EventBus;
 
+#[path = "support/tapestry.rs"]
+mod support;
+use support::tapestry_bin;
+
 fn sh(dir: &Path, program: &str, args: &[&str]) {
     let status = Command::new(program)
         .args(args)
@@ -27,14 +31,6 @@ fn sh(dir: &Path, program: &str, args: &[&str]) {
         .status()
         .unwrap_or_else(|e| panic!("failed to run {program}: {e}"));
     assert!(status.success(), "{program} {args:?} failed");
-}
-
-fn tapestry_bin() -> PathBuf {
-    let exe = std::env::current_exe().expect("test executable path");
-    exe.parent()
-        .and_then(Path::parent)
-        .expect("target dir")
-        .join("tapestry")
 }
 
 /// Best-effort: kill every supervisor under `sock_dir` so detached terminals

--- a/crates/loom/tests/support/tapestry.rs
+++ b/crates/loom/tests/support/tapestry.rs
@@ -1,0 +1,77 @@
+//! Pulled in with `#[path]` by every suite that spawns a real supervisor —
+//! separate integration-test targets can't share code any other way.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The `tapestry` binary built alongside this test binary.
+///
+/// A sibling two levels up from `<dir>/<profile>/deps/<test>` only holds while
+/// cargo's build and artifact directories are the same tree. `build.build-dir`
+/// splits them: test binaries stay in the build dir, `tapestry` is uplifted
+/// into `<workspace>/target/<profile>/`.
+pub fn tapestry_bin() -> PathBuf {
+    if let Some(bin) = std::env::var_os("WEAVER_TAPESTRY_BIN").map(PathBuf::from) {
+        if bin.is_file() {
+            return bin;
+        }
+    }
+
+    let exe = std::env::current_exe().expect("test executable path");
+    let profile_dir = exe
+        .parent()
+        .and_then(Path::parent)
+        .expect("<profile>/deps/<test>");
+    let profile = profile_dir.file_name().expect("profile directory name");
+
+    let mut tried = Vec::new();
+    let mut probe = |dir: PathBuf| {
+        let bin = dir.join("tapestry");
+        if bin.is_file() {
+            return Some(bin);
+        }
+        tried.push(bin.display().to_string());
+        None
+    };
+
+    if let Some(bin) = probe(profile_dir.to_path_buf()) {
+        return bin;
+    }
+    if let Some(dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        if let Some(bin) = probe(Path::new(&dir).join(profile)) {
+            return bin;
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    if let Some(workspace) = manifest_dir.parent().and_then(Path::parent) {
+        if let Some(bin) = probe(workspace.join("target").join(profile)) {
+            return bin;
+        }
+    }
+    // Last: the only candidate that catches a config-file `build.target-dir`,
+    // and the only one that costs a subprocess.
+    if let Some(dir) = metadata_target_dir(manifest_dir) {
+        if let Some(bin) = probe(dir.join(profile)) {
+            return bin;
+        }
+    }
+
+    panic!(
+        "tapestry binary missing — run `cargo build -p tapestry` (or `cargo test --workspace`) first.\nLooked in:\n  {}",
+        tried.join("\n  ")
+    );
+}
+
+fn metadata_target_dir(manifest_dir: &Path) -> Option<PathBuf> {
+    let out = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .arg("--manifest-path")
+        .arg(manifest_dir.join("Cargo.toml"))
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let meta: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    Some(PathBuf::from(meta.get("target_directory")?.as_str()?))
+}


### PR DESCRIPTION
The loom suites that spawn a real supervisor located `tapestry` two levels up from the test binary. That holds only while cargo's build directory and its artifact directory are the same tree. A `build.build-dir` in `~/.cargo/config.toml` — a shared build cache, say — splits them: test binaries are intermediate artifacts and stay in the build directory, while `tapestry` is uplifted into `<workspace>/target/<profile>/`. Every affected suite then panicked with `tapestry binary missing at …`, including after the `cargo build -p tapestry` the message told you to run, since that build also uplifts to the artifact directory. Swapping the config key is not a workaround: `build.target-dir` does not accept the `{workspace-path-hash}` placeholder.

The four copies of the lookup — `integration/fixtures.rs`, `hook_monitor.rs`, `repo_setup.rs`, `docker_runner.rs` — collapse into one helper. It tries the sibling first, so the common layout costs nothing, then `CARGO_TARGET_DIR`, the workspace `target/`, and finally `cargo metadata`, which is the only candidate that also accounts for a `build.target-dir` set in a config file and the only one worth a subprocess. Each candidate is probed before the next is computed, and the panic names every path it tried.

The helper lives in `tests/support/`, a subdirectory without a `main.rs`, so cargo does not auto-discover it as a test target. The other suites already use `CARGO_BIN_EXE_*`, which cargo points at the artifact directory itself; loom's tests cannot use it for `tapestry`, since it is only defined for binaries in the same package, which is why the hand-rolled lookup existed.

Agent lint review run; no findings.