### PR TITLE
fix(loom): keep worktree shells working across a loom install

### DIFF
--- a/crates/loom-ctx/src/backend.rs
+++ b/crates/loom-ctx/src/backend.rs
@@ -184,7 +184,7 @@ pub async fn new_session_derived(
     match &result {
         Ok(()) => tracing::info!(session = %name, owner, "derived terminal session spawned"),
         Err(error) => {
-            tracing::warn!(session = %name, owner, %error, "failed to spawn derived terminal session")
+            tracing::warn!(session = %name, owner, error = %format!("{error:#}"), "failed to spawn derived terminal session")
         }
     }
     result
@@ -225,7 +225,9 @@ async fn new_session_with_placement(
     };
     match &result {
         Ok(()) => tracing::info!(session = %name, "terminal session spawned"),
-        Err(e) => tracing::warn!(session = %name, error = %e, "failed to spawn terminal session"),
+        Err(e) => {
+            tracing::warn!(session = %name, error = %format!("{e:#}"), "failed to spawn terminal session")
+        }
     }
     result
 }

--- a/crates/loom-editor/src/terminal.rs
+++ b/crates/loom-editor/src/terminal.rs
@@ -110,7 +110,7 @@ pub async fn shell_ws(
         return (StatusCode::FORBIDDEN, "cross-origin websocket rejected").into_response();
     }
     if let Err(e) = crate::shell::ensure(&st).await {
-        tracing::error!(error = %e, "failed to bring up operator scratch shell");
+        tracing::error!(error = %format!("{e:#}"), "failed to bring up operator scratch shell");
         return (StatusCode::INTERNAL_SERVER_ERROR, "could not start shell").into_response();
     }
     let target = crate::shell::SHELL_SESSION.to_string();
@@ -151,7 +151,7 @@ pub async fn session_shell_ws(
     let target = match crate::shell::ensure_debug(&st, &session, idx).await {
         Ok(name) => name,
         Err(e) => {
-            tracing::error!(session = %key, idx, error = %e, "failed to bring up session debug shell");
+            tracing::error!(session = %key, idx, error = %format!("{e:#}"), "failed to bring up session debug shell");
             return (StatusCode::INTERNAL_SERVER_ERROR, "could not start shell").into_response();
         }
     };

--- a/crates/tapestry/src/lib.rs
+++ b/crates/tapestry/src/lib.rs
@@ -31,7 +31,7 @@ pub use supervisor::{run as supervise, SupervisorConfig};
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::os::unix::process::CommandExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 /// Which backend a supervisor runs. `Pty` is the historical terminal supervisor
@@ -167,6 +167,42 @@ fn encode_launch_spec_with_ambient(
     .context("encoding tapestry launch spec")
 }
 
+/// This process's own binary, to re-exec as a supervisor when the caller did not
+/// name one — plus the `argv[0]` to present it under, when that has to differ
+/// from the exec path.
+///
+/// The subtlety is an upgrade under a running process. `current_exe()` reads
+/// `/proc/self/exe`, which keeps naming the binary's *original* path with a
+/// ` (deleted)` suffix once that file is replaced — which installing a new loom
+/// does. Exec'ing that name fails with `ENOENT`, so a supervisor that predated
+/// the install could never spawn a sibling again: its own agent kept running,
+/// but every derived worktree shell died at launch with `spawning detached
+/// supervisor`, which the browser could only show as an endless "reconnecting".
+///
+/// `/proc/self/exe` itself stays a valid handle on the running image for the
+/// life of the process (a forked child inherits it right up to `execve`), so
+/// fall back to that. It also pins the sibling to the *owner's* build, which is
+/// what a derived supervisor wants — the replacement on disk may speak a
+/// different protocol. Only this fallback path pays its one cost, a `comm` of
+/// `exe` rather than `tapestry`, so carry the original name in `argv[0]` to keep
+/// the supervisor greppable in `ps`.
+fn self_exe() -> Result<(PathBuf, Option<PathBuf>)> {
+    let named = std::env::current_exe().context("resolving tapestry binary")?;
+    if !cfg!(target_os = "linux") || named.exists() {
+        return Ok((named, None));
+    }
+    let running = PathBuf::from("/proc/self/exe");
+    if !running.exists() {
+        return Ok((named, None)); // no /proc: let the spawn fail with the real cause
+    }
+    let argv0 = named
+        .to_str()
+        .and_then(|p| p.strip_suffix(" (deleted)"))
+        .map(PathBuf::from)
+        .unwrap_or(named);
+    Ok((running, Some(argv0)))
+}
+
 /// Launch a session's supervisor as a **detached** process: it `setsid`s into
 /// its own session, dropping its controlling terminal and stdio. With no
 /// controlling terminal it ignores the SIGHUP its launcher's exit would
@@ -181,13 +217,16 @@ fn encode_launch_spec_with_ambient(
 /// whole life of the long-running supervisor. It also means a script with spaces
 /// or quotes needs no shell-escaping.
 pub async fn spawn_detached(opts: &LaunchOptions<'_>) -> Result<()> {
-    let exe = match opts.supervisor_bin {
-        Some(p) => p.to_path_buf(),
-        None => std::env::current_exe().context("resolving tapestry binary")?,
+    let (exe, argv0) = match opts.supervisor_bin {
+        Some(p) => (p.to_path_buf(), None),
+        None => self_exe()?,
     };
     let spec = encode_launch_spec(opts, &[])?;
 
     let mut cmd = std::process::Command::new(&exe);
+    if let Some(argv0) = argv0 {
+        cmd.arg0(argv0);
+    }
     if opts.env_clear {
         // Pin the detached supervisor to the socket root the launcher already
         // resolved. Merely forwarding explicit overrides is insufficient: the

--- a/crates/tapestry/tests/detached.rs
+++ b/crates/tapestry/tests/detached.rs
@@ -200,6 +200,84 @@ async fn pty_and_relay_supervisors_derive_shells_with_their_exact_environment() 
     std::env::remove_var("TAPESTRY_OWNER_AMBIENT");
 }
 
+/// Installing a new loom replaces the `tapestry` binary underneath every
+/// supervisor already running. `current_exe()` then reports a path that no
+/// longer exists (Linux appends ` (deleted)`), so a supervisor that re-execs
+/// that name to launch a sibling fails with `ENOENT` — which is how every
+/// worktree shell derived from a pre-upgrade session died at launch, leaving the
+/// browser stuck on "reconnecting". A supervisor must keep deriving shells from
+/// its own running image instead.
+#[tokio::test]
+#[serial]
+async fn derives_shells_after_its_own_binary_is_replaced() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = TempDir::new().unwrap();
+    std::env::set_var("WEAVER_HOME", home.path());
+    let install = TempDir::new().unwrap();
+    let bin = install.path().join("tapestry");
+    std::fs::copy(env!("CARGO_BIN_EXE_tapestry"), &bin).unwrap();
+
+    let owner = format!("tap-replaced-owner-{}", std::process::id());
+    tapestry::spawn_detached(&LaunchOptions {
+        name: &owner,
+        cwd: &std::env::temp_dir(),
+        script: "exec sleep 60",
+        env: &[],
+        env_clear: false,
+        cols: 80,
+        rows: 24,
+        mode: Mode::Pty,
+        segment_max_bytes: None,
+        supervisor_bin: Some(&bin),
+    })
+    .await
+    .unwrap();
+
+    // The upgrade: unlink the file the supervisor was launched from and leave a
+    // different one at its path. The stub could never serve a session, so a
+    // shell that comes up proves the owner re-exec'd its own image rather than
+    // whatever now sits where it was installed.
+    std::fs::remove_file(&bin).unwrap();
+    std::fs::write(&bin, "#!/bin/sh\nexit 1\n").unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let shell = format!("tap-replaced-shell-{}", std::process::id());
+    Client::connect(&owner)
+        .await
+        .unwrap()
+        .derive(&DerivedLaunch {
+            name: shell.clone(),
+            cwd: std::env::temp_dir(),
+            script: "echo REPLACED_OK; exec sleep 60".to_string(),
+            cols: 80,
+            rows: 24,
+        })
+        .await
+        .expect("derive a shell after the supervisor's binary was replaced");
+
+    let mut screen = String::new();
+    for _ in 0..200 {
+        screen = Client::connect(&shell)
+            .await
+            .unwrap()
+            .capture(0)
+            .await
+            .unwrap();
+        if screen.contains("REPLACED_OK") {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(
+        screen.contains("REPLACED_OK"),
+        "derived shell never ran; got {screen:?}"
+    );
+
+    let _ = Client::connect(&shell).await.unwrap().kill().await;
+    let _ = Client::connect(&owner).await.unwrap().kill().await;
+}
+
 /// The supervisor is its session's subreaper: a process the agent detaches and
 /// orphans must reparent to the supervisor (not escape to PID 1) and then get
 /// reaped when it dies, instead of lingering as a zombie. Without this a


### PR DESCRIPTION
Opening a shell on a session failed silently: the tab sat on "reconnecting" forever while the server logged `spawning detached supervisor` on every retry.

A session's worktree shell is derived by the session's own Tapestry supervisor, which launches the sibling by re-execing its own binary — resolved through `current_exe()`. Installing a new loom unlinks that file, and `current_exe()` then reports the original path with a ` (deleted)` suffix, which cannot be exec'd. So every session whose supervisor predated the install permanently lost "+ Shell" (the agent under it kept running; only new spawns broke), and the WebSocket upgrade's 500 reached the browser as an opaque 1006 close, indistinguishable from a network blip.

Re-exec `/proc/self/exe` when the named path is gone. It stays a valid handle on the running image for the life of the process, and it pins the sibling to the owner's build rather than to whatever now sits at that path — which is what a derived supervisor wants, since the replacement may speak a different protocol. `argv[0]` carries the original name so supervisors stay greppable in `ps`. The normal case, where the binary is still there, is untouched.

The spawn and shell-attach sites now log the full error chain: the cause here was an `ENOENT` that never made it past the outermost context.

Note the fix applies to supervisors started after it lands — a session already running under a replaced binary keeps failing until its supervisor is restarted.