### PR TITLE
fix(loom): show conversation times in viewer locale

### DIFF
--- a/crates/loom/frontend/src/components/AcpConversation.vue
+++ b/crates/loom/frontend/src/components/AcpConversation.vue
@@ -53,6 +53,7 @@ import { openTopic, type TopicHandle } from '../lib/eventStream';
 import { chatBlockKey, ChatJournalReconciler } from '../lib/chatJournal';
 import { useFollowFoot } from '../lib/followFoot';
 import { formatTokens } from '../lib/usage';
+import { localTime } from '../lib/time';
 import MarkdownView from './MarkdownView.vue';
 import AgentUsage from './AgentUsage.vue';
 import ToolContentPreview from './ToolContentPreview.vue';
@@ -918,10 +919,6 @@ function titleOf(text: string): string {
   const f = firstLine(text) || '(no text)';
   return f.replace(/^[#>\-*`\s]+/, '').trim() || f;
 }
-function shortTime(ts: string): string {
-  return ts.length >= 16 && ts[10] === 'T' ? ts.slice(11, 16) : ts;
-}
-
 function usageFromPayload(payload: UsagePayload): AcpUsage | null {
   return typeof payload.used === 'number' && typeof payload.size === 'number' && payload.size > 0
     ? { used: payload.used, size: payload.size, cost: payload.cost ?? null }
@@ -1006,7 +1003,7 @@ const model = computed<{ rows: Row[]; toc: TocItem[]; usage: AcpUsage | null }>(
           anchor,
           n,
           turn: b.turn,
-          time: shortTime(b.created_at),
+          time: localTime(b.created_at),
           text,
           steered,
         });
@@ -1028,7 +1025,7 @@ const model = computed<{ rows: Row[]; toc: TocItem[]; usage: AcpUsage | null }>(
         rows.push({
           type: 'agent',
           key: k,
-          time: shortTime(b.created_at),
+          time: localTime(b.created_at),
           text,
           streaming: false,
         });
@@ -1601,7 +1598,7 @@ function goTo(anchor: string) {
                   data-testid="acp-permission-receipt"
                 >
                   {{ row.perm.outcome.cancelled ? 'cancelled' : row.perm.outcome.option_id }} ·
-                  {{ shortTime(row.perm.outcome.at) }}
+                  {{ localTime(row.perm.outcome.at) }}
                 </div>
                 <div v-else class="acp-perm-options">
                   <button

--- a/crates/loom/frontend/src/components/TerminalConversation.vue
+++ b/crates/loom/frontend/src/components/TerminalConversation.vue
@@ -15,6 +15,7 @@ import type { IrisLog, IrisBlock, Session } from '../types';
 import { canSend, conversationState, effectiveAttention, TONE_TEXT } from '../lib/sessionState';
 import { useFollowFoot } from '../lib/followFoot';
 import { openSessionEvents, type SessionEventsHandle } from '../lib/sessionEvents';
+import { localTime } from '../lib/time';
 import MarkdownView from './MarkdownView.vue';
 
 // The Conversation tab for a *terminal-backend* session (`protocol='terminal'`):
@@ -460,8 +461,7 @@ const banner = computed(() => {
 });
 
 function shortTime(ts?: string): string {
-  if (!ts) return '';
-  return ts.length >= 19 && ts[10] === 'T' ? ts.slice(11, 19) : ts;
+  return localTime(ts, { second: '2-digit' });
 }
 
 // A shell command (Bash `command`, Codex `cmd`) renders as the command itself;

--- a/crates/loom/frontend/src/lib/time.test.mjs
+++ b/crates/loom/frontend/src/lib/time.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { localTime } from './time.ts';
+
+test('clock times are converted from UTC to the viewer timezone', () => {
+  assert.equal(
+    localTime('2026-09-02T15:02:00Z', { timeZone: 'America/Los_Angeles' }, 'en-US'),
+    '8:02 AM',
+  );
+});
+
+test('clock times follow the viewer locale and can include seconds', () => {
+  assert.equal(
+    localTime(
+      '2026-09-02T15:02:09Z',
+      { timeZone: 'America/Los_Angeles', second: '2-digit' },
+      'en-GB',
+    ),
+    '8:02:09',
+  );
+});
+
+test('missing and invalid clock times remain safe to render', () => {
+  assert.equal(localTime(null), '');
+  assert.equal(localTime('not-a-time'), 'not-a-time');
+});

--- a/crates/loom/frontend/src/lib/time.ts
+++ b/crates/loom/frontend/src/lib/time.ts
@@ -32,3 +32,20 @@ export function exactTime(iso: string): string {
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
 }
+
+/** Compact clock time in the viewer's browser timezone and locale. Server
+ * timestamps stay absolute/UTC; only the presentation is localized here. */
+export function localTime(
+  iso: string | null | undefined,
+  options: Intl.DateTimeFormatOptions = {},
+  locales?: Intl.LocalesArgument,
+): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleTimeString(locales, {
+    hour: 'numeric',
+    minute: '2-digit',
+    ...options,
+  });
+}


### PR DESCRIPTION
Render ACP and terminal conversation timestamps through the browser's locale and timezone instead of slicing the UTC clock value from ISO strings. This keeps server timestamps canonical while making the chat match each viewer's local clock and 12/24-hour preference.\n\nAgent lint review skipped: narrow presentation-only change covered by focused unit tests and the deterministic frontend gate.