### PR TITLE
refactor(loom): discover remote MCP tools

### DIFF
--- a/crates/loom-agent/src/mcp/mod.rs
+++ b/crates/loom-agent/src/mcp/mod.rs
@@ -158,14 +158,13 @@ struct RemoteMcpRow {
     url: String,
     auth_json: String,
     digest: String,
-    tools_json: String,
     created_at: String,
     updated_at: String,
 }
 
 fn remote_mcp_query() -> &'static str {
     "SELECT s.identity, s.group_name, s.label, s.description, s.enabled,
-            s.current_revision, r.url, r.auth_json, r.digest, r.tools_json,
+            s.current_revision, r.url, r.auth_json, r.digest,
             s.created_at, s.updated_at
      FROM remote_mcp_servers s
      JOIN remote_mcp_revisions r
@@ -184,7 +183,6 @@ fn remote_mcp_view(row: RemoteMcpRow) -> Result<RemoteMcpView> {
         digest: row.digest,
         url: row.url,
         auth: serde_json::from_str(&row.auth_json).context("invalid remote MCP auth")?,
-        tools: serde_json::from_str(&row.tools_json).context("invalid remote MCP tools")?,
         created_at: row.created_at,
         updated_at: row.updated_at,
     })
@@ -219,7 +217,6 @@ pub fn ready_remote_snapshots(items: &[RemoteMcpView]) -> Vec<RemoteMcpSnapshot>
             server_name: item.server_name.clone(),
             url: item.url.clone(),
             auth: item.auth.clone(),
-            tools: item.tools.clone(),
         })
         .collect()
 }
@@ -499,12 +496,7 @@ pub fn rules_for_snapshot(snapshot: &weaver_api::McpPolicySnapshot) -> Result<Ve
         }
     }
     for server in &snapshot.remote_servers {
-        for tool in &server.tools {
-            push_unique(
-                &mut rules,
-                custom_permission_rule(&server.server_name, tool),
-            );
-        }
+        push_unique(&mut rules, custom_permission_rule(&server.server_name, "*"));
     }
     Ok(rules)
 }
@@ -1082,12 +1074,11 @@ mod tests {
                     environment: "MARINA_TOKEN".to_string(),
                     prefix: "Bearer ".to_string(),
                 },
-                tools: vec!["find_tool".to_string(), "call_tool".to_string()],
             }],
             ..Default::default()
         };
         let servers = super::acp_server_configs(
-            &["mcp__loom_remote_test__find_tool".to_string()],
+            &["mcp__loom_remote_test__*".to_string()],
             Some(&snapshot),
             &[("MARINA_TOKEN".to_string(), "secret".to_string())],
         )
@@ -1105,7 +1096,7 @@ mod tests {
         );
 
         let error = super::acp_server_configs(
-            &["mcp__loom_remote_test__find_tool".to_string()],
+            &["mcp__loom_remote_test__*".to_string()],
             Some(&snapshot),
             &[],
         )

--- a/crates/loom-policy/src/remote_mcp.rs
+++ b/crates/loom-policy/src/remote_mcp.rs
@@ -7,8 +7,6 @@ use weaver_api::{RemoteMcpAuth, RemoteMcpReq, RemoteMcpView};
 use crate::db::{now_iso, Db};
 pub use crate::mcp::{get_remote as get, list_remote as list, remote_server_name as server_name};
 
-const TOOL_MAX_COUNT: usize = 256;
-
 fn valid_name(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 128
@@ -79,29 +77,14 @@ fn validate_request(req: &RemoteMcpReq) -> Result<(String, String)> {
         bail!("remote MCP description must be at most 4096 bytes");
     }
     validate_auth(&req.auth)?;
-    if req.tools.is_empty() || req.tools.len() > TOOL_MAX_COUNT {
-        bail!("remote MCP must declare 1 to {TOOL_MAX_COUNT} tools");
-    }
-    let mut unique = std::collections::HashSet::new();
-    if req
-        .tools
-        .iter()
-        .any(|tool| !valid_name(tool) || !unique.insert(tool))
-    {
-        bail!("remote MCP tool names must be unique and use letters, digits, '-' or '_'");
-    }
     Ok((group, normalized_url(&req.url)?))
 }
 
-fn digest(url: &str, auth: &RemoteMcpAuth, tools: &[String]) -> Result<String> {
+fn digest(url: &str, auth: &RemoteMcpAuth) -> Result<String> {
     let mut hasher = Sha256::new();
     hasher.update(url);
     hasher.update([0]);
     hasher.update(serde_json::to_vec(auth)?);
-    for tool in tools {
-        hasher.update([0]);
-        hasher.update(tool);
-    }
     Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
 }
 
@@ -121,7 +104,6 @@ pub async fn upsert(db: &Db, req: &RemoteMcpReq) -> Result<RemoteMcpView> {
     if let Some(existing) = &existing {
         if existing.url == url
             && existing.auth == req.auth
-            && existing.tools == req.tools
             && existing.label == req.label.trim()
             && existing.description == req.description.trim()
             && existing.enabled == req.enabled
@@ -153,15 +135,14 @@ pub async fn upsert(db: &Db, req: &RemoteMcpReq) -> Result<RemoteMcpView> {
     .await?;
     sqlx::query(
         "INSERT INTO remote_mcp_revisions
-         (identity, revision, url, auth_json, digest, tools_json, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)",
+         (identity, revision, url, auth_json, digest, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)",
     )
     .bind(req.identity.trim())
     .bind(revision)
     .bind(&url)
     .bind(serde_json::to_string(&req.auth)?)
-    .bind(digest(&url, &req.auth, &req.tools)?)
-    .bind(serde_json::to_string(&req.tools)?)
+    .bind(digest(&url, &req.auth)?)
     .bind(&now)
     .execute(&mut *tx)
     .await?;
@@ -246,7 +227,6 @@ mod tests {
             identity: "/ops/api".to_string(),
             label: "API".to_string(),
             url: "http://example.com/mcp".to_string(),
-            tools: vec!["read".to_string()],
             ..Default::default()
         };
         assert!(validate_request(&req).is_err());
@@ -258,8 +238,7 @@ mod tests {
             "identity": "/ops/api",
             "label": "API",
             "url": "https://example.com/mcp",
-            "auth": {"type": "iap", "audience": "iap-client-id"},
-            "tools": ["read"]
+            "auth": {"type": "iap", "audience": "iap-client-id"}
         }))
         .unwrap();
 

--- a/crates/loom-store/migrations/0030_remote_mcp.sql
+++ b/crates/loom-store/migrations/0030_remote_mcp.sql
@@ -16,7 +16,6 @@ CREATE TABLE remote_mcp_revisions (
     url         TEXT NOT NULL,
     auth_json   TEXT NOT NULL,
     digest      TEXT NOT NULL,
-    tools_json  TEXT NOT NULL,
     created_at  TEXT NOT NULL,
     PRIMARY KEY (identity, revision)
 );

--- a/crates/loom/src/web/mcps.rs
+++ b/crates/loom/src/web/mcps.rs
@@ -38,7 +38,6 @@ pub(super) async fn create_remote_mcp_operation(
         description: input.description,
         url: input.url,
         auth: input.auth,
-        tools: input.tools,
         enabled: input.enabled,
     };
     let st = &context.state;
@@ -76,7 +75,6 @@ pub(super) async fn update_remote_mcp_operation(
         description: input.description,
         url: input.url,
         auth: input.auth,
-        tools: input.tools,
         enabled: input.enabled,
     };
     let st = &context.state;

--- a/crates/loom/tests/integration/profiles.rs
+++ b/crates/loom/tests/integration/profiles.rs
@@ -64,7 +64,6 @@ async fn remote_mcp_profile_pins_revisions_and_renders_http() {
             "environment": "MARINA_MCP_TOKEN",
             "prefix": "Bearer "
         },
-        "tools": ["find_tool", "call_tool"],
         "enabled": true
     });
     let created = ts
@@ -109,7 +108,7 @@ async fn remote_mcp_profile_pins_revisions_and_renders_http() {
         .as_array()
         .unwrap()
         .iter()
-        .any(|rule| rule.as_str().unwrap().ends_with("__find_tool")));
+        .any(|rule| rule.as_str().unwrap().ends_with("__*")));
 
     let mut changed = server;
     changed["url"] = json!("https://marina.example.com/api/marina/mcp/v2/");
@@ -946,7 +945,6 @@ async fn deployment_reconcile_rest_journey() {
                 "environment": "MARINA_MCP_TOKEN",
                 "prefix": "Bearer "
             },
-            "tools": ["find_tool", "call_tool"],
             "enabled": true
         }],
         "profiles": [{
@@ -1013,10 +1011,6 @@ async fn deployment_reconcile_rest_journey() {
     );
     assert_eq!(first["remote_mcps"][0]["identity"], "/marina/api");
     assert_eq!(first["remote_mcps"][0]["revision"], 1);
-    assert_eq!(
-        first["remote_mcps"][0]["tools"],
-        json!(["find_tool", "call_tool"])
-    );
     assert_eq!(first["remote_mcps"][0]["auth"]["type"], "environment");
     assert_eq!(first["profiles"][0]["env"][0]["source"], "gcp_secret");
     assert_eq!(

--- a/crates/weaver-api/src/dto.rs
+++ b/crates/weaver-api/src/dto.rs
@@ -855,7 +855,6 @@ pub struct RemoteMcpReq {
     pub url: String,
     #[serde(default)]
     pub auth: RemoteMcpAuth,
-    pub tools: Vec<String>,
     #[serde(default = "default_true")]
     pub enabled: bool,
 }
@@ -873,7 +872,6 @@ pub struct RemoteMcpView {
     pub server_name: String,
     pub url: String,
     pub auth: RemoteMcpAuth,
-    pub tools: Vec<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -888,7 +886,6 @@ pub struct RemoteMcpSnapshot {
     pub server_name: String,
     pub url: String,
     pub auth: RemoteMcpAuth,
-    pub tools: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]

--- a/crates/weaver-api/src/operations/mcps.rs
+++ b/crates/weaver-api/src/operations/mcps.rs
@@ -26,8 +26,6 @@ pub mod remote {
             pub url: String,
             #[operand(json, default = RemoteMcpAuth::default())]
             pub auth: RemoteMcpAuth,
-            #[operand(json)]
-            pub tools: Vec<String>,
             #[operand(default = true)]
             pub enabled: bool,
         }
@@ -89,8 +87,6 @@ pub mod remote {
             pub url: String,
             #[operand(json, default = RemoteMcpAuth::default())]
             pub auth: RemoteMcpAuth,
-            #[operand(json)]
-            pub tools: Vec<String>,
             #[operand(default = true)]
             pub enabled: bool,
         }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,7 +63,7 @@ and the rule for placing a new module.
 | `crates/loom-agent/src/agent.rs` | `AgentManager` plus launch mapping: resolves registered runtimes, launches terminal agents, builds ACP launches, and runs transient ACP judgement prompts for handoff summaries and `POST /api/agents/oneshot` |
 | `crates/loom-agent/src/mcp/` | trusted builtin MCP registry and stdio adapters: provider-neutral versioned capability sets, exact permission translation, and the fixed GitHub/messaging/self-history bridges |
 | `crates/loom-policy/src/custom_mcp.rs` | operator-authored MCP definitions: grouped path identities, immutable sqlite revisions, bounded `uv` validation, and exact session-snapshot execution |
-| `crates/loom-policy/src/remote_mcp.rs` | operator-registered Streamable HTTP MCP definitions: grouped identities, immutable URL/auth/tool revisions, deployment ownership, and profile pinning |
+| `crates/loom-policy/src/remote_mcp.rs` | operator-registered Streamable HTTP MCP definitions: grouped identities, immutable URL/auth revisions, deployment ownership, and profile pinning |
 | `crates/loom-policy/src/profile.rs` | named launch policy, including provider-neutral `mcp_access` resolution and the restricted-profile trust boundary |
 | `crates/loom-core/src/launch.rs` | canonical profile-template and override resolution for previews, creates, clones, and handoffs; returns the concrete private launch snapshot plus its transport-safe view |
 | `crates/loom-launch/src/handoff.rs` | provider handoff orchestration: canonical/legacy target resolution, conversation continuity, lifecycle fencing, rollback, and replacement cleanup; depends on runtime/domain owners, never the REST adapter |
@@ -1107,8 +1107,9 @@ enabled validated custom definitions, and enabled remote definitions, then pins
 the exact result to that profile revision. Launch copies capability identities,
 digests, custom source revisions, and remote HTTP descriptors into
 `sessions.policy_mcp_access`. Every ACP runtime receives native `mcpServers`
-descriptors whose exposed tools are filtered to the stamped rules; remote
-servers use ACP's HTTP transport directly rather than a Loom proxy process.
+descriptors. Custom-server tools are filtered to the stamped rules; remote
+servers use ACP's HTTP transport directly and advertise their tools with MCP
+`tools/list` rather than passing through a Loom proxy process.
 One built-in `loom` MCP server exposes namespaced context, channel, artifact,
 session, messaging, permission, issue, and fixed-repository GitHub tools.
 Resource tools return concise text plus

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,9 +102,6 @@ remote_mcps:
     auth:
       type: iap
       audience: IAP_CLIENT_ID
-    tools:
-      - find_tool
-      - call_tool
     enabled: true
 federations: []
 prune: true

--- a/docs/mcp-profiles.md
+++ b/docs/mcp-profiles.md
@@ -8,8 +8,8 @@ final boundary.
 ## Ownership
 
 - **The registry describes capability.** Each builtin, custom, or remote entry
-  has a stable identity, group, version or revision, content digest, and exact
-  tool names. Builtin and custom entries also pin advertised schemas. All
+  has a stable identity, group, version or revision, and content digest.
+  Builtin and custom entries also pin exact tool names and advertised schemas. All
   builtin entries share Loom's aggregate server descriptor.
 - **A profile selects and pins policy.** `mcp_access` is `none`, `all`, or an
   explicit group list. Saving the profile resolves enabled registry content and
@@ -69,10 +69,10 @@ restricted profile.
 Custom code is dependency-contained operator code, not an operating-system
 sandbox. Repository content cannot provide executable MCP configuration.
 
-Remote definitions register an HTTPS Streamable HTTP endpoint, its exact tool
-names, and a credential source under the same absolute grouped identities as
-custom definitions. Loom versions the URL, authentication policy, and tools;
-profiles and sessions pin the complete revision. It passes selected remotes to
+Remote definitions register an HTTPS Streamable HTTP endpoint and a credential
+source under the same absolute grouped identities as custom definitions. Loom
+versions the URL and authentication policy; profiles and sessions pin that
+revision. It passes selected remotes to
 ACP agents as native `type: http` server descriptors. No local proxy process is
 started.
 
@@ -84,12 +84,11 @@ credential sources. IAP tokens are minted when an ACP process starts, including
 recovery; ACP does not provide a mid-session header-refresh callback, so a
 continuously running process may need recovery after the token expires.
 
-The remote endpoint is the execution trust boundary. Loom pins the declared
-tool names for policy and audit, but direct ACP transport does not interpose on
-`tools/list` or calls and therefore cannot suppress an unexpected tool exposed
-later at the same URL. Register endpoints whose exposed inventory is itself
-controlled and versioned; use a proxy transport if runtime filtering or
-credential refresh becomes a requirement.
+The remote endpoint is the execution trust boundary. The ACP provider discovers
+its current inventory with MCP `tools/list`; Loom grants the selected server as
+a whole and does not hard-code or proxy its tools. Register endpoints whose
+exposed inventory is itself controlled and versioned; use a proxy transport if
+runtime filtering or credential refresh becomes a requirement.
 
 ## Revisions and resolution
 
@@ -144,8 +143,7 @@ loom mcp show loom/github/comment@v1
 loom mcp add /engineering/search/docs --file server.py --tests test_mcp.py
 loom mcps remote create /marina/api --label "Marina API" \
   --url https://marina.example.com/api/marina/mcp/ \
-  --auth '{"type":"iap","audience":"IAP_CLIENT_ID"}' \
-  --tools '["find_tool","call_tool"]'
+  --auth '{"type":"iap","audience":"IAP_CLIENT_ID"}'
 loom profile add ops --agent codex --mcp github,messaging
 loom profile show ops --effective
 ```


### PR DESCRIPTION
Remote HTTP MCP registrations now version the endpoint and authentication policy while the ACP provider discovers the live tool inventory through MCP tools/list. Selecting a remote grants that server as a whole, removing the stale duplicate tool list from Loom policy and deployment configuration.

The endpoint remains the execution trust boundary: changing the tools served at a registered URL changes the capabilities visible to future ACP connections without creating a Loom profile revision. Operators should register controlled, versioned endpoints when that distinction matters.