### PR TITLE
fix(loom): recover sessions from abandoned lifecycle transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,9 @@ wipes them. So unless the user explicitly asks:
 - **Don't** start your own `loom server run` or `loom sessions launch` against the default
   `~/.weaver`, kill the user's runtime supervisors, or run broad process cleanup
   (`pkill -f tapestry`, `pkill -f weaver`). Each wipes the user's agents at a
-  stroke. A server started from inside a session on the shared home now refuses
-  outright — set `WEAVER_HOME` for an isolated one.
+  stroke. A server started from inside a session refuses outright when
+  its home already hosts a loom — point `WEAVER_HOME` at a fresh directory for
+  an isolated one.
 - **If a task seems to need a live loom, ask first.**
 
 To exercise loom behaviour, extend the test suites — they isolate via a temp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ wipes them. So unless the user explicitly asks:
 - **Don't** start your own `loom server run` or `loom sessions launch` against the default
   `~/.weaver`, kill the user's runtime supervisors, or run broad process cleanup
   (`pkill -f tapestry`, `pkill -f weaver`). Each wipes the user's agents at a
-  stroke.
+  stroke. A server started from inside a session on the shared home now refuses
+  outright — set `WEAVER_HOME` for an isolated one.
 - **If a task seems to need a live loom, ask first.**
 
 To exercise loom behaviour, extend the test suites — they isolate via a temp

--- a/crates/loom-ctx/src/backend.rs
+++ b/crates/loom-ctx/src/backend.rs
@@ -360,6 +360,15 @@ pub async fn send_enter(name: &str) -> Result<()> {
     send_key(name, "Enter").await
 }
 
+/// How long a supervisor gets to release its control socket after being killed
+/// before the runner removes its runtime out from under it.
+const STOP_DEADLINE: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// How long the runner itself gets to remove a session runtime. The container
+/// runner talks to a daemon over a socket, so this call is as capable of
+/// wedging as the supervisor it is removing.
+const RUNTIME_REMOVE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Kill the session. Best-effort: a missing supervisor means already gone.
 pub async fn kill_session(name: &str) -> Result<()> {
     if let Ok(mut c) = tapestry::Client::connect(name).await {
@@ -368,7 +377,7 @@ pub async fn kill_session(name: &str) -> Result<()> {
             Err(e) => tracing::warn!(name = %name, error = %e, "failed to kill terminal"),
         }
     } else {
-        runner::remove(name).await?;
+        remove_runtime(name).await?;
     }
     Ok(())
 }
@@ -378,17 +387,39 @@ pub async fn kill_session(name: &str) -> Result<()> {
 /// A kill request is acknowledged before the supervisor finishes teardown. A
 /// caller that immediately reuses the same name (provider handoff does this)
 /// must wait, or the replacement can connect to the dying supervisor.
+///
+/// Every stage is bounded, because this is what session teardown blocks on: a
+/// supervisor that stops answering leaves the caller escalating to
+/// [`remove_runtime`] rather than waiting on it forever.
 pub async fn kill_session_and_wait(name: &str) -> Result<()> {
-    kill_session(name).await?;
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-    while has_session(name).await {
-        if tokio::time::Instant::now() >= deadline {
-            bail!("terminal {name} did not stop within 5 seconds");
+    let stopped = tokio::time::timeout(STOP_DEADLINE, async {
+        kill_session(name).await?;
+        while has_session(name).await {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+    match stopped {
+        Ok(result) => result?,
+        Err(_) => tracing::warn!(
+            name = %name,
+            "terminal did not stop within {STOP_DEADLINE:?}; removing its runtime"
+        ),
     }
-    runner::remove(name).await?;
+    remove_runtime(name).await?;
+    if has_session(name).await {
+        bail!("terminal {name} is still alive after its runtime was removed");
+    }
     Ok(())
+}
+
+/// Remove a session's runtime through the configured runner, bounded by
+/// [`RUNTIME_REMOVE_DEADLINE`].
+async fn remove_runtime(name: &str) -> Result<()> {
+    tokio::time::timeout(RUNTIME_REMOVE_DEADLINE, runner::remove(name))
+        .await
+        .unwrap_or_else(|_| bail!("removing the runtime for {name} timed out"))
 }
 
 /// Every session with a live supervisor.

--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -187,26 +187,102 @@ pub fn require_no_transition(session: &Session) -> Result<()> {
     Ok(())
 }
 
-/// Shared teardown after the caller has acquired the runtime lifecycle lock and
-/// refreshed the session row.
-pub async fn archive_locked(
+/// How long the external half of an archive gets before the row is committed
+/// anyway. Well under [`TRANSITION_STALE_SECS`], so a slow teardown finishes as
+/// itself rather than being taken over as abandoned.
+const TEARDOWN_DEADLINE: std::time::Duration = std::time::Duration::from_secs(90);
+
+/// How long a transition may sit before another operation may take it over.
+/// Transitions are seconds of work: a marker older than this belongs to a
+/// process that died mid-teardown — a killed server, or a session container
+/// that hosted the operation tearing down its own supervisor.
+pub const TRANSITION_STALE_SECS: i64 = 300;
+
+/// Whether `session`'s transition marker can still be finished by its owner.
+///
+/// A marker this process owns is never stale — its operation is bounded, so it
+/// either completes or releases the marker itself. A marker from another
+/// process is stale once that process is gone, or once it has outlived
+/// [`TRANSITION_STALE_SECS`]: pids are reused, and an owner in another pid
+/// namespace (a session container) is invisible from here, so age is the only
+/// evidence that survives.
+fn transition_is_stale(
+    started_at: Option<&str>,
+    owner_pid: Option<i64>,
+    my_pid: i64,
+    owner_alive: bool,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    if owner_pid == Some(my_pid) {
+        return false;
+    }
+    if !owner_alive {
+        return true;
+    }
+    started_at
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+        .is_none_or(|started| {
+            (now - started.with_timezone(&chrono::Utc)).num_seconds() >= TRANSITION_STALE_SECS
+        })
+}
+
+/// Whether the process that owns a transition still exists. Only meaningful for
+/// pids in this namespace; a pid from a container that has since been removed
+/// reads as gone, which is exactly what it is.
+fn owner_pid_alive(pid: Option<i64>) -> bool {
+    pid.is_some_and(|pid| std::path::Path::new(&format!("/proc/{pid}")).exists())
+}
+
+/// Whether this session's transition marker is abandoned and may be taken over.
+pub fn transition_abandoned(session: &Session) -> bool {
+    session.lifecycle_transition.is_some()
+        && transition_is_stale(
+            session.lifecycle_transition_started_at.as_deref(),
+            session.lifecycle_transition_owner_pid,
+            i64::from(std::process::id()),
+            owner_pid_alive(session.lifecycle_transition_owner_pid),
+            chrono::Utc::now(),
+        )
+}
+
+/// Release an abandoned transition marker so a new operation can run, and return
+/// the refreshed row. A live transition is left alone — the caller's
+/// [`require_no_transition`] refuses against it as usual.
+///
+/// Without this, one operation that dies between publishing its marker and
+/// committing its status locks the session out of both archive and adopt until
+/// the server restarts.
+pub async fn release_abandoned_transition(db: &Db, session: &Session) -> Result<Session> {
+    if !transition_abandoned(session) {
+        return Ok(session.clone());
+    }
+    let transition = session
+        .lifecycle_transition
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    tracing::warn!(
+        session = %session.id,
+        transition = %transition,
+        owner_pid = ?session.lifecycle_transition_owner_pid,
+        started_at = ?session.lifecycle_transition_started_at,
+        "releasing an abandoned lifecycle transition"
+    );
+    session_mod::clear_interrupted_transition(db, &session.id, &transition).await?;
+    session_mod::get(db, &session.id)
+        .await?
+        .ok_or_else(|| anyhow!("session not found"))
+}
+
+/// The external half of archiving: stop the agent, drop its credentials, and
+/// remove its worktree. Every step is best-effort and reported as a warning —
+/// only losing ownership of the transition (another operation took the session)
+/// aborts the archive.
+async fn archive_teardown(
     st: &AppState,
     session: &Session,
     branch: &Branch,
 ) -> Result<Vec<String>> {
-    tracing::info!(session = %session.id, branch = %branch.id, "archiving session");
-    require_no_transition(session)?;
-    if !session_mod::begin_transition(&st.db, &session.id, "archiving", "Capturing conversation")
-        .await?
-    {
-        return Err(anyhow!(Refusal::Conflict(
-            "another lifecycle transition already owns this session".to_string()
-        )));
-    }
-    record_transition(st, branch, "archiving", "Capturing conversation").await;
-
-    let result: Result<Vec<String>> = async {
-        let mut warnings: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
 
     // Capture the agent's conversation log before teardown. The transcript lives
     // outside the worktree so it would survive removal, but capturing first keeps
@@ -219,10 +295,12 @@ pub async fn archive_locked(
     // finishes provisioning after this point cannot promote itself.
     crate::runs::cancel_for_session_with_summary(&st.db, &session.id, "session archived").await?;
     transition_step(st, session, branch, "archiving", "Stopping agent").await?;
-    // The row must never say `archived` while its supervisor is still live.
-    // A tapestry kill is acknowledged before the socket disappears, so wait
-    // for teardown and fail without flipping the row if it cannot complete.
-    backend::kill_session_and_wait(&session.term_session).await?;
+    // A supervisor that will not stop is reported, not obeyed: the kill escalates
+    // to removing the runtime, and a session nobody can stop must still archive.
+    if let Err(error) = backend::kill_session_and_wait(&session.term_session).await {
+        tracing::warn!(session = %session.id, %error, "archive could not confirm the agent stopped");
+        warnings.push(format!("stop agent: {error}"));
+    }
     // The killed relay makes its ACP task exit; remove any handle that has not
     // observed that edge yet. For a terminal session this is a no-op.
     if session.protocol == "acp" {
@@ -242,44 +320,88 @@ pub async fn archive_locked(
             tokio::fs::remove_dir_all(&work_dir).await.ok();
         }
     }
-    transition_step(st, session, branch, "archiving", "Finalizing archive").await?;
-    if !session_mod::complete_transition(&st.db, &session.id, "archiving", "archived").await? {
-        return Err(anyhow!("archive lost ownership of its lifecycle transition"));
+    Ok(warnings)
+}
+
+/// Shared teardown after the caller has acquired the runtime lifecycle lock and
+/// refreshed the session row.
+pub async fn archive_locked(
+    st: &AppState,
+    session: &Session,
+    branch: &Branch,
+) -> Result<Vec<String>> {
+    tracing::info!(session = %session.id, branch = %branch.id, "archiving session");
+    // A person archiving a session is asking for it to go away; an abandoned
+    // marker from a dead operation must not be able to refuse that forever.
+    let refreshed = release_abandoned_transition(&st.db, session).await?;
+    let session = &refreshed;
+    require_no_transition(session)?;
+    if !session_mod::begin_transition(&st.db, &session.id, "archiving", "Capturing conversation")
+        .await?
+    {
+        return Err(anyhow!(Refusal::Conflict(
+            "another lifecycle transition already owns this session".to_string()
+        )));
     }
-    crate::channels::archive_session_channel(&st.db, &session.id).await?;
-    // A torn-down session cannot keep owning work. Return every issue it held
-    // to the repo backlog while preserving source-branch provenance and issue
-    // status, just as full session deletion does.
-    weaver_core::issue::unclaim_branch(&st.db, &branch.repo_root, &branch.branch).await?;
-    // An archived session is finished with: its agent is gone, so it can no
-    // longer "need me" — nor is it "resting". Clear every loud tag — the agent's
-    // own `attention` and any watch's typed marks (loudness is value-driven, so
-    // match on the value, not a fixed key set) — plus the soothing `idle` mark,
-    // so the dashboard stops flagging or labelling a torn-down workstream —
-    // absence is the calm state. The history (goal, status, events) is kept; the
-    // `description` message stays too, as do any free-form quiet pills.
-    for tag in tags::list(&st.db, &branch.id).await? {
-        if tags::is_loud_value(&tag.value) || tag.key == tags::IDLE_KEY {
-            tags::clear(&st.db, &branch.id, &tag.key).await?;
-            events::record_tag(&st.db, &st.bus, &branch.id, &tag.key, "", "", "manual")
-                .await
-                .ok();
+    record_transition(st, branch, "archiving", "Capturing conversation").await;
+
+    let result: Result<Vec<String>> = async {
+        let mut warnings: Vec<String> = Vec::new();
+        match tokio::time::timeout(TEARDOWN_DEADLINE, archive_teardown(st, session, branch)).await {
+            Ok(teardown) => warnings.extend(teardown?),
+            Err(_) => {
+                // Every teardown step is bounded on its own, so reaching this is
+                // an unknown external stall. Archiving is how a person gets rid
+                // of a session, so the row still reaches `archived` and the
+                // leftovers are reported rather than hidden.
+                tracing::warn!(
+                    session = %session.id,
+                    "archive teardown exceeded {TEARDOWN_DEADLINE:?}; archiving anyway"
+                );
+                warnings.push(format!(
+                    "teardown did not finish within {}s — the terminal or worktree may survive",
+                    TEARDOWN_DEADLINE.as_secs()
+                ));
+            }
         }
-    }
-    events::record(
-        &st.db,
-        &st.bus,
-        &branch.id,
-        "status",
-        json!({ "status": "archived", "reason": "session archived" }),
-    )
-    .await
-    .ok();
-    if warnings.is_empty() {
-        tracing::info!(session = %session.id, branch = %branch.id, "session archived");
-    } else {
-        tracing::warn!(branch = %branch.id, warnings = warnings.len(), "session archived with warnings");
-    }
+        transition_step(st, session, branch, "archiving", "Finalizing archive").await?;
+        if !session_mod::complete_transition(&st.db, &session.id, "archiving", "archived").await? {
+            return Err(anyhow!("archive lost ownership of its lifecycle transition"));
+        }
+        crate::channels::archive_session_channel(&st.db, &session.id).await?;
+        // A torn-down session cannot keep owning work. Return every issue it held
+        // to the repo backlog while preserving source-branch provenance and issue
+        // status, just as full session deletion does.
+        weaver_core::issue::unclaim_branch(&st.db, &branch.repo_root, &branch.branch).await?;
+        // An archived session is finished with: its agent is gone, so it can no
+        // longer "need me" — nor is it "resting". Clear every loud tag — the agent's
+        // own `attention` and any watch's typed marks (loudness is value-driven, so
+        // match on the value, not a fixed key set) — plus the soothing `idle` mark,
+        // so the dashboard stops flagging or labelling a torn-down workstream —
+        // absence is the calm state. The history (goal, status, events) is kept; the
+        // `description` message stays too, as do any free-form quiet pills.
+        for tag in tags::list(&st.db, &branch.id).await? {
+            if tags::is_loud_value(&tag.value) || tag.key == tags::IDLE_KEY {
+                tags::clear(&st.db, &branch.id, &tag.key).await?;
+                events::record_tag(&st.db, &st.bus, &branch.id, &tag.key, "", "", "manual")
+                    .await
+                    .ok();
+            }
+        }
+        events::record(
+            &st.db,
+            &st.bus,
+            &branch.id,
+            "status",
+            json!({ "status": "archived", "reason": "session archived" }),
+        )
+        .await
+        .ok();
+        if warnings.is_empty() {
+            tracing::info!(session = %session.id, branch = %branch.id, "session archived");
+        } else {
+            tracing::warn!(branch = %branch.id, warnings = warnings.len(), "session archived with warnings");
+        }
         Ok(warnings)
     }
     .await;
@@ -299,6 +421,125 @@ pub async fn archive_locked(
         }
     }
     result
+}
+
+/// Finish every lifecycle transition whose owner can no longer finish it.
+///
+/// A process can exit between publishing a transition and committing its stable
+/// status — a killed server, a rolling restart, or an operation running inside
+/// the very session container it tears down. The marker it leaves behind refuses
+/// both archive and adopt, so this runs at startup *and* on the monitor's
+/// retention cadence: a session must never need a server restart to become
+/// operable again.
+pub async fn reconcile_interrupted_transitions(state: &AppState) {
+    let sessions = match session_mod::list(&state.db).await {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            tracing::warn!(%error, "transition recovery: listing sessions failed");
+            return;
+        }
+    };
+    for session in sessions {
+        let Some(transition) = session.lifecycle_transition.as_deref() else {
+            continue;
+        };
+        if !transition_abandoned(&session) {
+            tracing::debug!(session = %session.id, transition, owner_pid = ?session.lifecycle_transition_owner_pid, "transition recovery: operation is still owned by a live server");
+            continue;
+        }
+        let Ok(Some(branch)) = branch_mod::get(&state.db, &session.branch_id).await else {
+            tracing::warn!(session = %session.id, transition, "transition recovery: branch missing");
+            continue;
+        };
+        match transition {
+            "archiving" => {
+                // Teardown is idempotent. Release the marker owned by the dead
+                // process and run the normal archive path to completion.
+                match session_mod::clear_interrupted_transition(&state.db, &session.id, "archiving")
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        tracing::warn!(session = %session.id, "transition recovery: archive marker changed before release");
+                        continue;
+                    }
+                    Err(error) => {
+                        tracing::warn!(session = %session.id, %error, "transition recovery: could not release archive marker");
+                        continue;
+                    }
+                }
+                if let Err(error) = archive(state, &session, &branch).await {
+                    tracing::warn!(session = %session.id, %error, "transition recovery: archive failed");
+                }
+            }
+            "adopting" => {
+                if backend::has_session(&session.term_session).await {
+                    let status = agent::initial_status(&state.db, &session.agent_kind).await;
+                    if let Err(error) = session_mod::complete_interrupted_transition(
+                        &state.db,
+                        &session.id,
+                        "adopting",
+                        status,
+                    )
+                    .await
+                    {
+                        tracing::warn!(session = %session.id, %error, "transition recovery: could not commit live adoption");
+                    } else if let Err(error) =
+                        crate::channels::reopen_session_channel(&state.db, &session.id).await
+                    {
+                        tracing::warn!(session = %session.id, %error, "transition recovery: could not reopen session channel");
+                    }
+                } else if std::path::Path::new(&session.work_dir).exists() {
+                    match session_mod::clear_interrupted_transition(
+                        &state.db,
+                        &session.id,
+                        "adopting",
+                    )
+                    .await
+                    {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            tracing::warn!(session = %session.id, "transition recovery: adoption marker changed before release");
+                            continue;
+                        }
+                        Err(error) => {
+                            tracing::warn!(session = %session.id, %error, "transition recovery: could not release adoption marker");
+                            continue;
+                        }
+                    }
+                    if let Err(error) = adopt(state, &session, &branch).await {
+                        tracing::warn!(session = %session.id, %error, "transition recovery: adoption failed");
+                    } else if let Err(error) =
+                        crate::channels::reopen_session_channel(&state.db, &session.id).await
+                    {
+                        tracing::warn!(session = %session.id, %error, "transition recovery: could not reopen session channel");
+                    }
+                } else if session.status == "created" {
+                    // Recovery had not rebuilt its worktree yet (or adoption
+                    // lost it externally). The branch/history still make this
+                    // a fully recoverable archived session.
+                    if let Err(error) = session_mod::complete_interrupted_transition(
+                        &state.db,
+                        &session.id,
+                        "adopting",
+                        "archived",
+                    )
+                    .await
+                    {
+                        tracing::warn!(session = %session.id, %error, "transition recovery: could not restore archived state");
+                    }
+                } else if let Err(error) =
+                    session_mod::clear_interrupted_transition(&state.db, &session.id, "adopting")
+                        .await
+                {
+                    tracing::warn!(session = %session.id, %error, "transition recovery: could not release failed adoption");
+                }
+            }
+            other => {
+                tracing::warn!(session = %session.id, transition = other, "transition recovery: unknown transition left intact");
+            }
+        }
+    }
 }
 
 async fn record_transition(st: &AppState, branch: &Branch, kind: &str, step: &str) {
@@ -736,7 +977,8 @@ pub async fn adopt(st: &AppState, session: &Session, _branch: &Branch) -> Result
     else {
         return Err(anyhow!("session not found"));
     };
-    let session = &current_session;
+    let refreshed = release_abandoned_transition(&st.db, &current_session).await?;
+    let session = &refreshed;
     let branch = &current_branch;
     require_no_transition(session)?;
     if session.status == "archived" {
@@ -1066,7 +1308,8 @@ pub async fn recover_acp_runtime(st: &AppState, session: &Session) -> Result<()>
     else {
         return Err(anyhow!("session not found"));
     };
-    let session = &current_session;
+    let refreshed = release_abandoned_transition(&st.db, &current_session).await?;
+    let session = &refreshed;
     require_no_transition(session)?;
     if session.protocol != "acp" {
         return Err(anyhow!(Refusal::Conflict(
@@ -1266,4 +1509,63 @@ pub async fn resume_agent(
     .ok();
     tracing::info!(session = %session.id, branch = %branch.id, reason = %reason, "session resumed");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{transition_is_stale, TRANSITION_STALE_SECS};
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn a_transition_this_process_owns_is_never_stale() {
+        let now = Utc::now();
+        let started = (now - Duration::seconds(TRANSITION_STALE_SECS * 10)).to_rfc3339();
+        // Own work is bounded and completes or releases its own marker, so age
+        // alone must never let a second operation run against it.
+        assert!(!transition_is_stale(
+            Some(&started),
+            Some(4242),
+            4242,
+            true,
+            now
+        ));
+    }
+
+    #[test]
+    fn a_transition_whose_owner_is_gone_is_stale_immediately() {
+        let now = Utc::now();
+        let started = now.to_rfc3339();
+        assert!(transition_is_stale(
+            Some(&started),
+            Some(4242),
+            7,
+            false,
+            now
+        ));
+    }
+
+    #[test]
+    fn a_live_foreign_owner_keeps_its_transition_until_the_deadline() {
+        let now = Utc::now();
+        let fresh = (now - Duration::seconds(TRANSITION_STALE_SECS - 1)).to_rfc3339();
+        // A rolling restart drains the old generation; its in-flight teardown
+        // owns the session until it has plainly outlived any real operation.
+        assert!(!transition_is_stale(Some(&fresh), Some(4242), 7, true, now));
+
+        let old = (now - Duration::seconds(TRANSITION_STALE_SECS)).to_rfc3339();
+        assert!(transition_is_stale(Some(&old), Some(4242), 7, true, now));
+    }
+
+    #[test]
+    fn an_unreadable_start_time_is_stale_rather_than_permanent() {
+        let now = Utc::now();
+        assert!(transition_is_stale(None, Some(4242), 7, true, now));
+        assert!(transition_is_stale(
+            Some("not a timestamp"),
+            None,
+            7,
+            true,
+            now
+        ));
+    }
 }

--- a/crates/loom-watch/src/monitor.rs
+++ b/crates/loom-watch/src/monitor.rs
@@ -199,6 +199,10 @@ async fn run_inner(state: AppState) {
         reap_tick += 1;
         if reap_tick >= REAP_EVERY_TICKS {
             reap_tick = 0;
+            // Take over any transition whose owner died mid-teardown. Recovery
+            // also runs at startup; on this cadence a session stops needing a
+            // server restart to be archivable again.
+            crate::lifecycle::reconcile_interrupted_transitions(&state).await;
             let slack_idle_archive_secs = core_config::get(&state.db, "slack.idle_archive_secs")
                 .await
                 .and_then(|value| value.trim().parse::<i64>().ok())

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1971,8 +1971,42 @@ async fn update_permission_resource(
     }
 }
 
+/// Why a server must not start here, if it must not.
+///
+/// A Loom session reaches its host loom over the API. A server started inside
+/// one opens the host's database and supervisor sockets a second time, giving
+/// the machine two monitors, two Slack clients, and two sets of lifecycle
+/// operations on the same rows. The failure is worse than duplication: an
+/// operation owned by the session's own process dies the instant it tears that
+/// session's supervisor down, stranding the transition it had already published
+/// and locking the session out of archive and adopt.
+///
+/// An explicit `WEAVER_HOME` is the documented way to exercise loom by hand, so
+/// that stays open — it is a different database and a different socket
+/// directory.
+fn nested_server_refusal(
+    session_id: Option<&str>,
+    weaver_home_is_explicit: bool,
+) -> Option<String> {
+    let session_id = session_id.filter(|id| !id.is_empty())?;
+    if weaver_home_is_explicit {
+        return None;
+    }
+    Some(format!(
+        "refusing to start: this is Loom session {session_id}, which already has a loom to talk to. A second server on the shared home would race the host's monitor, Slack client, and session teardown. Run `WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0` for an isolated instance."
+    ))
+}
+
 /// Dispatch the `loom server <verb>` daemon-lifecycle subcommands.
 async fn run_server(cmd: ServerCmd) -> Result<()> {
+    if matches!(cmd, ServerCmd::Run { .. } | ServerCmd::Start) {
+        if let Some(refusal) = nested_server_refusal(
+            std::env::var("LOOM_SESSION_ID").ok().as_deref(),
+            std::env::var_os("WEAVER_HOME").is_some(),
+        ) {
+            bail!("{refusal}");
+        }
+    }
     match cmd {
         ServerCmd::Run { addr } => {
             init_tracing();
@@ -5672,6 +5706,26 @@ fn capabilities_summary(o: &Value) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_session_may_not_start_a_server_on_the_shared_home() {
+        assert_eq!(
+            nested_server_refusal(Some("bej3oxrv"), false).unwrap(),
+            "refusing to start: this is Loom session bej3oxrv, which already has a loom to talk to. A second server on the shared home would race the host's monitor, Slack client, and session teardown. Run `WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0` for an isolated instance."
+        );
+    }
+
+    #[test]
+    fn an_explicit_weaver_home_keeps_hand_testing_available() {
+        assert!(nested_server_refusal(Some("bej3oxrv"), true).is_none());
+    }
+
+    #[test]
+    fn the_host_server_is_not_a_session() {
+        assert!(nested_server_refusal(None, false).is_none());
+        assert!(nested_server_refusal(Some(""), false).is_none());
+    }
+
     use super::*;
 
     #[test]

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1973,27 +1973,26 @@ async fn update_permission_resource(
 
 /// Why a server must not start here, if it must not.
 ///
-/// A Loom session reaches its host loom over the API. A server started inside
-/// one opens the host's database and supervisor sockets a second time, giving
-/// the machine two monitors, two Slack clients, and two sets of lifecycle
-/// operations on the same rows. The failure is worse than duplication: an
-/// operation owned by the session's own process dies the instant it tears that
-/// session's supervisor down, stranding the transition it had already published
-/// and locking the session out of archive and adopt.
+/// A Loom session reaches its host loom over the API; its `WEAVER_HOME` is the
+/// host's own home, so a server started inside one opens that database and
+/// those supervisor sockets a second time. The machine then runs two monitors,
+/// two Slack clients, and two sets of lifecycle operations on the same rows —
+/// and an operation owned by the session's process dies the instant it tears
+/// that session's supervisor down, stranding the transition it published.
 ///
-/// An explicit `WEAVER_HOME` is the documented way to exercise loom by hand, so
-/// that stays open — it is a different database and a different socket
-/// directory.
-fn nested_server_refusal(
-    session_id: Option<&str>,
-    weaver_home_is_explicit: bool,
-) -> Option<String> {
+/// The signal that a home already belongs to a loom is its `loom.json` state
+/// file. A private `WEAVER_HOME` has none, so the documented way to exercise
+/// loom by hand (`WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0`)
+/// still works.
+fn nested_server_refusal(session_id: Option<&str>, home: &std::path::Path) -> Option<String> {
     let session_id = session_id.filter(|id| !id.is_empty())?;
-    if weaver_home_is_explicit {
+    let state = home.join("loom.json");
+    if !state.exists() {
         return None;
     }
     Some(format!(
-        "refusing to start: this is Loom session {session_id}, which already has a loom to talk to. A second server on the shared home would race the host's monitor, Slack client, and session teardown. Run `WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0` for an isolated instance."
+        "refusing to start: this is Loom session {session_id}, and {} already belongs to a running loom. A second server on one home races the host's monitor, Slack client, and session teardown. Run `WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0` for an isolated instance.",
+        home.display()
     ))
 }
 
@@ -2002,7 +2001,7 @@ async fn run_server(cmd: ServerCmd) -> Result<()> {
     if matches!(cmd, ServerCmd::Run { .. } | ServerCmd::Start) {
         if let Some(refusal) = nested_server_refusal(
             std::env::var("LOOM_SESSION_ID").ok().as_deref(),
-            std::env::var_os("WEAVER_HOME").is_some(),
+            &loom::db::weaver_home(),
         ) {
             bail!("{refusal}");
         }
@@ -5708,22 +5707,34 @@ fn capabilities_summary(o: &Value) -> String {
 mod tests {
 
     #[test]
-    fn a_session_may_not_start_a_server_on_the_shared_home() {
+    fn a_session_may_not_start_a_server_on_the_host_home() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::write(home.path().join("loom.json"), "{}").unwrap();
         assert_eq!(
-            nested_server_refusal(Some("bej3oxrv"), false).unwrap(),
-            "refusing to start: this is Loom session bej3oxrv, which already has a loom to talk to. A second server on the shared home would race the host's monitor, Slack client, and session teardown. Run `WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0` for an isolated instance."
+            nested_server_refusal(Some("bej3oxrv"), home.path()).unwrap(),
+            format!(
+                "refusing to start: this is Loom session bej3oxrv, and {} already belongs to a running loom. A second server on one home races the host's monitor, Slack client, and session teardown. Run `WEAVER_HOME=$(mktemp -d) loom server run --addr 127.0.0.1:0` for an isolated instance.",
+                home.path().display()
+            )
         );
     }
 
     #[test]
-    fn an_explicit_weaver_home_keeps_hand_testing_available() {
-        assert!(nested_server_refusal(Some("bej3oxrv"), true).is_none());
+    fn a_private_weaver_home_keeps_hand_testing_available() {
+        // The session env always carries a WEAVER_HOME — the host's. What makes
+        // an isolated home safe is that no loom lives in it yet.
+        let home = tempfile::tempdir().unwrap();
+        assert!(nested_server_refusal(Some("bej3oxrv"), home.path()).is_none());
     }
 
     #[test]
     fn the_host_server_is_not_a_session() {
-        assert!(nested_server_refusal(None, false).is_none());
-        assert!(nested_server_refusal(Some(""), false).is_none());
+        // The host's own restart finds its predecessor's loom.json and must
+        // still start; only a session is refused.
+        let home = tempfile::tempdir().unwrap();
+        std::fs::write(home.path().join("loom.json"), "{}").unwrap();
+        assert!(nested_server_refusal(None, home.path()).is_none());
+        assert!(nested_server_refusal(Some(""), home.path()).is_none());
     }
 
     use super::*;

--- a/crates/loom/src/server.rs
+++ b/crates/loom/src/server.rs
@@ -12,7 +12,7 @@ use crate::events::EventBus;
 use crate::session as session_mod;
 use crate::AppState;
 use crate::Ctx;
-use crate::{agent, backend, config, db, github, monitor, runner, session_manager, watch, web};
+use crate::{backend, config, db, github, monitor, runner, session_manager, watch, web};
 use weaver_core::branch as branch_mod;
 use weaver_core::watch as watch_store;
 
@@ -114,7 +114,7 @@ pub async fn run(addr: &str) -> Result<()> {
     // A process can exit between publishing a lifecycle transition and
     // committing its stable status. Resume those durable operations before the
     // ordinary supervisor inventory interprets their partial external state.
-    reconcile_interrupted_transitions(&state).await;
+    crate::lifecycle::reconcile_interrupted_transitions(&state).await;
 
     // Detached supervisors outlive this control process. Before reattaching or
     // adopting anything, remove only Loom-namespaced runtimes that have no
@@ -183,120 +183,6 @@ pub async fn run(addr: &str) -> Result<()> {
         Err(e) => tracing::error!(error = %e, "loom stopped with error"),
     }
     result
-}
-
-async fn reconcile_interrupted_transitions(state: &AppState) {
-    let sessions = match session_mod::list(&state.db).await {
-        Ok(sessions) => sessions,
-        Err(error) => {
-            tracing::warn!(%error, "transition recovery: listing sessions failed");
-            return;
-        }
-    };
-    for session in sessions {
-        let Some(transition) = session.lifecycle_transition.as_deref() else {
-            continue;
-        };
-        let current_pid = i64::from(std::process::id());
-        if session.lifecycle_transition_owner_pid.is_some_and(|owner| {
-            owner != current_pid && std::path::Path::new(&format!("/proc/{owner}")).exists()
-        }) {
-            tracing::info!(session = %session.id, transition, owner_pid = ?session.lifecycle_transition_owner_pid, "transition recovery: operation is still owned by a draining server");
-            continue;
-        }
-        let Ok(Some(branch)) = branch_mod::get(&state.db, &session.branch_id).await else {
-            tracing::warn!(session = %session.id, transition, "transition recovery: branch missing");
-            continue;
-        };
-        match transition {
-            "archiving" => {
-                // Teardown is idempotent. Release the marker owned by the dead
-                // process and run the normal archive path to completion.
-                match session_mod::clear_interrupted_transition(&state.db, &session.id, "archiving")
-                    .await
-                {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        tracing::warn!(session = %session.id, "transition recovery: archive marker changed before release");
-                        continue;
-                    }
-                    Err(error) => {
-                        tracing::warn!(session = %session.id, %error, "transition recovery: could not release archive marker");
-                        continue;
-                    }
-                }
-                if let Err(error) = crate::lifecycle::archive(state, &session, &branch).await {
-                    tracing::warn!(session = %session.id, %error, "transition recovery: archive failed");
-                }
-            }
-            "adopting" => {
-                if backend::has_session(&session.term_session).await {
-                    let status = agent::initial_status(&state.db, &session.agent_kind).await;
-                    if let Err(error) = session_mod::complete_interrupted_transition(
-                        &state.db,
-                        &session.id,
-                        "adopting",
-                        status,
-                    )
-                    .await
-                    {
-                        tracing::warn!(session = %session.id, %error, "transition recovery: could not commit live adoption");
-                    } else if let Err(error) =
-                        crate::channels::reopen_session_channel(&state.db, &session.id).await
-                    {
-                        tracing::warn!(session = %session.id, %error, "transition recovery: could not reopen session channel");
-                    }
-                } else if std::path::Path::new(&session.work_dir).exists() {
-                    match session_mod::clear_interrupted_transition(
-                        &state.db,
-                        &session.id,
-                        "adopting",
-                    )
-                    .await
-                    {
-                        Ok(true) => {}
-                        Ok(false) => {
-                            tracing::warn!(session = %session.id, "transition recovery: adoption marker changed before release");
-                            continue;
-                        }
-                        Err(error) => {
-                            tracing::warn!(session = %session.id, %error, "transition recovery: could not release adoption marker");
-                            continue;
-                        }
-                    }
-                    if let Err(error) = crate::lifecycle::adopt(state, &session, &branch).await {
-                        tracing::warn!(session = %session.id, %error, "transition recovery: adoption failed");
-                    } else if let Err(error) =
-                        crate::channels::reopen_session_channel(&state.db, &session.id).await
-                    {
-                        tracing::warn!(session = %session.id, %error, "transition recovery: could not reopen session channel");
-                    }
-                } else if session.status == "created" {
-                    // Recovery had not rebuilt its worktree yet (or adoption
-                    // lost it externally). The branch/history still make this
-                    // a fully recoverable archived session.
-                    if let Err(error) = session_mod::complete_interrupted_transition(
-                        &state.db,
-                        &session.id,
-                        "adopting",
-                        "archived",
-                    )
-                    .await
-                    {
-                        tracing::warn!(session = %session.id, %error, "transition recovery: could not restore archived state");
-                    }
-                } else if let Err(error) =
-                    session_mod::clear_interrupted_transition(&state.db, &session.id, "adopting")
-                        .await
-                {
-                    tracing::warn!(session = %session.id, %error, "transition recovery: could not release failed adoption");
-                }
-            }
-            other => {
-                tracing::warn!(session = %session.id, transition = other, "transition recovery: unknown transition left intact");
-            }
-        }
-    }
 }
 
 /// Restore the Loom-side driver for every live ACP relay that currently lacks

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1101,6 +1101,11 @@ pub(super) async fn archive_session(
     };
     tracing::debug!(key = %key, session = %session.id, "handling archive session request");
     let warnings = archive(&st, &session, &branch).await.map_err(|error| {
+        // A refusal names a state the caller can act on (another transition owns
+        // the session); only a genuine failure becomes the reassuring 500.
+        if error.downcast_ref::<crate::lifecycle::Refusal>().is_some() {
+            return AppError::from(error);
+        }
         AppError::internal(
             format!(
                 "Could not finish archiving session {}. Its branch and conversation are safe; retry in a moment.",
@@ -1317,6 +1322,8 @@ async fn recover(st: &AppState, session: &Session, _branch: &Branch) -> Result<(
     let session = &current_session;
     let branch = &current_branch;
     tracing::info!(session = %session.id, branch = %branch.id, "recovering archived session");
+    let refreshed = crate::lifecycle::release_abandoned_transition(&st.db, session).await?;
+    let session = &refreshed;
     require_no_transition(session)?;
     if session.status != "archived" {
         return Err(AppError::conflict(format!(

--- a/crates/loom/tests/integration/recover.rs
+++ b/crates/loom/tests/integration/recover.rs
@@ -414,3 +414,119 @@ async fn respawn_accepts_same_profile_lifetime_and_rejects_recreate() {
             .contains("unavailable profile lifetime"));
     }
 }
+
+/// Plant the durable trace of an operation that died mid-teardown: the marker is
+/// published, but its owner is a pid in a namespace that no longer exists — a
+/// killed server, or an archive that ran inside the session container it was
+/// tearing down. `begin_transition` stamps the running process, so the owner is
+/// rewritten afterwards.
+async fn plant_abandoned_transition(ts: &TestServer, id: &str, transition: &str, step: &str) {
+    assert!(
+        loom::session::begin_transition(&ts.state.db, id, transition, step)
+            .await
+            .unwrap()
+    );
+    sqlx::query("UPDATE sessions SET lifecycle_transition_owner_pid = ? WHERE id = ?")
+        .bind(i64::from(i32::MAX))
+        .bind(id)
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+}
+
+/// A person must always be able to archive a session. An abandoned marker used
+/// to refuse every archive and adopt until the server restarted, because only
+/// startup reconciled interrupted transitions.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn archive_takes_over_a_transition_whose_owner_is_gone() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let sess = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "stuck archiving", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = sess["id"].as_str().unwrap().to_string();
+    let work_dir = sess["work_dir"].as_str().unwrap().to_string();
+    plant_abandoned_transition(&ts, &id, "archiving", "Stopping agent").await;
+
+    client
+        .post(&format!("/api/sessions/{id}/archive"), json!({}))
+        .await
+        .unwrap();
+
+    let detail = client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(detail["status"], "archived");
+    assert!(detail["transition"].is_null(), "{detail}");
+    assert!(
+        !Path::new(&work_dir).exists(),
+        "the take-over archive should still tear the worktree down"
+    );
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// The same recovery runs on the monitor's cadence, so a session left mid-archive
+/// finishes archiving on its own rather than waiting for the next restart.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reconciliation_finishes_an_abandoned_archive_without_a_restart() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let sess = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "abandoned mid-archive", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = sess["id"].as_str().unwrap().to_string();
+    plant_abandoned_transition(&ts, &id, "archiving", "Stopping agent").await;
+
+    loom::lifecycle::reconcile_interrupted_transitions(&ts.state).await;
+
+    let detail = client.get(&format!("/api/sessions/{id}")).await.unwrap();
+    assert_eq!(detail["status"], "archived");
+    assert!(detail["transition"].is_null(), "{detail}");
+
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}
+
+/// A transition this process still owns is live work: a concurrent archive must
+/// keep refusing it rather than tearing down a session mid-operation.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn archive_still_refuses_a_transition_owned_by_this_server() {
+    let ts = TestServer::start().await;
+    let client = &ts.client;
+
+    let sess = client
+        .post(
+            "/api/sessions",
+            json!({ "goal": "busy transitioning", "cwd": ts.cwd(), "agent": "shell" }),
+        )
+        .await
+        .unwrap();
+    let id = sess["id"].as_str().unwrap().to_string();
+    assert!(
+        loom::session::begin_transition(&ts.state.db, &id, "archiving", "Stopping agent")
+            .await
+            .unwrap()
+    );
+
+    let error = client
+        .post(&format!("/api/sessions/{id}/archive"), json!({}))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("already archiving"), "{error}");
+
+    loom::session::clear_transition(&ts.state.db, &id, "archiving")
+        .await
+        .unwrap();
+    client.delete(&format!("/api/sessions/{id}")).await.unwrap();
+}

--- a/crates/tapestry/src/client.rs
+++ b/crates/tapestry/src/client.rs
@@ -5,6 +5,8 @@
 //! interactive attach (the xterm bridge) uses [`Client::attach`], which splits
 //! the connection into an output stream + an input sink.
 
+use std::time::Duration;
+
 use anyhow::{bail, Context, Result};
 use tokio::net::unix::OwnedWriteHalf;
 use tokio::net::UnixStream;
@@ -17,6 +19,12 @@ use crate::DerivedLaunch;
 /// Bounded so a slow reader back-pressures the socket (and thus the supervisor)
 /// rather than buffering without limit on the client side.
 const ATTACH_BUFFER: usize = 256;
+
+/// How long a control request waits for its reply before the supervisor counts
+/// as unreachable. A supervisor whose core task is wedged still accepts
+/// connections on its socket, so an unbounded probe parks its caller forever —
+/// and every caller behind it, since liveness gates session teardown.
+const CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A connected control client for one session.
 pub struct Client {
@@ -39,12 +47,22 @@ impl Client {
     }
 
     /// Whether a supervisor is alive for `name` — connect and ping. A stale
-    /// socket file (no listener) or a supervisor reporting a dead child both read
-    /// as not-alive.
+    /// socket file (no listener), a supervisor reporting a dead child, and one
+    /// that does not answer within [`CONTROL_TIMEOUT`] all read as not-alive:
+    /// a probe that cannot be answered is indistinguishable from a dead
+    /// supervisor to every caller that acts on the result.
     pub async fn is_alive(name: &str) -> bool {
-        match Self::connect(name).await {
-            Ok(mut c) => c.ping().await.map(|p| p.alive).unwrap_or(false),
-            Err(_) => false,
+        let probe = async {
+            let mut client = Self::connect(name).await.ok()?;
+            client.ping().await.ok()
+        };
+        match tokio::time::timeout(CONTROL_TIMEOUT, probe).await {
+            Ok(Some(pong)) => pong.alive,
+            Ok(None) => false,
+            Err(_) => {
+                tracing::warn!(session = %name, "supervisor did not answer a liveness probe");
+                false
+            }
         }
     }
 
@@ -93,10 +111,20 @@ impl Client {
         self.expect_ok().await
     }
 
-    /// Kill the child and shut the supervisor down.
+    /// Kill the child and shut the supervisor down. Bounded by
+    /// [`CONTROL_TIMEOUT`]: the acknowledgement precedes teardown, so a
+    /// supervisor that does not answer one is wedged rather than slow, and the
+    /// caller escalates to removing its runtime.
     pub async fn kill(&mut self) -> Result<()> {
-        protocol::write_frame(&mut self.stream, &req::kill()).await?;
-        self.expect_ok().await
+        let request = async {
+            protocol::write_frame(&mut self.stream, &req::kill()).await?;
+            self.expect_ok().await
+        };
+        tokio::time::timeout(CONTROL_TIMEOUT, request)
+            .await
+            .unwrap_or_else(|_| {
+                bail!("supervisor did not acknowledge kill within {CONTROL_TIMEOUT:?}")
+            })
     }
 
     /// (Relay) Append raw bytes to the child's stdin — a one-shot `WRITE` outside

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -641,7 +641,9 @@ Orphan detection is independent: if the session's supervisor is no longer alive,
 the session becomes `orphaned` and is eligible for `loom adopt`.
 
 Archive and recovery serialize their external supervisor/worktree changes.
-Archive waits for the supervisor to disappear before committing `archived`;
+Archive stops the supervisor before committing `archived`, escalating to runtime
+removal and finally committing with a warning if it cannot be confirmed stopped
+— archiving is how a person disposes of a session, so it always terminates;
 recovery first moves `archived → created` with a compare-and-set, which reserves
 the branch's unique active-session slot before it rebuilds or launches anything.
 A failed recovery cleans up its new external state before restoring `archived`.
@@ -651,8 +653,12 @@ Both operations publish a durable `lifecycle_transition` (`archiving` or
 `adopting`) plus a human-readable `lifecycle_step` while external work is in
 flight. REST detail/summary views expose these as `transition`; the SPA shows
 the stage and suppresses lifecycle actions until completion. Transition claims
-are atomic across overlapping server generations, and startup reconciles a
-marker left by a process exit before normal supervisor inventory runs.
+are atomic across overlapping server generations. A marker whose owner process
+is gone, or that has outlived `TRANSITION_STALE_SECS`, is abandoned: startup
+reconciles it before normal supervisor inventory runs, the monitor reconciles it
+again on the retention cadence, and a user-driven archive or recovery takes it
+over rather than refusing. A live marker still refuses concurrent operations, so
+a draining generation keeps its in-flight teardown.
 
 **Retention and automation lifecycle.** Ordinary interactive sessions inherit a
 ten-day idle archive policy (`864000` seconds); a profile override is stamped


### PR DESCRIPTION
A session whose archive died mid-teardown kept its `archiving` marker forever. Only server startup reconciled interrupted transitions, so every later archive and adopt refused with a conflict until the process restarted, and the session could be neither archived nor restored.

Production reached that state because a second loom server was running inside a session container on the shared home. It picked up a Slack message, started archiving the unreachable session, killed that session's relay — and died with the container it was living in, one step into its own teardown.

A transition marker is now abandoned once its owner process is gone or it outlives `TRANSITION_STALE_SECS`. The monitor reconciles abandoned markers on the retention cadence, and archive, adopt, and recovery release one rather than refusing against it. A marker this process owns is still live work, so a draining generation keeps its in-flight teardown during a rolling restart.

Teardown is bounded end to end. Supervisor control requests time out, so a wedged supervisor that still accepts connections no longer parks its caller — the monitor included. Stopping a session escalates to bounded runtime removal, and archive commits `archived` with a warning instead of aborting: archiving is how a person disposes of a session, so it has to terminate. The archive route also stopped reporting a legitimate conflict as a 500.

The second server was reachable by accident: a session's `WEAVER_API` is the host's API (`http://loom:7878` under the compose deploy), and `bind_addr` resolves the *bind* address from it, so `loom server start` inside a session fails with `invalid bind address 'loom:7878'` and invites a retry on the default address — against `WEAVER_HOME=/home/app/.weaver`, the host's own database and sockets. `loom server run` and `loom server start` now refuse when `LOOM_SESSION_ID` is set and the resolved home already carries a `loom.json`. A private `WEAVER_HOME` has none, so hand testing still works, and a host restart is not a session.

Session containers still bind-mount the whole loom home, which is what put the host's database in reach; narrowing that mount is separate work.