### PR TITLE
fix(loom): expose retryable launch failures

### DIFF
--- a/crates/loom-store/src/runs.rs
+++ b/crates/loom-store/src/runs.rs
@@ -263,7 +263,8 @@ pub async fn route_channel(db: &Db, run_id: &str) -> Result<ChannelAction> {
             .await?;
             sqlx::query(
                 "UPDATE automation_runs
-                 SET status = 'creating', session_id = ?, updated_at = ?
+                 SET status = 'creating', session_id = ?, outcome = NULL,
+                     summary = '', updated_at = ?
                  WHERE id = ?",
             )
             .bind(&session_id)
@@ -273,6 +274,8 @@ pub async fn route_channel(db: &Db, run_id: &str) -> Result<ChannelAction> {
             .await?;
             run.session_id = session_id;
             run.status = "creating".to_string();
+            run.outcome = None;
+            run.summary.clear();
             ChannelAction::Launch(run)
         }
     };
@@ -371,6 +374,22 @@ pub async fn waiting(db: &Db, id: &str) -> Result<bool> {
         "UPDATE automation_runs SET status = 'waiting', updated_at = ?
          WHERE id = ? AND status IN ('creating', 'delivering', 'waiting')",
     )
+    .bind(now_iso())
+    .bind(id)
+    .execute(db)
+    .await?
+    .rows_affected()
+        == 1)
+}
+
+/// Return a retryable launch to the operator-visible queue with its failure reason.
+pub async fn waiting_after_failure(db: &Db, id: &str, summary: &str) -> Result<bool> {
+    Ok(sqlx::query(
+        "UPDATE automation_runs
+         SET status = 'waiting', summary = ?, updated_at = ?
+         WHERE id = ? AND status IN ('creating', 'delivering', 'waiting')",
+    )
+    .bind(summary)
     .bind(now_iso())
     .bind(id)
     .execute(db)
@@ -677,6 +696,42 @@ mod tests {
             route_channel(&db, &second.id).await.unwrap(),
             ChannelAction::Launch(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn retrying_a_waiting_launch_clears_its_previous_failure() {
+        let db = crate::db::connect_in_memory().await.unwrap();
+        let run = match reserve(
+            &db,
+            NewRun {
+                subject: "subject",
+                source: "grafana",
+                service_tag: "grafana",
+                profile: "default",
+                idempotency_key: "retry",
+                channel: Some("operator"),
+                request_json: "{}",
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Reservation::Created(run) => run,
+            Reservation::Existing(_) => unreachable!(),
+        };
+        assert!(matches!(
+            route_channel(&db, &run.id).await.unwrap(),
+            ChannelAction::Launch(_)
+        ));
+        assert!(waiting_after_failure(&db, &run.id, "credential missing")
+            .await
+            .unwrap());
+
+        let ChannelAction::Launch(retry) = route_channel(&db, &run.id).await.unwrap() else {
+            panic!("a waiting launch must be retried");
+        };
+        assert!(retry.summary.is_empty());
+        assert_eq!(retry.outcome, None);
     }
 
     #[tokio::test]

--- a/crates/loom-store/src/runs.rs
+++ b/crates/loom-store/src/runs.rs
@@ -369,24 +369,9 @@ pub async fn claim_stale_delivery(db: &Db, id: &str) -> Result<bool> {
         == 1)
 }
 
-pub async fn waiting(db: &Db, id: &str) -> Result<bool> {
+pub async fn waiting(db: &Db, id: &str, summary: &str) -> Result<bool> {
     Ok(sqlx::query(
-        "UPDATE automation_runs SET status = 'waiting', updated_at = ?
-         WHERE id = ? AND status IN ('creating', 'delivering', 'waiting')",
-    )
-    .bind(now_iso())
-    .bind(id)
-    .execute(db)
-    .await?
-    .rows_affected()
-        == 1)
-}
-
-/// Return a retryable launch to the operator-visible queue with its failure reason.
-pub async fn waiting_after_failure(db: &Db, id: &str, summary: &str) -> Result<bool> {
-    Ok(sqlx::query(
-        "UPDATE automation_runs
-         SET status = 'waiting', summary = ?, updated_at = ?
+        "UPDATE automation_runs SET status = 'waiting', summary = ?, updated_at = ?
          WHERE id = ? AND status IN ('creating', 'delivering', 'waiting')",
     )
     .bind(summary)
@@ -723,9 +708,7 @@ mod tests {
             route_channel(&db, &run.id).await.unwrap(),
             ChannelAction::Launch(_)
         ));
-        assert!(waiting_after_failure(&db, &run.id, "credential missing")
-            .await
-            .unwrap());
+        assert!(waiting(&db, &run.id, "credential missing").await.unwrap());
 
         let ChannelAction::Launch(retry) = route_channel(&db, &run.id).await.unwrap() else {
             panic!("a waiting launch must be retried");

--- a/crates/loom/frontend/src/components/AutomationRunRow.vue
+++ b/crates/loom/frontend/src/components/AutomationRunRow.vue
@@ -107,6 +107,16 @@ function onKeydown(event: KeyboardEvent) {
         {{ timeAgo(run.updated_at) }}
       </time>
     </div>
+    <button
+      v-if="projection === 'intervention' && canArchive"
+      type="button"
+      data-testid="run-action-clear"
+      class="shrink-0 rounded border border-line px-2 py-1 text-xs text-muted transition-colors hover:border-muted hover:text-fg"
+      :disabled="!!busy"
+      @click="requestConfirmation('archive')"
+    >
+      Clear
+    </button>
     <div class="relative z-10 shrink-0">
       <button
         ref="trigger"

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -238,7 +238,7 @@ async fn launch_run(
                     }
                 }
                 LaunchFailure::Retryable => {
-                    match crate::runs::waiting_after_failure(&st.db, &run.id, &summary).await {
+                    match crate::runs::waiting(&st.db, &run.id, &summary).await {
                         Ok(owned) => owned,
                         Err(record_error) => {
                             tracing::warn!(
@@ -268,18 +268,14 @@ async fn prompt_channel_run(
         .await?
         .filter(|session| session.status == "running" && session.protocol == "acp")
     else {
-        crate::runs::waiting(&st.db, &run.id).await.ok();
-        return Err(AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "automation channel session is not ready; retry this delivery",
-        ));
+        let message = "automation channel session is not ready; retry this delivery";
+        crate::runs::waiting(&st.db, &run.id, message).await.ok();
+        return Err(AppError::new(StatusCode::SERVICE_UNAVAILABLE, message));
     };
     let Some(handle) = st.acp.get(&session.id) else {
-        crate::runs::waiting(&st.db, &run.id).await.ok();
-        return Err(AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "automation channel session is being adopted; retry this delivery",
-        ));
+        let message = "automation channel session is being adopted; retry this delivery";
+        crate::runs::waiting(&st.db, &run.id, message).await.ok();
+        return Err(AppError::new(StatusCode::SERVICE_UNAVAILABLE, message));
     };
     let channel = run
         .channel
@@ -295,11 +291,9 @@ async fn prompt_channel_run(
         .stop_and_send(goal.clone(), Some(by.clone()), Vec::new())
         .await
     {
-        crate::runs::waiting(&st.db, &run.id).await.ok();
-        return Err(AppError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("automation channel rejected the update: {error}"),
-        ));
+        let message = format!("automation channel rejected the update: {error}");
+        crate::runs::waiting(&st.db, &run.id, &message).await.ok();
+        return Err(AppError::new(StatusCode::SERVICE_UNAVAILABLE, message));
     }
     crate::events::record(
         &st.db,

--- a/crates/loom/src/web/automation.rs
+++ b/crates/loom/src/web/automation.rs
@@ -122,6 +122,7 @@ async fn run_view(st: &AppState, id: &str) -> ApiResult<Json<RunView>> {
     Ok(Json(run.into()))
 }
 
+#[derive(Clone, Copy)]
 enum LaunchFailure {
     Final,
     Retryable,
@@ -211,9 +212,20 @@ async fn launch_run(
             }
         }
         Err(error) => {
+            let summary = error.to_string();
+            tracing::warn!(
+                run = %run.id,
+                session = %run.session_id,
+                source = %run.source,
+                service_tag = %run.service_tag,
+                profile = %run.profile,
+                retryable = matches!(failure, LaunchFailure::Retryable),
+                error = ?error,
+                "automation launch failed"
+            );
             let still_owned = match failure {
                 LaunchFailure::Final => {
-                    match crate::runs::failed(&st.db, &run.id, &format!("{error:?}")).await {
+                    match crate::runs::failed(&st.db, &run.id, &summary).await {
                         Ok(owned) => owned,
                         Err(record_error) => {
                             tracing::warn!(
@@ -225,17 +237,19 @@ async fn launch_run(
                         }
                     }
                 }
-                LaunchFailure::Retryable => match crate::runs::waiting(&st.db, &run.id).await {
-                    Ok(owned) => owned,
-                    Err(record_error) => {
-                        tracing::warn!(
-                            run = %run.id,
-                            error = %record_error,
-                            "could not return automation launch to waiting"
-                        );
-                        true
+                LaunchFailure::Retryable => {
+                    match crate::runs::waiting_after_failure(&st.db, &run.id, &summary).await {
+                        Ok(owned) => owned,
+                        Err(record_error) => {
+                            tracing::warn!(
+                                run = %run.id,
+                                error = %record_error,
+                                "could not return automation launch to waiting"
+                            );
+                            true
+                        }
                     }
-                },
+                }
             };
             if !still_owned {
                 remove_late_session(st, &run.session_id).await;

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -700,6 +700,89 @@ async fn automation_channel_reuses_one_acp_session_without_replaying_deliveries(
 }
 
 #[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn automation_channel_exposes_a_retryable_launch_failure() {
+    let ts = TestServer::start().await;
+    let repo_root = ts.repo_path().canonicalize().unwrap();
+    loom::repo::register(
+        &ts.state.db,
+        "marin-community/marin",
+        "https://github.com/marin-community/marin.git",
+        &repo_root.to_string_lossy(),
+    )
+    .await
+    .unwrap();
+    weaver_core::config::apply(
+        &ts.state.db,
+        &[
+            (
+                loom::github_app::APP_ID_KEY.to_string(),
+                Some("123456".to_string()),
+            ),
+            (
+                loom::github_app::APP_PRIVATE_KEY_KEY.to_string(),
+                Some("configured-for-preflight".to_string()),
+            ),
+        ],
+    )
+    .await
+    .unwrap();
+    ts.client
+        .post(
+            "/api/profiles",
+            json!({
+                "name": "ops",
+                "description": "operations intake",
+                "agent_kind": "claude",
+                "protocol": "acp",
+                "mode": "default",
+                "class": "automation",
+                "strict": true,
+                "env_clear": true,
+                "max_concurrent": 1,
+                "turn_budget": 20,
+                "prelude": "none"
+            }),
+        )
+        .await
+        .unwrap();
+
+    let error = ts
+        .client
+        .post(
+            "/api/runs",
+            json!({
+                "profile": "ops",
+                "source": "grafana",
+                "channel": "operator",
+                "idempotency_key": "alert:missing-credential",
+                "session": {
+                    "cwd": ts.cwd(),
+                    "title": "Grafana operator",
+                    "goal": "triage the alert"
+                }
+            }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("server returned 428"),
+        "unexpected response: {error}"
+    );
+
+    let runs = ts.client.get("/api/runs").await.unwrap();
+    let run = &runs.as_array().unwrap()[0];
+    assert_eq!(run["status"], "waiting");
+    assert!(
+        run["summary"]
+            .as_str()
+            .unwrap()
+            .contains("No GitHub credential configured"),
+        "retryable launch failures must remain actionable after the response is gone: {run}"
+    );
+}
+
+#[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn deployment_reconcile_rest_journey() {
     let ts = TestServer::start_api_only().await;

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -34,8 +34,9 @@ History are views over the same placement rather than separate ownership models.
 
 Successful automation is an ordinary session placed in the Ops space. A failed
 or incomplete run without a session appears as a typed **Intervention** in
-Attention and Ops, where the operator can inspect or clean it up. There is no
-separate Automations destination.
+Attention and Ops. The row shows the last launch error and exposes **Clear**,
+which archives the attempt while retaining it in History. There is no separate
+Automations destination.
 GitHub and Slack triggers land in their respective Inbox spaces. Delegated
 sessions inherit their parent's placement.
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -9,6 +9,9 @@ Automation launch attempts have a short phase before a session exists. Their
 `automation_runs` row reserves the future session id and remains visible when
 validation, capacity, clone, or fetch fails. Archive and remove accept that
 reserved id too, so an early failure is never an unactionable pseudo-session.
+Retryable channel failures remain `waiting` with their latest launch error. A
+redelivery clears that error when it claims a fresh provisioning attempt; the
+dashboard's Clear action archives an attempt that should no longer be retried.
 
 ## State transitions
 

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -720,9 +720,8 @@ test.describe("durable session workbench", () => {
 
     await page.getByTestId("attention-view").click();
     const intervention = page.getByTestId("automation-run-only");
-    await intervention.hover();
-    await intervention.getByTestId("run-actions").click();
-    await intervention.getByTestId("run-action-archive").click();
+    await expect(intervention).toContainText("is not inside a git repository");
+    await intervention.getByTestId("run-action-clear").click();
     await page
       .getByTestId("confirm-dialog")
       .getByTestId("confirm-dialog-confirm")


### PR DESCRIPTION
Persist the latest diagnostic whenever an automation channel returns to `waiting`, and log failed launches with their run, reserved session, source, service tag, and profile context. Retried launches clear the stale failure before provisioning again, so recovered runs do not retain an old error.

Intervention rows now render the stored diagnostic and expose a visible Clear action. Clear uses the existing archive-by-reserved-session behavior, moving the attempt to History while preserving its audit trail; permanent removal remains available from the overflow menu.

The incident record is https://echo.oa.dev/wiki/233.
