### PR TITLE
fix(loom): suffix duplicate session names

### DIFF
--- a/crates/loom-launch/src/provision.rs
+++ b/crates/loom-launch/src/provision.rs
@@ -960,8 +960,8 @@ async fn create_inner(
                 )));
             }
         }
-        let explicit = req.name.as_deref().map(str::trim).filter(|n| !n.is_empty());
-        let base_slug = branch_mod::slugify(explicit.unwrap_or(title.as_str()));
+        let requested_name = req.name.as_deref().map(str::trim).filter(|n| !n.is_empty());
+        let base_slug = branch_mod::slugify(requested_name.unwrap_or(title.as_str()));
         tracing::debug!(base_slug = %base_slug, base = %base, "creating new branch for session");
         let mut slug = base_slug.clone();
         let mut suffix = 2;
@@ -970,11 +970,6 @@ async fn create_inner(
             let dir = repo_root.join(".worktrees").join(&slug);
             if !git::branch_exists(&repo_root, &branch_name).await && !dir.exists() {
                 break;
-            }
-            if explicit.is_some() {
-                return Err(ProvisionError::conflict(format!(
-                    "a session named '{slug}' already exists — choose a different name"
-                )));
             }
             slug = format!("{base_slug}-{suffix}");
             suffix += 1;

--- a/crates/loom/tests/integration/sessions.rs
+++ b/crates/loom/tests/integration/sessions.rs
@@ -126,6 +126,58 @@ async fn create_lists_and_tears_down() {
     assert_eq!(recent[0]["active_branches"], 0);
 }
 
+/// Explicit names are hints for readable branches and worktrees, not globally
+/// reserved identities. Reusing one gets the same suffixing as a derived name.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn duplicate_explicit_name_gets_unique_suffix() {
+    let ts = TestServer::start().await;
+
+    let first = ts
+        .client
+        .post(
+            "/api/sessions/launch",
+            json!({
+                "goal": "first rollout",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "name": "iris-rollout",
+            }),
+        )
+        .await
+        .unwrap();
+    let second = ts
+        .client
+        .post(
+            "/api/sessions/launch",
+            json!({
+                "goal": "second rollout",
+                "cwd": ts.cwd(),
+                "agent": "shell",
+                "name": "iris-rollout",
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(first["branch"]["branch"], "weaver/iris-rollout");
+    assert_eq!(second["branch"]["branch"], "weaver/iris-rollout-2");
+    assert!(second["work_dir"]
+        .as_str()
+        .unwrap()
+        .ends_with("/.worktrees/iris-rollout-2"));
+
+    for session in [&first, &second] {
+        ts.client
+            .post(
+                "/api/sessions/delete",
+                json!({ "session": session["id"].as_str().unwrap() }),
+            )
+            .await
+            .unwrap();
+    }
+}
+
 /// New-session provisioning waits at the repository boundary before it fetches,
 /// selects a branch, or creates a worktree. Holding the same gate here gives the
 /// route a deterministic concurrency test without racing real git subprocesses.


### PR DESCRIPTION
Reuse Loom's existing numeric suffix fallback when an explicit session name collides with a branch or worktree. A repeated name such as iris-rollout now creates iris-rollout-2 instead of rejecting the launch, while preserving readable branch and worktree names.\n\nAdds an integration test covering duplicate explicitly named launches.\n\nAgent lint review skipped: narrow session-name collision handling change covered by a focused integration test.