### PR TITLE
feat(loom): allow credentialed browser embeddings

### DIFF
--- a/crates/loom/src/web/mod.rs
+++ b/crates/loom/src/web/mod.rs
@@ -125,8 +125,8 @@ use std::path::PathBuf;
 
 use axum::{
     body::HttpBody as _,
-    extract::{DefaultBodyLimit, Request},
-    http::{header, StatusCode},
+    extract::{DefaultBodyLimit, Request, State},
+    http::{header, HeaderValue, Method, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -138,6 +138,7 @@ use tower_http::cors::CorsLayer;
 use tower_http::services::{ServeDir, ServeFile};
 use tracing::Instrument;
 
+use crate::config;
 use crate::db::Db;
 use crate::github;
 use crate::session::{self as session_mod, Session};
@@ -714,6 +715,125 @@ fn static_dir() -> PathBuf {
         .join("dist")
 }
 
+const BROWSER_API_PATHS: &[&str] = &[
+    "/api/auth/me",
+    "/api/sessions/launch",
+    "/api/sessions/get",
+    "/api/sessions/url",
+    "/api/sessions/chat",
+    "/api/sessions/chat/stream",
+    "/api/sessions/prompt/create",
+    "/api/sessions/interrupt",
+    "/api/sessions/recover",
+    "/api/sessions/permissions/answer",
+];
+
+fn browser_origin_allowed(configured: &str, origin: &HeaderValue) -> bool {
+    let Ok(origin) = origin.to_str() else {
+        return false;
+    };
+    configured
+        .split(',')
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .any(|candidate| candidate == origin && browser_origin_is_safe(candidate))
+}
+
+fn browser_origin_is_safe(origin: &str) -> bool {
+    let Ok(parsed) = reqwest::Url::parse(origin) else {
+        return false;
+    };
+    if parsed.origin().ascii_serialization() != origin
+        || parsed.path() != "/"
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+    {
+        return false;
+    }
+    match parsed.scheme() {
+        "https" => true,
+        "http" => {
+            parsed.port().is_some()
+                && matches!(parsed.host_str(), Some("127.0.0.1" | "[::1]" | "::1"))
+        }
+        _ => false,
+    }
+}
+
+fn browser_request_headers_allowed(value: Option<&HeaderValue>) -> bool {
+    value.is_none_or(|value| {
+        value.to_str().is_ok_and(|headers| {
+            headers
+                .split(',')
+                .map(str::trim)
+                .all(|name| name.eq_ignore_ascii_case("content-type"))
+        })
+    })
+}
+
+fn add_browser_cors_headers(response: &mut Response, origin: HeaderValue, preflight: bool) {
+    response
+        .headers_mut()
+        .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+    response.headers_mut().insert(
+        header::ACCESS_CONTROL_ALLOW_CREDENTIALS,
+        HeaderValue::from_static("true"),
+    );
+    response
+        .headers_mut()
+        .append(header::VARY, HeaderValue::from_static("Origin"));
+    if preflight {
+        response.headers_mut().insert(
+            header::ACCESS_CONTROL_ALLOW_METHODS,
+            HeaderValue::from_static("GET, POST"),
+        );
+        response.headers_mut().insert(
+            header::ACCESS_CONTROL_ALLOW_HEADERS,
+            HeaderValue::from_static("Content-Type"),
+        );
+    }
+}
+
+async fn browser_cors(State(state): State<AppState>, request: Request, next: Next) -> Response {
+    if !BROWSER_API_PATHS.contains(&request.uri().path()) {
+        return next.run(request).await;
+    }
+    let Some(origin) = request.headers().get(header::ORIGIN).cloned() else {
+        return next.run(request).await;
+    };
+    let configured = config::get(&state.db, "browser.allowed_origins")
+        .await
+        .unwrap_or_default();
+    if !browser_origin_allowed(&configured, &origin) {
+        return next.run(request).await;
+    }
+    if request.method() == Method::OPTIONS {
+        let requested_method = request
+            .headers()
+            .get(header::ACCESS_CONTROL_REQUEST_METHOD)
+            .and_then(|value| value.to_str().ok());
+        let requested_headers = request
+            .headers()
+            .get(header::ACCESS_CONTROL_REQUEST_HEADERS);
+        if !matches!(requested_method, Some("GET" | "POST"))
+            || !browser_request_headers_allowed(requested_headers)
+        {
+            return next.run(request).await;
+        }
+        let mut response = StatusCode::NO_CONTENT.into_response();
+        add_browser_cors_headers(&mut response, origin, true);
+        return response;
+    }
+    if request.method() != Method::GET && request.method() != Method::POST {
+        return next.run(request).await;
+    }
+    let mut response = next.run(request).await;
+    add_browser_cors_headers(&mut response, origin, false);
+    response
+}
+
 fn registered_api_router() -> Router<AppState> {
     // Declarations and handlers must be the same set, and the moment to find
     // out is boot — not the first request to a descriptor nothing serves.
@@ -812,7 +932,14 @@ pub fn router(state: AppState) -> Router {
         .fallback_service(ServeDir::new(static_dir()).fallback(ServeFile::new(index)))
         .layer(axum::middleware::from_fn(static_cache_middleware))
         .layer(CompressionLayer::new())
+        // Preserve Loom's existing non-credentialed wildcard CORS behavior.
+        // The outer browser_cors layer replaces those headers with an exact
+        // origin only for the explicitly configured embedding surface.
         .layer(CorsLayer::permissive())
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            browser_cors,
+        ))
         // Outermost, so it wraps auth and every other layer: tag each request's log
         // lines with its method + path (see `request_context_span`).
         .layer(axum::middleware::from_fn(request_context_span))
@@ -840,6 +967,28 @@ mod tests {
             .as_deref()
             .unwrap()
             .contains("docker removal failed"));
+    }
+
+    #[test]
+    fn embedded_browser_origins_require_https_or_loopback_http() {
+        for origin in [
+            "https://marina.example",
+            "https://marina.example:8443",
+            "http://127.0.0.1:8080",
+            "http://[::1]:8080",
+        ] {
+            assert!(browser_origin_is_safe(origin), "{origin}");
+        }
+        for origin in [
+            "null",
+            "*",
+            "http://marina.example",
+            "https://marina.example/",
+            "https://marina.example/path",
+            "https://user@marina.example",
+        ] {
+            assert!(!browser_origin_is_safe(origin), "{origin}");
+        }
     }
 
     #[test]

--- a/crates/loom/tests/integration/auth.rs
+++ b/crates/loom/tests/integration/auth.rs
@@ -612,6 +612,69 @@ async fn health_is_public_but_protected_routes_are_not() {
 
 #[tokio::test]
 #[serial]
+async fn embedded_browser_cors_is_credentialed_and_route_scoped() {
+    let ts = TestServer::start_api_only().await;
+    ts.client
+        .post(
+            "/api/settings/patch",
+            json!({ "changes": { "browser.allowed_origins": "https://marina.example" } }),
+        )
+        .await
+        .unwrap();
+    let http = reqwest::Client::new();
+
+    let preflight = http
+        .request(reqwest::Method::OPTIONS, url(&ts, "/api/sessions/launch"))
+        .header("Origin", "https://marina.example")
+        .header("Access-Control-Request-Method", "POST")
+        .header("Access-Control-Request-Headers", "Content-Type")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(preflight.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        preflight.headers()["access-control-allow-origin"],
+        "https://marina.example"
+    );
+    assert_eq!(
+        preflight.headers()["access-control-allow-credentials"],
+        "true"
+    );
+
+    let actual = http
+        .post(url(&ts, "/api/auth/me"))
+        .header("Origin", "https://marina.example")
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(actual.status(), StatusCode::OK);
+    assert_eq!(
+        actual.headers()["access-control-allow-origin"],
+        "https://marina.example"
+    );
+
+    for (origin, path) in [
+        ("https://other.example", "/api/sessions/launch"),
+        ("https://marina.example", "/api/settings/get"),
+    ] {
+        let response = http
+            .request(reqwest::Method::OPTIONS, url(&ts, path))
+            .header("Origin", origin)
+            .header("Access-Control-Request-Method", "POST")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.headers()["access-control-allow-origin"], "*");
+        assert!(response
+            .headers()
+            .get("access-control-allow-credentials")
+            .is_none());
+    }
+}
+
+#[tokio::test]
+#[serial]
 async fn registered_and_custom_api_routes_are_both_protected() {
     let ts = TestServer::start().await;
     ts.client

--- a/crates/weaver-core/src/config.rs
+++ b/crates/weaver-core/src/config.rs
@@ -374,6 +374,15 @@ pub const REGISTRY: &[SettingSpec] = &[
         options: &[],
     },
     SettingSpec {
+        key: "browser.allowed_origins",
+        label: "Embedded browser origins",
+        description: "Comma-separated exact origins allowed to call the small browser-embedding API with Loom's login cookie. Leave blank to disable cross-origin browser access.",
+        kind: SettingKind::String,
+        default: "",
+        group: "Authentication",
+        options: &[],
+    },
+    SettingSpec {
         key: "terminal.theme",
         label: "Terminal theme",
         description: "Colour palette for the in-browser terminal. `dark` is \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,25 @@ deployment layer.
 Runtime setting overrides are never pruned. A full desired-state manifest
 should use `prune: true`; a partial update should use `false`.
 
+### Browser embeddings
+
+`browser.allowed_origins` is a comma-separated list of exact origins that may
+use Loom's login cookie from an embedded browser client. The built-in value is
+empty, which disables credentialed cross-origin access. For example:
+
+```yaml
+settings:
+  browser.allowed_origins: https://marina.example.com
+```
+
+Loom returns credentialed CORS headers only for the session operations needed
+by an embedded conversation: identity, launch, session state and URL, chat
+snapshot and stream, prompt, interrupt, recovery, and permission answers. Loom
+does not return credentialed CORS headers for administration, settings, GitHub,
+issue, or other operations; those retain Loom's existing non-credentialed
+wildcard policy. The origin setting grants browser transport; normal Loom
+authentication and operation authorization still apply.
+
 Infrastructure tooling may instead send the same document as JSON to the
 admin-only `POST /api/deployment/reconcile` route. Reconciliation is
 idempotent, so the normal deployment loop can apply it on every rollout.


### PR DESCRIPTION
Allow configured HTTPS origins, plus port-bound loopback origins for local development, to use Loom's login cookie on the session API needed by embedded agent clients. The credentialed policy covers identity, launch, session state and URL, chat snapshot and stream, prompt, interrupt, recovery, and permission answers.

Other endpoints retain Loom's existing wildcard, non-credentialed CORS behavior. Unlisted or malformed origins cannot make credentialed browser calls, and the new deployment setting defaults to empty.
