### PR TITLE
Fix bare datalist text input to be a searchable combobox

### DIFF
--- a/crates/loom/frontend/src/components/LaunchOverrides.vue
+++ b/crates/loom/frontend/src/components/LaunchOverrides.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, useId } from 'vue';
 import type { AgentMetadata, LaunchOverrides, ResolvedLaunch } from '../types';
+import ModelCombobox from './ModelCombobox.vue';
 
 const props = defineProps<{
   agents: AgentMetadata[];
@@ -75,22 +76,16 @@ function locked(field: keyof LaunchOverrides): boolean {
             {{ changed('model') ? 'changed' : 'from profile' }}
           </span>
         </span>
-        <input
+        <ModelCombobox
           v-if="metadata?.accepts_raw_model"
           :id="`${uid}-model`"
-          aria-label="Model"
-          :value="value('model')"
+          :choices="metadata.models"
+          :model-value="value('model')"
           :disabled="locked('model')"
-          data-testid="override-model"
-          list="launch-model-options"
-          autocomplete="off"
-          placeholder="Agent default"
-          class="w-full rounded bg-surface px-2 py-1.5 font-mono disabled:opacity-60"
-          @input="set('model', ($event.target as HTMLInputElement).value)"
+          field-class="bg-surface"
+          testid="override-model"
+          @update:model-value="set('model', $event)"
         />
-        <datalist v-if="metadata?.accepts_raw_model" id="launch-model-options">
-          <option v-for="choice in metadata.models" :key="choice.id" :value="choice.id" />
-        </datalist>
         <select
           v-else
           :id="`${uid}-model`"

--- a/crates/loom/frontend/src/components/ModelCombobox.vue
+++ b/crates/loom/frontend/src/components/ModelCombobox.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, useId } from 'vue';
+import type { AgentChoice } from '../types';
+
+const props = withDefaults(
+  defineProps<{
+    choices: AgentChoice[];
+    modelValue: string;
+    disabled?: boolean;
+    fieldClass?: string;
+    testid?: string;
+    id?: string;
+  }>(),
+  {
+    disabled: false,
+    fieldClass: 'bg-surface',
+    testid: '',
+  },
+);
+
+const emit = defineEmits<{
+  'update:modelValue': [string];
+}>();
+
+const uid = useId();
+const open = ref(false);
+const editing = ref(false);
+const query = ref('');
+const activeOption = ref(-1);
+
+/** The label of the current value, or its raw text when it is a custom model. */
+const currentDisplay = computed(() => {
+  const value = props.modelValue;
+  if (!value) return '';
+  return props.choices.find((choice) => choice.id === value)?.label ?? value;
+});
+
+const matches = computed(() => {
+  const q = (editing.value ? query.value : currentDisplay.value).trim().toLowerCase();
+  if (!q) return props.choices;
+  return props.choices.filter(
+    (choice) => choice.id.toLowerCase().includes(q) || choice.label.toLowerCase().includes(q),
+  );
+});
+
+const inputValue = computed(() => (editing.value ? query.value : currentDisplay.value));
+
+function optionId(index: number): string {
+  return `${uid}-option-${index}`;
+}
+
+function onFocus() {
+  if (props.disabled) return;
+  editing.value = true;
+  query.value = currentDisplay.value;
+  open.value = true;
+  activeOption.value = -1;
+}
+
+function onInput(event: Event) {
+  editing.value = true;
+  query.value = (event.target as HTMLInputElement).value;
+  open.value = true;
+  activeOption.value = -1;
+}
+
+function onBlur() {
+  commit();
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.stopPropagation();
+    editing.value = false;
+    open.value = false;
+    activeOption.value = -1;
+    return;
+  }
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    if (!open.value) {
+      event.preventDefault();
+      event.stopPropagation();
+      editing.value = true;
+      query.value = currentDisplay.value;
+      open.value = true;
+      return;
+    }
+    const count = matches.value.length;
+    if (!count) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const delta = event.key === 'ArrowDown' ? 1 : -1;
+    activeOption.value =
+      activeOption.value < 0
+        ? delta > 0
+          ? 0
+          : count - 1
+        : (activeOption.value + delta + count) % count;
+    void nextTick(() => {
+      document.getElementById(optionId(activeOption.value))?.scrollIntoView({ block: 'nearest' });
+    });
+    return;
+  }
+  if (event.key !== 'Enter') return;
+  event.preventDefault();
+  event.stopPropagation();
+  if (activeOption.value >= 0) pick(matches.value[activeOption.value]);
+  else commit();
+}
+
+function pick(choice: AgentChoice) {
+  emit('update:modelValue', choice.id);
+  editing.value = false;
+  open.value = false;
+  activeOption.value = -1;
+}
+
+/** The value to commit from the current edit: an exact choice match, else the raw text. */
+function commitValue(): string {
+  const q = query.value.trim();
+  if (!q) return '';
+  const exact = props.choices.find(
+    (choice) =>
+      choice.id.toLowerCase() === q.toLowerCase() || choice.label.toLowerCase() === q.toLowerCase(),
+  );
+  return exact ? exact.id : q;
+}
+
+/** Commit the pending edit, skipping the emit when nothing changed. */
+function commit() {
+  if (!editing.value) return;
+  const next = commitValue();
+  if (next !== props.modelValue) emit('update:modelValue', next);
+  editing.value = false;
+  open.value = false;
+  activeOption.value = -1;
+}
+</script>
+
+<template>
+  <div class="relative">
+    <input
+      :id="id"
+      role="combobox"
+      aria-autocomplete="list"
+      :aria-expanded="open && matches.length > 0"
+      :aria-controls="`${uid}-options`"
+      :aria-activedescendant="activeOption >= 0 ? optionId(activeOption) : undefined"
+      :value="inputValue"
+      :disabled="disabled"
+      :data-testid="testid || undefined"
+      autocomplete="off"
+      spellcheck="false"
+      placeholder="Agent default"
+      class="min-w-0 w-full rounded px-2 py-1.5 outline-none focus:ring-1 ring-accent disabled:opacity-60"
+      :class="fieldClass"
+      @focus="onFocus"
+      @input="onInput"
+      @blur="onBlur"
+      @keydown="onKeydown"
+    />
+    <ul
+      v-if="open && matches.length"
+      :id="`${uid}-options`"
+      role="listbox"
+      data-testid="model-options"
+      class="absolute left-0 right-0 z-20 mt-1 max-h-56 overflow-auto rounded border border-line bg-input shadow-lg"
+    >
+      <li v-for="(choice, index) in matches" :key="choice.id">
+        <button
+          :id="optionId(index)"
+          type="button"
+          role="option"
+          :aria-selected="activeOption === index"
+          data-testid="model-option"
+          @mousedown.prevent="pick(choice)"
+          class="flex w-full items-baseline gap-2 px-2 py-1.5 text-left hover:bg-subtle"
+          :class="{ 'bg-subtle text-fg': activeOption === index }"
+        >
+          <span class="truncate text-sm">{{ choice.label }}</span>
+          <code class="truncate font-mono text-xs text-muted">{{ choice.id }}</code>
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/crates/loom/frontend/src/components/ProfileEditor.vue
+++ b/crates/loom/frontend/src/components/ProfileEditor.vue
@@ -7,6 +7,7 @@ import type {
   ProfileEnv,
   ProfileInput,
 } from '../types';
+import ModelCombobox from './ModelCombobox.vue';
 
 const props = withDefaults(
   defineProps<{
@@ -200,32 +201,22 @@ watch(
 
     <div class="grid min-w-0 gap-1">
       <label class="text-xs" :for="`${uid}-model`">Model</label>
-      <input
+      <ModelCombobox
         v-if="selectedAgent?.accepts_raw_model"
         :id="`${uid}-model`"
         v-model="draft.model"
-        data-testid="profile-model"
-        :list="`${uid}-model-options`"
+        :choices="selectedAgent.models"
         :disabled="disabled"
-        autocomplete="off"
-        placeholder="Agent default"
-        class="min-w-0 rounded bg-input px-2 py-1.5"
+        field-class="bg-input"
+        testid="profile-model"
       />
-      <datalist v-if="selectedAgent?.accepts_raw_model" :id="`${uid}-model-options`">
-        <option
-          v-for="model in selectedAgent.models"
-          :key="model.id"
-          :value="model.id"
-          :label="model.label"
-        />
-      </datalist>
       <select
         v-else
         :id="`${uid}-model`"
         v-model="draft.model"
         data-testid="profile-model"
         :disabled="disabled"
-        class="min-w-0 rounded bg-input px-2 py-1.5"
+        class="min-w-0 w-full rounded bg-input px-2 py-1.5"
       >
         <option value="">Agent default</option>
         <option v-for="model in selectedAgent?.models ?? []" :key="model.id" :value="model.id">

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -29,7 +29,9 @@ test.describe("settings · profiles", () => {
     ]);
 
     await agent.selectOption("claude");
+    await model.click();
     await model.fill(claude.models[0].id);
+    await page.keyboard.press("Enter");
     await agent.selectOption("codex");
     await expect(model).toHaveValue("");
     await expect(model.locator("option")).toContainText([


### PR DESCRIPTION
As ttiled. Adds `ModelCombobox.vue`, a searchable dropdown over the agent's models that also accepts typed custom model names and uses it for Claude.