### PR TITLE
feat(loom): show handoff progress and pause sessions

### DIFF
--- a/crates/loom-forge/src/lifecycle.rs
+++ b/crates/loom-forge/src/lifecycle.rs
@@ -528,6 +528,34 @@ pub async fn reconcile_interrupted_transitions(state: &AppState) {
                     tracing::warn!(session = %session.id, %error, "transition recovery: could not release failed adoption");
                 }
             }
+            "handoff" => {
+                // A handoff keeps its source supervisor alive until the row is
+                // claimed as `handoff`, then replaces it. After an owner dies,
+                // a surviving supervisor is driveable again; a missing one is
+                // a recoverable error. Either way, release the durable pause so
+                // the operator can retry instead of leaving the session stuck.
+                let status = if backend::has_session(&session.term_session).await {
+                    if session.status == "handoff" {
+                        "running"
+                    } else {
+                        &session.status
+                    }
+                } else if session.status == "handoff" {
+                    "error"
+                } else {
+                    &session.status
+                };
+                if let Err(error) = session_mod::complete_interrupted_transition(
+                    &state.db,
+                    &session.id,
+                    "handoff",
+                    status,
+                )
+                .await
+                {
+                    tracing::warn!(session = %session.id, %error, "transition recovery: could not release interrupted handoff");
+                }
+            }
             other => {
                 tracing::warn!(session = %session.id, transition = other, "transition recovery: unknown transition left intact");
             }
@@ -535,7 +563,7 @@ pub async fn reconcile_interrupted_transitions(state: &AppState) {
     }
 }
 
-async fn record_transition(st: &AppState, branch: &Branch, kind: &str, step: &str) {
+pub async fn record_transition(st: &AppState, branch: &Branch, kind: &str, step: &str) {
     events::record(
         &st.db,
         &st.bus,

--- a/crates/loom-launch/src/handoff.rs
+++ b/crates/loom-launch/src/handoff.rs
@@ -9,7 +9,7 @@ use weaver_core::branch::{self as branch_mod, Branch};
 use weaver_core::BoxFut;
 
 use crate::session::{self as session_mod, Session};
-use crate::{agent, backend, custom_agents, events, repo, runtime, AppState};
+use crate::{agent, backend, custom_agents, events, lifecycle, repo, runtime, AppState};
 use weaver_api::operations::sessions;
 
 const HANDOFF_SUMMARY_CHARS: usize = 32 * 1024;
@@ -381,7 +381,17 @@ pub fn handoff_session(
     initial_session: Session,
     req: sessions::handoff::Input,
 ) -> BoxFut<'_, Result<(Session, Branch)>> {
-    Box::pin(handoff_session_inner(st, initial_session, req))
+    let st = st.clone();
+    Box::pin(async move {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        weaver_core::spawn_boxed(Box::pin(async move {
+            let result = handoff_session_inner(&st, initial_session, req).await;
+            let _ = result_tx.send(result);
+        }));
+        result_rx.await.map_err(|_| {
+            HandoffError::internal("handoff task stopped before reporting its result")
+        })?
+    })
 }
 
 async fn handoff_session_inner(
@@ -585,6 +595,14 @@ async fn handoff_session_inner(
             runtime::MISSING_GITHUB_TOKEN_MESSAGE.to_string(),
         ));
     }
+    if !session_mod::begin_transition(&st.db, &session.id, "handoff", "Pausing session").await? {
+        return Err(HandoffError::conflict(
+            "another lifecycle transition already owns this session",
+        ));
+    }
+    lifecycle::record_transition(st, &branch, "handoff", "Pausing session").await;
+
+    let result: Result<(Session, Branch)> = async {
     // A healthy task quiesces on its ordered command channel, preserving the
     // active-turn/queue safety gate. A missing task is the recovery case: settle
     // its persisted in-flight turn, retain the durable queue, and continue.
@@ -607,6 +625,14 @@ async fn handoff_session_inner(
         None
     };
     let source_task_quiesced = snapshot.is_some();
+    lifecycle::transition_step(
+        st,
+        &session,
+        &branch,
+        "handoff",
+        &format!("Transferring context to {target}"),
+    )
+    .await?;
     // Re-read after the task handshake: it may have vanished after our initial
     // route snapshot while persisting a newer in-flight turn.
     let persisted = session_mod::get(&st.db, &session.id)
@@ -868,6 +894,11 @@ async fn handoff_session_inner(
             "replacement provider token could not be committed: {error}"
         )));
     }
+    if !session_mod::clear_transition(&st.db, &session.id, "handoff").await? {
+        return Err(HandoffError::conflict(
+            "handoff lost ownership of its lifecycle transition",
+        ));
+    }
 
     events::record(
         &st.db,
@@ -881,6 +912,31 @@ async fn handoff_session_inner(
     session_mod::with_branch(&st.db, &session.id)
         .await?
         .ok_or_else(|| HandoffError::not_found("session"))
+    }
+    .await;
+
+    if result.is_err() {
+        match session_mod::clear_transition(&st.db, &session.id, "handoff").await {
+            Ok(true) => {
+                events::record(
+                    &st.db,
+                    &st.bus,
+                    &branch.id,
+                    "handoff",
+                    json!({ "state": "stopped" }),
+                )
+                .await
+                .ok();
+            }
+            Ok(false) => {
+                tracing::warn!(session = %session.id, "handoff error cleanup no longer owned its transition");
+            }
+            Err(error) => {
+                tracing::warn!(session = %session.id, %error, "handoff error cleanup could not clear its transition");
+            }
+        }
+    }
+    result
 }
 
 #[cfg(test)]

--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -1750,6 +1750,28 @@ function goTo(anchor: string) {
       </div>
     </template>
 
+    <div
+      v-if="session.transition?.kind === 'handoff'"
+      class="mx-3 mb-3 flex shrink-0 items-center gap-3 rounded border border-info-line/40 bg-info-soft px-3 py-2 text-info"
+      data-testid="handoff-progress"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <span class="relative flex h-3 w-3 shrink-0" aria-hidden="true">
+        <span
+          class="absolute inline-flex h-full w-full animate-ping rounded-full bg-info opacity-40"
+        ></span>
+        <span class="relative inline-flex h-3 w-3 rounded-full bg-info"></span>
+      </span>
+      <span class="min-w-0">
+        <span class="block text-xs font-medium">Handoff in progress</span>
+        <span class="block truncate text-2xs">
+          {{ session.transition.step || 'Transferring session context' }} · Session paused
+        </span>
+      </span>
+    </div>
+
     <!-- Composer. -->
     <form
       v-if="composerVisible"

--- a/crates/loom/frontend/src/components/SessionPageHeader.vue
+++ b/crates/loom/frontend/src/components/SessionPageHeader.vue
@@ -345,6 +345,7 @@ async function submitHandoff() {
       await resolveHandoff();
     }
     handoffError.value = message;
+    await emit('reload');
   } finally {
     handoffBusy.value = false;
   }

--- a/crates/loom/frontend/src/components/StatusBadge.vue
+++ b/crates/loom/frontend/src/components/StatusBadge.vue
@@ -17,6 +17,7 @@ const palette: Record<string, string> = {
   creating: 'bg-info-soft text-info ring-1 ring-inset ring-info-line/30',
   archiving: 'bg-info-soft text-info ring-1 ring-inset ring-info-line/30',
   adopting: 'bg-info-soft text-info ring-1 ring-inset ring-info-line/30',
+  handoff: 'bg-info-soft text-info ring-1 ring-inset ring-info-line/30',
   archived: 'bg-subtle text-faint',
 };
 

--- a/crates/loom/frontend/src/lib/sessionState.test.mjs
+++ b/crates/loom/frontend/src/lib/sessionState.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { effectiveAttention, messageOf } from './sessionState.ts';
+import { canSend, conversationState, effectiveAttention, messageOf } from './sessionState.ts';
 
 test('an orphaned ACP runtime surfaces Loom recovery guidance', () => {
   const session = {
@@ -28,5 +28,24 @@ test('an orphaned ACP runtime surfaces Loom recovery guidance', () => {
     raisedBy: 'watch',
     note: 'Loom lost its connection. Select Adopt to reconnect.',
     stale: false,
+  });
+});
+
+test('a handoff is presented as a paused lifecycle transition', () => {
+  const session = {
+    status: 'running',
+    transition: {
+      kind: 'handoff',
+      step: 'Transferring context to codex',
+      started_at: '2026-08-28T20:00:00Z',
+    },
+    branch: { tags: [] },
+  };
+
+  assert.equal(canSend(session), false);
+  assert.deepEqual(conversationState(session), {
+    glyph: '▶',
+    label: 'Handing off — Transferring context to codex',
+    tone: 'info',
   });
 });

--- a/crates/loom/frontend/src/lib/sessionState.ts
+++ b/crates/loom/frontend/src/lib/sessionState.ts
@@ -247,7 +247,12 @@ export interface ConvState {
 export function conversationState(s: SessionSummary): ConvState {
   // Lifecycle first for the unambiguous mechanical states.
   if (s.transition) {
-    const label = s.transition.kind === 'archiving' ? 'Archiving' : 'Adopting';
+    const label =
+      s.transition.kind === 'archiving'
+        ? 'Archiving'
+        : s.transition.kind === 'handoff'
+          ? 'Handing off'
+          : 'Adopting';
     return {
       glyph: '▶',
       label: s.transition.step ? `${label} — ${s.transition.step}` : label,

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1000,12 +1000,13 @@ fn require_acp(session: &Session) -> ApiResult<()> {
     }
 }
 
-/// The live ACP task handle for a session, or 409 while a lifecycle transition
-/// pauses input or when no task is running.
+/// The live ACP task handle for a session, or 409 while a provider handoff
+/// pauses input or when no task is running. Adoption deliberately remains
+/// driveable because setup-time permission requests must be answerable.
 fn require_acp_task(st: &AppState, session: &Session) -> ApiResult<crate::acp::AcpHandle> {
-    if let Some(transition) = session.lifecycle_transition.as_deref() {
+    if session.lifecycle_transition.as_deref() == Some("handoff") {
         return Err(AppError::conflict(format!(
-            "session '{}' is paused for {transition}; wait for the transition to finish",
+            "session '{}' is paused for handoff; wait for the transition to finish",
             session.id
         )));
     }

--- a/crates/loom/src/web/sessions.rs
+++ b/crates/loom/src/web/sessions.rs
@@ -1000,9 +1000,15 @@ fn require_acp(session: &Session) -> ApiResult<()> {
     }
 }
 
-/// The live ACP task handle for a session, or 409 when no task is running (the
-/// session is idle/orphaned — nothing to drive over the protocol right now).
+/// The live ACP task handle for a session, or 409 while a lifecycle transition
+/// pauses input or when no task is running.
 fn require_acp_task(st: &AppState, session: &Session) -> ApiResult<crate::acp::AcpHandle> {
+    if let Some(transition) = session.lifecycle_transition.as_deref() {
+        return Err(AppError::conflict(format!(
+            "session '{}' is paused for {transition}; wait for the transition to finish",
+            session.id
+        )));
+    }
     st.acp.get(&session.id).ok_or_else(|| {
         AppError::conflict(format!(
             "session '{}' has no live ACP task to drive",

--- a/crates/loom/tests/fixtures/fake-acp-agent.mjs
+++ b/crates/loom/tests/fixtures/fake-acp-agent.mjs
@@ -382,6 +382,7 @@ async function handlePrompt(id, params) {
     return;
   }
   if (summaryOutput !== undefined && text.startsWith("Summarize this coding session")) {
+    await sleepCancellable(Number(process.env.FAKE_ACP_SUMMARY_DELAY || "0"));
     if (summaryOutput.length > 0) {
       notify({
         sessionUpdate: "agent_message_chunk",

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -3379,10 +3379,6 @@ async fn handoff_replaces_provider_and_continues_the_journal() {
         "the stable lifecycle state is retained"
     );
     assert_eq!(paused.lifecycle_transition.as_deref(), Some("handoff"));
-    assert!(
-        !handoff.is_finished(),
-        "the progress state precedes completion"
-    );
 
     let paused_send = ts
         .client

--- a/crates/loom/tests/integration/acp.rs
+++ b/crates/loom/tests/integration/acp.rs
@@ -3338,7 +3338,7 @@ async fn handoff_replaces_provider_and_continues_the_journal() {
         &ts,
         "fake-b",
         format!(
-            "FAKE_ACP_MODELS=luna FAKE_ACP_SUMMARY_OUTPUT_B64={encoded} {}",
+            "FAKE_ACP_MODELS=luna FAKE_ACP_SUMMARY_OUTPUT_B64={encoded} FAKE_ACP_SUMMARY_DELAY=750 {}",
             agent_cmd()
         ),
     )
@@ -3353,19 +3353,62 @@ async fn handoff_replaces_provider_and_continues_the_journal() {
     })
     .await;
 
-    let handed = ts
+    let url = format!("http://{}/api/sessions/handoff", ts.addr);
+    let handoff_id = id.clone();
+    let handoff = tokio::spawn(async move {
+        reqwest::Client::new()
+            .post(url)
+            .json(&json!({ "agent": "fake-b", "session": handoff_id }))
+            .send()
+            .await
+            .unwrap()
+    });
+    let paused = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let current = session_mod::get(&ts.state.db, &id).await.unwrap().unwrap();
+            if current.lifecycle_step.as_deref() == Some("Transferring context to fake-b") {
+                break current;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("handoff publishes progress while the request is running");
+    assert_eq!(
+        paused.status, "running",
+        "the stable lifecycle state is retained"
+    );
+    assert_eq!(paused.lifecycle_transition.as_deref(), Some("handoff"));
+    assert!(
+        !handoff.is_finished(),
+        "the progress state precedes completion"
+    );
+
+    let paused_send = ts
         .client
         .post(
-            "/api/sessions/handoff",
-            json!({ "agent": "fake-b", "session": id }),
+            "/api/sessions/prompt/create",
+            json!({ "text": "say:too soon", "session": id }),
         )
         .await
-        .expect("handoff succeeds");
+        .expect_err("handoff pauses new prompts");
+    assert!(
+        paused_send.to_string().contains("paused for handoff"),
+        "{paused_send}"
+    );
+
+    let response = tokio::time::timeout(Duration::from_secs(15), handoff)
+        .await
+        .expect("handoff completes")
+        .unwrap();
+    assert!(response.status().is_success(), "{response:?}");
+    let handed: Value = response.json().await.unwrap();
     assert_eq!(handed["id"], id, "loom session id stays stable");
     assert_eq!(handed["branch"]["id"], branch_id);
     assert_eq!(handed["work_dir"], work_dir);
     assert_eq!(handed["agent_kind"], "fake-b");
     assert!(handed["acp_session_id"].as_str().is_some());
+    assert!(handed["transition"].is_null());
 
     let chat = poll_chat(&ts, &id, Duration::from_secs(15), |blocks| {
         blocks.iter().filter(|b| b["kind"] == "turn_end").count() >= 2
@@ -3900,6 +3943,7 @@ async fn handoff_failure_cleans_up_the_replacement() {
         .await
         .unwrap();
     assert_eq!(view["status"], "error");
+    assert!(view["transition"].is_null());
     assert_eq!(view["agent_kind"], "broken-acp");
     assert_eq!(view["acp_session_id"], Value::Null);
     assert!(!ts.state.acp.is_live(&id), "replacement task is gone");

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -186,7 +186,7 @@ impl From<&BranchView> for BranchSummaryView {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 pub struct SessionTransitionView {
-    /// Stable operation name: currently `archiving` or `adopting`.
+    /// Stable operation name: `archiving`, `adopting`, or `handoff`.
     pub kind: String,
     /// Human-readable current stage, suitable for direct UI presentation.
     pub step: String,

--- a/docs/loom-ui.md
+++ b/docs/loom-ui.md
@@ -83,6 +83,11 @@ promoted with **Stop & send**. Permission requests and runtime controls stay in
 the conversation that produced them; elapsed quiet time is evidence, not an
 automatic “stuck” verdict.
 
+An in-place model handoff pauses conversation input and shows the server-owned
+handoff stage until the incoming provider is ready. The same transition appears
+in the session header and fleet, so leaving the open Details popover does not
+hide a transfer that is still running.
+
 Review contains **Changes** and **Artifacts**. Both use the same staged review
 workflow:
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -70,12 +70,15 @@ Long-running external mutations keep that last completed status and publish a
 durable `transition` alongside it. Archive reports `archiving` with stages such
 as conversation capture, agent shutdown, worktree removal, and finalization.
 Adopt/recover report `adopting`, including worktree rebuild where recovery needs
-one. Fleet and detail views show the transition and current free-text stage;
-lifecycle actions and conversation input stay unavailable until it clears.
+one. Provider replacement reports `handoff` while it pauses the source and
+transfers context to the incoming model. Fleet and detail views show the
+transition and current free-text stage; lifecycle actions and conversation input
+stay unavailable until it clears.
 Competing operations serialize on the lifecycle lock and also claim the marker
 atomically, so overlapping server generations cannot both mutate the same row.
-On restart Loom resumes an interrupted archive/adoption or restores the last
-recoverable stable state before ordinary supervisor reconciliation.
+On restart Loom resumes an interrupted archive/adoption, releases an interrupted
+handoff into a driveable or recoverable state, or restores the last recoverable
+stable state before ordinary supervisor reconciliation.
 
 `automation_runs.status` describes delivery/provisioning rather than agent
 liveness: `creating`, `waiting`, `delivering`, `running`, `failed`,

--- a/e2e/tests/acp-conversation.spec.ts
+++ b/e2e/tests/acp-conversation.spec.ts
@@ -48,7 +48,11 @@ async function defineFakeAcpAgent(
   weaver: WeaverFixture,
   name: string,
   label: string,
+  options: { summaryDelay?: number } = {},
 ): Promise<void> {
+  const summaryEnv = options.summaryDelay
+    ? `FAKE_ACP_SUMMARY_OUTPUT_B64= FAKE_ACP_SUMMARY_DELAY=${options.summaryDelay} `
+    : '';
   const res = await fetch(`${weaver.baseUrl}/api/agents/custom/create`, {
     method: 'POST',
     headers: HEADERS,
@@ -56,7 +60,7 @@ async function defineFakeAcpAgent(
       name,
       label,
       setup: '',
-      launch: `node ${FAKE_AGENT}`,
+      launch: `${summaryEnv}node ${FAKE_AGENT}`,
       resume: '',
       reports_status: false,
       protocol: 'acp',
@@ -257,7 +261,9 @@ test.describe('acp conversation', () => {
     const conv = page.getByTestId('acp-conversation');
     await expect(conv.getByText('before handoff', { exact: true })).toBeVisible();
     await expect(page.getByTestId('acp-turn-rule')).toBeVisible();
-    await defineFakeAcpAgent(weaver, 'acp-fake-next', 'ACP fake next');
+    await defineFakeAcpAgent(weaver, 'acp-fake-next', 'ACP fake next', {
+      summaryDelay: 750,
+    });
     await fetch(`${weaver.baseUrl}/api/profiles/create`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -288,11 +294,17 @@ test.describe('acp conversation', () => {
     await expect(form.getByTestId('resolved-launch-summary')).toContainText('acp-fake-next');
     await form.getByRole('button', { name: 'Hand off now' }).click();
 
+    const progress = page.getByTestId('handoff-progress');
+    await expect(progress).toContainText('Handoff in progress');
+    await expect(progress).toContainText('Session paused');
+    await expect(page.getByTestId('acp-composer')).toHaveCount(0);
+
     // The stable session URL and earlier prose survive; only the provider and
     // its private ACP connection change. The journal makes that boundary clear.
     await expect(page).toHaveURL(new RegExp(`/s/${s.id}$`));
     await expect.poll(async () => (await weaver.getSession(s.id)).agent_kind).toBe('acp-fake-next');
     await expect(page.getByText('Handed off to acp-fake-next.')).toBeVisible();
+    await expect(progress).toHaveCount(0);
     await expect(conv.getByText('before handoff', { exact: true })).toBeVisible();
     await expect
       .poll(async () => {


### PR DESCRIPTION
Model handoffs now publish a durable lifecycle transition before quiescing the source session and advance it while context is transferred. Conversation input is rejected while the transition owns the session, and interrupted handoffs release into a driveable or recoverable state instead of remaining stuck.

The session header and fleet reuse that server-backed transition, while ACP conversations replace the composer with an animated handoff progress indicator until the incoming provider is ready. Integration and Playwright coverage exercise the visible pause, input rejection, successful completion, and failure cleanup.