### PR TITLE
test(loom): match the entrance note's current summary wording

### DIFF
--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -3998,7 +3998,7 @@ async fn builtin_codex_launches_over_codex_acp() {
         "the opening prompt contains the goal exactly once: {prompt}"
     );
     assert!(
-        prompt.contains("Use `loom summary` to recover context"),
+        prompt.contains("Use `loom summary` after compaction"),
         "summary is offered as recovery: {prompt}"
     );
     assert!(


### PR DESCRIPTION
#321 reworded the entrance note to "use `loom summary` after compaction" and updated the unit test beside it in `provision.rs`, but the ACP integration test still asserted the old "to recover context" phrasing. `cargo test --workspace` has been red on main ever since — `acp::builtin_codex_launches_over_codex_acp` is the one failure, and it fails on every branch cut from main.

Point the assertion at the wording the note actually carries. It still checks the same thing: the opening prompt offers `loom summary` as recovery rather than demanding a tool call that would reinject the goal.

Agent lint review skipped: a one-line test assertion catching up to wording that already shipped.