### PR TITLE
fix(loom): keep session credentials valid across upgrades

### DIFF
--- a/crates/loom-policy/src/auth.rs
+++ b/crates/loom-policy/src/auth.rs
@@ -105,9 +105,10 @@ pub enum Grant {
     Session {
         session_id: String,
         branch_id: String,
-        /// `None` is the compatibility form minted before operation-bound
-        /// authorization. Newly minted credentials always carry an explicit
-        /// capability set derived from the immutable launch policy.
+        /// `None` is an unrestricted session: actor and resource scope still
+        /// apply, but newly registered session operations remain reachable.
+        /// Restricted sessions carry the exact capability set derived from
+        /// their immutable launch policy.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         capabilities: Option<Vec<String>>,
     },
@@ -733,15 +734,14 @@ pub async fn lookup_token(db: &Db, token: &str) -> Result<Option<Principal>> {
     let hash = sha256_hex(token);
     let row = sqlx::query(
         "SELECT t.id AS id, t.username AS username, u.github_login AS github_login,
-                u.role AS role, t.kind AS kind, t.grant_json AS grant_json
-         FROM api_tokens t JOIN users u ON u.username = t.username
+                u.role AS role, t.kind AS kind, t.grant_json AS grant_json,
+                s.policy_restricted AS session_restricted
+         FROM api_tokens t
+         JOIN users u ON u.username = t.username
+         LEFT JOIN sessions s ON s.id = t.bound_session_id
          WHERE t.token_hash = ? AND (t.expires_at IS NULL OR t.expires_at > ?)
            AND (
-             t.kind != 'session' OR EXISTS(
-               SELECT 1 FROM sessions s
-               WHERE s.id = t.bound_session_id
-                 AND s.status NOT IN ('done', 'error', 'archived')
-             )
+             t.kind != 'session' OR s.status NOT IN ('done', 'error', 'archived')
            )",
     )
     .bind(&hash)
@@ -753,7 +753,7 @@ pub async fn lookup_token(db: &Db, token: &str) -> Result<Option<Principal>> {
     };
     let id: String = row.get("id");
     let kind: String = row.get("kind");
-    let grant = if kind == TokenKind::Pat.as_str() || kind == TokenKind::Local.as_str() {
+    let mut grant = if kind == TokenKind::Pat.as_str() || kind == TokenKind::Local.as_str() {
         row.get::<UserRole, _>("role").grant()
     } else {
         let grant_json: String = row.get("grant_json");
@@ -765,6 +765,17 @@ pub async fn lookup_token(db: &Db, token: &str) -> Result<Option<Principal>> {
             }
         }
     };
+    // Unrestricted session policy is forward-compatible by definition. Older
+    // Loom versions serialized the then-current complete grant list, which
+    // made a surviving token lose access whenever an upgrade registered a new
+    // grant. Normalize those durable credentials as they authenticate; the
+    // session row remains the source of truth and restricted credentials keep
+    // their exact launch-time capabilities.
+    if kind == "session" && row.get::<Option<bool>, _>("session_restricted") == Some(false) {
+        if let Grant::Session { capabilities, .. } = &mut grant {
+            *capabilities = None;
+        }
+    }
     let _ = sqlx::query("UPDATE api_tokens SET last_used_at = ? WHERE id = ?")
         .bind(now_iso())
         .bind(&id)
@@ -803,13 +814,24 @@ pub fn session_capabilities_for_policy(
     ))
 }
 
-async fn stored_session_capabilities(db: &Db, session_id: &str) -> Result<Vec<String>> {
+fn session_token_capabilities_for_policy(
+    restricted: bool,
+    policy_mcp_access: &str,
+) -> Result<Option<Vec<String>>> {
+    if restricted {
+        session_capabilities_for_policy(true, policy_mcp_access).map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+async fn stored_session_capabilities(db: &Db, session_id: &str) -> Result<Option<Vec<String>>> {
     let row = sqlx::query("SELECT policy_restricted, policy_mcp_access FROM sessions WHERE id = ?")
         .bind(session_id)
         .fetch_optional(db)
         .await?;
     match row {
-        Some(row) => session_capabilities_for_policy(
+        Some(row) => session_token_capabilities_for_policy(
             row.get::<bool, _>("policy_restricted"),
             row.get::<String, _>("policy_mcp_access").as_str(),
         ),
@@ -817,7 +839,7 @@ async fn stored_session_capabilities(db: &Db, session_id: &str) -> Result<Vec<St
         // first callback cannot race the token row. That path calls the
         // explicit-policy helper; retain unrestricted behavior as a safe
         // compatibility fallback for direct test fixtures.
-        None => Ok(weaver_api::all_session_capabilities()),
+        None => Ok(None),
     }
 }
 
@@ -826,7 +848,7 @@ async fn mint_staged_session_token(
     owner: Option<&str>,
     session_id: &str,
     branch_id: &str,
-    capabilities: Vec<String>,
+    capabilities: Option<Vec<String>>,
 ) -> Result<StagedSessionToken> {
     let username = match owner {
         Some(username) if get_user(db, username).await?.is_some() => username.to_string(),
@@ -839,7 +861,7 @@ async fn mint_staged_session_token(
     let grant = serde_json::to_string(&Grant::Session {
         session_id: session_id.to_string(),
         branch_id: branch_id.to_string(),
-        capabilities: Some(capabilities),
+        capabilities,
     })?;
     sqlx::query(
         "INSERT INTO api_tokens
@@ -880,7 +902,7 @@ pub async fn stage_session_token_with_policy(
     restricted: bool,
     policy_mcp_access: &str,
 ) -> Result<StagedSessionToken> {
-    let capabilities = session_capabilities_for_policy(restricted, policy_mcp_access)?;
+    let capabilities = session_token_capabilities_for_policy(restricted, policy_mcp_access)?;
     mint_staged_session_token(db, owner, session_id, branch_id, capabilities).await
 }
 
@@ -1463,7 +1485,44 @@ mod tests {
         };
         assert_eq!(session_id, "s1");
         assert_eq!(branch_id, branch.id);
-        assert_eq!(capabilities, Some(weaver_api::all_session_capabilities()));
+        assert_eq!(capabilities, None);
+
+        // Credentials minted by older Loom versions froze an unrestricted
+        // session to the complete capability list that existed at the time.
+        // Authentication upgrades that representation in memory so a server
+        // upgrade can register new operations without replacing the plaintext
+        // token held by a surviving runtime.
+        let legacy_grant = serde_json::to_string(&Grant::Session {
+            session_id: "s1".to_string(),
+            branch_id: branch.id.clone(),
+            capabilities: Some(vec!["loom/sessions/read@v1".to_string()]),
+        })
+        .unwrap();
+        sqlx::query("UPDATE api_tokens SET grant_json = ? WHERE bound_session_id = 's1'")
+            .bind(legacy_grant)
+            .execute(&db)
+            .await
+            .unwrap();
+        let upgraded = lookup_token(&db, &plain).await.unwrap().unwrap();
+        assert!(matches!(
+            upgraded.grant,
+            Grant::Session {
+                capabilities: None,
+                ..
+            }
+        ));
+        sqlx::query("UPDATE sessions SET policy_restricted = 1 WHERE id = 's1'")
+            .execute(&db)
+            .await
+            .unwrap();
+        let pinned = lookup_token(&db, &plain).await.unwrap().unwrap();
+        assert!(matches!(
+            pinned.grant,
+            Grant::Session {
+                capabilities: Some(ref values),
+                ..
+            } if values == &["loom/sessions/read@v1"]
+        ));
         assert_eq!(list_tokens(&db, "rjpower").await.unwrap().len(), 0);
         crate::session::set_status(&db, "s1", "archived")
             .await

--- a/crates/loom/src/cli/agent/channels.rs
+++ b/crates/loom/src/cli/agent/channels.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use clap::Subcommand;
 use serde_json::json;
 
-use weaver_api::operations::{branches, channels};
+use weaver_api::operations::{channels, sessions};
 
 use super::{branch_key, channel_key, client, render};
 
@@ -70,9 +70,7 @@ async fn cmd_channel(cmd: ChannelCmd) -> Result<()> {
             let repo_root = match branch_key() {
                 Ok(key) => Some(
                     client
-                        .invoke::<branches::get::Op>(&branches::get::Input {
-                            branch: key.to_string(),
-                        })
+                        .invoke::<sessions::context::Op>(&sessions::context::Input { session: key })
                         .await?
                         .repo_root,
                 ),

--- a/crates/loom/src/cli/agent/issues.rs
+++ b/crates/loom/src/cli/agent/issues.rs
@@ -3,8 +3,8 @@
 use anyhow::{anyhow, bail, Result};
 use clap::Subcommand;
 
-use weaver_api::operations::branches;
 use weaver_api::operations::issues as issue_ops;
+use weaver_api::operations::sessions;
 use weaver_api::render::sessions::{attention, status_line};
 use weaver_api::{Client, IssueAction, IssueView};
 use weaver_core::tags;
@@ -116,9 +116,7 @@ async fn cmd_issue(cmd: IssueCmd) -> Result<()> {
     let client = client();
     let key = branch_key()?;
     let b = client
-        .invoke::<branches::get::Op>(&branches::get::Input {
-            branch: key.to_string(),
-        })
+        .invoke::<sessions::status::get::Op>(&sessions::status::get::Input { session: key })
         .await?;
     match cmd {
         IssueCmd::Add {
@@ -549,8 +547,8 @@ async fn cmd_issue_wait(
             if let Some(name) = cur.claimed_branch.as_deref() {
                 let key = format!("{repo_root}:{name}");
                 if let Ok(row) = client
-                    .invoke::<branches::get::Op>(&branches::get::Input {
-                        branch: key.to_string(),
+                    .invoke::<sessions::status::get::Op>(&sessions::status::get::Input {
+                        session: key.to_string(),
                     })
                     .await
                 {

--- a/crates/loom/src/cli/agent/mod.rs
+++ b/crates/loom/src/cli/agent/mod.rs
@@ -35,7 +35,7 @@ pub use tags::{run as run_tag, TagCmd};
 use anyhow::{anyhow, bail, Result};
 use std::sync::OnceLock;
 
-use weaver_api::operations::{branches, Operation, Render};
+use weaver_api::operations::{sessions, Operation, Render};
 use weaver_api::render::sessions::status_line;
 use weaver_api::Client;
 
@@ -102,8 +102,8 @@ fn channel_key(explicit: Option<String>) -> Result<String> {
 async fn working_branch_status(client: &Client, repo_root: &str, claimed: &str) -> Option<String> {
     let key = format!("{repo_root}:{claimed}");
     let b = client
-        .invoke::<branches::get::Op>(&branches::get::Input {
-            branch: key.to_string(),
+        .invoke::<sessions::status::get::Op>(&sessions::status::get::Input {
+            session: key.to_string(),
         })
         .await
         .ok()?;

--- a/crates/loom/src/cli/agent/session.rs
+++ b/crates/loom/src/cli/agent/session.rs
@@ -4,7 +4,7 @@
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 
-use weaver_api::operations::branches;
+use weaver_api::operations::sessions;
 use weaver_api::BranchView;
 use weaver_core::tags;
 
@@ -34,11 +34,10 @@ pub fn run_chatlog(file: Option<String>, as_json: bool) -> Result<()> {
 async fn cmd_where() -> Result<()> {
     let client = client();
     let key = branch_key()?;
-    let b = client
-        .invoke::<branches::get::Op>(&branches::get::Input {
-            branch: key.to_string(),
-        })
+    let session = client
+        .invoke::<sessions::get::Op>(&sessions::get::Input { session: key })
         .await?;
+    let b = session.branch;
     println!("repo:      {}", b.repo_root);
     println!("branch:    {}", b.branch);
     println!("base:      {}", b.base_branch);
@@ -50,9 +49,7 @@ async fn cmd_log(limit: i64) -> Result<()> {
     let client = client();
     let key = branch_key()?;
     let mut history = client
-        .invoke::<branches::events::list::Op>(&branches::events::list::Input {
-            branch: key.to_string(),
-        })
+        .invoke::<sessions::events::list::Op>(&sessions::events::list::Input { session: key })
         .await?;
     history.truncate(limit.max(0) as usize);
     if history.is_empty() {
@@ -228,7 +225,11 @@ async fn cmd_hook(event: String) -> Result<()> {
         };
         let is_compact = source.as_deref() == Some("compact");
         client
-            .record_branch_event(&key, "hook", json!({ "event": event, "source": source }))
+            .invoke::<sessions::events::create::Op>(&sessions::events::create::Input {
+                kind: "hook".to_string(),
+                data: json!({ "event": event, "source": source }),
+                session: key.clone(),
+            })
             .await?;
         if is_session_start {
             // After a compaction the agent has lost its working context but the
@@ -236,9 +237,7 @@ async fn cmd_hook(event: String) -> Result<()> {
             // `loom summary` catch-up) rather than the full repository primer. On a
             // genuine start/resume/clear, inject the full primer.
             let b = client
-                .invoke::<branches::get::Op>(&branches::get::Input {
-                    branch: key.to_string(),
-                })
+                .invoke::<sessions::status::get::Op>(&sessions::status::get::Input { session: key })
                 .await?;
             let context = if is_compact {
                 let summary = render_summary(&client, &b).await.unwrap_or_default();

--- a/crates/loom/src/cli/agent/status.rs
+++ b/crates/loom/src/cli/agent/status.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use clap::Subcommand;
 
 use weaver_api::operations::issues as issue_ops;
-use weaver_api::operations::{artifacts, branches, channels, sessions};
+use weaver_api::operations::{artifacts, channels, sessions};
 use weaver_api::render::sessions::{github_wiring, status_line};
 use weaver_api::{BranchView, Client, IssueView, ThreadDto};
 use weaver_core::tags;
@@ -39,10 +39,9 @@ pub async fn run(cmd: StatusCmd) -> Result<()> {
 
 pub async fn run_summary() -> Result<()> {
     let client = client();
+    let key = branch_key()?;
     let branch = client
-        .invoke::<branches::get::Op>(&branches::get::Input {
-            branch: (branch_key()?).to_string(),
-        })
+        .invoke::<sessions::status::get::Op>(&sessions::status::get::Input { session: key })
         .await?;
     print!("{}", render_summary(&client, &branch).await?);
     Ok(())
@@ -303,9 +302,7 @@ async fn cmd_status(level: Option<String>, message: String) -> Result<()> {
         return cmd_status_write(&client, &key, &level, &message).await;
     }
     let b = client
-        .invoke::<branches::get::Op>(&branches::get::Input {
-            branch: key.to_string(),
-        })
+        .invoke::<sessions::status::get::Op>(&sessions::status::get::Input { session: key })
         .await?;
     println!("{}", render::<sessions::status::get::Op>(&b));
     Ok(())
@@ -314,7 +311,7 @@ async fn cmd_status(level: Option<String>, message: String) -> Result<()> {
 /// Report the agent's status: set the attention level and, when a message is
 /// given, the accompanying current-state note. The level lives on the
 /// `attention` tag — `ok` clears it (absence is the calm state), `attention`/
-/// `blocked` set it. One call (`POST /branches/{id}/status`) writes the
+/// `blocked` set it. One `sessions.status.set` call writes the
 /// description, sets or clears the tag, and records a single `tag` event
 /// atomically server-side. An empty message leaves the previous message in
 /// place — `loom status set --tag ok` lowers the level without wiping what
@@ -329,10 +326,10 @@ async fn cmd_status_write(client: &Client, key: &str, level: &str, message: &str
         bail!("unknown status '{level}' — expected one of ok, attention, blocked");
     }
     let updated = client
-        .invoke::<branches::status::set::Op>(&branches::status::set::Input {
+        .invoke::<sessions::status::set::Op>(&sessions::status::set::Input {
             level: level.to_string(),
             message: (!message.is_empty()).then(|| message.to_string()),
-            branch: key.to_string(),
+            session: key.to_string(),
         })
         .await?;
     println!("{}", render::<sessions::status::set::Op>(&updated));

--- a/crates/loom/src/cli/agent/tags.rs
+++ b/crates/loom/src/cli/agent/tags.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, bail, Result};
 use clap::Subcommand;
 
-use weaver_api::operations::branches;
+use weaver_api::operations::sessions;
 use weaver_api::{BranchView, Client};
 use weaver_core::tags;
 
@@ -57,23 +57,22 @@ pub async fn run(cmd: TagCmd) -> Result<()> {
 /// `repo:branch`, or unambiguous prefix) when given, else the current branch.
 async fn resolve_tag_target(
     client: &Client,
-    current_key: &str,
     session: Option<&str>,
-) -> Result<BranchView> {
+) -> Result<(BranchView, String)> {
+    let key = match session {
+        Some(key) => key.to_string(),
+        None => branch_key()?,
+    };
+    let resolved = client
+        .invoke::<sessions::tags::list::Op>(&sessions::tags::list::Input {
+            session: key.clone(),
+        })
+        .await;
     match session {
-        Some(key) => client
-            .invoke::<branches::get::Op>(&branches::get::Input {
-                branch: key.to_string(),
-            })
-            .await
-            .map_err(|_| anyhow!("no session matching '{key}'")),
-        None => {
-            client
-                .invoke::<branches::get::Op>(&branches::get::Input {
-                    branch: current_key.to_string(),
-                })
-                .await
-        }
+        Some(spelled) => resolved
+            .map(|branch| (branch, key))
+            .map_err(|_| anyhow!("no session matching '{spelled}'")),
+        None => resolved.map(|branch| (branch, key)),
     }
 }
 
@@ -81,7 +80,6 @@ async fn resolve_tag_target(
 /// self-report and a watch's `triage` assessment with any free-form axis.
 async fn cmd_tag(cmd: TagCmd) -> Result<()> {
     let client = client();
-    let key = branch_key()?;
     match cmd {
         TagCmd::Set {
             key: tag_key,
@@ -90,7 +88,7 @@ async fn cmd_tag(cmd: TagCmd) -> Result<()> {
             session,
             by,
         } => {
-            let target = resolve_tag_target(&client, &key, session.as_deref()).await?;
+            let (target, session_key) = resolve_tag_target(&client, session.as_deref()).await?;
             let tag_key = tag_key.trim();
             let value = value.trim();
             let note = note.trim();
@@ -105,12 +103,12 @@ async fn cmd_tag(cmd: TagCmd) -> Result<()> {
                 bail!("a tag value cannot be empty — use `loom sessions tags delete {tag_key}` to clear it");
             }
             client
-                .invoke::<branches::tags::set::Op>(&branches::tags::set::Input {
+                .invoke::<sessions::tags::set::Op>(&sessions::tags::set::Input {
                     key: tag_key.to_string(),
                     value: value.to_string(),
                     note: note.to_string(),
                     by: Some(by.to_string()),
-                    branch: target.id.to_string(),
+                    session: session_key,
                 })
                 .await?;
             if note.is_empty() {
@@ -126,19 +124,19 @@ async fn cmd_tag(cmd: TagCmd) -> Result<()> {
             key: tag_key,
             session,
         } => {
-            let target = resolve_tag_target(&client, &key, session.as_deref()).await?;
+            let (target, session_key) = resolve_tag_target(&client, session.as_deref()).await?;
             let tag_key = tag_key.trim();
             client
-                .invoke::<branches::tags::delete::Op>(&branches::tags::delete::Input {
+                .invoke::<sessions::tags::delete::Op>(&sessions::tags::delete::Input {
                     key: tag_key.to_string(),
                     by: Some("manual".to_string()),
-                    branch: target.id.to_string(),
+                    session: session_key,
                 })
                 .await?;
             println!("tag: {} → cleared {tag_key}", target.branch);
         }
         TagCmd::Ls { session } => {
-            let target = resolve_tag_target(&client, &key, session.as_deref()).await?;
+            let (target, _) = resolve_tag_target(&client, session.as_deref()).await?;
             if target.tags.is_empty() {
                 println!("(no tags)");
                 return Ok(());

--- a/crates/loom/src/web/auth.rs
+++ b/crates/loom/src/web/auth.rs
@@ -251,7 +251,10 @@ pub(super) async fn require_auth(
                             {
                                 "this operation requires a human operator"
                             }
-                            _ => "credential lacks this operation's registered capability or scope",
+                            // Scope is checked from the decoded operation input
+                            // by `operations::authorize`; this middleware has
+                            // only checked actor and registered capabilities.
+                            _ => "credential lacks this operation's registered capability",
                         })
                         .unwrap_or("credential grant forbids this route");
                 return AppError::new(StatusCode::FORBIDDEN, message).into_response();

--- a/crates/loom/src/web/operations.rs
+++ b/crates/loom/src/web/operations.rs
@@ -200,8 +200,8 @@ fn grants_allow(principal: &Principal, operation: &OperationSpec) -> bool {
     let Grant::Session { capabilities, .. } = &principal.grant else {
         return true;
     };
-    // `None` is the compatibility form minted before capability-bound
-    // credentials; it is unrestricted by construction.
+    // `None` is the forward-compatible form for an unrestricted session;
+    // actor and resource scope still constrain it.
     capabilities.as_ref().is_none_or(|granted| {
         operation
             .grants

--- a/crates/loom/src/web/scope.rs
+++ b/crates/loom/src/web/scope.rs
@@ -102,7 +102,16 @@ pub(crate) async fn require_session_access(
     if session.is_empty() || session == "self" || session == own {
         return Ok(());
     }
-    if super::auth::is_session_descendant(st, own, session).await {
+    // Session handlers accept every key `session::resolve_key` understands:
+    // session id, branch id/name, or `repo:branch`. Resolve before comparing
+    // ancestry so the scope check and handler cannot disagree about the same
+    // typed operand.
+    let Some((resolved, _)) = crate::session::resolve_key(&st.db, session).await? else {
+        return Err(denied(
+            "session credentials are limited to their own session",
+        ));
+    };
+    if super::auth::is_session_descendant(st, own, &resolved.id).await {
         return Ok(());
     }
     Err(denied(

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1106,12 +1106,12 @@ async fn prompt_resources(work_dir: &str, files: &[String]) -> ApiResult<Vec<Val
 // ---------------------------------------------------------------------------
 // Operation registry bindings
 //
-// The `sessions` bundle: 17 operations under `weaver_api::operations::sessions`.
+// The `sessions` bundle under `weaver_api::operations::sessions`.
 // `sessions.summary.get` lives in the sibling `session_summary.rs` and is
 // folded in below, and `sessions.github.access.list` is bound below to a
 // handler in `github_access.rs`, beside the repository-access helpers it reads
 // through. `sessions.context` also lives in a sibling file
-// (`self_context.rs`), but `registry()` (`web/operations.rs`, coordinator-owned)
+// (`self_context.rs`), but the top-level registry (`web/operations.rs`)
 // already wires `self_context::bound_operations()` in on its own and treats
 // it as independent, so it is deliberately NOT re-added here; doing so would
 // register `sessions.context` twice and panic the router on startup. Every

--- a/crates/loom/tests/agent_cli.rs
+++ b/crates/loom/tests/agent_cli.rs
@@ -40,7 +40,11 @@ fn loom_bin() -> std::path::PathBuf {
 /// suite is that a session row exists at all, because a session credential is
 /// how the server resolves the caller's own repository, branch, and session for
 /// every declaration-served command.
-async fn seed_session(db: &weaver_core::db::Db, branch_id: &str) -> loom::session::Session {
+async fn seed_session(
+    db: &weaver_core::db::Db,
+    branch_id: &str,
+    policy: &session_mod::SessionLaunchPolicy,
+) -> loom::session::Session {
     session_mod::insert_with_policy(
         db,
         &session_mod::NewSession {
@@ -61,15 +65,15 @@ async fn seed_session(db: &weaver_core::db::Db, branch_id: &str) -> loom::sessio
             class: "interactive".to_string(),
             tracking_issue_id: None,
         },
-        &launch_policy(),
+        policy,
     )
     .await
     .unwrap()
 }
 
 /// An ordinary unrestricted launch policy — what loom assigns to a session
-/// it starts. `restricted: false` mints a credential carrying the full session
-/// capability set, as a real agent's does.
+/// it starts. `restricted: false` mints a forward-compatible credential whose
+/// capabilities follow the registered session operation set.
 fn launch_policy() -> session_mod::SessionLaunchPolicy {
     session_mod::SessionLaunchPolicy {
         profile: loom::profile::DEFAULT_PROFILE.to_string(),
@@ -94,6 +98,13 @@ fn launch_policy() -> session_mod::SessionLaunchPolicy {
     }
 }
 
+fn restricted_launch_policy() -> session_mod::SessionLaunchPolicy {
+    session_mod::SessionLaunchPolicy {
+        restricted: true,
+        ..launch_policy()
+    }
+}
+
 /// A running loom server, isolated in its own temp `WEAVER_HOME`/sqlite db,
 /// with one branch row seeded — the target `$WEAVER_BRANCH` names, exactly as
 /// loom would set it for a real session — plus the session running on it and
@@ -106,9 +117,9 @@ struct Env {
     session_id: String,
     /// The session credential loom hands an agent as `$LOOM_TOKEN`.
     ///
-    /// A declaration-served command resolves `repo_root`, `branch` and
-    /// `session` from the caller's own credential, so without a session token
-    /// every operand the dispatcher supplies would be empty.
+    /// A declaration-served command can resolve `repo_root`, `branch` and
+    /// `session` from the caller's own credential when its context operands are
+    /// omitted.
     token: String,
     db: weaver_core::db::Db,
     _home: tempfile::TempDir,
@@ -116,6 +127,10 @@ struct Env {
 
 impl Env {
     async fn start() -> Self {
+        Self::start_with_policy(launch_policy()).await
+    }
+
+    async fn start_with_policy(policy: session_mod::SessionLaunchPolicy) -> Self {
         let home = tempfile::tempdir().unwrap();
         std::env::set_var("WEAVER_HOME", home.path());
         seed_migrated_db();
@@ -160,7 +175,7 @@ impl Env {
         };
         tokio::spawn(server::serve(state, listener));
 
-        let session = seed_session(&pool, &branch.id).await;
+        let session = seed_session(&pool, &branch.id, &policy).await;
         let token = auth::create_session_token(&pool, None, &session.id, &branch.id)
             .await
             .unwrap();
@@ -244,6 +259,21 @@ impl Env {
     fn run_raw(&self, args: &[&str]) -> std::process::Output {
         self.command(args).output().expect("failed to spawn weaver")
     }
+
+    async fn replace_token_capabilities(&self, capabilities: Vec<String>) {
+        let grant = serde_json::to_string(&auth::Grant::Session {
+            session_id: self.session_id.clone(),
+            branch_id: self.branch_id.clone(),
+            capabilities: Some(capabilities),
+        })
+        .unwrap();
+        sqlx::query("UPDATE api_tokens SET grant_json = ? WHERE bound_session_id = ?")
+            .bind(grant)
+            .bind(&self.session_id)
+            .execute(&self.db)
+            .await
+            .unwrap();
+    }
 }
 
 /// The goal lives as the `goal` artifact; writing it keeps the branch's
@@ -268,6 +298,45 @@ async fn where_reports_resolved_branch() {
         out.contains("branch:    feature-test"),
         "where output: {out}"
     );
+}
+
+/// Session orientation is baseline access for a restricted agent. These
+/// commands describe `sessions.*` operations, so their hand-written rendering
+/// must not introduce a hidden dependency on a `branches.*` capability the
+/// launch policy did not grant.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn restricted_session_can_run_orientation_commands() {
+    let env = Env::start_with_policy(restricted_launch_policy()).await;
+
+    let summary = env.run(&["summary"]);
+    assert!(summary.contains(BRANCH_GOAL), "summary: {summary}");
+
+    let context = env.run(&["self"]);
+    assert!(
+        context.contains("branch:    feature-test"),
+        "self: {context}"
+    );
+
+    let status = env.run(&["status", "get"]);
+    assert!(status.contains(BRANCH_GOAL), "status: {status}");
+
+    env.run(&["sessions", "events"]);
+}
+
+/// A live runtime keeps its plaintext token across Loom server upgrades. An
+/// unrestricted token minted before a newly registered grant existed must
+/// therefore acquire that grant from the durable session policy rather than
+/// remain frozen to its old serialized list.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn legacy_unrestricted_token_reaches_new_operation_grants() {
+    let env = Env::start().await;
+    env.replace_token_capabilities(vec!["loom/sessions/read@v1".to_string()])
+        .await;
+
+    let branch = env.run(&["branches", "get"]);
+    assert!(branch.contains(&env.branch_name), "branch: {branch}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loom/tests/integration/auth.rs
+++ b/crates/loom/tests/integration/auth.rs
@@ -995,7 +995,7 @@ async fn session_token_can_delegate_through_the_cli_resolve_then_create_path() {
         ])
         .env("WEAVER_API", format!("http://{}", ts.addr))
         .env("WEAVER_BRANCH", parent_branch_id)
-        .env("LOOM_TOKEN", token)
+        .env("LOOM_TOKEN", &token)
         .output()
         .expect("running scoped loom session launch");
     assert!(
@@ -1014,6 +1014,26 @@ async fn session_token_can_delegate_through_the_cli_resolve_then_create_path() {
         child.parent_branch_id, None,
         "branch ancestry is repository-scoped"
     );
+
+    // The handler and its declared Session scope accept the same key forms.
+    // In particular, a cross-repository child can be addressed by
+    // `repo:branch`; authorization resolves that spelling before checking the
+    // session tree instead of rejecting it as though it were a literal id.
+    let child_branch = weaver_core::branch::get(&ts.state.db, &child.branch_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let child_key = format!("{}:{}", child_branch.repo_root, child_branch.branch);
+    let response = reqwest::Client::new()
+        .post(url(&ts, "/api/sessions/get"))
+        .bearer_auth(&token)
+        .json(&json!({ "session": child_key }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let resolved: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(resolved["id"], child.id);
 }
 
 /// A branch key is not a branch. Whatever a session credential spells, the

--- a/e2e/tests/session-layout.spec.ts
+++ b/e2e/tests/session-layout.spec.ts
@@ -74,19 +74,45 @@ async function seedAutomationSession(baseUrl: string, repoPath: string): Promise
   return (await response.json()) as { id: string };
 }
 
+let failedRunProfileSequence = 0;
+
 async function createFailedRun(baseUrl: string) {
+  const profile = `failed-run-${++failedRunProfileSequence}`;
+  const profileResponse = await fetch(`${baseUrl}/api/profiles/create`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      name: profile,
+      description: 'Playwright failed automation run',
+      agent_kind: 'shell',
+      model: '',
+      effort: '',
+      protocol: 'terminal',
+      mode: 'auto',
+      class: 'automation',
+      strict: true,
+      env_clear: true,
+      ambient_allowlist: [],
+      max_concurrent: 0,
+      prelude: 'none',
+      restricted: false,
+      runtime_permissions: [],
+      mcp_access: { mode: 'none', groups: [] },
+    }),
+  });
+  expect(profileResponse.ok, await profileResponse.text()).toBe(true);
+
   const response = await fetch(`${baseUrl}/api/runs/create`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
-      profile: 'default',
+      profile,
       idempotency_key: `failed-workbench-${Date.now()}`,
       source: 'ops',
       session: {
         cwd: '/definitely/missing/automation-repo',
         title: 'failed-automation-task',
         goal: 'Exercise launch failure visibility',
-        agent: 'shell',
       },
     }),
   });


### PR DESCRIPTION
Keep unrestricted session credentials forward-compatible with operation-registry additions while preserving exact grants for restricted sessions.

Route current-session CLI workflows through their declared sessions operations, make session scope resolution accept the same aliases as handlers, and correct misleading authorization diagnostics. This restores existing ACP sessions after a server upgrade and makes effective permissions agree with actual authorization.

Also repair the stale automation E2E fixture exposed by the operation-model migration.