### PR TITLE
fix(loom): honor repository grants in CLI workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -304,10 +304,27 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
       echo "Loom-managed GitHub auth is missing its session credential" >&2
       exit 1
     fi
-    # Same per-repository scoping as the git helper. gh names its target with
-    # GH_REPO or the checkout's origin; without either, fall back to the
-    # session's whole set, which the App can mint while it stays single-owner.
-    repository="${GH_REPO:-}"
+    # Same per-repository scoping as the git helper. Match gh's repository
+    # selection precedence: an explicit --repo/-R flag, then GH_REPO, then the
+    # checkout's origin. Without any of them, fall back to the session's whole
+    # set, which the App can mint while it stays single-owner.
+    repository=
+    repository_argument=
+    for argument in "$@"; do
+      if [ "$repository_argument" = next ]; then
+        repository="$argument"
+        break
+      fi
+      case "$argument" in
+        --repo|-R) repository_argument=next ;;
+        --repo=*) repository="${argument#--repo=}"; break ;;
+        -R?*) repository="${argument#-R}"; break ;;
+        --) break ;;
+      esac
+    done
+    if [ -z "$repository" ]; then
+      repository="${GH_REPO:-}"
+    fi
     if [ -z "$repository" ]; then
       origin="$(git config --get remote.origin.url 2>/dev/null || true)"
       origin="${origin%.git}"
@@ -315,6 +332,7 @@ case "${LOOM_GITHUB_AUTH_MODE:-}" in
         *github.com[:/]*) repository="${origin##*github.com[:/]}" ;;
       esac
     fi
+    repository="${repository#github.com/}"
     if [ -n "$repository" ]; then
       GH_TOKEN="$(/usr/local/bin/loom github-token --repository "$repository")" || exit $?
     else

--- a/crates/loom/src/bin/loom.rs
+++ b/crates/loom/src/bin/loom.rs
@@ -16,11 +16,11 @@ use serde_json::{json, Value};
 use weaver_api::{
     AddReviewCommentReq, ArtifactTextAnchorDto, CreatePermissionRequestReq, CreateReviewReq,
     CreateSessionGroupReq, CreateSessionSpaceReq, DecidePermissionRequestReq,
-    DeleteSessionGroupReq, DeleteSessionSpaceReq, MoveSessionsReq, ReorderSessionLayoutReq,
-    RestoreSessionGroupsReq, ReviewAnchorDto, ReviewAnchorKindDto, ReviewSubjectKindDto,
-    SearchSessionsOptions, SessionCreatorFilter, SessionGroupPreferenceReq, SessionLayoutItemKind,
-    SessionLayoutView, SessionPlacementSelectorKind, SessionSearchAttention, SessionSearchStatus,
-    SetSessionGithubAccessReq, SetSessionPlacementDefaultReq, SubmitReviewReq,
+    DeleteSessionGroupReq, DeleteSessionSpaceReq, MoveSessionsReq, PermissionRequestView,
+    ReorderSessionLayoutReq, RestoreSessionGroupsReq, ReviewAnchorDto, ReviewAnchorKindDto,
+    ReviewSubjectKindDto, SearchSessionsOptions, SessionCreatorFilter, SessionGroupPreferenceReq,
+    SessionLayoutItemKind, SessionLayoutView, SessionPlacementSelectorKind, SessionSearchAttention,
+    SessionSearchStatus, SetSessionGithubAccessReq, SetSessionPlacementDefaultReq, SubmitReviewReq,
     UpdateReviewCommentReq, UpdateReviewReq, UpdateSessionGroupReq, UpdateSessionSpaceReq,
 };
 
@@ -1896,10 +1896,7 @@ async fn run_permissions(cmd: PermissionsCmd) -> Result<()> {
                         },
                     )
                     .await?;
-                println!(
-                    "request {} pending — {} {}",
-                    request.id, request.mode, request.repository
-                );
+                println!("{}", permission_request_confirmation(&request));
                 Ok(())
             }
         },
@@ -1959,6 +1956,13 @@ async fn run_permissions(cmd: PermissionsCmd) -> Result<()> {
             update_permission_resource(&client, resource, "none").await
         }
     }
+}
+
+fn permission_request_confirmation(request: &PermissionRequestView) -> String {
+    format!(
+        "request {} {} — {} {}",
+        request.id, request.state, request.mode, request.repository
+    )
 }
 
 async fn update_permission_resource(
@@ -6519,5 +6523,34 @@ settings:
                 "sessions {verb} did not parse as canonical {expected}"
             );
         }
+    }
+
+    #[test]
+    fn permission_request_confirmation_reports_the_returned_state() {
+        let mut request = PermissionRequestView {
+            id: "req-1".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "github_repository".to_string(),
+            repository: "acme/widgets".to_string(),
+            mode: "write".to_string(),
+            reason: "open the pull request".to_string(),
+            state: "pending".to_string(),
+            requested_by: "session:session-1".to_string(),
+            requested_at: "2026-08-24T00:00:00Z".to_string(),
+            decided_by: None,
+            decided_at: None,
+            decision_reason: None,
+        };
+        assert_eq!(
+            permission_request_confirmation(&request),
+            "request req-1 pending — write acme/widgets"
+        );
+
+        request.state = "approved".to_string();
+        request.decided_by = Some("policy:acme/*".to_string());
+        assert_eq!(
+            permission_request_confirmation(&request),
+            "request req-1 approved — write acme/widgets"
+        );
     }
 }

--- a/crates/loom/tests/docker_github_auth.rs
+++ b/crates/loom/tests/docker_github_auth.rs
@@ -236,6 +236,41 @@ fn gh_wrapper_obeys_loom_owned_auth_mode() {
         "GH_TOKEN=broker-token:marin-community/vllm\nGITHUB_TOKEN=unset\n"
     );
 
+    // An explicit repository flag must beat both an ambient token and GH_REPO.
+    // Otherwise a cross-repository `gh pr create --repo ...` can be silently
+    // re-authenticated for the checkout's unrelated repository.
+    let explicit = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "broker"),
+            ("LOOM_SESSION_ID", "session"),
+            ("LOOM_TOKEN", "session-token"),
+            ("GH_TOKEN", "broker-token:wrong/repository"),
+            ("GH_REPO", "wrong/repository"),
+        ],
+        &["pr", "create", "--repo", "marin-community/harbor"],
+    );
+    assert!(explicit.status.success());
+    assert_eq!(
+        String::from_utf8(explicit.stdout).unwrap(),
+        "GH_TOKEN=broker-token:marin-community/harbor\nGITHUB_TOKEN=unset\n"
+    );
+
+    let short_flag = run_script(
+        &script,
+        &[
+            ("LOOM_GITHUB_AUTH_MODE", "broker"),
+            ("LOOM_SESSION_ID", "session"),
+            ("LOOM_TOKEN", "session-token"),
+        ],
+        &["pr", "create", "-Rgithub.com/Open-Athena/mumwelt"],
+    );
+    assert!(short_flag.status.success());
+    assert_eq!(
+        String::from_utf8(short_flag.stdout).unwrap(),
+        "GH_TOKEN=broker-token:Open-Athena/mumwelt\nGITHUB_TOKEN=unset\n"
+    );
+
     let direct = run_script(
         &script,
         &[

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -934,11 +934,12 @@ owner, so a session holding access under two owners has no single token that
 spans them. `credential.useHttpPath` is enabled for github.com, so git names the
 repository in every helper request and the helper forwards it as
 `loom github-token --repository owner/name`; the `gh` wrapper resolves the same
-from `GH_REPO` or the checkout's origin. The server refuses a repository the
-session has no access to, so naming one narrows the token and never widens it.
-Omitting the repository falls back to the session's whole set, which the App can
-mint only while it stays single-owner. The `gh` wrapper translates the selected mode into
-the stock CLI's native authentication contract for each invocation.
+from an explicit `--repo`/`-R` flag, `GH_REPO`, or the checkout's origin, in
+that order. The server refuses a repository the session has no access to, so
+naming one narrows the token and never widens it. Omitting the repository falls
+back to the session's whole set, which the App can mint only while it stays
+single-owner. The `gh` wrapper translates the selected mode into the stock
+CLI's native authentication contract for each invocation.
 Adapter registration stays in the image's system Git config: linked worktrees
 share repository-local config, agents may clone additional repositories, and
 the helper must be available before a target repository exists. Session


### PR DESCRIPTION
Report the actual permission-request state so owner-policy grants no longer appear to be waiting for human approval.\n\nTeach the brokered gh wrapper to honor an explicit --repo/-R target before GH_REPO or the checkout origin. This prevents cross-repository commands from being re-authenticated for the current checkout and makes newly granted access usable for PR creation.\n\nAdds focused coverage for pending and auto-approved request output plus long and short gh repository flags.