### PR TITLE
perf(test): stop paying a schema migration per test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,12 @@ opt-level = "z"
 
 [profile.release.package."*"]
 opt-level = 3
+
+# SQLite is the one dependency whose *unoptimized* build shows up in test wall
+# clock: the suites open and migrate hundreds of throwaway databases, and at the
+# dev profile's `opt-level = 0` the C engine spends about twice as long doing it
+# (measured: a pooled open of an already-migrated database, 76ms -> 42ms; ~30s
+# per `cargo test --workspace`). Compiling this one leaf C crate optimized costs
+# ~20s, paid once per dependency-cache generation rather than once per run.
+[profile.dev.package.libsqlite3-sys]
+opt-level = 2

--- a/crates/loom/tests/agent_cli.rs
+++ b/crates/loom/tests/agent_cli.rs
@@ -19,6 +19,10 @@ use serial_test::serial;
 use tokio::net::TcpListener;
 use weaver_core::events::EventBus;
 
+#[path = "support/schema.rs"]
+mod support_schema;
+use support_schema::seed_migrated_db;
+
 /// Path to the freshly-built `weaver` binary the test will drive.
 fn loom_bin() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_BIN_EXE_loom"))
@@ -40,6 +44,7 @@ impl Env {
     async fn start() -> Self {
         let home = tempfile::tempdir().unwrap();
         std::env::set_var("WEAVER_HOME", home.path());
+        seed_migrated_db();
         // `seed_owner` no longer defaults to a real login — this suite's
         // requests (the `weaver` CLI, over loopback) need a seeded owner to
         // resolve to.

--- a/crates/loom/tests/hook_monitor.rs
+++ b/crates/loom/tests/hook_monitor.rs
@@ -18,7 +18,10 @@ use weaver_core::events::EventBus;
 
 #[path = "support/tapestry.rs"]
 mod support;
+#[path = "support/schema.rs"]
+mod support_schema;
 use support::tapestry_bin;
+use support_schema::seed_migrated_db;
 
 fn sh(dir: &Path, program: &str, args: &[&str]) {
     let status = Command::new(program)
@@ -63,6 +66,7 @@ impl Drop for TestHome {
 async fn hook_event_drives_session_status() {
     let home = TestHome(tempfile::tempdir().unwrap());
     std::env::set_var("WEAVER_HOME", home.0.path());
+    seed_migrated_db();
     std::env::set_var("WEAVER_TAPESTRY_BIN", tapestry_bin());
     std::env::remove_var("LOOM_TOKEN");
     // `seed_owner` no longer defaults to a real login — this test's requests

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -17,7 +17,7 @@ use loom::acp::{self, AcpLaunch, AcpPromptEffort, AcpPromptModel, NewOrLoad, Sse
 use loom::backend;
 use loom::session::{self as session_mod, NewSession};
 
-use crate::fixtures::{branch_tag_value, TestServer};
+use crate::fixtures::{age_past_runtime_start_grace, branch_tag_value, TestServer};
 
 /// The relay command that launches the scripted fake ACP agent over stdio.
 fn agent_cmd() -> String {
@@ -3523,6 +3523,7 @@ async fn adopt_can_answer_a_permission_replayed_during_load() {
 
     assert!(ts.state.acp.stop(&id), "the original task was live");
     backend::kill_session_and_wait(&relay).await.unwrap();
+    age_past_runtime_start_grace(&ts.state.db, &id).await;
     poll_view(&ts, &id, Duration::from_secs(15), |view| {
         view["status"] == "orphaned"
     })
@@ -3620,6 +3621,7 @@ async fn adopt_reopens_via_load_without_duplicates() {
     backend::kill_session(&term_session).await.ok();
 
     // The monitor notices the dead terminal and marks the row orphaned.
+    age_past_runtime_start_grace(&ts.state.db, &id).await;
     poll_view(&ts, &id, Duration::from_secs(15), |v| {
         v["status"] == "orphaned"
     })

--- a/crates/loom/tests/integration/fixtures.rs
+++ b/crates/loom/tests/integration/fixtures.rs
@@ -25,6 +25,7 @@ use weaver_core::config as core_config;
 use weaver_core::events::EventBus;
 
 use crate::support::tapestry_bin;
+use crate::support_schema::seed_migrated_db;
 
 /// Run `program args` in `dir`, asserting it succeeds.
 pub fn sh(dir: &Path, program: &str, args: &[&str]) {
@@ -161,6 +162,7 @@ impl TestServer {
         // at the sibling supervisor binary.
         let home = tempfile::tempdir().unwrap();
         std::env::set_var("WEAVER_HOME", home.path());
+        seed_migrated_db();
         std::env::set_var("WEAVER_TAPESTRY_BIN", tapestry_bin());
         // Never let the outer loom session's scoped bearer leak into this
         // isolated server or CLI subprocesses spawned by a test.
@@ -263,6 +265,27 @@ impl TestServer {
     pub fn cwd(&self) -> String {
         self.repo.path().to_string_lossy().into_owned()
     }
+}
+
+/// Age a session past the monitor's runtime-start grace window.
+///
+/// The orphan sweep leaves a session alone for the first several seconds after
+/// it was created, so a runtime that is still coming up is never mistaken for a
+/// dead one. A test proving the *dead terminal → orphaned* transition is not
+/// testing that window — `monitor`'s own unit tests cover it — so it backdates
+/// `created_at` instead of sitting out ten seconds of wall-clock per case.
+pub async fn age_past_runtime_start_grace(db: &loom::db::Db, id: &str) {
+    let backdated = (chrono::Utc::now() - chrono::Duration::minutes(1))
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string();
+    let updated = sqlx::query("UPDATE sessions SET created_at = ? WHERE id = ?")
+        .bind(&backdated)
+        .bind(id)
+        .execute(db)
+        .await
+        .expect("backdating the session's creation time")
+        .rows_affected();
+    assert_eq!(updated, 1, "no session {id} to age past the start grace");
 }
 
 /// Restores `$HOME` on drop, so a test that points it at a temp dir (to exercise

--- a/crates/loom/tests/integration/main.rs
+++ b/crates/loom/tests/integration/main.rs
@@ -9,6 +9,8 @@
 
 #[path = "../support/tapestry.rs"]
 mod support;
+#[path = "../support/schema.rs"]
+mod support_schema;
 
 mod fixtures;
 

--- a/crates/loom/tests/integration/pane.rs
+++ b/crates/loom/tests/integration/pane.rs
@@ -13,16 +13,36 @@ use loom::backend;
 
 use crate::fixtures::TestServer;
 
-/// Submit `text` and poll `GET /preview` until the captured screen contains
-/// `marker`, **re-submitting** between polls. The launch script `exec`s the shell
+/// How a poller re-sends `text` between polls: as a submitted line, or as input
+/// staged on the prompt without an Enter.
+#[derive(Clone, Copy)]
+enum SendMode {
+    Submit,
+    Stage,
+}
+
+impl SendMode {
+    fn submits(self) -> bool {
+        matches!(self, SendMode::Submit)
+    }
+}
+
+/// Send `text` and poll `GET /preview` until the captured screen contains
+/// `marker`, **re-sending** between polls. The launch script `exec`s the shell
 /// only after the supervisor socket is already up, and shell startup flushes any
 /// input typed during that window — so a command sent right after create can be
-/// echoed but never run. Re-submitting steps past that startup window; once the
-/// shell is reading, the command executes and the marker appears.
-async fn submit_until(ts: &TestServer, id: &str, text: &str, marker: &str) -> String {
+/// echoed but never run, and staged input can vanish before it is ever drawn.
+/// Re-sending steps past that startup window.
+///
+/// With [`SendMode::Submit`] the marker is the command's *output*, which appears only
+/// once the shell has executed it. With [`SendMode::Stage`] nothing executes, so the
+/// marker is the staged text itself — its appearance on the prompt line is the
+/// proof the input reached the PTY, and the point at which a caller can
+/// meaningfully assert the command has *not* run.
+async fn send_until(ts: &TestServer, id: &str, send: SendMode, text: &str, marker: &str) -> String {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     loop {
-        // Poll the current screen for a short window before re-submitting.
+        // Poll the current screen for a short window before re-sending.
         let inner = tokio::time::Instant::now() + Duration::from_secs(2);
         loop {
             let res = ts
@@ -40,12 +60,15 @@ async fn submit_until(ts: &TestServer, id: &str, text: &str, marker: &str) -> St
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
         if tokio::time::Instant::now() >= deadline {
-            panic!("marker {marker:?} never appeared in the pane after re-submitting");
+            panic!("marker {marker:?} never appeared in the pane after re-sending");
         }
-        // Not yet — (re)submit. Harmless if the earlier submit already ran.
+        // Not yet — (re)send. Harmless if the earlier send already landed.
         let _ = ts
             .client
-            .post(&format!("/api/sessions/{id}/send"), json!({ "text": text }))
+            .post(
+                &format!("/api/sessions/{id}/send"),
+                json!({ "text": text, "submit": send.submits() }),
+            )
             .await;
     }
 }
@@ -78,7 +101,14 @@ async fn send_runs_a_command_and_preview_reads_it() {
         .unwrap();
     assert_eq!(sent["submitted"], true, "submit defaults to true");
 
-    let screen = submit_until(&ts, &id, "echo PANE_$((6 * 7))", "PANE_42").await;
+    let screen = send_until(
+        &ts,
+        &id,
+        SendMode::Submit,
+        "echo PANE_$((6 * 7))",
+        "PANE_42",
+    )
+    .await;
     assert!(screen.contains("PANE_42"), "command output missing");
 
     client.delete(&format!("/api/sessions/{id}")).await.unwrap();
@@ -109,14 +139,11 @@ async fn send_without_submit_does_not_execute() {
         .unwrap();
     assert_eq!(sent["submitted"], false);
 
-    // Give the pane a beat, then confirm the arithmetic never ran: the literal
-    // text is on the prompt line, but the evaluated `STAGED_2` is not.
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    let res = client
-        .get(&format!("/api/sessions/{id}/preview"))
-        .await
-        .unwrap();
-    let screen = res["screen"].as_str().unwrap_or("");
+    // Wait for the staged text to be echoed on the prompt line — that is the
+    // proof the input actually reached the PTY, and it anchors the negative:
+    // the literal is on screen, the evaluated `STAGED_2` never is.
+    let staged = "echo STAGED_$((1 + 1))";
+    let screen = send_until(&ts, &id, SendMode::Stage, staged, staged).await;
     assert!(
         !screen.contains("STAGED_2"),
         "unsubmitted input should not have executed; screen:\n{screen}"

--- a/crates/loom/tests/integration/terminal.rs
+++ b/crates/loom/tests/integration/terminal.rs
@@ -54,15 +54,21 @@ async fn terminal_websocket_roundtrip() {
     }
     assert!(ready, "shell never came up");
 
-    // Drive a real size, give the supervisor a moment to apply the SIGWINCH, then
-    // run a command that prints the terminal width. The 0x01 → master.resize →
-    // SIGWINCH path must reach the shell.
+    // Drive a real size, then ask the shell what width it thinks it has until it
+    // answers with the new one. The 0x01 → master.resize → SIGWINCH path must
+    // reach the shell, but it gets there asynchronously — so poll the signal
+    // itself rather than guessing a delay that is usually far too long.
     term.send(Message::Binary(resize_frame(120, 40).into()))
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    send_input(&mut term, "echo DIMS COLS=$(tput cols)\n").await;
-    let dims = drain_until(&mut term, "COLS=120", Duration::from_secs(10)).await;
+    let mut dims = String::new();
+    for _ in 0..20 {
+        send_input(&mut term, "echo DIMS COLS=$(tput cols)\n").await;
+        dims = drain_until(&mut term, "COLS=120", Duration::from_millis(500)).await;
+        if dims.contains("COLS=120") {
+            break;
+        }
+    }
     assert!(
         dims.contains("COLS=120"),
         "resize did not propagate to the pty width; got:\n{dims}"

--- a/crates/loom/tests/repo_setup.rs
+++ b/crates/loom/tests/repo_setup.rs
@@ -22,7 +22,10 @@ use weaver_core::events::EventBus;
 
 #[path = "support/tapestry.rs"]
 mod support;
+#[path = "support/schema.rs"]
+mod support_schema;
 use support::tapestry_bin;
+use support_schema::seed_migrated_db;
 
 fn sh(dir: &Path, program: &str, args: &[&str]) {
     let status = Command::new(program)
@@ -82,6 +85,7 @@ fn repo_with_config(config_body: &str) -> (tempfile::TempDir, PathBuf) {
 async fn start_server() -> (TestHome, loom::client::Client, db::Db, String) {
     let home = TestHome(tempfile::tempdir().unwrap());
     std::env::set_var("WEAVER_HOME", home.0.path());
+    seed_migrated_db();
     std::env::set_var("WEAVER_TAPESTRY_BIN", tapestry_bin());
     // `seed_owner` no longer defaults to a real login — this suite's requests
     // ride loopback trust, which needs a seeded owner to resolve to.

--- a/crates/loom/tests/support/schema.rs
+++ b/crates/loom/tests/support/schema.rs
@@ -1,0 +1,60 @@
+//! A migrated-schema template, shared by every suite that boots a server on a
+//! throwaway `WEAVER_HOME`. Pulled in with `#[path]` like `support/tapestry.rs`
+//! — separate integration-test targets can't share code any other way.
+//!
+//! `loom::db::connect` on an empty file replays the whole ordered migration set
+//! (weaver-core's stream, then loom's), each migration in its own transaction.
+//! That costs ~250ms, and these suites are `#[serial]`, so it is ~250ms of dead
+//! wall-clock in front of *every* test before it does any work of its own.
+//!
+//! The migration run is deterministic, so run it once per test process and hand
+//! each test a byte-identical copy of the result. What a test connects to is
+//! still the real migrated schema — it is literally the output of the real
+//! runner — and the from-scratch migrate path keeps its own coverage in the
+//! `weaver-core` and `loom-store` unit tests (plus the one run this template
+//! itself performs).
+
+use std::sync::OnceLock;
+
+/// Plant the migrated schema at `WEAVER_HOME`'s database path, so the
+/// `db::connect` that follows finds every migration already applied and only
+/// has to open the pool.
+///
+/// Call it after pointing `WEAVER_HOME` at the test's temp home and before
+/// connecting; the path is resolved the same way `connect`'s caller resolves it.
+pub fn seed_migrated_db() {
+    let path = loom::db::default_db_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("creating the test weaver home");
+    }
+    std::fs::write(&path, template()).expect("planting the migrated schema template");
+}
+
+/// The bytes of a freshly migrated database, built once per test process.
+fn template() -> &'static [u8] {
+    static TEMPLATE: OnceLock<Vec<u8>> = OnceLock::new();
+    TEMPLATE.get_or_init(|| {
+        // Build on a dedicated thread with its own runtime: callers run inside a
+        // `#[tokio::test]` runtime that is torn down at the end of the test, and
+        // the template must outlive whichever test happened to be first.
+        std::thread::spawn(|| {
+            let dir = tempfile::tempdir().expect("schema template directory");
+            let path = dir.path().join("weaver.db");
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("schema template runtime")
+                .block_on(async {
+                    let pool = loom::db::connect(&path)
+                        .await
+                        .expect("migrating the schema template");
+                    // Closing the last connection checkpoints the WAL back into
+                    // the main file, so these bytes are the whole database.
+                    pool.close().await;
+                });
+            std::fs::read(&path).expect("reading the schema template")
+        })
+        .join()
+        .expect("schema template thread")
+    })
+}


### PR DESCRIPTION
## Where the time actually went

Measured before changing anything, on a 16-core box with everything already
built. `cargo test --workspace` spends **166s** *running* tests (compilation is
separate), and it is not spread evenly:

| target | time | share |
|---|---|---|
| `loom` **integration** | **123.3s** | 74% |
| `loom` agent_cli | 11.7s | 7% |
| loom_store (lib) | 7.5s | 5% |
| loom_policy (lib) | 5.3s | 3% |
| loom_forge (lib) | 4.0s | 2% |
| `loom` hook_monitor | 3.5s | 2% |
| weaver_core (lib) | 2.6s | 2% |
| 19 other targets | 8.3s | 5% |

Inside the integration target (189 tests, all `#[serial]`), the distribution is
almost flat — 135 of 189 tests land between 0.30s and 0.60s. That shape says the
cost is a **fixed per-test floor**, not a few slow journeys. Timing the fixture
confirmed it:

```
TestServer::start        = 300ms
  db::connect            = 254ms   <- 47 ordered migrations, one txn each
  git init + commit      =  18ms
  server boot + seeds    =  28ms
```

254ms × 189 tests ≈ **48s of the 123s was replaying the same migrations**, and
`agent_cli` / `hook_monitor` / `repo_setup` pay it per test too. It is not
fsync-bound (identical on tmpfs) — it is SQLite doing DDL, compiled unoptimized.

The two genuine outliers were `acp::adopt_reopens_via_load_without_duplicates`
and `acp::adopt_can_answer_a_permission_replayed_during_load`, at **11.0s each**
— 18% of the target for two tests. Both were sitting out the monitor's
`RUNTIME_START_GRACE_SECS` (10s) before their dead relay could be marked
`orphaned`.

`cd e2e && npm test`: **1m04s** wall, 130 tests, 155 test-seconds across 4
workers. Already well built — one server per worker, sessions wiped per test,
and only two `waitForTimeout` calls in 5,800 lines. Not where the time is.

## What changed

1. **Migrate once per test process, not once per test.** `tests/support/schema.rs`
   runs the real migrations into a scratch database on first use, keeps the
   resulting file's bytes, and plants a copy at each test's `WEAVER_HOME`. What a
   test opens is still the real migrated schema — it is the runner's own output —
   and the from-scratch path keeps its coverage in the weaver-core/loom-store unit
   tests. `db::connect` 254ms → 76ms.
2. **Build `libsqlite3-sys` optimized in the dev profile.** SQLite does real work
   here (hundreds of opens and migrations per run) and at `opt-level = 0` it takes
   about twice as long. A pooled open of a migrated database: 76ms → 42ms. Costs
   ~20s of dependency build, paid per cache generation rather than per run.
3. **The two ACP adopt cases backdate `created_at`** past the runtime-start grace
   instead of waiting it out. That window is a guard against orphaning a runtime
   that is still coming up; neither test is about it, and `monitor`'s own unit
   tests already cover it (`runtime_starting`). 11.0s → 2.0s each.
4. **Two fixed sleeps become waits on the signal they approximated.** The terminal
   resize case slept 500ms then asked `tput cols` once; it now re-asks until the
   width lands, inside the same 10s budget. The pane staging case slept 500ms and
   asserted the command had *not* run — a negative with nothing anchoring it,
   which would have passed against a shell that never started. It now waits for
   the staged text to be echoed on the prompt line first, so the negative means
   what it claims.

No test deleted, no assertion weakened, no tolerance widened, no skip added.

## Results

| | before | after |
|---|---|---|
| `cargo test --workspace` (warm, wall) | 2m46s | **1m34s** |
| — test execution, all targets | 166.2s | **94.5s** |
| — integration target | 123.3s | **63.5s** |
| — agent_cli | 11.7s | **4.8s** |
| — repo_setup | 1.5s | **0.8s** |
| `cd e2e && npm test` | 1m04s | unchanged |

933 tests, 0 failures.

## What I did not do, and why

**Parallelising the integration suite is the one remaining structural lever, and
it needs a production refactor.** The `#[serial]` is not decorative: the fixture
sets `WEAVER_HOME` process-wide, and the server resolves it *at runtime* in ~15
places across nine crates — `run_dir`, the tapestry socket dir, `ide_home`,
`repos`, `loom-token`, `loom-jwt.key`. Decisively, `server::serve` writes
`loom.json` into `weaver_home()` while serving, so two concurrent test servers
would clobber each other's state file. Freeing this means threading an explicit
home through `AppState` instead of reading an ambient global. That is arguably
the cleaner model, but it is a nine-crate change to the runtime and belongs in
its own reviewed PR, not bundled into a test-speed change. The prize is real:
the remaining 63s is ~15s of fixture floor plus ~48s of genuine cross-layer work
that would parallelise to roughly 10-15s.

**Some of it is irreducible.** The per-test floor is now ~77ms, of which ~59ms is
`db::connect` eagerly opening the production 32-connection pool
(`SHARED_POOL_CONNECTIONS`, `min_connections = max_connections`). Shrinking it
for tests would mean parameterising a deliberate production durability choice, so
I left it. The lib suites spend ~10s of their ~17s in `connect_in_memory`
migrations (55ms each); the fix there is a schema snapshot for the in-memory
path, which I did not attempt because a hand-rolled schema replay could silently
diverge from the real migration output and quietly weaken 300 unit tests. Two
`hook_monitor` tests and the two ACP adopt tests each wait ~1.5s for a real
monitor tick — that is the loop under test.

**I found no redundant coverage worth deleting.** The measured cost is fixture
overhead spread flat across 189 tests, not a few tests re-proving unit-level
logic; deleting a handful would save ~0.3s each against a real risk of losing
the only coverage of a behaviour. Trimming tests here would have bought almost
nothing.

**CI's critical path is not the tests.** From the last two runs on `main`:
`infrastructure` 8.9–9.25min, `test` 4.34–5.25min, `build` ~1.5min, `lint`
~1.2–1.55min, `python-binding` ~0.9min. They run in parallel, so wall time is
gated by `infrastructure` — which is a full **release** Docker build of the
workspace. Its Dockerfile already uses BuildKit cache mounts, but those do not
persist between GitHub Actions runs without a cache exporter, so every PR
recompiles the workspace in release from scratch. This PR takes roughly a minute
off the `test` job and does not move CI wall time at all. Making it move means
persisting the Docker build cache across runs — a CI-infrastructure change with
its own risk profile (a wrongly-cached production container), which I have not
touched here.

## Pre-existing e2e failure, not from this branch

`acp-conversation.spec.ts` → "ArrowUp and Edit pull unseen queued feedback back
into the composer" fails most full-suite runs: `acp-edit-queued` never appears,
i.e. the durable queue's `pendingPrompt` is falsy 15s after `POST /prompt` while
a `wait:30000` turn is live. **It failed on my untouched baseline run**, before
any edit, and this branch changes no product code and nothing under `e2e/`. It is
a real ACP-queue/SSE flake worth its own issue; diagnosing it inside a
test-performance PR would be guessing, so I have left it and flagged it here.

## Testing

- `cargo test --workspace` — 933 passed, 0 failed
- `./scripts/pre-commit.sh` — clean
- `scripts/lint-review.py` — no findings (run: new shared test-harness module plus a build-profile change)
- `cd e2e && npm test` — 129 passed, 1 failed (the pre-existing flake above)
