### PR TITLE
feat(loom): fix the GitHub access dead-ends for detached sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -255,7 +255,22 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
       echo "Loom-managed GitHub auth is missing its session credential" >&2
       exit 1
     fi
-    token="$(/usr/local/bin/loom github-token)" || exit $?
+    # git writes the request as key=value lines on stdin. `credential.useHttpPath`
+    # is enabled for github.com below, so `path` carries `owner/repo`; ask for a
+    # token scoped to exactly that repository. An App installation token covers
+    # one owner, so a session whose access spans owners has no single token.
+    repository=
+    while IFS= read -r line; do
+      case "$line" in
+        path=*) repository="${line#path=}" ;;
+      esac
+    done
+    repository="${repository%.git}"
+    if [ -n "$repository" ]; then
+      token="$(/usr/local/bin/loom github-token --repository "$repository")" || exit $?
+    else
+      token="$(/usr/local/bin/loom github-token)" || exit $?
+    fi
     ;;
   direct)
     # Loom sets direct only after injecting the launching user's Account token.
@@ -289,7 +304,22 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
       echo "Loom-managed GitHub auth is missing its session credential" >&2
       exit 1
     fi
-    GH_TOKEN="$(/usr/local/bin/loom github-token)" || exit $?
+    # Same per-repository scoping as the git helper. gh names its target with
+    # GH_REPO or the checkout's origin; without either, fall back to the
+    # session's whole set, which the App can mint while it stays single-owner.
+    repository="${GH_REPO:-}"
+    if [ -z "$repository" ]; then
+      origin="$(git config --get remote.origin.url 2>/dev/null || true)"
+      origin="${origin%.git}"
+      case "$origin" in
+        *github.com[:/]*) repository="${origin##*github.com[:/]}" ;;
+      esac
+    fi
+    if [ -n "$repository" ]; then
+      GH_TOKEN="$(/usr/local/bin/loom github-token --repository "$repository")" || exit $?
+    else
+      GH_TOKEN="$(/usr/local/bin/loom github-token)" || exit $?
+    fi
     export GH_TOKEN
     unset GITHUB_TOKEN
     ;;
@@ -318,6 +348,9 @@ exec /usr/bin/gh "$@"
 SH
 chmod +x /usr/local/bin/gh
 git config --system credential.https://github.com.helper ghtoken
+# Without this git omits `path` from the helper request, leaving the broker
+# unable to tell which repository a push is for.
+git config --system credential.https://github.com.useHttpPath true
 git config --system url.https://github.com/.insteadOf git@github.com:
 git config --system url.https://github.com/.insteadOf ssh://git@github.com/
 EOF

--- a/README.md
+++ b/README.md
@@ -184,8 +184,12 @@ loom channels send "ready for review"
 ```
 
 `loom permissions show` reports the session's effective operations and external
-repository scope. `loom permissions request --help` exposes the durable human
-approval flow when another repository is needed.
+repository scope. A session always has App scope for its own repository;
+`loom permissions request --help` exposes the durable approval flow for any
+other one. That request raises the session's attention and posts to its
+channel, so you decide from Session Details in the browser — no shell needed.
+A profile that allowlists `owner/*` turns those decisions into a standing
+approval for that owner, applied without waiting on you.
 
 ## Status & attention
 

--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -90,9 +90,7 @@ pub async fn resume_environment(
     let github_repositories =
         serde_json::from_str::<Vec<String>>(&session.policy_github_repositories)
             .unwrap_or_default();
-    let github_app = crate::runtime::scopes_an_app_token(&github_repositories)
-        .then(|| st.trigger.app())
-        .flatten();
+    let github_app = crate::runtime::app_for_allowlist(&github_repositories, st.trigger.app());
     configure_session_github_auth(
         &st.db,
         &mut env,
@@ -780,9 +778,7 @@ pub async fn create_warm_session(
     .await?;
     let session_token =
         crate::auth::create_session_token(&st.db, None, &session_id, &branch.id).await?;
-    let github_app = crate::runtime::scopes_an_app_token(&github_repositories)
-        .then(|| st.trigger.app())
-        .flatten();
+    let github_app = crate::runtime::app_for_allowlist(&github_repositories, st.trigger.app());
     stamp_github_auth_mode(&mut extra_env, github_app, launch_profile.restricted, false).await;
     set_env(&mut extra_env, "LOOM_TOKEN", session_token);
     set_env(&mut extra_env, "LOOM_SESSION_ID", session_id.clone());

--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -90,7 +90,7 @@ pub async fn resume_environment(
     let github_repositories =
         serde_json::from_str::<Vec<String>>(&session.policy_github_repositories)
             .unwrap_or_default();
-    let github_app = (!github_repositories.is_empty())
+    let github_app = crate::runtime::scopes_an_app_token(&github_repositories)
         .then(|| st.trigger.app())
         .flatten();
     configure_session_github_auth(
@@ -780,7 +780,7 @@ pub async fn create_warm_session(
     .await?;
     let session_token =
         crate::auth::create_session_token(&st.db, None, &session_id, &branch.id).await?;
-    let github_app = (!github_repositories.is_empty())
+    let github_app = crate::runtime::scopes_an_app_token(&github_repositories)
         .then(|| st.trigger.app())
         .flatten();
     stamp_github_auth_mode(&mut extra_env, github_app, launch_profile.restricted, false).await;

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -259,6 +259,16 @@ pub fn scopes_an_app_token(entries: &[String]) -> bool {
     entries.iter().any(|entry| !is_repository_pattern(entry))
 }
 
+/// Select the App credential for a session, given the allowlist stamped on it.
+/// An allowlist that names no repository scopes no token, so it selects no App
+/// however the deployment is configured.
+pub fn app_for_allowlist<'a>(
+    entries: &[String],
+    app: Option<&'a crate::github_app::GithubApp>,
+) -> Option<&'a crate::github_app::GithubApp> {
+    scopes_an_app_token(entries).then_some(app).flatten()
+}
+
 /// Resolve a profile's App-token allowlist into the repositories stamped on
 /// one session. Automation profiles intentionally retain their complete list
 /// for cross-repository work.

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -205,10 +205,70 @@ pub async fn configure_session_github_auth(
     stamp_github_auth_mode(env, github_app, restricted, user_token_applied).await
 }
 
+/// The owner an `owner/*` allowlist entry covers, or `None` for a concrete
+/// `owner/name` entry. A pattern scopes no token on its own: it declares which
+/// repositories a session may expand into without a human decision, so a
+/// brokered token stays narrow to what was actually asked for.
+pub fn pattern_owner(entry: &str) -> Option<&str> {
+    entry
+        .split_once('/')
+        .filter(|(owner, name)| *name == "*" && !owner.is_empty())
+        .map(|(owner, _)| owner)
+}
+
+pub fn is_repository_pattern(entry: &str) -> bool {
+    pattern_owner(entry).is_some()
+}
+
+/// The concrete `owner/name` entries of an allowlist — the only ones that can
+/// scope a GitHub App installation token.
+pub fn concrete_repositories(entries: &[String]) -> Vec<String> {
+    entries
+        .iter()
+        .filter(|entry| !is_repository_pattern(entry))
+        .cloned()
+        .collect()
+}
+
+/// The `owner/*` entries of an allowlist.
+pub fn repository_patterns(entries: &[String]) -> Vec<String> {
+    entries
+        .iter()
+        .filter(|entry| is_repository_pattern(entry))
+        .cloned()
+        .collect()
+}
+
+/// Whether an allowlist's patterns already cover `repository`. GitHub owners
+/// are case-insensitive and these patterns are hand-authored, so the owner
+/// comparison is too.
+pub fn pattern_allows(entries: &[String], repository: &str) -> bool {
+    let Some((owner, _)) = repository.split_once('/') else {
+        return false;
+    };
+    entries
+        .iter()
+        .filter_map(|entry| pattern_owner(entry))
+        .any(|candidate| candidate.eq_ignore_ascii_case(owner))
+}
+
+/// Whether a stamped allowlist can scope a GitHub App token at all. Patterns
+/// authorize expansion but name no repository, so an allowlist holding only
+/// patterns selects no App credential.
+pub fn scopes_an_app_token(entries: &[String]) -> bool {
+    entries.iter().any(|entry| !is_repository_pattern(entry))
+}
+
 /// Resolve a profile's App-token allowlist into the repositories stamped on
 /// one session. Automation profiles intentionally retain their complete list
-/// for cross-repository work. Interactive sessions receive only their current
-/// repository, and only when the profile explicitly allowlists it.
+/// for cross-repository work.
+///
+/// An interactive session receives its own repository unconditionally. Such a
+/// session already selects the launching user's Account PAT first, which
+/// reaches every repository that user can write; gating the narrower, audited,
+/// per-repository App token on a profile allowlist only ever withheld the
+/// safer credential for the one repository the session was created in.
+/// Expanding *beyond* it still needs a human decision or a matching pattern.
 pub fn session_github_repositories(
     class: &str,
     configured: &[String],
@@ -217,10 +277,9 @@ pub fn session_github_repositories(
     if class != "interactive" {
         return configured.to_vec();
     }
-    current_repo
-        .filter(|repo| configured.iter().any(|candidate| candidate == repo))
-        .map(|repo| vec![repo.to_string()])
-        .unwrap_or_default()
+    let mut stamped: Vec<String> = current_repo.map(str::to_string).into_iter().collect();
+    stamped.extend(repository_patterns(configured));
+    stamped
 }
 
 /// A GitHub repository may be launched only when Loom can provide either the
@@ -425,12 +484,15 @@ mod tests {
             session_github_repositories("interactive", &configured, Some("marin-community/marin")),
             ["marin-community/marin"]
         );
-        assert!(session_github_repositories(
-            "interactive",
-            &configured,
-            Some("marin-community/loom")
-        )
-        .is_empty());
+        // The session's own repository no longer has to appear in the profile
+        // allowlist: it is the baseline scope for the repository the session
+        // was created in.
+        assert_eq!(
+            session_github_repositories("interactive", &configured, Some("marin-community/loom")),
+            ["marin-community/loom"]
+        );
+        assert!(session_github_repositories("interactive", &configured, None).is_empty());
+        assert!(session_github_repositories("interactive", &[], None).is_empty());
         assert_eq!(
             session_github_repositories("automation", &configured, None),
             configured
@@ -438,6 +500,52 @@ mod tests {
         assert!(user_github_token_allowed("interactive", false));
         assert!(!user_github_token_allowed("automation", false));
         assert!(!user_github_token_allowed("interactive", true));
+    }
+
+    #[test]
+    fn owner_patterns_travel_with_the_session_but_never_scope_a_token() {
+        let configured = vec![
+            "marin-community/*".to_string(),
+            "marin-community/marin".to_string(),
+        ];
+        // An interactive session carries its own repository plus the patterns
+        // that let it expand without a human.
+        assert_eq!(
+            session_github_repositories("interactive", &configured, Some("marin-community/loom")),
+            ["marin-community/loom", "marin-community/*"]
+        );
+        assert_eq!(
+            session_github_repositories("automation", &configured, None),
+            configured
+        );
+
+        let stamped = session_github_repositories("interactive", &configured, Some("owner/repo"));
+        assert_eq!(concrete_repositories(&stamped), ["owner/repo"]);
+        assert_eq!(repository_patterns(&stamped), ["marin-community/*"]);
+
+        assert_eq!(pattern_owner("marin-community/*"), Some("marin-community"));
+        assert_eq!(pattern_owner("marin-community/marin"), None);
+        assert_eq!(pattern_owner("/*"), None);
+        assert!(is_repository_pattern("marin-community/*"));
+        assert!(!is_repository_pattern("marin-community/marin"));
+        assert!(!is_repository_pattern("/*"));
+
+        // An allowlist of patterns alone names no repository, so it selects no
+        // App credential.
+        assert!(scopes_an_app_token(&stamped));
+        assert!(!scopes_an_app_token(&["marin-community/*".to_string()]));
+        assert!(!scopes_an_app_token(&[]));
+
+        assert!(pattern_allows(&configured, "marin-community/vllm"));
+        // Owners are case-insensitive on GitHub.
+        assert!(pattern_allows(&configured, "Marin-Community/vllm"));
+        assert!(!pattern_allows(&configured, "Open-Athena/marinmirror"));
+        // An exact entry is not a pattern, so it grants no wildcard expansion.
+        assert!(!pattern_allows(
+            &["marin-community/marin".to_string()],
+            "marin-community/vllm"
+        ));
+        assert!(!pattern_allows(&configured, "no-slash"));
     }
 
     #[tokio::test]

--- a/crates/loom-forge/src/runtime.rs
+++ b/crates/loom-forge/src/runtime.rs
@@ -273,12 +273,10 @@ pub fn app_for_allowlist<'a>(
 /// one session. Automation profiles intentionally retain their complete list
 /// for cross-repository work.
 ///
-/// An interactive session receives its own repository unconditionally. Such a
-/// session already selects the launching user's Account PAT first, which
-/// reaches every repository that user can write; gating the narrower, audited,
-/// per-repository App token on a profile allowlist only ever withheld the
-/// safer credential for the one repository the session was created in.
-/// Expanding *beyond* it still needs a human decision or a matching pattern.
+/// An interactive session is stamped with its own repository, whether or not
+/// the profile lists it, plus the profile's `owner/*` patterns. The profile's
+/// concrete entries govern nothing here: reaching any other repository is an
+/// expansion, granted by a human decision or by a matching pattern.
 pub fn session_github_repositories(
     class: &str,
     configured: &[String],

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -570,7 +570,7 @@ async fn handoff_session_inner(
             .map_err(|error| HandoffError::bad_request(error.to_string()))?;
         extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
     }
-    let github_app = (!session_github_repositories.is_empty())
+    let github_app = runtime::scopes_an_app_token(&session_github_repositories)
         .then(|| st.trigger.app())
         .flatten();
     if current_github_repo.is_some()

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -570,9 +570,7 @@ async fn handoff_session_inner(
             .map_err(|error| HandoffError::bad_request(error.to_string()))?;
         extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
     }
-    let github_app = runtime::scopes_an_app_token(&session_github_repositories)
-        .then(|| st.trigger.app())
-        .flatten();
+    let github_app = runtime::app_for_allowlist(&session_github_repositories, st.trigger.app());
     if current_github_repo.is_some()
         && !runtime::github_credential_available(
             &st.db,

--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -686,7 +686,7 @@ async fn create_inner(st: AppState, req: CreateReq, actor: Actor) -> Result<Prov
         extra_env = crate::profile::cleared_environment(extra_env, &allowlist);
     }
     tracing::debug!(model = %model, effort = %effort, protocol = %protocol, "resolved and validated model/effort/protocol");
-    let github_app = if (!session_github_repositories.is_empty())
+    let github_app = if crate::runtime::scopes_an_app_token(&session_github_repositories)
         || (launch_profile.restricted && managed_slug.is_some())
     {
         st.trigger.app()

--- a/crates/loom-policy/src/profile.rs
+++ b/crates/loom-policy/src/profile.rs
@@ -51,6 +51,8 @@ const DEFAULT_PROFILE_INSTRUCTIONS: &str = include_str!("../profiles/default/ins
 const MAX_PROFILE_INSTRUCTIONS_BYTES: usize = 64 * 1024;
 const MAX_GITHUB_REPOSITORIES: usize = 64;
 
+/// An allowlist entry: a concrete `owner/name`, or an `owner/*` pattern that
+/// lets a session expand into that owner without a human decision.
 fn valid_github_repository(value: &str) -> bool {
     let mut parts = value.split('/');
     let valid_part = |part: &str| {
@@ -61,7 +63,7 @@ fn valid_github_repository(value: &str) -> bool {
                 .bytes()
                 .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
     };
-    matches!((parts.next(), parts.next(), parts.next()), (Some(owner), Some(name), None) if valid_part(owner) && valid_part(name))
+    matches!((parts.next(), parts.next(), parts.next()), (Some(owner), Some(name), None) if valid_part(owner) && (name == "*" || valid_part(name)))
 }
 
 fn is_restricted_mcp_tool_set(rule: &str) -> bool {
@@ -149,7 +151,7 @@ async fn validate_input(
             .iter()
             .any(|repository| !valid_github_repository(repository))
     {
-        bail!("GitHub repositories must be clean owner/name identifiers (maximum {MAX_GITHUB_REPOSITORIES})");
+        bail!("GitHub repositories must be clean owner/name identifiers or owner/* patterns (maximum {MAX_GITHUB_REPOSITORIES})");
     }
     if input.class.trim() == "automation"
         && input

--- a/crates/loom/frontend/src/types.ts
+++ b/crates/loom/frontend/src/types.ts
@@ -106,6 +106,9 @@ export interface EffectivePermissions {
   actor: string;
   operations: string[];
   github_repositories: string[];
+  /** `owner/*` launch-policy entries: owners this session may expand into
+   *  without a human decision. */
+  github_repository_patterns: string[];
   pending_requests: PermissionRequest[];
 }
 

--- a/crates/loom/src/agent_cli.rs
+++ b/crates/loom/src/agent_cli.rs
@@ -435,8 +435,8 @@ pub async fn run_hook(event: String) -> Result<()> {
     cmd_hook(event).await
 }
 
-pub async fn run_github_token() -> Result<()> {
-    cmd_github_token().await
+pub async fn run_github_token(repository: Option<&str>) -> Result<()> {
+    cmd_github_token(repository).await
 }
 
 pub fn run_chatlog(file: Option<String>, as_json: bool) -> Result<()> {
@@ -499,10 +499,10 @@ fn channel_key(explicit: Option<String>) -> Result<String> {
     Ok(key.to_string())
 }
 
-async fn cmd_github_token() -> Result<()> {
+async fn cmd_github_token(repository: Option<&str>) -> Result<()> {
     let session_id =
         std::env::var("LOOM_SESSION_ID").map_err(|_| anyhow!("$LOOM_SESSION_ID is not set"))?;
-    let credential = client().github_token(&session_id).await?;
+    let credential = client().github_token(&session_id, repository).await?;
     println!("{}", credential.token);
     Ok(())
 }

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -1844,6 +1844,15 @@ async fn run_permissions(cmd: PermissionsCmd) -> Result<()> {
                 for repository in view.github_repositories {
                     println!("  {repository}");
                 }
+                if !view.github_repository_patterns.is_empty() {
+                    println!(
+                        "GitHub owners grantable without review ({}):",
+                        view.github_repository_patterns.len()
+                    );
+                    for pattern in view.github_repository_patterns {
+                        println!("  {pattern}");
+                    }
+                }
                 println!("pending requests ({}):", view.pending_requests.len());
                 for request in view.pending_requests {
                     println!(

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -7,7 +7,7 @@
 //! terminal (the browser terminal is the other interaction surface).
 
 use anyhow::{anyhow, bail, Context, Result};
-use clap::{ArgMatches, Args, Command, CommandFactory, FromArgMatches, Parser, Subcommand};
+use clap::{Arg, ArgMatches, Args, Command, CommandFactory, FromArgMatches, Parser, Subcommand};
 use loom::agent_cli::{
     ArtifactCmd as AgentArtifactCmd, ChannelCmd as AgentChannelCmd, ConfigCmd as AgentConfigCmd,
     IssueCmd as AgentIssueCmd, StatusCmd as AgentStatusCmd, TagCmd as AgentTagCmd,
@@ -219,7 +219,7 @@ enum RegisteredCliCommand {
     Review(ReviewCmd),
     Issues(AgentIssueCmd),
     Permissions(PermissionsCmd),
-    GithubToken,
+    GithubToken(Option<String>),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -377,11 +377,18 @@ fn parse_hook_command(matches: &ArgMatches) -> clap::error::Result<RegisteredCli
 }
 
 fn github_token_command() -> Command {
-    Command::new("github-token").hide(true)
+    Command::new("github-token").hide(true).arg(
+        Arg::new("repository")
+            .long("repository")
+            .value_name("OWNER/NAME")
+            .help("Scope the credential to one repository this session may write"),
+    )
 }
 
-fn parse_github_token_command(_: &ArgMatches) -> clap::error::Result<RegisteredCliCommand> {
-    Ok(RegisteredCliCommand::GithubToken)
+fn parse_github_token_command(matches: &ArgMatches) -> clap::error::Result<RegisteredCliCommand> {
+    Ok(RegisteredCliCommand::GithubToken(
+        matches.get_one::<String>("repository").cloned(),
+    ))
 }
 
 const SESSION_CLI_COMMANDS: &[CliCommandFactory] = &[
@@ -1696,9 +1703,9 @@ async fn run_registered_cli(command: RegisteredCliCommand) -> Result<()> {
             loom::agent_cli::run_issue(cmd).await
         }
         RegisteredCliCommand::Permissions(cmd) => run_permissions(cmd).await,
-        RegisteredCliCommand::GithubToken => {
+        RegisteredCliCommand::GithubToken(repository) => {
             configure_agent_client()?;
-            loom::agent_cli::run_github_token().await
+            loom::agent_cli::run_github_token(repository.as_deref()).await
         }
     }
 }

--- a/crates/loom/src/web/github_access.rs
+++ b/crates/loom/src/web/github_access.rs
@@ -26,11 +26,15 @@ fn require_human(principal: &Principal) -> ApiResult<()> {
     }
 }
 
+/// The concrete repositories one session's App token may be scoped to. Any
+/// `owner/*` entry in the launch policy is dropped here: a pattern authorizes
+/// expansion, it is not itself a token scope.
 pub(super) async fn effective_repositories(
     db: &crate::Db,
     session: &crate::session::Session,
 ) -> anyhow::Result<Vec<String>> {
-    let mut repositories: Vec<String> = serde_json::from_str(&session.policy_github_repositories)?;
+    let policy: Vec<String> = serde_json::from_str(&session.policy_github_repositories)?;
+    let mut repositories = crate::runtime::concrete_repositories(&policy);
     for grant in crate::github_access::list(db, &session.id).await? {
         repositories.retain(|candidate| candidate != &grant.repository);
         if grant.mode == crate::github_access::Mode::Write {
@@ -40,6 +44,15 @@ pub(super) async fn effective_repositories(
     repositories.sort();
     repositories.dedup();
     Ok(repositories)
+}
+
+/// The `owner/*` entries stamped on one session's launch policy — the owners it
+/// may expand into without a human decision.
+pub(super) fn policy_repository_patterns(
+    session: &crate::session::Session,
+) -> anyhow::Result<Vec<String>> {
+    let policy: Vec<String> = serde_json::from_str(&session.policy_github_repositories)?;
+    Ok(crate::runtime::repository_patterns(&policy))
 }
 
 /// Validate that a prospective repository expansion can be represented by one

--- a/crates/loom/src/web/github_access.rs
+++ b/crates/loom/src/web/github_access.rs
@@ -55,18 +55,15 @@ pub(super) fn policy_repository_patterns(
     Ok(crate::runtime::repository_patterns(&policy))
 }
 
-/// Validate that a prospective repository expansion can be represented by one
-/// GitHub App installation token. Nothing is stored until this succeeds.
-pub(super) async fn validate_github_write(
-    st: &AppState,
-    session: &crate::session::Session,
-    repository: &str,
-) -> ApiResult<()> {
-    let mut repositories = effective_repositories(&st.db, session)
-        .await
-        .map_err(|error| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
-    repositories.retain(|candidate| candidate != repository);
-    repositories.push(repository.to_string());
+/// Validate that the GitHub App can actually grant write access to one
+/// repository. Nothing is stored until this succeeds.
+///
+/// Only the new repository is minted, never the session's whole prospective
+/// set: tokens are brokered per repository, so a session may hold access
+/// spanning several owners even though no single installation token could
+/// cover them all.
+pub(super) async fn validate_github_write(st: &AppState, repository: &str) -> ApiResult<()> {
+    let repositories = vec![repository.to_string()];
     let app = st.trigger.app().ok_or_else(|| {
         AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
@@ -127,11 +124,11 @@ pub(super) async fn set_github_access(
     let mode = crate::github_access::Mode::try_from(mode_text.as_str())
         .map_err(|_| AppError::bad_request("GitHub access mode must be 'write' or 'none'"))?;
 
-    // Validate the complete prospective token scope before changing durable
-    // access. This catches an uninstalled repo and cross-installation mixes at
-    // grant time instead of surprising the agent on its next push.
+    // Prove the App can grant this repository before changing durable access,
+    // so an uninstalled repo fails here rather than surprising the agent on its
+    // next push.
     if mode == crate::github_access::Mode::Write {
-        validate_github_write(&st, &session, &repository).await?;
+        validate_github_write(&st, &repository).await?;
     }
 
     crate::github_access::set(&st.db, &session.id, &repository, mode, &principal.username).await?;

--- a/crates/loom/src/web/permission_requests.rs
+++ b/crates/loom/src/web/permission_requests.rs
@@ -266,7 +266,7 @@ pub(super) async fn create_permission_request_operation(
         .iter()
         .find(|pattern| crate::runtime::pattern_allows(std::slice::from_ref(pattern), &repository))
     {
-        match validate_github_write(&st, &session, &repository).await {
+        match validate_github_write(&st, &repository).await {
             Ok(()) => {
                 return apply_policy_grant(&st, &session, &branch.id, request, pattern).await;
             }
@@ -345,7 +345,7 @@ pub(super) async fn decide_permission_request(
     let reason = req.reason.trim();
     let changed = match decision.as_str() {
         "approve" => {
-            validate_github_write(&st, &session, &request.repository).await?;
+            validate_github_write(&st, &request.repository).await?;
             permission_requests::approve_github(&st.db, &id, &principal.username, reason).await?
         }
         "deny" => permission_requests::deny(&st.db, &id, &principal.username, reason).await?,

--- a/crates/loom/src/web/permission_requests.rs
+++ b/crates/loom/src/web/permission_requests.rs
@@ -21,8 +21,8 @@ use crate::{
 
 use super::{
     channels::{append_and_deliver, record_channel_message_event},
-    effective_repositories, register_operation, require_session, validate_github_write, ApiResult,
-    AppError, AppState, OperationContext, RegisteredOperation,
+    effective_repositories, policy_repository_patterns, register_operation, require_session,
+    validate_github_write, ApiResult, AppError, AppState, OperationContext, RegisteredOperation,
 };
 
 pub(super) fn registered_operations() -> Vec<RegisteredOperation> {
@@ -96,6 +96,8 @@ pub(super) async fn effective_permissions_operation(
     let github_repositories = effective_repositories(&st.db, &session)
         .await
         .map_err(|error| AppError::internal("could not resolve GitHub access", error))?;
+    let github_repository_patterns = policy_repository_patterns(&session)
+        .map_err(|error| AppError::internal("could not resolve GitHub access", error))?;
     let pending_requests =
         permission_requests::list(&st.db, &session.id, Some(permission_requests::PENDING))
             .await?
@@ -122,6 +124,7 @@ pub(super) async fn effective_permissions_operation(
         actor: "session_self".to_string(),
         operations,
         github_repositories,
+        github_repository_patterns,
         pending_requests,
     })
 }
@@ -139,6 +142,65 @@ pub(super) async fn list_permission_requests_operation(
         .into_iter()
         .map(view)
         .collect())
+}
+
+/// Apply an expansion the launch policy already authorizes. Same durable
+/// record and audit trail as a human decision, minus the wait: the session
+/// channel gets an ordinary informational message and no attention is raised.
+async fn apply_policy_grant(
+    st: &AppState,
+    session: &crate::session::Session,
+    branch_id: &str,
+    request: permission_requests::PermissionRequest,
+    pattern: &str,
+) -> ApiResult<PermissionRequestView> {
+    let decided_by = format!("policy:{pattern}");
+    let decision_reason = format!("launch policy allowlists {pattern}");
+    if !permission_requests::approve_github(&st.db, &request.id, &decided_by, &decision_reason)
+        .await?
+    {
+        return Err(AppError::conflict("permission request is already resolved"));
+    }
+    let decided = permission_requests::get(&st.db, &request.id)
+        .await?
+        .ok_or_else(|| AppError::not_found("permission request"))?;
+    let author = Subject::new(SubjectKind::Session, &session.id);
+    crate::channels::append(
+        &st.db,
+        &session.id,
+        NewMessage {
+            kind: MessageKind::System,
+            urgency: Urgency::Normal,
+            author: &author,
+            body: &format!(
+                "GitHub write access granted for {} by launch policy ({pattern}).",
+                decided.repository
+            ),
+            payload: &json!({
+                "permission_request_id": decided.id,
+                "decision": "approve",
+                "repository": decided.repository,
+                "pattern": pattern,
+            }),
+            reply_to: None,
+            idempotency_key: Some(&format!("permission-decision:{}", decided.id)),
+        },
+    )
+    .await?;
+    crate::events::record(
+        &st.db,
+        &st.bus,
+        branch_id,
+        "permission_decision",
+        json!({
+            "request_id": decided.id,
+            "decision": "approve",
+            "repository": decided.repository,
+            "by": decided_by,
+        }),
+    )
+    .await?;
+    Ok(view(decided))
 }
 
 pub(super) async fn create_permission_request_operation(
@@ -191,6 +253,30 @@ pub(super) async fn create_permission_request_operation(
         &requested_by,
     )
     .await?;
+
+    // An `owner/*` entry on the launch policy is a standing human decision for
+    // that owner, so a matching request is applied now instead of parking the
+    // session on a human who may not be at a terminal. The App installation is
+    // still validated, and the grant is still recorded and revocable. If the
+    // App cannot actually grant it, fall through to the human path — a person
+    // can install the App and then approve.
+    let patterns = policy_repository_patterns(&session)
+        .map_err(|error| AppError::internal("could not resolve GitHub access", error))?;
+    if let Some(pattern) = patterns
+        .iter()
+        .find(|pattern| crate::runtime::pattern_allows(std::slice::from_ref(pattern), &repository))
+    {
+        match validate_github_write(&st, &session, &repository).await {
+            Ok(()) => {
+                return apply_policy_grant(&st, &session, &branch.id, request, pattern).await;
+            }
+            Err(error) => tracing::warn!(
+                session = %session.id, %repository, pattern = %pattern, detail = %error.message,
+                "launch policy allows this expansion but the GitHub App cannot grant it; \
+                 falling back to human approval"
+            ),
+        }
+    }
 
     let message = format!("GitHub write access requested for {repository}: {reason}");
     branch_mod::set_description(&st.db, &branch.id, &message).await?;

--- a/crates/loom/src/web/permission_requests.rs
+++ b/crates/loom/src/web/permission_requests.rs
@@ -144,6 +144,32 @@ pub(super) async fn list_permission_requests_operation(
         .collect())
 }
 
+/// Record the durable audit event for one resolved access request. Both the
+/// human decision and the launch-policy grant land the same event; they differ
+/// only in who decided and how the session is told.
+async fn record_decision_event(
+    st: &AppState,
+    branch_id: &str,
+    decided: &permission_requests::PermissionRequest,
+    decision: &str,
+    by: &str,
+) -> ApiResult<()> {
+    crate::events::record(
+        &st.db,
+        &st.bus,
+        branch_id,
+        "permission_decision",
+        json!({
+            "request_id": decided.id,
+            "decision": decision,
+            "repository": decided.repository,
+            "by": by,
+        }),
+    )
+    .await?;
+    Ok(())
+}
+
 /// Apply an expansion the launch policy already authorizes. Same durable
 /// record and audit trail as a human decision, minus the wait: the session
 /// channel gets an ordinary informational message and no attention is raised.
@@ -187,19 +213,7 @@ async fn apply_policy_grant(
         },
     )
     .await?;
-    crate::events::record(
-        &st.db,
-        &st.bus,
-        branch_id,
-        "permission_decision",
-        json!({
-            "request_id": decided.id,
-            "decision": "approve",
-            "repository": decided.repository,
-            "by": decided_by,
-        }),
-    )
-    .await?;
+    record_decision_event(st, branch_id, &decided, "approve", &decided_by).await?;
     Ok(view(decided))
 }
 
@@ -388,19 +402,7 @@ pub(super) async fn decide_permission_request(
             append_and_deliver(&st, &session.id, &channel, &author, &message).await?;
         record_channel_message_event(&st, &session.id, &author, &message, inserted).await;
     }
-    crate::events::record(
-        &st.db,
-        &st.bus,
-        &branch.id,
-        "permission_decision",
-        json!({
-            "request_id": decided.id,
-            "decision": decision,
-            "repository": decided.repository,
-            "by": principal.username,
-        }),
-    )
-    .await?;
+    record_decision_event(&st, &branch.id, &decided, &decision, &principal.username).await?;
     Ok(Json(view(decided)))
 }
 

--- a/crates/loom/src/web/restricted_github.rs
+++ b/crates/loom/src/web/restricted_github.rs
@@ -6,7 +6,7 @@
 //! the repository nor the credential is caller-controlled.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     Extension, Json,
 };
@@ -32,9 +32,20 @@ fn principal_owns_session(principal: &Principal, id: &str) -> bool {
     matches!(&principal.grant, Grant::Session { session_id, .. } if session_id == id)
 }
 
+/// Which repository the caller wants a credential for. An App installation
+/// token covers exactly one owner, so a session whose access spans owners has
+/// no single token — it asks per repository instead.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GithubTokenQuery {
+    #[serde(default)]
+    repository: Option<String>,
+}
+
 pub(super) async fn github_token(
     State(st): State<AppState>,
     Path(id): Path<String>,
+    Query(query): Query<GithubTokenQuery>,
     Extension(principal): Extension<Principal>,
 ) -> ApiResult<Json<GithubTokenView>> {
     if !principal_owns_session(&principal, &id) {
@@ -61,9 +72,32 @@ pub(super) async fn github_token(
             "session profile has no GitHub repository credential",
         ));
     }
+    // Named repository: the narrowest useful scope, and the only form that
+    // works once a session's access spans more than one owner. Unnamed keeps
+    // the whole set, which the App can mint only while it stays single-owner.
+    let scope = match query
+        .repository
+        .as_deref()
+        .map(str::trim)
+        .filter(|repository| !repository.is_empty())
+    {
+        Some(requested) => {
+            let slug = crate::repo::parse_slug(requested)
+                .map_err(AppError::bad_request)?
+                .slug();
+            if !repositories.iter().any(|candidate| candidate == &slug) {
+                return Err(AppError::new(
+                    StatusCode::FORBIDDEN,
+                    format!("session has no GitHub access to {slug}"),
+                ));
+            }
+            vec![slug]
+        }
+        None => repositories,
+    };
     let app = super::configured_github_app(&st).await?;
     let token = app
-        .token_for_repositories(&repositories)
+        .token_for_repositories(&scope)
         .await
         .map_err(|error| AppError::new(StatusCode::BAD_GATEWAY, error.to_string()))?;
     Ok(Json(GithubTokenView { token }))

--- a/crates/loom/tests/docker_github_auth.rs
+++ b/crates/loom/tests/docker_github_auth.rs
@@ -5,6 +5,17 @@ use std::process::{Command, Output, Stdio};
 
 const DOCKERFILE: &str = include_str!("../../../Dockerfile");
 
+/// The broker CLI stands in for `loom github-token` and echoes the repository
+/// it was asked for, so a test can assert which scope the adapter requested.
+const BROKER_STUB: &str = "loom_github_token() {
+  if [ \"$1\" = --repository ]; then
+    printf 'broker-token:%s\\n' \"$2\"
+  else
+    printf 'broker-token\\n'
+  fi
+}
+";
+
 fn embedded_script(path: &str) -> String {
     let start = format!("cat > {path} <<'SH'\n");
     let (_, tail) = DOCKERFILE
@@ -13,13 +24,30 @@ fn embedded_script(path: &str) -> String {
     let (script, _) = tail
         .split_once("\nSH\n")
         .unwrap_or_else(|| panic!("unterminated {path} heredoc"));
-    script.replace("/usr/local/bin/loom github-token", "printf broker-token")
+    let body = script.replace("/usr/local/bin/loom github-token", "loom_github_token");
+    format!("{BROKER_STUB}{body}")
 }
 
 fn run_script(script: &str, env: &[(&str, &str)], args: &[&str]) -> Output {
+    run_credential_script(script, env, args, "")
+}
+
+/// Run one adapter from a file so its stdin carries the credential request git
+/// would write, and from a directory that is not a git checkout so the `gh`
+/// wrapper cannot pick up this repository's own origin.
+fn run_credential_script(
+    script: &str,
+    env: &[(&str, &str)],
+    args: &[&str],
+    request: &str,
+) -> Output {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("adapter.sh");
+    std::fs::write(&path, script).unwrap();
     let mut child = Command::new("sh")
-        .arg("-s")
+        .arg(&path)
         .args(args)
+        .current_dir(dir.path())
         .env_clear()
         .env("PATH", "/usr/bin:/bin")
         .envs(env.iter().copied())
@@ -32,7 +60,7 @@ fn run_script(script: &str, env: &[(&str, &str)], args: &[&str]) -> Output {
         .stdin
         .take()
         .unwrap()
-        .write_all(script.as_bytes())
+        .write_all(request.as_bytes())
         .unwrap();
     child.wait_with_output().unwrap()
 }
@@ -108,6 +136,67 @@ fn git_helper_obeys_loom_owned_auth_mode() {
         .contains("missing GH_TOKEN"));
 }
 
+/// An installation token covers one owner, so the helper must ask for the
+/// repository git named rather than the session's whole set. Without this a
+/// session holding access under two owners can push to neither.
+#[test]
+fn git_helper_scopes_the_brokered_token_to_the_repository_git_asked_for() {
+    let script = embedded_script("/usr/local/bin/git-credential-ghtoken");
+    let broker = &[
+        ("LOOM_GITHUB_AUTH_MODE", "broker"),
+        ("LOOM_SESSION_ID", "session"),
+        ("LOOM_TOKEN", "session-token"),
+    ];
+
+    let scoped = run_credential_script(
+        &script,
+        broker,
+        &["get"],
+        "protocol=https\nhost=github.com\npath=marin-community/vllm.git\n\n",
+    );
+    assert!(scoped.status.success());
+    assert_eq!(
+        String::from_utf8(scoped.stdout).unwrap(),
+        "username=x-access-token\npassword=broker-token:marin-community/vllm\n"
+    );
+
+    // A different owner in the same session resolves independently.
+    let other_owner = run_credential_script(
+        &script,
+        broker,
+        &["get"],
+        "protocol=https\nhost=github.com\npath=Open-Athena/mumwelt\n\n",
+    );
+    assert!(other_owner.status.success());
+    assert_eq!(
+        String::from_utf8(other_owner.stdout).unwrap(),
+        "username=x-access-token\npassword=broker-token:Open-Athena/mumwelt\n"
+    );
+
+    // Git omits `path` unless credential.useHttpPath is set; fall back to the
+    // session's whole set rather than failing.
+    let unscoped = run_credential_script(
+        &script,
+        broker,
+        &["get"],
+        "protocol=https\nhost=github.com\n\n",
+    );
+    assert!(unscoped.status.success());
+    assert_eq!(
+        String::from_utf8(unscoped.stdout).unwrap(),
+        "username=x-access-token\npassword=broker-token\n"
+    );
+}
+
+/// The Dockerfile must enable `credential.useHttpPath` for github.com, or git
+/// never sends the `path` the helper above scopes on.
+#[test]
+fn git_is_configured_to_send_the_repository_path_to_the_helper() {
+    assert!(
+        DOCKERFILE.contains("git config --system credential.https://github.com.useHttpPath true")
+    );
+}
+
 #[test]
 fn gh_wrapper_obeys_loom_owned_auth_mode() {
     let script = embedded_script("/usr/local/bin/gh").replace(
@@ -129,6 +218,22 @@ fn gh_wrapper_obeys_loom_owned_auth_mode() {
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
         "GH_TOKEN=broker-token\nGITHUB_TOKEN=unset\n"
+    );
+
+    let scoped = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "broker"),
+            ("LOOM_SESSION_ID", "session"),
+            ("LOOM_TOKEN", "session-token"),
+            ("GH_REPO", "marin-community/vllm"),
+        ],
+        &["pr", "create"],
+    );
+    assert!(scoped.status.success());
+    assert_eq!(
+        String::from_utf8(scoped.stdout).unwrap(),
+        "GH_TOKEN=broker-token:marin-community/vllm\nGITHUB_TOKEN=unset\n"
     );
 
     let direct = run_script(

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -271,7 +271,8 @@ async fn interactive_session_uses_the_launching_users_account_token() {
 }
 
 /// An interactive profile can use the configured GitHub App as its default
-/// credential while stamping only the current allowlisted repository.
+/// credential while stamping only the current repository — never the profile's
+/// other entries.
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn interactive_profile_brokers_its_current_github_repository() {
@@ -322,6 +323,78 @@ async fn interactive_profile_brokers_its_current_github_repository() {
             "/api/sessions",
             json!({
                 "goal": "use brokered credentials",
+                "cwd": ts.cwd(),
+                "agent": "codex",
+            }),
+        )
+        .await
+        .unwrap();
+    let id = session["id"].as_str().unwrap();
+    let repositories: String =
+        sqlx::query_scalar("SELECT policy_github_repositories FROM sessions WHERE id = ?")
+            .bind(id)
+            .fetch_one(&ts.state.db)
+            .await
+            .unwrap();
+    assert_eq!(repositories, r#"["marin-community/marin"]"#);
+    ts.client
+        .delete(&format!("/api/sessions/{id}"))
+        .await
+        .unwrap();
+}
+
+/// A session's own repository is its baseline App scope. The profile allowlist
+/// governs expansion *beyond* the current repository, so an empty one no longer
+/// leaves the session unable to push the branch it was created on.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interactive_session_brokers_its_own_repository_without_an_allowlist() {
+    let _adapter = EnvVarGuard::set(
+        "WEAVER_CODEX_ACP_CMD",
+        &crate::fixtures::fake_acp_agent_cmd(),
+    );
+    let ts = TestServer::start().await;
+    let repo_root = ts.repo_path().canonicalize().unwrap();
+    loom::repo::register(
+        &ts.state.db,
+        "marin-community/marin",
+        "https://github.com/marin-community/marin.git",
+        &repo_root.to_string_lossy(),
+    )
+    .await
+    .unwrap();
+    // The stock profile allowlists nothing at all.
+    assert!(
+        loom::profile::get(&ts.state.db, loom::profile::DEFAULT_PROFILE)
+            .await
+            .unwrap()
+            .unwrap()
+            .github_repositories()
+            .unwrap()
+            .is_empty()
+    );
+    weaver_core::config::apply(
+        &ts.state.db,
+        &[
+            (
+                loom::github_app::APP_ID_KEY.to_string(),
+                Some("123456".to_string()),
+            ),
+            (
+                loom::github_app::APP_PRIVATE_KEY_KEY.to_string(),
+                Some("configured-for-preflight".to_string()),
+            ),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let session = ts
+        .client
+        .post(
+            "/api/sessions",
+            json!({
+                "goal": "push my own branch",
                 "cwd": ts.cwd(),
                 "agent": "codex",
             }),

--- a/crates/loom/tests/integration/typed_client.rs
+++ b/crates/loom/tests/integration/typed_client.rs
@@ -252,6 +252,85 @@ async fn operation_discovery_and_permission_request_round_trip() {
     assert_eq!(denied.decided_by.as_deref(), Some("rjpower"));
 }
 
+/// An `owner/*` launch-policy entry is a standing decision: a request for that
+/// owner is applied immediately, with the same durable record a human decision
+/// leaves, and without parking the session on someone who may not be reachable.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn owner_pattern_applies_repository_access_without_a_human() {
+    let ts = TestServer::start_with_app().await;
+    let created = ts
+        .client
+        .create_session(&CreateReq {
+            cwd: ts.cwd(),
+            goal: Some("push to a sibling repository".to_string()),
+            agent: Some("shell".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    // Stamp the pattern the way a profile allowlist would at launch.
+    sqlx::query("UPDATE sessions SET policy_github_repositories = ? WHERE id = ?")
+        .bind(r#"["marin-community/*"]"#)
+        .bind(&created.id)
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+
+    let token = loom::auth::create_session_token(
+        &ts.state.db,
+        Some("rjpower"),
+        &created.id,
+        &created.branch.id,
+    )
+    .await
+    .unwrap();
+    let session = weaver_api::Client::new(format!("http://{}", ts.addr)).with_token(Some(token));
+
+    let granted = session
+        .create_permission_request(
+            &created.id,
+            &CreatePermissionRequestReq {
+                kind: "github_repository".to_string(),
+                repository: "marin-community/vllm".to_string(),
+                mode: "write".to_string(),
+                reason: "open the PR".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(granted.state, "approved");
+    assert_eq!(
+        granted.decided_by.as_deref(),
+        Some("policy:marin-community/*")
+    );
+
+    let effective = session.effective_permissions(&created.id).await.unwrap();
+    assert_eq!(effective.github_repositories, ["marin-community/vllm"]);
+    assert_eq!(effective.github_repository_patterns, ["marin-community/*"]);
+    assert!(effective.pending_requests.is_empty());
+    // A policy grant is not an interruption.
+    let branch = session.get_session(&created.id).await.unwrap().branch;
+    assert_ne!(tag_value(&branch, "attention"), Some("attention"));
+
+    // An owner the policy says nothing about still needs a person.
+    let pending = session
+        .create_permission_request(
+            &created.id,
+            &CreatePermissionRequestReq {
+                kind: "github_repository".to_string(),
+                repository: "acme/widgets".to_string(),
+                mode: "write".to_string(),
+                reason: "unrelated".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(pending.state, "pending");
+    let branch = session.get_session(&created.id).await.unwrap().branch;
+    assert_eq!(tag_value(&branch, "attention"), Some("attention"));
+}
+
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn channel_result_delivers_once_to_the_bound_slack_origin() {

--- a/crates/loom/tests/integration/typed_client.rs
+++ b/crates/loom/tests/integration/typed_client.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Map, Value};
 use std::sync::{Arc, Mutex};
 use weaver_api::{
     CreateChannelMessageReq, CreatePermissionRequestReq, CreateReq, DecidePermissionRequestReq,
-    SettingKind, SettingSource,
+    SetSessionGithubAccessReq, SettingKind, SettingSource,
 };
 
 use crate::fixtures::TestServer;
@@ -250,6 +250,91 @@ async fn operation_discovery_and_permission_request_round_trip() {
         .unwrap();
     assert_eq!(denied.state, "denied");
     assert_eq!(denied.decided_by.as_deref(), Some("rjpower"));
+}
+
+/// A GitHub App installation token covers one owner, so a session holding
+/// access under two owners has no single token. Each repository is brokered on
+/// its own, and granting the second owner no longer has to mint the union.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn github_credentials_are_brokered_per_repository_across_owners() {
+    let ts = TestServer::start_with_app().await;
+    let created = ts
+        .client
+        .create_session(&CreateReq {
+            cwd: ts.cwd(),
+            goal: Some("work across two owners".to_string()),
+            agent: Some("shell".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    sqlx::query("UPDATE sessions SET policy_github_repositories = ? WHERE id = ?")
+        .bind(r#"["marin-community/marin"]"#)
+        .bind(&created.id)
+        .execute(&ts.state.db)
+        .await
+        .unwrap();
+
+    // A human grants the second owner. Before per-repository brokering this
+    // failed here, because validation minted the whole prospective set.
+    ts.client
+        .set_session_github_access(
+            &created.id,
+            &SetSessionGithubAccessReq {
+                repository: "Open-Athena/mumwelt".to_string(),
+                mode: "write".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let token = loom::auth::create_session_token(
+        &ts.state.db,
+        Some("rjpower"),
+        &created.id,
+        &created.branch.id,
+    )
+    .await
+    .unwrap();
+    let session = weaver_api::Client::new(format!("http://{}", ts.addr)).with_token(Some(token));
+
+    assert_eq!(
+        session
+            .effective_permissions(&created.id)
+            .await
+            .unwrap()
+            .github_repositories,
+        ["Open-Athena/mumwelt", "marin-community/marin"]
+    );
+
+    for repository in ["marin-community/marin", "Open-Athena/mumwelt"] {
+        let credential = session
+            .github_token(&created.id, Some(repository))
+            .await
+            .unwrap();
+        assert!(!credential.token.is_empty(), "no token for {repository}");
+    }
+
+    // The unscoped form cannot represent a set spanning owners, which is
+    // exactly why the adapters name a repository.
+    let error = session
+        .github_token(&created.id, None)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("one owner"), "unexpected error: {error}");
+
+    // A repository the session has no grant for is refused before any minting.
+    let denied = session
+        .github_token(&created.id, Some("marin-community/vllm"))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        denied.contains("no GitHub access to marin-community/vllm"),
+        "unexpected error: {denied}"
+    );
 }
 
 /// An `owner/*` launch-policy entry is a standing decision: a request for that

--- a/crates/weaver-api/src/client.rs
+++ b/crates/weaver-api/src/client.rs
@@ -225,13 +225,20 @@ impl Client {
         .await
     }
 
-    pub async fn github_token(&self, session_id: &str) -> Result<GithubTokenView> {
-        self.send_typed::<Value, GithubTokenView>(
-            Method::POST,
-            &format!("/api/sessions/{}/github/token", Self::seg(session_id)),
-            None,
-        )
-        .await
+    /// Mint an App credential for this session. `repository` narrows the token
+    /// to one repository, which is required once the session's access spans
+    /// more than one owner — an installation token covers a single owner.
+    pub async fn github_token(
+        &self,
+        session_id: &str,
+        repository: Option<&str>,
+    ) -> Result<GithubTokenView> {
+        let mut path = format!("/api/sessions/{}/github/token", Self::seg(session_id));
+        if let Some(repository) = repository {
+            path.push_str(&format!("?repository={}", Self::seg(repository)));
+        }
+        self.send_typed::<Value, GithubTokenView>(Method::POST, &path, None)
+            .await
     }
 
     pub async fn session_github_access(

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -1095,6 +1095,11 @@ pub struct EffectivePermissionsView {
     pub actor: String,
     pub operations: Vec<String>,
     pub github_repositories: Vec<String>,
+    /// `owner/*` launch-policy entries: owners this session may expand into
+    /// without a human decision. They scope no token until a request applies
+    /// one concrete repository.
+    #[serde(default)]
+    pub github_repository_patterns: Vec<String>,
     pub pending_requests: Vec<PermissionRequestView>,
 }
 

--- a/crates/weaver-core/src/agent.rs
+++ b/crates/weaver-core/src/agent.rs
@@ -56,7 +56,7 @@ You are working in a detached Loom session. Your opening task is the goal.
 
 - Run `loom summary` to recover durable context after interruption or compaction.
 - Run `loom help` to discover resource groups and `loom <group> --help` for commands.
-- Run `loom permissions show` to inspect effective access; request another GitHub repository with `loom permissions request github-repository owner/repo --reason "..."`.
+- Run `loom permissions show` to inspect effective access; request another GitHub repository with `loom permissions request github-repository owner/repo --reason "..."`. That request is the whole mechanism — it reaches a person in the web UI. Never ask the user to run a command instead; they usually have no shell on this machine.
 - Keep `loom status set --tag <ok|attention|blocked> --message "..."` honest. `attention` and `blocked` mean a person must act.
 - Use `loom channels read` and `loom channels send` for durable communication.
 - Finish delegated work with `loom channels send --kind result "<outcome or PR>"`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -689,11 +689,25 @@ a Slack conversation.
 
 ## GitHub integration
 
-An agent can request access to an additional repository when a live task
-expands beyond its launch policy. A human grants or revokes that session-only
-access from `loom github access` or Session Details, without restarting it.
-Loom validates write access against the GitHub App installation before storing
-the audited override.
+A session's own repository is its baseline App scope — it is stamped at launch
+whether or not the profile allowlists it, because an interactive session
+already selects the launching user's far broader Account PAT first.
+
+Expanding *beyond* that repository goes through
+`loom permissions request github-repository <owner/repo> --reason "…"`. That
+raises the session's attention tag, posts to its channel, and mirrors the
+status to Slack; a human approves or denies from Session Details in the SPA or
+with `loom permissions approve|deny`, and can grant or revoke directly with
+`loom permissions grant|revoke github-repository`. An agent must never ask a
+person to run a CLI command — the request operation is the whole mechanism, and
+a human operator can act on it from a browser.
+
+When the launch profile carries an `owner/*` allowlist entry, a matching
+request is applied immediately instead of waiting on a person: the pattern is a
+standing decision for that owner. The grant is still validated against the App
+installation, still recorded, and still revocable, and the token is still
+scoped only to the repositories actually asked for. Loom validates write access
+against the GitHub App installation before storing any audited override.
 
 When the GitHub App is configured, loom keeps a per-branch pull-request
 snapshot alongside the session. A second background loop

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -907,9 +907,19 @@ helper and a `gh` wrapper because those clients do not speak Loom's session API.
 They are transport adapters, not policy owners: every fresh, resumed, warm, or
 handed-off session receives a reserved `LOOM_GITHUB_AUTH_MODE` selected by Loom.
 `direct` uses the launching user's write-only PAT stored in Loom Account
-settings, `broker` requests the session's short-lived App installation token,
-and `disabled` rejects direct GitHub CLI access. The adapters fail closed when
-the reserved mode is absent. The `gh` wrapper translates the selected mode into
+settings, `broker` requests a short-lived App installation token, and
+`disabled` rejects direct GitHub CLI access. The adapters fail closed when
+the reserved mode is absent.
+
+A `broker` token is minted **per repository**. An App installation covers one
+owner, so a session holding access under two owners has no single token that
+spans them. `credential.useHttpPath` is enabled for github.com, so git names the
+repository in every helper request and the helper forwards it as
+`loom github-token --repository owner/name`; the `gh` wrapper resolves the same
+from `GH_REPO` or the checkout's origin. The server refuses a repository the
+session has no access to, so naming one narrows the token and never widens it.
+Omitting the repository falls back to the session's whole set, which the App can
+mint only while it stays single-owner. The `gh` wrapper translates the selected mode into
 the stock CLI's native authentication contract for each invocation.
 Adapter registration stays in the image's system Git config: linked worktrees
 share repository-local config, agents may clone additional repositories, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,13 +109,23 @@ environment or runtime used by existing triggers.
 
 Profiles may declare `github_repositories` to define the GitHub App broker's
 scope. Ordinary interactive sessions select the launching user's Account PAT
-first and use this broker when the App path is selected. Interactive profiles
-stamp only the session's current allowlisted repository. Strict,
-environment-cleared automation profiles retain the complete list for reviewed
-cross-repository workflows, so their entries must use one owner. Tokens grant
-write access to repository contents, issues, pull requests, Actions, and
-workflow files. The configured GitHub App must have those permissions and be
-installed on every listed repository.
+first and use this broker when the App path is selected. An interactive session
+stamps only its own current repository, which it gets whether or not the
+profile lists it — the allowlist governs expansion beyond that repository.
+Strict, environment-cleared automation profiles retain the complete list for
+reviewed cross-repository workflows, so their entries must use one owner.
+Tokens grant write access to repository contents, issues, pull requests,
+Actions, and workflow files. The configured GitHub App must have those
+permissions and be installed on every listed repository.
+
+An entry may also be an `owner/*` pattern. A pattern scopes no token by itself;
+it declares that this session may expand into that owner without a human
+decision, so `loom permissions request github-repository owner/repo` is applied
+on the spot rather than raising attention and waiting. Each expansion is still
+validated against the App installation, recorded as an audited grant, and
+revocable with `loom permissions revoke github-repository`. Use it for an
+organization whose repositories the profile's sessions are already trusted
+with; leave it off when every expansion deserves a person's eyes.
 
 ```yaml
 profiles:


### PR DESCRIPTION
## Why

An agent that couldn't push told its user to run `loom github access marin-community/marin --session … --mode write` — a command that doesn't exist — after the human-only grant operation rejected it with "this operation requires a human operator". Users don't have a shell on the production loom servers, so that instruction was unactionable even if the command were real.

Three separate things made GitHub access a dead end for detached sessions. This fixes all three.

## A session's own repository is its baseline App scope

An interactive session's App scope was the *intersection* of the profile allowlist with its current repository:

```rust
current_repo.filter(|repo| configured.iter().any(|c| c == repo))
```

So a profile that didn't list a repository left sessions in it unable to broker at all. Interactive sessions already select the launching user's Account PAT first, which reaches every repository that user can write — gating the narrower, audited, per-repository App token behind an allowlist only ever withheld the safer credential. The current repository is now stamped unconditionally; the allowlist governs expansion beyond it.

## Expansion can carry a standing decision

A profile allowlist entry may now be `owner/*`. A pattern scopes no token by itself: it records that this session may expand into that owner without a human. A matching `loom permissions request` is applied on the spot instead of raising attention and waiting on someone who may have no shell. Each expansion is still validated against the App installation, still stored as a revocable audited grant (`decided_by = "policy:<pattern>"`), and still scoped only to what was asked for. If the App can't grant it, the request falls back to the human path.

## Credentials are brokered per repository

A GitHub App installation covers one owner, so a session holding access under two owners had no single token spanning them — and both ends assumed one. `github_token` minted the whole effective set, and a grant was validated by minting the entire *prospective* set, so cross-owner expansion failed at grant time with "must use one owner" before any push.

Tokens are now minted per repository. `POST /sessions/{id}/github/token` takes an optional `repository`, refuses one the session has no access to, and scopes the token to it alone; validation proves only the repository being granted. `credential.useHttpPath` is enabled for github.com so git names the repository in every helper request, which the helper forwards as `loom github-token --repository owner/name`; the `gh` wrapper resolves the same from `GH_REPO` or the checkout's origin. Naming a repository can only narrow the token — a session that used to hold one token covering its whole allowlist now gets one repository at a time.

## Notes for the reviewer

- Patterns never reach `token_for_repositories`; `effective_repositories` filters them out and `parse_slug` would reject `*` loudly if one leaked.
- The unscoped token form still returns the whole set, which the App can mint while it stays single-owner. That is what a caller with no repository context falls back to.
- Automation profiles are unchanged: they still stamp their list verbatim and profile validation still requires one owner for them.
- One behaviour shift worth naming: an interactive session in a GitHub repo with no user PAT and a configured-but-not-installed App now launches and fails at push with the App's error, where it previously refused at launch with `No GitHub credential configured`. The preflight still refuses when no App is configured at all.
- `docs/ARCHITECTURE.md` pointed humans at the removed `loom github access`; it now documents the request → Session Details / `loom permissions approve` flow, and the builtin session primer tells agents to raise a request rather than hand a person a command to type.
- The Dockerfile adapter tests grew a stdin channel. They piped the script under test into `sh -s`, leaving no way to feed the credential request git actually writes; they now run it from a file, in a directory that is not a checkout so the `gh` wrapper can't pick up this repository's own origin.

## Testing

`cargo test --workspace` (41 targets), `./scripts/pre-commit.sh`, and `cd python/weaver-loom && uv run pytest` all green. New coverage: an empty allowlist still stamps the current repo; a pattern request returns `approved` with no attention raised while an unmatched owner still goes pending and does raise it; a session granted two owners brokers each repository independently, is refused a repository it has no grant for, and gets the one-owner error only from the unscoped form; and the git helper and `gh` wrapper each request the repository they were pointed at.

`scripts/lint-review.py` run after each commit; every advisory finding applied.

Companion: marin-community/marin#8450 converts the production profile allowlist to owner patterns. Merge this first — `loom deployment apply` rejects a pattern entry until this image ships.